### PR TITLE
CLI: Remove any return type of getAbsolutePath

### DIFF
--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -415,7 +415,7 @@ export async function baseGenerator(
           * This function is used to resolve the absolute path of a package.
           * It is needed in projects that use Yarn PnP or are set up within a monorepo.
           */
-          function getAbsolutePath(value: string): any {
+          function getAbsolutePath(value: string) {
             return dirname(fileURLToPath(import.meta.resolve(\`\${value}/package.json\`)))
           }`,
         ]


### PR DESCRIPTION
## What I did

Removes the unnecessary `any` return type from the auto-generated `getAbsolutePath` function in the `.storybook/main.ts` file of monorepo projects.

This function always return a string. I also checked past PRs related to this code but found no clear reason why the `any` type was specified. In general, when a project uses linter like ESLint, the `any` type would trigger an error, so unnecessary `any` types should not be used.

ref: https://nodejs.org/docs/latest-v20.x/api/path.html#pathdirnamepath
ref: #23458


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Since I wasn’t sure how to create a monorepo project on the Storybook sandbox, I manually set up the environment.

1. Create a monorepo project with `npx create-turbo@latest`
2. Inside the generated frontend application, run `yarn add path/to/create-storybook`
3. Run `yarn create-storybook`
4. After completion, check the output of `.storybook/main.ts`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type annotations for internal functions to enhance code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->