### PR TITLE
Docs: Rewrite frameworks to focus on new users

### DIFF
--- a/docs/get-started/frameworks/angular.mdx
+++ b/docs/get-started/frameworks/angular.mdx
@@ -14,10 +14,19 @@ To install Storybook in an existing Angular project, run this command in your pr
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with Angular ≥ 18.0 \< 21.0, and Webpack 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your Angular project.
+### Compatible versions
 
+<GetStartedVersions versions={[{
+  name: 'Angular',
+  range: '≥ 18.0 < 21.0',
+  icon: '/images/logos/renderers/logo-angular.svg'
+}, {
+  name: 'Webpack',
+  range: '5',
+  icon: '/images/logos/builders/webpack.svg'
+}]} />
 
 ## Run Storybook
 

--- a/docs/get-started/frameworks/angular.mdx
+++ b/docs/get-started/frameworks/angular.mdx
@@ -6,102 +6,22 @@ sidebar:
   title: Angular
 ---
 
-Storybook for Angular is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [Angular](https://angular.io/) applications. It includes:
+Storybook for Angular is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [Angular](https://angular.io/) applications. It uses Angular builders and integrates with [Compodoc](https://compodoc.app/) to provide automatic documentation generation.
 
-* 🧱 Uses Angular builders
-* 🎛️ Compodoc integration
-* 💫 and more!
+## Install
 
-## Requirements
+To install Storybook in an existing Angular project, run this command in your project's root directory:
 
-* Angular ≥ 18.0 \< 21.0
-* Webpack ≥ 5.0
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-## Getting started
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
 
-### In a project without Storybook
+Storybook is compatible with Angular ≥ 18.0 \< 21.0, and Webpack 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your Angular project.
 
-Follow the prompts after running this command in your Angular project's root directory:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="create-command.md" />
-
-{/* prettier-ignore-end */}
-
-[More on getting started with Storybook.](../install.mdx)
-
-### In a project with Storybook
-
-This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="storybook-upgrade.md" />
-
-{/* prettier-ignore-end */}
-
-#### Automatic migration
-
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/angular`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
-
-#### Manual migration
-
-First, install the framework:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="angular-install.md" />
-
-{/* prettier-ignore-end */}
-
-Then, update your `.storybook/main.js|ts` to change the framework property:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="angular-add-framework.md" />
-
-{/* prettier-ignore-end */}
-
-Finally, update your `angular.json` to include the Storybook builder:
-
-```jsonc title="angular.json"
-{
-  "projects": {
-    "your-project": {
-      "architect": {
-        "storybook": {
-          "builder": "@storybook/angular:start-storybook",
-          "options": {
-            // The path to the storybook config directory
-            "configDir": ".storybook",
-            // The build target of your project
-            "browserTarget": "your-project:build",
-            // The port you want to start Storybook on
-            "port": 6006
-            // More options available, documented here:
-            // https://github.com/storybookjs/storybook/tree/next/code/frameworks/angular/src/builders/start-storybook/schema.json
-          }
-        },
-        "build-storybook": {
-          "builder": "@storybook/angular:build-storybook",
-          "options": {
-            "configDir": ".storybook",
-            "browserTarget": "your-project:build",
-            "outputDir": "dist/storybook/your-project"
-            // More options available, documented here:
-            // https://github.com/storybookjs/storybook/tree/next/code/frameworks/angular/src/builders/build-storybook/schema.json
-          }
-        }
-      }
-    }
-  }
-}
-```
 
 ## Run Storybook
 
-To run Storybook for a particular project, please run the following:
+To run Storybook for a particular project, run the following:
 
 ```sh
 ng run <your-project>:storybook
@@ -115,15 +35,19 @@ ng run <your-project>:build-storybook
 
 You will find the output in the configured `outputDir` (default is `dist/storybook/<your-project>`).
 
-## Setup Compodoc
+## Configure
+
+To make the most out of Storybook in your Angular project, you can set up Compodoc integration and Storybook [decorators](/docs/writing-stories/decorators/) based on your project needs.
+
+### Compodoc
 
 You can include JSDoc comments above components, directives, and other parts of your Angular code to include documentation for those elements. Compodoc uses these comments to [generate documentation](../../writing-docs/autodocs.mdx) for your application. In Storybook, it is useful to add explanatory comments above `@Inputs` and `@Outputs`, since these are the main elements that Storybook displays in its user interface. The `@Inputs` and `@Outputs` are elements you can interact with in Storybook, such as [controls](../../essentials/controls.mdx).
 
-### Automatic setup
+#### Automatic setup
 
 When installing Storybook via `npx storybook@latest init`, you can set up Compodoc automatically.
 
-### Manual setup
+#### Manual setup
 
 If you have already installed Storybook, you can set up Compodoc manually.
 
@@ -187,7 +111,7 @@ const preview: Preview = {};
 export default preview;
 ```
 
-## `applicationConfig` decorator
+### Application-wide providers
 
 If your component relies on application-wide providers, like the ones defined by [`BrowserAnimationsModule`](https://angular.dev/api/platform-browser/animations/BrowserAnimationsModule) or any other modules that use the forRoot pattern to provide a [`ModuleWithProviders`](https://angular.dev/api/core/ModuleWithProviders), you can apply the `applicationConfig` [decorator](../../writing-stories/decorators.mdx) to all stories for that component. This will provide them with the [bootstrapApplication function](https://angular.io/guide/standalone-components#configuring-dependency-injection), used to bootstrap the component in Storybook.
 
@@ -230,7 +154,7 @@ export const WithCustomApplicationProvider: Story = {
 }
 ```
 
-## `moduleMetadata` decorator
+### Angular dependencies
 
 If your component has dependencies on other Angular directives and modules, these can be supplied using the `moduleMetadata` [decorator](../../writing-stories/decorators.mdx) either for all stories of a component or for individual stories.
 
@@ -270,66 +194,104 @@ export const WithCustomProvider: Story = {
 };
 ```
 
+
 ## FAQ
+
+### How do I manually install the Angular framework?
+
+The easiest way to install the Angular framework is to run the upgrade command, but you can also set it up manually. First, install the framework:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="angular-install.md" />
+
+{/* prettier-ignore-end */}
+
+Then, update your `.storybook/main.js|ts` to change the framework property:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="angular-add-framework.md" />
+
+{/* prettier-ignore-end */}
+
+Finally, update your `angular.json` to include the Storybook builder:
+
+```jsonc title="angular.json"
+{
+  "projects": {
+    "your-project": {
+      "architect": {
+        "storybook": {
+          "builder": "@storybook/angular:start-storybook",
+          "options": {
+            // The path to the storybook config directory
+            "configDir": ".storybook",
+            // The build target of your project
+            "browserTarget": "your-project:build",
+            // The port you want to start Storybook on
+            "port": 6006
+            // More options available, documented here:
+            // https://github.com/storybookjs/storybook/tree/next/code/frameworks/angular/src/builders/start-storybook/schema.json
+          }
+        },
+        "build-storybook": {
+          "builder": "@storybook/angular:build-storybook",
+          "options": {
+            "configDir": ".storybook",
+            "browserTarget": "your-project:build",
+            "outputDir": "dist/storybook/your-project"
+            // More options available, documented here:
+            // https://github.com/storybookjs/storybook/tree/next/code/frameworks/angular/src/builders/build-storybook/schema.json
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ### How do I migrate to an Angular Storybook builder?
 
 The Storybook [Angular builder](https://angular.io/guide/glossary#builder) is a way to run Storybook in an Angular workspace. It is a drop-in replacement for running `storybook dev` and `storybook build` directly.
 
-You can run `npx storybook@latest automigrate` to try letting Storybook detect and automatically fix your configuration. Otherwise, you can follow the next steps to adjust your configuration manually.
+You can run `npx storybook@latest automigrate` to let Storybook detect and automatically fix your configuration. Otherwise, you can follow the next steps to adjust your configuration manually.
 
-#### Do you have only one Angular project in your workspace?
+#### With a single project in your Angular workspace
 
-First, go to your `angular.json` and add `storybook` and `build-storybook` entries in your project's `architect` section, as shown [above](#manual-setup).
+Go to your `angular.json` and add `storybook` and `build-storybook` entries in your project's `architect` section, as shown [above](#manual-setup).
 
-Second, adjust your `package.json` script section. Usually, it will look like this:
+Then, adjust your `package.json` script section, to replace the existing Storybook scripts with the Angular CLI commands:
 
-```jsonc title="package.json"
+```diff title="package.json"
 {
   "scripts": {
-    "storybook": "start-storybook -p 6006", // or `storybook dev -p 6006`
-    "build-storybook": "build-storybook" // or `storybook build`
+-    "storybook": "start-storybook -p 6006", // or `storybook dev -p 6006`
+-    "build-storybook": "build-storybook" // or `storybook build`
++    "storybook": "ng run <project-name:storybook",
++    "storybook": "ng run <project-name:storybook",
   }
 }
 ```
 
-Now, you can run Storybook with `ng run <your-project>:storybook` and build it with `ng run <your-project>:build-storybook`. Adjust the scripts in your `package.json` accordingly.
+Note that `compodoc` is now built into `@storybook/angular`; you don't have to call it explicitly. If you were running `compodoc` in your `package.json` scripts, you can remove the related script:
 
-```json title="package.json"
+```diff title="package.json"
 {
   "scripts": {
-    "storybook": "ng run <project-name>:storybook",
-    "build-storybook": "ng run <project-name>:build-storybook"
+-    "docs:json": "compodoc -p tsconfig.json -e json -d ./documentation",
+-    "storybook": "npm run docs:json && start-storybook -p 6006",
+-    "build-storybook": "npm run docs:json && build-storybook"
++    "storybook": "ng run <project-name:storybook",
++    "storybook": "ng run <project-name:storybook",
   }
 }
 ```
 
-  Also, `compodoc` is now built into `@storybook/angular`; you don't have to call it explicitly. If we're running `compodoc` in your `package.json` scripts like this:
 
-```json title="package.json"
-{
-  "scripts": {
-    "docs:json": "compodoc -p tsconfig.json -e json -d ./documentation",
-    "storybook": "npm run docs:json && start-storybook -p 6006",
-    "build-storybook": "npm run docs:json && build-storybook"
-  }
-}
-```
+#### With multiple projects in your Angular workspace
 
-Change it to:
-
-```json title="package.json"
-{
-  "scripts": {
-    "storybook": "ng run <project-name>:storybook",
-    "build-storybook": "ng run <project-name>:build-storybook"
-  }
-}
-```
-
-#### I have multiple projects in my Angular workspace
-
-In this case, you have to adjust your `angular.json` and `package.json` as described above for each project you want to use Storybook. Please note that each project should have a dedicated `.storybook` folder placed at the project's root.
+In case you have multiple projects, you will have to adjust your `angular.json` and `package.json` as described above for each project you want to use Storybook with. Please note that each project should have a dedicated `.storybook` folder placed at the project's root directory.
 
 You can run `npx storybook@latest init` sequentially for each project to set up Storybook for each of them to automatically create the `.storybook` folder and create the necessary configuration in your `angular.json`.
 

--- a/docs/get-started/frameworks/index.mdx
+++ b/docs/get-started/frameworks/index.mdx
@@ -5,4 +5,13 @@ sidebar:
   title: Frameworks
 ---
 
+
+## Supported frameworks
+
 <HomeRenderers />
+
+## Community-maintained frameworks
+
+Storybook includes an active community that supports additional frameworks and libraries. These community-maintained frameworks are actively developed and maintained by community contributors.
+
+<CommunityRenderers />

--- a/docs/get-started/frameworks/nextjs-vite.mdx
+++ b/docs/get-started/frameworks/nextjs-vite.mdx
@@ -6,137 +6,67 @@ sidebar:
   title: Next.js (Vite)
 ---
 
-Storybook for Next.js (Vite) is the **recommended** [framework](../../contribute/framework.mdx) for developing and testing UI components in isolation for [Next.js](https://nextjs.org/) applications. It uses [Vite](https://vitejs.dev/) for faster builds and better performance. It includes:
+Storybook for Next.js (Vite) is the **recommended** [framework](../../contribute/framework.mdx) for developing and testing UI components in isolation for [Next.js](https://nextjs.org/) applications. It uses [Vite](https://vitejs.dev/) for faster builds, better performance and [Storybook Testing](https://storybook.js.org/docs/writing-tests) support.
 
-* 🔀 Routing
-* 🖼 Image optimization
-* ⤵️ Absolute imports
-* 🎨 Styling
-* ⚡ Vite-powered builds
-* 💫 and more!
+## Install
 
-This Vite-based framework offers several advantages over the Webpack-based [`@storybook/nextjs`](./nextjs.mdx) framework:
+To install Storybook in an existing Next.js project, run this command in your project's root directory:
+
+<CodeSnippets path="create-command.md" variant="new-users" />
+
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+
+Storybook is compatible with Next.js ≥ 14.1 with Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to [configure Storybook](#configure) with your Next.js project.
+
+
+## Choose between Vite and Webpack
+
+This Vite-based framework offers several advantages over the Webpack-based [`@storybook/nextjs`](./nextjs.mdx) framework, and is the recommended option:
 
 * ⚡ **Faster builds** - Vite's build system is significantly faster than Webpack
 * 🔧 **Modern tooling** - Uses the latest build tools and optimizations
 * 🧪 **Better test support** - Full support for the [Vitest addon](../../writing-tests/integrations/vitest-addon.mdx) and other testing features
 * 📦 **Simpler configuration** - No need for Babel or complex Webpack configurations
-* 🎯 **Better development experience** - Faster HMR (Hot Module Replacement) and dev server startup
+* 🎯 **Better development experience** - Faster Hot Module Replacement and dev server startup
 
-## Requirements
+Storybook will automatically detect your project and select the `nextjs-vite` framework **unless** your project has custom Webpack or Babel configurations. If you have custom configurations, Storybook will ask you which framework to install.
 
-* Next.js ≥ 14.1
+Choose `nextjs-vite` if you're willing to migrate existing Babel or Webpack configurations to Vite. Choose `nextjs` (Webpack 5) if you need to keep your existing Webpack/Babel setup.
 
-## Getting started
 
-### In a project without Storybook
+## Run Storybook
 
-When you run `storybook init` in your Next.js project, Storybook will automatically detect your project and select the `@storybook/nextjs-vite` framework **unless** your project has custom Webpack or Babel configurations that may be incompatible with Vite.
+To run Storybook for a particular project, run the following:
 
-Follow the prompts after running this command in your Next.js project's root directory:
+<CodeSnippets path="storybook-run-dev.md" />
 
-{/* prettier-ignore-start */}
+To build Storybook, run:
 
-<CodeSnippets path="create-command.md" />
+<CodeSnippets path="build-storybook-production-mode.md" />
 
-{/* prettier-ignore-end */}
+You will find the output in the configured `outputDir` (default is `storybook-static`).
 
-[More on getting started with Storybook.](../install.mdx)
 
-<Callout variant="info">
 
-If your project has a custom `webpack.config.js` or `.babelrc` file, `storybook init` will prompt you to choose between:
 
-- **`@storybook/nextjs-vite`** (recommended) - Faster, more modern, supports latest testing features
-- **`@storybook/nextjs`** (Webpack 5) - Better compatibility with custom Webpack/Babel configurations
+## Configure
 
-Choose `nextjs-vite` if you're willing to migrate your custom configurations to Vite. Choose `nextjs` (Webpack 5) if you need to keep your existing Webpack/Babel setup.
+Storybook for Next.js with Vite supports many Next.js features including:
 
-</Callout>
+* 🖼 [Image optimization](#nextjss-image-component)
+* 🔤 [Font optimization](#nextjs-font-optimization)
+* 🔀 [Routing and navigation](#nextjs-routing)
+* 🌐 [`next/head`](#nextjs-head)
+* ⤵️ [Absolute imports](#imports)
+* 🎨 [Styling](#styling)
+* 🎭 [Module mocking](#mocking-modules)
+* ☁️ [React Server Component (experimental)](#react-server-components-rsc)
 
-### In a project with Storybook
-
-This framework is designed to work with Storybook 10+. If you're not already using v10, upgrade with this command:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="storybook-upgrade.md" />
-
-{/* prettier-ignore-end */}
-
-#### Automatic migration
-
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/nextjs-vite`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
-
-You can also use the [`nextjs-to-nextjs-vite` automigration](#migrating-from-webpack) to migrate from the Webpack-based `@storybook/nextjs` framework to this Vite-based framework.
-
-#### Manual migration
-
-First, install the framework:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="nextjs-vite-install.md" />
-
-{/* prettier-ignore-end */}
-
-Then, update your `.storybook/main.js|ts` to change the framework property:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="nextjs-vite-add-framework.md" />
-
-{/* prettier-ignore-end */}
-
-<Callout variant="info">
-
-If your Storybook configuration contains custom Webpack operations in [`webpackFinal`](../../api/main-config/main-config-webpack-final.mdx), you will likely need to create equivalents in [`viteFinal`](../../api/main-config/main-config-vite-final.mdx).
-
-For more information, see the [Vite builder documentation](../../builders/vite.mdx#migrating-from-webpack).
-
-</Callout>
-
-Finally, if you were using Storybook plugins to integrate with Next.js, those are no longer necessary when using this framework and can be removed:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="nextjs-remove-addons.md" />
-
-{/* prettier-ignore-end */}
-
-#### Migrating from Webpack
-
-Storybook provides a migration tool for migrating to this framework from the Webpack-based Next.js framework, `@storybook/nextjs`. To migrate, run this command:
-
-```bash
-npx storybook automigrate nextjs-to-nextjs-vite
-```
-
-This automigration tool performs the following actions:
-
-1. Updates `package.json` files to replace `@storybook/nextjs` with `@storybook/nextjs-vite`
-2. Updates `.storybook/main.js|ts` to change the framework property
-3. Scans and updates import statements in your story files and configuration files
-
-<Callout variant="info">
-
-If your project has custom Webpack configurations in `.storybook/main.js|ts` (via `webpackFinal`), you'll need to migrate those to Vite configuration (via `viteFinal`) after running this automigration. See the [Vite builder documentation](../builders/vite.mdx#migrating-from-webpack) for more information.
-
-</Callout>
-
-## Run the Setup Wizard
-
-If all goes well, you should see a setup wizard that will help you get started with Storybook introducing you to the main concepts and features, including how the UI is organized, how to write your first story, and how to test your components' response to various inputs utilizing [controls](../../essentials/controls.mdx).
-
-![Storybook onboarding](../../_assets/get-started/example-onboarding-wizard.png)
-
-If you skipped the wizard, you can always run it again by adding the `?path=/onboarding` query parameter to the URL of your Storybook instance, provided that the example stories are still available.
-
-## Next.js's Image component
+### Next.js's Image component
 
 This framework allows you to use Next.js's [next/image](https://nextjs.org/docs/pages/api-reference/components/image) with no configuration.
 
-### Local images
+#### Local images
 
 [Local images](https://nextjs.org/docs/pages/building-your-application/optimizing/images#local-images) are supported.
 
@@ -162,7 +92,7 @@ function Home() {
 }
 ```
 
-### Remote images
+#### Remote images
 
 [Remote images](https://nextjs.org/docs/pages/building-your-application/optimizing/images#remote-images) are also supported.
 
@@ -180,15 +110,15 @@ export default function Home() {
 }
 ```
 
-## Next.js font optimization
+### Next.js font optimization
 
 [next/font](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) is partially supported in Storybook. The packages `next/font/google` and `next/font/local` are supported.
 
-### `next/font/google`
+#### `next/font/google`
 
 You don't have to do anything. `next/font/google` is supported out of the box.
 
-### `next/font/local`
+#### `next/font/local`
 
 For local fonts you have to define the [src](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts#local-fonts) property.
 The path is relative to the directory where the font loader function is called.
@@ -203,7 +133,7 @@ const localRubikStorm = localFont({ src: './fonts/RubikStorm-Regular.ttf' });
 
 The Vite-based framework automatically handles font path mapping, so you don't need to configure `staticDirs` for fonts like you would with the Webpack-based framework.
 
-### Not supported features of `next/font`
+#### Not supported features of `next/font`
 
 The following features are not supported (yet). Support for these features might be planned for the future:
 
@@ -213,7 +143,7 @@ The following features are not supported (yet). Support for these features might
 * [preload](https://nextjs.org/docs/pages/api-reference/components/font#preload) option gets ignored. Storybook handles Font loading its own way.
 * [display](https://nextjs.org/docs/pages/api-reference/components/font#display) option gets ignored. All fonts are loaded with display set to "block" to make Storybook load the font properly.
 
-### Mocking fonts during testing
+#### Mocking fonts during testing
 
 Occasionally fetching fonts from Google may fail as part of your Storybook build step. It is highly recommended to mock these requests, as those failures can cause your pipeline to fail as well. Next.js [supports mocking fonts](https://github.com/vercel/next.js/blob/725ddc7371f80cca273779d37f961c3e20356f95/packages/font/src/google/fetch-css-from-google-fonts.ts#L36) via a JavaScript module located where the env var `NEXT_FONT_GOOGLE_MOCKED_RESPONSES` references.
 
@@ -257,7 +187,7 @@ module.exports = {
 };
 ```
 
-## Next.js routing
+### Next.js routing
 
 [Next.js's router](https://nextjs.org/docs/pages/building-your-application/routing) is automatically stubbed for you so that when the router is interacted with, all of its interactions are automatically logged to the [Actions panel](../../essentials/actions.mdx).
 
@@ -267,7 +197,7 @@ You should only use `next/router` in the `pages` directory. In the `app` directo
 
 </Callout>
 
-### Overriding defaults
+#### Overriding defaults
 
 Per-story overrides can be done by adding a `nextjs.router` property onto the story [parameters](../../writing-stories/parameters.mdx). The framework will shallowly merge whatever you put here into the router.
 
@@ -283,7 +213,7 @@ These overrides can also be applied to [all stories for a component](../../api/p
 
 </Callout>
 
-### Default router
+#### Default router
 
 The default values on the stubbed router are as follows (see [globals](../../essentials/toolbars-and-globals.mdx#globals) for more details on how globals work).
 
@@ -332,7 +262,7 @@ const preview: Preview = {
 };
 ```
 
-## Next.js navigation
+### Next.js navigation
 
 <Callout>
 
@@ -340,7 +270,7 @@ Please note that [`next/navigation`](https://nextjs.org/docs/app/building-your-a
 
 </Callout>
 
-### Set `nextjs.appDirectory` to `true`
+#### Set `nextjs.appDirectory` to `true`
 
 If your story imports components that use `next/navigation`, you need to set the parameter `nextjs.appDirectory` to `true` in for that component's stories:
 
@@ -358,7 +288,7 @@ If your Next.js project uses the `app` directory for every page (in other words,
 
 {/* prettier-ignore-end */}
 
-### Overriding defaults
+#### Overriding defaults
 
 Per-story overrides can be done by adding a `nextjs.navigation` property onto the story [parameters](../../writing-stories/parameters.mdx). The framework will shallowly merge whatever you put here into the router.
 
@@ -374,7 +304,7 @@ These overrides can also be applied to [all stories for a component](../../api/p
 
 </Callout>
 
-### `useSelectedLayoutSegment`, `useSelectedLayoutSegments`, and `useParams` hooks
+#### `useSelectedLayoutSegment`, `useSelectedLayoutSegments`, and `useParams` hooks
 
 The `useSelectedLayoutSegment`, `useSelectedLayoutSegments`, and `useParams` hooks are supported in Storybook. You have to set the `nextjs.navigation.segments` parameter to return the segments or the params you want to use.
 
@@ -426,7 +356,7 @@ These overrides can also be applied to [a single story](../../api/parameters.mdx
 
 The default value of `nextjs.navigation.segments` is `[]` if not set.
 
-### Default navigation context
+#### Default navigation context
 
 The default values on the stubbed navigation context are as follows:
 
@@ -466,11 +396,13 @@ const preview: Preview = {
 };
 ```
 
-## Next.js Head
+### Next.js Head
 
 [`next/head`](https://nextjs.org/docs/pages/api-reference/components/head) is supported out of the box. You can use it in your stories like you would in your Next.js application. Please keep in mind, that the Head `children` are placed into the head element of the iframe that Storybook uses to render your stories.
 
-## Sass/Scss
+### Styling
+
+#### Sass/Scss
 
 [Global Sass/Scss stylesheets](https://nextjs.org/docs/pages/building-your-application/styling/sass) are supported without any additional configuration as well. Just import them into [`.storybook/preview.js|ts`](../../configure/index.mdx#configure-story-rendering)
 
@@ -491,7 +423,7 @@ export default {
 };
 ```
 
-## CSS/Sass/Scss Modules
+#### CSS/Sass/Scss Modules
 
 [CSS modules](https://nextjs.org/docs/pages/building-your-application/styling/css-modules) work as expected.
 
@@ -511,13 +443,14 @@ export function Button() {
 }
 ```
 
-## PostCSS
+#### PostCSS
 
 Next.js lets you [customize PostCSS config](https://nextjs.org/docs/pages/building-your-application/configuring/post-css). Thus this framework will automatically handle your PostCSS config for you.
 
 This allows for cool things like zero-config Tailwind! (See [Next.js' example](https://github.com/vercel/next.js/tree/canary/packages/create-next-app/templates/default-tw))
 
-## Absolute imports
+### Imports
+#### Absolute imports
 
 [Absolute imports](https://nextjs.org/docs/pages/building-your-application/configuring/absolute-imports-and-module-aliases#absolute-imports) from the root directory are supported.
 
@@ -551,7 +484,7 @@ Absolute imports **cannot** be mocked in stories/tests. See the [Mocking modules
 
 </Callout>
 
-## Module aliases
+#### Module aliases
 
 [Module aliases](https://nextjs.org/docs/app/building-your-application/configuring/absolute-imports-and-module-aliases#module-aliases) are also supported.
 
@@ -571,7 +504,7 @@ export default function HomePage() {
 }
 ```
 
-## Subpath imports
+#### Subpath imports
 
 As an alternative to [module aliases](#module-aliases), you can use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) to import modules. This follows Node package standards and has benefits when [mocking modules](#mocking-modules).
 
@@ -607,11 +540,11 @@ export default function HomePage() {
 }
 ```
 
-## Mocking modules
+### Mocking modules
 
 Components often depend on modules that are imported into the component file. These can be from external packages or internal to your project. When rendering those components in Storybook or testing them, you may want to [mock those modules](../../writing-stories/mocking-data-and-modules/mocking-modules.mdx) to control and assert their behavior.
 
-### Built-in mocked modules
+#### Built-in mocked modules
 
 This framework provides mocks for many of Next.js' internal modules:
 
@@ -620,11 +553,11 @@ This framework provides mocks for many of Next.js' internal modules:
 3. [`@storybook/nextjs-vite/navigation.mock`](#storybooknextjs-vitenavigationmock)
 4. [`@storybook/nextjs-vite/router.mock`](#storybooknextjs-viteroutermock)
 
-### Mocking other modules
+#### Mocking other modules
 
 To mock other modules, use [automocking](../../writing-stories/mocking-data-and-modules/mocking-modules.mdx#automocking) or one of the [alternative methods](../../writing-stories/mocking-data-and-modules/mocking-modules.mdx#alternative-methods) documented in the mocking modules guide.
 
-## Runtime config
+### Runtime config
 
 Next.js allows for [Runtime Configuration](https://nextjs.org/docs/pages/api-reference/next-config-js/runtime-configuration) which lets you import a handy `getConfig` function to get certain configuration defined in your `next.config.js` file at runtime.
 
@@ -658,13 +591,13 @@ Calls to `getConfig` would return the following object when called within Storyb
 }
 ```
 
-## Custom Vite configuration
+### Custom Vite configuration
 
 You can customize the [Vite configuration](../../builders/vite.mdx#configuration) used by Storybook in your `.storybook/main.js|ts` file. By default, Storybook's configuration extends the Vite configuration used by your project, but you can configure it to not do so.
 
 Not all Vite modifications are copy/paste-able between `next.config.js` and `.storybook/main.js|ts`. It is recommended to do your research on how to properly make your modification to Storybook's Vite config and on how [Vite works](https://vitejs.dev/guide/).
 
-## Typescript
+### Typescript
 
 Storybook handles most [Typescript](https://www.typescriptlang.org/) configurations, but this framework adds additional support for Next.js's support for [Absolute Imports and Module path aliases](https://nextjs.org/docs/pages/building-your-application/configuring/absolute-imports-and-module-aliases). In short, it takes into account your `tsconfig.json`'s [baseUrl](https://www.typescriptlang.org/tsconfig#baseUrl) and [paths](https://www.typescriptlang.org/tsconfig#paths). Thus, a `tsconfig.json` like the one below would work out of the box.
 
@@ -679,7 +612,7 @@ Storybook handles most [Typescript](https://www.typescriptlang.org/) configurati
 }
 ```
 
-## React Server Components (RSC)
+### React Server Components (RSC)
 
 (⚠️ **Experimental**)
 
@@ -710,6 +643,65 @@ If your server components access data via the network, we recommend using the [M
 In the future we will provide better mocking support in Storybook and support for [Server Actions](https://nextjs.org/docs/app/api-reference/functions/server-actions).
 
 ## FAQ
+
+
+### How do I migrate from the `nextjs` (Webpack 5) addon?
+
+#### Automatic migration
+
+Storybook provides a migration tool for migrating to this framework from the Webpack-based Next.js framework, [`@storybook/nextjs`](./nextjs.mdx). To migrate, run this command:
+
+```bash
+npx storybook automigrate nextjs-to-nextjs-vite
+```
+
+This automigration tool performs the following actions:
+
+1. Updates `package.json` files to replace `@storybook/nextjs` with `@storybook/nextjs-vite`
+2. Updates `.storybook/main.js|ts` to change the framework property
+3. Scans and updates import statements in your story files and configuration files
+
+<Callout variant="info">
+
+If your project has custom Webpack configurations in `.storybook/main.js|ts` (via `webpackFinal`), you'll need to migrate those to Vite configuration (via `viteFinal`) after running this automigration. See the [Vite builder documentation](../builders/vite.mdx#migrating-from-webpack) for more information.
+
+</Callout>
+
+#### Manual migration
+
+First, install the framework:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="nextjs-vite-install.md" />
+
+{/* prettier-ignore-end */}
+
+Then, update your `.storybook/main.js|ts` to change the framework property:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="nextjs-vite-add-framework.md" />
+
+{/* prettier-ignore-end */}
+
+<Callout variant="info">
+
+If your Storybook configuration contains custom Webpack operations in [`webpackFinal`](../../api/main-config/main-config-webpack-final.mdx), you will likely need to create equivalents in [`viteFinal`](../../api/main-config/main-config-vite-final.mdx).
+
+For more information, see the [Vite builder documentation](../../builders/vite.mdx#migrating-from-webpack).
+
+</Callout>
+
+Finally, if you were using Storybook plugins to integrate with Next.js, those are no longer necessary when using this framework and can be removed:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="nextjs-remove-addons.md" />
+
+{/* prettier-ignore-end */}
+
+
 
 ### Stories for pages/components which fetch data
 

--- a/docs/get-started/frameworks/nextjs-vite.mdx
+++ b/docs/get-started/frameworks/nextjs-vite.mdx
@@ -14,10 +14,20 @@ To install Storybook in an existing Next.js project, run this command in your pr
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with Next.js ≥ 14.1 with Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to [configure Storybook](#configure) with your Next.js project.
 
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'Next.js',
+  range: '≥ 14.1',
+  icon: '/images/logos/renderers/logo-nextjs.svg'
+}, {
+  name: 'Vite',
+  range: '≥ 5',
+  icon: '/images/logos/builders/vite.svg'
+}]} />
 
 ## Choose between Vite and Webpack
 

--- a/docs/get-started/frameworks/nextjs.mdx
+++ b/docs/get-started/frameworks/nextjs.mdx
@@ -27,11 +27,20 @@ To install Storybook in an existing Next.js project, run this command in your pr
 
 The command will prompt you to choose between this framework and [`@storybook/nextjs-vite`](./nextjs-vite.mdx). We recommend the Vite-based framework ([learn why](./nextjs-vite.mdx#choose-between-vite-and-webpack)).
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
-
-Storybook is compatible with Next.js ≥ 14.1 with Webpack 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to [configure Storybook](#configure) with your Next.js project.
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
 
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'Next.js',
+  range: '≥ 14.1',
+  icon: '/images/logos/renderers/logo-nextjs.svg'
+}, {
+  name: 'Webpack',
+  range: '5',
+  icon: '/images/logos/builders/webpack.svg'
+}]} />
 
 ## Run Storybook
 

--- a/docs/get-started/frameworks/nextjs.mdx
+++ b/docs/get-started/frameworks/nextjs.mdx
@@ -6,14 +6,8 @@ sidebar:
   title: Next.js (Webpack)
 ---
 
-Storybook for Next.js (Webpack) is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [Next.js](https://nextjs.org/) applications using Webpack 5. It includes:
+Storybook for Next.js (Webpack) is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [Next.js](https://nextjs.org/) applications using [Webpack 5](https://webpack.js.org/).
 
-* 🔀 Routing
-* 🖼 Image optimization
-* ⤵️ Absolute imports
-* 🎨 Styling
-* 🎛 Webpack & Babel config
-* 💫 and more!
 
 <Callout variant="info">
 
@@ -23,99 +17,65 @@ Use this Webpack-based framework (`@storybook/nextjs`) only if:
 - Your project has custom Webpack configurations that are incompatible with Vite
 - Your project has custom Babel configurations that require Webpack
 - You need specific Webpack features not available in Vite
-
 </Callout>
 
-## Requirements
+## Install
 
-* Next.js ≥ 14.1
+To install Storybook in an existing Next.js project, run this command in your project's root directory:
 
-## Getting started
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-### In a project without Storybook
+The command will prompt you to choose between this framework and [`@storybook/nextjs-vite`](./nextjs-vite.mdx). We recommend the Vite-based framework ([learn why](./nextjs-vite.mdx#choose-between-vite-and-webpack)).
 
-When you run `storybook init` in your Next.js project, Storybook will automatically detect your project and select the [`@storybook/nextjs-vite`](./nextjs-vite.mdx) framework (which we recommend) unless your project has custom Webpack or Babel configurations that may be incompatible with Vite.
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+
+Storybook is compatible with Next.js ≥ 14.1 with Webpack 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to [configure Storybook](#configure) with your Next.js project.
 
 
-<details>
-<summary>If your project has custom Webpack/Babel configurations</summary>
 
-If `storybook init` detects a custom Webpack configuration in your Next.js config file or `.babelrc` file, it will prompt you to choose between:
+## Run Storybook
 
-- **`@storybook/nextjs-vite`** (recommended) - Faster, more modern, supports latest testing features, but may be incompatible with your custom Webpack/Babel config
-- **`@storybook/nextjs`** (Webpack 5) - Better compatibility with custom Webpack/Babel configurations
+To run Storybook for a particular project, run the following:
 
-Choose `@storybook/nextjs` (Webpack 5) if you need to keep your existing Webpack/Babel setup and cannot migrate to Vite.
+<CodeSnippets path="storybook-run-dev.md" />
 
-</details>
+To build Storybook, run:
 
-Follow the prompts after running this command in your Next.js project's root directory:
+<CodeSnippets path="build-storybook-production-mode.md" />
 
-{/* prettier-ignore-start */}
+You will find the output in the configured `outputDir` (default is `storybook-static`).
 
-<CodeSnippets path="create-command.md" />
 
-{/* prettier-ignore-end */}
 
-[More on getting started with Storybook.](../install.mdx)
 
-### In a project with Storybook
+## Configure
 
-This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
+Storybook for Next.js with Vite supports many Next.js features including:
 
-{/* prettier-ignore-start */}
+* 🖼 [Image optimization](#nextjss-image-component)
+* 🔤 [Font optimization](#nextjs-font-optimization)
+* 🔀 [Routing and navigation](#nextjs-routing)
+* 🌐 [`next/head`](#nextjs-head)
+* ⤵️ [Absolute imports](#imports)
+* 🎨 [Styling](#styling)
+* 🎭 [Module mocking](#mocking-modules)
+* ☁️ [React Server Component (experimental)](#react-server-components-rsc)
 
-<CodeSnippets path="storybook-upgrade.md" />
 
-{/* prettier-ignore-end */}
 
-#### Automatic migration
 
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/nextjs`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
 
-#### Manual migration
 
-First, install the framework:
 
-{/* prettier-ignore-start */}
 
-<CodeSnippets path="nextjs-install.md" />
 
-{/* prettier-ignore-end */}
 
-Then, update your `.storybook/main.js|ts` to change the framework property:
 
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="nextjs-add-framework.md" />
-
-{/* prettier-ignore-end */}
-
-Finally, if you were using Storybook plugins to integrate with Next.js, those are no longer necessary when using this framework and can be removed:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="nextjs-remove-addons.md" />
-
-{/* prettier-ignore-end */}
-
-#### Migrating to Vite
-
-Please refer to the [migration instructions for `@storybook/nextjs-vite`](./nextjs-vite.mdx#migrating-from-webpack).
-
-## Run the Setup Wizard
-
-If all goes well, you should see a setup wizard that will help you get started with Storybook introducing you to the main concepts and features, including how the UI is organized, how to write your first story, and how to test your components' response to various inputs utilizing [controls](../../essentials/controls.mdx).
-
-![Storybook onboarding](../../_assets/get-started/example-onboarding-wizard.png)
-
-If you skipped the wizard, you can always run it again by adding the `?path=/onboarding` query parameter to the URL of your Storybook instance, provided that the example stories are still available.
-
-## Next.js's Image component
+### Next.js's Image component
 
 This framework allows you to use Next.js's [next/image](https://nextjs.org/docs/pages/api-reference/components/image) with no configuration.
 
-### Local images
+#### Local images
 
 [Local images](https://nextjs.org/docs/pages/building-your-application/optimizing/images#local-images) are supported.
 
@@ -141,7 +101,7 @@ function Home() {
 }
 ```
 
-### Remote images
+#### Remote images
 
 [Remote images](https://nextjs.org/docs/pages/building-your-application/optimizing/images#remote-images) are also supported.
 
@@ -159,15 +119,15 @@ export default function Home() {
 }
 ```
 
-## Next.js font optimization
+### Next.js font optimization
 
 [next/font](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) is partially supported in Storybook. The packages `next/font/google` and `next/font/local` are supported.
 
-### `next/font/google`
+#### `next/font/google`
 
 You don't have to do anything. `next/font/google` is supported out of the box.
 
-### `next/font/local`
+#### `next/font/local`
 
 For local fonts you have to define the [src](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts#local-fonts) property.
 The path is relative to the directory where the font loader function is called.
@@ -180,7 +140,7 @@ import localFont from 'next/font/local';
 const localRubikStorm = localFont({ src: './fonts/RubikStorm-Regular.ttf' });
 ```
 
-#### `staticDir` mapping
+##### `staticDir` mapping
 
 You have to tell Storybook where the `fonts` directory is located, via the [`staticDirs` configuration](../../api/main-config/main-config-static-dirs.mdx#with-configuration-objects). The `from` value is relative to the `.storybook` directory. The `to` value is relative to the execution context of Storybook. Very likely it is the root of your project.
 
@@ -190,7 +150,7 @@ You have to tell Storybook where the `fonts` directory is located, via the [`sta
 
 {/* prettier-ignore-end */}
 
-### Not supported features of `next/font`
+#### Not supported features of `next/font`
 
 The following features are not supported (yet). Support for these features might be planned for the future:
 
@@ -200,7 +160,7 @@ The following features are not supported (yet). Support for these features might
 * [preload](https://nextjs.org/docs/pages/api-reference/components/font#preload) option gets ignored. Storybook handles Font loading its own way.
 * [display](https://nextjs.org/docs/pages/api-reference/components/font#display) option gets ignored. All fonts are loaded with display set to "block" to make Storybook load the font properly.
 
-### Mocking fonts during testing
+#### Mocking fonts during testing
 
 Occasionally fetching fonts from Google may fail as part of your Storybook build step. It is highly recommended to mock these requests, as those failures can cause your pipeline to fail as well. Next.js [supports mocking fonts](https://github.com/vercel/next.js/blob/725ddc7371f80cca273779d37f961c3e20356f95/packages/font/src/google/fetch-css-from-google-fonts.ts#L36) via a JavaScript module located where the env var `NEXT_FONT_GOOGLE_MOCKED_RESPONSES` references.
 
@@ -244,7 +204,7 @@ module.exports = {
 };
 ```
 
-## Next.js routing
+### Next.js routing
 
 [Next.js's router](https://nextjs.org/docs/pages/building-your-application/routing) is automatically stubbed for you so that when the router is interacted with, all of its interactions are automatically logged to the [Actions panel](../../essentials/actions.mdx).
 
@@ -252,7 +212,7 @@ module.exports = {
   You should only use `next/router` in the `pages` directory. In the `app` directory, it is necessary to use `next/navigation`.
 </Callout>
 
-### Overriding defaults
+#### Overriding defaults
 
 Per-story overrides can be done by adding a `nextjs.router` property onto the story [parameters](../../writing-stories/parameters.mdx). The framework will shallowly merge whatever you put here into the router.
 
@@ -266,7 +226,7 @@ Per-story overrides can be done by adding a `nextjs.router` property onto the st
   These overrides can also be applied to [all stories for a component](../../api/parameters.mdx#meta-parameters) or [all stories in your project](../../api/parameters.mdx#project-parameters). Standard [parameter inheritance](../../api/parameters.mdx#parameter-inheritance) rules apply.
 </Callout>
 
-### Default router
+#### Default router
 
 The default values on the stubbed router are as follows (see [globals](../../essentials/toolbars-and-globals.mdx#globals) for more details on how globals work).
 
@@ -315,13 +275,13 @@ const preview: Preview = {
 };
 ```
 
-## Next.js navigation
+### Next.js navigation
 
 <Callout>
   Please note that [`next/navigation`](https://nextjs.org/docs/app/building-your-application/routing) can only be used in components/pages in the `app` directory.
 </Callout>
 
-### Set `nextjs.appDirectory` to `true`
+#### Set `nextjs.appDirectory` to `true`
 
 If your story imports components that use `next/navigation`, you need to set the parameter `nextjs.appDirectory` to `true` in for that component's stories:
 
@@ -339,7 +299,7 @@ If your Next.js project uses the `app` directory for every page (in other words,
 
 {/* prettier-ignore-end */}
 
-### Overriding defaults
+#### Overriding defaults
 
 Per-story overrides can be done by adding a `nextjs.navigation` property onto the story [parameters](../../writing-stories/parameters.mdx). The framework will shallowly merge whatever you put here into the router.
 
@@ -353,7 +313,7 @@ Per-story overrides can be done by adding a `nextjs.navigation` property onto th
   These overrides can also be applied to [all stories for a component](../../api/parameters.mdx#meta-parameters) or [all stories in your project](../../api/parameters.mdx#project-parameters). Standard [parameter inheritance](../../api/parameters.mdx#parameter-inheritance) rules apply.
 </Callout>
 
-### `useSelectedLayoutSegment`, `useSelectedLayoutSegments`, and `useParams` hooks
+#### `useSelectedLayoutSegment`, `useSelectedLayoutSegments`, and `useParams` hooks
 
 The `useSelectedLayoutSegment`, `useSelectedLayoutSegments`, and `useParams` hooks are supported in Storybook. You have to set the `nextjs.navigation.segments` parameter to return the segments or the params you want to use.
 
@@ -403,7 +363,7 @@ export default function ParamsBasedComponent() {
 
 The default value of `nextjs.navigation.segments` is `[]` if not set.
 
-### Default navigation context
+#### Default navigation context
 
 The default values on the stubbed navigation context are as follows:
 
@@ -443,11 +403,13 @@ const preview: Preview = {
 };
 ```
 
-## Next.js Head
+### Next.js Head
 
 [`next/head`](https://nextjs.org/docs/pages/api-reference/components/head) is supported out of the box. You can use it in your stories like you would in your Next.js application. Please keep in mind, that the Head `children` are placed into the head element of the iframe that Storybook uses to render your stories.
 
-## Sass/Scss
+### Styling
+
+#### Sass/Scss
 
 [Global Sass/Scss stylesheets](https://nextjs.org/docs/pages/building-your-application/styling/sass) are supported without any additional configuration as well. Just import them into [`.storybook/preview.js|ts`](../../configure/index.mdx#configure-story-rendering)
 
@@ -468,7 +430,7 @@ export default {
 };
 ```
 
-## CSS/Sass/Scss Modules
+#### CSS/Sass/Scss Modules
 
 [CSS modules](https://nextjs.org/docs/pages/building-your-application/styling/css-modules) work as expected.
 
@@ -488,7 +450,7 @@ export function Button() {
 }
 ```
 
-## Styled JSX
+#### Styled JSX
 
 The built in CSS-in-JS solution for Next.js is [styled-jsx](https://nextjs.org/docs/pages/building-your-application/styling/css-in-js), and this framework supports that out of the box too, zero config.
 
@@ -542,13 +504,14 @@ You can use your own babel config too. This is an example of how you can customi
 }
 ```
 
-## PostCSS
+#### PostCSS
 
 Next.js lets you [customize PostCSS config](https://nextjs.org/docs/pages/building-your-application/configuring/post-css). Thus this framework will automatically handle your PostCSS config for you.
 
 This allows for cool things like zero-config Tailwind! (See [Next.js' example](https://github.com/vercel/next.js/tree/canary/packages/create-next-app/templates/default-tw))
 
-## Absolute imports
+### Imports
+#### Absolute imports
 
 [Absolute imports](https://nextjs.org/docs/pages/building-your-application/configuring/absolute-imports-and-module-aliases#absolute-imports) from the root directory are supported.
 
@@ -580,7 +543,7 @@ import 'styles/globals.scss';
   Absolute imports **cannot** be mocked in stories/tests. See the [Mocking modules](#mocking-modules) section for more information.
 </Callout>
 
-## Module aliases
+#### Module aliases
 
 [Module aliases](https://nextjs.org/docs/app/building-your-application/configuring/absolute-imports-and-module-aliases#module-aliases) are also supported.
 
@@ -600,7 +563,7 @@ export default function HomePage() {
 }
 ```
 
-## Subpath imports
+#### Subpath imports
 
 As an alternative to [module aliases](#module-aliases), you can use [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) to import modules. This follows Node package standards and has benefits when [mocking modules](#mocking-modules).
 
@@ -634,11 +597,11 @@ export default function HomePage() {
 }
 ```
 
-## Mocking modules
+### Mocking modules
 
 Components often depend on modules that are imported into the component file. These can be from external packages or internal to your project. When rendering those components in Storybook or testing them, you may want to [mock those modules](../../writing-stories/mocking-data-and-modules/mocking-modules.mdx) to control and assert their behavior.
 
-### Built-in mocked modules
+#### Built-in mocked modules
 
 This framework provides mocks for many of Next.js' internal modules:
 
@@ -647,11 +610,11 @@ This framework provides mocks for many of Next.js' internal modules:
 3. [`@storybook/nextjs/navigation.mock`](#storybooknextjsnavigationmock)
 4. [`@storybook/nextjs/router.mock`](#storybooknextjsroutermock)
 
-### Mocking other modules
+#### Mocking other modules
 
 To mock other modules, use [automocking](../../writing-stories/mocking-data-and-modules/mocking-modules.mdx#automocking) or one of the [alternative methods](../../writing-stories/mocking-data-and-modules/mocking-modules.mdx#alternative-methods) documented in the mocking modules guide.
 
-## Runtime config
+### Runtime config
 
 Next.js allows for [Runtime Configuration](https://nextjs.org/docs/pages/api-reference/next-config-js/runtime-configuration) which lets you import a handy `getConfig` function to get certain configuration defined in your `next.config.js` file at runtime.
 
@@ -685,7 +648,7 @@ Calls to `getConfig` would return the following object when called within Storyb
 }
 ```
 
-## Custom Webpack config
+### Custom Webpack config
 
 Next.js comes with a lot of things for free out of the box like Sass support, but sometimes you add [custom Webpack config modifications to Next.js](https://nextjs.org/docs/pages/api-reference/next-config-js/webpack). This framework takes care of most of the Webpack modifications you would want to add. If Next.js supports a feature out of the box, then that feature will work out of the box in Storybook. If Next.js doesn't support something out of the box, but makes it easy to configure, then this framework will do the same for that thing for Storybook.
 
@@ -701,7 +664,7 @@ Below is an example of how to add SVGR support to Storybook with this framework.
 
 {/* prettier-ignore-end */}
 
-## Typescript
+### Typescript
 
 Storybook handles most [Typescript](https://www.typescriptlang.org/) configurations, but this framework adds additional support for Next.js's support for [Absolute Imports and Module path aliases](https://nextjs.org/docs/pages/building-your-application/configuring/absolute-imports-and-module-aliases). In short, it takes into account your `tsconfig.json`'s [baseUrl](https://www.typescriptlang.org/tsconfig#baseUrl) and [paths](https://www.typescriptlang.org/tsconfig#paths). Thus, a `tsconfig.json` like the one below would work out of the box.
 
@@ -716,7 +679,7 @@ Storybook handles most [Typescript](https://www.typescriptlang.org/) configurati
 }
 ```
 
-## React Server Components (RSC)
+### React Server Components (RSC)
 
 (⚠️ **Experimental**)
 
@@ -764,6 +727,36 @@ Module not found: Error: Can't resolve 'style-loader'
 This is because those versions of Yarn have different package resolution rules than Yarn v1.x. If this is the case for you, please install the package directly.
 
 ## FAQ
+
+### How do I manually install the Next.js framework?
+
+First, install the framework:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="nextjs-install.md" />
+
+{/* prettier-ignore-end */}
+
+Then, update your `.storybook/main.js|ts` to change the framework property:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="nextjs-add-framework.md" />
+
+{/* prettier-ignore-end */}
+
+Finally, if you were using Storybook plugins to integrate with Next.js, those are no longer necessary when using this framework and can be removed:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="nextjs-remove-addons.md" />
+
+{/* prettier-ignore-end */}
+
+### How do I migrate to the Next.js Vite framework?
+
+Please refer to the [migration instructions for `@storybook/nextjs-vite`](./nextjs-vite.mdx#how-do-i-migrate-from-the-nextjs-webpack-5-addon).
 
 ### Stories for pages/components which fetch data
 

--- a/docs/get-started/frameworks/preact-vite.mdx
+++ b/docs/get-started/frameworks/preact-vite.mdx
@@ -14,9 +14,19 @@ To install Storybook in an existing Preact project, run this command in your pro
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with Preact 8.x or 10.x, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your Preact project.
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'Preact',
+  range: '8.x || 10.x',
+  icon: '/images/logos/renderers/logo-preact.svg'
+}, {
+  name: 'Vite',
+  range: '≥ 5',
+  icon: '/images/logos/builders/vite.svg'
+}]} />
 
 
 ## Run Storybook

--- a/docs/get-started/frameworks/preact-vite.mdx
+++ b/docs/get-started/frameworks/preact-vite.mdx
@@ -6,46 +6,34 @@ sidebar:
   title: Preact (Vite)
 ---
 
-Storybook for Preact & Vite is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [Preact](https://preactjs.com/) applications built with [Vite](https://vitejs.dev/). It includes:
+Storybook for Preact & Vite is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [Preact](https://preactjs.com/) applications built with [Vite](https://vitejs.dev/).
 
-* 🏎️ Pre-bundled for performance
-* 🪄 Zero config
-* 💫 and more!
+## Install
 
-## Requirements
+To install Storybook in an existing Preact project, run this command in your project's root directory:
 
-* Preact 8.x || 10.x
-* Vite ≥ 5.0
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-## Getting started
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
 
-### In a project without Storybook
+Storybook is compatible with Preact 8.x or 10.x, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your Preact project.
 
-Follow the prompts after running this command in your Preact project's root directory:
 
-{/* prettier-ignore-start */}
+## Run Storybook
 
-<CodeSnippets path="create-command.md" />
+To run Storybook for a particular project, run the following:
 
-{/* prettier-ignore-end */}
+<CodeSnippets path="storybook-run-dev.md" />
 
-[More on getting started with Storybook.](../install.mdx)
+To build Storybook, run:
 
-### In a project with Storybook
+<CodeSnippets path="build-storybook-production-mode.md" />
 
-This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
+You will find the output in the configured `outputDir` (default is `storybook-static`).
 
-{/* prettier-ignore-start */}
 
-<CodeSnippets path="storybook-upgrade.md" />
-
-{/* prettier-ignore-end */}
-
-#### Automatic migration
-
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/preact-vite`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
-
-#### Manual migration
+## FAQ
+### How do I manually install the Preact framework?
 
 First, install the framework:
 

--- a/docs/get-started/frameworks/react-native-web-vite.mdx
+++ b/docs/get-started/frameworks/react-native-web-vite.mdx
@@ -18,7 +18,7 @@ Storybook for React Native Web is a [framework](../../contribute/framework.mdx) 
 
 ## Install
 
-To install Storybook in an existing React project, run this command in your project's root directory:
+To install Storybook in an existing React Native project, run this command in your project's root directory:
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 

--- a/docs/get-started/frameworks/react-native-web-vite.mdx
+++ b/docs/get-started/frameworks/react-native-web-vite.mdx
@@ -22,9 +22,24 @@ To install Storybook in an existing React Native project, run this command in yo
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with React Native ≥ 0.72, [React Native Web](https://necolas.github.io/react-native-web/) ≥ 0.19, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your React project.
+
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'React Native',
+  range: '≥ 0.72',
+  icon: '/images/logos/renderers/logo-react.svg'
+}, {
+  name: 'React Native Web',
+  range: '≥ 0.19',
+  icon: '/images/logos/renderers/logo-react.svg'
+}, {
+  name: 'Vite',
+  range: '≥ 5',
+  icon: '/images/logos/builders/vite.svg'
+}]} />
 
 
 ## Run Storybook

--- a/docs/get-started/frameworks/react-native-web-vite.mdx
+++ b/docs/get-started/frameworks/react-native-web-vite.mdx
@@ -6,57 +6,92 @@ sidebar:
   title: React Native Web
 ---
 
-Storybook for React Native Web is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [React Native](https://reactnative.dev/) applications. It uses [Vite](https://vitejs.dev/) to build your components for web browsers. The framework includes:
-
-* ⚛️ React Native components
-* 🧑‍💻 Shareable on the web
-* 🪄 Zero config
-* 💫 and more!
+Storybook for React Native Web is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [React Native](https://reactnative.dev/). It uses [Vite](https://vitejs.dev/) to build your components for web browsers.
 
 <Callout variant="info">
   In addition to React Native Web, Storybook supports on-device [React Native](https://github.com/storybookjs/react-native) development. If you're unsure what's right for you, read our [comparison](#react-native-vs-react-native-web).
 </Callout>
 
-## Requirements
 
-* React-Native ≥ 0.72
-* React-Native-Web ≥ 0.19
-* Vite ≥ 5.0
 
-## Getting started
 
-### In a project without Storybook
 
-When you run `storybook init` in your React Native project, Storybook will detect your project and present you with a prompt to choose which type of Storybook you want to install:
+## Install
 
-**React Native options:**
+To install Storybook in an existing React project, run this command in your project's root directory:
 
-- **"React Native"**: Storybook on your device/simulator
-  - High-fidelity, runs in your actual React Native application
-  - Limited feature set compared to web version
-  - Best for projects that rely on native modules or device-specific features
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-- **"React Native Web"**: Storybook on web for docs, test, and sharing
-  - Feature-rich web-based Storybook
-  - Full support for documentation, testing, and accessibility features
-  - Best for projects that want web-based sharing and testing
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
 
-- **"Both"**: Add both native and web Storybooks
-  - Installs and configures both environments
-  - Allows you to run Storybook for both native and web in the same project
-  - Best for projects that want both native fidelity and web features
+Storybook is compatible with React Native ≥ 0.72, [React Native Web](https://necolas.github.io/react-native-web/) ≥ 0.19, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your React project.
 
-Follow the prompts after running this command in your React Native project's root directory:
 
-{/* prettier-ignore-start */}
+## Run Storybook
 
-<CodeSnippets path="create-command.md" />
+To run Storybook for a particular project, run the following:
 
-{/* prettier-ignore-end */}
+<CodeSnippets path="storybook-run-dev.md" />
 
-[More on getting started with Storybook.](../install.mdx)
+To build Storybook, run:
 
-### In a project with Storybook `addon-react-native-web`
+<CodeSnippets path="build-storybook-production-mode.md" />
+
+You will find the output in the configured `outputDir` (default is `storybook-static`).
+
+
+
+## React Native vs React Native Web
+
+If you’re building React Native (RN) components, Storybook has two options: Native and Web.
+
+Both options provide a catalog of your stories that hot refreshes as you edit the code in your favorite editor. However, their implementations are quite different:
+
+- **Native** - Runs inside your React Native application. It’s high-fidelity but has a limited feature set.
+- **Web** - Displays your React Native components in the browser. It’s based on Storybook for Web, which is feature-rich and mature.
+
+{/* TODO: Don't forget about this image, otherwise remove it */}
+
+{/* [Image: native + web] */}
+
+### Comparison
+
+So, which option is right for you?
+
+**Native.** You should choose this option if you want:
+
+- **Native features** - Your components rely on device-specific features like native modules. It runs in your actual application, in-simulator, or on-device and provides full fidelity. The web version uses `react-native-web`, which works for most components but has [limitations](https://necolas.github.io/react-native-web/docs/react-native-compatibility/).
+- **Mobile publication** - You want to share your Storybook on-device as part of a test build or embedded inside your application.
+
+**Web.** You should choose this option if you want:
+
+- [**Sharing**](../../sharing/publish-storybook.mdx) - Publish to the web and share with your team or publicly.
+- [**Documentation**](../../writing-docs/index.mdx) - Auto-generated component docs or rich markdown docs in MDX.
+- [**Testing**](../../writing-tests/index.mdx) - Component, visual, and a11y tests for your components.
+- [**Addons**](https://storybook.js.org/addons) - 500+ addons that improve development, documentation, testing, and integration with other tools.
+
+**Both.** It’s also possible to use both options together. This increases Storybook’s install footprint but is a good option if you want native fidelity in addition to all of the web features. Learn more below.
+
+
+### Using both React Native and React Native Web
+
+The easiest way to use React Native and React Native Web is to select the **"Both"** option when installing Storybook. This will install and create configurations for both environments, allowing you to run Storybook for both in the same project.
+
+When you select "Both", the installation will:
+1. Install and configure React Native Storybook (on-device)
+2. Install and configure React Native Web Storybook (web-based)
+3. Set up both configurations in your project
+
+After installation, you'll see instructions for both environments:
+- React Native Storybook will require additional manual configuration steps (replacing app entry, wrapping metro config)
+- React Native Web Storybook can be started immediately using the `storybook` command
+
+However, you can install them separately if one version is installed. You can add a React Native Web Storybook alongside an existing React Native Storybook by running the install command and selecting "React Native Web" in the setup wizard, and vice versa.
+
+
+## FAQ
+
+### How do I migrate from the React Native Web addon?
 
 The [React Native Web addon](https://github.com/storybookjs/addon-react-native-web) was a Webpack-based precursor to the React Native Web Vite framework (i.e., `@storybook/react-native-web-vite`). If you're using the addon, you should migrate to the framework, which is faster, more stable, maintained, and better documented. To do so, follow the steps below.
 
@@ -90,63 +125,6 @@ Update your `.storybook/main.js|ts` to change the framework property and remove 
 
 Finally, remove the addon and similar packages (i.e., `@storybook/react-webpack5` and `@storybook/addon-react-native-web`) from your project.
 
-### In a project with Storybook `react-native`
-
-[Storybook for React Native](https://github.com/storybookjs/react-native) is a framework that runs in a simulator or on your mobile device. It's possible to run React Native Web alongside React Native, but we are still working on a seamless integration. In the meantime, we recommend running one or the other. If you need help figuring out what's right for you, read our [comparison](#react-native-vs-react-native-web).
-
-## Run the Setup Wizard
-
-If all goes well, you should see a setup wizard that will help you get started with Storybook. The wizard will introduce you to the main concepts and features, including how the UI is organized, how to write your first story, and how to test your components' response to various inputs utilizing [controls](../../essentials/controls.mdx).
-
-![Storybook onboarding](../../_assets/get-started/example-onboarding-wizard.png)
-
-If you skipped the wizard, you can always run it again by adding the `?path=/onboarding` query parameter to the URL of your Storybook instance, provided that the example stories are still available.
-
-## React Native vs React Native Web
-
-If you’re building React Native (RN) components, Storybook has two options: Native and Web.
-
-Both options provide a catalog of your stories that hot refreshes as you edit the code in your favorite editor. However, their implementations are quite different:
-
-- **Native** - Runs inside your React Native application. It’s high-fidelity but has a limited feature set.
-- **Web** - Displays your React Native components in the browser. It’s based on Storybook for Web, which is feature-rich and mature.
-
-{/* TODO: Don't forget about this image, otherwise remove it */}
-
-{/* [Image: native + web] */}
-
-### Comparison
-
-So, which option is right for you?
-
-**Native.** You should choose this option if you want:
-
-- **Native features** - Your components rely on device-specific features like native modules. It runs in your actual application, in-simulator, or on-device and provides full fidelity. The web version uses `react-native-web`, which works for most components but has [limitations](https://necolas.github.io/react-native-web/docs/react-native-compatibility/).
-- **Mobile publication** - You want to share your Storybook on-device as part of a test build or embedded inside your application.
-
-**Web.** You should choose this option if you want:
-
-- [**Sharing**](../../sharing/publish-storybook.mdx) - Publish to the web and share with your team or publicly.
-- [**Documentation**](../../writing-docs/index.mdx) - Auto-generated component docs or rich markdown docs in MDX.
-- [**Testing**](../../writing-tests/index.mdx) - Component, visual, and a11y tests for your components.
-- [**Addons**](https://storybook.js.org/addons) - 500+ addons that improve development, documentation, testing, and integration with other tools.
-
-**Both.** It’s also possible to use both options together. This increases Storybook’s install footprint but is a good option if you want native fidelity in addition to all of the web features. Learn more below.
-
-## Using both React Native and React Native Web
-
-The easiest way to use React Native and React Native Web is to select the **"Both"** option when installing Storybook. This will install and create configurations for both environments, allowing you to run Storybook for both in the same project.
-
-When you select "Both", the installation will:
-1. Install and configure React Native Storybook (on-device)
-2. Install and configure React Native Web Storybook (web-based)
-3. Set up both configurations in your project
-
-After installation, you'll see instructions for both environments:
-- React Native Storybook will require additional manual configuration steps (replacing app entry, wrapping metro config)
-- React Native Web Storybook can be started immediately using the `storybook` command
-
-However, you can install them separately if one version is installed. You can add a React Native Web Storybook alongside an existing React Native Storybook by running the install command and selecting "React Native Web" in the setup wizard, and vice versa.
 
 ## API
 

--- a/docs/get-started/frameworks/react-vite.mdx
+++ b/docs/get-started/frameworks/react-vite.mdx
@@ -6,34 +6,36 @@ sidebar:
   title: React (Vite)
 ---
 
-Storybook for React & Vite is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [React](https://react.dev/) applications built with [Vite](https://vitejs.dev/). It includes:
+Storybook for React & Vite is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [React](https://react.dev/) applications built with [Vite](https://vitejs.dev/).
 
-* 🏎️ Pre-bundled for performance
-* 🪄 Zero config
-* 💫 and more!
+## Install
 
-## Requirements
+To install Storybook in an existing React project, run this command in your project's root directory:
 
-* React ≥ 16.8
-* Vite ≥ 5.0
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-## Getting started
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
 
-### In a project without Storybook
+Storybook is compatible with React ≥ 16.8, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your React project.
 
-Follow the prompts after running this command in your React project's root directory:
 
-{/* prettier-ignore-start */}
+## Run Storybook
 
-<CodeSnippets path="create-command.md" />
+To run Storybook for a particular project, run the following:
 
-{/* prettier-ignore-end */}
+<CodeSnippets path="storybook-run-dev.md" />
 
-[More on getting started with Storybook.](../install.mdx)
+To build Storybook, run:
 
-### In a project with Storybook
+<CodeSnippets path="build-storybook-production-mode.md" />
 
-This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
+You will find the output in the configured `outputDir` (default is `storybook-static`).
+
+
+## FAQ
+### How do I migrate from the React Webpack framework?
+
+The `upgrade` command should prompt you to migrate to `@storybook/react-vite` when you run it:
 
 {/* prettier-ignore-start */}
 
@@ -41,11 +43,9 @@ This framework is designed to work with Storybook 7+. If you’re not already us
 
 {/* prettier-ignore-end */}
 
-#### Automatic migration
+In case that auto-migration does not work for your project, refer to the manual installation instructions below.
 
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/react-vite`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
-
-#### Manual migration
+### How do I manually install the React framework?
 
 First, install the framework:
 
@@ -63,13 +63,6 @@ Then, update your `.storybook/main.js|ts` to change the framework property:
 
 {/* prettier-ignore-end */}
 
-## Run the Setup Wizard
-
-If all goes well, you should see a setup wizard that will help you get started with Storybook introducing you to the main concepts and features, including how the UI is organized, how to write your first story, and how to test your components' response to various inputs utilizing [controls](../../essentials/controls.mdx).
-
-![Storybook onboarding](../../_assets/get-started/example-onboarding-wizard.png)
-
-If you skipped the wizard, you can always run it again by adding the `?path=/onboarding` query parameter to the URL of your Storybook instance, provided that the example stories are still available.
 
 ## API
 

--- a/docs/get-started/frameworks/react-vite.mdx
+++ b/docs/get-started/frameworks/react-vite.mdx
@@ -14,9 +14,20 @@ To install Storybook in an existing React project, run this command in your proj
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with React ≥ 16.8, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your React project.
+
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'React',
+  range: '≥ 16.8',
+  icon: '/images/logos/renderers/logo-react.svg'
+}, {
+  name: 'Vite',
+  range: '≥ 5',
+  icon: '/images/logos/builders/vite.svg'
+}]} />
 
 
 ## Run Storybook

--- a/docs/get-started/frameworks/react-webpack5.mdx
+++ b/docs/get-started/frameworks/react-webpack5.mdx
@@ -8,40 +8,53 @@ sidebar:
 
 Storybook for React & Webpack is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [React](https://react.dev/) applications built with [Webpack](https://webpack.js.org/).
 
-## Requirements
+<Callout variant="info">
 
-* React ≥ 16.8
-* Webpack ≥ 5.0
+**We recommend using [`@storybook/react-vite`](./react-vite.mdx)** for most React projects. The Vite-based framework is faster, more modern, and offers better support for testing features.
 
-## Getting started
+Use this Webpack-based framework (`@storybook/react-webpack5`) only if you need specific Webpack features not available in Vite.
+</Callout>
 
-### In a project without Storybook
+## Install
 
-Follow the prompts after running this command in your React project's root directory:
+To install Storybook in an existing React project, run this command in your project's root directory:
 
-{/* prettier-ignore-start */}
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-<CodeSnippets path="create-command.md" />
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
 
-{/* prettier-ignore-end */}
+Storybook is compatible with React ≥ 16.8, and Webpack ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your React project.
 
-[More on getting started with Storybook.](../install.mdx)
 
-### In a project with Storybook
+## Run Storybook
 
-This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
+To run Storybook for a particular project, run the following:
 
-{/* prettier-ignore-start */}
+<CodeSnippets path="storybook-run-dev.md" />
 
-<CodeSnippets path="storybook-upgrade.md" />
+To build Storybook, run:
 
-{/* prettier-ignore-end */}
+<CodeSnippets path="build-storybook-production-mode.md" />
 
-#### Automatic migration
+You will find the output in the configured `outputDir` (default is `storybook-static`).
 
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/react-webpack5`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
 
-#### Manual migration
+## Configure
+
+### Create React App (CRA)
+
+Support for [Create React App](https://create-react-app.dev/) is handled by [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app).
+
+This preset enables support for all CRA features, including Sass/SCSS and TypeScript.
+
+### Manually initialized apps
+
+If you're working on an app that was initialized manually (i.e., without the use of CRA), ensure that your app has [react-dom](https://www.npmjs.com/package/react-dom) included as a dependency. Failing to do so can lead to unforeseen issues with Storybook and your project.
+
+
+## FAQ
+
+### How do I manually install the React Webpack framework?
 
 First, install the framework:
 
@@ -81,21 +94,9 @@ Finally, update your `.storybook/main.js|ts` to change the framework property:
 
 {/* prettier-ignore-end */}
 
-## Run the Setup Wizard
+### How do I migrate to the React Vite framework?
 
-If all goes well, you should see a setup wizard that will help you get started with Storybook introducing you to the main concepts and features, including how the UI is organized, how to write your first story, and how to test your components' response to various inputs utilizing [controls](../../essentials/controls.mdx).
-
-![Storybook onboarding](../../_assets/get-started/example-onboarding-wizard.png)
-
-If you skipped the wizard, you can always run it again by adding the `?path=/onboarding` query parameter to the URL of your Storybook instance, provided that the example stories are still available.
-
-## Create React App (CRA)
-
-Support for [Create React App](https://create-react-app.dev/) is handled by [`@storybook/preset-create-react-app`](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app).
-
-This preset enables support for all CRA features, including Sass/SCSS and TypeScript.
-
-If you're working on an app that was initialized manually (i.e., without the use of CRA), ensure that your app has [react-dom](https://www.npmjs.com/package/react-dom) included as a dependency. Failing to do so can lead to unforeseen issues with Storybook and your project.
+Please refer to the [migration instructions for `@storybook/react-vite`](./react-vite.mdx#how-do-i-migrate-from-the-react-webpack-framework).
 
 ## API
 

--- a/docs/get-started/frameworks/react-webpack5.mdx
+++ b/docs/get-started/frameworks/react-webpack5.mdx
@@ -21,9 +21,19 @@ To install Storybook in an existing React project, run this command in your proj
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with React ≥ 16.8, and Webpack ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your React project.
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'React',
+  range: '≥ 16.8',
+  icon: '/images/logos/renderers/logo-react.svg'
+}, {
+  name: 'Webpack',
+  range: '5',
+  icon: '/images/logos/builders/webpack.svg'
+}]} />
 
 
 ## Run Storybook

--- a/docs/get-started/frameworks/svelte-vite.mdx
+++ b/docs/get-started/frameworks/svelte-vite.mdx
@@ -15,9 +15,19 @@ To install Storybook in an existing Svelte project, run this command in your pro
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with Svelte ≥ 5, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your Svelte project.
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'Svelte',
+  range: '≥ 5',
+  icon: '/images/logos/renderers/logo-svelte.svg'
+}, {
+  name: 'Vite',
+  range: '≥ 5',
+  icon: '/images/logos/builders/vite.svg'
+}]} />
 
 
 ## Run Storybook

--- a/docs/get-started/frameworks/svelte-vite.mdx
+++ b/docs/get-started/frameworks/svelte-vite.mdx
@@ -8,56 +8,30 @@ sidebar:
 
 Storybook for Svelte & Vite is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for applications using [Svelte](https://svelte.dev/) built with [Vite](https://vitejs.dev/).
 
-## Requirements
 
-* Svelte ≥ 5.0
-* Vite ≥ 5.0
+## Install
 
-## Getting started
+To install Storybook in an existing Svelte project, run this command in your project's root directory:
 
-### In a project without Storybook
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-Follow the prompts after running this command in your Svelte project's root directory:
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
 
-{/* prettier-ignore-start */}
+Storybook is compatible with Svelte ≥ 5, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your Svelte project.
 
-<CodeSnippets path="create-command.md" />
 
-{/* prettier-ignore-end */}
+## Run Storybook
 
-[More on getting started with Storybook.](../install.mdx)
+To run Storybook for a particular project, run the following:
 
-### In a project with Storybook
+<CodeSnippets path="storybook-run-dev.md" />
 
-This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
+To build Storybook, run:
 
-{/* prettier-ignore-start */}
+<CodeSnippets path="build-storybook-production-mode.md" />
 
-<CodeSnippets path="storybook-upgrade.md" />
+You will find the output in the configured `outputDir` (default is `storybook-static`).
 
-{/* prettier-ignore-end */}
-
-#### Automatic migration
-
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/svelte-vite`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
-
-#### Manual migration
-
-First, install the framework:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="svelte-vite-install.md" />
-
-{/* prettier-ignore-end */}
-
-Then, update your `.storybook/main.js|ts` to change the framework property:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="svelte-vite-add-framework.md" />
-
-{/* prettier-ignore-end */}
 
 ## Writing native Svelte stories
 
@@ -174,6 +148,27 @@ If you enabled automatic documentation generation with the `autodocs` story prop
 <CodeSnippets path="svelte-csf-addon-tags.md" />
 
 {/* prettier-ignore-end */}
+
+
+## FAQ 
+### How do I manually install the Svelte framework?
+
+First, install the framework:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="svelte-vite-install.md" />
+
+{/* prettier-ignore-end */}
+
+Then, update your `.storybook/main.js|ts` to change the framework property:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="svelte-vite-add-framework.md" />
+
+{/* prettier-ignore-end */}
+
 
 ## API
 

--- a/docs/get-started/frameworks/sveltekit.mdx
+++ b/docs/get-started/frameworks/sveltekit.mdx
@@ -6,70 +6,37 @@ sidebar:
   title: SvelteKit
 ---
 
-Storybook for SvelteKit is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [SvelteKit](https://kit.svelte.dev/) applications. It includes:
+Storybook for SvelteKit is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [SvelteKit](https://kit.svelte.dev/) applications.
 
-* 🪄 Zero config
-* 🧩 Easily mock many SvelteKit modules
-* 🔗 Automatic link handling
-* 💫 and more!
+## Install
 
-## Requirements
+To install Storybook in an existing SvelteKit project, run this command in your project's root directory:
 
-* SvelteKit ≥ 1.0
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-## Getting started
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
 
-### In a project without Storybook
+Storybook is compatible with SvelteKit ≥ 1.0, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your SvelteKit project.
 
-Follow the prompts after running this command in your Sveltekit project's root directory:
 
-{/* prettier-ignore-start */}
+## Run Storybook
 
-<CodeSnippets path="create-command.md" />
+To run Storybook for a particular project, run the following:
 
-{/* prettier-ignore-end */}
+<CodeSnippets path="storybook-run-dev.md" />
 
-[More on getting started with Storybook.](../install.mdx)
+To build Storybook, run:
 
-### In a project with Storybook
+<CodeSnippets path="build-storybook-production-mode.md" />
 
-This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
+You will find the output in the configured `outputDir` (default is `storybook-static`).
 
-{/* prettier-ignore-start */}
 
-<CodeSnippets path="storybook-upgrade.md" />
+## Configure
 
-{/* prettier-ignore-end */}
+This section covers SvelteKit support and configuration options.
 
-#### Automatic migration
-
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/sveltekit`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
-
-#### Manual migration
-
-First, install the framework:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="sveltekit-install.md" />
-
-{/* prettier-ignore-end */}
-
-Then, update your `.storybook/main.js|ts` to change the framework property:
-
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="sveltekit-add-framework.md" />
-
-{/* prettier-ignore-end */}
-
-Finally, these packages are now either obsolete or part of `@storybook/sveltekit`, so you no longer need to depend on them directly. You can remove them (`npm uninstall`, `yarn remove`, `pnpm remove`) from your project:
-
-* `@storybook/svelte-vite`
-* `storybook-builder-vite`
-* `@storybook/builder-vite`
-
-## Supported features
+### Supported features
 
 All Svelte language features are supported out of the box, as the Storybook framework uses the Svelte compiler directly.
 However, SvelteKit has some [Kit-specific modules](https://kit.svelte.dev/docs/modules) that aren't supported. Here's a breakdown of what will and will not work within Storybook:
@@ -90,7 +57,7 @@ However, SvelteKit has some [Kit-specific modules](https://kit.svelte.dev/docs/m
 | [`$env/static/private`](https://svelte.dev/docs/kit/$env-static-private)           | ⛔ Not supported       | This is a server-side feature, and Storybook renders all components on the client.                                                      |
 | [`$service-worker`](https://svelte.dev/docs/kit/$service-worker)                   | ⛔ Not supported       | This is a service worker feature, which does not apply to Storybook.                                                                    |
 
-## How to mock
+### How to mock
 
 To mock a SvelteKit import you can define it within `parameters.sveltekit_experimental`:
 
@@ -102,7 +69,7 @@ To mock a SvelteKit import you can define it within `parameters.sveltekit_experi
 
 The [available parameters](#parameters) are documented in the API section, below.
 
-### Mocking links
+#### Mocking links
 
 The default link-handling behavior (e.g., when clicking an `<a href="..." />` element) is to log an action to the [Actions panel](../../essentials/actions.mdx).
 
@@ -231,6 +198,44 @@ If you enabled automatic documentation generation with the `autodocs` story prop
 <CodeSnippets path="svelte-csf-addon-tags.md" />
 
 {/* prettier-ignore-end */}
+
+## FAQ
+
+### How do I manually install the SvelteKit framework?
+
+First, install the framework:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="sveltekit-install.md" />
+
+{/* prettier-ignore-end */}
+
+Then, update your `.storybook/main.js|ts` to change the framework property:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="sveltekit-add-framework.md" />
+
+{/* prettier-ignore-end */}
+
+Finally, these packages are now either obsolete or part of `@storybook/sveltekit`, so you no longer need to depend on them directly. You can remove them (`npm uninstall`, `yarn remove`, `pnpm remove`) from your project:
+
+* `@storybook/svelte-vite`
+* `storybook-builder-vite`
+* `@storybook/builder-vite`
+
+
+### Error when starting Storybook
+
+When starting Storybook after upgrading to v7.0, it may quit with the following error:
+
+```sh
+ERR! SyntaxError: Identifier '__esbuild_register_import_meta_url__' has already been declared
+```
+
+This can occur when manually upgrading from 6.5 to 7.0. To resolve it, you'll need to remove the `svelteOptions` property in `.storybook/main.js`, as that is not supported (and no longer necessary) in Storybook 7+ with SvelteKit.
+
 
 ## API
 
@@ -381,15 +386,3 @@ Enables or disables automatic documentation generation for component properties.
 #### When to disable docgen
 
 Disabling docgen can improve build performance for large projects, but [argTypes won't be inferred automatically](../../api/arg-types.mdx#automatic-argtype-inference), which will prevent features like [Controls](../../essentials/controls.mdx) and [docs](../../writing-docs/autodocs.mdx) from working as expected. To use those features, you will need to [define `argTypes` manually](../../api/arg-types.mdx#manually-specifying-argtypes).
-
-## Troubleshooting
-
-### Error when starting Storybook
-
-When starting Storybook after upgrading to v7.0, it may quit with the following error:
-
-```sh
-ERR! SyntaxError: Identifier '__esbuild_register_import_meta_url__' has already been declared
-```
-
-This can occur when manually upgrading from 6.5 to 7.0. To resolve it, you'll need to remove the `svelteOptions` property in `.storybook/main.js`, as that is not supported (and no longer necessary) in Storybook 7+ with SvelteKit.

--- a/docs/get-started/frameworks/sveltekit.mdx
+++ b/docs/get-started/frameworks/sveltekit.mdx
@@ -14,9 +14,19 @@ To install Storybook in an existing SvelteKit project, run this command in your 
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with SvelteKit ≥ 1.0, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your SvelteKit project.
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'SvelteKit',
+  range: '≥ 1.0',
+  icon: '/images/logos/renderers/logo-svelte.svg'
+}, {
+  name: 'Vite',
+  range: '≥ 5',
+  icon: '/images/logos/builders/vite.svg'
+}]} />
 
 
 ## Run Storybook

--- a/docs/get-started/frameworks/sveltekit.mdx
+++ b/docs/get-started/frameworks/sveltekit.mdx
@@ -226,17 +226,6 @@ Finally, these packages are now either obsolete or part of `@storybook/sveltekit
 * `@storybook/builder-vite`
 
 
-### Error when starting Storybook
-
-When starting Storybook after upgrading to v7.0, it may quit with the following error:
-
-```sh
-ERR! SyntaxError: Identifier '__esbuild_register_import_meta_url__' has already been declared
-```
-
-This can occur when manually upgrading from 6.5 to 7.0. To resolve it, you'll need to remove the `svelteOptions` property in `.storybook/main.js`, as that is not supported (and no longer necessary) in Storybook 7+ with SvelteKit.
-
-
 ## API
 
 ### Parameters

--- a/docs/get-started/frameworks/vue3-vite.mdx
+++ b/docs/get-started/frameworks/vue3-vite.mdx
@@ -6,65 +6,45 @@ sidebar:
   title: Vue (Vite)
 ---
 
-Storybook for Vue & Vite is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [Vue](https://vuejs.org/) applications built with [Vite](https://vitejs.dev/). It includes:
+Storybook for Vue & Vite is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for [Vue](https://vuejs.org/) applications built with [Vite](https://vitejs.dev/).
 
-* 🏎️ Pre-bundled for performance
-* 🪄 Zero config
-* 🧠 Comprehensive docgen
-* 💫 and more!
+## Install
 
-## Requirements
+To install Storybook in an existing Vue project, run this command in your project's root directory:
 
-* Vue ≥ 3
-* Vite ≥ 5.0
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-## Getting started
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
 
-### In a project without Storybook
+Storybook is compatible with Vue ≥ 3, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your Vue project.
 
-Follow the prompts after running this command in your Vue project's root directory:
+## Run Storybook
 
-{/* prettier-ignore-start */}
+To run Storybook for a particular project, run the following:
 
-<CodeSnippets path="create-command.md" />
+<CodeSnippets path="storybook-run-dev.md" />
 
-{/* prettier-ignore-end */}
+To build Storybook, run:
 
-[More on getting started with Storybook.](../install.mdx)
+<CodeSnippets path="build-storybook-production-mode.md" />
 
-### In a project with Storybook
+You will find the output in the configured `outputDir` (default is `storybook-static`).
 
-This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
 
-{/* prettier-ignore-start */}
 
-<CodeSnippets path="storybook-upgrade.md" />
 
-{/* prettier-ignore-end */}
 
-#### Automatic migration
 
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/vue3-vite`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
 
-#### Manual migration
 
-First, install the framework:
 
-{/* prettier-ignore-start */}
 
-<CodeSnippets path="vue3-vite-install.md" />
 
-{/* prettier-ignore-end */}
+## Configure
 
-Then, update your `.storybook/main.js|ts` to change the framework property:
+Storybook for Vue 3 with Vite is designed to work out of the box with minimal configuration. This section covers configuration options for the framework.
 
-{/* prettier-ignore-start */}
-
-<CodeSnippets path="vue3-vite-add-framework.md" />
-
-{/* prettier-ignore-end */}
-
-## Extending the Vue application
+### Extending the Vue application
 
 Storybook creates a [Vue 3 application](https://vuejs.org/api/application.html#application-api) for your component preview. When using global custom components (`app.component`), directives (`app.directive`), extensions (`app.use`), or other application methods, you will need to configure those in the `./storybook/preview.js|ts` file.
 
@@ -82,7 +62,7 @@ setup((app) => {
 });
 ```
 
-## Using `vue-component-meta`
+### Using `vue-component-meta`
 
 <Callout variant="info">
   `vue-component-meta` is only available in Storybook ≥ 8. It is currently an opt-in, but it will become the default in a future version of Storybook.
@@ -109,13 +89,13 @@ export default config;
 
 `vue-component-meta` comes with many benefits and enables more documentation features, such as:
 
-### Support for multiple component types
+#### Support for multiple component types
 
 `vue-component-meta` supports all types of Vue components (including SFC, functional, composition/options API components) from `.vue`, `.ts`, `.tsx`, `.js`, and `.jsx` files.
 
 It also supports both default and named component exports.
 
-### Prop description and JSDoc tag annotations
+#### Prop description and JSDoc tag annotations
 
 To describe a prop, including tags, you can use JSDoc comments in your component's props definition:
 
@@ -142,7 +122,7 @@ The props definition above will generate the following controls:
 
 ![Controls generated from props](../../_assets/get-started/vue-component-meta-prop-types-controls.png)
 
-### Events types extraction
+#### Events types extraction
 
 To provide a type for an emitted event, you can use TypeScript types (including JSDoc comments) in your component's `defineEmits` call:
 
@@ -167,7 +147,7 @@ Which will generate the following controls:
 
 ![Controls generated from events](../../_assets/get-started/vue-component-meta-event-types-controls.png)
 
-### Slots types extraction
+#### Slots types extraction
 
 The slot types are automatically extracted from your component definition and displayed in the controls panel.
 
@@ -204,7 +184,7 @@ The definition above will generate the following controls:
 
 ![Controls generated from slots](../../_assets/get-started/vue-component-meta-slot-types-controls.png)
 
-### Exposed properties and methods
+#### Exposed properties and methods
 
 The properties and methods exposed by your component are automatically extracted and displayed in the [Controls](../../essentials/controls.mdx) panel.
 
@@ -228,7 +208,7 @@ The definition above will generate the following controls:
 
 ![Controls generated from exposed properties and methods](../../_assets/get-started/vue-component-meta-exposed-types-controls.png)
 
-### Override the default configuration
+#### Override the default configuration
 
 If you're working with a project that relies on [`tsconfig references`](https://www.typescriptlang.org/docs/handbook/project-references.html) to link to other existing configuration files (e.g., `tsconfig.app.json`, `tsconfig.node.json`), we recommend that you update your [`.storybook/main.js|ts`](../../configure/index.mdx) configuration file and add the following:
 
@@ -256,7 +236,27 @@ export default config;
 
 Otherwise, you might face missing component types/descriptions or unresolvable import aliases like `@/some/import`.
 
-## Troubleshooting
+
+
+## FAQ
+
+### How do I manually install the Vue framework?
+
+First, install the framework:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="vue3-vite-install.md" />
+
+{/* prettier-ignore-end */}
+
+Then, update your `.storybook/main.js|ts` to change the framework property:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="vue3-vite-add-framework.md" />
+
+{/* prettier-ignore-end */}
 
 ### Storybook doesn't work with my Vue 2 project
 
@@ -267,6 +267,9 @@ Otherwise, you might face missing component types/descriptions or unresolvable i
 <CodeSnippets path="storybook-init-v7.md" />
 
 {/* prettier-ignore-end */}
+
+
+
 
 ## API
 

--- a/docs/get-started/frameworks/vue3-vite.mdx
+++ b/docs/get-started/frameworks/vue3-vite.mdx
@@ -14,9 +14,19 @@ To install Storybook in an existing Vue project, run this command in your projec
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with Vue ≥ 3, and Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your Vue project.
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'Vue',
+  range: '≥ 3',
+  icon: '/images/logos/renderers/logo-vue.svg'
+}, {
+  name: 'Vite',
+  range: '≥ 5',
+  icon: '/images/logos/builders/vite.svg'
+}]} />
 
 ## Run Storybook
 

--- a/docs/get-started/frameworks/web-components-vite.mdx
+++ b/docs/get-started/frameworks/web-components-vite.mdx
@@ -15,9 +15,16 @@ To install Storybook in an existing project, run this command in your project's 
 
 <CodeSnippets path="create-command.md" variant="new-users" />
 
-You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/). For more control over the installation process, refer to the [installation guide](/docs/install/).
 
-Storybook is compatible with Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your project.
+### Compatible versions
+
+<GetStartedVersions versions={[{
+  name: 'Vite',
+  range: '≥ 5',
+  icon: '/images/logos/builders/vite.svg'
+}]} />
+
 
 ## Run Storybook
 

--- a/docs/get-started/frameworks/web-components-vite.mdx
+++ b/docs/get-started/frameworks/web-components-vite.mdx
@@ -8,39 +8,32 @@ sidebar:
 
 Storybook for Web components & Vite is a [framework](../../contribute/framework.mdx) that makes it easy to develop and test UI components in isolation for applications using [Web components](https://www.webcomponents.org/introduction) built with [Vite](https://vitejs.dev/).
 
-## Requirements
 
-* Vite ≥ 5.0
+## Install
 
-## Getting started
+To install Storybook in an existing project, run this command in your project's root directory:
 
-### In a project without Storybook
+<CodeSnippets path="create-command.md" variant="new-users" />
 
-Follow the prompts after running this command in your Web components project's root directory:
+You can then get started [writing stories](/docs/get-started/whats-a-story/), [running tests](/docs/writing-tests/) and [documenting your components](/docs/writing-docs/).
 
-{/* prettier-ignore-start */}
+Storybook is compatible with Vite ≥ 5. For more control over the installation process, refer to the [installation guide](/docs/install/). Keep reading to learn how to better integrate Storybook with your project.
 
-<CodeSnippets path="create-command.md" />
+## Run Storybook
 
-{/* prettier-ignore-end */}
+To run Storybook for a particular project, run the following:
 
-[More on getting started with Storybook.](../install.mdx)
+<CodeSnippets path="storybook-run-dev.md" />
 
-### In a project with Storybook
+To build Storybook, run:
 
-This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
+<CodeSnippets path="build-storybook-production-mode.md" />
 
-{/* prettier-ignore-start */}
+You will find the output in the configured `outputDir` (default is `storybook-static`).
 
-<CodeSnippets path="storybook-upgrade.md" />
 
-{/* prettier-ignore-end */}
-
-#### Automatic migration
-
-When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/web-components-vite`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
-
-#### Manual migration
+## FAQ
+### How do I manually install the Web Components framework?
 
 First, install the framework:
 


### PR DESCRIPTION
This is the PR that's specifically about reorganising framework doc copy heavily around new users.

* All pages are restructured around the following structure:
  * Install
  * Run Storybook
  * Configure
  * FAQ
  * API
* Framework choice / migration callouts were kept only when we want to encourage towards specific frameworks (e.g. Webpack -> Vite)

The idea being that the further down the headings we go, the more likely we are to be addressing existing users who are more knowledgeable about our product and likely have more specific needs. We want to maximise our chances of new users installing and running SB so we focus on these actions.

This is a pretty radical change, so I isolated it from the rest of the growth experiment. Please be liberal with your feedback, and please let me know what you consider acceptable for a temporary experiment vs for a potentially permanent change in prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote and reorganized many framework getting-started guides into clear Install, Run, Configure, and FAQ flows.
  * Introduced a version-aware compatible-versions display and consolidated install/configuration guidance (including Angular Compodoc and builder options).
  * Replaced multi-step migration wizards with streamlined automatic/manual migration notes and inline configuration examples across Next.js, React, Vue, Svelte, Preact, RN Web, Web Components, and Angular.
  * Clarified run/build commands and output guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->