### PR TITLE
Build: Update CI workflow to only trigger when specific PR labels are set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,1437 +1,1436 @@
 commands:
-    cancel-workflow-on-failure:
-        description: Cancels the entire workflow in case the previous step has failed
-        steps:
-            - run:
-                command: |
-                    echo "Canceling workflow as previous step resulted in failure."
-                    echo "To execute all checks locally, please run yarn ci-tests"
-                    curl -X POST --header "Content-Type: application/json" "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${WORKFLOW_CANCELER}"
-                name: Cancel current workflow
-                when: on_fail
-    report-workflow-on-failure:
-        description: Reports failures to discord
-        parameters:
-            template:
-                default: none
-                description: |
-                    Which template to report in discord. Applicable for parallel sandbox jobs
-                type: string
-        steps:
-            - run:
-                command: git fetch --unshallow
-                when: on_fail
-            - discord/status:
-                fail_only: true
-                failure_message: $(yarn get-report-message << pipeline.parameters.workflow >> << parameters.template >>)
-                only_for_branches: main,next,next-release,latest-release
-    start-event-collector:
-        description: Starts the event collector
-        steps:
-            - run:
-                background: true
-                command: yarn jiti ./event-log-collector.ts
-                name: Start Event Collector
-                working_directory: scripts
+  cancel-workflow-on-failure:
+    description: Cancels the entire workflow in case the previous step has failed
+    steps:
+      - run:
+          command: |
+            echo "Canceling workflow as previous step resulted in failure."
+            echo "To execute all checks locally, please run yarn ci-tests"
+            curl -X POST --header "Content-Type: application/json" "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${WORKFLOW_CANCELER}"
+          name: Cancel current workflow
+          when: on_fail
+  report-workflow-on-failure:
+    description: Reports failures to discord
+    parameters:
+      template:
+        default: none
+        description: |
+          Which template to report in discord. Applicable for parallel sandbox jobs
+        type: string
+    steps:
+      - run:
+          command: git fetch --unshallow
+          when: on_fail
+      - discord/status:
+          fail_only: true
+          failure_message: $(yarn get-report-message << pipeline.parameters.workflow >> << parameters.template >>)
+          only_for_branches: main,next,next-release,latest-release
+  start-event-collector:
+    description: Starts the event collector
+    steps:
+      - run:
+          background: true
+          command: yarn jiti ./event-log-collector.ts
+          name: Start Event Collector
+          working_directory: scripts
 executors:
-    sb_node_18_browsers:
-        docker:
-            - environment:
-                NODE_OPTIONS: --max_old_space_size=6144
-              image: cimg/node:18.20.3-browsers
-        parameters:
-            class:
-                default: small
-                description: The Resource class
-                enum:
-                    - small
-                    - medium
-                    - medium+
-                    - large
-                    - xlarge
-                type: enum
-        resource_class: <<parameters.class>>
-        working_directory: /tmp/storybook
-    sb_node_22_browsers:
-        docker:
-            - environment:
-                NODE_OPTIONS: --max_old_space_size=6144
-              image: cimg/node:22.15.0-browsers
-        parameters:
-            class:
-                default: small
-                description: The Resource class
-                enum:
-                    - small
-                    - medium
-                    - medium+
-                    - large
-                    - xlarge
-                type: enum
-        resource_class: <<parameters.class>>
-        working_directory: /tmp/storybook
-    sb_node_22_classic:
-        docker:
-            - environment:
-                NODE_OPTIONS: --max_old_space_size=6144
-              image: cimg/node:22.15.0
-        parameters:
-            class:
-                default: small
-                description: The Resource class
-                enum:
-                    - small
-                    - medium
-                    - medium+
-                    - large
-                    - xlarge
-                type: enum
-        resource_class: <<parameters.class>>
-        working_directory: /tmp/storybook
-    sb_playwright:
-        docker:
-            - environment:
-                NODE_OPTIONS: --max_old_space_size=6144
-              image: mcr.microsoft.com/playwright:v1.52.0-noble
-        parameters:
-            class:
-                default: small
-                description: The Resource class
-                enum:
-                    - small
-                    - medium
-                    - medium+
-                    - large
-                    - xlarge
-                type: enum
-        resource_class: <<parameters.class>>
-        working_directory: /tmp/storybook
+  sb_node_18_browsers:
+    docker:
+      - environment:
+          NODE_OPTIONS: --max_old_space_size=6144
+        image: cimg/node:18.20.3-browsers
+    parameters:
+      class:
+        default: small
+        description: The Resource class
+        enum:
+          - small
+          - medium
+          - medium+
+          - large
+          - xlarge
+        type: enum
+    resource_class: <<parameters.class>>
+    working_directory: /tmp/storybook
+  sb_node_22_browsers:
+    docker:
+      - environment:
+          NODE_OPTIONS: --max_old_space_size=6144
+        image: cimg/node:22.15.0-browsers
+    parameters:
+      class:
+        default: small
+        description: The Resource class
+        enum:
+          - small
+          - medium
+          - medium+
+          - large
+          - xlarge
+        type: enum
+    resource_class: <<parameters.class>>
+    working_directory: /tmp/storybook
+  sb_node_22_classic:
+    docker:
+      - environment:
+          NODE_OPTIONS: --max_old_space_size=6144
+        image: cimg/node:22.15.0
+    parameters:
+      class:
+        default: small
+        description: The Resource class
+        enum:
+          - small
+          - medium
+          - medium+
+          - large
+          - xlarge
+        type: enum
+    resource_class: <<parameters.class>>
+    working_directory: /tmp/storybook
+  sb_playwright:
+    docker:
+      - environment:
+          NODE_OPTIONS: --max_old_space_size=6144
+        image: mcr.microsoft.com/playwright:v1.52.0-noble
+    parameters:
+      class:
+        default: small
+        description: The Resource class
+        enum:
+          - small
+          - medium
+          - medium+
+          - large
+          - xlarge
+        type: enum
+    resource_class: <<parameters.class>>
+    working_directory: /tmp/storybook
 jobs:
