### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/nx/schemas/workspace-schema.json",
-  "nxCloudId": "606dc2e0c2e8d5671d813305",
+  "nxCloudId": "6929fbef73e98d8094d2a343",
   "defaultBase": "next",
   "parallel": 8,
   "pluginsConfig": {
@@ -23,178 +23,401 @@
   },
   "targetDefaults": {
     "compile": {
-      "dependsOn": ["^compile"],
+      "dependsOn": [
+        "^compile"
+      ],
       "command": "yarn exec jiti ./scripts/build/build-package.ts --cwd {projectRoot}",
-      "configurations": { "production": { "args": "--prod" } },
+      "configurations": {
+        "production": {
+          "args": "--prod"
+        }
+      },
       "cache": true,
-      "inputs": ["production", "^production"],
+      "inputs": [
+        "production",
+        "^production"
+      ],
       "outputs": [
         "{projectRoot}/dist",
         "{workspaceRoot}/code/bench/esbuild-metafiles/{projectName}"
       ]
     },
     "check": {
-      "dependsOn": [{ "projects": ["*"], "target": "compile" }],
+      "dependsOn": [
+        {
+          "projects": [
+            "*"
+          ],
+          "target": "compile"
+        }
+      ],
       "command": "yarn exec jiti ./scripts/check/check-package.ts --cwd {projectRoot}",
       "cache": true,
-      "inputs": ["default", "^production"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "default",
+        "^production"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "publish": {
-      "dependsOn": [{ "projects": ["*"], "target": "compile" }],
+      "dependsOn": [
+        {
+          "projects": [
+            "*"
+          ],
+          "target": "compile"
+        }
+      ],
       "command": "yarn workspace @storybook/scripts local-registry --publish",
       "cache": true,
-      "inputs": ["all-production"],
-      "outputs": ["{workspaceRoot}/.verdaccio-cache"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "all-production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/.verdaccio-cache"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "run-registry": {
-      "dependsOn": [{ "projects": ["scripts"], "target": "publish" }],
+      "dependsOn": [
+        {
+          "projects": [
+            "scripts"
+          ],
+          "target": "publish"
+        }
+      ],
       "command": "yarn workspace @storybook/scripts local-registry --open",
       "continuous": true,
-      "configurations": { "production": {} }
+      "configurations": {
+        "production": {}
+      }
     },
     "sandbox": {
-      "dependsOn": [{ "projects": ["scripts"], "target": "run-registry" }],
+      "dependsOn": [
+        {
+          "projects": [
+            "scripts"
+          ],
+          "target": "run-registry"
+        }
+      ],
       "command": "yarn task sandbox -s task --debug --no-link --template={projectName}",
       "cache": true,
-      "inputs": ["^production"],
-      "outputs": ["{workspaceRoot}/sandbox/{options.dir}"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/sandbox/{options.dir}"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "prepare-sandbox": {
-      "dependsOn": ["sandbox", { "projects": ["scripts"], "target": "run-registry" }],
+      "dependsOn": [
+        "sandbox",
+        {
+          "projects": [
+            "scripts"
+          ],
+          "target": "run-registry"
+        }
+      ],
       "command": "yarn workspace @storybook/scripts prepare-sandbox --template={projectName} --no-link",
       "cache": false,
-      "configurations": { "production": {} }
+      "configurations": {
+        "production": {}
+      }
     },
     "check-sandbox": {
-      "dependsOn": ["prepare-sandbox"],
+      "dependsOn": [
+        "prepare-sandbox"
+      ],
       "command": "yarn task check-sandbox -s task --debug --no-link --template={projectName}",
       "cache": true,
-      "inputs": ["^production"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "^production"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "build": {
-      "dependsOn": ["prepare-sandbox"],
+      "dependsOn": [
+        "prepare-sandbox"
+      ],
       "command": "yarn task build -s task --debug --no-link --template={projectName}",
       "cache": true,
-      "inputs": ["^production"],
-      "outputs": ["{workspaceRoot}/sandbox/{options.dir}/storybook-static"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/sandbox/{options.dir}/storybook-static"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "prepare-build-sandbox": {
-      "dependsOn": [{ "projects": ["scripts"], "target": "run-registry" }, "build"],
+      "dependsOn": [
+        {
+          "projects": [
+            "scripts"
+          ],
+          "target": "run-registry"
+        },
+        "build"
+      ],
       "command": "yarn workspace @storybook/scripts prepare-sandbox --template={projectName} --no-link",
       "cache": false,
-      "configurations": { "production": {} }
+      "configurations": {
+        "production": {}
+      }
     },
     "dev": {
-      "dependsOn": ["prepare-sandbox"],
+      "dependsOn": [
+        "prepare-sandbox"
+      ],
       "command": "yarn task dev -s task --debug --no-link --template={projectName}",
       "continuous": true,
-      "configurations": { "production": {} }
+      "configurations": {
+        "production": {}
+      }
     },
     "vitest-integration": {
-      "dependsOn": ["prepare-sandbox"],
+      "dependsOn": [
+        "prepare-sandbox"
+      ],
       "command": "yarn task vitest-integration -s task --debug --no-link --template={projectName}",
       "cache": true,
-      "inputs": ["^production"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "^production"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "chromatic": {
-      "dependsOn": ["prepare-build-sandbox"],
+      "dependsOn": [
+        "prepare-build-sandbox"
+      ],
       "command": "yarn task chromatic -s task --debug --no-link --template={projectName}",
       "cache": true,
-      "inputs": ["^production"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "^production"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "serve": {
-      "dependsOn": ["prepare-build-sandbox"],
+      "dependsOn": [
+        "prepare-build-sandbox"
+      ],
       "command": "yarn task serve -s task --debug --no-link --template={projectName}",
       "continuous": true,
-      "configurations": { "production": {} }
+      "configurations": {
+        "production": {}
+      }
     },
     "e2e-tests": {
-      "dependsOn": ["serve"],
+      "dependsOn": [
+        "serve"
+      ],
       "command": "yarn task e2e-tests --junit -s task --debug --no-link --template={projectName}",
       "cache": true,
-      "inputs": ["^production"],
-      "outputs": ["{workspaceRoot}/test-results"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/test-results"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "test-runner": {
-      "dependsOn": ["serve"],
+      "dependsOn": [
+        "serve"
+      ],
       "command": "yarn task test-runner --junit -s task --debug --no-link --template={projectName}",
       "cache": true,
-      "inputs": ["^production"],
-      "outputs": ["{workspaceRoot}/test-results"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/test-results"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "e2e-tests-dev": {
-      "dependsOn": ["dev"],
+      "dependsOn": [
+        "dev"
+      ],
       "command": "yarn task e2e-tests-dev --junit -s task --debug --no-link --template={projectName}",
       "cache": true,
-      "inputs": ["^production"],
-      "outputs": ["{workspaceRoot}/test-results"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/test-results"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "test-runner-dev": {
-      "dependsOn": ["dev"],
+      "dependsOn": [
+        "dev"
+      ],
       "command": "yarn task test-runner-dev --junit -s task --debug --no-link --template={projectName}",
       "cache": true,
-      "inputs": ["^production"],
-      "outputs": ["{workspaceRoot}/test-results"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/test-results"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
-
     "e2e-ui": {
-      "dependsOn": [{ "projects": ["*"], "target": "compile" }],
+      "dependsOn": [
+        {
+          "projects": [
+            "*"
+          ],
+          "target": "compile"
+        }
+      ],
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
         "command": "yarn --no-immutable && yarn playwright-e2e"
       },
       "cache": true,
-      "inputs": ["default", "^production"],
-      "outputs": ["{workspaceRoot}/test-results"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "default",
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/test-results"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "jest": {
-      "dependsOn": [{ "projects": ["*"], "target": "compile" }],
+      "dependsOn": [
+        {
+          "projects": [
+            "*"
+          ],
+          "target": "compile"
+        }
+      ],
       "executor": "nx:run-commands",
-      "options": { "cwd": "{projectRoot}", "command": "yarn --no-immutable && yarn jest" },
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "yarn --no-immutable && yarn jest"
+      },
       "cache": true,
-      "inputs": ["default", "^production"],
-      "outputs": ["{workspaceRoot}/test-results"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "default",
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/test-results"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "vitest": {
-      "dependsOn": [{ "projects": ["*"], "target": "compile" }],
+      "dependsOn": [
+        {
+          "projects": [
+            "*"
+          ],
+          "target": "compile"
+        }
+      ],
       "executor": "nx:run-commands",
-      "options": { "cwd": "{projectRoot}", "command": "yarn --no-immutable && yarn vitest" },
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "yarn --no-immutable && yarn vitest"
+      },
       "cache": true,
-      "inputs": ["default", "^production"],
-      "outputs": ["{workspaceRoot}/test-results"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "default",
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/test-results"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "playwright-ct": {
-      "dependsOn": [{ "projects": ["*"], "target": "compile" }],
+      "dependsOn": [
+        {
+          "projects": [
+            "*"
+          ],
+          "target": "compile"
+        }
+      ],
       "executor": "nx:run-commands",
-      "options": { "cwd": "{projectRoot}", "command": "yarn --no-immutable && yarn playwright-ct" },
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "yarn --no-immutable && yarn playwright-ct"
+      },
       "cache": true,
-      "inputs": ["default", "^production"],
-      "outputs": ["{workspaceRoot}/test-results"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "default",
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/test-results"
+      ],
+      "configurations": {
+        "production": {}
+      }
     },
     "cypress": {
-      "dependsOn": [{ "projects": ["*"], "target": "compile" }],
+      "dependsOn": [
+        {
+          "projects": [
+            "*"
+          ],
+          "target": "compile"
+        }
+      ],
       "executor": "nx:run-commands",
-      "options": { "cwd": "{projectRoot}", "command": "yarn --no-immutable && yarn cypress" },
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "yarn --no-immutable && yarn cypress"
+      },
       "cache": true,
-      "inputs": ["default", "^production"],
-      "outputs": ["{workspaceRoot}/test-results"],
-      "configurations": { "production": {} }
+      "inputs": [
+        "default",
+        "^production"
+      ],
+      "outputs": [
+        "{workspaceRoot}/test-results"
+      ],
+      "configurations": {
+        "production": {}
+      }
     }
   },
   "namedInputs": {
@@ -204,7 +427,10 @@
       "{workspaceRoot}/.github/workflows/nx.yml",
       "{workspaceRoot}/.nx/workflows/*"
     ],
-    "default": ["sharedGlobals", "{projectRoot}/**/*"],
+    "default": [
+      "sharedGlobals",
+      "{projectRoot}/**/*"
+    ],
     "production": [
       "sharedGlobals",
       "{projectRoot}/**/*",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/606dcb5cdc2a2b00059cc0e9/workspaces/6929fbef73e98d8094d2a343

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.