### PR TITLE
Core: Enhance warning for Testing Library's `screen` usage in docs mode

### DIFF
--- a/code/core/src/test/testing-library.ts
+++ b/code/core/src/test/testing-library.ts
@@ -25,10 +25,18 @@ const testingLibrary = instrument(
 
 testingLibrary.screen = new Proxy(testingLibrary.screen, {
   get(target, prop, receiver) {
-    once.warn(dedent`
-          You are using Testing Library's \`screen\` object. Use \`within(canvasElement)\` instead.
-          More info: https://storybook.js.org/docs/writing-tests/interaction-testing?ref=error
-        `);
+    if (typeof window !== 'undefined') {
+      const isInDocsViewMode =
+        globalThis.location?.href?.includes('viewMode=docs') ||
+        globalThis.parent?.location?.href?.includes('/docs/');
+      if (isInDocsViewMode) {
+        once.warn(dedent`
+            You are using Testing Library's \`screen\` object while the story is rendered in docs mode. This will likely lead to issues, as multiple stories are rendered in the same page and therefore screen will potentially find multiple elements. Use the \`canvas\` utility from the story context instead, which will scope the queries to each story's canvas.
+
+            More info: https://storybook.js.org/docs/writing-tests/interaction-testing?ref=error#querying-the-canvas
+          `);
+      }
+    }
     return Reflect.get(target, prop, receiver);
   },
 });

--- a/code/core/src/test/testing-library.ts
+++ b/code/core/src/test/testing-library.ts
@@ -25,23 +25,12 @@ const testingLibrary = instrument(
 
 testingLibrary.screen = new Proxy(testingLibrary.screen, {
   get(target, prop, receiver) {
-    if (typeof window !== 'undefined') {
-      let isInDocsViewMode = false;
+    if (typeof window !== 'undefined' && globalThis.location?.href?.includes('viewMode=docs')) {
+      once.warn(dedent`
+        You are using Testing Library's \`screen\` object while the story is rendered in docs mode. This will likely lead to issues, as multiple stories are rendered in the same page and therefore screen will potentially find multiple elements. Use the \`canvas\` utility from the story context instead, which will scope the queries to each story's canvas.
 
-      try {
-        isInDocsViewMode =
-          globalThis.location?.href?.includes('viewMode=docs') ||
-          globalThis.parent?.location?.href?.includes('/docs/');
-        if (isInDocsViewMode) {
-          once.warn(dedent`
-            You are using Testing Library's \`screen\` object while the story is rendered in docs mode. This will likely lead to issues, as multiple stories are rendered in the same page and therefore screen will potentially find multiple elements. Use the \`canvas\` utility from the story context instead, which will scope the queries to each story's canvas.
-
-            More info: https://storybook.js.org/docs/writing-tests/interaction-testing?ref=error#querying-the-canvas
-          `);
-        }
-      } catch {
-        // Ignore cross-origin errors when accessing parent.location
-      }
+        More info: https://storybook.js.org/docs/writing-tests/interaction-testing?ref=error#querying-the-canvas
+      `);
     }
     return Reflect.get(target, prop, receiver);
   },

--- a/code/core/src/test/testing-library.ts
+++ b/code/core/src/test/testing-library.ts
@@ -26,15 +26,21 @@ const testingLibrary = instrument(
 testingLibrary.screen = new Proxy(testingLibrary.screen, {
   get(target, prop, receiver) {
     if (typeof window !== 'undefined') {
-      const isInDocsViewMode =
-        globalThis.location?.href?.includes('viewMode=docs') ||
-        globalThis.parent?.location?.href?.includes('/docs/');
-      if (isInDocsViewMode) {
-        once.warn(dedent`
+      let isInDocsViewMode = false;
+
+      try {
+        isInDocsViewMode =
+          globalThis.location?.href?.includes('viewMode=docs') ||
+          globalThis.parent?.location?.href?.includes('/docs/');
+        if (isInDocsViewMode) {
+          once.warn(dedent`
             You are using Testing Library's \`screen\` object while the story is rendered in docs mode. This will likely lead to issues, as multiple stories are rendered in the same page and therefore screen will potentially find multiple elements. Use the \`canvas\` utility from the story context instead, which will scope the queries to each story's canvas.
 
             More info: https://storybook.js.org/docs/writing-tests/interaction-testing?ref=error#querying-the-canvas
           `);
+        }
+      } catch {
+        // Ignore cross-origin errors when accessing parent.location
       }
     }
     return Reflect.get(target, prop, receiver);


### PR DESCRIPTION
Closes #31598

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR scopes the TL `screen` warning so it only really warns when a story which uses the screen utility is rendered in docs mode

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Testing Library warning behavior so alerts only appear in Storybook docs view, providing contextual guidance there and remaining silent during normal development. The change also improves robustness against cross-origin environments to avoid spurious warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->