-    bench-packages:
-        executor:
-            class: small
-            name: sb_node_22_classic
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - when:
-                condition:
-                    and:
-                        - << pipeline.parameters.ghBaseBranch >>
-                        - << pipeline.parameters.ghPrNumber >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                    - run:
-                        command: yarn bench-packages --base-branch << pipeline.parameters.ghBaseBranch >> --pull-request << pipeline.parameters.ghPrNumber >> --upload
-                        name: Benchmarking packages against base branch
-                        working_directory: scripts
-            - when:
-                condition:
-                    or:
-                        - not: << pipeline.parameters.ghBaseBranch >>
-                        - not: << pipeline.parameters.ghPrNumber >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                    - run:
-                        command: yarn bench-packages --upload
-                        name: Uploading package benchmarks for branch
-                        working_directory: scripts
-            - store_artifacts:
-                path: bench/packages/results.json
-            - report-workflow-on-failure
-            - cancel-workflow-on-failure
-    bench-sandboxes:
-        executor:
-            class: small
-            name: sb_playwright
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task bench)
-                    cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
-                name: Install sandbox dependencies
-            - run:
-                command: yarn task --task bench --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task bench) --no-link --start-from=never --junit
-                name: Running Bench
-            - run:
-                command: yarn upload-bench $(yarn get-template --cadence << pipeline.parameters.workflow >> --task bench) << pipeline.parameters.ghPrNumber >> << pipeline.parameters.ghBaseBranch >>
-                name: Uploading results
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task bench)
-    build:
-        executor:
-            class: large
-            name: sb_node_22_classic
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - restore_cache:
-                keys:
-                    - build-yarn-2-cache-v5--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
-                name: Restore Yarn cache
-            - run:
-                command: |
-                    yarn task --task compile --start-from=auto --no-link --debug
-                    git diff --exit-code
-                    yarn dedupe --check
-                name: Compile
-            - run:
-                command: |
-                    cd code
-                    yarn local-registry --publish
-                name: Publish to Verdaccio
-            - report-workflow-on-failure
-            - store_artifacts:
-                path: code/bench/esbuild-metafiles
-            - save_cache:
-                key: build-yarn-2-cache-v5--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
-                name: Save Yarn cache
-                paths:
-                    - ~/.yarn/berry/cache
-            - persist_to_workspace:
-                paths:
-                    - code/node_modules
-                    - code/addons
-                    - scripts/node_modules
-                    - code/bench
-                    - code/examples
-                    - code/frameworks
-                    - code/lib
-                    - code/core
-                    - code/builders
-                    - code/renderers
-                    - code/presets
-                    - .verdaccio-cache
-                root: .
-    check:
-        executor:
-            class: large
-            name: sb_node_22_classic
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - nx/set-shas:
-                main-branch-name: next
-                workflow-name: << pipeline.parameters.workflow >>
-            - restore_cache:
-                keys:
-                    - build-yarn-2-cache-v5--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
-                name: Restore Yarn cache
-            - run:
-                command: |
-                    yarn task --task compile --start-from=auto --no-link --debug
-                name: Compile
-            - run:
-                command: |
-                    yarn task --task check --start-from=auto --no-link --debug
-                name: Check
-            - run:
-                command: |
-                    git diff --exit-code
-                name: Ensure no changes pending
-            - report-workflow-on-failure
-            - cancel-workflow-on-failure
-    check-sandboxes:
-        executor:
-            class: medium
-            name: sb_node_22_classic
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task check-sandbox)
-                    cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
-                name: Install sandbox dependencies
-            - run:
-                command: yarn task --task check-sandbox --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task check-sandbox) --no-link --start-from=never --junit
-                name: Type check Sandboxes
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task check-sandbox)
-            - store_test_results:
-                path: test-results
-    chromatic-internal-storybook:
-        environment:
-            NODE_OPTIONS: --max_old_space_size=4096
-        executor:
-            class: large
-            name: sb_node_22_browsers
-        steps:
-            - checkout
-            - attach_workspace:
-                at: .
-            - run:
-                command: yarn storybook:ui:chromatic
-                name: Running Chromatic
-                working_directory: code
-            - report-workflow-on-failure
-            - store_test_results:
-                path: test-results
-    chromatic-sandboxes:
-        executor:
-            class: medium
-            name: sb_node_22_browsers
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - checkout
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task chromatic)
-                    cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
-                name: Install sandbox dependencies
-            - run:
-                command: yarn task --task chromatic --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task chromatic) --no-link --start-from=never --junit
-                name: Running Chromatic
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task chromatic)
-            - store_test_results:
-                path: test-results
-    coverage:
-        executor:
-            class: small
-            name: sb_node_22_browsers
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - codecov/upload
-            - report-workflow-on-failure
-    create-sandboxes:
-        executor:
-            class: large
-            name: sb_node_22_browsers
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    # Enable corepack
-                    sudo corepack enable
-
-                    # Verify yarn is working
-                    which yarn
-                    yarn --version
-                name: Setup Corepack
-            - start-event-collector
-            - run:
-                command: |
-                    TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task sandbox)
-                    yarn task --task build --template $TEMPLATE --no-link --start-from=sandbox --junit
-                    if [[ $TEMPLATE != bench/* ]]; then
-                      yarn --cwd scripts jiti ./event-log-checker.ts build $TEMPLATE
-                    fi
-                    cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && rm -rf node_modules
-                environment:
-                    STORYBOOK_TELEMETRY_DEBUG: 1
-                    STORYBOOK_TELEMETRY_URL: http://localhost:6007/event-log
-                name: Create Sandboxes
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task sandbox)
-            - persist_to_workspace:
-                paths:
-                    - sandbox/**
-                root: .
-            - store_test_results:
-                path: test-results
-    e2e-dev:
-        executor:
-            class: medium+
-            name: sb_playwright
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests-dev)
-                    cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
-                name: Install sandbox dependencies
-            - run:
-                command: |
-                    TEST_FILES=$(circleci tests glob "code/e2e-tests/*.{test,spec}.{ts,js,mjs}")
-                    echo "$TEST_FILES" | circleci tests run --command="xargs yarn task --task e2e-tests-dev --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests-dev) --no-link --start-from=never --junit" --verbose --index=0 --total=1
-                name: Running E2E Tests
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests-dev)
-            - store_test_results:
-                path: test-results
-            - store_artifacts:
-                destination: playwright
-                path: code/playwright-results/
-    e2e-production:
-        executor:
-            class: medium
-            name: sb_playwright
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests)
-                    cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
-                name: Install sandbox dependencies
-            - run:
-                command: |
-                    TEST_FILES=$(circleci tests glob "code/e2e-tests/*.{test,spec}.{ts,js,mjs}")
-                    echo "$TEST_FILES" | circleci tests run --command="xargs yarn task --task e2e-tests --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests) --no-link --start-from=never --junit" --verbose --index=0 --total=1
-                name: Running E2E Tests
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests)
-            - store_test_results:
-                path: test-results
-            - store_artifacts:
-                destination: playwright
-                path: code/playwright-results/
-    e2e-ui:
-        executor:
-            class: medium
-            name: sb_playwright
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: yarn install --no-immutable
-                environment:
-                    YARN_ENABLE_IMMUTABLE_INSTALLS: false
-                name: Install dependencies
-                working_directory: test-storybooks/portable-stories-kitchen-sink/react
-            - run:
-                command: yarn playwright-e2e
-                name: Run E2E tests
-                working_directory: test-storybooks/portable-stories-kitchen-sink/react
-            - store_test_results:
-                path: test-results
-            - store_artifacts:
-                destination: playwright
-                path: test-storybooks/portable-stories-kitchen-sink/react/test-results/
-            - report-workflow-on-failure
-    e2e-ui-vitest-3:
-        executor:
-            class: medium
-            name: sb_playwright
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: yarn install --no-immutable
-                environment:
-                    YARN_ENABLE_IMMUTABLE_INSTALLS: false
-                name: Install dependencies
-                working_directory: test-storybooks/portable-stories-kitchen-sink/react-vitest-3
-            - run:
-                command: yarn playwright-e2e
-                name: Run E2E tests
-                working_directory: test-storybooks/portable-stories-kitchen-sink/react-vitest-3
-            - store_test_results:
-                path: test-results
-            - store_artifacts:
-                destination: playwright
-                path: test-storybooks/portable-stories-kitchen-sink/react-vitest-3/test-results/
-            - report-workflow-on-failure
-    knip:
-        executor:
-            class: large
-            name: sb_node_22_classic
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    cd code
-                    yarn knip --no-exit-code
-                name: Knip
-            - report-workflow-on-failure
-            - cancel-workflow-on-failure
-    lint:
-        executor:
-            class: medium+
-            name: sb_node_22_classic
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    cd code
-                    yarn lint
-                name: Lint
-            - report-workflow-on-failure
-            - cancel-workflow-on-failure
-    pretty-docs:
-        executor:
-            class: medium
-            name: sb_node_22_classic
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - restore_cache:
-                keys:
-                    - prettydocs-yarn-2-cache-v8--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
-                name: Restore Yarn cache
-            - run:
-                command: |
-                    cd scripts
-                    yarn install
-                name: Install
-            - save_cache:
-                key: prettydocs-yarn-2-cache-v8--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
-                name: Save Yarn cache
-                paths:
-                    - ~/.yarn/berry/cache
-            - run:
-                command: |
-                    cd scripts
-                    yarn docs:prettier:check
-                name: Prettier
-    script-checks:
-        executor: sb_node_22_browsers
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    cd scripts
-                    yarn get-template --check
-                name: Check parallelism count
-            - run:
-                command: |
-                    cd scripts
-                    yarn check
-                name: Type check
-            - run:
-                command: |
-                    cd scripts
-                    yarn test --coverage
-                name: Run tests
-            - store_test_results:
-                path: scripts/junit.xml
-            - report-workflow-on-failure
-            - cancel-workflow-on-failure
-    smoke-test-sandboxes:
-        executor:
-            class: medium
-            name: sb_node_18_browsers
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: yarn task --task smoke-test --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task smoke-test) --no-link --start-from=never --junit
-                name: Smoke Testing Sandboxes
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task smoke-test)
-            - store_test_results:
-                path: test-results
-    stories-tests:
-        executor:
-            class: xlarge
-            name: sb_playwright
-        parallelism: 2
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    cd code
-                    TEST_FILES=$(circleci tests glob "**/*.{stories}.{ts,tsx,js,jsx,cjs}" | sed "/^e2e-tests\//d" | sed "/^node_modules\//d")
-                    echo "$TEST_FILES" | circleci tests run --command="xargs yarn test --reporter=junit --reporter=default --outputFile=../test-results/junit-${CIRCLE_NODE_INDEX}.xml" --verbose
-                name: Run tests
-            - store_test_results:
-                path: test-results
-            - report-workflow-on-failure
-            - cancel-workflow-on-failure
-    test-init-empty:
-        executor:
-            class: small
-            name: sb_node_22_browsers
-        parameters:
-            packageManager:
-                type: string
-            template:
-                type: string
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - when:
-                condition:
-                    equal:
-                        - npm
-                        - << parameters.packageManager >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                    - run:
-                        command: |
-                            cd ..
-                            mkdir empty-<< parameters.template >>
-                            cd empty-<< parameters.template >>
-                            npm set registry http://localhost:6001
-                            npx storybook init --yes --package-manager npm
-                            npm run storybook -- --smoke-test
-                        environment:
-                            IN_STORYBOOK_SANDBOX: true
-                            STORYBOOK_DISABLE_TELEMETRY: true
-                            STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
-                        name: Storybook init from empty directory (NPM)
-            - when:
-                condition:
-                    equal:
-                        - yarn2
-                        - << parameters.packageManager >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                    - run:
-                        command: |
-                            cd ..
-                            mkdir empty-<< parameters.template >>
-                            cd empty-<< parameters.template >>
-                            yarn set version berry
-                            yarn config set registry http://localhost:6001
-                            yarn dlx storybook init --yes --package-manager yarn2
-                            yarn storybook --smoke-test
-                        environment:
-                            IN_STORYBOOK_SANDBOX: true
-                            STORYBOOK_DISABLE_TELEMETRY: true
-                            STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
-                        name: Storybook init from empty directory (Yarn 2)
-            - when:
-                condition:
-                    equal:
-                        - pnpm
-                        - << parameters.packageManager >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                    - run:
-                        command: |
-                            cd ..
-                            mkdir empty-<< parameters.template >>
-                            cd empty-<< parameters.template >>
-                            npm i -g pnpm
-                            pnpm config set registry http://localhost:6001
-                            pnpm dlx storybook init --yes --package-manager pnpm
-                            pnpm run storybook --smoke-test
-                        environment:
-                            IN_STORYBOOK_SANDBOX: true
-                            STORYBOOK_DISABLE_TELEMETRY: true
-                            STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
-                        name: Storybook init from empty directory (PNPM)
-            - when:
-                condition:
-                    equal:
-                        - react-vite-ts
-                        - << parameters.template >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                    - run:
-                        command: |
-                            cd ..
-                            mkdir empty-<< parameters.template >>-no-install
-                            cd empty-<< parameters.template >>-no-install
-                            npx storybook init --yes --skip-install
-                            npm install
-                            npm run build-storybook
-                        environment:
-                            IN_STORYBOOK_SANDBOX: true
-                            STORYBOOK_DISABLE_TELEMETRY: true
-                            STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
-                        name: Storybook init from empty directory (--skip-install)
-            - report-workflow-on-failure
-    test-init-empty-windows:
-        executor: win/default
-        parameters:
-            packageManager:
-                type: string
-            template:
-                type: string
-        steps:
-            - checkout
-            - attach_workspace:
-                at: .
-            - run:
-                command: |
-                    choco install nodejs-lts --version=22.11.0 -y
-                    corepack enable
-                name: Setup Node & Yarn on Windows
-                shell: bash.exe
-            - run:
-                command: yarn install
-                name: Install code dependencies
-                shell: bash.exe
-                working_directory: code
-            - run:
-                command: yarn install
-                name: Install script dependencies
-                shell: bash.exe
-                working_directory: scripts
-            - when:
-                condition:
-                    equal:
-                        - npm
-                        - << parameters.packageManager >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                        shell: bash.exe
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                        shell: bash.exe
-                    - run:
-                        command: |
-                            cd ..
-                            mkdir empty-<< parameters.template >>
-                            cd empty-<< parameters.template >>
-                            npm set registry http://localhost:6001
-                            npx storybook init --yes --package-manager npm
-                            npm run storybook -- --smoke-test
-                        environment:
-                            IN_STORYBOOK_SANDBOX: true
-                            STORYBOOK_DISABLE_TELEMETRY: true
-                            STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
-                        name: Storybook init from empty directory (Windows NPM)
-                        shell: bash.exe
-            - when:
-                condition:
-                    equal:
-                        - yarn2
-                        - << parameters.packageManager >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                        shell: bash.exe
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                        shell: bash.exe
-                    - run:
-                        command: |
-                            cd ..
-                            mkdir empty-<< parameters.template >>
-                            cd empty-<< parameters.template >>
-                            yarn set version berry
-                            yarn config set registry http://localhost:6001
-                            yarn dlx storybook init --yes --package-manager yarn2
-                            yarn storybook --smoke-test
-                        environment:
-                            IN_STORYBOOK_SANDBOX: true
-                            STORYBOOK_DISABLE_TELEMETRY: true
-                            STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
-                        name: Storybook init from empty directory (Windows Yarn 2)
-                        shell: bash.exe
-            - when:
-                condition:
-                    equal:
-                        - pnpm
-                        - << parameters.packageManager >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                        shell: bash.exe
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                        shell: bash.exe
-                    - run:
-                        command: |
-                            cd ..
-                            mkdir empty-<< parameters.template >>
-                            cd empty-<< parameters.template >>
-                            npm i -g pnpm
-                            pnpm config set registry http://localhost:6001
-                            pnpm dlx storybook init --yes --package-manager pnpm
-                            pnpm run storybook --smoke-test
-                        environment:
-                            IN_STORYBOOK_SANDBOX: true
-                            STORYBOOK_DISABLE_TELEMETRY: true
-                            STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
-                        name: Storybook init from empty directory (Windows PNPM)
-                        shell: bash.exe
-            - when:
-                condition:
-                    equal:
-                        - react-vite-ts
-                        - << parameters.template >>
-                steps:
-                    - run:
-                        background: true
-                        command: |
-                            cd code
-                            yarn local-registry --open
-                        name: Verdaccio
-                        shell: bash.exe
-                    - run:
-                        command: |
-                            cd code
-                            yarn wait-on tcp:127.0.0.1:6001
-                            yarn wait-on tcp:127.0.0.1:6002
-                        name: Wait on Verdaccio
-                        shell: bash.exe
-                    - run:
-                        command: |
-                            cd ..
-                            mkdir empty-<< parameters.template >>-no-install
-                            cd empty-<< parameters.template >>-no-install
-                            npx storybook init --yes --skip-install
-                            npm install
-                            npm run build-storybook
-                        environment:
-                            IN_STORYBOOK_SANDBOX: true
-                            STORYBOOK_DISABLE_TELEMETRY: true
-                            STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
-                        name: Storybook init from empty directory (Windows --skip-install)
-                        shell: bash.exe
-    test-init-features:
-        executor:
-            class: small
-            name: sb_node_22_browsers
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
+  bench-packages:
+    executor:
+      class: small
+      name: sb_node_22_classic
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - when:
+          condition:
+            and:
+              - << pipeline.parameters.ghBaseBranch >>
+              - << pipeline.parameters.ghPrNumber >>
+          steps:
             - run:
                 background: true
                 command: |
-                    cd code
-                    yarn local-registry --open
+                  cd code
+                  yarn local-registry --open
                 name: Verdaccio
             - run:
                 command: |
-                    cd code
-                    yarn wait-on tcp:127.0.0.1:6001
-                    yarn wait-on tcp:127.0.0.1:6002
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
+                name: Wait on Verdaccio
+            - run:
+                command: yarn bench-packages --base-branch << pipeline.parameters.ghBaseBranch >> --pull-request << pipeline.parameters.ghPrNumber >> --upload
+                name: Benchmarking packages against base branch
+                working_directory: scripts
+      - when:
+          condition:
+            or:
+              - not: << pipeline.parameters.ghBaseBranch >>
+              - not: << pipeline.parameters.ghPrNumber >>
+          steps:
+            - run:
+                background: true
+                command: |
+                  cd code
+                  yarn local-registry --open
+                name: Verdaccio
+            - run:
+                command: |
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
+                name: Wait on Verdaccio
+            - run:
+                command: yarn bench-packages --upload
+                name: Uploading package benchmarks for branch
+                working_directory: scripts
+      - store_artifacts:
+          path: bench/packages/results.json
+      - report-workflow-on-failure
+      - cancel-workflow-on-failure
+  bench-sandboxes:
+    executor:
+      class: small
+      name: sb_playwright
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task bench)
+            cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
+          name: Install sandbox dependencies
+      - run:
+          command: yarn task --task bench --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task bench) --no-link --start-from=never --junit
+          name: Running Bench
+      - run:
+          command: yarn upload-bench $(yarn get-template --cadence << pipeline.parameters.workflow >> --task bench) << pipeline.parameters.ghPrNumber >> << pipeline.parameters.ghBaseBranch >>
+          name: Uploading results
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task bench)
+  build:
+    executor:
+      class: large
+      name: sb_node_22_classic
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - restore_cache:
+          keys:
+            - build-yarn-2-cache-v5--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
+          name: Restore Yarn cache
+      - run:
+          command: |
+            yarn task --task compile --start-from=auto --no-link --debug
+            git diff --exit-code
+            yarn dedupe --check
+          name: Compile
+      - run:
+          command: |
+            cd code
+            yarn local-registry --publish
+          name: Publish to Verdaccio
+      - report-workflow-on-failure
+      - store_artifacts:
+          path: code/bench/esbuild-metafiles
+      - save_cache:
+          key: build-yarn-2-cache-v5--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
+          name: Save Yarn cache
+          paths:
+            - ~/.yarn/berry/cache
+      - persist_to_workspace:
+          paths:
+            - code/node_modules
+            - code/addons
+            - scripts/node_modules
+            - code/bench
+            - code/examples
+            - code/frameworks
+            - code/lib
+            - code/core
+            - code/builders
+            - code/renderers
+            - code/presets
+            - .verdaccio-cache
+          root: .
+  check:
+    executor:
+      class: large
+      name: sb_node_22_classic
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - nx/set-shas:
+          main-branch-name: next
+          workflow-name: << pipeline.parameters.workflow >>
+      - restore_cache:
+          keys:
+            - build-yarn-2-cache-v5--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
+          name: Restore Yarn cache
+      - run:
+          command: |
+            yarn task --task compile --start-from=auto --no-link --debug
+          name: Compile
+      - run:
+          command: |
+            yarn task --task check --start-from=auto --no-link --debug
+          name: Check
+      - run:
+          command: |
+            git diff --exit-code
+          name: Ensure no changes pending
+      - report-workflow-on-failure
+      - cancel-workflow-on-failure
+  check-sandboxes:
+    executor:
+      class: medium
+      name: sb_node_22_classic
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task check-sandbox)
+            cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
+          name: Install sandbox dependencies
+      - run:
+          command: yarn task --task check-sandbox --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task check-sandbox) --no-link --start-from=never --junit
+          name: Type check Sandboxes
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task check-sandbox)
+      - store_test_results:
+          path: test-results
+  chromatic-internal-storybook:
+    environment:
+      NODE_OPTIONS: --max_old_space_size=4096
+    executor:
+      class: large
+      name: sb_node_22_browsers
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          command: yarn storybook:ui:chromatic
+          name: Running Chromatic
+          working_directory: code
+      - report-workflow-on-failure
+      - store_test_results:
+          path: test-results
+  chromatic-sandboxes:
+    executor:
+      class: medium
+      name: sb_node_22_browsers
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task chromatic)
+            cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
+          name: Install sandbox dependencies
+      - run:
+          command: yarn task --task chromatic --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task chromatic) --no-link --start-from=never --junit
+          name: Running Chromatic
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task chromatic)
+      - store_test_results:
+          path: test-results
+  coverage:
+    executor:
+      class: small
+      name: sb_node_22_browsers
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - codecov/upload
+      - report-workflow-on-failure
+  create-sandboxes:
+    executor:
+      class: large
+      name: sb_node_22_browsers
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            # Enable corepack
+            sudo corepack enable
+
+            # Verify yarn is working
+            which yarn
+            yarn --version
+          name: Setup Corepack
+      - start-event-collector
+      - run:
+          command: |
+            TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task sandbox)
+            yarn task --task build --template $TEMPLATE --no-link --start-from=sandbox --junit
+            if [[ $TEMPLATE != bench/* ]]; then
+              yarn --cwd scripts jiti ./event-log-checker.ts build $TEMPLATE
+            fi
+            cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && rm -rf node_modules
+          environment:
+            STORYBOOK_TELEMETRY_DEBUG: 1
+            STORYBOOK_TELEMETRY_URL: http://localhost:6007/event-log
+          name: Create Sandboxes
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task sandbox)
+      - persist_to_workspace:
+          paths:
+            - sandbox/**
+          root: .
+      - store_test_results:
+          path: test-results
+  e2e-dev:
+    executor:
+      class: medium+
+      name: sb_playwright
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests-dev)
+            cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
+          name: Install sandbox dependencies
+      - run:
+          command: |
+            TEST_FILES=$(circleci tests glob "code/e2e-tests/*.{test,spec}.{ts,js,mjs}")
+            echo "$TEST_FILES" | circleci tests run --command="xargs yarn task --task e2e-tests-dev --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests-dev) --no-link --start-from=never --junit" --verbose --index=0 --total=1
+          name: Running E2E Tests
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests-dev)
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          destination: playwright
+          path: code/playwright-results/
+  e2e-production:
+    executor:
+      class: medium
+      name: sb_playwright
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests)
+            cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
+          name: Install sandbox dependencies
+      - run:
+          command: |
+            TEST_FILES=$(circleci tests glob "code/e2e-tests/*.{test,spec}.{ts,js,mjs}")
+            echo "$TEST_FILES" | circleci tests run --command="xargs yarn task --task e2e-tests --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests) --no-link --start-from=never --junit" --verbose --index=0 --total=1
+          name: Running E2E Tests
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests)
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          destination: playwright
+          path: code/playwright-results/
+  e2e-ui:
+    executor:
+      class: medium
+      name: sb_playwright
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: yarn install --no-immutable
+          environment:
+            YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          name: Install dependencies
+          working_directory: test-storybooks/portable-stories-kitchen-sink/react
+      - run:
+          command: yarn playwright-e2e
+          name: Run E2E tests
+          working_directory: test-storybooks/portable-stories-kitchen-sink/react
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          destination: playwright
+          path: test-storybooks/portable-stories-kitchen-sink/react/test-results/
+      - report-workflow-on-failure
+  e2e-ui-vitest-3:
+    executor:
+      class: medium
+      name: sb_playwright
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: yarn install --no-immutable
+          environment:
+            YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          name: Install dependencies
+          working_directory: test-storybooks/portable-stories-kitchen-sink/react-vitest-3
+      - run:
+          command: yarn playwright-e2e
+          name: Run E2E tests
+          working_directory: test-storybooks/portable-stories-kitchen-sink/react-vitest-3
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          destination: playwright
+          path: test-storybooks/portable-stories-kitchen-sink/react-vitest-3/test-results/
+      - report-workflow-on-failure
+  knip:
+    executor:
+      class: large
+      name: sb_node_22_classic
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            cd code
+            yarn knip --no-exit-code
+          name: Knip
+      - report-workflow-on-failure
+      - cancel-workflow-on-failure
+  lint:
+    executor:
+      class: medium+
+      name: sb_node_22_classic
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            cd code
+            yarn lint
+          name: Lint
+      - report-workflow-on-failure
+      - cancel-workflow-on-failure
+  pretty-docs:
+    executor:
+      class: medium
+      name: sb_node_22_classic
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - restore_cache:
+          keys:
+            - prettydocs-yarn-2-cache-v8--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
+          name: Restore Yarn cache
+      - run:
+          command: |
+            cd scripts
+            yarn install
+          name: Install
+      - save_cache:
+          key: prettydocs-yarn-2-cache-v8--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
+          name: Save Yarn cache
+          paths:
+            - ~/.yarn/berry/cache
+      - run:
+          command: |
+            cd scripts
+            yarn docs:prettier:check
+          name: Prettier
+  script-checks:
+    executor: sb_node_22_browsers
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            cd scripts
+            yarn get-template --check
+          name: Check parallelism count
+      - run:
+          command: |
+            cd scripts
+            yarn check
+          name: Type check
+      - run:
+          command: |
+            cd scripts
+            yarn test --coverage
+          name: Run tests
+      - store_test_results:
+          path: scripts/junit.xml
+      - report-workflow-on-failure
+      - cancel-workflow-on-failure
+  smoke-test-sandboxes:
+    executor:
+      class: medium
+      name: sb_node_18_browsers
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: yarn task --task smoke-test --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task smoke-test) --no-link --start-from=never --junit
+          name: Smoke Testing Sandboxes
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task smoke-test)
+      - store_test_results:
+          path: test-results
+  stories-tests:
+    executor:
+      class: xlarge
+      name: sb_playwright
+    parallelism: 2
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            cd code
+            TEST_FILES=$(circleci tests glob "**/*.{stories}.{ts,tsx,js,jsx,cjs}" | sed "/^e2e-tests\//d" | sed "/^node_modules\//d")
+            echo "$TEST_FILES" | circleci tests run --command="xargs yarn test --reporter=junit --reporter=default --outputFile=../test-results/junit-${CIRCLE_NODE_INDEX}.xml" --verbose
+          name: Run tests
+      - store_test_results:
+          path: test-results
+      - report-workflow-on-failure
+      - cancel-workflow-on-failure
+  test-init-empty:
+    executor:
+      class: small
+      name: sb_node_22_browsers
+    parameters:
+      packageManager:
+        type: string
+      template:
+        type: string
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - when:
+          condition:
+            equal:
+              - npm
+              - << parameters.packageManager >>
+          steps:
+            - run:
+                background: true
+                command: |
+                  cd code
+                  yarn local-registry --open
+                name: Verdaccio
+            - run:
+                command: |
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
                 name: Wait on Verdaccio
             - run:
                 command: |
-                    cd ..
-                    mkdir features-1
-                    cd features-1
-                    npm set registry http://localhost:6001
-                    npx create-storybook --yes --package-manager npm --features dev docs test
-                    npx vitest
+                  cd ..
+                  mkdir empty-<< parameters.template >>
+                  cd empty-<< parameters.template >>
+                  npm set registry http://localhost:6001
+                  npx storybook init --yes --package-manager npm
+                  npm run storybook -- --smoke-test
                 environment:
-                    IN_STORYBOOK_SANDBOX: true
-                    STORYBOOK_DISABLE_TELEMETRY: true
-                    STORYBOOK_INIT_EMPTY_TYPE: react-vite-ts
-                name: Storybook init for features
-    test-portable-stories:
-        executor:
-            class: medium
-            name: sb_playwright
-        parameters:
-            directory:
-                type: string
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
+                  IN_STORYBOOK_SANDBOX: true
+                  STORYBOOK_DISABLE_TELEMETRY: true
+                  STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
+                name: Storybook init from empty directory (NPM)
+      - when:
+          condition:
+            equal:
+              - yarn2
+              - << parameters.packageManager >>
+          steps:
             - run:
-                command: yarn install --no-immutable
-                environment:
-                    YARN_ENABLE_IMMUTABLE_INSTALLS: false
-                name: Install dependencies
-                working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
-            - run:
-                command: yarn jest
-                name: Run Jest tests
-                working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
-            - run:
-                command: yarn vitest
-                name: Run Vitest tests
-                working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
-            - run:
-                command: yarn playwright-ct
-                name: Run Playwright CT tests
-                working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
-            - run:
-                command: yarn cypress
-                name: Run Cypress CT tests
-                working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
-            - report-workflow-on-failure
-    test-runner-dev:
-        executor:
-            class: large
-            name: sb_playwright
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: yarn task --task test-runner-dev --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner-dev) --no-link --start-from=never --junit
-                name: Running Test Runner in Dev mode
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner-dev)
-            - store_test_results:
-                path: test-results
-    test-runner-production:
-        executor:
-            class: medium+
-            name: sb_playwright
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
+                background: true
+                command: |
+                  cd code
+                  yarn local-registry --open
+                name: Verdaccio
             - run:
                 command: |
