### PR TITLE
UI: Fix excessive height in TabbedArgsTable

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/TabbedArgsTable.stories.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/TabbedArgsTable.stories.tsx
@@ -1,11 +1,20 @@
+import { TabsView } from 'storybook/internal/components';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ArgsTable } from './ArgsTable';
 import { Compact, Normal, Sections } from './ArgsTable.stories';
 import { TabbedArgsTable } from './TabbedArgsTable';
 
-export default {
+const meta = {
   component: TabbedArgsTable,
-};
+  tags: ['autodocs'],
+  subcomponents: { TabbedArgsTable: TabbedArgsTable, ArgsTable, TabsView },
+} satisfies Meta<typeof TabbedArgsTable>;
 
-export const Tabs = {
+export default meta;
+
+export const Tabs: StoryObj<typeof meta> = {
   args: {
     tabs: {
       Normal: Normal.args,
@@ -15,7 +24,7 @@ export const Tabs = {
   },
 };
 
-export const TabsInAddonPanel = {
+export const TabsInAddonPanel: StoryObj<typeof meta> = {
   args: {
     tabs: {
       Normal: Normal.args,
@@ -26,8 +35,25 @@ export const TabsInAddonPanel = {
   },
 };
 
-export const Empty = {
+export const Empty: StoryObj<typeof meta> = {
   args: {
     tabs: {},
   },
+};
+
+export const WithContentAround: StoryObj<typeof meta> = {
+  args: {
+    tabs: {
+      Normal: Normal.args,
+      Compact: Compact.args,
+      Sections: Sections.args,
+    },
+  },
+  render: (args) => (
+    <>
+      <p>This is some content above the TabbedArgsTable.</p>
+      <TabbedArgsTable {...args} />
+      <p>This is some content below the TabbedArgsTable.</p>
+    </>
+  ),
 };

--- a/code/addons/docs/src/blocks/components/ArgsTable/TabbedArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/TabbedArgsTable.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 import { TabsView } from 'storybook/internal/components';
 
+import { styled } from 'storybook/theming';
+
 import type { ArgsTableProps } from './ArgsTable';
 import { ArgsTable } from './ArgsTable';
 
@@ -11,6 +13,10 @@ type DistributiveOmit<T, K extends PropertyKey> = T extends any ? Omit<T, K> : n
 export type TabbedArgsTableProps = DistributiveOmit<ArgsTableProps, 'rows'> & {
   tabs: Record<string, ArgsTableProps>;
 };
+
+const StyledTabsView = styled(TabsView)({
+  height: 'fit-content',
+});
 
 export const TabbedArgsTable: FC<TabbedArgsTableProps> = ({ tabs, ...props }) => {
   const entries = Object.entries(tabs);
@@ -34,5 +40,5 @@ export const TabbedArgsTable: FC<TabbedArgsTableProps> = ({ tabs, ...props }) =>
     },
   }));
 
-  return <TabsView tabs={tabsFromEntries} />;
+  return <StyledTabsView tabs={tabsFromEntries} />;
 };


### PR DESCRIPTION
Closes #33196

## What I did

Set TabsView height to fit content in TabbedArgsTable. I chose to do that rather than edit TabsView because the height: 100% really helps with ensuring ScrollArea correctly works. If you remove it, for instance, you'll see the secondary TabsView in the A11y addon panel stops scrolling.

My reasoning is it's a lot easier to notice and debug an excessive height in the UI than it is to debug and notice an incorrect scroll behaviour.

We were missing stories to notice and diagnose this specific case, so I added them. Interestingly, the bug only occurs in DocsPage and not in standalone stories. I added an autodocs with TabbedArgsTable on the TabbedArgsTable stories so we have a repro case, even though it won't be covered by smoke tests.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Visit http://localhost:6006/?path=/docs/addons-docs-blocks-components-argstable-tabbedargstable--docs

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual consistency for the tabbed arguments table with improved wrapper styling.

* **Tests**
  * Added a new test case demonstrating the tabbed arguments table with surrounding content context.

* **Refactor**
  * Improved type safety and code organization for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->