### PR TITLE
Core: Improve file path resolution on Windows

### DIFF
--- a/code/builders/builder-webpack5/src/index.ts
+++ b/code/builders/builder-webpack5/src/index.ts
@@ -1,5 +1,4 @@
 import { cp } from 'node:fs/promises';
-import { dirname, join, parse } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { PREVIEW_BUILDER_PROGRESS } from 'storybook/internal/core-events';
@@ -13,6 +12,7 @@ import type { Builder, Options } from 'storybook/internal/types';
 
 import { checkWebpackVersion } from '@storybook/core-webpack';
 
+import { dirname, join, parse } from 'pathe';
 import prettyTime from 'pretty-hrtime';
 import sirv from 'sirv';
 import type { Configuration, Stats, StatsOptions } from 'webpack';

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises';
-import { join, relative, resolve } from 'node:path';
 
 import {
   JsPackageManagerFactory,
@@ -20,6 +19,7 @@ import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook
 
 import { global } from '@storybook/global';
 
+import { join, relative, resolve } from 'pathe';
 import prompts from 'prompts';
 import invariant from 'tiny-invariant';
 import { dedent } from 'ts-dedent';

--- a/code/core/src/core-server/build-static.ts
+++ b/code/core/src/core-server/build-static.ts
@@ -1,6 +1,5 @@
 import { cp, mkdir } from 'node:fs/promises';
 import { rm } from 'node:fs/promises';
-import { join, relative, resolve } from 'node:path';
 
 import {
   loadAllPresets,
@@ -15,6 +14,7 @@ import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook
 
 import { global } from '@storybook/global';
 
+import { join, relative, resolve } from 'pathe';
 import picocolors from 'picocolors';
 
 import { resolvePackageDir } from '../shared/utils/module';

--- a/code/core/src/core-server/load.ts
+++ b/code/core/src/core-server/load.ts
@@ -1,5 +1,3 @@
-import { join, relative, resolve } from 'node:path';
-
 import {
   getProjectRoot,
   loadAllPresets,
@@ -11,6 +9,8 @@ import { oneWayHash } from 'storybook/internal/telemetry';
 import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
+
+import { join, relative, resolve } from 'pathe';
 
 import { resolvePackageDir } from '../shared/utils/module';
 

--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -1,6 +1,5 @@
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { isAbsolute, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { Channel } from 'storybook/internal/channels';
@@ -26,6 +25,7 @@ import type {
   PresetPropertyFn,
 } from 'storybook/internal/types';
 
+import { isAbsolute, join } from 'pathe';
 import * as pathe from 'pathe';
 import { dedent } from 'ts-dedent';
 

--- a/code/core/src/core-server/presets/favicon.test.ts
+++ b/code/core/src/core-server/presets/favicon.test.ts
@@ -1,9 +1,10 @@
 import * as fs from 'node:fs';
-import { dirname, join } from 'node:path';
 
 import { expect, it, vi } from 'vitest';
 
 import { logger } from 'storybook/internal/node-logger';
+
+import { dirname, join } from 'pathe';
 
 import * as m from './common-preset';
 

--- a/code/core/src/core-server/presets/favicon.test.ts
+++ b/code/core/src/core-server/presets/favicon.test.ts
@@ -4,7 +4,7 @@ import { expect, it, vi } from 'vitest';
 
 import { logger } from 'storybook/internal/node-logger';
 
-import { dirname, join } from 'pathe';
+import { dirname, join, normalize } from 'pathe';
 
 import * as m from './common-preset';
 
@@ -76,67 +76,73 @@ it('with no staticDirs favicon should return default', async () => {
 it('with staticDirs referencing a favicon.ico directly should return the found favicon', async () => {
   const location = 'favicon.ico';
   existsSyncMock.mockImplementation((p) => {
-    return p === createPath(location);
+    return normalize(String(p)) === normalize(createPath(location));
   });
   statSyncMock.mockImplementation((p) => {
     return {
-      isFile: () => p === createPath('favicon.ico'),
+      isFile: () => normalize(String(p)) === normalize(createPath('favicon.ico')),
     } as any;
   });
   const options = createOptions([location]);
 
-  expect(await m.favicon(undefined, options)).toBe(createPath('favicon.ico'));
+  expect(normalize(await m.favicon(undefined, options))).toBe(normalize(createPath('favicon.ico')));
 });
 
 it('with staticDirs containing a single favicon.ico should return the found favicon', async () => {
   const location = 'static';
   existsSyncMock.mockImplementation((p) => {
-    if (p === createPath(location)) {
+    if (normalize(String(p)) === normalize(createPath(location))) {
       return true;
     }
-    if (p === createPath(location, 'favicon.ico')) {
+    if (normalize(String(p)) === normalize(createPath(location, 'favicon.ico'))) {
       return true;
     }
     return false;
   });
   const options = createOptions([location]);
 
-  expect(await m.favicon(undefined, options)).toBe(createPath(location, 'favicon.ico'));
+  expect(normalize(await m.favicon(undefined, options))).toBe(
+    normalize(createPath(location, 'favicon.ico'))
+  );
 });
 
 it('with staticDirs containing a single favicon.svg should return the found favicon', async () => {
   const location = 'static';
   existsSyncMock.mockImplementation((p) => {
-    if (p === createPath(location)) {
+    if (normalize(String(p)) === normalize(createPath(location))) {
       return true;
     }
-    if (p === createPath(location, 'favicon.svg')) {
+    if (normalize(String(p)) === normalize(createPath(location, 'favicon.svg'))) {
       return true;
     }
     return false;
   });
   const options = createOptions([location]);
 
-  expect(await m.favicon(undefined, options)).toBe(createPath(location, 'favicon.svg'));
+  expect(normalize(await m.favicon(undefined, options))).toBe(
+    normalize(createPath(location, 'favicon.svg'))
+  );
 });
 
 it('with staticDirs containing a multiple favicons should return the first favicon and warn', async () => {
   const location = 'static';
   existsSyncMock.mockImplementation((p) => {
-    if (p === createPath(location)) {
+    if (normalize(String(p)) === normalize(createPath(location))) {
       return true;
     }
-    if (p === createPath(location, 'favicon.ico')) {
+    if (normalize(String(p)) === normalize(createPath(location, 'favicon.ico'))) {
       return true;
     }
-    if (p === createPath(location, 'favicon.svg')) {
+    if (normalize(String(p)) === normalize(createPath(location, 'favicon.svg'))) {
       return true;
     }
     return false;
   });
   const options = createOptions([location]);
 
-  expect(await m.favicon(undefined, options)).toBe(createPath(location, 'favicon.svg'));
+  expect(normalize(await m.favicon(undefined, options))).toBe(
+    normalize(createPath(location, 'favicon.svg'))
+  );
 
   expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('multiple favicons'));
 });
@@ -145,23 +151,25 @@ it('with multiple staticDirs containing a multiple favicons should return the fi
   const locationA = 'static-a';
   const locationB = 'static-b';
   existsSyncMock.mockImplementation((p) => {
-    if (p === createPath(locationA)) {
+    if (normalize(String(p)) === normalize(createPath(locationA))) {
       return true;
     }
-    if (p === createPath(locationB)) {
+    if (normalize(String(p)) === normalize(createPath(locationB))) {
       return true;
     }
-    if (p === createPath(locationA, 'favicon.ico')) {
+    if (normalize(String(p)) === normalize(createPath(locationA, 'favicon.ico'))) {
       return true;
     }
-    if (p === createPath(locationB, 'favicon.svg')) {
+    if (normalize(String(p)) === normalize(createPath(locationB, 'favicon.svg'))) {
       return true;
     }
     return false;
   });
   const options = createOptions([locationA, locationB]);
 
-  expect(await m.favicon(undefined, options)).toBe(createPath(locationA, 'favicon.ico'));
+  expect(normalize(await m.favicon(undefined, options))).toBe(
+    normalize(createPath(locationA, 'favicon.ico'))
+  );
 
   expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('multiple favicons'));
 });


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32872

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32893-sha-331baf0a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32893-sha-331baf0a sandbox` or in an existing project with `npx storybook@0.0.0-pr-32893-sha-331baf0a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32893-sha-331baf0a`](https://npmjs.com/package/storybook/v/0.0.0-pr-32893-sha-331baf0a) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/fix-preset-path-joining-windows`](https://github.com/storybookjs/storybook/tree/yann/fix-preset-path-joining-windows) |
| **Commit** | [`331baf0a`](https://github.com/storybookjs/storybook/commit/331baf0a82f84541d07ce07085330c7649be0a41) |
| **Datetime** | Thu Oct 30 11:39:01 UTC 2025 (`1761824341`) |
| **Workflow run** | [18939383750](https://github.com/storybookjs/storybook/actions/runs/18939383750) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=32893`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched internal path utility implementation to an alternative path library across the codebase; no runtime behavior or public APIs changed.
* **Tests**
  * Updated tests to use normalized path comparisons and adjusted expectations to align with the new path utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->