### PR TITLE
Angular: Replace deprecated import of ApplicationConfig

### DIFF
--- a/code/frameworks/angular/src/client/decorators.ts
+++ b/code/frameworks/angular/src/client/decorators.ts
@@ -1,7 +1,6 @@
 import type { DecoratorFunction, StoryContext } from 'storybook/internal/types';
 
-import type { Type } from '@angular/core';
-import type { ApplicationConfig } from '@angular/platform-browser';
+import type { ApplicationConfig, Type } from '@angular/core';
 
 import { computesTemplateFromComponent } from './angular-beta/ComputesTemplateFromComponent';
 import { isComponent } from './angular-beta/utils/NgComponentAnalyzer';

--- a/code/frameworks/angular/src/client/types.ts
+++ b/code/frameworks/angular/src/client/types.ts
@@ -4,8 +4,7 @@ import type {
   WebRenderer,
 } from 'storybook/internal/types';
 
-import type { Provider } from '@angular/core';
-import type { ApplicationConfig } from '@angular/platform-browser';
+import type { ApplicationConfig, Provider } from '@angular/core';
 
 export interface NgModuleMetadata {
   /** List of components, directives, and pipes that belong to your component. */


### PR DESCRIPTION
## What I did

I replaced:
```TS
import { ApplicationConfig } from '@angular/platform-browser';
```
with:
```TS
import { ApplicationConfig } from '@angular/core';
```
because Angular 21 removed the deprecated ApplicationConfig import from @angular/platform-browser entirely.

<img width="707" height="204" alt="image" src="https://github.com/user-attachments/assets/7680dc54-326f-46a8-8733-4d7057e38c63" />

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal code organization for improved maintainability with no changes to user-facing functionality or features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->