### PR TITLE
Angular: Migrate from RxJS to async/await in command builders and run Compodoc utility as spinner

### DIFF
--- a/code/frameworks/angular/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.ts
@@ -10,7 +10,6 @@ import type {
   BuilderContext,
   BuilderHandlerFn,
   BuilderOutput,
-  BuilderOutputLike,
   Target,
   Builder as DevkitBuilder,
 } from '@angular-devkit/architect';
@@ -27,8 +26,6 @@ import type {
 import type { JsonObject } from '@angular-devkit/core';
 import * as find from 'empathic/find';
 import * as pkg from 'empathic/package';
-import { from, of, throwError } from 'rxjs';
-import { catchError, map, mapTo, switchMap } from 'rxjs/operators';
 
 import { errorSummary, printErrorDetails } from '../utils/error-handler';
 import { runCompodoc } from '../utils/run-compodoc';
@@ -70,94 +67,85 @@ export type StorybookBuilderOutput = JsonObject & BuilderOutput & { [key: string
 
 type StandaloneBuildOptions = StandaloneOptions & { outputDir: string };
 
-const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (
+const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = async (
   options,
   context
-): BuilderOutputLike => {
-  const builder = from(setup(options, context)).pipe(
-    switchMap(({ tsConfig }) => {
-      const docTSConfig = find.up('tsconfig.doc.json', {
-        cwd: options.configDir,
-        last: getProjectRoot(),
-      });
-      const runCompodoc$ = options.compodoc
-        ? runCompodoc(
-            { compodocArgs: options.compodocArgs, tsconfig: docTSConfig ?? tsConfig },
-            context
-          ).pipe(mapTo({ tsConfig }))
-        : of({});
+): Promise<BuilderOutput> => {
+  const { tsConfig } = await setup(options, context);
 
-      return runCompodoc$.pipe(mapTo({ tsConfig }));
-    }),
-    map(({ tsConfig }) => {
-      getEnvConfig(options, {
-        staticDir: 'SBCONFIG_STATIC_DIR',
-        outputDir: 'SBCONFIG_OUTPUT_DIR',
-        configDir: 'SBCONFIG_CONFIG_DIR',
-      });
+  const docTSConfig = find.up('tsconfig.doc.json', {
+    cwd: options.configDir,
+    last: getProjectRoot(),
+  });
 
-      const {
-        browserTarget,
-        stylePreprocessorOptions,
-        styles,
-        configDir,
-        docs,
-        loglevel,
-        test,
-        outputDir,
-        quiet,
-        enableProdMode = true,
-        webpackStatsJson,
-        statsJson,
-        debugWebpack,
-        disableTelemetry,
-        assets,
-        previewUrl,
-        sourceMap = false,
-        preserveSymlinks = false,
-        experimentalZoneless = !!(VERSION.major && Number(VERSION.major) >= 21),
-      } = options;
+  if (options.compodoc) {
+    await runCompodoc(
+      { compodocArgs: options.compodocArgs, tsconfig: docTSConfig ?? tsConfig },
+      context
+    );
+  }
 
-      const packageJsonPath = pkg.up({ cwd: __dirname });
-      const packageJson =
-        packageJsonPath != null ? JSON.parse(readFileSync(packageJsonPath, 'utf8')) : null;
+  getEnvConfig(options, {
+    staticDir: 'SBCONFIG_STATIC_DIR',
+    outputDir: 'SBCONFIG_OUTPUT_DIR',
+    configDir: 'SBCONFIG_CONFIG_DIR',
+  });
 
-      const standaloneOptions: StandaloneBuildOptions = {
-        packageJson,
-        configDir,
-        ...(docs ? { docs } : {}),
-        loglevel,
-        outputDir,
-        test,
-        quiet,
-        enableProdMode,
-        disableTelemetry,
-        angularBrowserTarget: browserTarget,
-        angularBuilderContext: context,
-        angularBuilderOptions: {
-          ...(stylePreprocessorOptions ? { stylePreprocessorOptions } : {}),
-          ...(styles ? { styles } : {}),
-          ...(assets ? { assets } : {}),
-          sourceMap,
-          preserveSymlinks,
-          experimentalZoneless,
-        },
-        tsConfig,
-        webpackStatsJson,
-        statsJson,
-        debugWebpack,
-        previewUrl,
-      };
+  const {
+    browserTarget,
+    stylePreprocessorOptions,
+    styles,
+    configDir,
+    docs,
+    loglevel,
+    test,
+    outputDir,
+    quiet,
+    enableProdMode = true,
+    webpackStatsJson,
+    statsJson,
+    debugWebpack,
+    disableTelemetry,
+    assets,
+    previewUrl,
+    sourceMap = false,
+    preserveSymlinks = false,
+    experimentalZoneless = !!(VERSION.major && Number(VERSION.major) >= 21),
+  } = options;
 
-      return standaloneOptions;
-    }),
-    switchMap((standaloneOptions) => runInstance({ ...standaloneOptions, mode: 'static' })),
-    map(() => {
-      return { success: true };
-    })
-  );
+  const packageJsonPath = pkg.up({ cwd: __dirname });
+  const packageJson =
+    packageJsonPath != null ? JSON.parse(readFileSync(packageJsonPath, 'utf8')) : null;
 
-  return builder as any as BuilderOutput;
+  const standaloneOptions: StandaloneBuildOptions = {
+    packageJson,
+    configDir,
+    ...(docs ? { docs } : {}),
+    loglevel,
+    outputDir,
+    test,
+    quiet,
+    enableProdMode,
+    disableTelemetry,
+    angularBrowserTarget: browserTarget,
+    angularBuilderContext: context,
+    angularBuilderOptions: {
+      ...(stylePreprocessorOptions ? { stylePreprocessorOptions } : {}),
+      ...(styles ? { styles } : {}),
+      ...(assets ? { assets } : {}),
+      sourceMap,
+      preserveSymlinks,
+      experimentalZoneless,
+    },
+    tsConfig,
+    webpackStatsJson,
+    statsJson,
+    debugWebpack,
+    previewUrl,
+  };
+
+  await runInstance({ ...standaloneOptions, mode: 'static' });
+  return { success: true } as BuilderOutput;
 };
 
 export default createBuilder(commandBuilder) as DevkitBuilder<StorybookBuilderOptions & JsonObject>;
@@ -182,9 +170,9 @@ async function setup(options: StorybookBuilderOptions, context: BuilderContext) 
   };
 }
 
-function runInstance(options: StandaloneBuildOptions) {
-  return from(
-    withTelemetry(
+async function runInstance(options: StandaloneBuildOptions) {
+  try {
+    await withTelemetry(
       'build',
       {
         cliOptions: options,
@@ -197,6 +185,9 @@ function runInstance(options: StandaloneBuildOptions) {
         logger.outro('Storybook build completed successfully');
         return result;
       }
-    )
-  ).pipe(catchError((error: any) => throwError(errorSummary(error))));
+    );
+  } catch (error) {
+    const summary = errorSummary(error);
+    throw new Error(summary);
+  }
 }

--- a/code/frameworks/angular/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.ts
@@ -71,6 +71,8 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = async (
   options,
   context
 ): Promise<BuilderOutput> => {
+  logger.intro('Building Storybook');
+
   const { tsConfig } = await setup(options, context);
 
   const docTSConfig = find.up('tsconfig.doc.json', {
@@ -145,6 +147,7 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = async (
   };
 
   await runInstance({ ...standaloneOptions, mode: 'static' });
+  logger.outro('Storybook build completed successfully');
   return { success: true } as BuilderOutput;
 };
 
@@ -180,9 +183,7 @@ async function runInstance(options: StandaloneBuildOptions) {
         printError: printErrorDetails,
       },
       async () => {
-        logger.intro('Building storybook');
         const result = await buildStaticStandalone(options);
-        logger.outro('Storybook build completed successfully');
         return result;
       }
     );

--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -76,6 +76,8 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = async (
   options,
   context
 ): Promise<BuilderOutput> => {
+  logger.intro('Starting Storybook');
+
   const { tsConfig } = await setup(options, context);
 
   const docTSConfig = find.up('tsconfig.doc.json', {
@@ -207,7 +209,6 @@ async function runInstance(options: StandaloneOptions) {
         printError: printErrorDetails,
       },
       () => {
-        logger.intro('Starting storybook');
         return buildDevStandalone(options);
       }
     );

--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -26,8 +26,6 @@ import type {
 import type { JsonObject } from '@angular-devkit/core';
 import * as find from 'empathic/find';
 import * as pkg from 'empathic/package';
-import { Observable, from, of } from 'rxjs';
-import { map, mapTo, switchMap } from 'rxjs/operators';
 
 import { errorSummary, printErrorDetails } from '../utils/error-handler';
 import { runCompodoc } from '../utils/run-compodoc';
@@ -74,115 +72,108 @@ export type StorybookBuilderOptions = JsonObject & {
 
 export type StorybookBuilderOutput = JsonObject & BuilderOutput & {};
 
-const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (options, context) => {
-  const builder = from(setup(options, context)).pipe(
-    switchMap(({ tsConfig }) => {
-      const docTSConfig = find.up('tsconfig.doc.json', {
-        cwd: options.configDir,
-        last: getProjectRoot(),
-      });
+const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = async (
+  options,
+  context
+): Promise<BuilderOutput> => {
+  const { tsConfig } = await setup(options, context);
 
-      const runCompodoc$ = options.compodoc
-        ? runCompodoc(
-            {
-              compodocArgs: [...options.compodocArgs, ...(options.quiet ? ['--silent'] : [])],
-              tsconfig: docTSConfig ?? tsConfig,
-            },
-            context
-          ).pipe(mapTo({ tsConfig }))
-        : of({});
+  const docTSConfig = find.up('tsconfig.doc.json', {
+    cwd: options.configDir,
+    last: getProjectRoot(),
+  });
 
-      return runCompodoc$.pipe(mapTo({ tsConfig }));
-    }),
-    map(({ tsConfig }) => {
-      getEnvConfig(options, {
-        port: 'SBCONFIG_PORT',
-        host: 'SBCONFIG_HOSTNAME',
-        staticDir: 'SBCONFIG_STATIC_DIR',
-        configDir: 'SBCONFIG_CONFIG_DIR',
-        ci: 'CI',
-      });
+  if (options.compodoc) {
+    await runCompodoc(
+      {
+        compodocArgs: [...options.compodocArgs, ...(options.quiet ? ['--silent'] : [])],
+        tsconfig: docTSConfig ?? tsConfig,
+      },
+      context
+    );
+  }
 
-      options.port = parseInt(`${options.port}`, 10);
+  getEnvConfig(options, {
+    port: 'SBCONFIG_PORT',
+    host: 'SBCONFIG_HOSTNAME',
+    staticDir: 'SBCONFIG_STATIC_DIR',
+    configDir: 'SBCONFIG_CONFIG_DIR',
+    ci: 'CI',
+  });
 
-      const {
-        browserTarget,
-        stylePreprocessorOptions,
-        styles,
-        ci,
-        configDir,
-        docs,
-        host,
-        https,
-        port,
-        quiet,
-        enableProdMode = false,
-        smokeTest,
-        sslCa,
-        sslCert,
-        sslKey,
-        disableTelemetry,
-        assets,
-        initialPath,
-        open,
-        debugWebpack,
-        loglevel,
-        webpackStatsJson,
-        statsJson,
-        previewUrl,
-        sourceMap = false,
-        preserveSymlinks = false,
-        experimentalZoneless = !!(VERSION.major && Number(VERSION.major) >= 21),
-      } = options;
+  options.port = parseInt(`${options.port}`, 10);
 
-      const packageJsonPath = pkg.up({ cwd: __dirname });
-      const packageJson =
-        packageJsonPath != null ? JSON.parse(readFileSync(packageJsonPath, 'utf8')) : null;
+  const {
+    browserTarget,
+    stylePreprocessorOptions,
+    styles,
+    ci,
+    configDir,
+    docs,
+    host,
+    https,
+    port,
+    quiet,
+    enableProdMode = false,
+    smokeTest,
+    sslCa,
+    sslCert,
+    sslKey,
+    disableTelemetry,
+    assets,
+    initialPath,
+    open,
+    debugWebpack,
+    loglevel,
+    webpackStatsJson,
+    statsJson,
+    previewUrl,
+    sourceMap = false,
+    preserveSymlinks = false,
+    experimentalZoneless = !!(VERSION.major && Number(VERSION.major) >= 21),
+  } = options;
 
-      const standaloneOptions: StandaloneOptions = {
-        packageJson,
-        ci,
-        configDir,
-        ...(docs ? { docs } : {}),
-        host,
-        https,
-        port,
-        quiet,
-        enableProdMode,
-        smokeTest,
-        sslCa,
-        sslCert,
-        sslKey,
-        disableTelemetry,
-        angularBrowserTarget: browserTarget,
-        angularBuilderContext: context,
-        angularBuilderOptions: {
-          ...(stylePreprocessorOptions ? { stylePreprocessorOptions } : {}),
-          ...(styles ? { styles } : {}),
-          ...(assets ? { assets } : {}),
-          preserveSymlinks,
-          sourceMap,
-          experimentalZoneless,
-        },
-        tsConfig,
-        initialPath,
-        open,
-        debugWebpack,
-        webpackStatsJson,
-        statsJson,
-        loglevel,
-        previewUrl,
-      };
+  const packageJsonPath = pkg.up({ cwd: __dirname });
+  const packageJson =
+    packageJsonPath != null ? JSON.parse(readFileSync(packageJsonPath, 'utf8')) : null;
 
-      return standaloneOptions;
-    }),
-    switchMap((standaloneOptions) => runInstance(standaloneOptions)),
-    map((port: number) => {
-      return { success: true, info: { port } };
-    })
-  );
+  const standaloneOptions: StandaloneOptions = {
+    packageJson,
+    ci,
+    configDir,
+    ...(docs ? { docs } : {}),
+    host,
+    https,
+    port,
+    quiet,
+    enableProdMode,
+    smokeTest,
+    sslCa,
+    sslCert,
+    sslKey,
+    disableTelemetry,
+    angularBrowserTarget: browserTarget,
+    angularBuilderContext: context,
+    angularBuilderOptions: {
+      ...(stylePreprocessorOptions ? { stylePreprocessorOptions } : {}),
+      ...(styles ? { styles } : {}),
+      ...(assets ? { assets } : {}),
+      preserveSymlinks,
+      sourceMap,
+      experimentalZoneless,
+    },
+    tsConfig,
+    initialPath,
+    open,
+    debugWebpack,
+    webpackStatsJson,
+    statsJson,
+    loglevel,
+    previewUrl,
+  };
 
-  return builder as any as BuilderOutput;
+  const startedPort = await runInstance(standaloneOptions);
+  return { success: true, info: { port: startedPort } } as BuilderOutput;
 };
 
 export default createBuilder(commandBuilder) as DevkitBuilder<StorybookBuilderOptions & JsonObject>;
@@ -206,10 +197,9 @@ async function setup(options: StorybookBuilderOptions, context: BuilderContext) 
       browserOptions.tsConfig,
   };
 }
-function runInstance(options: StandaloneOptions) {
-  return new Observable<number>((observer) => {
-    // This Observable intentionally never complete, leaving the process running ;)
-    withTelemetry(
+async function runInstance(options: StandaloneOptions) {
+  try {
+    const { port } = await withTelemetry(
       'dev',
       {
         cliOptions: options,
@@ -220,10 +210,10 @@ function runInstance(options: StandaloneOptions) {
         logger.intro('Starting storybook');
         return buildDevStandalone(options);
       }
-    )
-      .then(({ port }) => observer.next(port))
-      .catch((error) => {
-        observer.error(errorSummary(error));
-      });
-  });
+    );
+    return port;
+  } catch (error) {
+    const summarized = errorSummary(error);
+    throw new Error(String(summarized));
+  }
 }

--- a/code/frameworks/angular/src/builders/utils/run-compodoc.spec.ts
+++ b/code/frameworks/angular/src/builders/utils/run-compodoc.spec.ts
@@ -1,7 +1,6 @@
 import type { BuilderContext } from '@angular-devkit/architect';
 // @ts-expect-error (TODO)
 import type { LoggerApi } from '@angular-devkit/core/src/logger';
-import { take } from 'rxjs/operators';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { runCompodoc } from './run-compodoc';
@@ -13,6 +12,13 @@ vi.mock('storybook/internal/common', () => ({
     getPackageManager: () => ({
       runPackageCommand: mockRunScript,
     }),
+  },
+}));
+vi.mock('storybook/internal/node-logger', () => ({
+  prompt: {
+    executeTaskWithSpinner: async (fn: any) => {
+      await fn();
+    },
   },
 }));
 
@@ -37,15 +43,13 @@ describe('runCompodoc', () => {
   } as BuilderContext;
 
   it('should run compodoc with tsconfig from context', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: [],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith({
       args: ['compodoc', '-p', 'path/to/tsconfig.json', '-d', 'path/to/project'],
@@ -54,15 +58,13 @@ describe('runCompodoc', () => {
   });
 
   it('should run compodoc with tsconfig from compodocArgs', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: ['-p', 'path/to/tsconfig.stories.json'],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith({
       args: ['compodoc', '-d', 'path/to/project', '-p', 'path/to/tsconfig.stories.json'],
@@ -71,15 +73,13 @@ describe('runCompodoc', () => {
   });
 
   it('should run compodoc with default output folder.', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: [],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith({
       args: ['compodoc', '-p', 'path/to/tsconfig.json', '-d', 'path/to/project'],
@@ -88,15 +88,13 @@ describe('runCompodoc', () => {
   });
 
   it('should run with custom output folder specified with --output compodocArgs', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: ['--output', 'path/to/customFolder'],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith({
       args: ['compodoc', '-p', 'path/to/tsconfig.json', '--output', 'path/to/customFolder'],
@@ -105,15 +103,13 @@ describe('runCompodoc', () => {
   });
 
   it('should run with custom output folder specified with -d compodocArgs', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: ['-d', 'path/to/customFolder'],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith({
       args: ['compodoc', '-p', 'path/to/tsconfig.json', '-d', 'path/to/customFolder'],


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Running Storybook for Angular hasn't indicated during startup that Compodoc is built, leading to the impression that the CLI got stuck. This got fixed by using a spinner for Compodoc's progress.

Additionally, the Angular builders were refactored to be asynchronous rather than using rxjs.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33156-sha-ed50d99f`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33156-sha-ed50d99f sandbox` or in an existing project with `npx storybook@0.0.0-pr-33156-sha-ed50d99f upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33156-sha-ed50d99f`](https://npmjs.com/package/storybook/v/0.0.0-pr-33156-sha-ed50d99f) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/show-compodoc-progress`](https://github.com/storybookjs/storybook/tree/valentin/show-compodoc-progress) |
| **Commit** | [`ed50d99f`](https://github.com/storybookjs/storybook/commit/ed50d99f8dcd565c9ce978a1462571fbe3171d81) |
| **Datetime** | Tue Nov 25 08:01:35 UTC 2025 (`1764057695`) |
| **Workflow run** | [19662405347](https://github.com/storybookjs/storybook/actions/runs/19662405347) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33156`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Rewrote builder flows to a simpler async/await model for more predictable execution and improved error handling
  * Simplified runtime logic for start/build operations to streamline control flow and results reporting
* **UX**
  * Added clearer visual progress indicators and messages during documentation generation
* **Tests**
  * Updated tests to align with promise-based execution and simplified mocks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->