### PR TITLE
Docs-Blocks: Fix broken tooltip in ArgValue details

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.stories.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.stories.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 
 import { ResetWrapper } from 'storybook/internal/components';
 
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { expect, screen } from 'storybook/test';
+
 import { ArgRow } from './ArgRow';
 import { TableWrapper } from './ArgsTable';
 
@@ -10,7 +14,7 @@ export default {
   title: 'Components/ArgsTable/ArgRow',
 
   decorators: [
-    (getStory: any) => (
+    (getStory) => (
       <ResetWrapper>
         <TableWrapper>
           <tbody>{getStory()}</tbody>
@@ -21,7 +25,7 @@ export default {
   argTypes: {
     updateArgs: { action: 'updateArgs' },
   },
-};
+} satisfies Meta<typeof ArgRow>;
 
 export const String = {
   args: {
@@ -346,7 +350,14 @@ export const LongFunc = {
       },
     },
   },
-};
+  play: async ({ canvas }) => {
+    const funcButton = canvas.getByRole('button', { name: 'func' });
+    funcButton.click();
+    expect(
+      await screen.findByText(/Calculate various metrics between a and b/)
+    ).toBeInTheDocument();
+  },
+} satisfies StoryObj<typeof ArgRow>;
 
 const enumeration =
   '"search" | "arrow-to-bottom" | "arrow-to-right" | "bell" | "check" | "check-circle"';
@@ -384,7 +395,20 @@ export const LongEnum = {
       },
     },
   },
-};
+  play: async ({ canvas, step }) => {
+    await step('Expand long enum', async () => {
+      canvas.getByRole('button', { name: 'Show 26 more...' }).click();
+      expect(await canvas.findByText(/exclamation-triangle/)).toBeVisible();
+    });
+    await step('Collapse long enum', async () => {
+      (await canvas.findByRole('button', { name: 'Show less...' })).click();
+      expect(await canvas.findByText(/exclamation-triangle/)).not.toBeVisible();
+    });
+    await step('Re-expand for visual test', async () => {
+      (await canvas.findByRole('button', { name: 'Show 26 more...' })).click();
+    });
+  },
+} satisfies StoryObj<typeof ArgRow>;
 
 const complexUnion =
   '((a: string | SVGSVGElement) => void) | RefObject<SVGSVGElement | number> | [a|b] | {a|b}';

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.stories.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.stories.tsx
@@ -309,7 +309,7 @@ export const Func = {
   },
 };
 
