### PR TITLE
NextJS: Alias image to use fileURLToPath for better resolution

### DIFF
--- a/code/frameworks/nextjs/src/images/webpack.ts
+++ b/code/frameworks/nextjs/src/images/webpack.ts
@@ -19,14 +19,16 @@ const configureImageDefaults = (baseConfig: WebpackConfig): void => {
   resolve.alias = {
     ...resolve.alias,
     'sb-original/next/image': fileURLToPath(import.meta.resolve('next/image')),
-    'next/image': '@storybook/nextjs/images/next-image',
+    'next/image': fileURLToPath(import.meta.resolve('@storybook/nextjs/images/next-image')),
   };
 
   if (semver.satisfies(version, '>=13.0.0')) {
     resolve.alias = {
       ...resolve.alias,
       'sb-original/next/legacy/image': fileURLToPath(import.meta.resolve('next/legacy/image')),
-      'next/legacy/image': '@storybook/nextjs/images/next-legacy-image',
+      'next/legacy/image': fileURLToPath(
+        import.meta.resolve('@storybook/nextjs/images/next-legacy-image')
+      ),
     };
   }
 };


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/33252

## What I did

Wrap the string with a resolve

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- The Issue does not have a simple repro, so I did this based on experience, no testing
- We'd need to replicate the user's setup, a monorepo where storybook for nextjs is installed in a monorepo subdir, referencing stories from a root dir, and in that story in the root dir uses `nextjs/image`
- A stand-alone repro from the user reporting the issue would be nice.

Here are the reproduction steps provided by the user:
1. Create a monorepo using the tool(s) of your choice
2. Create a package and install Storybook with the `@storybook/nextjs` framework
3. Create a second package and install `next`
4. In the NextJS package, create a component that imports `next/image` or `next/router`
5. In the Storybook package, create a component that imports the component in the NextJS package
6. Create a Story for the Storybook component
7. The build should fail

I assume "The build" refers to creating a static version of storybook.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
