### PR TITLE
Addon-A11y: Fix a11y postinstall

### DIFF
--- a/code/addons/a11y/src/postinstall.ts
+++ b/code/addons/a11y/src/postinstall.ts
@@ -1,32 +1,29 @@
-// eslint-disable-next-line depend/ban-dependencies
-import { execa } from 'execa';
+import { JsPackageManagerFactory } from 'storybook/internal/common';
 
 import type { PostinstallOptions } from '../../../lib/cli-storybook/src/add';
 
-const $ = execa({
-  preferLocal: true,
-  stdio: 'inherit',
-  // we stream the stderr to the console
-  reject: false,
-});
-
 export default async function postinstall(options: PostinstallOptions) {
-  const command = ['storybook', 'automigrate', 'addon-a11y-addon-test'];
+  const args = ['automigrate', 'addon-a11y-addon-test'];
 
-  command.push('--loglevel', 'silent');
-  command.push('--skip-doctor');
+  args.push('--loglevel', 'silent');
+  args.push('--skip-doctor');
 
   if (options.yes) {
-    command.push('--yes');
+    args.push('--yes');
   }
 
   if (options.packageManager) {
-    command.push('--package-manager', options.packageManager);
+    args.push('--package-manager', options.packageManager);
   }
 
   if (options.configDir) {
-    command.push('--config-dir', `"${options.configDir}"`);
+    args.push('--config-dir', options.configDir);
   }
 
-  await $`${command.join(' ')}`;
+  const jsPackageManager = JsPackageManagerFactory.getPackageManager({
+    force: options.packageManager,
+    configDir: options.configDir,
+  });
+
+  await jsPackageManager.runPackageCommand('storybook', args);
 }

--- a/code/lib/cli-storybook/src/automigrate/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/index.ts
@@ -324,17 +324,19 @@ export async function runFixes({
             break;
           }
         } else if (promptType === 'auto') {
-          const shouldRun = await prompt.confirm(
-            {
-              message: `Do you want to run the '${picocolors.cyan(f.id)}' migration on your project?`,
-              initialValue: f.defaultSelected ?? true,
-            },
-            {
-              onCancel: () => {
-                throw new Error();
-              },
-            }
-          );
+          const shouldRun = yes
+            ? true
+            : await prompt.confirm(
+                {
+                  message: `Do you want to run the '${picocolors.cyan(f.id)}' migration on your project?`,
+                  initialValue: f.defaultSelected ?? true,
+                },
+                {
+                  onCancel: () => {
+                    throw new Error();
+                  },
+                }
+              );
           runAnswer = { fix: shouldRun };
         } else if (promptType === 'notification') {
           const shouldContinue = await prompt.confirm(


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32242

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixes an issue of calling an automigration while running the addon-a11y's postinstall script.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automigrations now automatically execute when using the `yes` flag, bypassing interactive confirmation prompts for streamlined, non-interactive workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->