-export const FuncWithLongDetail = {
+export const LongFunc = {
   args: {
     row: {
       ...Func.args.row,

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.stories.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.stories.tsx
@@ -309,6 +309,45 @@ export const Func = {
   },
 };
 
+export const FuncWithLongDetail = {
+  args: {
+    row: {
+      ...Func.args.row,
+      table: {
+        ...Func.args.row.table,
+        defaultValue: {
+          summary: 'func',
+          detail: `(a, b) => {
+  // Calculate various metrics between a and b
+  const lengthA = a.length;
+  const lengthB = b.length;
+  
+  // Determine the longer string
+  const maxLength = Math.max(lengthA, lengthB);
+  const minLength = Math.min(lengthA, lengthB);
+  
+  // Calculate similarity score
+  let matchCount = 0;
+  for (let i = 0; i < minLength; i++) {
+    if (a[i] === b[i]) {
+      matchCount++;
+    }
+  }
+  
+  // Compute weighted average
+  const similarity = (matchCount / maxLength) * 100;
+  
+  // Generate result string
+  const result = \`Similarity: \${similarity.toFixed(2)}%, Length diff: \${Math.abs(lengthA - lengthB)}\`;
+  
+  return result;
+}`,
+        },
+      },
+    },
+  },
+};
+
 const enumeration =
   '"search" | "arrow-to-bottom" | "arrow-to-right" | "bell" | "check" | "check-circle"';
 export const Enum = {

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
@@ -37,6 +37,27 @@ const Summary = styled.div<{ isExpanded?: boolean }>(({ isExpanded }) => ({
   minWidth: 100,
 }));
 
+const DetailsContainer = styled.details({
+  display: 'flex',
+  flexDirection: 'column',
+  summary: {
+    order: 2,
+  },
+  'summary::-webkit-details-marker': {
+    display: 'none',
+  },
+  'summary::marker': {
+    content: 'none',
+  },
+});
+
+const AlignedDetails = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  flexWrap: 'wrap',
+  alignItems: 'flex-start',
+});
+
 const Text = styled.span<{ simple?: boolean }>(codeCommon, ({ theme, simple = false }) => ({
   flex: '0 0 auto',
   fontFamily: theme.typography.fonts.mono,
@@ -57,7 +78,7 @@ const Text = styled.span<{ simple?: boolean }>(codeCommon, ({ theme, simple = fa
   }),
 }));
 
-const ExpandButton = styled.button(({ theme }) => ({
+const ExpandButton = styled.summary(({ theme }) => ({
   fontFamily: theme.typography.fonts.mono,
   color: theme.color.secondary,
   marginBottom: '4px',
@@ -123,13 +144,16 @@ const getSummaryItems = (summary: string) => {
   return uniq(summaryItems);
 };
 
-const renderSummaryItems = (summaryItems: string[], isExpanded = true) => {
-  let items = summaryItems;
-  if (!isExpanded) {
-    items = summaryItems.slice(0, ITEMS_BEFORE_EXPANSION);
-  }
+const renderSummaryItems = (summaryItems: string[]) => {
+  return summaryItems
+    .slice(0, ITEMS_BEFORE_EXPANSION)
+    .map((item) => <ArgText key={item} text={item === '' ? '""' : item} />);
+};
 
-  return items.map((item) => <ArgText key={item} text={item === '' ? '""' : item} />);
+const renderExpandedItems = (summaryItems: string[]) => {
+  return summaryItems
+    .slice(ITEMS_BEFORE_EXPANSION)
+    .map((item) => <ArgText key={item} text={item === '' ? '""' : item} />);
 };
 
 const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
@@ -160,10 +184,13 @@ const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
 
     return hasManyItems ? (
       <Summary isExpanded={isExpanded}>
-        {renderSummaryItems(summaryItems, isExpanded)}
-        <ExpandButton onClick={() => setIsExpanded(!isExpanded)}>
-          {isExpanded ? 'Show less...' : `Show ${itemsCount - ITEMS_BEFORE_EXPANSION} more...`}
-        </ExpandButton>
+        {renderSummaryItems(summaryItems)}
+        <DetailsContainer>
+          <AlignedDetails>{renderExpandedItems(summaryItems)}</AlignedDetails>
+          <ExpandButton onClick={() => setIsExpanded(!isExpanded)}>
+            {isExpanded ? 'Show less...' : `Show ${itemsCount - ITEMS_BEFORE_EXPANSION} more...`}
+          </ExpandButton>
+        </DetailsContainer>
       </Summary>
     ) : (
       <Summary>{renderSummaryItems(summaryItems)}</Summary>

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
@@ -80,6 +80,7 @@ const Text = styled.span<{ simple?: boolean }>(codeCommon, ({ theme, simple = fa
 const ExpandButton = styled.summary(({ theme }) => ({
   fontFamily: theme.typography.fonts.mono,
   color: theme.color.secondary,
+  cursor: 'pointer',
   marginBottom: '4px',
   background: 'none',
   border: 'none',
@@ -177,9 +178,9 @@ const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
     return hasManyItems ? (
       <Summary isExpanded={isExpanded}>
         {renderSummaryItems(summaryItems)}
-        <DetailsContainer>
+        <DetailsContainer open={isExpanded} onToggle={(e) => setIsExpanded(e.currentTarget.open)}>
           <AlignedDetails>{renderExpandedItems(summaryItems)}</AlignedDetails>
-          <ExpandButton onClick={() => setIsExpanded(!isExpanded)}>
+          <ExpandButton role="button">
             {isExpanded ? 'Show less...' : `Show ${itemsCount - ITEMS_BEFORE_EXPANSION} more...`}
           </ExpandButton>
         </DetailsContainer>

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
@@ -86,7 +86,7 @@ const ExpandButton = styled.summary(({ theme }) => ({
   border: 'none',
 }));
 
-const Expandable = styled.div(codeCommon, ({ theme }) => ({
+const Expandable = styled.button(codeCommon, ({ theme }) => ({
   fontFamily: theme.typography.fonts.mono,
   color: theme.color.secondary,
   fontSize: theme.typography.size.s1, // overrides codeCommon
@@ -94,6 +94,15 @@ const Expandable = styled.div(codeCommon, ({ theme }) => ({
   whiteSpace: 'nowrap',
   display: 'flex',
   alignItems: 'center',
+  cursor: 'pointer',
+  '&:hover': {
+    border:
+      theme.base === 'light' ? '1px solid hsl(0 0 0 / 0.15)' : '1px solid hsl(0 0 100 / 0.15)',
+  },
+  '&:focus-visible': {
+    outline: `2px solid ${theme.color.secondary}`,
+    outlineOffset: '2px',
+  },
 }));
 
 const Detail = styled.div(({ theme }) => ({

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
@@ -81,7 +81,9 @@ const ExpandButton = styled.summary(({ theme }) => ({
   fontFamily: theme.typography.fonts.mono,
   color: theme.color.secondary,
   cursor: 'pointer',
-  marginBottom: '4px',
+  lineHeight: 'normal',
+  margin: '0 0 4px',
+  padding: '1px 6px',
   background: 'none',
   border: 'none',
 }));

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
@@ -1,12 +1,11 @@
 import type { FC } from 'react';
 import React, { useState } from 'react';
 
-import { SyntaxHighlighter, TooltipProvider, codeCommon } from 'storybook/internal/components';
+import { PopoverProvider, SyntaxHighlighter, codeCommon } from 'storybook/internal/components';
 
 import { ChevronSmallDownIcon, ChevronSmallUpIcon } from '@storybook/icons';
 
 import { uniq } from 'es-toolkit/array';
-import memoize from 'memoizerific';
 import { styled } from 'storybook/theming';
 
 import type { PropSummaryValue } from './types';
@@ -96,11 +95,10 @@ const Expandable = styled.div(codeCommon, ({ theme }) => ({
   alignItems: 'center',
 }));
 
-const Detail = styled.div<{ width: string }>(({ theme, width }) => ({
-  width,
+const Detail = styled.div(({ theme }) => ({
   minWidth: 200,
   maxWidth: 800,
-  padding: 15,
+  paddingRight: 16,
   // Don't remove the mono fontFamily here even if it seems useless, this is used by the browser to calculate the length of a "ch" unit.
   fontFamily: theme.typography.fonts.mono,
   fontSize: theme.typography.size.s1,
@@ -127,12 +125,6 @@ const EmptyArg = () => {
 const ArgText: FC<ArgTextProps> = ({ text, simple }) => {
   return <Text simple={simple}>{text}</Text>;
 };
-
-const calculateDetailWidth = memoize(1000)((detail: string): string => {
-  const lines = detail.split(/\r?\n/);
-
-  return `${Math.max(...lines.map((x) => x.length))}ch`;
-});
 
 const getSummaryItems = (summary: string) => {
   if (!summary) {
@@ -198,14 +190,15 @@ const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
   }
 
   return (
-    <TooltipProvider
+    <PopoverProvider
       placement="bottom"
       visible={isOpen}
       onVisibleChange={(isVisible) => {
         setIsOpen(isVisible);
       }}
-      tooltip={
-        <Detail width={calculateDetailWidth(detail)}>
+      hasCloseButton
+      popover={
+        <Detail>
           <SyntaxHighlighter language="jsx" format={false}>
             {detail}
           </SyntaxHighlighter>
@@ -216,7 +209,7 @@ const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
         <span>{summaryAsString}</span>
         {isOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}
       </Expandable>
-    </TooltipProvider>
+    </PopoverProvider>
   );
 };
 

--- a/code/core/src/components/components/Popover/PopoverProvider.tsx
+++ b/code/core/src/components/components/Popover/PopoverProvider.tsx
@@ -77,7 +77,7 @@ export const PopoverProvider = ({
     },
     [onVisibleChange]
   );
-  const onHide = useCallback(() => setIsOpen(false), []);
+  const onHide = useCallback(() => onOpenChange(false), [onOpenChange]);
 
   return (
     <DialogTrigger


### PR DESCRIPTION
Closes #33248

## What I did

* Fixed a bug in PopoverProvider's built-in close button, that didn't work with controlled-state PopoverProviders
* Fixed the HTML markup for the "show more" button in long type enums, to use HTML `details` for better keyboard and AT support
* Replaced the type `detail` tooltip with a popover
  * Fixed up the width calculation logic which was outdated and caused unnecessary horizontal scrollbars
  * Fixed the transparency bug
  * Switched to a popover, because this tooltip sometimes requires scrolling, hinting we need to be able to navigate inside it including with a keyboard (hence it needs to grab keyboard focus)
  * Added a close button, so KB users can easily close the popover

This is a pretty opinionated change. The alternative would be to use `aria-describedby` (which is the default behaviour of RAC tooltips) but I'm worried the content can be a bit long for ARIA descriptions.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run SB instance
2. Navigate to the [Func story](http://localhost:6006/?path=/story/addons-docs-blocks-components-argstable-argrow--func) and the new [LongFunc story](http://localhost:6006/?path=/story/addons-docs-blocks-components-argstable-argrow--long-func)
3. Navigate to the [LongEnum story](http://localhost:6006/?path=/story/addons-docs-blocks-components-argstable-argrow--long-enum)

### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added interactive story examples (LongFunc and LongEnum) demonstrating expanded-detail behavior and automated play routines that validate expand/collapse and content visibility.

* **Refactor**
  * Argument-value display now uses a popover/details pattern instead of tooltips, simplifying expansion and rendering of long details.
  * Popover hide/show now flows through the standard open/close handler for consistent visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->