### PR TITLE
CLI: Fix CSF factories addon syncing in storybook add command

### DIFF
--- a/code/core/src/common/utils/load-main-config.ts
+++ b/code/core/src/common/utils/load-main-config.ts
@@ -14,16 +14,18 @@ import { validateConfigurationFiles } from './validate-configuration-files';
 export async function loadMainConfig({
   configDir = '.storybook',
   cwd,
+  skipCache,
 }: {
   configDir: string;
   cwd?: string;
+  skipCache?: boolean;
 }): Promise<StorybookConfig> {
   await validateConfigurationFiles(configDir, cwd);
 
   const mainPath = getInterpretedFile(resolve(configDir, 'main')) as string;
 
   try {
-    const out = await importModule(mainPath, { skipCache: true });
+    const out = await importModule(mainPath, { skipCache });
     return out;
   } catch (e) {
     if (!(e instanceof Error)) {

--- a/code/core/src/common/utils/load-main-config.ts
+++ b/code/core/src/common/utils/load-main-config.ts
@@ -23,7 +23,7 @@ export async function loadMainConfig({
   const mainPath = getInterpretedFile(resolve(configDir, 'main')) as string;
 
   try {
-    const out = await importModule(mainPath);
+    const out = await importModule(mainPath, { skipCache: true });
     return out;
   } catch (e) {
     if (!(e instanceof Error)) {

--- a/code/core/src/shared/utils/module.ts
+++ b/code/core/src/shared/utils/module.ts
@@ -51,7 +51,10 @@ let isTypescriptLoaderRegistered = false;
  * // Returns the default export or the entire module
  * ```
  */
-export async function importModule(path: string) {
+export async function importModule(
+  path: string,
+  { skipCache = false }: { skipCache?: boolean } = {}
+) {
   if (!isTypescriptLoaderRegistered) {
     const typescriptLoaderUrl = importMetaResolve('storybook/internal/bin/loader');
     register(typescriptLoaderUrl, import.meta.url);
@@ -61,12 +64,17 @@ export async function importModule(path: string) {
   let mod;
   try {
     const resolvedPath = win32.isAbsolute(path) ? pathToFileURL(path).href : path;
-    mod = await import(resolvedPath);
+    // When applicable, add a hash to the import URL to bypass cache
+    const importUrl = skipCache ? `${resolvedPath}?${Date.now()}` : resolvedPath;
+    mod = await import(importUrl);
   } catch (importError) {
     try {
       // fallback to require to support older behavior
       // this is relevant for presets that are only available with the "require" condition in a package's export map
       const require = createRequire(import.meta.url);
+      if (skipCache) {
+        delete require.cache[require.resolve(path)];
+      }
       mod = require(path);
     } catch (requireError) {
       /*

--- a/code/lib/cli-storybook/src/add.ts
+++ b/code/lib/cli-storybook/src/add.ts
@@ -1,8 +1,6 @@
-import { isAbsolute, join } from 'node:path';
-
 import {
   type PackageManagerName,
-  serverRequire,
+  loadMainConfig,
   syncStorybookAddons,
   versions,
 } from 'storybook/internal/common';
@@ -182,7 +180,8 @@ export async function add(
 
   // TODO: remove try/catch once CSF factories is shipped, for now gracefully handle any error
   try {
-    await syncStorybookAddons(mainConfig, previewConfigPath!, configDir);
+    const newMainConfig = await loadMainConfig({ configDir });
+    await syncStorybookAddons(newMainConfig, previewConfigPath!, configDir);
   } catch (e) {
     //
   }

--- a/code/lib/cli-storybook/src/add.ts
+++ b/code/lib/cli-storybook/src/add.ts
@@ -180,7 +180,7 @@ export async function add(
 
   // TODO: remove try/catch once CSF factories is shipped, for now gracefully handle any error
   try {
-    const newMainConfig = await loadMainConfig({ configDir });
+    const newMainConfig = await loadMainConfig({ configDir, skipCache: true });
     await syncStorybookAddons(newMainConfig, previewConfigPath!, configDir);
   } catch (e) {
     //


### PR DESCRIPTION
Closes #32647, #32626

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The CSF factories syncing in the add command was not working because the main config passed was actually the "old" one, where the new addon wasn't present. This PR fixes that and adds a way to bypass cache when importing the main config file as a module, otherwise the main config would always be resolving with the old values.
## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Always loads a fresh main configuration (cache bypass) to prevent stale settings.
  * Improves reliability of addon synchronization to reflect the latest project config.
  * Adds more resilient module loading with better handling for mixed ESM/CommonJS setups.
  * Reduces caching-related import issues for more predictable behavior after config changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->