### PR TITLE
Presets: Fix incorrect imports

### DIFF
--- a/code/presets/create-react-app/preset.js
+++ b/code/presets/create-react-app/preset.js
@@ -1,1 +1,1 @@
-export * from './src/index.js';
+export * from './dist/index.js';

--- a/code/presets/react-webpack/preset.js
+++ b/code/presets/react-webpack/preset.js
@@ -1,1 +1,1 @@
-export * from './src/index.js';
+export * from './dist/index.js';

--- a/code/presets/server-webpack/preset.js
+++ b/code/presets/server-webpack/preset.js
@@ -1,1 +1,1 @@
-export * from './src/index.js';
+export * from './dist/index.js';

--- a/code/presets/server-webpack/src/index.ts
+++ b/code/presets/server-webpack/src/index.ts
@@ -10,14 +10,14 @@ export const webpack: StorybookConfig['webpack'] = (config) => {
     {
       type: 'javascript/auto',
       test: /\.stories\.json$/,
-      use: fileURLToPath(import.meta.resolve('@storybook/preset-server-webpack/webpack-loader')),
+      use: fileURLToPath(import.meta.resolve('@storybook/preset-server-webpack/loader')),
     },
 
     {
       type: 'javascript/auto',
       test: /\.stories\.ya?ml/,
       use: [
-        fileURLToPath(import.meta.resolve('@storybook/preset-server-webpack/webpack-loader')),
+        fileURLToPath(import.meta.resolve('@storybook/preset-server-webpack/loader')),
         {
           loader: fileURLToPath(import.meta.resolve('yaml-loader')),
           options: { asJSON: true },


### PR DESCRIPTION
Closes #32871

## What I did

- The import was wrong, and I also noticed the entry-files (only used when `require.resolve` is used to find the package) were wrong also

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module export paths across preset configurations to reference compiled distribution files
  * Modified loader references in server-webpack preset configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->