### PR TITLE
Fixes running building angular in a path with spaces

### DIFF
--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -605,7 +605,10 @@ export abstract class JsPackageManager {
     ignoreError?: boolean;
   }): string {
     try {
-      const commandResult = execaCommandSync([command, ...args].join(' '), {
+      // `execaSync` shares the same node.js limitation of spawnSync: if `shell: true` is used, the command filename and arguments
+      // must be quoted: https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
+      // `execa` doesn't seems to offer an helper to do so, so manually quote arguments with spaces
+      const commandResult = execaCommandSync([command, ...args].map(c => c.includes(' ') ? `"${c}"` : c).join(' '), {
         cwd: cwd ?? this.cwd,
         stdio: stdio ?? 'pipe',
         shell: true,


### PR DESCRIPTION
Closes #32778

## What I did

I supported the execution of scripts with arguments with spaces.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

No current test is available for `JsPackageManager` around `executeCommand`.

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

Checkout the sample described in https://storybook.js.org/tutorials/intro-to-storybook/angular/en/get-started/ on a folder with spaces. Tested on MacOS. 

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed command execution on Windows systems by properly handling arguments containing spaces in shell commands, ensuring reliable command-line operations across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->