### PR TITLE
Docs: Update monorepo contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
 # Contributors Guide
+> Tip: If you want to make a fast contribution, check the “good first issue” label in the Issues tab for small frontend and docs tasks that are easy to fix directly on GitHub.
+
 
 We welcome contributions of any type and skill level. As an open-source project, we believe in the power of community and welcome any contributions that help us improve Storybook. Whether you are a developer, designer, writer, or someone who wants to help, we'd love to have you on board. If you are interested in contributing, please read the following guidelines.
 


### PR DESCRIPTION
Small docs improvement: added a short tip recommending contributors check the "good first issue" label for fast frontend/docs tasks that can be done via the GitHub web editor.

- Change: added a one-line tip to CONTRIBUTING.md
- Why: helps new contributors find easy issues and make quick PRs (no local setup required)
- Type: documentation only — no code changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines with improved information about getting started with contributions and the contribution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->