### PR TITLE
Build: No nx cache in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,7 @@ jobs:
                 name: Restore Yarn cache
             - run:
                 command: |
+                    yarn
                     yarn task --task check --start-from=auto --no-link --debug
                 name: Check
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,11 +254,6 @@ jobs:
                 name: Restore Yarn cache
             - run:
                 command: |
-                    yarn
-                    yarn task --task compile --start-from=auto --no-link --debug
-                name: Compile
-            - run:
-                command: |
                     yarn task --task check --start-from=auto --no-link --debug
                 name: Check
             - run:

--- a/.circleci/src/jobs/check.yml
+++ b/.circleci/src/jobs/check.yml
@@ -15,6 +15,7 @@ steps:
   - run:
       name: Check
       command: |
+        yarn
         yarn task --task check --start-from=auto --no-link --debug
   - run:
       name: Ensure no changes pending

--- a/.circleci/src/jobs/check.yml
+++ b/.circleci/src/jobs/check.yml
@@ -13,11 +13,6 @@ steps:
       keys:
         - build-yarn-2-cache-v5--{{ checksum "yarn.lock" }}
   - run:
-      name: Compile
-      command: |
-        yarn
-        yarn task --task compile --start-from=auto --no-link --debug
-  - run:
       name: Check
       command: |
         yarn task --task check --start-from=auto --no-link --debug

