### PR TITLE
Nextjs: Fix Nextjs version detection with prereleases

### DIFF
--- a/code/frameworks/nextjs/src/config/webpack.ts
+++ b/code/frameworks/nextjs/src/config/webpack.ts
@@ -1,13 +1,11 @@
 import { fileURLToPath } from 'node:url';
 
 import type { NextConfig } from 'next';
-import semver from 'semver';
 import type { Configuration as WebpackConfig } from 'webpack';
 
-import { addScopedAlias, getNextjsVersion, resolveNextConfig } from '../utils';
+import { addScopedAlias, isNextVersionGte, resolveNextConfig } from '../utils';
 
-const nextjsVersion = getNextjsVersion();
-const isNext16orNewer = semver.gte(nextjsVersion, '16.0.0');
+const isNext16orNewer = isNextVersionGte('16.0.0');
 
 const tryResolve = (path: string) => {
   try {

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -15,7 +15,7 @@ import nextBabelPreset from './babel/preset';
 import { configureConfig } from './config/webpack';
 import TransformFontImports from './font/babel';
 import type { FrameworkOptions, StorybookConfig } from './types';
-import { getNextjsVersion } from './utils';
+import { isNextVersionGte } from './utils';
 
 export const addons: PresetProperty<'addons'> = [
   fileURLToPath(import.meta.resolve('@storybook/preset-react-webpack')),
@@ -51,8 +51,7 @@ export const core: PresetProperty<'core'> = async (config, options) => {
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry = []) => {
   const annotations = [...entry, fileURLToPath(import.meta.resolve('@storybook/nextjs/preview'))];
 
-  const nextjsVersion = getNextjsVersion();
-  const isNext16orNewer = semver.gte(nextjsVersion, '16.0.0');
+  const isNext16orNewer = isNextVersionGte('16.0.0');
 
   // TODO: Remove this once we only support Next.js v16 and above
   if (!isNext16orNewer) {

--- a/code/frameworks/nextjs/src/utils.ts
+++ b/code/frameworks/nextjs/src/utils.ts
@@ -9,6 +9,7 @@ import { WebpackDefinePlugin } from '@storybook/builder-webpack5';
 import type { NextConfig } from 'next';
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants.js';
 import nextJsLoadConfigModule from 'next/dist/server/config.js';
+import semver from 'semver';
 import type { Configuration as WebpackConfig } from 'webpack';
 
 import { resolvePackageDir } from '../../../core/src/shared/utils/module';
@@ -23,6 +24,12 @@ export const configureRuntimeNextjsVersionResolution = (baseConfig: WebpackConfi
 
 export const getNextjsVersion = (): string =>
   JSON.parse(readFileSync(join(resolvePackageDir('next'), 'package.json'), 'utf8')).version;
+
+export const isNextVersionGte = (version: string): boolean => {
+  const currentVersion = getNextjsVersion();
+  const coercedVersion = semver.coerce(currentVersion);
+  return coercedVersion ? semver.gte(coercedVersion, version) : false;
+};
 
 export const resolveNextConfig = async ({
   nextConfigPath,


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed version detection, which before didn't account for prereleases (e.g. 16.0.0-canary.4)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32724-sha-ec66cb67`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32724-sha-ec66cb67 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32724-sha-ec66cb67 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32724-sha-ec66cb67`](https://npmjs.com/package/storybook/v/0.0.0-pr-32724-sha-ec66cb67) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/fix-nextjs-v16-detection`](https://github.com/storybookjs/storybook/tree/yann/fix-nextjs-v16-detection) |
| **Commit** | [`ec66cb67`](https://github.com/storybookjs/storybook/commit/ec66cb67c2d5ac1bd03bce7ad9fdf3bf384d7fb6) |
| **Datetime** | Tue Oct 14 11:00:34 UTC 2025 (`1760439634`) |
| **Workflow run** | [18494303004](https://github.com/storybookjs/storybook/actions/runs/18494303004) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=32724`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-visible features added.

- Refactor
  - Streamlined Next.js version detection used in build and preset configuration, replacing manual checks with a centralized approach.
  - Ensures consistent behavior when gating features for Next.js v16 and newer, while preserving existing runtime configuration paths.
  - No changes to app behavior or configuration; future compatibility improved.
  - No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->