-                    TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner)
-                    cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
-                name: Install sandbox dependencies
-            - start-event-collector
-            - run:
-                command: yarn task --task test-runner --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner) --no-link --start-from=never --junit
-                environment:
-                    STORYBOOK_TELEMETRY_DEBUG: 1
-                    STORYBOOK_TELEMETRY_URL: http://localhost:6007/event-log
-                name: Running Test Runner
-            - run:
-                command: yarn --cwd scripts jiti ./event-log-checker.ts test-run $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner)
-                name: Check Telemetry
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner)
-            - store_test_results:
-                path: test-results
-    test-yarn-pnp:
-        executor:
-            class: medium
-            name: sb_playwright
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
-            - run:
-                command: yarn install --no-immutable
-                environment:
-                    YARN_ENABLE_IMMUTABLE_INSTALLS: false
-                name: Install dependencies
-                working_directory: test-storybooks/yarn-pnp
-            - run:
-                command: yarn storybook --smoke-test
-                name: Run Storybook smoke test
-                working_directory: test-storybooks/yarn-pnp
-            - report-workflow-on-failure
-    unit-tests:
-        executor:
-            class: xlarge
-            name: sb_playwright
-        parallelism: 2
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
+                name: Wait on Verdaccio
             - run:
                 command: |
