### PR TITLE
Docs: Improve vitest addon config snippets

### DIFF
--- a/docs/_snippets/vitest-plugin-vitest-config.md
+++ b/docs/_snippets/vitest-plugin-vitest-config.md
@@ -1,5 +1,5 @@
 ```ts filename="vitest.config.ts" renderer="react" tabTitle="Vitest 4"
-import { defineConfig, defineProject, mergeConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
@@ -17,7 +17,8 @@ export default mergeConfig(
     test: {
       // Use `workspace` field in Vitest < 3.2
       projects: [
-        defineProject({
+        {
+          extends: true,
           plugins: [
             storybookTest({
               // The location of your Storybook config, main.js|ts
@@ -39,7 +40,7 @@ export default mergeConfig(
             },
             setupFiles: ['./.storybook/vitest.setup.ts'],
           },
-        }),
+        },
       ],
     },
   }),
@@ -47,7 +48,7 @@ export default mergeConfig(
 ```
 
 ```ts filename="vitest.config.ts" renderer="react" tabTitle="Vitest 3"
-import { defineConfig, defineProject, mergeConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 
@@ -64,7 +65,8 @@ export default mergeConfig(
     test: {
       // Use `workspace` field in Vitest < 3.2
       projects: [
-        defineProject({
+        {
+          extends: true,
           plugins: [
             storybookTest({
               // The location of your Storybook config, main.js|ts
@@ -86,7 +88,7 @@ export default mergeConfig(
             },
             setupFiles: ['./.storybook/vitest.setup.ts'],
           },
-        }),
+        },
       ],
     },
   }),
@@ -94,7 +96,7 @@ export default mergeConfig(
 ```
 
 ```ts filename="vitest.config.ts" renderer="vue" tabTitle="Vitest 4"
-import { defineConfig, defineProject, mergeConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
@@ -112,7 +114,8 @@ export default mergeConfig(
     test: {
       // Use `workspace` field in Vitest < 3.2
       projects: [
-        defineProject({
+        {
+          extends: true,
           plugins: [
             storybookTest({
               // The location of your Storybook config, main.js|ts
@@ -134,7 +137,7 @@ export default mergeConfig(
             },
             setupFiles: ['./.storybook/vitest.setup.ts'],
           },
-        }),
+        },
       ],
     },
   }),
@@ -142,7 +145,7 @@ export default mergeConfig(
 ```
 
 ```ts filename="vitest.config.ts" renderer="vue" tabTitle="Vitest 3"
-import { defineConfig, defineProject, mergeConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 
@@ -159,7 +162,8 @@ export default mergeConfig(
     test: {
       // Use `workspace` field in Vitest < 3.2
       projects: [
-        defineProject({
+        {
+          extends: true,
           plugins: [
             storybookTest({
               // The location of your Storybook config, main.js|ts
@@ -181,7 +185,7 @@ export default mergeConfig(
             },
             setupFiles: ['./.storybook/vitest.setup.ts'],
           },
-        }),
+        },
       ],
     },
   }),
@@ -189,7 +193,7 @@ export default mergeConfig(
 ```
 
 ```ts filename="vitest.config.ts" renderer="svelte" tabTitle="Vitest 4"
-import { defineConfig, defineProject, mergeConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
@@ -207,7 +211,8 @@ export default mergeConfig(
     test: {
       // Use `workspace` field in Vitest < 3.2
       projects: [
-        defineProject({
+        {
+          extends: true,
           plugins: [
             storybookTest({
               // The location of your Storybook config, main.js|ts
@@ -229,7 +234,7 @@ export default mergeConfig(
             },
             setupFiles: ['./.storybook/vitest.setup.ts'],
           },
-        }),
+        },
       ],
     },
   }),
@@ -237,7 +242,7 @@ export default mergeConfig(
 ```
 
 ```ts filename="vitest.config.ts" renderer="svelte" tabTitle="Vitest 3"
-import { defineConfig, defineProject, mergeConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 
@@ -254,7 +259,8 @@ export default mergeConfig(
     test: {
       // Use `workspace` field in Vitest < 3.2
       projects: [
-        defineProject({
+        {
+          extends: true,
           plugins: [
             storybookTest({
               // The location of your Storybook config, main.js|ts
@@ -276,7 +282,7 @@ export default mergeConfig(
             },
             setupFiles: ['./.storybook/vitest.setup.ts'],
           },
-        }),
+        },
       ],
     },
   }),
@@ -284,7 +290,7 @@ export default mergeConfig(
 ```
 
 ```ts filename="vitest.config.ts" renderer="web-components" tabTitle="Vitest 4"
-import { defineConfig, defineProject, mergeConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
@@ -302,7 +308,8 @@ export default mergeConfig(
     test: {
       // Use `workspace` field in Vitest < 3.2
       projects: [
-        defineProject({
+        {
+          extends: true,
           plugins: [
             storybookTest({
               // The location of your Storybook config, main.js|ts
@@ -324,7 +331,7 @@ export default mergeConfig(
             },
             setupFiles: ['./.storybook/vitest.setup.ts'],
           },
-        }),
+        },
       ],
     },
   }),
@@ -332,7 +339,7 @@ export default mergeConfig(
 ```
 
 ```ts filename="vitest.config.ts" renderer="web-components" tabTitle="Vitest 3"
-import { defineConfig, defineProject, mergeConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 
@@ -349,7 +356,8 @@ export default mergeConfig(
     test: {
       // Use `workspace` field in Vitest < 3.2
       projects: [
-        defineProject({
+        {
+          extends: true,
           plugins: [
             storybookTest({
               // The location of your Storybook config, main.js|ts
@@ -371,7 +379,7 @@ export default mergeConfig(
             },
             setupFiles: ['./.storybook/vitest.setup.ts'],
           },
-        }),
+        },
       ],
     },
   }),


### PR DESCRIPTION
Relates [#32895](https://github.com/storybookjs/storybook/issues/32895#issuecomment-3468077138), as well as to 2 previous PRS: #32896, #32228.

Originally, in my issue above, I reported that an `extends: true` block from the docs didn't work when it was inside `defineProject` - it was then removed from the docs in #32896. However, it's an important part when you want to preserve configuration from `vite.config.ts` (or any other shared config) - in my case, I needed to preserve some aliases, as well as some variables in the `define` block. It lead me to understand when `extends: true` is used and when not, and how I can correctly add it to my project.

`extends: true` indeed cannot be a part of `defineProject` - TS reports that as an unknown key. Instead, it should be used with inline projects. [Example from their docs](https://main.vitest.dev/guide/projects?utm_source=chatgpt.com#:~:text=//%20add%20%22extends%3A%20true%22%20to%20inherit%20the%20options%20from%20the%20root%20config%0A%20%20%20%20%20%20%20%20extends%3A%20true%2C):
<img width="768" height="500" alt="image" src="https://github.com/user-attachments/assets/4578a180-95dc-4a88-976e-ad102878fa13" />
Okay then. But... vitest mention in their docs that:
> "Projects do not support all configuration properties. For better type safety, use the `defineProject` method instead of `defineConfig` within project configuration files"

How come?
That's because `defineProject` should only be used when a project is extracted to its own `<project>.vitest.config.ts` file. See how in their docs `defineProject` is only used in that case:
<img width="718" height="251" alt="image" src="https://github.com/user-attachments/assets/b88a7a57-caee-47ce-a91a-df9d5b580d3c" />

How would you `extends: true` in a project that is extracted to its own file then? Well, with its own `mergeConfig` of the config you need. Here they show both cases:

<img width="653" height="761" alt="image" src="https://github.com/user-attachments/assets/c73c72dc-3710-4513-bf80-fc9c7877f9e8" />

So, to sum it up - I think that `extends: true` should be brought back to the docs examples, as its valuable. For that, we just need replace `defineProject` with inline projects.

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples for Vitest projects across React, Vue, Svelte, and Web Components frameworks to demonstrate simplified configuration patterns.
  * Adjusted configuration samples for both Vitest 3 and Vitest 4 variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->