### PR TITLE
UI: Underline links to avoid using only color

### DIFF
--- a/code/core/src/components/components/typography/DocumentWrapper.tsx
+++ b/code/core/src/components/components/typography/DocumentWrapper.tsx
@@ -64,7 +64,7 @@ export const DocumentWrapper = styled.div(({ theme }) => ({
   },
   a: {
     color: theme.color.secondary,
-    textDecoration: 'none',
+    textDecoration: 'underline',
   },
   'a.absent': {
     color: '#cc0000',

--- a/code/core/src/components/components/typography/elements/A.tsx
+++ b/code/core/src/components/components/typography/elements/A.tsx
@@ -8,7 +8,7 @@ export const A = styled(Link)(withReset, ({ theme }) => ({
   lineHeight: '24px',
 
   color: theme.color.secondary,
-  textDecoration: 'none',
+  textDecoration: 'underline',
   '&.absent': {
     color: '#cc0000',
   },

--- a/code/core/src/components/components/typography/link/link.tsx
+++ b/code/core/src/components/components/typography/link/link.tsx
@@ -67,7 +67,7 @@ const A = styled.a<LinkStylesProps>(
   ({ theme }) => ({
     display: 'inline-block',
     transition: 'all 150ms ease-out',
-    textDecoration: 'none',
+    textDecoration: 'underline',
 
     color: theme.color.secondary,
 


### PR DESCRIPTION
Closes #33017

## What I did

Fixes some violations of https://dequeuniversity.com/rules/axe/4.10/link-in-text-block?application=axeAPI.

Flagged on https://www.chromatic.com/test?appId=635781f3500dd2c49e189caf&id=6913769e99ba81e2674e55f8.

@MichaelArestad you may want to go in another direction (font-style, font-weight, box-shadow, border, etc.). Do let me know if you prefer another approach to fixing this.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated link styling to display underlines by default across typography components, providing improved visual distinction for interactive link elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->