--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/addons/a11y"
   },
   "funding": {

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/addons/docs"
   },
   "funding": {

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/addons/links"
   },
   "funding": {

--- a/code/addons/onboarding/package.json
+++ b/code/addons/onboarding/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/addons/onboarding"
   },
   "funding": {

--- a/code/addons/pseudo-states/package.json
+++ b/code/addons/pseudo-states/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/addons/pseudo-states"
   },
   "funding": {

--- a/code/addons/themes/package.json
+++ b/code/addons/themes/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/addons/themes"
   },
   "funding": {

--- a/code/addons/vitest/package.json
+++ b/code/addons/vitest/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/addons/vitest"
   },
   "funding": {

--- a/code/builders/builder-vite/package.json
+++ b/code/builders/builder-vite/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/builders/builder-vite"
   },
   "funding": {

--- a/code/builders/builder-webpack5/package.json
+++ b/code/builders/builder-webpack5/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/builders/builder-webpack5"
   },
   "funding": {

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/core"
   },
   "funding": {

--- a/code/core/src/bin/dispatcher.ts
+++ b/code/core/src/bin/dispatcher.ts
@@ -74,9 +74,13 @@ async function run() {
     // the package couldn't be imported, use npx to install and run it instead
   }
 
+  const { default: packageJson } = await import(`storybook/package.json`, {
+    with: { type: 'json' },
+  });
+
   const child = executeCommand({
     command: 'npx',
-    args: ['--yes', `${targetCli.pkg}@${versions[targetCli.pkg]}`, ...targetCli.args],
+    args: ['--yes', `${targetCli.pkg}@${packageJson.version}`, ...targetCli.args],
     stdio: 'inherit',
   });
   child.on('exit', (code) => {

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -380,6 +380,10 @@ export abstract class JsPackageManager {
 
         const isLatestStableRelease = currentVersion === latestInRange;
 
+        if (latestInRange?.includes('-local.')) {
+          return `${packageName}@local`;
+        }
+
         if (isLatestStableRelease || !currentVersion) {
           return `${packageName}@^${latestInRange}`;
         }
@@ -440,7 +444,8 @@ export abstract class JsPackageManager {
       current && (!constraint || satisfies(current, constraint)) && gt(current, latest)
         ? current
         : latest;
-    return `^${versionToUse}`;
+
+    return latest.includes('-local.') ? 'local' : `^${versionToUse}`;
   }
 
   /**

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -216,6 +216,7 @@ export class NPMProxy extends JsPackageManager {
       const process = executeCommand({
         command: 'npm',
         args: ['info', packageName, ...args],
+        cwd: this.cwd,
       });
       const result = await process;
       const commandResult = result.stdout ?? '';

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -219,6 +219,7 @@ export class PNPMProxy extends JsPackageManager {
       const process = executeCommand({
         command: 'pnpm',
         args: ['info', packageName, ...args],
+        cwd: this.cwd,
       });
       const result = await process;
       const commandResult = result.stdout ?? '';

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.ts
@@ -172,6 +172,7 @@ export class Yarn1Proxy extends JsPackageManager {
       const process = executeCommand({
         command: 'yarn',
         args: ['info', packageName, ...args],
+        cwd: this.cwd,
       });
       const result = await process;
       const commandResult = result.stdout ?? '';

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.ts
@@ -265,6 +265,7 @@ export class Yarn2Proxy extends JsPackageManager {
       const process = executeCommand({
         command: 'yarn',
         args: ['npm', 'info', packageName, ...args],
+        cwd: this.cwd,
       });
       const result = await process;
       const commandResult = result.stdout ?? '';

--- a/code/frameworks/angular/package.json
+++ b/code/frameworks/angular/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/angular"
   },
   "funding": {

--- a/code/frameworks/ember/package.json
+++ b/code/frameworks/ember/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/ember"
   },
   "funding": {

--- a/code/frameworks/html-vite/package.json
+++ b/code/frameworks/html-vite/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/html-vite"
   },
   "funding": {

--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/nextjs"
   },
   "funding": {

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/nextjs"
   },
   "funding": {

--- a/code/frameworks/preact-vite/package.json
+++ b/code/frameworks/preact-vite/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/preact-vite"
   },
   "funding": {

--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/react-native-web-vite"
   },
   "funding": {

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/react-vite"
   },
   "funding": {

--- a/code/frameworks/react-webpack5/package.json
+++ b/code/frameworks/react-webpack5/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/react-webpack5"
   },
   "funding": {

--- a/code/frameworks/server-webpack5/package.json
+++ b/code/frameworks/server-webpack5/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/server-webpack5"
   },
   "funding": {

--- a/code/frameworks/svelte-vite/package.json
+++ b/code/frameworks/svelte-vite/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/svelte-vite"
   },
   "funding": {

--- a/code/frameworks/sveltekit/package.json
+++ b/code/frameworks/sveltekit/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/sveltekit"
   },
   "funding": {

--- a/code/frameworks/vue3-vite/package.json
+++ b/code/frameworks/vue3-vite/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/vue3-vite"
   },
   "funding": {

--- a/code/frameworks/web-components-vite/package.json
+++ b/code/frameworks/web-components-vite/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/frameworks/web-components-vite"
   },
   "funding": {

--- a/code/lib/cli-sb/package.json
+++ b/code/lib/cli-sb/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/lib/cli-sb"
   },
   "funding": {

--- a/code/lib/cli-storybook/package.json
+++ b/code/lib/cli-storybook/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/lib/cli-storybook"
   },
   "funding": {

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/lib/codemod"
   },
   "funding": {

--- a/code/lib/core-webpack/package.json
+++ b/code/lib/core-webpack/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/lib/core-webpack"
   },
   "funding": {

--- a/code/lib/create-storybook/package.json
+++ b/code/lib/create-storybook/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/lib/cli"
   },
   "funding": {

--- a/code/lib/csf-plugin/package.json
+++ b/code/lib/csf-plugin/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/lib/csf-plugin"
   },
   "funding": {

--- a/code/lib/eslint-plugin/package.json
+++ b/code/lib/eslint-plugin/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/lib/eslint-plugin"
   },
   "license": "MIT",

--- a/code/lib/react-dom-shim/package.json
+++ b/code/lib/react-dom-shim/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/lib/react-dom-shim"
   },
   "funding": {

--- a/code/presets/create-react-app/package.json
+++ b/code/presets/create-react-app/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/presets/create-react-app"
   },
   "funding": {

--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/presets/react-webpack"
   },
   "funding": {

--- a/code/presets/server-webpack/package.json
+++ b/code/presets/server-webpack/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/presets/server-webpack"
   },
   "funding": {

--- a/code/renderers/html/package.json
+++ b/code/renderers/html/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/renderers/html"
   },
   "funding": {

--- a/code/renderers/preact/package.json
+++ b/code/renderers/preact/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/renderers/preact"
   },
   "funding": {

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/renderers/react"
   },
   "funding": {

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/renderers/server"
   },
   "funding": {

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/renderers/svelte"
   },
   "funding": {

--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/renderers/vue3"
   },
   "funding": {

--- a/code/renderers/web-components/package.json
+++ b/code/renderers/web-components/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/storybook.git",
+    "url": "git+https://github.com/storybookjs/storybook.git",
     "directory": "code/renderers/web-components"
   },
   "funding": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -175,16 +175,12 @@
     "type-fest": "~2.19",
     "typescript": "^5.9.3",
     "uuid": "^9.0.1",
+    "verdaccio": "^6.2.3",
     "vitest": "^3.2.4",
     "wait-on": "^8.0.3",
     "window-size": "^1.1.1",
     "yaml": "^2.7.0",
     "zod": "^3.23.8"
-  },
-  "optionalDependencies": {
-    "@verdaccio/types": "^10.8.0",
-    "verdaccio": "^5.31.1",
-    "verdaccio-auth-memory": "^10.2.2"
   },
   "packageManager": "yarn@4.10.3"
 }

--- a/scripts/tasks/check.ts
+++ b/scripts/tasks/check.ts
@@ -8,8 +8,8 @@ const amountOfVCPUs = 8;
 
 const parallel = `--parallel=${process.env.CI ? amountOfVCPUs - 1 : maxConcurrentTasks}`;
 
-const linkCommand = `yarn nx run-many -t check ${parallel}`;
-const nolinkCommand = `yarn nx run-many -t check -c production ${parallel}`;
+const linkCommand = `yarn nx run-many -t check ${parallel} --skip-nx-cache`;
+const nolinkCommand = `yarn nx run-many -t check -c production ${parallel} --skip-nx-cache`;
 
 export const check: Task = {
   description: 'Typecheck the source code of the monorepo',

--- a/scripts/tasks/compile.ts
+++ b/scripts/tasks/compile.ts
@@ -37,11 +37,11 @@ export const compile: Task = {
       return false;
     }
   },
-  async run({ codeDir }, { link, dryRun, debug, prod, skipCache }) {
+  async run({ codeDir }, { link, dryRun, debug, prod }) {
     const command = link && !prod ? linkCommand : noLinkCommand;
     await rm(join(codeDir, 'bench/esbuild-metafiles'), { recursive: true, force: true });
     return exec(
-      `${command} ${skipCache ? '--skip-nx-cache' : ''}`,
+      `${command} --skip-nx-cache`,
       { cwd: ROOT_DIRECTORY },
       {
         startMessage: '🥾 Bootstrapping',

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -2,7 +2,6 @@ import { access, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 // TODO -- should we generate this file a second time outside of CLI?
-import storybookVersions from '../../code/core/src/common/versions';
 import type { TemplateKey } from '../get-template';
 import { exec } from './exec';
 import touch from './touch';
@@ -35,8 +34,6 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   const content = await readFile(packageJsonPath, 'utf-8');
   const packageJson = JSON.parse(content);
   packageJson.resolutions = {
-    ...packageJson.resolutions,
-    ...storybookVersions,
     // this is for our CI test, ensure we use the same version as docker image, it should match version specified in `./code/package.json` and `.circleci/config.yml`
     playwright: '1.52.0',
     'playwright-core': '1.52.0',
@@ -130,8 +127,7 @@ export const configureYarn2ForVerdaccio = async ({
   const command = [
     // We don't want to use the cache or we might get older copies of our built packages
     // (with identical versions), as yarn (correctly I guess) assumes the same version hasn't changed
-    // TODO publish unique versions instead
-    `yarn config set enableGlobalCache false`,
+    `yarn config set enableGlobalCache true`,
     `yarn config set enableMirror false`,
     // ⚠️ Need to set registry because Yarn 2 is not using the conf of Yarn 1 (URL is hardcoded in CircleCI config.yml)
     `yarn config set npmRegistryServer "http://localhost:6001/"`,

--- a/scripts/verdaccio.yaml
+++ b/scripts/verdaccio.yaml
@@ -2,226 +2,25 @@ storage: .verdaccio-cache
 
 max_body_size: 60mb
 
-auth:
-  auth-memory:
-    users:
-      foo:
-        name: foo
-        password: s3cret
-      bar:
-        name: bar
-        password: s3cret
-
-uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
-    cache: true
+# no auth needed, this is just for e2e testing
+auth: {}
 
 packages:
-  # storybook's 'legacy' packages
-  '@storybook/react-simple-di':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/react-stubber':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/builder-manager':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/channels':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/client-logger':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/components':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/core-common':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/core-events':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/core-server':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/csf-tools':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/docs-tools':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/manager-api':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/manager':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/node-logger':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/preview-api':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/preview':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/router':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/telemetry':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/theming':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/types':
-    access: $all
-    publish: $all
-    proxy: npmjs
-
-  # storybook's packages never hosted in this monorepo
-  '@storybook/csf':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/global':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/design-system':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/preset-ie11':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/preset-scss':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/bench':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/addon-coverage':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/addon-bench':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/addon-styling':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/addon-svelte-csf':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/create-svelte-with-args':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/react-docgen-typescript-plugin':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/testing-library':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/test-runner':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/expect':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/docs-mdx':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/semver':
-    # TODO: remove this when new versions of all dependents have been published and updated. It is not used anymore but still referenced in the latest packages
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/icons':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/ember-cli-storybook':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/addon-webpack5-compiler-swc':
-    access: $all
-    publish: $all
-    proxy: npmjs
-  '@storybook/addon-webpack5-compiler-babel':
-    access: $all
-    publish: $all
-    proxy: npmjs
-
-  # storybook packages are NOT proxied to global registry
-  # allowing us to republish any version during tests
-  '@storybook/*':
-    access: $all
-    publish: $all
-
-  'sb':
-    access: $all
-    publish: $all
-
-  'create-storybook':
-    access: $all
-    publish: $all
-
-  'storybook':
-    access: $all
-    publish: $all
-
-  'storybook-addon-pseudo-states':
-    access: $all
-    publish: $all
-
-  'eslint-plugin-storybook':
-    access: $all
-    publish: $all
-
   '@*/*':
     access: $all
     publish: $all
-    proxy: npmjs
+    unpublish: $all
 
   '**':
     access: $all
     publish: $all
-    proxy: npmjs
+    unpublish: $all
 
-logs:
-  - { type: stdout, format: pretty, level: warn }
+log:
+  type: stdout
+  format: pretty
+  level: debug
+
+publish:
+  # no npm connection needed
+  allow_offline: true


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Remove the nx cloud connection in circel CI, as two seperate connection seem to trip up NX.
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced skipping of build cache during type-checking and compilation to ensure fresh checks.
  * CI simplified: removed separate compile stage; dependency install now runs directly inside the check step.
  * Normalized repository URLs across many packages to a git+https format.
  * Updated local registry tooling and config for offline-friendly publishing and deterministic local package publishing.

* **Chores (dev tooling)**
  * Adjusted Yarn and package-registry settings and dependencies for the local publish flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->