-                    cd code
-                    TEST_FILES=$(circleci tests glob "**/*.{test,spec,stories}.{ts,tsx,js,jsx,cjs}" | sed "/^e2e-tests\//d" | sed "/^node_modules\//d")
-                    echo "$TEST_FILES" | circleci tests run --command="xargs yarn test --reporter=junit --reporter=default --outputFile=../test-results/junit-${CIRCLE_NODE_INDEX}.xml" --verbose
-                name: Run tests
-            - store_test_results:
-                path: test-results
-            - report-workflow-on-failure
-            - cancel-workflow-on-failure
-    vitest-integration:
-        executor:
-            class: xlarge
-            name: sb_playwright
-        parallelism: << parameters.parallelism >>
-        parameters:
-            parallelism:
-                type: integer
-        steps:
-            - git-shallow-clone/checkout_advanced:
-                clone_options: --depth 1 --verbose
-            - attach_workspace:
-                at: .
+                  cd ..
+                  mkdir empty-<< parameters.template >>
+                  cd empty-<< parameters.template >>
+                  yarn set version berry
+                  yarn config set registry http://localhost:6001
+                  yarn dlx storybook init --yes --package-manager yarn2
+                  yarn storybook --smoke-test
+                environment:
+                  IN_STORYBOOK_SANDBOX: true
+                  STORYBOOK_DISABLE_TELEMETRY: true
+                  STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
+                name: Storybook init from empty directory (Yarn 2)
+      - when:
+          condition:
+            equal:
+              - pnpm
+              - << parameters.packageManager >>
+          steps:
+            - run:
+                background: true
+                command: |
+                  cd code
+                  yarn local-registry --open
+                name: Verdaccio
             - run:
                 command: |
-                    TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task vitest-integration)
-                    cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
-                name: Install sandbox dependencies
-            - start-event-collector
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
+                name: Wait on Verdaccio
             - run:
-                command: yarn task --task vitest-integration --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task vitest-integration) --no-link --start-from=never --junit
+                command: |
+                  cd ..
+                  mkdir empty-<< parameters.template >>
+                  cd empty-<< parameters.template >>
+                  npm i -g pnpm
+                  pnpm config set registry http://localhost:6001
+                  pnpm dlx storybook init --yes --package-manager pnpm
+                  pnpm run storybook --smoke-test
                 environment:
-                    STORYBOOK_TELEMETRY_DEBUG: 1
-                    STORYBOOK_TELEMETRY_URL: http://localhost:6007/event-log
-                name: Running story tests in Vitest
+                  IN_STORYBOOK_SANDBOX: true
+                  STORYBOOK_DISABLE_TELEMETRY: true
+                  STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
+                name: Storybook init from empty directory (PNPM)
+      - when:
+          condition:
+            equal:
+              - react-vite-ts
+              - << parameters.template >>
+          steps:
             - run:
