### PR TITLE
A11Y: Bugfix missing `manager.js` entry-file

### DIFF
--- a/code/addons/a11y/manager.js
+++ b/code/addons/a11y/manager.js
@@ -1,0 +1,1 @@
+export * from './dist/manager.js';


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32459

## What I did

When users wrap their addons-strings using `getAbsolutePath`, node (sometimes?) no longer uses the `exportMap` defined in `package.json` of out package, and so root files are needed to have our preset loading code "see" these as `managerEntries` it needs to add to the list.

I check if any other addons had their missing, but that didn't seem like the case.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- A repo (preferably a monorepo) using storybook & vite is needed.
- Add (or ensure it's added) the addon-vitest, and it's all correctly setup.
- Add the a11y addon.
- Ensure the `main.ts` files had wrapped the addon-string with `getAbsolutePath`
- Run the storybook in dev mode and absolute the checkboxes in the testing module.
- You can check the issue linked above, for extra details.
- You should no longer be able to reproduce the bug after this change.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the accessibility addon manager module structure to improve export handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->