### PR TITLE
React: Improve error handling of component manifest generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ code/core/report
 node_modules/.svelte2tsx-language-server-files
 
 *storybook.log
+
+.junie

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -478,26 +478,20 @@ export class CsfFile {
             // export default meta;
             const variableName = (node.declaration as t.Identifier).name;
             self._metaVariableName = variableName;
-            const isVariableDeclarator = (declaration: t.VariableDeclarator) =>
+            const isMetaVariable = (declaration: t.VariableDeclarator) =>
               t.isIdentifier(declaration.id) && declaration.id.name === variableName;
 
-            self._metaStatement = self._ast.program.body.find(
-              (topLevelNode) =>
-                t.isVariableDeclaration(topLevelNode) &&
-                topLevelNode.declarations.find(isVariableDeclarator)
-            );
+            self._metaStatementPath = self._file.path
+              .get('body')
+              .find(
+                (path) =>
+                  path.isVariableDeclaration() && path.node.declarations.some(isMetaVariable)
+              );
 
-            self._metaStatementPath =
-              self._file.path
-                .get('body')
-                .find(
-                  (topLevelPath) =>
-                    topLevelPath.isVariableDeclaration() &&
-                    topLevelPath.node.declarations.some(isVariableDeclarator)
-                ) ?? undefined;
+            self._metaStatement = self._metaStatementPath?.node;
 
             decl = ((self?._metaStatement as t.VariableDeclaration)?.declarations || []).find(
-              isVariableDeclarator
+              isMetaVariable
             )?.init;
           } else {
             self._metaStatement = node;

--- a/code/core/src/csf-tools/enrichCsf.test.ts
+++ b/code/core/src/csf-tools/enrichCsf.test.ts
@@ -14,11 +14,9 @@ expect.addSnapshotSerializer({
 const enrich = async (code: string, originalCode: string, options?: EnrichCsfOptions) => {
   // we don't actually care about the title
 
-  const csf = loadCsf(code, {
-    makeTitle: (userTitle) => userTitle || 'default',
-  }).parse();
+  const csf = loadCsf(code, { makeTitle: (userTitle) => userTitle ?? 'Unknown' }).parse();
   const csfSource = loadCsf(originalCode, {
-    makeTitle: (userTitle) => userTitle || 'default',
+    makeTitle: (userTitle) => userTitle ?? 'Unknown',
   }).parse();
   await enrichCsf(csf, csfSource, options);
   return formatCsf(csf);

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -347,12 +347,14 @@ export type TagsOptions = Record<Tag, Partial<TagOptions>>;
 
 export interface ComponentManifest {
   id: string;
-  name: string;
+  path: string;
+  name?: string;
   description?: string;
   import?: string;
   summary?: string;
-  examples: { name: string; snippet: string }[];
+  examples: { name: string; snippet?: string; error?: { message: string } }[];
   jsDocTags: Record<string, string[]>;
+  error?: { message: string };
 }
 
 export interface ComponentsManifest {

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -348,7 +348,7 @@ export type TagsOptions = Record<Tag, Partial<TagOptions>>;
 export interface ComponentManifest {
   id: string;
   path: string;
-  name?: string;
+  name: string;
   description?: string;
   import?: string;
   summary?: string;

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -11,7 +11,7 @@ function generateExample(code: string) {
   const csf = loadCsf(code, { makeTitle: (userTitle?: string) => userTitle ?? 'title' }).parse();
 
   const snippets = Object.keys(csf._storyExports)
-    .map((name) => getCodeSnippet(csf, name))
+    .map((name) => getCodeSnippet(csf, name, csf._meta?.component ?? 'ComponentTitle'))
     .filter(Boolean);
 
   return recast.print(t.program(snippets)).code;

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -81,8 +81,15 @@ test('Edge case identifier we can not find', () => {
   const input = withCSF3(`
     export const Default = someImportOrWhatever;
   `);
-  expect(generateExample(input)).toMatchInlineSnapshot(
-    `"const Default = () => <Button>Click me</Button>;"`
+  expect(() => generateExample(input)).toThrowErrorMatchingInlineSnapshot(
+    `
+    [SyntaxError: Expected story to be csf factory, function or an object expression
+      11 |
+      12 |
+    > 13 |     export const Default = someImportOrWhatever;
+         |                            ^^^^^^^^^^^^^^^^^^^^
+      14 |   ]
+  `
   );
 });
 

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -97,6 +97,15 @@ test('Default- CSF4', () => {
   );
 });
 
+test('StoryWithoutArguments - CSF4', () => {
+  const input = withCSF4(`
+    export const StoryWithoutArguments = meta.story();
+  `);
+  expect(generateExample(input)).toMatchInlineSnapshot(
+    `"const StoryWithoutArguments = () => <Button>Click me</Button>;"`
+  );
+});
+
 test('Replace children', () => {
   const input = withCSF3(dedent`
     export const WithEmoji: Story = {

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -252,7 +252,11 @@ test('CustomRenderBlockBody only', async () => {
     };`
   );
   expect(generateExample(input)).toMatchInlineSnapshot(
-    `"const CustomRenderBlockBody = (args) => { return <Button {...args}>Render</Button> };"`
+    `
+    "const CustomRenderBlockBody = () => {
+        return <Button foo="bar">Render</Button>;
+    };"
+  `
   );
 });
 
@@ -508,8 +512,8 @@ test('top level args injection and spreading in different places', async () => {
   `);
   expect(generateExample(input)).toMatchInlineSnapshot(`
     "const MultipleSpreads = () => <div count={0}>
-        <Button disabled={false} count={0} empty="" />
-        <Button disabled={false} count={0} empty="" />
+        <Button disabled={false} count={0} empty="">Click me</Button>
+        <Button disabled={false} count={0} empty="">Click me</Button>
     </div>;"
   `);
 });
@@ -525,12 +529,12 @@ test('allow top level export functions', async () => {
     }
   `);
   expect(generateExample(input)).toMatchInlineSnapshot(`
-    "function Usage(args) {
-      return (
-        <div style={{ padding: 40 }}>
-          <Button {...args}></Button>
-        </div>
-      );
+    "function Usage() {
+        return (
+            <div style={{ padding: 40 }}>
+                <Button>Click me</Button>
+            </div>
+        );
     }"
   `);
 });

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -1,7 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { recast } from 'storybook/internal/babel';
-import { types as t } from 'storybook/internal/babel';
+import { recast, types as t } from 'storybook/internal/babel';
 import { loadCsf } from 'storybook/internal/csf-tools';
 
 import { dedent } from 'ts-dedent';
@@ -205,6 +204,28 @@ test('CustomRenderWithOverideArgs only', async () => {
   );
   expect(generateExample(input)).toMatchInlineSnapshot(
     `"const CustomRenderWithOverideArgs = () => <Button foo="bar" override="overide">Render</Button>;"`
+  );
+});
+
+test('Meta level render', async () => {
+  const input = dedent`
+    import type { Meta } from '@storybook/react';
+    import { Button } from '@design-system/button';
+
+    const meta: Meta<typeof Button> = {
+      render: (args) => <Button {...args} override="overide" />,
+      args: {
+        children: 'Click me'
+      }
+    };
+    export default meta;
+
+    export const CustomRenderWithOverideArgs = {
+      args: { foo: 'bar', override: 'value' }
+    };
+  `;
+  expect(generateExample(input)).toMatchInlineSnapshot(
+    `"const CustomRenderWithOverideArgs = () => <Button foo="bar" override="overide">Click me</Button>;"`
   );
 });
 

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -10,10 +10,9 @@ import { getCodeSnippet } from './generateCodeSnippet';
 
 function generateExample(code: string) {
   const csf = loadCsf(code, { makeTitle: (userTitle?: string) => userTitle ?? 'title' }).parse();
-  const component = csf._meta?.component ?? 'Unknown';
 
-  const snippets = Object.entries(csf._storyDeclarationPath)
-    .map(([name, path]) => getCodeSnippet(path, name, csf._metaNode ?? null, component))
+  const snippets = Object.keys(csf._storyExports)
+    .map((name) => getCodeSnippet(csf, name))
     .filter(Boolean);
 
   return recast.print(t.program(snippets)).code;

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
@@ -49,7 +49,10 @@ export function getCodeSnippet(
 
       if (obj.isIdentifier() && isBind) {
         const resolved = resolveBindIdentifierInit(storyDeclaration, obj);
-        if (resolved) normalizedPath = resolved;
+
+        if (resolved) {
+          normalizedPath = resolved;
+        }
       }
     }
 
@@ -209,7 +212,9 @@ export function getCodeSnippet(
 
 /** Build a spread `{...{k: v}}` for props that aren't valid JSX attributes. */
 function buildInvalidSpread(entries: ReadonlyArray<[string, t.Node]>): t.JSXSpreadAttribute | null {
-  if (entries.length === 0) return null;
+  if (entries.length === 0) {
+    return null;
+  }
   const objectProps = entries.map(([k, v]) =>
     t.objectProperty(t.stringLiteral(k), t.isExpression(v) ? v : t.identifier('undefined'))
   );
@@ -243,7 +248,9 @@ const argsRecordFromObjectNode = (obj?: t.ObjectExpression | null) =>
     : {};
 
 const metaArgsRecord = (meta?: t.ObjectExpression | null) => {
-  if (!meta) return {};
+  if (!meta) {
+    return {};
+  }
   const argsProp = meta.properties.find(
     (p): p is t.ObjectProperty => t.isObjectProperty(p) && keyOf(p) === 'args'
   );
@@ -258,10 +265,14 @@ const toAttr = (key: string, value: t.Node) => {
       ? t.jsxAttribute(t.jsxIdentifier(key), null)
       : t.jsxAttribute(t.jsxIdentifier(key), t.jsxExpressionContainer(value));
   }
-  if (t.isStringLiteral(value))
+
+  if (t.isStringLiteral(value)) {
     return t.jsxAttribute(t.jsxIdentifier(key), t.stringLiteral(value.value));
-  if (t.isExpression(value))
+  }
+
+  if (t.isExpression(value)) {
     return t.jsxAttribute(t.jsxIdentifier(key), t.jsxExpressionContainer(value));
+  }
   return null;
 };
 
@@ -279,8 +290,13 @@ const toJsxChildren = (node: t.Node | null | undefined) =>
 /** Return `key` if expression is `args.key` (incl. optional chaining), else `null`. */
 function getArgsMemberKey(expr: t.Node) {
   if (t.isMemberExpression(expr) && t.isIdentifier(expr.object) && expr.object.name === 'args') {
-    if (t.isIdentifier(expr.property) && !expr.computed) return expr.property.name;
-    if (t.isStringLiteral(expr.property) && expr.computed) return expr.property.value;
+    if (t.isIdentifier(expr.property) && !expr.computed) {
+      return expr.property.name;
+    }
+
+    if (t.isStringLiteral(expr.property) && expr.computed) {
+      return expr.property.value;
+    }
   }
   if (
     t.isOptionalMemberExpression?.(expr) &&
@@ -288,8 +304,14 @@ function getArgsMemberKey(expr: t.Node) {
     expr.object.name === 'args'
   ) {
     const prop = expr.property;
-    if (t.isIdentifier(prop) && !expr.computed) return prop.name;
-    if (t.isStringLiteral(prop) && expr.computed) return prop.value;
+
+    if (t.isIdentifier(prop) && !expr.computed) {
+      return prop.name;
+    }
+
+    if (t.isStringLiteral(prop) && expr.computed) {
+      return prop.value;
+    }
   }
   return null;
 }
@@ -305,12 +327,20 @@ function inlineArgsInJsx(
     const opening = node.openingElement;
 
     const newAttrs = opening.attributes.flatMap<t.JSXAttribute | t.JSXSpreadAttribute>((a) => {
-      if (!t.isJSXAttribute(a)) return [a];
+      if (!t.isJSXAttribute(a)) {
+        return [a];
+      }
       const name = t.isJSXIdentifier(a.name) ? a.name.name : null;
-      if (!(name && a.value && t.isJSXExpressionContainer(a.value))) return [a];
+
+      if (!(name && a.value && t.isJSXExpressionContainer(a.value))) {
+        return [a];
+      }
 
       const key = getArgsMemberKey(a.value.expression);
-      if (!(key && key in merged)) return [a];
+
+      if (!(key && key in merged)) {
+        return [a];
+      }
 
       const repl = toAttr(name, merged[key]);
       changed = true;
@@ -464,13 +494,21 @@ function resolveBindIdentifierInit(
   identifier: NodePath<t.Identifier>
 ) {
   const programPath = storyPath.findParent((p) => p.isProgram()) as NodePath<t.Program> | null;
-  if (!programPath) return null;
+
+  if (!programPath) {
+    return null;
+  }
 
   const declarators = programPath.get('body').flatMap((stmt) => {
-    if (stmt.isVariableDeclaration()) return stmt.get('declarations');
+    if (stmt.isVariableDeclaration()) {
+      return stmt.get('declarations');
+    }
     if (stmt.isExportNamedDeclaration()) {
       const decl = stmt.get('declaration');
-      if (decl && decl.isVariableDeclaration()) return decl.get('declarations');
+
+      if (decl && decl.isVariableDeclaration()) {
+        return decl.get('declarations');
+      }
     }
     return [];
   });
@@ -480,7 +518,9 @@ function resolveBindIdentifierInit(
     return id.isIdentifier() && id.node.name === identifier.node.name;
   });
 
-  if (!match) return null;
+  if (!match) {
+    return null;
+  }
   const init = match.get('init');
   return init && init.isExpression() ? init : null;
 }
@@ -489,7 +529,9 @@ export function pathForNode<T extends t.Node>(
   program: NodePath<t.Program>,
   target: T | undefined
 ): NodePath<T> | undefined {
-  if (!target) return undefined;
+  if (!target) {
+    return undefined;
+  }
   let found: NodePath<T> | undefined;
 
   program.traverse({

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
@@ -5,11 +5,11 @@ import { invariant } from './utils';
 
 export function getCodeSnippet(
   csf: CsfFile,
-  storyName: string
+  storyName: string,
+  componentName?: string
 ): t.VariableDeclaration | t.FunctionDeclaration {
   const storyDeclaration = csf._storyDeclarationPath[storyName];
   const metaObj = csf._metaNode;
-  const componentName = csf._meta?.component;
 
   if (!storyDeclaration) {
     const message = 'Expected story to be a function or variable declaration';

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
@@ -140,8 +140,8 @@ export function getCodeSnippet(
   if (storyFn) {
     const fn = storyFn.node;
 
-    // Handle arrow function returning JSX directly: () => <Button {...args} />
-    if (t.isArrowFunctionExpression(fn) && t.isJSXElement(fn.body)) {
+    // Handle arrow function returning JSX directly: () => <Button {...args} /> or () => <></>
+    if (t.isArrowFunctionExpression(fn) && (t.isJSXElement(fn.body) || t.isJSXFragment(fn.body))) {
       const body = fn.body;
 
       const spreadTransformed = transformArgsSpreadsInJsx(body, merged);
@@ -167,8 +167,12 @@ export function getCodeSnippet(
       let changed = false;
 
       const newBody = body.map((stmt) => {
-        // Only transform return statements that return JSX
-        if (t.isReturnStatement(stmt) && stmt.argument && t.isJSXElement(stmt.argument)) {
+        // Only transform return statements that return JSX or Fragments
+        if (
+          t.isReturnStatement(stmt) &&
+          stmt.argument &&
+          (t.isJSXElement(stmt.argument) || t.isJSXFragment(stmt.argument))
+        ) {
           const spreadTransformed = transformArgsSpreadsInJsx(stmt.argument, merged);
           const inlined = inlineArgsInJsx(spreadTransformed.node, merged);
 

--- a/code/renderers/react/src/componentManifest/generator.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.test.ts
@@ -495,7 +495,7 @@ test('no component field', async () => {
   expect(await getManifestForStory(code)).toMatchInlineSnapshot(`
     {
       "error": {
-        "message": "Specify meta.component for the component to be included in the manifest.
+        "message": "Specify meta.component for reactDocgen data to be included in the manifest.
       2 | import { Button } from './Button';
       3 |
     > 4 | export default {
@@ -504,7 +504,14 @@ test('no component field', async () => {
       6 | };
       7 |",
       },
-      "examples": [],
+      "examples": [
+        {
+          "error": {
+            "message": "Could not generate snippet without component name.",
+          },
+          "name": "Primary",
+        },
+      ],
       "id": "example-button",
       "jsDocTags": {},
       "path": "./src/stories/Button.stories.ts",
@@ -523,7 +530,7 @@ test('component exported from other file', async () => {
       "examples": [
         {
           "error": {
-            "message": "Expected story to be a variable declaration
+            "message": "Expected story to be a function or variable declaration
        8 | export default meta;
        9 |
     > 10 | export { Primary } from './other-file';

--- a/code/renderers/react/src/componentManifest/generator.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.test.ts
@@ -481,7 +481,7 @@ function withCSF3(body: string) {
   `;
 }
 
-test('no component field', async () => {
+test('fall back to index title when no component name', async () => {
   const code = dedent`
     import type { Meta } from '@storybook/react';
     import { Button } from './Button';
@@ -494,27 +494,41 @@ test('no component field', async () => {
   `;
   expect(await getManifestForStory(code)).toMatchInlineSnapshot(`
     {
-      "error": {
-        "message": "Specify meta.component for reactDocgen data to be included in the manifest.
-      2 | import { Button } from './Button';
-      3 |
-    > 4 | export default {
-        | ^
-      5 |   args: { onClick: fn() },
-      6 | };
-      7 |",
-      },
+      "description": "Primary UI component for user interaction",
+      "error": undefined,
       "examples": [
         {
-          "error": {
-            "message": "Could not generate snippet without component name.",
-          },
           "name": "Primary",
+          "snippet": "const Primary = () => <Button onClick={fn()}></Button>;",
         },
       ],
       "id": "example-button",
+      "import": undefined,
       "jsDocTags": {},
+      "name": "Button",
       "path": "./src/stories/Button.stories.ts",
+      "reactDocgen": {
+        "actualName": "Button",
+        "definedInFile": "/app/src/stories/Button.tsx",
+        "description": "Primary UI component for user interaction",
+        "displayName": "Button",
+        "exportName": "Button",
+        "methods": [],
+        "props": {
+          "primary": {
+            "defaultValue": {
+              "computed": false,
+              "value": "false",
+            },
+            "description": "Description of primary",
+            "required": false,
+            "tsType": {
+              "name": "boolean",
+            },
+          },
+        },
+      },
+      "summary": undefined,
     }
   `);
 });

--- a/code/renderers/react/src/componentManifest/generator.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.test.ts
@@ -490,7 +490,7 @@ test('fall back to index title when no component name', async () => {
       args: { onClick: fn() },
     };
     
-    export const Primary = {};
+    export const Primary = () => <Button csf1="story" />;
   `;
   expect(await getManifestForStory(code)).toMatchInlineSnapshot(`
     {
@@ -499,7 +499,7 @@ test('fall back to index title when no component name', async () => {
       "examples": [
         {
           "name": "Primary",
-          "snippet": "const Primary = () => <Button onClick={fn()}></Button>;",
+          "snippet": "const Primary = () => <Button csf1="story" />;",
         },
       ],
       "id": "example-button",

--- a/code/renderers/react/src/componentManifest/generator.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.test.ts
@@ -4,13 +4,12 @@ import { type StoryIndexGenerator } from 'storybook/internal/core-server';
 
 import { vol } from 'memfs';
 import { dedent } from 'ts-dedent';
-import { loadConfig } from 'tsconfig-paths';
 
 import { componentManifestGenerator } from './generator';
 
 vi.mock('node:fs/promises', async () => (await import('memfs')).fs.promises);
 vi.mock('node:fs', async () => (await import('memfs')).fs);
-vi.mock('tsconfig-paths', { spy: true });
+vi.mock('tsconfig-paths', () => ({ loadConfig: () => ({ resultType: null!, message: null! }) }));
 
 // Use the provided indexJson from this file
 const indexJson = {
@@ -95,7 +94,6 @@ const indexJson = {
 };
 
 beforeEach(() => {
-  vi.mocked(loadConfig).mockImplementation(() => ({ resultType: null!, message: null! }));
   vi.spyOn(process, 'cwd').mockReturnValue('/app');
   vol.fromJSON(
     {
@@ -217,6 +215,7 @@ test('componentManifestGenerator generates correct id, name, description and exa
       "components": {
         "example-button": {
           "description": "Primary UI component for user interaction",
+          "error": undefined,
           "examples": [
             {
               "name": "Primary",
@@ -239,6 +238,7 @@ test('componentManifestGenerator generates correct id, name, description and exa
           "import": undefined,
           "jsDocTags": {},
           "name": "Button",
+          "path": "./src/stories/Button.stories.ts",
           "reactDocgen": {
             "actualName": "Button",
             "definedInFile": "/app/src/stories/Button.tsx",
@@ -319,6 +319,7 @@ test('componentManifestGenerator generates correct id, name, description and exa
         },
         "example-header": {
           "description": "Description from meta and very long.",
+          "error": undefined,
           "examples": [
             {
               "name": "LoggedIn",
@@ -344,6 +345,7 @@ test('componentManifestGenerator generates correct id, name, description and exa
             ],
           },
           "name": "Header",
+          "path": "./src/stories/Header.stories.ts",
           "reactDocgen": {
             "actualName": "",
             "definedInFile": "/app/src/stories/Header.tsx",
@@ -409,6 +411,205 @@ test('componentManifestGenerator generates correct id, name, description and exa
         },
       },
       "v": 0,
+    }
+  `);
+});
+
+async function getManifestForStory(code: string) {
+  vol.fromJSON(
+    {
+      ['./src/stories/Button.stories.ts']: code,
+      ['./src/stories/Button.tsx']: dedent`
+        import React from 'react';
+        export interface ButtonProps {
+          /** Description of primary */
+          primary?: boolean;
+        }
+        
+        /** Primary UI component for user interaction */
+        export const Button = ({
+          primary = false,
+        }: ButtonProps) => {
+          const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+          return (
+            <button
+              type="button"
+            ></button>
+          );
+        };`,
+    },
+    '/app'
+  );
+
+  const generator = await componentManifestGenerator();
+  const indexJson = {
+    v: 5,
+    entries: {
+      'example-button--primary': {
+        type: 'story',
+        subtype: 'story',
+        id: 'example-button--primary',
+        name: 'Primary',
+        title: 'Example/Button',
+        importPath: './src/stories/Button.stories.ts',
+        componentPath: './src/stories/Button.tsx',
+        tags: ['dev', 'test', 'vitest', 'autodocs'],
+        exportName: 'Primary',
+      },
+    },
+  };
+
+  const manifest = await generator({
+    getIndex: async () => indexJson,
+  } as unknown as StoryIndexGenerator);
+
+  return manifest.components['example-button'];
+}
+
+function withCSF3(body: string) {
+  return dedent`
+    import type { Meta } from '@storybook/react';
+    import { Button } from './Button';
+
+    const meta = {
+      component: Button,
+      args: { onClick: fn() },
+    } satisfies Meta<typeof Button>;
+    export default meta;
+
+    ${body}
+  `;
+}
+
+test('no component field', async () => {
+  const code = dedent`
+    import type { Meta } from '@storybook/react';
+    import { Button } from './Button';
+
+    export default {
+      args: { onClick: fn() },
+    };
+    
+    export const Primary = {};
+  `;
+  expect(await getManifestForStory(code)).toMatchInlineSnapshot(`
+    {
+      "error": {
+        "message": "Specify meta.component for the component to be included in the manifest.
+      2 | import { Button } from './Button';
+      3 |
+    > 4 | export default {
+        | ^
+      5 |   args: { onClick: fn() },
+      6 | };
+      7 |",
+      },
+      "examples": [],
+      "id": "example-button",
+      "jsDocTags": {},
+      "path": "./src/stories/Button.stories.ts",
+    }
+  `);
+});
+
+test('component exported from other file', async () => {
+  const code = withCSF3(dedent`
+    export { Primary } from './other-file';
+  `);
+  expect(await getManifestForStory(code)).toMatchInlineSnapshot(`
+    {
+      "description": "Primary UI component for user interaction",
+      "error": undefined,
+      "examples": [
+        {
+          "error": {
+            "message": "Expected story to be a variable declaration
+       8 | export default meta;
+       9 |
+    > 10 | export { Primary } from './other-file';
+         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+          },
+          "name": "Primary",
+        },
+      ],
+      "id": "example-button",
+      "import": undefined,
+      "jsDocTags": {},
+      "name": "Button",
+      "path": "./src/stories/Button.stories.ts",
+      "reactDocgen": {
+        "actualName": "Button",
+        "definedInFile": "/app/src/stories/Button.tsx",
+        "description": "Primary UI component for user interaction",
+        "displayName": "Button",
+        "exportName": "Button",
+        "methods": [],
+        "props": {
+          "primary": {
+            "defaultValue": {
+              "computed": false,
+              "value": "false",
+            },
+            "description": "Description of primary",
+            "required": false,
+            "tsType": {
+              "name": "boolean",
+            },
+          },
+        },
+      },
+      "summary": undefined,
+    }
+  `);
+});
+
+test('unknown expressions', async () => {
+  const code = withCSF3(dedent`
+    export const Primary = someWeirdExpression;
+  `);
+  expect(await getManifestForStory(code)).toMatchInlineSnapshot(`
+    {
+      "description": "Primary UI component for user interaction",
+      "error": undefined,
+      "examples": [
+        {
+          "error": {
+            "message": "Expected story to be csf factory, function or an object expression
+       8 | export default meta;
+       9 |
+    > 10 | export const Primary = someWeirdExpression;
+         |                        ^^^^^^^^^^^^^^^^^^^",
+          },
+          "name": "Primary",
+        },
+      ],
+      "id": "example-button",
+      "import": undefined,
+      "jsDocTags": {},
+      "name": "Button",
+      "path": "./src/stories/Button.stories.ts",
+      "reactDocgen": {
+        "actualName": "Button",
+        "definedInFile": "/app/src/stories/Button.tsx",
+        "description": "Primary UI component for user interaction",
+        "displayName": "Button",
+        "exportName": "Button",
+        "methods": [],
+        "props": {
+          "primary": {
+            "defaultValue": {
+              "computed": false,
+              "value": "false",
+            },
+            "description": "Description of primary",
+            "required": false,
+            "tsType": {
+              "name": "boolean",
+            },
+          },
+        },
+      },
+      "summary": undefined,
     }
   `);
 });

--- a/code/renderers/react/src/componentManifest/generator.ts
+++ b/code/renderers/react/src/componentManifest/generator.ts
@@ -37,25 +37,8 @@ export const componentManifestGenerator = async () => {
         const id = entry.id.split('--')[0];
         const importPath = entry.importPath;
 
-        const base = {
-          id,
-          path: importPath,
-          examples: [],
-          jsDocTags: {},
-        } satisfies Partial<ComponentManifest>;
-
-        if (!componentName) {
-          const message =
-            'Specify meta.component for the component to be included in the manifest.';
-          return {
-            ...base,
-            error: {
-              message: csf._metaStatementPath?.buildCodeFrameError(message).message ?? message,
-            },
-          };
-        }
-
         const name = componentName;
+
         const examples = Object.entries(csf._storyDeclarationPath)
           .map(([storyName, path]) => {
             try {
@@ -75,6 +58,24 @@ export const componentManifestGenerator = async () => {
             }
           })
           .filter(Boolean);
+
+        const base = {
+          id,
+          path: importPath,
+          examples,
+          jsDocTags: {},
+        } satisfies Partial<ComponentManifest>;
+
+        if (!componentName) {
+          const message =
+            'Specify meta.component for reactDocgen data to be included in the manifest.';
+          return {
+            ...base,
+            error: {
+              message: csf._metaStatementPath?.buildCodeFrameError(message).message ?? message,
+            },
+          };
+        }
 
         if (!entry.componentPath) {
           const message = `No component file found for the "${name}" component.`;

--- a/code/renderers/react/src/componentManifest/generator.ts
+++ b/code/renderers/react/src/componentManifest/generator.ts
@@ -23,7 +23,7 @@ export const componentManifestGenerator = async () => {
     const groupByComponentId = groupBy(
       Object.values(index.entries)
         .filter((entry) => entry.type === 'story')
-        .filter((entry) => entry.subtype === 'story' && entry.componentPath),
+        .filter((entry) => entry.subtype === 'story'),
       (it) => it.id.split('--')[0]
     );
     const singleEntryPerComponent = Object.values(groupByComponentId).flatMap((group) =>

--- a/code/renderers/react/src/componentManifest/generator.ts
+++ b/code/renderers/react/src/componentManifest/generator.ts
@@ -56,12 +56,13 @@ export const componentManifestGenerator = async () => {
         }
 
         const name = componentName;
-        const examples = Object.entries(csf._storyPaths)
+        const examples = Object.entries(csf._storyDeclarationPath)
           .map(([storyName, path]) => {
             try {
               return {
                 name: storyName,
-                snippet: recast.print(getCodeSnippet(path, csf._metaNode ?? null, name)).code,
+                snippet: recast.print(getCodeSnippet(path, storyName, csf._metaNode ?? null, name))
+                  .code,
               };
             } catch (e) {
               invariant(e instanceof Error);

--- a/code/renderers/react/src/componentManifest/generator.ts
+++ b/code/renderers/react/src/componentManifest/generator.ts
@@ -97,7 +97,11 @@ export const componentManifestGenerator = async () => {
         });
         const docgen = getMatchingDocgen(docgens, csf);
 
-        const error = !docgen ? { message: 'Docgen could not find a component' } : undefined;
+        const error = !docgen
+          ? {
+              message: `Could not parse props information for the located at ${entry.componentPath}`,
+            }
+          : undefined;
 
         const metaDescription = extractDescription(csf._metaStatement);
         const jsdocComment = metaDescription || docgen?.description;

--- a/code/renderers/react/src/componentManifest/generator.ts
+++ b/code/renderers/react/src/componentManifest/generator.ts
@@ -39,13 +39,12 @@ export const componentManifestGenerator = async () => {
 
         const name = componentName;
 
-        const examples = Object.entries(csf._storyDeclarationPath)
-          .map(([storyName, path]) => {
+        const examples = Object.keys(csf._stories)
+          .map((storyName) => {
             try {
               return {
                 name: storyName,
-                snippet: recast.print(getCodeSnippet(path, storyName, csf._metaNode ?? null, name))
-                  .code,
+                snippet: recast.print(getCodeSnippet(csf, storyName)).code,
               };
             } catch (e) {
               invariant(e instanceof Error);

--- a/code/renderers/react/src/componentManifest/utils.ts
+++ b/code/renderers/react/src/componentManifest/utils.ts
@@ -11,7 +11,11 @@ export const groupBy = <K extends PropertyKey, T>(
   }, {});
 };
 
-export function invariant(condition: any, message?: string | (() => string)): asserts condition {
+// This invariant allows for lazy evaluation of the message, which we need to avoid excessive computation.
+export function invariant(
+  condition: unknown,
+  message?: string | (() => string)
+): asserts condition {
   if (condition) {
     return;
   }

--- a/code/renderers/react/src/componentManifest/utils.ts
+++ b/code/renderers/react/src/componentManifest/utils.ts
@@ -10,3 +10,10 @@ export const groupBy = <K extends PropertyKey, T>(
     return acc;
   }, {});
 };
+
+export function invariant(condition: any, message?: string | (() => string)): asserts condition {
+  if (condition) {
+    return;
+  }
+  throw new Error((typeof message === 'function' ? message() : message) ?? 'Invariant failed');
+}

--- a/code/renderers/react/src/enrichCsf.ts
+++ b/code/renderers/react/src/enrichCsf.ts
@@ -18,17 +18,21 @@ export const enrichCsf: PresetPropertyFn<'experimental_enrichCsf'> = async (inpu
         return;
       }
       const { format } = await getPrettier();
+      let node;
+      try {
+        node = getCodeSnippet(storyExport, csfSource._metaNode, csfSource._meta?.component);
+      } catch (e) {
+        // don't bother the user if we can't generate a snippet
+        return;
+      }
 
       let snippet;
       try {
-        const code = recast.print(
-          getCodeSnippet(storyExport, csfSource._metaNode, csfSource._meta?.component)
-        ).code;
-
         // TODO read the user config
-        snippet = await format(code, { filepath: join(process.cwd(), 'component.tsx') });
+        snippet = await format(recast.print(node).code, {
+          filepath: join(process.cwd(), 'component.tsx'),
+        });
       } catch (e) {
-        // don't bother the user if we can't generate a snippet
         return;
       }
 

--- a/code/renderers/react/src/enrichCsf.ts
+++ b/code/renderers/react/src/enrichCsf.ts
@@ -13,14 +13,14 @@ export const enrichCsf: PresetPropertyFn<'experimental_enrichCsf'> = async (inpu
     return;
   }
   return async (csf: CsfFile, csfSource: CsfFile) => {
-    const promises = Object.entries(csf._storyDeclarationPath).map(async ([key, storyExport]) => {
+    const promises = Object.keys(csf._stories).map(async (key) => {
       if (!csfSource._meta?.component) {
         return;
       }
       const { format } = await getPrettier();
       let node;
       try {
-        node = getCodeSnippet(storyExport, key, csfSource._metaNode, csfSource._meta?.component);
+        node = getCodeSnippet(csfSource, key);
       } catch (e) {
         // don't bother the user if we can't generate a snippet
         return;

--- a/code/renderers/react/src/enrichCsf.ts
+++ b/code/renderers/react/src/enrichCsf.ts
@@ -19,20 +19,31 @@ export const enrichCsf: PresetPropertyFn<'experimental_enrichCsf'> = async (inpu
       }
       const { format } = await getPrettier();
       let node;
-      try {
-        node = getCodeSnippet(csfSource, key);
-      } catch (e) {
-        // don't bother the user if we can't generate a snippet
-        return;
-      }
-
       let snippet;
       try {
-        // TODO read the user config
-        snippet = await format(recast.print(node).code, {
-          filepath: join(process.cwd(), 'component.tsx'),
-        });
+        node = getCodeSnippet(csfSource, key, csfSource._meta?.component);
       } catch (e) {
+        if (!(e instanceof Error)) {
+          return;
+        }
+        snippet = e.message;
+      }
+
+      try {
+        // TODO read the user config
+        if (!snippet && node) {
+          snippet = await format(recast.print(node).code, {
+            filepath: join(process.cwd(), 'component.tsx'),
+          });
+        }
+      } catch (e) {
+        if (!(e instanceof Error)) {
+          return;
+        }
+        snippet = e.message;
+      }
+
+      if (!snippet) {
         return;
       }
 


### PR DESCRIPTION
Closes #32848

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32855-sha-350cba2a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32855-sha-350cba2a sandbox` or in an existing project with `npx storybook@0.0.0-pr-32855-sha-350cba2a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32855-sha-350cba2a`](https://npmjs.com/package/storybook/v/0.0.0-pr-32855-sha-350cba2a) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/error-manifest`](https://github.com/storybookjs/storybook/tree/kasper/error-manifest) |
| **Commit** | [`350cba2a`](https://github.com/storybookjs/storybook/commit/350cba2ab9f42ce66963bb1f75b882fe53f73ce8) |
| **Datetime** | Tue Oct 28 14:14:32 UTC 2025 (`1761660872`) |
| **Workflow run** | [18877200892](https://github.com/storybookjs/storybook/actions/runs/18877200892) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=32855`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifests now include component file path; examples may have optional snippets and per-entry/top-level error info.
  * Snippet generation accepts story identifiers and can emit either function- or variable-style snippets; improved code-location utilities and path helpers.
  * Added a runtime assertion helper.

* **Bug Fixes**
  * Improved metadata synchronization and more robust, error-captured snippet generation and parsing.

* **Tests**
  * Updated tests for manifest shape, error paths, meta-level and top-level export scenarios.

* **Chores**
  * Added .junie to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->