-                command: yarn --cwd scripts jiti ./event-log-checker.ts test-run $(yarn get-template --cadence << pipeline.parameters.workflow >> --task vitest-integration)
-                name: Check Telemetry
-            - report-workflow-on-failure:
-                template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task vitest-integration)
-            - store_test_results:
-                path: test-results
+                background: true
+                command: |
+                  cd code
+                  yarn local-registry --open
+                name: Verdaccio
+            - run:
+                command: |
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
+                name: Wait on Verdaccio
+            - run:
+                command: |
+                  cd ..
+                  mkdir empty-<< parameters.template >>-no-install
+                  cd empty-<< parameters.template >>-no-install
+                  npx storybook init --yes --skip-install
+                  npm install
+                  npm run build-storybook
+                environment:
+                  IN_STORYBOOK_SANDBOX: true
+                  STORYBOOK_DISABLE_TELEMETRY: true
+                  STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
+                name: Storybook init from empty directory (--skip-install)
+      - report-workflow-on-failure
+  test-init-empty-windows:
+    executor: win/default
+    parameters:
+      packageManager:
+        type: string
+      template:
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            choco install nodejs-lts --version=22.11.0 -y
+            corepack enable
+          name: Setup Node & Yarn on Windows
+          shell: bash.exe
+      - run:
+          command: yarn install
+          name: Install code dependencies
+          shell: bash.exe
+          working_directory: code
+      - run:
+          command: yarn install
+          name: Install script dependencies
+          shell: bash.exe
+          working_directory: scripts
+      - when:
+          condition:
+            equal:
+              - npm
+              - << parameters.packageManager >>
+          steps:
+            - run:
+                background: true
+                command: |
+                  cd code
+                  yarn local-registry --open
+                name: Verdaccio
+                shell: bash.exe
+            - run:
+                command: |
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
+                name: Wait on Verdaccio
+                shell: bash.exe
+            - run:
+                command: |
+                  cd ..
+                  mkdir empty-<< parameters.template >>
+                  cd empty-<< parameters.template >>
+                  npm set registry http://localhost:6001
+                  npx storybook init --yes --package-manager npm
+                  npm run storybook -- --smoke-test
+                environment:
+                  IN_STORYBOOK_SANDBOX: true
+                  STORYBOOK_DISABLE_TELEMETRY: true
+                  STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
+                name: Storybook init from empty directory (Windows NPM)
+                shell: bash.exe
+      - when:
+          condition:
+            equal:
+              - yarn2
+              - << parameters.packageManager >>
+          steps:
+            - run:
+                background: true
+                command: |
+                  cd code
+                  yarn local-registry --open
+                name: Verdaccio
+                shell: bash.exe
+            - run:
+                command: |
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
+                name: Wait on Verdaccio
+                shell: bash.exe
+            - run:
+                command: |
+                  cd ..
+                  mkdir empty-<< parameters.template >>
+                  cd empty-<< parameters.template >>
+                  yarn set version berry
+                  yarn config set registry http://localhost:6001
+                  yarn dlx storybook init --yes --package-manager yarn2
+                  yarn storybook --smoke-test
+                environment:
+                  IN_STORYBOOK_SANDBOX: true
+                  STORYBOOK_DISABLE_TELEMETRY: true
+                  STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
+                name: Storybook init from empty directory (Windows Yarn 2)
+                shell: bash.exe
+      - when:
+          condition:
+            equal:
+              - pnpm
+              - << parameters.packageManager >>
+          steps:
+            - run:
+                background: true
+                command: |
+                  cd code
+                  yarn local-registry --open
+                name: Verdaccio
+                shell: bash.exe
+            - run:
+                command: |
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
+                name: Wait on Verdaccio
+                shell: bash.exe
+            - run:
+                command: |
+                  cd ..
+                  mkdir empty-<< parameters.template >>
+                  cd empty-<< parameters.template >>
+                  npm i -g pnpm
+                  pnpm config set registry http://localhost:6001
+                  pnpm dlx storybook init --yes --package-manager pnpm
+                  pnpm run storybook --smoke-test
+                environment:
+                  IN_STORYBOOK_SANDBOX: true
+                  STORYBOOK_DISABLE_TELEMETRY: true
+                  STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
+                name: Storybook init from empty directory (Windows PNPM)
+                shell: bash.exe
+      - when:
+          condition:
+            equal:
+              - react-vite-ts
+              - << parameters.template >>
+          steps:
+            - run:
+                background: true
+                command: |
+                  cd code
+                  yarn local-registry --open
+                name: Verdaccio
+                shell: bash.exe
+            - run:
+                command: |
+                  cd code
+                  yarn wait-on tcp:127.0.0.1:6001
+                  yarn wait-on tcp:127.0.0.1:6002
+                name: Wait on Verdaccio
+                shell: bash.exe
+            - run:
+                command: |
+                  cd ..
+                  mkdir empty-<< parameters.template >>-no-install
+                  cd empty-<< parameters.template >>-no-install
+                  npx storybook init --yes --skip-install
+                  npm install
+                  npm run build-storybook
+                environment:
+                  IN_STORYBOOK_SANDBOX: true
+                  STORYBOOK_DISABLE_TELEMETRY: true
+                  STORYBOOK_INIT_EMPTY_TYPE: << parameters.template >>
+                name: Storybook init from empty directory (Windows --skip-install)
+                shell: bash.exe
+  test-init-features:
+    executor:
+      class: small
+      name: sb_node_22_browsers
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          background: true
+          command: |
+            cd code
+            yarn local-registry --open
+          name: Verdaccio
+      - run:
+          command: |
+            cd code
+            yarn wait-on tcp:127.0.0.1:6001
+            yarn wait-on tcp:127.0.0.1:6002
+          name: Wait on Verdaccio
+      - run:
+          command: |
+            cd ..
+            mkdir features-1
+            cd features-1
+            npm set registry http://localhost:6001
+            npx create-storybook --yes --package-manager npm --features dev docs test
+            npx vitest
+          environment:
+            IN_STORYBOOK_SANDBOX: true
+            STORYBOOK_DISABLE_TELEMETRY: true
+            STORYBOOK_INIT_EMPTY_TYPE: react-vite-ts
+          name: Storybook init for features
+  test-portable-stories:
+    executor:
+      class: medium
+      name: sb_playwright
+    parameters:
+      directory:
+        type: string
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: yarn install --no-immutable
+          environment:
+            YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          name: Install dependencies
+          working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
+      - run:
+          command: yarn jest
+          name: Run Jest tests
+          working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
+      - run:
+          command: yarn vitest
+          name: Run Vitest tests
+          working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
+      - run:
+          command: yarn playwright-ct
+          name: Run Playwright CT tests
+          working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
+      - run:
+          command: yarn cypress
+          name: Run Cypress CT tests
+          working_directory: test-storybooks/portable-stories-kitchen-sink/<< parameters.directory >>
+      - report-workflow-on-failure
+  test-runner-dev:
+    executor:
+      class: large
+      name: sb_playwright
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: yarn task --task test-runner-dev --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner-dev) --no-link --start-from=never --junit
+          name: Running Test Runner in Dev mode
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner-dev)
+      - store_test_results:
+          path: test-results
+  test-runner-production:
+    executor:
+      class: medium+
+      name: sb_playwright
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner)
+            cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
+          name: Install sandbox dependencies
+      - start-event-collector
+      - run:
+          command: yarn task --task test-runner --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner) --no-link --start-from=never --junit
+          environment:
+            STORYBOOK_TELEMETRY_DEBUG: 1
+            STORYBOOK_TELEMETRY_URL: http://localhost:6007/event-log
+          name: Running Test Runner
+      - run:
+          command: yarn --cwd scripts jiti ./event-log-checker.ts test-run $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner)
+          name: Check Telemetry
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task test-runner)
+      - store_test_results:
+          path: test-results
+  test-yarn-pnp:
+    executor:
+      class: medium
+      name: sb_playwright
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: yarn install --no-immutable
+          environment:
+            YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          name: Install dependencies
+          working_directory: test-storybooks/yarn-pnp
+      - run:
+          command: yarn storybook --smoke-test
+          name: Run Storybook smoke test
+          working_directory: test-storybooks/yarn-pnp
+      - report-workflow-on-failure
+  unit-tests:
+    executor:
+      class: xlarge
+      name: sb_playwright
+    parallelism: 2
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            cd code
+            TEST_FILES=$(circleci tests glob "**/*.{test,spec,stories}.{ts,tsx,js,jsx,cjs}" | sed "/^e2e-tests\//d" | sed "/^node_modules\//d")
+            echo "$TEST_FILES" | circleci tests run --command="xargs yarn test --reporter=junit --reporter=default --outputFile=../test-results/junit-${CIRCLE_NODE_INDEX}.xml" --verbose
+          name: Run tests
+      - store_test_results:
+          path: test-results
+      - report-workflow-on-failure
+      - cancel-workflow-on-failure
+  vitest-integration:
+    executor:
+      class: xlarge
+      name: sb_playwright
+    parallelism: << parameters.parallelism >>
+    parameters:
+      parallelism:
+        type: integer
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            TEMPLATE=$(yarn get-template --cadence << pipeline.parameters.workflow >> --task vitest-integration)
+            cd sandbox/$(yarn get-sandbox-dir --template $TEMPLATE) && yarn
+          name: Install sandbox dependencies
+      - start-event-collector
+      - run:
+          command: yarn task --task vitest-integration --template $(yarn get-template --cadence << pipeline.parameters.workflow >> --task vitest-integration) --no-link --start-from=never --junit
+          environment:
+            STORYBOOK_TELEMETRY_DEBUG: 1
+            STORYBOOK_TELEMETRY_URL: http://localhost:6007/event-log
+          name: Running story tests in Vitest
+      - run:
+          command: yarn --cwd scripts jiti ./event-log-checker.ts test-run $(yarn get-template --cadence << pipeline.parameters.workflow >> --task vitest-integration)
+          name: Check Telemetry
+      - report-workflow-on-failure:
+          template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task vitest-integration)
+      - store_test_results:
+          path: test-results
 orbs:
-    browser-tools: circleci/browser-tools@1.4.1
-    codecov: codecov/codecov@3.2.4
-    discord: antonioned/discord@0.1.0
-    git-shallow-clone: guitarrapc/git-shallow-clone@2.5.0
-    node: circleci/node@5.2.0
-    nx: nrwl/nx@1.6.2
-    win: circleci/windows@5.0.0
+  browser-tools: circleci/browser-tools@1.4.1
+  codecov: codecov/codecov@3.2.4
+  discord: antonioned/discord@0.1.0
+  git-shallow-clone: guitarrapc/git-shallow-clone@2.5.0
+  node: circleci/node@5.2.0
+  nx: nrwl/nx@1.6.2
+  win: circleci/windows@5.0.0
 parameters:
-    ghBaseBranch:
-        default: next
-        description: The name of the base branch (the target of the PR)
-        type: string
-    ghPrNumber:
-        default: ""
-        description: The PR number
-        type: string
-    workflow:
-        default: skipped
-        description: Which workflow to run
-        enum:
-            - normal
-            - merged
-            - daily
-            - skipped
-            - docs
-        type: enum
+  ghBaseBranch:
+    default: next
+    description: The name of the base branch (the target of the PR)
+    type: string
+  ghPrNumber:
+    default: ''
+    description: The PR number
+    type: string
+  workflow:
+    default: skipped
+    description: Which workflow to run
+    enum:
+      - normal
+      - merged
+      - daily
+      - skipped
+      - docs
+    type: enum
 version: 2.1
 workflows:
-    daily:
-        jobs:
-            - pretty-docs
+  daily:
+    jobs:
+      - pretty-docs
+      - build
+      - lint:
+          requires:
             - build
-            - lint:
-                requires:
-                    - build
-            - knip:
-                requires:
-                    - build
-            - bench-packages:
-                requires:
-                    - build
-            - check
-            - unit-tests:
-                requires:
-                    - build
-            - stories-tests:
-                requires:
-                    - build
-            - script-checks:
-                requires:
-                    - build
-            - chromatic-internal-storybook:
-                requires:
-                    - build
-            - create-sandboxes:
-                parallelism: 34
-                requires:
-                    - build
-            - check-sandboxes:
-                parallelism: 1
-                requires:
-                    - create-sandboxes
-            - chromatic-sandboxes:
-                parallelism: 31
-                requires:
-                    - create-sandboxes
-            - e2e-production:
-                parallelism: 7
-                requires:
-                    - create-sandboxes
-            - e2e-dev:
-                parallelism: 28
-                requires:
-                    - create-sandboxes
-            - test-runner-production:
-                parallelism: 29
-                requires:
-                    - create-sandboxes
-            - vitest-integration:
-                parallelism: 13
-                requires:
-                    - create-sandboxes
-            - test-portable-stories:
-                matrix:
-                    parameters:
-                        directory:
-                            - react
-                            - vue3
-                            - nextjs
-                            - svelte
-                requires:
-                    - build
-            - test-yarn-pnp:
-                requires:
-                    - build
-            - e2e-ui:
-                requires:
-                    - build
-            - e2e-ui-vitest-3:
-                requires:
-                    - build
-            - test-init-features:
-                requires:
-                    - build
-            - test-init-empty:
-                matrix:
-                    parameters:
-                        packageManager:
-                            - npm
-                        template:
-                            - react-vite-ts
-                            - nextjs-ts
-                            - vue-vite-ts
-                            - lit-vite-ts
-                requires:
-                    - build
-            - test-init-empty-windows:
-                matrix:
-                    parameters:
-                        packageManager:
-                            - npm
-                        template:
-                            - react-vite-ts
-                            - nextjs-ts
-                            - vue-vite-ts
-                            - lit-vite-ts
-                requires:
-                    - build
-        when:
-            equal:
-                - daily
-                - << pipeline.parameters.workflow >>
-    docs:
-        jobs:
-            - pretty-docs
-        when:
-            equal:
-                - docs
-                - << pipeline.parameters.workflow >>
-    merged:
-        jobs:
-            - pretty-docs
+      - knip:
+          requires:
             - build
