### PR TITLE
Core: Better handling for TypeScript satisfies/as syntaxes

### DIFF
--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -99,6 +99,17 @@ describe('ConfigFile', () => {
           )
         ).toEqual('webpack5');
       });
+      it('resolves values through various TS satisfies/as syntaxes', () => {
+        const syntaxes = [
+          'const coreVar = { builder: "webpack5" } as const; export const core = coreVar satisfies any;',
+          'const coreVar = { builder: "webpack5" } as const; export const core = coreVar as any;',
+          'const coreVar = { builder: "webpack5" } as const satisfies Record<string, unknown>; export { coreVar as core };',
+        ];
+
+        for (const source of syntaxes) {
+          expect(getField(['core', 'builder'], source)).toEqual('webpack5');
+        }
+      });
     });
 
     describe('module exports', () => {

--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -1877,5 +1877,23 @@ describe('ConfigFile', () => {
 
       expect(Object.keys(config._exportDecls)).toHaveLength(3);
     });
+
+    it('detects exports object on various TS satisfies/as export syntaxes', () => {
+      const syntaxes = [
+        'const config = { framework: "foo" }; export default config;',
+        'const config = { framework: "foo" }; export default config satisfies StorybookConfig;',
+        'const config = { framework: "foo" }; export default config as StorybookConfig;',
+        'const config = { framework: "foo" }; export default config as unknown as StorybookConfig;',
+        'export default { framework: "foo" };',
+        'export default { framework: "foo" } satisfies StorybookConfig;',
+        'export default { framework: "foo" } as StorybookConfig;',
+        'export default { framework: "foo" } as unknown as StorybookConfig;',
+      ];
+      for (const source of syntaxes) {
+        const config = loadConfig(source).parse();
+        expect(config._exportsObject?.type).toBe('ObjectExpression');
+        expect(config._exportsObject?.properties).toHaveLength(1);
+      }
+    });
   });
 });

--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
@@ -58,6 +58,36 @@ describe('main/preview codemod: general parsing functionality', () => {
       });
     `);
   });
+  it('should wrap defineMain call from const declared default export with different type annotations', async () => {
+    const typedVariants = [
+      'export default config;',
+      'export default config satisfies StorybookConfig;',
+      'export default config as StorybookConfig;',
+      'export default config as unknown as StorybookConfig;',
+    ];
+
+    for (const variant of typedVariants) {
+      await expect(
+        transform(dedent`
+          const config = {
+            stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+            addons: ['@storybook/addon-essentials'],
+            framework: '@storybook/react-vite',
+          };
+
+          ${variant}
+        `)
+      ).resolves.toMatchInlineSnapshot(`
+        import { defineMain } from '@storybook/react-vite/node';
+
+        export default defineMain({
+          stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+          addons: ['@storybook/addon-essentials'],
+          framework: '@storybook/react-vite',
+        });
+      `);
+    }
+  });
 
   it('should wrap defineMain call from const declared default export and default export mix', async () => {
     await expect(

--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
@@ -119,8 +119,11 @@ export async function configToCsfFactory(
 
     programNode.body.forEach((node) => {
       // Detect Syntax 1
-      if (t.isExportDefaultDeclaration(node) && t.isIdentifier(node.declaration)) {
-        const declarationName = node.declaration.name;
+      const declaration =
+        t.isExportDefaultDeclaration(node) && config._unwrap(node.declaration as t.Node);
+
+      if (t.isExportDefaultDeclaration(node) && t.isIdentifier(declaration)) {
+        const declarationName = declaration.name;
 
         declarationNodeIndex = findDeclarationNodeIndex(declarationName);
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32890

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR enhances ConfigFile (the AST helper) to include two utilities: `_unwrap` and `_resolveDeclaration`. They are used to support new use cases, such as expressions that use type syntaxes like:
```ts
export default { framework: "foo" } satisfies StorybookConfig;
export default { framework: "foo" } as StorybookConfig;
export default { framework: "foo" } as unknown as StorybookConfig;
```

This should make it so that when the ConfigFile wants to detect named or default exports, it will try to unwrap and find the variable initialization and therefore extract the correct node.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for various TypeScript export and annotation syntaxes to ensure correct config detection and wrapping.

* **Bug Fixes**
  * Improved resolution of default and named exports when TypeScript assertions/annotations are present.

* **Refactor**
  * Centralized and simplified internal logic for unwrapping and resolving exported values to make parsing more robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->