### PR TITLE
Core: Update `getDocsUrl` to add a default `ref` param and set `guide` as ref for links in the Guide

### DIFF
--- a/code/core/src/manager-api/modules/versions.ts
+++ b/code/core/src/manager-api/modules/versions.ts
@@ -49,17 +49,19 @@ export interface SubAPI {
    * Returns the URL of the Storybook documentation for the current version.
    *
    * @param options - The options for the documentation URL.
-   * @param options.asset - Links to the docs-assets directory instead of docs.
+   * @param options.asset - Like subpath, but links to the docs-assets directory.
    * @param options.subpath - The subpath of the documentation URL.
    * @param options.versioned - Whether to include the versioned path.
    * @param options.renderer - Whether to include the renderer path.
+   * @param options.ref - Tracking reference for the docs site. E.g. 'ui', 'error', 'upgrade', etc.
    * @returns {string} The URL of the Storybook Manager documentation.
    */
   getDocsUrl: (options: {
-    asset?: boolean;
+    asset?: string;
     subpath?: string;
     versioned?: boolean;
     renderer?: boolean;
+    ref?: string;
   }) => string;
   /**
    * Checks if an update is available for the Storybook Manager.
@@ -99,7 +101,7 @@ export const init: ModuleFn = ({ store }) => {
       return latest as API_Version;
     },
     // TODO: Move this to it's own "info" module later
-    getDocsUrl: ({ asset, subpath, versioned, renderer }) => {
+    getDocsUrl: ({ asset, subpath = asset, versioned, renderer, ref = 'ui' }) => {
       const {
         versions: { latest, current },
       } = store.getState();
@@ -133,6 +135,10 @@ export const init: ModuleFn = ({ store }) => {
         if (rendererName) {
           url += `?renderer=${normalizeRendererName(rendererName)}`;
         }
+      }
+
+      if (ref) {
+        url += `${url.includes('?') ? '&' : '?'}ref=${ref}`;
       }
 
       if (hash) {

--- a/code/core/src/manager-api/tests/versions.test.js
+++ b/code/core/src/manager-api/tests/versions.test.js
@@ -48,6 +48,38 @@ function createMockStore() {
 
 vi.mock('storybook/internal/client-logger');
 
+const latest = {
+  current: { version: '7.6.1' },
+  latest: { version: '7.6.1' },
+};
+const patchDiff = {
+  current: { version: '7.6.1' },
+  latest: { version: '7.6.10' },
+};
+const minorDiff = {
+  current: { version: '7.2.5' },
+  latest: { version: '7.6.10' },
+};
+const majorDiff = {
+  current: { version: '6.2.1' },
+  latest: { version: '7.6.10' },
+};
+const newerPrerelease = {
+  current: { version: '8.0.0-beta' },
+  latest: { version: '7.6.10' },
+};
+const olderPrerelease = {
+  current: { version: '5.2.1-prerelease.0' },
+  latest: { version: '6.2.1' },
+};
+const prereleaseAvailable = {
+  current: { version: '5.2.1' },
+  latest: { version: '6.2.1-prerelease.0' },
+};
+
+const setVersions = (store, state, versions) =>
+  store.setState({ ...state, versions: { ...state.versions, ...versions } });
+
 describe('versions API', () => {
   it('sets initial state with current version', async () => {
     const store = createMockStore();
@@ -72,9 +104,8 @@ describe('versions API', () => {
 
   it('sets versions in the init function', async () => {
     const store = createMockStore();
-    const { state: initialState, init } = initVersions({
-      store,
-    });
+    const { state: initialState, init } = initVersions({ store });
+
     store.setState(initialState);
     store.setState.mockReset();
 
@@ -91,13 +122,8 @@ describe('versions API', () => {
 
   it('getCurrentVersion works', async () => {
     const store = createMockStore();
-    const {
-      init,
-      api,
-      state: initialState,
-    } = initVersions({
-      store,
-    });
+    const { init, api, state: initialState } = initVersions({ store });
+
     store.setState(initialState);
 
     await init();
@@ -109,13 +135,8 @@ describe('versions API', () => {
 
   it('getLatestVersion works', async () => {
     const store = createMockStore();
-    const {
-      init,
-      api,
-      state: initialState,
-    } = initVersions({
-      store,
-    });
+    const { init, api, state: initialState } = initVersions({ store });
+
     store.setState(initialState);
 
     await init();
@@ -132,174 +153,101 @@ describe('versions API', () => {
 
     it('returns the latest url when current version is latest', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '7.6.1' },
-          latest: { version: '7.6.1' },
-        },
-      });
+      setVersions(store, initialState, latest);
 
-      expect(api.getDocsUrl({ versioned: true })).toEqual('https://storybook.js.org/docs/');
+      expect(api.getDocsUrl({ versioned: true })).toEqual('https://storybook.js.org/docs/?ref=ui');
     });
 
     it('returns the latest url when version has patch diff with latest', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '7.6.1' },
-          latest: { version: '7.6.10' },
-        },
-      });
+      setVersions(store, initialState, patchDiff);
 
-      expect(api.getDocsUrl({ versioned: true })).toEqual('https://storybook.js.org/docs/');
+      expect(api.getDocsUrl({ versioned: true })).toEqual('https://storybook.js.org/docs/?ref=ui');
     });
 
     it('returns the versioned url when current has different docs to latest', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '7.2.5' },
-          latest: { version: '7.6.10' },
-        },
-      });
+      setVersions(store, initialState, minorDiff);
 
-      expect(api.getDocsUrl({ versioned: true })).toEqual('https://storybook.js.org/docs/7.2/');
+      expect(api.getDocsUrl({ versioned: true })).toEqual(
+        'https://storybook.js.org/docs/7.2/?ref=ui'
+      );
     });
 
     it('returns the versioned url when current is a prerelease', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '8.0.0-beta' },
-          latest: { version: '7.6.10' },
-        },
-      });
+      setVersions(store, initialState, newerPrerelease);
 
-      expect(api.getDocsUrl({ versioned: true })).toEqual('https://storybook.js.org/docs/8.0/');
+      expect(api.getDocsUrl({ versioned: true })).toEqual(
+        'https://storybook.js.org/docs/8.0/?ref=ui'
+      );
     });
 
     it('returns a url with a renderer query param when "renderer" is true', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '5.2.1' },
-          latest: { version: '5.2.1' },
-        },
-      });
+      const { init, api, state: initialState } = initVersions({ store });
+
+      setVersions(store, initialState, latest);
 
       await init();
 
       global.STORYBOOK_RENDERER = 'vue';
 
       expect(api.getDocsUrl({ renderer: true })).toEqual(
-        'https://storybook.js.org/docs/?renderer=vue'
+        'https://storybook.js.org/docs/?renderer=vue&ref=ui'
       );
     });
 
-    it('returns a url with assets path when "asset" is true', async () => {
+    it('returns a url with a custom ref query param when provided', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '7.6.1' },
-          latest: { version: '7.6.1' },
-        },
-      });
+      setVersions(store, initialState, latest);
 
-      expect(api.getDocsUrl({ asset: true })).toEqual('https://storybook.js.org/docs-assets/7.6/');
+      expect(api.getDocsUrl({ ref: 'custom' })).toEqual(
+        'https://storybook.js.org/docs/?ref=custom'
+      );
     });
 
-    it('returns a url with subpath when provided', async () => {
+    it('returns a url without ref query param when empty', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '7.2.5' },
-          latest: { version: '7.6.10' },
-        },
-      });
+      setVersions(store, initialState, latest);
 
-      expect(api.getDocsUrl({ asset: true, subpath: 'api/doc-block-controls.png' })).toEqual(
-        'https://storybook.js.org/docs-assets/7.2/api/doc-block-controls.png'
+      expect(api.getDocsUrl({ ref: '' })).toEqual('https://storybook.js.org/docs/');
+    });
+
+    it('returns a versioned url with assets path when provided', async () => {
+      const store = createMockStore();
+      const { init, api, state: initialState } = initVersions({ store });
+
+      await init();
+
+      setVersions(store, initialState, latest);
+
+      expect(api.getDocsUrl({ asset: 'api/doc-block-controls.png' })).toEqual(
+        'https://storybook.js.org/docs-assets/7.6/api/doc-block-controls.png?ref=ui'
       );
     });
   });
@@ -307,21 +255,9 @@ describe('versions API', () => {
   describe('versionUpdateAvailable', () => {
     it('matching version', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '5.2.1' },
-          latest: { version: '5.2.1' },
-        },
-      });
+      const { init, api, state: initialState } = initVersions({ store });
+
+      setVersions(store, initialState, latest);
 
       await init();
 
@@ -330,21 +266,9 @@ describe('versions API', () => {
 
     it('new patch version', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '5.2.1' },
-          latest: { version: '5.2.2' },
-        },
-      });
+      const { init, api, state: initialState } = initVersions({ store });
+
+      setVersions(store, initialState, patchDiff);
 
       await init();
 
@@ -353,72 +277,33 @@ describe('versions API', () => {
 
     it('new minor version', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '5.2.1' },
-          latest: { version: '5.3.1' },
-        },
-      });
+      setVersions(store, initialState, minorDiff);
 
       expect(api.versionUpdateAvailable()).toEqual(true);
     });
 
     it('new major version', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '5.2.1' },
-          latest: { version: '6.2.1' },
-        },
-      });
+      setVersions(store, initialState, majorDiff);
 
       expect(api.versionUpdateAvailable()).toEqual(true);
     });
 
     it('new prerelease version', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '5.2.1' },
-          latest: { version: '6.2.1-prerelease.0' },
-        },
-      });
+      setVersions(store, initialState, prereleaseAvailable);
 
       expect(api.versionUpdateAvailable()).toEqual(false);
     });
@@ -429,38 +314,18 @@ describe('versions API', () => {
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '5.2.1-prerelease.0' },
-          latest: { version: '6.2.1' },
-        },
-      });
+      setVersions(store, initialState, olderPrerelease);
 
       expect(api.versionUpdateAvailable()).toEqual(true);
     });
 
     it('from newer prerelease version', async () => {
       const store = createMockStore();
-      const {
-        init,
-        api,
-        state: initialState,
-      } = initVersions({
-        store,
-      });
+      const { init, api, state: initialState } = initVersions({ store });
 
       await init();
 
-      store.setState({
-        ...initialState,
-        versions: {
-          ...initialState.versions,
-          current: { version: '5.2.1-prerelease.0' },
-          latest: { version: '3.2.1' },
-        },
-      });
+      setVersions(store, initialState, newerPrerelease);
 
       expect(api.versionUpdateAvailable()).toEqual(false);
     });

--- a/code/core/src/shared/checklist-store/checklistData.tsx
+++ b/code/core/src/shared/checklist-store/checklistData.tsx
@@ -264,7 +264,7 @@ export const Primary: Story = {
                 Autocomplete, or even full pages.
               </p>
               <img
-                src={api.getDocsUrl({ subpath: 'onboarding/sidebar-components.png', asset: true })}
+                src={api.getDocsUrl({ asset: 'onboarding/sidebar-components.png' })}
                 alt="Components in the sidebar"
               />
               <p>
@@ -301,10 +301,7 @@ export const Primary: Story = {
                 More stories for your components means better documentation and more test coverage.
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'onboarding/sidebar-many-stories.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'onboarding/sidebar-many-stories.png' })}
                 alt="Stories in the sidebar"
               />
               <p>
@@ -363,7 +360,7 @@ export const Primary: Story = {
                 component handles various inputs.
               </p>
               <img
-                src={api.getDocsUrl({ subpath: 'api/doc-block-controls.png', asset: true })}
+                src={api.getDocsUrl({ asset: 'api/doc-block-controls.png' })}
                 alt="Screenshot of Controls block"
               />
               <strong>Take it further</strong>
@@ -398,7 +395,7 @@ export const Primary: Story = {
                 built-in support for previewing stories in various device sizes.
               </p>
               <img
-                src={api.getDocsUrl({ subpath: 'onboarding/viewports-menu.png', asset: true })}
+                src={api.getDocsUrl({ asset: 'onboarding/viewports-menu.png' })}
                 alt="Screenshot of Viewports menu"
               />
               <strong>Take it further</strong>
@@ -449,7 +446,7 @@ export default {
               </CodeSnippet>
               <p>Which would look like:</p>
               <img
-                src={api.getDocsUrl({ subpath: 'onboarding/sidebar-with-groups.png', asset: true })}
+                src={api.getDocsUrl({ asset: 'onboarding/sidebar-with-groups.png' })}
                 alt="Grouped components in the sidebar"
               />
               <strong>Take it further</strong>
@@ -502,10 +499,7 @@ export default {
                 <em>Restart your Storybook after installing the addon.</em>
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'writing-tests/testing-ui-overview.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'writing-tests/testing-ui-overview.png' })}
                 alt="Storybook app with story status indicators, testing widget, and addon panel annotated"
               />
               <p>
@@ -575,10 +569,7 @@ export default {
                 from the test widget, at the bottom of the sidebar.
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'onboarding/test-widget-with-failures.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'onboarding/test-widget-with-failures.png' })}
                 alt="Test widget showing test failures"
               />
 
@@ -587,10 +578,7 @@ export default {
                 tests for just that selection.
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'writing-tests/context-menu.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'writing-tests/context-menu.png' })}
                 alt="Screenshot of story sidebar item with open menu"
               />
               <strong>Take it further</strong>
@@ -676,10 +664,7 @@ export const Disabled: Story = {
                 Interactions panel.
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'writing-tests/interaction-test-pass.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'writing-tests/interaction-test-pass.png' })}
                 alt="Storybook with a LoginForm component and passing interactions in the Interactions panel"
               />
               <strong>Take it further</strong>
@@ -762,10 +747,7 @@ export const Disabled: Story = {
                 component tests button.
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'writing-tests/test-widget-a11y-enabled.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'writing-tests/test-widget-a11y-enabled.png' })}
                 alt="Testing widget with accessibility activated"
               />
               <p>
@@ -773,10 +755,7 @@ export const Disabled: Story = {
                 violations.
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'writing-tests/addon-a11y-debug-violations.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'writing-tests/addon-a11y-debug-violations.png' })}
                 alt="Storybook app with accessibility panel open, showing violations and an interactive popover on the violating elements in the preview"
               />
               <strong>Take it further</strong>
@@ -850,10 +829,7 @@ export const Disabled: Story = {
             <>
               <p>Expand the test widget and click the Run visual tests button.</p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'writing-tests/test-widget-expanded-with-vta.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'writing-tests/test-widget-expanded-with-vta.png' })}
                 alt="Expanded testing widget, showing the Visual tests section"
               />
               <p>
@@ -862,10 +838,7 @@ export const Disabled: Story = {
                 and become the new baseline.
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'writing-tests/vta-run-from-panel.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'writing-tests/vta-run-from-panel.png' })}
                 alt="Visual tests addon panel showing a diff from the baseline"
               />
               <strong>Take it further</strong>
@@ -913,10 +886,7 @@ export const Disabled: Story = {
                 widget.
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'writing-tests/test-widget-coverage-summary.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'writing-tests/test-widget-coverage-summary.png' })}
                 alt="Test widget with coverage summary"
               />
               <strong>Take it further</strong>
@@ -956,8 +926,7 @@ export const Disabled: Story = {
               </p>
               <img
                 src={api.getDocsUrl({
-                  subpath: 'writing-tests/test-ci-workflow-pr-status-checks.png',
-                  asset: true,
+                  asset: 'writing-tests/test-ci-workflow-pr-status-checks.png',
                 })}
                 alt='GitHub pull request status checks, with a failing "UI Tests / test" check'
               />
@@ -1054,10 +1023,7 @@ export default {
                 documentation for <em>all</em> components.
               </p>
               <img
-                src={api.getDocsUrl({
-                  subpath: 'writing-docs/autodocs.png',
-                  asset: true,
-                })}
+                src={api.getDocsUrl({ asset: 'writing-docs/autodocs.png' })}
                 alt="Storybook autodocs page, showing a title, description, primary story, controls table, and additional stories"
               />
               <strong>Take it further</strong>
@@ -1179,8 +1145,7 @@ npm install @my/awesome-project
               </p>
               <img
                 src={api.getDocsUrl({
-                  subpath: 'sharing/prbadge-publish.png',
-                  asset: true,
+                  asset: 'sharing/prbadge-publish.png',
                 })}
                 alt="PR check for publish action"
               />

--- a/code/core/src/shared/checklist-store/checklistData.tsx
+++ b/code/core/src/shared/checklist-store/checklistData.tsx
@@ -196,14 +196,22 @@ export const checklistData = {
               <p>
                 Rendering your components can often require{' '}
                 <Link
-                  href={api.getDocsUrl({ subpath: 'writing-stories/decorators', renderer: true })}
+                  href={api.getDocsUrl({
+                    subpath: 'writing-stories/decorators',
+                    renderer: true,
+                    ref: 'guide',
+                  })}
                   target="_blank"
                 >
                   setting up surrounding context in decorators
                 </Link>{' '}
                 or{' '}
                 <Link
-                  href={api.getDocsUrl({ subpath: 'configure/styling-and-css', renderer: true })}
+                  href={api.getDocsUrl({
+                    subpath: 'configure/styling-and-css',
+                    renderer: true,
+                    ref: 'guide',
+                  })}
                   target="_blank"
                 >
                   applying global styles
@@ -242,7 +250,11 @@ export const Primary: Story = {
               </CodeSnippet>
               <p>
                 <Link
-                  href={api.getDocsUrl({ subpath: 'writing-stories', renderer: true })}
+                  href={api.getDocsUrl({
+                    subpath: 'writing-stories',
+                    renderer: true,
+                    ref: 'guide',
+                  })}
                   target="_blank"
                   withArrow
                 >
@@ -264,7 +276,10 @@ export const Primary: Story = {
                 Autocomplete, or even full pages.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'onboarding/sidebar-components.png' })}
+                src={api.getDocsUrl({
+                  asset: 'onboarding/sidebar-components.png',
+                  ref: 'guide',
+                })}
                 alt="Components in the sidebar"
               />
               <p>
@@ -272,6 +287,7 @@ export const Primary: Story = {
                   href={api.getDocsUrl({
                     subpath: 'get-started/whats-a-story#create-a-new-story',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                   withArrow
@@ -301,7 +317,10 @@ export const Primary: Story = {
                 More stories for your components means better documentation and more test coverage.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'onboarding/sidebar-many-stories.png' })}
+                src={api.getDocsUrl({
+                  asset: 'onboarding/sidebar-many-stories.png',
+                  ref: 'guide',
+                })}
                 alt="Stories in the sidebar"
               />
               <p>
@@ -309,6 +328,7 @@ export const Primary: Story = {
                   href={api.getDocsUrl({
                     subpath: 'essentials/controls#creating-and-editing-stories-from-controls',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                   withArrow
@@ -360,14 +380,21 @@ export const Primary: Story = {
                 component handles various inputs.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'api/doc-block-controls.png' })}
+                src={api.getDocsUrl({
+                  asset: 'api/doc-block-controls.png',
+                  ref: 'guide',
+                })}
                 alt="Screenshot of Controls block"
               />
               <strong>Take it further</strong>
               <p>
                 Read the{' '}
                 <Link
-                  href={api.getDocsUrl({ subpath: 'essentials/controls', renderer: true })}
+                  href={api.getDocsUrl({
+                    subpath: 'essentials/controls',
+                    renderer: true,
+                    ref: 'guide',
+                  })}
                   target="_blank"
                 >
                   Controls documentation
@@ -395,14 +422,21 @@ export const Primary: Story = {
                 built-in support for previewing stories in various device sizes.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'onboarding/viewports-menu.png' })}
+                src={api.getDocsUrl({
+                  asset: 'onboarding/viewports-menu.png',
+                  ref: 'guide',
+                })}
                 alt="Screenshot of Viewports menu"
               />
               <strong>Take it further</strong>
               <p>
                 Read the{' '}
                 <Link
-                  href={api.getDocsUrl({ subpath: 'essentials/viewport', renderer: true })}
+                  href={api.getDocsUrl({
+                    subpath: 'essentials/viewport',
+                    renderer: true,
+                    ref: 'guide',
+                  })}
                   target="_blank"
                 >
                   Viewports documentation
@@ -446,7 +480,10 @@ export default {
               </CodeSnippet>
               <p>Which would look like:</p>
               <img
-                src={api.getDocsUrl({ asset: 'onboarding/sidebar-with-groups.png' })}
+                src={api.getDocsUrl({
+                  asset: 'onboarding/sidebar-with-groups.png',
+                  ref: 'guide',
+                })}
                 alt="Grouped components in the sidebar"
               />
               <strong>Take it further</strong>
@@ -456,6 +493,7 @@ export default {
                   href={api.getDocsUrl({
                     subpath: 'writing-stories/naming-components-and-hierarchy',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >
@@ -499,7 +537,10 @@ export default {
                 <em>Restart your Storybook after installing the addon.</em>
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'writing-tests/testing-ui-overview.png' })}
+                src={api.getDocsUrl({
+                  asset: 'writing-tests/testing-ui-overview.png',
+                  ref: 'guide',
+                })}
                 alt="Storybook app with story status indicators, testing widget, and addon panel annotated"
               />
               <p>
@@ -507,6 +548,7 @@ export default {
                   href={api.getDocsUrl({
                     subpath: 'writing-tests/integrations/vitest-addon',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                   withArrow
@@ -569,7 +611,10 @@ export default {
                 from the test widget, at the bottom of the sidebar.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'onboarding/test-widget-with-failures.png' })}
+                src={api.getDocsUrl({
+                  asset: 'onboarding/test-widget-with-failures.png',
+                  ref: 'guide',
+                })}
                 alt="Test widget showing test failures"
               />
 
@@ -578,7 +623,10 @@ export default {
                 tests for just that selection.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'writing-tests/context-menu.png' })}
+                src={api.getDocsUrl({
+                  asset: 'writing-tests/context-menu.png',
+                  ref: 'guide',
+                })}
                 alt="Screenshot of story sidebar item with open menu"
               />
               <strong>Take it further</strong>
@@ -588,6 +636,7 @@ export default {
                   href={api.getDocsUrl({
                     subpath: 'writing-tests#component-tests',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >
@@ -664,7 +713,10 @@ export const Disabled: Story = {
                 Interactions panel.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'writing-tests/interaction-test-pass.png' })}
+                src={api.getDocsUrl({
+                  asset: 'writing-tests/interaction-test-pass.png',
+                  ref: 'guide',
+                })}
                 alt="Storybook with a LoginForm component and passing interactions in the Interactions panel"
               />
               <strong>Take it further</strong>
@@ -674,6 +726,7 @@ export const Disabled: Story = {
                   href={api.getDocsUrl({
                     subpath: 'writing-tests/interaction-testing',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >
@@ -720,6 +773,7 @@ export const Disabled: Story = {
                   href={api.getDocsUrl({
                     subpath: 'writing-tests/accessibility-testing',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                   withArrow
@@ -747,7 +801,10 @@ export const Disabled: Story = {
                 component tests button.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'writing-tests/test-widget-a11y-enabled.png' })}
+                src={api.getDocsUrl({
+                  asset: 'writing-tests/test-widget-a11y-enabled.png',
+                  ref: 'guide',
+                })}
                 alt="Testing widget with accessibility activated"
               />
               <p>
@@ -755,7 +812,10 @@ export const Disabled: Story = {
                 violations.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'writing-tests/addon-a11y-debug-violations.png' })}
+                src={api.getDocsUrl({
+                  asset: 'writing-tests/addon-a11y-debug-violations.png',
+                  ref: 'guide',
+                })}
                 alt="Storybook app with accessibility panel open, showing violations and an interactive popover on the violating elements in the preview"
               />
               <strong>Take it further</strong>
@@ -765,6 +825,7 @@ export const Disabled: Story = {
                   href={api.getDocsUrl({
                     subpath: 'writing-tests/accessibility-testing',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >
@@ -808,6 +869,7 @@ export const Disabled: Story = {
                   href={api.getDocsUrl({
                     subpath: 'writing-tests/visual-testing',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                   withArrow
@@ -829,7 +891,10 @@ export const Disabled: Story = {
             <>
               <p>Expand the test widget and click the Run visual tests button.</p>
               <img
-                src={api.getDocsUrl({ asset: 'writing-tests/test-widget-expanded-with-vta.png' })}
+                src={api.getDocsUrl({
+                  asset: 'writing-tests/test-widget-expanded-with-vta.png',
+                  ref: 'guide',
+                })}
                 alt="Expanded testing widget, showing the Visual tests section"
               />
               <p>
@@ -838,7 +903,10 @@ export const Disabled: Story = {
                 and become the new baseline.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'writing-tests/vta-run-from-panel.png' })}
+                src={api.getDocsUrl({
+                  asset: 'writing-tests/vta-run-from-panel.png',
+                  ref: 'guide',
+                })}
                 alt="Visual tests addon panel showing a diff from the baseline"
               />
               <strong>Take it further</strong>
@@ -848,6 +916,7 @@ export const Disabled: Story = {
                   href={api.getDocsUrl({
                     subpath: 'writing-tests/visual-testing',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >
@@ -886,7 +955,10 @@ export const Disabled: Story = {
                 widget.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'writing-tests/test-widget-coverage-summary.png' })}
+                src={api.getDocsUrl({
+                  asset: 'writing-tests/test-widget-coverage-summary.png',
+                  ref: 'guide',
+                })}
                 alt="Test widget with coverage summary"
               />
               <strong>Take it further</strong>
@@ -896,6 +968,7 @@ export const Disabled: Story = {
                   href={api.getDocsUrl({
                     subpath: 'writing-tests/test-coverage',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >
@@ -927,6 +1000,7 @@ export const Disabled: Story = {
               <img
                 src={api.getDocsUrl({
                   asset: 'writing-tests/test-ci-workflow-pr-status-checks.png',
+                  ref: 'guide',
                 })}
                 alt='GitHub pull request status checks, with a failing "UI Tests / test" check'
               />
@@ -937,6 +1011,7 @@ export const Disabled: Story = {
                   href={api.getDocsUrl({
                     subpath: 'writing-tests/in-ci',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >
@@ -983,6 +1058,7 @@ export const Disabled: Story = {
                   href={api.getDocsUrl({
                     subpath: 'writing-docs',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                   withArrow
@@ -1023,7 +1099,10 @@ export default {
                 documentation for <em>all</em> components.
               </p>
               <img
-                src={api.getDocsUrl({ asset: 'writing-docs/autodocs.png' })}
+                src={api.getDocsUrl({
+                  asset: 'writing-docs/autodocs.png',
+                  ref: 'guide',
+                })}
                 alt="Storybook autodocs page, showing a title, description, primary story, controls table, and additional stories"
               />
               <strong>Take it further</strong>
@@ -1033,6 +1112,7 @@ export default {
                   href={api.getDocsUrl({
                     subpath: 'writing-docs/autodocs',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >
@@ -1069,7 +1149,11 @@ export default {
                 For a start, create an <code>introduction.mdx</code> file and (using markdown and
                 Storybook&apos;s{' '}
                 <Link
-                  href={api.getDocsUrl({ subpath: 'writing-docs/doc-blocks', renderer: true })}
+                  href={api.getDocsUrl({
+                    subpath: 'writing-docs/doc-blocks',
+                    renderer: true,
+                    ref: 'guide',
+                  })}
                   target="_blank"
                 >
                   doc blocks
@@ -1104,6 +1188,7 @@ npm install @my/awesome-project
                   href={api.getDocsUrl({
                     subpath: 'writing-docs/mdx',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >
@@ -1146,6 +1231,7 @@ npm install @my/awesome-project
               <img
                 src={api.getDocsUrl({
                   asset: 'sharing/prbadge-publish.png',
+                  ref: 'guide',
                 })}
                 alt="PR check for publish action"
               />
@@ -1156,6 +1242,7 @@ npm install @my/awesome-project
                   href={api.getDocsUrl({
                     subpath: 'sharing/publish-storybook',
                     renderer: true,
+                    ref: 'guide',
                   })}
                   target="_blank"
                 >


### PR DESCRIPTION
## What I did

Updated `api.getDocsUrl` (manager-api):
- Updated `asset` option to take a subpath string rather than a boolean, to avoid having to set `subpath` as well.
- Added `ref` option with `'ui'` as default
- Generated URLs include this `ref` as query param (unless set to `''`)
- Refactored and added unit tests

Updated `checklistData`:
- All generated links now specify `'guide'` as `ref` option.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced documentation URL generation to support reference tracking parameters, enabling better identification and organization of documentation resources. All documentation links, assets, and references throughout the application have been updated to utilize this improved URL structure. These changes improve how documentation sources are categorized and accessed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->