### PR TITLE
Docs: Add visible focus outline for keyboard navigation

### DIFF
--- a/code/addons/docs/src/blocks/components/DocsPage.tsx
+++ b/code/addons/docs/src/blocks/components/DocsPage.tsx
@@ -255,6 +255,20 @@ export const DocsContent = styled.div(({ theme }) => {
       color: theme.color.defaultText,
       '& code': code,
     },
+    // Ensure keyboard focus is visible for interactive elements inside docs
+    [toGlobalSelector('a, button, input, textarea, select')]: {
+      '&:focus-visible': {
+        outline:
+          theme.base === 'light'
+            ? `2px solid ${theme.color.secondary}`
+            : `2px solid ${theme.color.secondary}`,
+        outlineOffset: '2px',
+        // fallback for high-contrast / forced-colors environments
+        '@media (forced-colors: active)': {
+          outline: '2px solid Highlight',
+        },
+      },
+    },
     [toGlobalSelector('pre')]: {
       ...reset,
       // reset


### PR DESCRIPTION
Closes #33025

## What I did

Added visible `:focus-visible` styles for interactive elements (links, buttons, inputs, textareas, and selects) within the Docs view to ensure keyboard focus indicators are visible when navigating with Tab/Shift+Tab.

### Changes:
- Added a new style rule in `DocsPage.tsx` that applies a `2px solid` outline using the theme's secondary color to all interactive elements when focused via keyboard
- Included `outline-offset: 2px` for better visual separation
- Added fallback support for high-contrast/forced-colors environments using `@media (forced-colors: active)`

This fix improves accessibility compliance with WCAG 2.1.1 (Keyboard) and WCAG 2.4.7 (Focus Visible).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser at http://localhost:6006
3. Navigate to any story's Docs view
4. Use the `Tab` key to navigate between interactive elements (links, buttons, "Show code", "Copy" buttons)
5. Verify that each focused element displays a visible outline (2px solid border)
6. Test with both light and dark themes

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced keyboard focus visibility for interactive elements including links, buttons, and form inputs with improved outline styling
  * Added high-contrast mode support for improved visibility in accessibility-focused environments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->