### PR TITLE
A11y: Add high-contrast border for ArgsTable (#24147)

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -162,6 +162,24 @@ export const TableWrapper = styled.table<{
               borderBottomRightRadius: theme.appBorderRadius,
             },
           }),
+          
+        '@media (forced-colors: active)': {
+          '> tr > *': {
+            borderColor: 'CanvasText',
+          },
+          '> tr:first-of-type > *': {
+            borderColor: 'CanvasText',
+          },
+          '> tr:last-of-type > *': {
+            borderColor: 'CanvasText',
+          },
+          '> tr > *:first-of-type': {
+            borderColor: 'CanvasText',
+          },
+          '> tr > *:last-of-type': {
+            borderColor: 'CanvasText',
+          },
+        },
     },
     // End awesome table styling
   },


### PR DESCRIPTION
Hi there! I'm a Software Engineering student at the Federal University of Ceará (UFC) in Brazil, and this contribution is part of a university assignment on open-source.

This PR fixes issue #24147.

I've added a `forced-colors: active` media query to the `TableWrapper` component. This ensures that the table borders use the system's `CanvasText` color in Windows High Contrast Mode, making them visible again as requested in the issue.

Let me know if any changes are needed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table component styling for enhanced visibility and contrast in high-contrast accessibility mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->