### PR TITLE
UI: Fix keyboard navigation bug for "reset" option in `Select`

### DIFF
--- a/code/core/src/components/components/Select/Select.stories.tsx
+++ b/code/core/src/components/components/Select/Select.stories.tsx
@@ -429,6 +429,47 @@ export const KeyboardSelectionMultiSS = meta.story({
   play: kbMultiSelectionTest(' ', ' '),
 });
 
+export const FullArrowNavigation = meta.story({
+  play: async ({ canvas, step }) => {
+    const selectButton = await canvas.findByRole('button');
+    await step('Open select', async () => {
+      selectButton.focus();
+      await userEvent.keyboard('{ArrowDown}');
+      expect(selectButton).toHaveTextContent('Tadpole');
+    });
+
+    await step('Navigate to option 2 with ArrowDown', async () => {
+      await userEvent.keyboard('{ArrowDown}');
+      expect(selectButton).toHaveTextContent('Pollywog');
+    });
+
+    await step('Navigate to option 3 with ArrowDown', async () => {
+      await userEvent.keyboard('{ArrowDown}');
+      expect(selectButton).toHaveTextContent('Frog');
+    });
+
+    await step('Loop back to option 1 with ArrowDown', async () => {
+      await userEvent.keyboard('{ArrowDown}');
+      expect(selectButton).toHaveTextContent('Tadpole');
+    });
+
+    await step('Navigate backwards with ArrowUp', async () => {
+      await userEvent.keyboard('{ArrowUp}');
+      expect(selectButton).toHaveTextContent('Frog');
+    });
+
+    await step('Navigate backwards with ArrowUp', async () => {
+      await userEvent.keyboard('{ArrowUp}');
+      expect(selectButton).toHaveTextContent('Pollywog');
+    });
+
+    await step('Navigate back to option 1 with ArrowUp', async () => {
+      await userEvent.keyboard('{ArrowUp}');
+      expect(selectButton).toHaveTextContent('Tadpole');
+    });
+  },
+});
+
 export const MouseOpenNoAutoselect = meta.story({
   name: 'AutoSelect - nothing selected on Mouse open (single)',
   play: async ({ canvas, args, step }) => {

--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -325,8 +325,10 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
           return;
         }
 
-        const currentIndex = options.findIndex(
-          (option) => externalToValue(option.value) === activeOption.value
+        const currentIndex = options.findIndex((option) =>
+          activeOption.type === 'reset'
+            ? 'type' in option && option.type === 'reset'
+            : externalToValue(option.value) === activeOption.value
         );
         const nextIndex = currentIndex + step;
 
@@ -349,8 +351,11 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
           setActiveOption(options[Math.max(0, options.length - step)]);
           return;
         }
-        const currentIndex = options.findIndex(
-          (option) => externalToValue(option.value) === activeOption.value
+
+        const currentIndex = options.findIndex((option) =>
+          activeOption.type === 'reset'
+            ? 'type' in option && option.type === 'reset'
+            : externalToValue(option.value) === activeOption.value
         );
         const nextIndex = currentIndex - step;
 


### PR DESCRIPTION
## What I did

* Fixes a recent regression introduced by b10fed890abbdd3a3d858134753756a40c27c093 that blocks some KB nav events (ArrowUp/ArrowDown) on the reset option
* Adds a non-regression test


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Go to http://localhost:6006/?path=/story/select-component--full-arrow-navigation, notice it works
2. Open the viewport tool and navigate with ArrowDown and ArrowUp, it works too

### Documentation
ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive story demonstrating full arrow-key navigation through select options (including looping and reset behavior).

* **Bug Fixes**
  * Improved keyboard navigation in select components to correctly handle the reset option when moving up/down, ensuring accurate next/previous indexing during arrow-key navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->