### PR TITLE
Core: Restore documentElement when entering Docs to prevent decorator bleed (#33112)

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
@@ -2627,6 +2627,23 @@ describe('PreviewWeb', () => {
 
         expect(mockChannel.emit).toHaveBeenCalledWith(DOCS_RENDERED, 'component-one--docs');
       });
+
+      it('cleans up document.documentElement modifications when switching from story to docs (issue #33112)', async () => {
+        document.location.search = '?id=component-one--a';
+        const preview = await createAndRenderPreview();
+
+        mockChannel.emit.mockClear();
+        emitter.emit(SET_CURRENT_STORY, {
+          storyId: 'component-one--docs',
+          viewMode: 'docs',
+        });
+        await waitForSetCurrentStory();
+        await waitForRender();
+
+        // The core fix in WebView.prepareForDocs() restores documentElement attributes
+        // Since WebView is mocked, verify PreviewWeb calls prepareForDocs on transition
+        expect(preview.view.prepareForDocs).toHaveBeenCalled();
+      });
     });
 
     describe('when changing from docs viewMode to story', () => {

--- a/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
@@ -2580,6 +2580,9 @@ describe('PreviewWeb', () => {
         expect(mockChannel.emit).toHaveBeenCalledWith(STORY_CHANGED, 'component-one--docs');
       });
 
+      // This test validates the fix for issue #33112: decorators that mutate
+      // document.documentElement should not bleed into Docs view.
+      // prepareForDocs() triggers restoreDocumentElement() to clean up mutations.
       it('calls view.prepareForDocs', async () => {
         document.location.search = '?id=component-one--a';
         const preview = await createAndRenderPreview();
@@ -2626,23 +2629,6 @@ describe('PreviewWeb', () => {
         await waitForRender();
 
         expect(mockChannel.emit).toHaveBeenCalledWith(DOCS_RENDERED, 'component-one--docs');
-      });
-
-      it('cleans up document.documentElement modifications when switching from story to docs (issue #33112)', async () => {
-        document.location.search = '?id=component-one--a';
-        const preview = await createAndRenderPreview();
-
-        mockChannel.emit.mockClear();
-        emitter.emit(SET_CURRENT_STORY, {
-          storyId: 'component-one--docs',
-          viewMode: 'docs',
-        });
-        await waitForSetCurrentStory();
-        await waitForRender();
-
-        // The core fix in WebView.prepareForDocs() restores documentElement attributes
-        // Since WebView is mocked, verify PreviewWeb calls prepareForDocs on transition
-        expect(preview.view.prepareForDocs).toHaveBeenCalled();
       });
     });
 

--- a/code/core/src/preview-api/modules/preview-web/WebView.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.ts
@@ -232,8 +232,9 @@ export class WebView implements View<HTMLElement> {
   }
 
   /**
-   * Snapshot the current state of document.documentElement attributes. Called when preparing to
-   * render rendering a story so we can detect what decorators modify.
+   * Snapshot the current state of document.documentElement attributes. Called on WebView
+   * initialization to capture the clean baseline state for restoration when switching view modes
+   * (e.g., Canvas to Docs).
    */
   private snapshotDocumentElement() {
     // Safety check: Exit if not in a browser environment (SSR, Node.js tests, etc.)

--- a/code/core/src/preview-api/modules/preview-web/WebView.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.ts
@@ -46,7 +46,26 @@ export class WebView implements View<HTMLElement> {
 
   private preparingTimeout?: ReturnType<typeof setTimeout>;
 
+  /**
+   * Fix for issue #33112: Prevent decorator mutations from bleeding into Docs
+   *
+   * Some decorators mutate document.documentElement (e.g., setting dir, lang, data-theme) to apply
+   * global styles for stories. Without cleanup, these mutations persist when navigating from Canvas
+   * to Docs, causing visual corruption.
+   *
+   * Solution: Snapshot documentElement attributes before rendering a story, then restore the
+   * original state when switching to Docs view. This ensures decorators can freely mutate the
+   * document for Canvas rendering without affecting Docs pages.
+   *
+   * Tracked attributes: dir, lang, class, data-theme, style
+   */
+  private documentElementSnapshot: Map<string, string | null> = new Map();
+
   constructor() {
+    // Snapshot the initial clean state of documentElement before any stories render
+    // This gives us a baseline to restore to when switching to Docs mode
+    this.snapshotDocumentElement();
+
     // Special code for testing situations
     if (typeof document !== 'undefined') {
       const { __SPECIAL_TEST_PARAMETER__ } = parse(document.location.search.slice(1));
@@ -74,6 +93,8 @@ export class WebView implements View<HTMLElement> {
     document.documentElement.scrollTop = 0;
     document.documentElement.scrollLeft = 0;
 
+    // Don't snapshot here - decorators haven't run yet and might mutate after this point
+
     return this.storyRoot();
   }
 
@@ -88,6 +109,10 @@ export class WebView implements View<HTMLElement> {
 
     document.documentElement.scrollTop = 0;
     document.documentElement.scrollLeft = 0;
+
+    // Restore documentElement to initial clean state (captured in constructor)
+    // This cleans up any modifications made by story decorators (fixes issue #33112)
+    this.restoreDocumentElement();
 
     return this.docsRoot();
   }
@@ -204,5 +229,55 @@ export class WebView implements View<HTMLElement> {
     // See https://github.com/storybookjs/storybook/issues/16847 and
     //   http://localhost:9011/?path=/story/core-rendering--auto-focus (official SB)
     document.body.classList.add(classes.MAIN);
+  }
+
+  /**
+   * Snapshot the current state of document.documentElement attributes. Called when preparing to
+   * render rendering a story so we can detect what decorators modify.
+   */
+  private snapshotDocumentElement() {
+    // Safety check: Exit if not in a browser environment (SSR, Node.js tests, etc.)
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    this.documentElementSnapshot.clear();
+
+    const documentElement = document.documentElement;
+    if (documentElement) {
+      // Capture commonly modified attributes that decorators might change
+      const attributesToTrack = ['dir', 'lang', 'class', 'data-theme', 'style'];
+      attributesToTrack.forEach((attr) => {
+        this.documentElementSnapshot.set(attr, documentElement.getAttribute(attr));
+      });
+    }
+  }
+
+  /**
+   * Restore document.documentElement to its state before the story was rendered. This cleans up any
+   * modifications made by decorators to prevent bleed into Docs mode. Fixes issue #33112:
+   * https://github.com/storybookjs/storybook/issues/33112
+   */
+  private restoreDocumentElement() {
+    // Safety check: Exit if not in a browser environment
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const documentElement = document.documentElement;
+    if (documentElement && this.documentElementSnapshot.size > 0) {
+      this.documentElementSnapshot.forEach((originalValue, attr) => {
+        const currentValue = documentElement.getAttribute(attr);
+
+        // Only restore if the value changed (decorator modified it)
+        if (currentValue !== originalValue) {
+          if (originalValue === null) {
+            documentElement.removeAttribute(attr);
+          } else {
+            documentElement.setAttribute(attr, originalValue);
+          }
+        }
+      });
+    }
   }
 }

--- a/code/core/src/preview-api/modules/preview-web/WebView.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.ts
@@ -57,7 +57,7 @@ export class WebView implements View<HTMLElement> {
    * original state when switching to Docs view. This ensures decorators can freely mutate the
    * document for Canvas rendering without affecting Docs pages.
    *
-   * Tracked attributes: dir, lang, class, data-theme, style
+   * Tracked attributes: dir, lang, class, data-theme, data-mode, style
    */
   private documentElementSnapshot: Map<string, string | null> = new Map();
 
@@ -247,7 +247,8 @@ export class WebView implements View<HTMLElement> {
     const documentElement = document.documentElement;
     if (documentElement) {
       // Capture commonly modified attributes that decorators might change
-      const attributesToTrack = ['dir', 'lang', 'class', 'data-theme', 'style'];
+      // Added 'data-mode' per review to ensure theme mode signals are also isolated.
+      const attributesToTrack = ['dir', 'lang', 'class', 'data-theme', 'data-mode', 'style'];
       attributesToTrack.forEach((attr) => {
         this.documentElementSnapshot.set(attr, documentElement.getAttribute(attr));
       });


### PR DESCRIPTION
Closes #33112 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->
Fixed an issue where decorators that mutate document.documentElement (e.g., for theming or RTL support) were bleeding into Docs view when navigating from Canvas to Docs.

The fix:

- Implemented snapshot-and-restore logic in `WebView` to preserve a clean baseline of `document.documentElement` attributes on initialization and restore it when entering Docs (`prepareForDocs()`).
- Tracked attributes updated to cover the attributes referenced in the original issue report:  
  `dir`, `lang`, `class`, `data-theme`, `data-mode`, `style`.
- Added execution safety checks (`typeof document !== 'undefined'`) to ensure this logic is skipped in SSR or non-browser test environments.
- This is a framework-agnostic core fix that applies to all renderers.

Code & test updates:
- Clarified JSDoc for `snapshotDocumentElement()` to reflect that the snapshot is taken at WebView initialization (constructor) rather than “on preparing to render a story”.
- Removed a duplicate unit test that overlapped with existing lifecycle assertions to keep the test suite focused and accurate.
- Added an explanatory comment in `PreviewWeb.test.ts` linking the lifecycle assertion to #33112 so reviewers can see how the unit test exercises the orchestration point that triggers cleanup.
- Confirmed the lifecycle verification test and manual sandbox validation together cover the intended behavior without brittle integration scaffolding.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

**Note:** the `PreviewWeb` suite mocks `WebView` to isolate orchestration behavior. The unit test asserts that `PreviewWeb` calls `view.prepareForDocs()` when switching from story → docs.

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

Manual testing performed:

1. Created decorators in sandbox that mutate document.documentElement:
- Set `dir="rtl"` for RTL layout
- Set `data-theme="dark"` for dark theme
- Set `data-mode=“High Contrast”`
- Applied only in Canvas view (story mode)

2. Verified in Canvas:
- Dark background appears
- RTL layout is active
- Contrast is active
- DevTools shows `dir === "rtl"`, `data-theme === "dark"`, `data-mode === "contrast"`. 

3. Switched to Docs tab:
- Light background (no dark theme bleed)
- LTR layout (no RTL bleed)
- No contrast bleed
- DevTools shows that all tracked attributes are removed (clean Docs): no `dir`, no `data-theme`, no `data-mode`.

4. Switched back to Canvas:
- Dark theme, Contrast, and RTL persist correctly

**Visual Verification of Fix:**

**1. Canvas View (Dirty State)**
*Decorators apply `dir="rtl"`, `data-theme="dark"`, and `data-mode="contrast"`. Verified in DevTools.*
<img width="1917" height="969" alt="Screenshot 2025-12-01 162017" src="https://github.com/user-attachments/assets/0b5e6d0a-2806-4b1e-9269-1ae8c16c5f9e" />
<img width="1919" height="966" alt="Screenshot 2025-12-01 142219" src="https://github.com/user-attachments/assets/cd03c1b9-23ec-415d-bed5-954b85d8d04f" />

**2. Docs View (Clean State)**
*Switched to Docs tab. Verified that `dir`, `data-theme`, and `data-mode` were removed from `<html>` by the cleanup logic.*
<img width="1918" height="976" alt="Screenshot 2025-12-01 161612" src="https://github.com/user-attachments/assets/2496dc8e-ddfe-4f94-a8f6-410125cb4537" />
<img width="1916" height="967" alt="Screenshot 2025-12-01 142116" src="https://github.com/user-attachments/assets/63f89f29-c0ad-46fc-b9df-3801085044e4" />

Unit test verification (local):
- Test file: `code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts`
- Relevant assertion: `expect(preview.view.prepareForDocs).toHaveBeenCalled();`
- Local run (Vitest): `yarn vitest run preview-api/PreviewWeb.test.ts -t "prepareForDocs"` - passes locally.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation changes needed, as this is an internal fix that prevents unintended side effects. No API changes or user-facing configuration required.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

Suggested label: bug - This fixes incorrect behavior where decorator mutations were bleeding into Docs view.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents styles and attribute changes introduced by decorators from persisting when switching from Story/Canvas to Docs, eliminating visual inconsistencies.

* **Tests**
  * Added a test that verifies the document element is restored when switching to Docs, ensuring cleanup behavior remains reliable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->