### PR TITLE
Bug: Prevent keyboard shortcut focus issues on WCs with a closed shadow root

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
@@ -3729,6 +3729,27 @@ describe('PreviewWeb', () => {
       expect(mockChannel.emit).toHaveBeenCalledWith(PREVIEW_KEYDOWN, expect.objectContaining({}));
     });
 
+    it('does not emit PREVIEW_KEYDOWN for input-like custom elements when the composedPath is retargeted', async () => {
+      document.location.search = '?id=component-one--docs&viewMode=docs';
+      const preview = await createAndRenderPreview();
+
+      const getAttribute = vi.fn((attr: string) => {
+        if (attr === 'role') {
+          return 'textbox';
+        }
+        return null;
+      });
+
+      preview.onKeydown({
+        composedPath: vi.fn().mockReturnValue([{ tagName: 'inp-element', getAttribute }]),
+      } as any);
+
+      expect(mockChannel.emit).not.toHaveBeenCalledWith(
+        PREVIEW_KEYDOWN,
+        expect.objectContaining({})
+      );
+    });
+
     it('emits PREVIEW_KEYDOWN for regular elements, fallback to event.target', async () => {
       document.location.search = '?id=component-one--docs&viewMode=docs';
       const preview = await createAndRenderPreview();

--- a/docs/configure/user-interface/features-and-behavior.mdx
+++ b/docs/configure/user-interface/features-and-behavior.mdx
@@ -30,6 +30,14 @@ The following table details how to use the API values:
 | **sidebar**              | Object          | Sidebar options, see below                              | `{ showRoots: false }`                                                                         |
 | **toolbar**              | Object          | Modify the tools in the toolbar using the addon id      | `{ fullscreen: { hidden: false } } `                                                           |
 
+<Callout variant="info">
+  Storybook suppresses global keyboard shortcuts while you're typing in text inputs, to prevent focus-stealing shortcuts from interrupting typing. If you're building
+  custom elements (Web Components) that render an internal input inside a <code>closed</code> shadow
+  root, event retargeting may hide the internal <code>&lt;input&gt;</code> from Storybook. In that
+  case, add an ARIA role such as <code>textbox</code>, <code>searchbox</code>, <code>combobox</code>,
+  or <code>input</code> to the custom element host so Storybook can treat it as an editable control.
+</Callout>
+
 The following options are configurable under the `sidebar` namespace:
 
 | Name               | Type     | Description                                                   | Example Value                                         |


### PR DESCRIPTION
Closes #23670

## What I did

Implemented the more complex fix for this bug. The current fix is fine unless the web component's shadow root is closed. This fix will not change the focus on a web component whose shadow root is closed if the web component has an approporiate ARIA role ('input' || 'searchbox' || 'textbox' || 'combobox').

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard input detection to properly recognize text fields in custom web components and shadow DOM.

* **Documentation**
  * Added guidance on keyboard shortcut suppression while typing in inputs.
  * Added recommendations for configuring custom elements with ARIA roles for improved input recognition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->