### PR TITLE
Telemetry: Fix preview-first-load event

### DIFF
--- a/code/core/src/core-server/server-channel/preview-initialized-channel.test.ts
+++ b/code/core/src/core-server/server-channel/preview-initialized-channel.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makePayload } from './preview-initialized-channel';
+
+describe('makePayload', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('new user init session', () => {
+    const userAgent = 'Mozilla/5.0';
+    const sessionId = 'session-123';
+    const lastInit = {
+      timestamp: Date.now() - 3000,
+      body: {
+        sessionId,
+        payload: { newUser: true },
+      },
+    };
+
+    expect(makePayload(userAgent, lastInit as any, sessionId)).toMatchInlineSnapshot(`
+      {
+        "isNewUser": true,
+        "timeSinceInit": 3000,
+        "userAgent": "Mozilla/5.0",
+      }
+    `);
+  });
+
+  it('existing user init session', () => {
+    const userAgent = 'Mozilla/5.0';
+    const sessionId = 'session-123';
+    const lastInit = {
+      timestamp: Date.now() - 3000,
+      body: {
+        sessionId,
+        payload: {},
+      },
+    };
+
+    expect(makePayload(userAgent, lastInit as any, sessionId)).toMatchInlineSnapshot(`
+      {
+        "isNewUser": false,
+        "timeSinceInit": 3000,
+        "userAgent": "Mozilla/5.0",
+      }
+    `);
+  });
+
+  it('no init session', () => {
+    const userAgent = 'Mozilla/5.0';
+    const sessionId = 'session-123';
+    const lastInit = undefined;
+
+    expect(makePayload(userAgent, lastInit, sessionId)).toMatchInlineSnapshot(`
+      {
+        "isNewUser": false,
+        "timeSinceInit": undefined,
+        "userAgent": "Mozilla/5.0",
+      }
+    `);
+  });
+
+  it('init session with different sessionId', () => {
+    const userAgent = 'Mozilla/5.0';
+    const sessionId = 'session-123';
+    const lastInit = {
+      timestamp: Date.now() - 3000,
+      body: {
+        sessionId: 'session-456',
+      },
+    };
+
+    expect(makePayload(userAgent, lastInit as any, sessionId)).toMatchInlineSnapshot(`
+      {
+        "isNewUser": false,
+        "timeSinceInit": undefined,
+        "userAgent": "Mozilla/5.0",
+      }
+    `);
+  });
+});

--- a/code/core/src/telemetry/index.ts
+++ b/code/core/src/telemetry/index.ts
@@ -43,21 +43,21 @@ export const telemetry = async (
       telemetryData.metadata = await getStorybookMetadata(options?.configDir);
     }
   } catch (error: any) {
-    telemetryData.payload.metadataErrorMessage = sanitizeError(error).message;
+    payload.metadataErrorMessage = sanitizeError(error).message;
 
     if (options?.enableCrashReports) {
-      telemetryData.payload.metadataError = sanitizeError(error);
+      payload.metadataError = sanitizeError(error);
     }
   } finally {
-    const { error } = telemetryData.payload;
+    const { error } = payload;
     // make sure to anonymise possible paths from error messages
 
     // make sure to anonymise possible paths from error messages
     if (error) {
-      telemetryData.payload.error = sanitizeError(error);
+      payload.error = sanitizeError(error);
     }
 
-    if (!telemetryData.payload.error || options?.enableCrashReports) {
+    if (!payload.error || options?.enableCrashReports) {
       if (process.env?.STORYBOOK_TELEMETRY_DEBUG) {
         logger.info('\n[telemetry]');
         logger.info(JSON.stringify(telemetryData, null, 2));

--- a/code/core/src/telemetry/types.ts
+++ b/code/core/src/telemetry/types.ts
@@ -34,7 +34,6 @@ export type EventType =
   | 'onboarding-survey'
   | 'mocking'
   | 'preview-first-load';
-
 export interface Dependency {
   version: string | undefined;
   versionSpecifier?: string;
@@ -90,6 +89,10 @@ export interface Payload {
   [key: string]: any;
 }
 
+export interface Context {
+  [key: string]: any;
+}
+
 export interface Options {
   retryDelay: number;
   immediate: boolean;
@@ -103,4 +106,18 @@ export interface TelemetryData {
   eventType: EventType;
   payload: Payload;
   metadata?: StorybookMetadata;
+}
+
+export interface TelemetryEvent extends TelemetryData {
+  eventId: string;
+  sessionId: string;
+  context: Context;
+}
+
+export interface InitPayload {
+  projectType: string;
+  features: { dev: boolean; docs: boolean; test: boolean; onboarding: boolean };
+  newUser: boolean;
+  versionSpecifier: string | undefined;
+  cliIntegration: string | undefined;
 }


### PR DESCRIPTION
Closes N/A

## What I did

Follow-up to #32770

- [x] Fix typescript types
- [x] Record whether the user is a new user

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

See #32770

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32859-sha-0ff3fd82`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32859-sha-0ff3fd82 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32859-sha-0ff3fd82 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32859-sha-0ff3fd82`](https://npmjs.com/package/storybook/v/0.0.0-pr-32859-sha-0ff3fd82) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/first-load-new-user`](https://github.com/storybookjs/storybook/tree/shilman/first-load-new-user) |
| **Commit** | [`0ff3fd82`](https://github.com/storybookjs/storybook/commit/0ff3fd828984a2a32b05db94f5c9532b9c52e07e) |
| **Datetime** | Tue Oct 28 08:52:12 UTC 2025 (`1761641532`) |
| **Workflow run** | [18869205798](https://github.com/storybookjs/storybook/actions/runs/18869205798) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=32859`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added deterministic tests for preview initialization covering new vs. existing sessions, timing calculations, and user-agent preservation.

* **Refactor**
  * Centralized preview-init payload construction and improved telemetry type safety; strengthened event caching typings and error-sanitization handling to make telemetry reporting more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->