### PR TITLE
UI: Add padding for ArgsTable shadow in TabbedArgsTable

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -106,6 +106,7 @@ export const TableWrapper = styled.table<{
 
     // Makes border alignment consistent w/other DocBlocks
     marginInline: inAddonPanel || inTabPanel ? 0 : 1,
+    paddingInline: inTabPanel ? 3 : 0,
 
     tbody: {
       // Safari doesn't love shadows on tbody so we need to use a shadow filter. In order to do this,


### PR DESCRIPTION
## What I did

See https://www.chromatic.com/test?appId=635781f3500dd2c49e189caf&id=6913769e99ba81e2674e568e

This one is opinionated. I cannot realistically remove the `overflow: hidden` that causes the shadow cropping, as TabPanel now has support for a ScrollArea, implying a vertical `overflow-y: scroll`, and so that `overflow-x: visible` is impossible to achieve.

Considering the impact here, and the benefits of natively supporting scrolling in TabPanels, I propose to just add enough padding for the shadow to render well. Alternatively, we could also just drop the shadow.

@MichaelArestad let me know what you think please!

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories

#### Manual testing

http://localhost:6006/?path=/story/addons-docs-blocks-blocks-controls--subcomponents-of-story


## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved horizontal padding for the Arguments Table when shown inside tab panels: horizontal spacing is increased in that context to improve visual alignment and readability while keeping the compact layout elsewhere.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->