### PR TITLE
UI: Make checkbox in TagsFilter presentational

### DIFF
--- a/code/core/src/manager/components/sidebar/TagsFilterPanel.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilterPanel.tsx
@@ -159,6 +159,7 @@ export const TagsFilterPanel = ({
                     onChange={() => onToggle(!isChecked)}
                     data-tag={title}
                     aria-hidden={true}
+                    role="presentation"
                     tabIndex={-1}
                   />
                 </>


### PR DESCRIPTION

## What I did

Make it even clearer that checkboxes in TagsFilter aren't interactive controls.

Axe-core fails to notice that the nested interactive element is aria-hidden. I've added a presentation role to double down and make it even clearer but axe still won't pick up on it.

I'm happy with the a11y OMs in Chrome and Firefox DevTools and with the NVDA output so resolving this one.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

_not covered_

#### Manual testing

Check NVDA output or Accessibility Object Model in your browser.

### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved semantic markup for filter checkboxes by refining their accessibility role to better convey presentation intent without changing behavior or state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->