### PR TITLE
Addon Vitest: Fix incorrect file modifications during setup

### DIFF
--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -468,11 +468,14 @@ export default async function postInstall(options: PostinstallOptions) {
       logger.plain(`  ${rootConfig}`);
 
       const formattedContent = await formatFileContent(rootConfig, generate(target).code);
+      // Only add triple slash reference to vite.config files, not vitest.config files
+      // vitest.config files already have the vitest/config types available
+      const shouldAddReference = !configFileHasTypeReference && !vitestConfigFile;
       await writeFile(
         rootConfig,
-        configFileHasTypeReference
-          ? formattedContent
-          : '/// <reference types="vitest/config" />\n' + formattedContent
+        shouldAddReference
+          ? '/// <reference types="vitest/config" />\n' + formattedContent
+          : formattedContent
       );
     } else {
       logErrors(

--- a/code/addons/vitest/src/updateVitestFile.test.ts
+++ b/code/addons/vitest/src/updateVitestFile.test.ts
@@ -771,6 +771,194 @@ describe('updateConfigFile', () => {
         }));"
     `);
   });
+
+  it('extracts coverage config and keeps it at top level when using workspace', async () => {
+    const source = babel.babelParse(
+      await loadTemplate('vitest.config.template.ts', {
+        CONFIG_DIR: '.storybook',
+        BROWSER_CONFIG: "{ provider: 'playwright' }",
+        SETUP_FILE: '../.storybook/vitest.setup.ts',
+      })
+    );
+    const target = babel.babelParse(`
+      import { mergeConfig, defineConfig } from 'vitest/config'
+      import viteConfig from './vite.config'
+
+      export default mergeConfig(
+        viteConfig,
+        defineConfig({
+          test: {
+            name: 'node',
+            environment: 'happy-dom',
+            include: ['**/*.test.ts'],
+            coverage: {
+              exclude: [
+                'storybook.setup.ts',
+                '**/*.stories.*',
+              ],
+            },
+          },
+        })
+      )
+    `);
+
+    const before = babel.generate(target).code;
+    const updated = updateConfigFile(source, target);
+    expect(updated).toBe(true);
+
+    const after = babel.generate(target).code;
+
+    // check if the code was updated at all
+    expect(after).not.toBe(before);
+
+    // check if the code was updated correctly
+    // Coverage should stay at the top level, not moved into the workspace
+    expect(getDiff(before, after)).toMatchInlineSnapshot(`
+      "  import { mergeConfig, defineConfig } from 'vitest/config';
+        import viteConfig from './vite.config';
+        
+      + import path from 'node:path';
+      + import { fileURLToPath } from 'node:url';
+      + import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+      + const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+      + 
+      + // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
+      + 
+        export default mergeConfig(viteConfig, defineConfig({
+          test: {
+        
+      -     name: 'node',
+      -     environment: 'happy-dom',
+      -     include: ['**/*.test.ts'],
+      - 
+            coverage: {
+              exclude: ['storybook.setup.ts', '**/*.stories.*']
+        
+      -     }
+      - 
+      +     },
+      +     workspace: [{
+      +       extends: true,
+      +       test: {
+      +         name: 'node',
+      +         environment: 'happy-dom',
+      +         include: ['**/*.test.ts']
+      +       }
+      +     }, {
+      +       extends: true,
+      +       plugins: [
+      +       // The plugin will run tests for the stories defined in your Storybook config
+      +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
+      +       storybookTest({
+      +         configDir: path.join(dirname, '.storybook')
+      +       })],
+      +       test: {
+      +         name: 'storybook',
+      +         browser: {
+      +           provider: 'playwright'
+      +         },
+      +         setupFiles: ['../.storybook/vitest.setup.ts']
+      +       }
+      +     }]
+      + 
+          }
+        }));"
+    `);
+  });
+
+  it('extracts coverage config and keeps it at top level when using projects', async () => {
+    const source = babel.babelParse(
+      await loadTemplate('vitest.config.3.2.template.ts', {
+        CONFIG_DIR: '.storybook',
+        BROWSER_CONFIG: "{ provider: 'playwright' }",
+        SETUP_FILE: '../.storybook/vitest.setup.ts',
+      })
+    );
+    const target = babel.babelParse(`
+      import { mergeConfig, defineConfig } from 'vitest/config'
+      import viteConfig from './vite.config'
+
+      export default mergeConfig(
+        viteConfig,
+        defineConfig({
+          test: {
+            name: 'node',
+            environment: 'happy-dom',
+            include: ['**/*.test.ts'],
+            coverage: {
+              exclude: [
+                'storybook.setup.ts',
+                '**/*.stories.*',
+              ],
+            },
+          },
+        })
+      )
+    `);
+
+    const before = babel.generate(target).code;
+    const updated = updateConfigFile(source, target);
+    expect(updated).toBe(true);
+
+    const after = babel.generate(target).code;
+
+    // check if the code was updated at all
+    expect(after).not.toBe(before);
+
+    // check if the code was updated correctly
+    // Coverage should stay at the top level, not moved into the projects
+    expect(getDiff(before, after)).toMatchInlineSnapshot(`
+      "  import { mergeConfig, defineConfig } from 'vitest/config';
+        import viteConfig from './vite.config';
+        
+      + import path from 'node:path';
+      + import { fileURLToPath } from 'node:url';
+      + import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+      + const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+      + 
+      + // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
+      + 
+        export default mergeConfig(viteConfig, defineConfig({
+          test: {
+        
+      -     name: 'node',
+      -     environment: 'happy-dom',
+      -     include: ['**/*.test.ts'],
+      - 
+            coverage: {
+              exclude: ['storybook.setup.ts', '**/*.stories.*']
+        
+      -     }
+      - 
+      +     },
+      +     projects: [{
+      +       extends: true,
+      +       test: {
+      +         name: 'node',
+      +         environment: 'happy-dom',
+      +         include: ['**/*.test.ts']
+      +       }
+      +     }, {
+      +       extends: true,
+      +       plugins: [
+      +       // The plugin will run tests for the stories defined in your Storybook config
+      +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
+      +       storybookTest({
+      +         configDir: path.join(dirname, '.storybook')
+      +       })],
+      +       test: {
+      +         name: 'storybook',
+      +         browser: {
+      +           provider: 'playwright'
+      +         },
+      +         setupFiles: ['../.storybook/vitest.setup.ts']
+      +       }
+      +     }]
+      + 
+          }
+        }));"
+    `);
+  });
 });
 
 describe('updateWorkspaceFile', () => {

--- a/code/addons/vitest/src/updateVitestFile.ts
+++ b/code/addons/vitest/src/updateVitestFile.ts
@@ -123,14 +123,7 @@ export const updateConfigFile = (source: BabelFile['ast'], target: BabelFile['as
     targetExportDefault.declaration.callee.name === 'mergeConfig' &&
     targetExportDefault.declaration.arguments.length >= 2
   ) {
-    const defineConfigNodes = targetExportDefault.declaration.arguments.filter(
-      (arg): arg is t.CallExpression =>
-        arg?.type === 'CallExpression' &&
-        arg.callee.type === 'Identifier' &&
-        arg.callee.name === 'defineConfig' &&
-        arg.arguments[0]?.type === 'ObjectExpression'
-    );
-    canHandleConfig = defineConfigNodes.length > 0;
+    canHandleConfig = true;
   }
 
   if (!canHandleConfig) {
@@ -194,37 +187,40 @@ export const updateConfigFile = (source: BabelFile['ast'], target: BabelFile['as
           exportDefault.declaration.callee.name === 'mergeConfig' &&
           exportDefault.declaration.arguments.length >= 2
         ) {
-          const defineConfigNodes = exportDefault.declaration.arguments.filter(
-            (arg): arg is t.CallExpression =>
+          // We first collect all the potential config object nodes from mergeConfig, these can be:
+          // - defineConfig({ ... }) calls
+          // - plain object expressions { ... } without a defineConfig helper
+          const configObjectNodes: t.ObjectExpression[] = [];
+
+          for (const arg of exportDefault.declaration.arguments) {
+            if (
               arg?.type === 'CallExpression' &&
               arg.callee.type === 'Identifier' &&
               arg.callee.name === 'defineConfig' &&
               arg.arguments[0]?.type === 'ObjectExpression'
+            ) {
+              configObjectNodes.push(arg.arguments[0] as t.ObjectExpression);
+            } else if (arg?.type === 'ObjectExpression') {
+              configObjectNodes.push(arg);
+            }
+          }
+
+          // Prefer a config object that already contains a `test` property
+          const configObjectWithTest = configObjectNodes.find((obj) =>
+            obj.properties.some(
+              (p) =>
+                p.type === 'ObjectProperty' && p.key.type === 'Identifier' && p.key.name === 'test'
+            )
           );
 
-          const defineConfigNodeWithTest = defineConfigNodes.find(
-            (node) =>
-              node.arguments[0].type === 'ObjectExpression' &&
-              node.arguments[0].properties.some(
-                (p) =>
-                  p.type === 'ObjectProperty' &&
-                  p.key.type === 'Identifier' &&
-                  p.key.name === 'test'
-              )
-          );
+          const targetConfigObject = configObjectWithTest || configObjectNodes[0];
 
-          // Give precedence for the defineConfig expression which contains a test config property
-          // As with mergeConfig you never know where the test could be e.g. mergeConfig(viteConfig, defineConfig({}), defineConfig({ test: {...} }))
-          const defineConfigNode = defineConfigNodeWithTest || defineConfigNodes[0];
-
-          if (!defineConfigNode) {
+          if (!targetConfigObject) {
             return false;
           }
 
-          const defineConfigProps = defineConfigNode.arguments[0] as t.ObjectExpression;
-
-          // Check if there's already a test property in the defineConfig
-          const existingTestProp = defineConfigProps.properties.find(
+          // Check if there's already a test property in the target config
+          const existingTestProp = targetConfigObject.properties.find(
             (p) =>
               p.type === 'ObjectProperty' && p.key.type === 'Identifier' && p.key.name === 'test'
           ) as t.ObjectProperty | undefined;
@@ -291,8 +287,8 @@ export const updateConfigFile = (source: BabelFile['ast'], target: BabelFile['as
                 // Add the existing test project to the template's array
                 workspaceOrProjectsProp.value.elements.unshift(existingTestProject);
 
-                // Remove the existing test property from defineConfig since we're moving it to the array
-                defineConfigProps.properties = defineConfigProps.properties.filter(
+                // Remove the existing test property from the target config since we're moving it to the array
+                targetConfigObject.properties = targetConfigObject.properties.filter(
                   (p) => p !== existingTestProp
                 );
 
@@ -303,18 +299,18 @@ export const updateConfigFile = (source: BabelFile['ast'], target: BabelFile['as
                 }
 
                 // Merge the template properties (which now include our existing test project in the array)
-                mergeProperties(properties, defineConfigProps.properties);
+                mergeProperties(properties, targetConfigObject.properties);
               } else {
                 // Fallback to original behavior if template structure is unexpected
-                mergeProperties(properties, defineConfigProps.properties);
+                mergeProperties(properties, targetConfigObject.properties);
               }
             } else {
               // Fallback to original behavior if template doesn't have expected structure
-              mergeProperties(properties, defineConfigProps.properties);
+              mergeProperties(properties, targetConfigObject.properties);
             }
           } else {
             // No existing test config, just merge normally
-            mergeProperties(properties, defineConfigProps.properties);
+            mergeProperties(properties, targetConfigObject.properties);
           }
           updated = true;
         }


### PR DESCRIPTION
Closes #32804, Closes #32806

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

1. Only add `/// <reference types="vitest/config" />` to vite.config files,
not vitest.config files, because vitest.config files already have the
vitest/config types available by default.

2. Modified the updateConfigFile function in updateVitestFile.ts to:

- Extract the coverage property before creating workspace/projects items
- Filter it out from the test config that goes into the array
- Preserve it at the top-level test object where it belongs

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32844-sha-03847137`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32844-sha-03847137 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32844-sha-03847137 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32844-sha-03847137`](https://npmjs.com/package/storybook/v/0.0.0-pr-32844-sha-03847137) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/vitest-addon-setup-fixes`](https://github.com/storybookjs/storybook/tree/yann/vitest-addon-setup-fixes) |
| **Commit** | [`03847137`](https://github.com/storybookjs/storybook/commit/0384713710fd1914c57d29bbd49a23fa5395ee99) |
| **Datetime** | Mon Oct 27 12:35:09 UTC 2025 (`1761568509`) |
| **Workflow run** | [18841123309](https://github.com/storybookjs/storybook/actions/runs/18841123309) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=32844`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Smarter insertion of Vitest type references to avoid duplicates and only add them where appropriate.
  * Improved handling of merged/configured Vitest setups so coverage settings stay at the top level and are preserved across workspace/project configurations.

* **Tests**
  * Expanded test coverage for complex Vitest config merge scenarios and multi-project/workspace setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->