### PR TITLE
UI: Fix crashes in Select when passed falsy non-string options

### DIFF
--- a/code/addons/pseudo-states/src/manager/PseudoStateTool.tsx
+++ b/code/addons/pseudo-states/src/manager/PseudoStateTool.tsx
@@ -36,7 +36,8 @@ export const PseudoStateTool = () => {
       multiSelect
       onChange={(selected) => {
         updateGlobals({
-          [PARAM_KEY]: selected.reduce((acc, curr) => ({ ...acc, [curr]: true }), {}),
+          // We know curr is a string because we are using string values in options
+          [PARAM_KEY]: selected.reduce((acc, curr) => ({ ...acc, [curr as string]: true }), {}),
         });
       }}
     />

--- a/code/core/src/backgrounds/components/Tool.tsx
+++ b/code/core/src/backgrounds/components/Tool.tsx
@@ -104,7 +104,7 @@ const Pure = memo(function PureTool(props: PureProps) {
           tooltip={isLocked ? 'Background set by story parameters' : 'Change background'}
           defaultOptions={backgroundName}
           options={options}
-          onSelect={(selected) => update({ value: selected, grid: isGrid })}
+          onSelect={(selected) => update({ value: selected as string, grid: isGrid })}
         />
       ) : null}
     </Fragment>

--- a/code/core/src/backgrounds/components/Tool.tsx
+++ b/code/core/src/backgrounds/components/Tool.tsx
@@ -54,7 +54,6 @@ interface PureProps {
 
 const Pure = memo(function PureTool(props: PureProps) {
   const {
-    item,
     length,
     updateGlobals,
     backgroundMap,

--- a/code/core/src/components/components/Select/Select.stories.tsx
+++ b/code/core/src/components/components/Select/Select.stories.tsx
@@ -1055,3 +1055,279 @@ export const WithoutReset = meta.story({
     expect(options.length).toBe(3);
   },
 });
+
+const nonStringOptions = [
+  { title: 'Number (42)', value: 42 },
+  { title: 'Number (0)', value: 0 },
+  { title: 'Boolean (true)', value: true },
+  { title: 'Boolean (false)', value: false },
+  { title: 'Null', value: null },
+  { title: 'Undefined', value: undefined },
+  { title: 'String', value: 'string' },
+];
+
+export const NonStringValuesSingleSelect = meta.story({
+  name: 'Non-String Values (single)',
+  args: {
+    options: nonStringOptions,
+    onSelect: fn(),
+    onChange: fn(),
+  },
+  play: async ({ canvas, args, step }) => {
+    const selectButton = await canvas.findByRole('button');
+
+    await step('Select number value (42)', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Number (42)' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(42);
+      expect(args.onChange).toHaveBeenLastCalledWith([42]);
+    });
+
+    await step('Select boolean value (true)', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Boolean (true)' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(true);
+      expect(args.onChange).toHaveBeenLastCalledWith([true]);
+    });
+
+    await step('Select boolean value (false)', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Boolean (false)' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(false);
+      expect(args.onChange).toHaveBeenLastCalledWith([false]);
+    });
+
+    await step('Select null value', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Null' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(null);
+      expect(args.onChange).toHaveBeenLastCalledWith([null]);
+    });
+
+    await step('Select undefined value', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Undefined' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(undefined);
+      expect(args.onChange).toHaveBeenLastCalledWith([undefined]);
+    });
+
+    await step('Select number value (0 - falsy)', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Number (0)' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(0);
+      expect(args.onChange).toHaveBeenLastCalledWith([0]);
+    });
+  },
+});
+
+export const NonStringValuesMultiSelect = meta.story({
+  name: 'Non-String Values (multi)',
+  args: {
+    options: nonStringOptions,
+    multiSelect: true,
+    onSelect: fn(),
+    onDeselect: fn(),
+    onChange: fn(),
+  },
+  play: async ({ canvas, args, step }) => {
+    const selectButton = await canvas.findByRole('button');
+
+    await step('Select number (42)', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Number (42)' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(42);
+      expect(args.onChange).toHaveBeenLastCalledWith([42]);
+    });
+
+    await step('Add boolean (true)', async () => {
+      await userEvent.click(await screen.findByRole('option', { name: 'Boolean (true)' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(true);
+      expect(args.onChange).toHaveBeenLastCalledWith([42, true]);
+    });
+
+    await step('Add null', async () => {
+      await userEvent.click(await screen.findByRole('option', { name: 'Null' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(null);
+      expect(args.onChange).toHaveBeenLastCalledWith([42, true, null]);
+    });
+
+    await step('Add undefined', async () => {
+      await userEvent.click(await screen.findByRole('option', { name: 'Undefined' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(undefined);
+      expect(args.onChange).toHaveBeenLastCalledWith([42, true, null, undefined]);
+    });
+
+    await step('Deselect number (42)', async () => {
+      await userEvent.click(await screen.findByRole('option', { name: 'Number (42)' }));
+      expect(args.onDeselect).toHaveBeenLastCalledWith(42);
+      expect(args.onChange).toHaveBeenLastCalledWith([true, null, undefined]);
+    });
+
+    await step('Deselect undefined', async () => {
+      await userEvent.click(await screen.findByRole('option', { name: 'Undefined' }));
+      expect(args.onDeselect).toHaveBeenLastCalledWith(undefined);
+      expect(args.onChange).toHaveBeenLastCalledWith([true, null]);
+    });
+  },
+});
+
+export const DefaultOptionNumber = meta.story({
+  name: 'Default Option - Number',
+  args: {
+    options: nonStringOptions,
+    defaultOptions: 42,
+  },
+  play: async ({ canvas }) => {
+    const selectButton = await canvas.findByRole('button');
+    await expect(selectButton).toHaveTextContent('Number (42)');
+  },
+});
+
+export const DefaultOptionZero = meta.story({
+  name: 'Default Option - Zero',
+  args: {
+    options: nonStringOptions,
+    defaultOptions: 0,
+  },
+  play: async ({ canvas }) => {
+    const selectButton = await canvas.findByRole('button');
+    await expect(selectButton).toHaveTextContent('Number (0)');
+  },
+});
+
+export const DefaultOptionBooleanTrue = meta.story({
+  name: 'Default Option - Boolean True',
+  args: {
+    options: nonStringOptions,
+    defaultOptions: true,
+  },
+  play: async ({ canvas }) => {
+    const selectButton = await canvas.findByRole('button');
+    await expect(selectButton).toHaveTextContent('Boolean (true)');
+  },
+});
+
+export const DefaultOptionBooleanFalse = meta.story({
+  name: 'Default Option - Boolean False',
+  args: {
+    options: nonStringOptions,
+    defaultOptions: false,
+  },
+  play: async ({ canvas }) => {
+    const selectButton = await canvas.findByRole('button');
+    await expect(selectButton).toHaveTextContent('Boolean (false)');
+  },
+});
+
+export const DefaultOptionNull = meta.story({
+  name: 'Default Option - Null',
+  args: {
+    options: nonStringOptions,
+    defaultOptions: null,
+  },
+  play: async ({ canvas }) => {
+    const selectButton = await canvas.findByRole('button');
+    await expect(selectButton).toHaveTextContent('Null');
+  },
+});
+
+export const DefaultOptionUndefinedDoesNotWork = meta.story({
+  name: 'Default Option - Bare undefined does NOT select',
+  args: {
+    options: nonStringOptions,
+    defaultOptions: undefined,
+    children: 'Nothing selected',
+  },
+  play: async ({ canvas }) => {
+    const selectButton = await canvas.findByRole('button');
+    await expect(selectButton).toHaveTextContent('Nothing selected');
+    await expect(selectButton).not.toHaveTextContent('Undefined');
+  },
+});
+
+export const DefaultOptionUndefinedInArrayWorks = meta.story({
+  name: 'Default Option - [undefined] selects undefined option',
+  args: {
+    options: nonStringOptions,
+    defaultOptions: [undefined],
+  },
+  play: async ({ canvas }) => {
+    const selectButton = await canvas.findByRole('button');
+    await expect(selectButton).toHaveTextContent('Undefined');
+  },
+});
+
+export const DefaultOptionsMultipleNonStringValues = meta.story({
+  name: 'Default Options - Multiple Non-String Values',
+  args: {
+    options: nonStringOptions,
+    defaultOptions: [42, false, null],
+    multiSelect: true,
+  },
+  play: async ({ canvas }) => {
+    const selectButton = await canvas.findByRole('button');
+    await expect(selectButton).toHaveTextContent('3');
+
+    await userEvent.click(selectButton);
+    const option42 = await screen.findByRole('option', { name: 'Number (42)' });
+    const optionFalse = await screen.findByRole('option', { name: 'Boolean (false)' });
+    const optionNull = await screen.findByRole('option', { name: 'Null' });
+
+    expect(option42).toHaveAttribute('aria-selected', 'true');
+    expect(optionFalse).toHaveAttribute('aria-selected', 'true');
+    expect(optionNull).toHaveAttribute('aria-selected', 'true');
+  },
+});
+
+const optionsWithUndefinedForReset = [
+  { title: 'Apple', value: 'apple' },
+  { title: 'Undefined Value', value: undefined },
+  { title: 'Banana', value: 'banana' },
+];
+
+export const ResetWithUndefinedOption = meta.story({
+  name: 'Reset vs Undefined Option',
+  args: {
+    options: optionsWithUndefinedForReset,
+    children: 'Select fruit',
+    onReset: fn(),
+    onChange: fn(),
+    onSelect: fn(),
+  },
+  play: async ({ canvas, args, step }) => {
+    const selectButton = await canvas.findByRole('button');
+
+    await step('Select a regular option first', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Apple' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith('apple');
+      expect(args.onChange).toHaveBeenLastCalledWith(['apple']);
+      await expect(selectButton).toHaveTextContent('Apple');
+    });
+
+    await step('Select the undefined value option - it should work', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Undefined Value' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(undefined);
+      expect(args.onChange).toHaveBeenLastCalledWith([undefined]);
+      await expect(selectButton).toHaveTextContent('Undefined Value');
+    });
+
+    await step('Click Reset - should clear, not select undefined option', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Reset selection' }));
+      expect(args.onReset).toHaveBeenCalledTimes(1);
+      expect(args.onChange).toHaveBeenLastCalledWith([]);
+      await expect(selectButton).toHaveTextContent('Select fruit');
+      await expect(selectButton).not.toHaveTextContent('Undefined Value');
+    });
+
+    await step('Can still select undefined value after reset', async () => {
+      await userEvent.click(selectButton);
+      await userEvent.click(await screen.findByRole('option', { name: 'Undefined Value' }));
+      expect(args.onSelect).toHaveBeenLastCalledWith(undefined);
+      expect(args.onChange).toHaveBeenLastCalledWith([undefined]);
+      await expect(selectButton).toHaveTextContent('Undefined Value');
+    });
+  },
+});

--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -15,7 +15,7 @@ import { Form } from '../Form/Form';
 import { Popover } from '../Popover/Popover';
 import { SelectOption } from './SelectOption';
 import type { Option, ResetOption } from './helpers';
-import { Listbox, PAGE_STEP_SIZE } from './helpers';
+import { Listbox, PAGE_STEP_SIZE, UNDEFINED_VALUE } from './helpers';
 
 export interface SelectProps
   extends Omit<ButtonProps, 'onClick' | 'onChange' | 'onSelect' | 'variant'> {
@@ -54,7 +54,7 @@ export interface SelectProps
   options: Option[];
 
   /** IDs of the preselected options. */
-  defaultOptions?: string | string[];
+  defaultOptions?: Option['value'] | Option['value'][];
 
   /** Whether the Select should render open. */
   defaultOpen?: boolean;
@@ -84,11 +84,7 @@ function setSelectedFromDefault(
   options: SelectProps['options'],
   defaultOptions: SelectProps['defaultOptions']
 ): Option[] {
-  if (!defaultOptions) {
-    return [];
-  }
-
-  if (typeof defaultOptions === 'string') {
+  if (defaultOptions === UNDEFINED_VALUE || defaultOptions === null || typeof defaultOptions !== 'object') {
     return options.filter((opt) => opt.value === defaultOptions);
   }
 

--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -543,7 +543,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
 
                   return (
                     <SelectOption
-                      key={String(option.value) ?? 'sb-reset'}
+                      key={option.value === undefined ? 'sb-reset' : String(option.value)}
                       title={option.title}
                       description={option.description}
                       icon={

--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -549,7 +549,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
                       icon={
                         !isReset && multiSelect ? (
                           // Purely decorative.
-                          <Form.Checkbox checked={isSelected} hidden />
+                          <Form.Checkbox checked={isSelected} hidden role="presentation" />
                         ) : (
                           option.icon
                         )

--- a/code/core/src/components/components/Select/helpers.tsx
+++ b/code/core/src/components/components/Select/helpers.tsx
@@ -8,7 +8,7 @@ export interface Option {
   title: string;
   description?: string;
   icon?: React.ReactNode;
-  value: string;
+  value: string | number | null | boolean | Symbol;
 }
 
 export interface ResetOption extends Omit<Option, 'value'> {
@@ -26,3 +26,5 @@ export const Listbox = styled('ul')({
   margin: 0,
   padding: 4,
 });
+
+export const UNDEFINED_VALUE = Symbol.for('undefined');

--- a/code/core/src/components/components/Select/helpers.tsx
+++ b/code/core/src/components/components/Select/helpers.tsx
@@ -2,20 +2,70 @@ import type React from 'react';
 
 import { styled } from 'storybook/theming';
 
+export const PAGE_STEP_SIZE = 5;
+export const UNDEFINED_VALUE = Symbol.for('undefined');
+
+export type Value = string | number | null | boolean | undefined;
+export type InternalValue = string | number | null | boolean | typeof UNDEFINED_VALUE;
+
 export interface Option {
   /** Optional rendering of the option. */
   children?: React.ReactNode;
   title: string;
   description?: string;
   icon?: React.ReactNode;
-  value: string | number | null | boolean | Symbol;
+  value: Value;
 }
-
+export interface InternalOption extends Omit<Option, 'value'> {
+  type: 'option';
+  value: InternalValue;
+}
 export interface ResetOption extends Omit<Option, 'value'> {
+  type: 'reset';
   value: undefined;
 }
 
-export const PAGE_STEP_SIZE = 5;
+export function isLiteralValue(value: Value | Value[] | undefined): value is Value {
+  return (
+    value === undefined ||
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'symbol'
+  );
+}
+
+export function optionToInternal(option: Option): InternalOption {
+  return {
+    ...option,
+    type: 'option',
+    value: externalToValue(option.value),
+  };
+}
+
+export function optionOrResetToInternal(
+  option: Option | ResetOption
+): InternalOption | ResetOption {
+  if ('type' in option && option.type === 'reset') {
+    return option;
+  }
+  return optionToInternal(option);
+}
+
+export function valueToExternal(value: InternalValue): Value {
+  if (value === UNDEFINED_VALUE) {
+    return undefined;
+  }
+  return value;
+}
+
+export function externalToValue(value: Value): InternalValue {
+  if (value === undefined) {
+    return UNDEFINED_VALUE;
+  }
+  return value;
+}
 
 export const Listbox = styled('ul')({
   minWidth: 180,
@@ -26,5 +76,3 @@ export const Listbox = styled('ul')({
   margin: 0,
   padding: 4,
 });
-
-export const UNDEFINED_VALUE = Symbol.for('undefined');

--- a/code/core/src/manager/components/sidebar/RefIndicator.tsx
+++ b/code/core/src/manager/components/sidebar/RefIndicator.tsx
@@ -199,7 +199,8 @@ export const RefIndicator = React.memo(
                 tooltip="Choose version"
                 defaultOptions={currentVersion}
                 onSelect={(item) => {
-                  const href = ref.versions?.[item];
+                  // We only pass strings as version ids, so item is always a string
+                  const href = ref.versions?.[item as string];
                   if (href) {
                     api.changeRefVersion(ref.id, href);
                   }

--- a/code/core/src/toolbar/components/ToolbarMenuSelect.tsx
+++ b/code/core/src/toolbar/components/ToolbarMenuSelect.tsx
@@ -93,7 +93,7 @@ export const ToolbarMenuSelect: FC<ToolbarMenuSelectProps> = withKeyboardCycle(
 
     return (
       <Select
-        defaultOptions={currentValue}
+        defaultOptions={[currentValue]}
         options={options}
         disabled={isOverridden}
         ariaLabel={ariaLabel}

--- a/code/core/src/toolbar/components/ToolbarMenuSelect.tsx
+++ b/code/core/src/toolbar/components/ToolbarMenuSelect.tsx
@@ -59,7 +59,7 @@ export const ToolbarMenuSelect: FC<ToolbarMenuSelectProps> = withKeyboardCycle(
     const options = items
       .filter((item): item is ToolbarItem => item.type === 'item')
       .map((item) => {
-        const itemTitle = item.title ?? item.value;
+        const itemTitle = item.title ?? item.value ?? 'Untitled';
         const iconComponent =
           !item.hideIcon && item.icon ? (
             <Icons icon={item.icon} __suppressDeprecationWarning={true} />

--- a/code/core/src/toolbar/components/ToolbarMenuSelect.tsx
+++ b/code/core/src/toolbar/components/ToolbarMenuSelect.tsx
@@ -57,8 +57,7 @@ export const ToolbarMenuSelect: FC<ToolbarMenuSelectProps> = withKeyboardCycle(
     const resetItem = items.find((item) => item.type === 'reset');
     const resetLabel = resetItem?.title;
     const options = items
-      .filter((item) => item.type === 'item')
-      .filter((item): item is ToolbarItem & { value: string } => item.value !== undefined)
+      .filter((item): item is ToolbarItem => item.type === 'item')
       .map((item) => {
         const itemTitle = item.title ?? item.value;
         const iconComponent =

--- a/code/core/src/viewport/components/Tool.tsx
+++ b/code/core/src/viewport/components/Tool.tsx
@@ -121,7 +121,7 @@ const Pure = React.memo(function PureTool(props: PureProps) {
         tooltip={isLocked ? 'Viewport size set by story parameters' : 'Resize viewport'}
         defaultOptions={viewportName}
         options={options}
-        onSelect={(selected) => update({ value: selected, isRotated: false })}
+        onSelect={(selected) => update({ value: selected as string, isRotated: false })}
         icon={<GrowIcon />}
       >
         {item !== responsiveViewport ? (


### PR DESCRIPTION
## What I did

Fixes an internal bug report, where a global type created with `true` and `undefined` values did not work well with Select:
* The `undefined` value was filtered out
* The `true` value caused a crash upon selection because type checking in `defaultOptions` was not defensive enough

The fix is performed by allowing a wider range of values in Select `options` and internally converting `undefined` to `Symbol.for('undefined')` so it does not conflict with the 'Reset' option.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

@yannbf has a repo with a local addon using both `true` and `undefined`, to be tested against.

Anyone else: please run the new stories that should cover all potential use cases within Select.

### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select now supports non-string option values (numbers, booleans, null, undefined) for single and multi-select; callbacks and defaults accept and emit these values.

* **Bug Fixes**
  * Improved handling of undefined and other non-string default/reset cases for consistent select/deselect/reset behavior and aria-selected state.

* **Documentation**
  * Added Storybook examples demonstrating selection, deselection, defaults, multi-select, accessibility, keyboard navigation, and reset interactions with non-string values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->