-            - lint:
-                requires:
-                    - build
-            - knip:
-                requires:
-                    - build
-            - bench-packages:
-                requires:
-                    - build
-            - check
-            - unit-tests:
-                requires:
-                    - build
-            - stories-tests:
-                requires:
-                    - build
-            - script-checks:
-                requires:
-                    - build
-            - chromatic-internal-storybook:
-                requires:
-                    - build
-            - coverage:
-                requires:
-                    - unit-tests
-            - create-sandboxes:
-                parallelism: 19
-                requires:
-                    - build
-            - chromatic-sandboxes:
-                parallelism: 16
-                requires:
-                    - create-sandboxes
-            - e2e-production:
-                parallelism: 6
-                requires:
-                    - create-sandboxes
-            - e2e-dev:
-                parallelism: 14
-                requires:
-                    - create-sandboxes
-            - test-runner-production:
-                parallelism: 14
-                requires:
-                    - create-sandboxes
-            - vitest-integration:
-                parallelism: 7
-                requires:
-                    - create-sandboxes
-            - check-sandboxes:
-                parallelism: 1
-                requires:
-                    - create-sandboxes
-            - test-portable-stories:
-                matrix:
-                    parameters:
-                        directory:
-                            - react
-                            - vue3
-                            - nextjs
-                            - svelte
-                requires:
-                    - build
-            - test-yarn-pnp:
-                requires:
-                    - build
-            - e2e-ui:
-                requires:
-                    - build
-            - e2e-ui-vitest-3:
-                requires:
-                    - build
-            - test-init-features:
-                requires:
-                    - build
-            - test-init-empty-windows:
-                matrix:
-                    parameters:
-                        packageManager:
-                            - npm
-                        template:
-                            - react-vite-ts
-                            - nextjs-ts
-                            - vue-vite-ts
-                            - lit-vite-ts
-                requires:
-                    - build
-        when:
-            equal:
-                - merged
-                - << pipeline.parameters.workflow >>
-    normal:
-        jobs:
-            - pretty-docs
+      - bench-packages:
+          requires:
             - build
-            - lint:
-                requires:
-                    - build
-            - knip:
-                requires:
-                    - build
-            - bench-packages:
-                requires:
-                    - build
-            - check
-            - unit-tests:
-                requires:
-                    - build
-            - stories-tests:
-                requires:
-                    - build
-            - script-checks:
-                requires:
-                    - build
-            - chromatic-internal-storybook:
-                requires:
-                    - build
-            - coverage:
-                requires:
-                    - unit-tests
-            - create-sandboxes:
-                parallelism: 13
-                requires:
-                    - build
-            - chromatic-sandboxes:
-                parallelism: 10
-                requires:
-                    - create-sandboxes
-            - e2e-production:
-                parallelism: 6
-                requires:
-                    - create-sandboxes
-            - e2e-dev:
-                parallelism: 8
-                requires:
-                    - create-sandboxes
-            - test-runner-production:
-                parallelism: 8
-                requires:
-                    - create-sandboxes
-            - vitest-integration:
-                parallelism: 5
-                requires:
-                    - create-sandboxes
-            - check-sandboxes:
-                parallelism: 1
-                requires:
-                    - create-sandboxes
-            - test-yarn-pnp:
-                requires:
-                    - build
-            - e2e-ui:
-                requires:
-                    - build
-            - e2e-ui-vitest-3:
-                requires:
-                    - build
-            - test-init-features:
-                requires:
-                    - build
-            - test-portable-stories:
-                matrix:
-                    parameters:
-                        directory:
-                            - react
-                            - vue3
-                            - nextjs
-                            - svelte
-                requires:
-                    - build
-        when:
-            equal:
-                - normal
-                - << pipeline.parameters.workflow >>
-
+      - check
+      - unit-tests:
+          requires:
+            - build
+      - stories-tests:
+          requires:
+            - build
+      - script-checks:
+          requires:
+            - build
+      - chromatic-internal-storybook:
+          requires:
+            - build
+      - create-sandboxes:
+          parallelism: 34
+          requires:
+            - build
+      - check-sandboxes:
+          parallelism: 1
+          requires:
+            - create-sandboxes
+      - chromatic-sandboxes:
+          parallelism: 31
+          requires:
+            - create-sandboxes
+      - e2e-production:
+          parallelism: 7
+          requires:
+            - create-sandboxes
+      - e2e-dev:
+          parallelism: 28
+          requires:
+            - create-sandboxes
+      - test-runner-production:
+          parallelism: 29
+          requires:
+            - create-sandboxes
+      - vitest-integration:
+          parallelism: 13
+          requires:
+            - create-sandboxes
+      - test-portable-stories:
+          matrix:
+            parameters:
+              directory:
+                - react
+                - vue3
+                - nextjs
+                - svelte
+          requires:
+            - build
+      - test-yarn-pnp:
+          requires:
+            - build
+      - e2e-ui:
+          requires:
+            - build
+      - e2e-ui-vitest-3:
+          requires:
+            - build
+      - test-init-features:
+          requires:
+            - build
+      - test-init-empty:
+          matrix:
+            parameters:
+              packageManager:
+                - npm
+              template:
+                - react-vite-ts
+                - nextjs-ts
+                - vue-vite-ts
+                - lit-vite-ts
+          requires:
+            - build
+      - test-init-empty-windows:
+          matrix:
+            parameters:
+              packageManager:
+                - npm
+              template:
+                - react-vite-ts
+                - nextjs-ts
+                - vue-vite-ts
+                - lit-vite-ts
+          requires:
+            - build
+    when:
+      equal:
+        - daily
+        - << pipeline.parameters.workflow >>
+  docs:
+    jobs:
+      - pretty-docs
+    when:
+      equal:
+        - docs
+        - << pipeline.parameters.workflow >>
+  merged:
+    jobs:
+      - pretty-docs
+      - build
+      - lint:
+          requires:
+            - build
+      - knip:
+          requires:
+            - build
+      - bench-packages:
+          requires:
+            - build
+      - check
+      - unit-tests:
+          requires:
+            - build
+      - stories-tests:
+          requires:
+            - build
+      - script-checks:
+          requires:
+            - build
+      - chromatic-internal-storybook:
+          requires:
+            - build
+      - coverage:
+          requires:
+            - unit-tests
+      - create-sandboxes:
+          parallelism: 19
+          requires:
+            - build
+      - chromatic-sandboxes:
+          parallelism: 16
+          requires:
+            - create-sandboxes
+      - e2e-production:
+          parallelism: 6
+          requires:
+            - create-sandboxes
+      - e2e-dev:
+          parallelism: 14
+          requires:
+            - create-sandboxes
+      - test-runner-production:
+          parallelism: 14
+          requires:
+            - create-sandboxes
+      - vitest-integration:
+          parallelism: 7
+          requires:
+            - create-sandboxes
+      - check-sandboxes:
+          parallelism: 1
+          requires:
+            - create-sandboxes
+      - test-portable-stories:
+          matrix:
+            parameters:
+              directory:
+                - react
+                - vue3
+                - nextjs
+                - svelte
+          requires:
+            - build
+      - test-yarn-pnp:
+          requires:
+            - build
+      - e2e-ui:
+          requires:
+            - build
+      - e2e-ui-vitest-3:
+          requires:
+            - build
+      - test-init-features:
+          requires:
+            - build
+      - test-init-empty-windows:
+          matrix:
+            parameters:
+              packageManager:
+                - npm
+              template:
+                - react-vite-ts
+                - nextjs-ts
+                - vue-vite-ts
+                - lit-vite-ts
+          requires:
+            - build
+    when:
+      equal:
+        - merged
+        - << pipeline.parameters.workflow >>
+  normal:
+    jobs:
+      - pretty-docs
+      # - build
+      # - lint:
+      #     requires:
+      #         - build
+      # - knip:
+      #     requires:
+      #         - build
+      # - bench-packages:
+      #     requires:
+      #         - build
+      # - check
+      # - unit-tests:
+      #     requires:
+      #         - build
+      # - stories-tests:
+      #     requires:
+      #         - build
+      # - script-checks:
+      #     requires:
+      #         - build
+      # - chromatic-internal-storybook:
+      #     requires:
+      #         - build
+      # - coverage:
+      #     requires:
+      #         - unit-tests
+      # - create-sandboxes:
+      #     parallelism: 13
+      #     requires:
+      #         - build
+      # - chromatic-sandboxes:
+      #     parallelism: 10
+      #     requires:
+      #         - create-sandboxes
+      # - e2e-production:
+      #     parallelism: 6
+      #     requires:
+      #         - create-sandboxes
+      # - e2e-dev:
+      #     parallelism: 8
+      #     requires:
+      #         - create-sandboxes
+      # - test-runner-production:
+      #     parallelism: 8
+      #     requires:
+      #         - create-sandboxes
+      # - vitest-integration:
+      #     parallelism: 5
+      #     requires:
+      #         - create-sandboxes
+      # - check-sandboxes:
+      #     parallelism: 1
+      #     requires:
+      #         - create-sandboxes
+      # - test-yarn-pnp:
+      #     requires:
+      #         - build
+      # - e2e-ui:
+      #     requires:
+      #         - build
+      # - e2e-ui-vitest-3:
+      #     requires:
+      #         - build
+      # - test-init-features:
+      #     requires:
+      #         - build
+      # - test-portable-stories:
+      #     matrix:
+      #         parameters:
+      #             directory:
+      #                 - react
+      #                 - vue3
+      #                 - nextjs
+      #                 - svelte
+      #     requires:
+      #         - build
+    when:
+      equal:
+        - normal
+        - << pipeline.parameters.workflow >>

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -25,11 +25,11 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           PR_REF_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          if  [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+          if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
             export BRANCH=pull/${{ github.event.pull_request.number }}/head
-            elif [ "${{ github.event_name }}" = "push" ]; then
+          elif [ "${{ github.event_name }}" = "push" ]; then
             export BRANCH="$REF_NAME"
-            else
+          else
             export BRANCH="$PR_REF_NAME"
           fi
           echo "$BRANCH"
@@ -41,14 +41,43 @@ jobs:
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'pull_request_target' && (contains(github.event.pull_request.labels.*.name, 'ci:normal'))
-        run: echo "workflow=normal" >> $GITHUB_ENV
-      - if: github.event_name == 'pull_request_target' && (contains(github.event.pull_request.labels.*.name, 'ci:docs'))
-        run: echo "workflow=docs" >> $GITHUB_ENV
-      - if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci:merged')
-        run: echo "workflow=merged" >> $GITHUB_ENV
-      - if: github.event_name == 'pull_request_target' && (contains(github.event.pull_request.labels.*.name, 'ci:daily'))
-        run: echo "workflow=daily" >> $GITHUB_ENV
+      # We must reset the workflow because it is reused in future runs even if the workflow should not be triggered.
+      # E.g. if "ci:normal" was set in a previous run, but this new run only adds a "bug" label, CI would still end up having "ci:normal" in the environment variable.
+      - name: Reset workflow
+        run: echo "workflow=" >> $GITHUB_ENV
+      - name: Determine workflow from labels on pull_request_target labeled event
+        if: github.event_name == 'pull_request_target' && github.event.action == 'labeled'
+        run: |
+          case "${{ github.event.label.name }}" in
+            ci:normal) echo "workflow=normal" >> $GITHUB_ENV ;;
+            ci:docs) echo "workflow=docs" >> $GITHUB_ENV ;;
+            ci:merged) echo "workflow=merged" >> $GITHUB_ENV ;;
+            ci:daily) echo "workflow=daily" >> $GITHUB_ENV ;;
+          esac
+      - name: Determine workflow from labels on push event
+        if: github.event_name == 'push' && github.event.pull_request != null
+        run: |
+          LABELS=$(jq -r '.pull_request.labels[].name' <<<"${{ toJSON(github.event) }}")
+          for label in $LABELS; do
+            case "$label" in
+              ci:normal)
+                echo "workflow=normal" >> $GITHUB_ENV
+                break
+                ;;
+              ci:docs)
+                echo "workflow=docs" >> $GITHUB_ENV
+                break
+                ;;
+              ci:merged)
+                echo "workflow=merged" >> $GITHUB_ENV
+                break
+                ;;
+              ci:daily)
+                echo "workflow=daily" >> $GITHUB_ENV
+                break
+                ;;
+            esac
+          done
     outputs:
       workflow: ${{ env.workflow }}
       ghBaseBranch: ${{ github.event.pull_request.base.ref }}
