### PR TITLE
Core: Add sitemap.xml handler

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -318,6 +318,7 @@
     "resolve": "^1.22.11",
     "resolve.exports": "^2.0.3",
     "sirv": "^2.0.4",
+    "sitemap": "^9.0.0",
     "slash": "^5.0.0",
     "source-map": "^0.7.4",
     "store2": "^2.14.2",

--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -153,6 +153,10 @@ command('build')
   .option('--docs', 'Build a documentation-only site using addon-docs')
   .option('--test', 'Build stories optimized for testing purposes.')
   .option('--preview-only', 'Use the preview without the manager UI')
+  .option(
+    '--site-url <string>',
+    'The URL where the built site will be deployed, for sitemap generation'
+  )
   .action(async (options) => {
     const { env } = process;
     env.NODE_ENV = env.NODE_ENV || 'production';
@@ -169,6 +173,7 @@ command('build')
       staticDir: 'SBCONFIG_STATIC_DIR',
       outputDir: 'SBCONFIG_OUTPUT_DIR',
       configDir: 'SBCONFIG_CONFIG_DIR',
+      siteUrl: 'SBCONFIG_SITE_URL',
     });
 
     await build({

--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -173,7 +173,19 @@ command('build')
       staticDir: 'SBCONFIG_STATIC_DIR',
       outputDir: 'SBCONFIG_OUTPUT_DIR',
       configDir: 'SBCONFIG_CONFIG_DIR',
-      siteUrl: 'SBCONFIG_SITE_URL',
+      siteUrl: [
+        // Our own environment variable naming convention
+        'SBCONFIG_SITE_URL',
+        // Netlify: https://docs.netlify.com/build/configure-builds/environment-variables/
+        'URL',
+        // Vercel: https://vercel.com/docs/environment-variables/system-environment-variables
+        'VERCEL_PROJECT_PRODUCTION_URL',
+        // Cloudflare Pages: https://developers.cloudflare.com/pages/configuration/build-configuration/
+        'CF_PAGES_URL',
+        // Render: https://render.com/docs/environment-variables
+        'RENDER_EXTERNAL_URL',
+        // GH Pages, AWS Amplify, Azure Static Web Apps, Heroku do not expose an env var.
+      ],
     });
 
     await build({

--- a/code/core/src/cli/build.ts
+++ b/code/core/src/cli/build.ts
@@ -9,6 +9,7 @@ export const build = async (cliOptions: any) => {
     ...cliOptions,
     configDir: cliOptions.configDir || './.storybook',
     outputDir: cliOptions.outputDir || './storybook-static',
+    siteUrl: cliOptions.siteUrl || undefined,
     ignorePreview: !!cliOptions.previewUrl && !cliOptions.forceBuildPreview,
     configType: 'PRODUCTION',
     cache,

--- a/code/core/src/common/utils/cli.ts
+++ b/code/core/src/common/utils/cli.ts
@@ -66,12 +66,18 @@ export function parseList(str: string): string[] {
     .filter((item) => item.length > 0);
 }
 
-export function getEnvConfig(program: Record<string, any>, configEnv: Record<string, any>): void {
+export function getEnvConfig(
+  program: Record<string, unknown>,
+  configEnv: Record<string, string | string[]>
+): void {
   Object.keys(configEnv).forEach((fieldName) => {
-    const envVarName = configEnv[fieldName];
-    const envVarValue = process.env[envVarName];
+    const envVarNames = Array.isArray(configEnv[fieldName])
+      ? configEnv[fieldName]
+      : [configEnv[fieldName]];
+
+    const envVarValue = envVarNames.find((envVarName) => process.env[envVarName]);
     if (envVarValue) {
-      program[fieldName] = envVarValue;
+      program[fieldName] = process.env[envVarValue];
     }
   });
 }

--- a/code/core/src/core-server/build-static.ts
+++ b/code/core/src/core-server/build-static.ts
@@ -25,12 +25,15 @@ import { copyAllStaticFilesRelativeToMain } from './utils/copy-all-static-files'
 import { getBuilders } from './utils/get-builders';
 import { extractStorybookMetadata } from './utils/metadata';
 import { outputStats } from './utils/output-stats';
-import { extractStoriesJson } from './utils/stories-json';
+import { extractSitemap, extractStoriesJson } from './utils/stories-json';
 import { summarizeIndex } from './utils/summarizeIndex';
 
 export type BuildStaticStandaloneOptions = CLIOptions &
   LoadOptions &
-  BuilderOptions & { outputDir: string };
+  BuilderOptions & {
+    outputDir: string;
+    siteUrl?: string;
+  };
 
 export async function buildStaticStandalone(options: BuildStaticStandaloneOptions) {
   options.configType = 'PRODUCTION';
@@ -160,6 +163,14 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
       extractStoriesJson(
         join(options.outputDir, 'index.json'),
         initializedStoryIndexGenerator as Promise<StoryIndexGenerator>
+      )
+    );
+
+    effects.push(
+      extractSitemap(
+        join(options.outputDir, 'sitemap.xml'),
+        initializedStoryIndexGenerator as Promise<StoryIndexGenerator>,
+        options
       )
     );
 

--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -22,6 +22,7 @@ import { openInBrowser } from './utils/open-browser/open-in-browser';
 import { getServerAddresses } from './utils/server-address';
 import { getServer } from './utils/server-init';
 import { useStatics } from './utils/server-statics';
+import { useSitemap } from './utils/stories-json';
 import { summarizeIndex } from './utils/summarizeIndex';
 
 export async function storybookDevServer(options: Options) {
@@ -137,6 +138,9 @@ export async function storybookDevServer(options: Options) {
     await previewBuilder?.bail().catch();
     throw indexError;
   }
+
+  // StoryIndexGenerator should now be guaranteed to be defined as `indexError` if not set.
+  useSitemap(app, initializedStoryIndexGenerator as Promise<StoryIndexGenerator>, options);
 
   const features = await options.presets.apply('features');
   if (features?.experimentalComponentsManifest) {

--- a/code/core/src/core-server/utils/getStoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/getStoryIndexGenerator.ts
@@ -39,6 +39,7 @@ export async function getStoryIndexGenerator(
     serverChannel,
     workingDir,
     configDir,
+    options,
   });
 
   return initializedStoryIndexGenerator;

--- a/code/core/src/core-server/utils/stories-json.ts
+++ b/code/core/src/core-server/utils/stories-json.ts
@@ -1,14 +1,19 @@
 import { writeFile } from 'node:fs/promises';
 import { basename } from 'node:path';
+import { createGzip } from 'node:zlib';
 
 import { STORY_INDEX_INVALIDATED } from 'storybook/internal/core-events';
+import type { Options } from 'storybook/internal/types';
 import type { NormalizedStoriesSpecifier, StoryIndex } from 'storybook/internal/types';
 
 import { debounce } from 'es-toolkit/function';
 import type { Polka } from 'polka';
+import { SitemapStream, streamToPromise } from 'sitemap';
+import invariant from 'tiny-invariant';
 
 import type { StoryIndexGenerator } from './StoryIndexGenerator';
 import type { ServerChannel } from './get-server-channel';
+import { getServerAddresses } from './server-address';
 import { watchStorySpecifiers } from './watch-story-specifiers';
 import { watchConfig } from './watchConfig';
 
@@ -31,6 +36,7 @@ export function useStoriesJson({
   configDir,
   serverChannel,
   normalizedStories,
+  options,
 }: {
   app: Polka;
   initializedStoryIndexGenerator: Promise<StoryIndexGenerator>;
@@ -38,13 +44,17 @@ export function useStoriesJson({
   workingDir?: string;
   configDir?: string;
   normalizedStories: NormalizedStoriesSpecifier[];
+  options: Options;
 }) {
+  let cachedSitemap: Buffer | undefined;
+
   const maybeInvalidate = debounce(() => serverChannel.emit(STORY_INDEX_INVALIDATED), DEBOUNCE, {
     edges: ['leading', 'trailing'],
   });
   watchStorySpecifiers(normalizedStories, { workingDir }, async (specifier, path, removed) => {
     const generator = await initializedStoryIndexGenerator;
     generator.invalidate(specifier, path, removed);
+    cachedSitemap = undefined;
     maybeInvalidate();
   });
   if (configDir) {
@@ -52,6 +62,7 @@ export function useStoriesJson({
       if (basename(filePath).startsWith('preview')) {
         const generator = await initializedStoryIndexGenerator;
         generator.invalidateAll();
+        cachedSitemap = undefined;
         maybeInvalidate();
       }
     });
@@ -63,6 +74,57 @@ export function useStoriesJson({
       const index = await generator.getIndex();
       res.setHeader('Content-Type', 'application/json');
       res.end(JSON.stringify(index));
+    } catch (err) {
+      res.statusCode = 500;
+      res.end(err instanceof Error ? err.toString() : String(err));
+    }
+  });
+
+  app.use('/sitemap.xml', async (req, res) => {
+    try {
+      res.setHeader('Content-Type', 'application/xml');
+      res.setHeader('Content-Encoding', 'gzip');
+
+      // serve cached gzip if available
+      if (cachedSitemap) {
+        res.end(cachedSitemap);
+        return;
+      }
+
+      const generator = await initializedStoryIndexGenerator;
+      const index = await generator.getIndex();
+
+      const { port, host, initialPath } = options;
+      invariant(port, 'expected options to have a port');
+      const proto = options.https ? 'https' : 'http';
+      const { networkAddress } = getServerAddresses(port, host, proto, initialPath);
+
+      const smStream = new SitemapStream({ hostname: networkAddress });
+      const pipeline = smStream.pipe(createGzip());
+
+      const now = new Date();
+
+      // static settings pages; those with backlinks to storybook.js.org are the most important.
+      smStream.write({ url: '/?path=/settings/about', lastmod: now, priority: 1 });
+      smStream.write({ url: '/?path=/settings/whats-new', lastmod: now, priority: 1 });
+      smStream.write({ url: '/?path=/settings/guide', lastmod: now, priority: 0.3 });
+      smStream.write({ url: '/?path=/settings/shortcuts', lastmod: now, priority: 0.3 });
+
+      // entries from story index; we prefer indexing docs over stories
+      const entries = Object.values(index.entries || {});
+      for (const entry of entries) {
+        if (entry.type === 'docs') {
+          smStream.write({ url: `/?path=/docs/${entry.id}`, lastmod: now, priority: 0.9 });
+        } else if (entry.type === 'story' && entry.subtype !== 'test') {
+          smStream.write({ url: `/?path=/story/${entry.id}`, lastmod: now, priority: 0.5 });
+        }
+      }
+
+      smStream.end();
+
+      // await and cache the gzipped buffer
+      cachedSitemap = await streamToPromise(pipeline);
+      res.end(cachedSitemap);
     } catch (err) {
       res.statusCode = 500;
       res.end(err instanceof Error ? err.toString() : String(err));

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -334,6 +334,9 @@ export interface TestBuildFlags {
 }
 
 export interface TestBuildConfig {
+  /** URL of the deployed website (needed for sitemap computation). */
+  siteUrl?: string;
+
   test?: TestBuildFlags;
 }
 

--- a/code/e2e-tests/sitemap.spec.ts
+++ b/code/e2e-tests/sitemap.spec.ts
@@ -1,0 +1,47 @@
+import { gunzipSync } from 'node:zlib';
+
+import { expect, test } from '@playwright/test';
+import process from 'process';
+
+const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:8001';
+
+test.describe('Sitemap', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(storybookUrl);
+  });
+
+  test('should have sitemap.xml with gzipped content', async ({ page }) => {
+    const response = await page.evaluate(async () => {
+      const res = await fetch('/sitemap.xml');
+      const buffer = await res.arrayBuffer();
+      return {
+        status: res.status,
+        contentType: res.headers.get('content-type'),
+        contentEncoding: res.headers.get('content-encoding'),
+        buffer: Array.from(new Uint8Array(buffer)),
+      };
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.contentType).toBe('application/xml');
+    expect(response.contentEncoding).toBe('gzip');
+
+    const decompressed = gunzipSync(Uint8Array.from(response.buffer)).toString('utf-8');
+
+    expect(decompressed).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(decompressed).toContain('<urlset');
+    expect(decompressed).toContain('</urlset>');
+
+    expect(decompressed).toContain('<loc>');
+    expect(decompressed).toMatch(/\?path=\/docs\/example-button--docs/);
+    expect(decompressed).toMatch(/\?path=\/story\/example-button--primary/);
+
+    expect(decompressed).toContain('/?path=/settings/about');
+    expect(decompressed).toContain('/?path=/settings/whats-new');
+    expect(decompressed).toContain('/?path=/settings/guide');
+    expect(decompressed).toContain('/?path=/settings/shortcuts');
+
+    expect(decompressed).toContain('<lastmod>');
+    expect(decompressed).toContain('<priority>');
+  });
+});

--- a/code/e2e-tests/sitemap.spec.ts
+++ b/code/e2e-tests/sitemap.spec.ts
@@ -1,32 +1,18 @@
-import { gunzipSync } from 'node:zlib';
-
 import { expect, test } from '@playwright/test';
 import process from 'process';
 
 const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:8001';
 
 test.describe('Sitemap', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(storybookUrl);
-  });
-
   test('should have sitemap.xml with gzipped content', async ({ page }) => {
-    const response = await page.evaluate(async () => {
-      const res = await fetch('/sitemap.xml');
-      const buffer = await res.arrayBuffer();
-      return {
-        status: res.status,
-        contentType: res.headers.get('content-type'),
-        contentEncoding: res.headers.get('content-encoding'),
-        buffer: Array.from(new Uint8Array(buffer)),
-      };
-    });
+    const response = await page.goto(`${storybookUrl}/sitemap.xml`);
 
-    expect(response.status).toBe(200);
-    expect(response.contentType).toBe('application/xml');
-    expect(response.contentEncoding).toBe('gzip');
+    expect(response?.status()).toBe(200);
+    expect(response?.headers()['content-type']).toBe('application/xml');
+    expect(response?.headers()['content-encoding']).toBe('gzip');
 
-    const decompressed = gunzipSync(Uint8Array.from(response.buffer)).toString('utf-8');
+    const decompressed = (await response?.body())?.toString('utf-8');
+    expect(decompressed).toBeDefined();
 
     expect(decompressed).toContain('<?xml version="1.0" encoding="UTF-8"?>');
     expect(decompressed).toContain('<urlset');

--- a/yarn.lock
+++ b/yarn.lock
@@ -10050,6 +10050,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/sax@npm:^1.2.1":
+  version: 1.2.7
+  resolution: "@types/sax@npm:1.2.7"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/d077a761a0753b079bf8279b3993948030ca86ed9125437b9b29c1de40db9b2deb7fddc369f014b58861d450e8b8cc75f163aa29dc8cea81952efbfd859168cf
+  languageName: node
+  linkType: hard
+
 "@types/semver@npm:^7, @types/semver@npm:^7.3.12, @types/semver@npm:^7.3.4, @types/semver@npm:^7.5.6, @types/semver@npm:^7.5.8, @types/semver@npm:^7.7.0":
   version: 7.7.1
   resolution: "@types/semver@npm:7.7.1"
@@ -12071,6 +12080,13 @@ __metadata:
     delegates: "npm:^1.0.0"
     readable-stream: "npm:^2.0.6"
   checksum: 10c0/03cb45f2892767773c86a616205fc67feb8dfdd56685d1b34999cfa6c0d2aebe73ec0e6ba88a406422b998dea24138337fdb9a3f9b172d7c2a7f75d02f3df088
+  languageName: node
+  linkType: hard
+
+"arg@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "arg@npm:5.0.2"
+  checksum: 10c0/ccaf86f4e05d342af6666c569f844bec426595c567d32a8289715087825c2ca7edd8a3d204e4d2fb2aa4602e09a57d0c13ea8c9eea75aac3dbb4af5514e6800e
   languageName: node
   linkType: hard
 
@@ -28090,7 +28106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sax@npm:^1.2.4":
+"sax@npm:^1.2.4, sax@npm:^1.4.1":
   version: 1.4.3
   resolution: "sax@npm:1.4.3"
   checksum: 10c0/45bba07561d93f184a8686e1a543418ced8c844b994fbe45cc49d5cd2fc8ac7ec949dae38565e35e388ad0cca2b75997a29b6857c927bf6553da3f80ed0e4e62
@@ -28702,6 +28718,20 @@ __metadata:
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
   checksum: 10c0/230ac975cca485b7f6fe2b96a711aa62a6a26ead3e6fb8ba17c5a00d61b8bed0d7adc21f5626b70d7c33c62ff4e63933017a6462942c719d1980bb0b1207ad46
+  languageName: node
+  linkType: hard
+
+"sitemap@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "sitemap@npm:9.0.0"
+  dependencies:
+    "@types/node": "npm:^24.9.2"
+    "@types/sax": "npm:^1.2.1"
+    arg: "npm:^5.0.0"
+    sax: "npm:^1.4.1"
+  bin:
+    sitemap: dist/esm/cli.js
+  checksum: 10c0/970c51f88185268676aa2e242de0155fa0a3fd915e56987fdbe51f44bf8d5246f2c4b05cf290e57ab5505820e081ce471e1a5a38572944f724ace705c61bf675
   languageName: node
   linkType: hard
 
@@ -29322,6 +29352,7 @@ __metadata:
     resolve.exports: "npm:^2.0.3"
     semver: "npm:^7.6.2"
     sirv: "npm:^2.0.4"
+    sitemap: "npm:^9.0.0"
     slash: "npm:^5.0.0"
     source-map: "npm:^0.7.4"
     store2: "npm:^2.14.2"


### PR DESCRIPTION
## What I did
Adds a sitemap.xml to help with the indexing of Storybook instances.

Part of an experiment on [SEO improvements through the About page](https://www.notion.so/chromatic-ui/SEO-about-page-2626e816203480979918cced6e150198).

## TODO list

### Now
* [x] create canary
* [x] apply to icons pkg

### Later
* [ ] fix E2E builds so sitemap.spec.ts can run
* [ ] fix `main.ts`'s `build.siteUrl` not being used
* [ ] add documentation for the option (main.ts + --site-url + ENV var)
* [ ] if experiment works, add onboarding/init step to encourage setting url?
* [ ] review deploy/prod documentation to encourage use of sitemap?
* [x] change `getEnvConfig` in `bin/core` to read Netlify/Vercel/GH pages URL env vars
* [ ] encourage chromatic to set SBCONFIG_SITE_URL env var for permabuilds?

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

1. Run local instance
2. Visit http://localhost:6006/sitemap.xml

### Documentation

> [!CAUTION]
> Documentation is missing for now.

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33243-sha-278c6240`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33243-sha-278c6240 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33243-sha-278c6240 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33243-sha-278c6240`](https://npmjs.com/package/storybook/v/0.0.0-pr-33243-sha-278c6240) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`sidnioulz/growth-exp-sitemap`](https://github.com/storybookjs/storybook/tree/sidnioulz/growth-exp-sitemap) |
| **Commit** | [`278c6240`](https://github.com/storybookjs/storybook/commit/278c62400739c90ebe9e530517db0d08e7c42138) |
| **Datetime** | Mon Dec  8 06:22:56 UTC 2025 (`1765174976`) |
| **Workflow run** | [20018778053](https://github.com/storybookjs/storybook/actions/runs/20018778053) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33243`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /sitemap.xml endpoint that returns a gzipped XML sitemap of stories and docs for SEO.
  * Sitemap generation added to static builds and the dev server, with configurable site URL and cached gzipped output.

* **Tests**
  * Added unit/integration tests covering sitemap generation, headers, compression, host/protocol handling, caching, debounce/simultaneous access, and an end-to-end sitemap gzip/format test.

* **Chores**
  * Added a runtime dependency for sitemap generation and a new CLI/build option to supply site URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->