### PR TITLE
Manager: Ensure reset item only appears in globals toolbar when specified

### DIFF
--- a/code/core/src/toolbar/components/ToolbarMenuSelect.tsx
+++ b/code/core/src/toolbar/components/ToolbarMenuSelect.tsx
@@ -98,7 +98,7 @@ export const ToolbarMenuSelect: FC<ToolbarMenuSelectProps> = withKeyboardCycle(
         ariaLabel={ariaLabel}
         tooltip={ariaLabel}
         resetLabel={resetLabel}
-        onReset={() => updateGlobals({ [id]: '_reset' })}
+        onReset={resetItem ? () => updateGlobals({ [id]: resetItem?.value }) : undefined}
         onSelect={(selected) => updateGlobals({ [id]: selected })}
         icon={icon && <Icons icon={icon} __suppressDeprecationWarning={true} />}
       >

--- a/code/core/src/toolbar/utils/normalize-toolbar-arg-type.ts
+++ b/code/core/src/toolbar/utils/normalize-toolbar-arg-type.ts
@@ -22,6 +22,7 @@ export const normalizeArgType = (
       if (item.type === 'reset' && argType.toolbar.icon) {
         item.icon = argType.toolbar.icon;
         item.hideIcon = true;
+        item.value = undefined;
       }
 
       return { ...defaultItemValues, ...item };


### PR DESCRIPTION
Closes #33271

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The `Select` component would add a 'reset' option if `onReset` was specified. The `ToolbarMenuSelect` component was unconditionally providing this callback.

The fix is to only pass in the `onReset` handler if a reset item has been specified by the user.

In addition, the reset handler is called with the reset value, instead of the static string `_reset`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

In the default storybook, note that the theme global no longer has a reset option:

<img width="231" height="182" alt="image" src="https://github.com/user-attachments/assets/c1712b75-91b7-46a8-a639-1e812c7175c5" />

but the locale one does

<img width="292" height="221" alt="image" src="https://github.com/user-attachments/assets/7037e34a-2ca8-438e-88c2-c8ebeb8e70d5" />

and clicking it now sets the locale to `undefined` instead of `'_reset'`

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toolbar reset functionality now applies conditionally based on reset item configuration instead of using a static value.

* **Refactor**
  * Improved reset item normalization handling in toolbar.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->