@@ -59,10 +88,10 @@ jobs:
     needs: [get-branch, get-parameters]
     if: github.repository_owner == 'storybookjs' && needs.get-parameters.outputs.workflow != ''
     steps:
-      - name: Trigger Normal tests
+      - name: Trigger CircleCI workflow
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline'
-          method: 'POST'
+          url: "https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline"
+          method: "POST"
           customHeaders: '{"Content-Type": "application/json", "Circle-Token": "${{ secrets.CIRCLE_CI_TOKEN }}"}'
           data: '{ "branch": "${{needs.get-branch.outputs.branch}}", "parameters": ${{toJson(needs.get-parameters.outputs)}} }'

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -1,24 +1,29 @@
 name: Trigger CircleCI workflow
 
 on:
-  # Temporarily using pull_request for experimentation - normally uses pull_request_target
-  # to trigger Circle CI API on forks as well.
-  pull_request:
+  # Use pull_request_target, as we don't need to check out the actual code of the fork in this script.
+  # And this is the only way to trigger the Circle CI API on forks as well.
+  pull_request_target:
     types: [opened, synchronize, labeled, reopened]
   push:
-    # For experimentation, trigger on pushes to any branch
-    # Normally this would only be next/main branches
+    # branches:
+    #   - next
+    #   - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  get-branch2:
+  get-branch:
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
-      - id: get-branch2
+      - id: get-branch
         env:
           # Stored as environment variable to prevent script injection
           REF_NAME: ${{ github.ref_name }}
@@ -36,134 +41,75 @@ jobs:
     outputs:
       branch: ${{ env.branch }}
 
-  get-parameters2:
+  get-parameters:
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
-    # NB: We'll set the job output from the final step (id: set_workflow).
     steps:
-      - name: Reset workflow (start clean)
+      - name: Determine workflow from labeled event
+        if: github.event_name == 'pull_request_target' && github.event.action == 'labeled'
         run: |
-          echo "Resetting workflow env"
-          # ensure workflow env var is empty for the job
-          echo "workflow=" >> $GITHUB_ENV
-
-      - name: Determine workflow from labels on pull_request labeled event
-        if: github.event_name == 'pull_request' && github.event.action == 'labeled'
-        run: |
-          echo "Labeled event detected"
-          echo "Added label: ${{ github.event.label.name }}"
+          echo "PR Labeled event detected with label: ${{ github.event.label.name }}"
           case "${{ github.event.label.name }}" in
             ci:normal) echo "workflow=normal" >> $GITHUB_ENV ;;
             ci:docs)   echo "workflow=docs" >> $GITHUB_ENV ;;
             ci:merged) echo "workflow=merged" >> $GITHUB_ENV ;;
             ci:daily)  echo "workflow=daily" >> $GITHUB_ENV ;;
             *)
-              echo "Label is not a ci: label — leaving workflow empty"
+              echo "Label '${{ github.event.label.name }}' is not a ci: label — leaving workflow empty"
               ;;
           esac
 
-      - name: Determine workflow from labels on push event
+      - name: Determine workflow from push events based on existing labels
         if: github.event_name == 'push'
         run: |
-          echo "Push event detected - checking for associated PR labels"
-          # For push events, we need to find the associated PR and get its labels via GitHub API
-          BRANCH_NAME="$GITHUB_REF_NAME"
-          echo "Current branch: $BRANCH_NAME"
-          echo "Repository: $GITHUB_REPOSITORY"
-          echo "Repository owner: $GITHUB_REPOSITORY_OWNER"
+          echo "Resolving PR number for ref: ${{ github.ref_name }}"
+          PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --json number -q '.[0].number' 2>/dev/null || echo "")
+          echo "Found PR number: $PR_NUMBER"
 
-          # Try different head parameter formats
-          echo "Trying head=$GITHUB_REPOSITORY_OWNER:$BRANCH_NAME"
-          PR_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls?head=$GITHUB_REPOSITORY_OWNER:$BRANCH_NAME&state=open" 2>&1)
-          echo "API Response: $PR_DATA"
-
-          # If that didn't work, try without owner
-          if echo "$PR_DATA" | jq -e '. == [] or . == null' >/dev/null 2>&1; then
-            echo "Trying head=$BRANCH_NAME (same repo)"
-            PR_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-              "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls?head=$BRANCH_NAME&state=open" 2>&1)
-            echo "API Response: $PR_DATA"
+          # If PR number not found, try alternative methods
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Trying alternative PR detection methods..."
+            # Try to find PR by checking recent PRs that might be associated with this branch
+            PR_NUMBER=$(gh pr list --state open --json number,headRefName -q ".[] | select(.headRefName == \"${{ github.ref_name }}\") | .number" 2>/dev/null || echo "")
+            echo "Alternative PR search found: $PR_NUMBER"
           fi
 
-          # Extract first PR from response
-          PR_DATA=$(echo "$PR_DATA" | jq -r '.[0]' 2>/dev/null || echo "null")
-
-          if [ "$PR_DATA" != "null" ] && [ "$PR_DATA" != "" ]; then
-            PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number' 2>/dev/null || echo "")
-            if [ -n "$PR_NUMBER" ]; then
-              echo "Found associated PR: #$PR_NUMBER"
-              # Get PR labels
-              LABELS=$(echo "$PR_DATA" | jq -r '.labels[].name' 2>/dev/null || echo "")
-              echo "PR labels: $LABELS"
-            else
-              echo "Could not extract PR number from: $PR_DATA"
-              LABELS=""
-            fi
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Fetching labels for PR #$PR_NUMBER"
+            LABELS=$(gh pr view "$PR_NUMBER" --json labels -q ".labels[].name" 2>/dev/null || echo "")
+            echo "Fetched labels: $LABELS"
           else
-            echo "No associated PR found for branch $BRANCH_NAME"
-            echo "Final API response: $PR_DATA"
+            echo "No PR found for ref: ${{ github.ref_name }}; no labels detected."
             LABELS=""
           fi
+          echo "Detected PR labels: $LABELS"
 
-          for label in $LABELS; do
-            case "$label" in
-              ci:normal)
-                echo "Matched ci:normal"
-                echo "workflow=normal" >> $GITHUB_ENV
-                break
-                ;;
-              ci:docs)
-                echo "Matched ci:docs"
-                echo "workflow=docs" >> $GITHUB_ENV
-                break
-                ;;
-              ci:merged)
-                echo "Matched ci:merged"
-                echo "workflow=merged" >> $GITHUB_ENV
-                break
-                ;;
-              ci:daily)
-                echo "Matched ci:daily"
-                echo "workflow=daily" >> $GITHUB_ENV
-                break
-                ;;
-            esac
-          done
-
-      - name: Finalize workflow output and debug
-        id: set_workflow
-        run: |
-          echo "=== Finalize and debug workflow value ==="
-          # Show what was written into the $GITHUB_ENV file (last lines containing workflow)
-          echo "-- GITHUB_ENV contents for workflow --"
-          grep '^workflow=' $GITHUB_ENV || echo "(no workflow entry found in GITHUB_ENV)"
-
-          # The environment variable 'workflow' should now be available to steps.
-          echo "ENV workflow (the value we will publish): '${workflow}'"
-
-          # For extra safety convert literal 'workflow=' to empty string
-          # and set the job output explicitly via GITHUB_OUTPUT
-          # (this makes needs.get-parameters2.outputs.workflow deterministic)
-          # If workflow is unset, this will write an empty value which is what we want.
-          echo "workflow=${workflow}" >> $GITHUB_OUTPUT
-
-          if [ -z "${workflow}" ]; then
-            echo "FINAL STATE: no ci:* workflow selected (empty)"
-          else
-            echo "FINAL STATE: workflow='${workflow}'"
+          WORKFLOW=""
+          if echo "$LABELS" | grep -q "ci:merged"; then
+            WORKFLOW="merged"
+          elif echo "$LABELS" | grep -q "ci:normal"; then
+            WORKFLOW="normal"
+          elif echo "$LABELS" | grep -q "ci:docs"; then
+            WORKFLOW="docs"
+          elif echo "$LABELS" | grep -q "ci:daily"; then
+            WORKFLOW="daily"
           fi
 
-    # Make job outputs come from the step (set_workflow)
+          if [ -n "$WORKFLOW" ]; then
+            echo "Workflow detected: $WORKFLOW"
+            echo "workflow=$WORKFLOW" >> $GITHUB_ENV
+          else
+            echo "No ci:* label found in PR labels. Skipping CI trigger."
+          fi
     outputs:
-      workflow: ${{ steps.set_workflow.outputs.workflow }}
-      ghBaseBranch: ${{ github.event.pull_request && github.event.pull_request.base.ref || '' }}
-      ghPrNumber: ${{ github.event.pull_request && github.event.pull_request.number || '' }}
+      workflow: ${{ env.workflow }}
+      ghBaseBranch: ${{ github.event.pull_request.base.ref || github.ref_name }}
+      ghPrNumber: ${{ github.event.pull_request.number || '' }}
 
   trigger-circle-ci-workflow:
     runs-on: ubuntu-latest
-    needs: [get-branch2, get-parameters2]
-    if: github.repository_owner == 'storybookjs' && needs.get-parameters2.outputs.workflow != ''
+    needs: [get-branch, get-parameters]
+    if: github.repository_owner == 'storybookjs' && needs.get-parameters.outputs.workflow != ''
     steps:
       - name: Trigger CircleCI workflow
         uses: fjogeleit/http-request-action@v1
@@ -171,4 +117,4 @@ jobs:
           url: "https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline"
           method: "POST"
           customHeaders: '{"Content-Type": "application/json", "Circle-Token": "${{ secrets.CIRCLE_CI_TOKEN }}"}'
-          data: '{ "branch": "${{needs.get-branch2.outputs.branch}}", "parameters": ${{toJson(needs.get-parameters2.outputs)}} }'
+          data: '{ "branch": "${{needs.get-branch.outputs.branch}}", "parameters": ${{toJson(needs.get-parameters.outputs)}} }'

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -40,48 +40,99 @@ jobs:
   get-parameters:
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
+    # NB: We'll set the job output from the final step (id: set_workflow).
     steps:
