### PR TITLE
Next.js: Update SWC loader to support new wasm detection

### DIFF
--- a/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
+++ b/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
@@ -29,7 +29,7 @@ DEALINGS IN THE SOFTWARE.
 import { isAbsolute, relative } from 'node:path';
 
 import type { NextConfig } from 'next';
-import { isWasm, transform } from 'next/dist/build/swc/index.js';
+import * as nextSwcUtils from 'next/dist/build/swc/index.js';
 import { getLoaderSWCOptions } from 'next/dist/build/swc/options.js';
 
 export interface SWCLoaderOptions {
@@ -136,7 +136,7 @@ async function loaderTransform(this: any, parentTrace: any, source?: string, inp
 
   const swcSpan = parentTrace.traceChild('next-swc-transform');
   return swcSpan.traceAsyncFn(() =>
-    transform(source as any, programmaticOptions).then((output) => {
+    nextSwcUtils.transform(source as any, programmaticOptions).then((output) => {
       if (output.eliminatedPackages && this.eliminatedPackages) {
         for (const pkg of JSON.parse(output.eliminatedPackages)) {
           this.eliminatedPackages.add(pkg);
@@ -152,6 +152,16 @@ const EXCLUDED_PATHS = /[\\/](cache[\\/][^\\/]+\.zip[\\/]node_modules|__virtual_
 export function pitch(this: any) {
   const callback = this.async();
   (async () => {
+    let isWasm: boolean = false;
+
+    if (!!nextSwcUtils.isWasm) {
+      isWasm = await nextSwcUtils.isWasm();
+      // @ts-expect-error Relevant from Next.js >= 16.0.2-canary.12
+    } else if (!!nextSwcUtils.getBindingsSync) {
+      // @ts-expect-error Relevant from Next.js >= 16.0.2-canary.12
+      isWasm = nextSwcUtils.getBindingsSync().isWasm;
+    }
+
     if (
       // TODO: Evaluate if this is correct after removing pnp compatibility code in SB11
       // TODO: investigate swc file reading in PnP mode?
@@ -159,7 +169,7 @@ export function pitch(this: any) {
       !EXCLUDED_PATHS.test(this.resourcePath) &&
       this.loaders.length - 1 === this.loaderIndex &&
       isAbsolute(this.resourcePath) &&
-      !(await isWasm())
+      !isWasm
     ) {
       const loaderSpan = mockCurrentTraceSpan.traceChild('next-swc-loader');
       this.addDependency(this.resourcePath);

--- a/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
+++ b/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
@@ -158,6 +158,7 @@ export function pitch(this: any) {
       isWasm = await nextSwcUtils.isWasm();
       // @ts-expect-error Relevant from Next.js >= 16.0.2-canary.12
     } else if (!!nextSwcUtils.getBindingsSync) {
+      await nextSwcUtils.loadBindings();
       // @ts-expect-error Relevant from Next.js >= 16.0.2-canary.12
       isWasm = nextSwcUtils.getBindingsSync().isWasm;
     }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The failure started at [v16.0.2-canary.12](https://github.com/vercel/next.js/releases/tag/v16.0.2-canary.12) where they removed `isWasm` from the swc index file [as can be seen here](https://github.com/vercel/next.js/pull/85787/files#diff-907b7be0cfc75bd37773e5ebc38d1deffa40861b8ac1cde92e4992e284a1ee59L1542) in favor of using a new utility `getBindingsSync`. This PR updates the code to be compatible with the new and old way.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Storybook with Nextjs 15 should work as intented (no changes)
2. Storybook with Nextjs 16 should work as intended (it was crashing before)

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal SWC utility usage reorganized for more consistent and maintainable tooling behavior; runtime behavior and public interfaces unchanged.
* **Style**
  * Updated how CSS modules are imported/referenced to standardize styling usage without changing exported APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->