-      # We must reset the workflow because it is reused in future runs even if the workflow should not be triggered.
-      # E.g. if "ci:normal" was set in a previous run, but this new run only adds a "bug" label, CI would still end up having "ci:normal" in the environment variable.
-      - name: Reset workflow
-        run: echo "workflow=" >> $GITHUB_ENV
+      - name: Reset workflow (start clean)
+        run: |
+          echo "Resetting workflow env"
+          # ensure workflow env var is empty for the job
+          echo "workflow=" >> $GITHUB_ENV
+
+      - name: Debug - show github context
+        run: |
+          echo "=== GITHUB CONTEXT / EVENT INFO ==="
+          echo "event_name: $GITHUB_EVENT_NAME"
+          echo "event.action: ${{ github.event.action || 'null' }}"
+          echo "pull_request exists? : ${{ github.event.pull_request != null }}"
+          echo "---- full event JSON (truncated to 20000 chars) ----"
+          # for readability, print parsed JSON (toJSON is safe here)
+          jq -C . <<<"${{ toJSON(github.event) }}" | sed -n '1,200p'
+
       - name: Determine workflow from labels on pull_request_target labeled event
         if: github.event_name == 'pull_request_target' && github.event.action == 'labeled'
         run: |
+          echo "Labeled event detected"
+          echo "Added label: ${{ github.event.label.name }}"
           case "${{ github.event.label.name }}" in
             ci:normal) echo "workflow=normal" >> $GITHUB_ENV ;;
-            ci:docs) echo "workflow=docs" >> $GITHUB_ENV ;;
+            ci:docs)   echo "workflow=docs" >> $GITHUB_ENV ;;
             ci:merged) echo "workflow=merged" >> $GITHUB_ENV ;;
-            ci:daily) echo "workflow=daily" >> $GITHUB_ENV ;;
+            ci:daily)  echo "workflow=daily" >> $GITHUB_ENV ;;
+            *)
+              echo "Label is not a ci: label — leaving workflow empty"
+              ;;
           esac
+
       - name: Determine workflow from labels on push event
         if: github.event_name == 'push' && github.event.pull_request != null
         run: |
-          LABELS=$(jq -r '.pull_request.labels[].name' <<<"${{ toJSON(github.event) }}")
+          echo "Push event with associated pull_request detected"
+          # Collect labels from the embedded pull_request JSON
+          LABELS=$(jq -r '.pull_request.labels[].name' <<<"${{ toJSON(github.event) }}" 2>/dev/null || true)
+          echo "PR labels: $LABELS"
           for label in $LABELS; do
             case "$label" in
               ci:normal)
+                echo "Matched ci:normal"
                 echo "workflow=normal" >> $GITHUB_ENV
                 break
                 ;;
               ci:docs)
+                echo "Matched ci:docs"
                 echo "workflow=docs" >> $GITHUB_ENV
                 break
                 ;;
               ci:merged)
+                echo "Matched ci:merged"
                 echo "workflow=merged" >> $GITHUB_ENV
                 break
                 ;;
               ci:daily)
+                echo "Matched ci:daily"
                 echo "workflow=daily" >> $GITHUB_ENV
                 break
                 ;;
             esac
           done
+
+      - name: Finalize workflow output and debug
+        id: set_workflow
+        run: |
+          echo "=== Finalize and debug workflow value ==="
+          # Show what was written into the $GITHUB_ENV file (last lines containing workflow)
+          echo "-- GITHUB_ENV contents for workflow --"
+          grep '^workflow=' $GITHUB_ENV || echo "(no workflow entry found in GITHUB_ENV)"
+
+          # The environment variable 'workflow' should now be available to steps.
+          echo "ENV workflow (the value we will publish): '${workflow}'"
+
+          # For extra safety convert literal 'workflow=' to empty string
+          # and set the job output explicitly via GITHUB_OUTPUT
+          # (this makes needs.get-parameters.outputs.workflow deterministic)
+          # If workflow is unset, this will write an empty value which is what we want.
+          echo "workflow=${workflow}" >> $GITHUB_OUTPUT
+
+          if [ -z "${workflow}" ]; then
+            echo "FINAL STATE: no ci:* workflow selected (empty)"
+          else
+            echo "FINAL STATE: workflow='${workflow}'"
+          fi
+
+    # Make job outputs come from the step (set_workflow)
     outputs:
-      workflow: ${{ env.workflow }}
-      ghBaseBranch: ${{ github.event.pull_request.base.ref }}
-      ghPrNumber: ${{ github.event.pull_request.number }}
+      workflow: ${{ steps.set_workflow.outputs.workflow }}
+      ghBaseBranch: ${{ github.event.pull_request && github.event.pull_request.base.ref || '' }}
+      ghPrNumber: ${{ github.event.pull_request && github.event.pull_request.number || '' }}
 
   trigger-circle-ci-workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -1,25 +1,24 @@
 name: Trigger CircleCI workflow
 
 on:
-  # Use pull_request_target, as we don't need to check out the actual code of the fork in this script.
-  # And this is the only way to trigger the Circle CI API on forks as well.
-  pull_request_target:
+  # Temporarily using pull_request for experimentation - normally uses pull_request_target
+  # to trigger Circle CI API on forks as well.
+  pull_request:
     types: [opened, synchronize, labeled, reopened]
   push:
-    branches:
-      - next
-      - main
+    # For experimentation, trigger on pushes to any branch
+    # Normally this would only be next/main branches
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  get-branch:
+  get-branch2:
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
-      - id: get-branch
+      - id: get-branch2
         env:
           # Stored as environment variable to prevent script injection
           REF_NAME: ${{ github.ref_name }}
@@ -37,7 +36,7 @@ jobs:
     outputs:
       branch: ${{ env.branch }}
 
-  get-parameters:
+  get-parameters2:
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     # NB: We'll set the job output from the final step (id: set_workflow).
@@ -48,18 +47,8 @@ jobs:
           # ensure workflow env var is empty for the job
           echo "workflow=" >> $GITHUB_ENV
 
-      - name: Debug - show github context
-        run: |
-          echo "=== GITHUB CONTEXT / EVENT INFO ==="
-          echo "event_name: $GITHUB_EVENT_NAME"
-          echo "event.action: ${{ github.event.action || 'null' }}"
-          echo "pull_request exists? : ${{ github.event.pull_request != null }}"
-          echo "---- full event JSON (truncated to 20000 chars) ----"
-          # for readability, print parsed JSON (toJSON is safe here)
-          jq -C . <<<"${{ toJSON(github.event) }}" | sed -n '1,200p'
-
-      - name: Determine workflow from labels on pull_request_target labeled event
-        if: github.event_name == 'pull_request_target' && github.event.action == 'labeled'
+      - name: Determine workflow from labels on pull_request labeled event
+        if: github.event_name == 'pull_request' && github.event.action == 'labeled'
         run: |
           echo "Labeled event detected"
           echo "Added label: ${{ github.event.label.name }}"
@@ -74,12 +63,49 @@ jobs:
           esac
 
       - name: Determine workflow from labels on push event
-        if: github.event_name == 'push' && github.event.pull_request != null
+        if: github.event_name == 'push'
         run: |
-          echo "Push event with associated pull_request detected"
-          # Collect labels from the embedded pull_request JSON
-          LABELS=$(jq -r '.pull_request.labels[].name' <<<"${{ toJSON(github.event) }}" 2>/dev/null || true)
-          echo "PR labels: $LABELS"
+          echo "Push event detected - checking for associated PR labels"
+          # For push events, we need to find the associated PR and get its labels via GitHub API
+          BRANCH_NAME="$GITHUB_REF_NAME"
+          echo "Current branch: $BRANCH_NAME"
+          echo "Repository: $GITHUB_REPOSITORY"
+          echo "Repository owner: $GITHUB_REPOSITORY_OWNER"
+
+          # Try different head parameter formats
+          echo "Trying head=$GITHUB_REPOSITORY_OWNER:$BRANCH_NAME"
+          PR_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls?head=$GITHUB_REPOSITORY_OWNER:$BRANCH_NAME&state=open" 2>&1)
+          echo "API Response: $PR_DATA"
+
+          # If that didn't work, try without owner
+          if echo "$PR_DATA" | jq -e '. == [] or . == null' >/dev/null 2>&1; then
+            echo "Trying head=$BRANCH_NAME (same repo)"
+            PR_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls?head=$BRANCH_NAME&state=open" 2>&1)
+            echo "API Response: $PR_DATA"
+          fi
+
+          # Extract first PR from response
+          PR_DATA=$(echo "$PR_DATA" | jq -r '.[0]' 2>/dev/null || echo "null")
+
+          if [ "$PR_DATA" != "null" ] && [ "$PR_DATA" != "" ]; then
+            PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number' 2>/dev/null || echo "")
+            if [ -n "$PR_NUMBER" ]; then
+              echo "Found associated PR: #$PR_NUMBER"
+              # Get PR labels
+              LABELS=$(echo "$PR_DATA" | jq -r '.labels[].name' 2>/dev/null || echo "")
+              echo "PR labels: $LABELS"
+            else
+              echo "Could not extract PR number from: $PR_DATA"
+              LABELS=""
+            fi
+          else
+            echo "No associated PR found for branch $BRANCH_NAME"
+            echo "Final API response: $PR_DATA"
+            LABELS=""
+          fi
+
           for label in $LABELS; do
             case "$label" in
               ci:normal)
@@ -118,7 +144,7 @@ jobs:
 
           # For extra safety convert literal 'workflow=' to empty string
           # and set the job output explicitly via GITHUB_OUTPUT
-          # (this makes needs.get-parameters.outputs.workflow deterministic)
+          # (this makes needs.get-parameters2.outputs.workflow deterministic)
           # If workflow is unset, this will write an empty value which is what we want.
           echo "workflow=${workflow}" >> $GITHUB_OUTPUT
 
@@ -136,8 +162,8 @@ jobs:
 
   trigger-circle-ci-workflow:
     runs-on: ubuntu-latest
-    needs: [get-branch, get-parameters]
-    if: github.repository_owner == 'storybookjs' && needs.get-parameters.outputs.workflow != ''
+    needs: [get-branch2, get-parameters2]
+    if: github.repository_owner == 'storybookjs' && needs.get-parameters2.outputs.workflow != ''
     steps:
       - name: Trigger CircleCI workflow
         uses: fjogeleit/http-request-action@v1
@@ -145,4 +171,4 @@ jobs:
           url: "https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline"
           method: "POST"
           customHeaders: '{"Content-Type": "application/json", "Circle-Token": "${{ secrets.CIRCLE_CI_TOKEN }}"}'
-          data: '{ "branch": "${{needs.get-branch.outputs.branch}}", "parameters": ${{toJson(needs.get-parameters.outputs)}} }'
+          data: '{ "branch": "${{needs.get-branch2.outputs.branch}}", "parameters": ${{toJson(needs.get-parameters2.outputs)}} }'


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When we create PRs and later update labels e.g. "bug" or "patch:yes", etc. they end up triggering a whole CI run which is bad. They can also cancel an already running CI process which is even worse. This PR attempts to fix that, by changing the checking to only trigger specifically if the added label is one of the ci:* ones.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow selection clarified to pick pipelines based on PR labels and on push events tied to PRs; workflow state reset at start.
  * Parameter and branch passing standardized across jobs; downstream payload references normalized.
  * New public outputs exposed: ghBaseBranch and ghPrNumber.
  * Trigger step renamed to "Trigger CircleCI workflow".

Note: No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->