### PR TITLE
Build: Wait for composed Storybooks to load before continuing E2E test

### DIFF
--- a/test-storybooks/portable-stories-kitchen-sink/react-vitest-3/e2e-tests/composition.spec.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react-vitest-3/e2e-tests/composition.spec.ts
@@ -1,19 +1,25 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from '@playwright/test';
 
-import { SbPage } from "../../../../code/e2e-tests/util";
+import { SbPage } from '../../../../code/e2e-tests/util';
 
-const STORYBOOK_URL = "http://localhost:6006";
+const STORYBOOK_URL = 'http://localhost:6006';
 
-test.describe("composition", () => {
+test.describe('composition', () => {
   // the composed storybook can be slow to load, so we need to increase the timeout
-  test.describe.configure({ mode: "serial", timeout: 60000, retries: 2 });
-  test("should filter and render composed stories", async ({ page }) => {
+  test.describe.configure({ mode: 'serial', timeout: 60000, retries: 2 });
+  test('should filter and render composed stories', async ({ page }) => {
     await page.goto(STORYBOOK_URL);
     await new SbPage(page, expect).waitUntilLoaded();
 
-    // Expect that composed Storybooks are visible
-    await expect(page.getByTitle("Storybook 8.0.0")).toBeVisible();
-    await expect(page.getByTitle("Storybook 7.6.18")).toBeVisible();
+    // Expect that composed Storybooks are visible and loaded
+    await expect(page.getByTitle('Storybook 8.0.0')).toBeVisible();
+    await expect(page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTitle('Storybook 7.6.18')).toBeVisible();
+    await expect(page.locator('[id="storybook\\@7\\.6\\.18_components-badge"]')).toBeVisible({
+      timeout: 15000,
+    });
 
     // Expect composed stories to be available in the sidebar
     await page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]').click();
@@ -21,27 +27,25 @@ test.describe("composition", () => {
       page.locator('[id="storybook\\@8\\.0\\.0_components-badge--default"]')
     ).toBeVisible();
 
-    await page
-      .locator('[id="storybook\\@7\\.6\\.18_components-badge"]')
-      .click();
+    await page.locator('[id="storybook\\@7\\.6\\.18_components-badge"]').click();
     await expect(
       page
         .locator('iframe[title="storybook-ref-storybook\\@7\\.6\\.18"]')
         .contentFrame()
-        .locator("#storybook-root")
-        .getByText("Default")
+        .locator('#storybook-root')
+        .getByText('Default')
     ).toBeVisible({ timeout: 15000 });
 
     // Expect composed stories `to be available in the search
-    await page.getByPlaceholder("Find components").fill("Button primary");
+    await page.getByPlaceholder('Find components').fill('Button primary');
     await expect(
-      page.getByRole("option", {
-        name: "Primary Storybook 7.6.18 / @components / Button",
+      page.getByRole('option', {
+        name: 'Primary Storybook 7.6.18 / @components / Button',
       })
     ).toBeVisible();
 
-    const buttonStory = page.getByRole("option", {
-      name: "Primary Storybook 8.0.0 / @blocks / examples / Button",
+    const buttonStory = page.getByRole('option', {
+      name: 'Primary Storybook 8.0.0 / @blocks / examples / Button',
     });
     await expect(buttonStory).toBeVisible();
     await buttonStory.click();
@@ -51,13 +55,11 @@ test.describe("composition", () => {
       page
         .locator('iframe[title="storybook-ref-storybook\\@8\\.0\\.0"]')
         .contentFrame()
-        .getByRole("button")
+        .getByRole('button')
     ).toBeVisible({ timeout: 15000 });
   });
 
-  test("should filter and render composed stories on mobile", async ({
-    page,
-  }) => {
+  test('should filter and render composed stories on mobile', async ({ page }) => {
     page.setViewportSize({ width: 320, height: 800 });
     await page.goto(STORYBOOK_URL);
     await new SbPage(page, expect).waitUntilLoaded();
@@ -66,47 +68,41 @@ test.describe("composition", () => {
 
     // scroll down to the bottom of the element getByText('Skip to canvasStorybookSearch')
 
-    await page.getByTitle("Storybook 7.6.18").scrollIntoViewIfNeeded();
+    await page.getByTitle('Storybook 7.6.18').scrollIntoViewIfNeeded();
 
     // Expect that composed Storybooks are visible
-    await expect(page.getByTitle("Storybook 8.0.0")).toBeVisible();
-    await expect(page.getByTitle("Storybook 7.6.18")).toBeVisible();
+    await expect(page.getByTitle('Storybook 8.0.0')).toBeVisible();
+    await expect(page.getByTitle('Storybook 7.6.18')).toBeVisible();
 
     // Expect composed stories to be available in the sidebar
-    await expect(
-      page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]')
-    ).toBeVisible();
+    await expect(page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]')).toBeVisible();
     await page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]').click();
     await expect(
       page.locator('[id="storybook\\@8\\.0\\.0_components-badge--default"]')
     ).toBeVisible();
 
-    await page
-      .locator('[id="storybook\\@7\\.6\\.18_components-badge"]')
-      .click();
-    await page
-      .locator('[id="storybook\\@7\\.6\\.18_components-badge--default"]')
-      .click();
+    await page.locator('[id="storybook\\@7\\.6\\.18_components-badge"]').click();
+    await page.locator('[id="storybook\\@7\\.6\\.18_components-badge--default"]').click();
     await expect(
       page
         .locator('iframe[title="storybook-ref-storybook\\@7\\.6\\.18"]')
         .contentFrame()
-        .locator("#storybook-root")
-        .getByText("Default")
+        .locator('#storybook-root')
+        .getByText('Default')
     ).toBeVisible({ timeout: 15000 });
 
     await page.click('button[aria-label="Open navigation menu"]');
 
     // Expect composed stories `to be available in the search
-    await page.getByPlaceholder("Find components").fill("Button primary");
+    await page.getByPlaceholder('Find components').fill('Button primary');
     await expect(
-      page.getByRole("option", {
-        name: "Primary Storybook 7.6.18 / @components / Button",
+      page.getByRole('option', {
+        name: 'Primary Storybook 7.6.18 / @components / Button',
       })
     ).toBeVisible();
 
-    const buttonStory = page.getByRole("option", {
-      name: "Primary Storybook 8.0.0 / @blocks / examples / Button",
+    const buttonStory = page.getByRole('option', {
+      name: 'Primary Storybook 8.0.0 / @blocks / examples / Button',
     });
     await expect(buttonStory).toBeVisible();
     await buttonStory.click();
@@ -116,7 +112,7 @@ test.describe("composition", () => {
       page
         .locator('iframe[title="storybook-ref-storybook\\@8\\.0\\.0"]')
         .contentFrame()
-        .getByRole("button")
+        .getByRole('button')
     ).toBeVisible({ timeout: 15000 });
   });
 });

--- a/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/composition.spec.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/composition.spec.ts
@@ -1,19 +1,25 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from '@playwright/test';
 
-import { SbPage } from "../../../../code/e2e-tests/util";
+import { SbPage } from '../../../../code/e2e-tests/util';
 
-const STORYBOOK_URL = "http://localhost:6006";
+const STORYBOOK_URL = 'http://localhost:6006';
 
-test.describe("composition", () => {
+test.describe('composition', () => {
   // the composed storybook can be slow to load, so we need to increase the timeout
-  test.describe.configure({ mode: "serial", timeout: 60000, retries: 2 });
-  test("should filter and render composed stories", async ({ page }) => {
+  test.describe.configure({ mode: 'serial', timeout: 60000, retries: 2 });
+  test('should filter and render composed stories', async ({ page }) => {
     await page.goto(STORYBOOK_URL);
     await new SbPage(page, expect).waitUntilLoaded();
 
-    // Expect that composed Storybooks are visible
-    await expect(page.getByTitle("Storybook 8.0.0")).toBeVisible();
-    await expect(page.getByTitle("Storybook 7.6.18")).toBeVisible();
+    // Expect that composed Storybooks are visible and loaded
+    await expect(page.getByTitle('Storybook 8.0.0')).toBeVisible();
+    await expect(page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTitle('Storybook 7.6.18')).toBeVisible();
+    await expect(page.locator('[id="storybook\\@7\\.6\\.18_components-badge"]')).toBeVisible({
+      timeout: 15000,
+    });
 
     // Expect composed stories to be available in the sidebar
     await page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]').click();
@@ -21,27 +27,25 @@ test.describe("composition", () => {
       page.locator('[id="storybook\\@8\\.0\\.0_components-badge--default"]')
     ).toBeVisible();
 
-    await page
-      .locator('[id="storybook\\@7\\.6\\.18_components-badge"]')
-      .click();
+    await page.locator('[id="storybook\\@7\\.6\\.18_components-badge"]').click();
     await expect(
       page
         .locator('iframe[title="storybook-ref-storybook\\@7\\.6\\.18"]')
         .contentFrame()
-        .locator("#storybook-root")
-        .getByText("Default")
+        .locator('#storybook-root')
+        .getByText('Default')
     ).toBeVisible({ timeout: 15000 });
 
-    // Expect composed stories `to be available in the search
-    await page.getByPlaceholder("Find components").fill("Button primary");
+    // Expect composed stories to be available in the search
+    await page.getByPlaceholder('Find components').fill('Button primary');
     await expect(
-      page.getByRole("option", {
-        name: "Primary Storybook 7.6.18 / @components / Button",
+      page.getByRole('option', {
+        name: 'Primary Storybook 7.6.18 / @components / Button',
       })
     ).toBeVisible();
 
-    const buttonStory = page.getByRole("option", {
-      name: "Primary Storybook 8.0.0 / @blocks / examples / Button",
+    const buttonStory = page.getByRole('option', {
+      name: 'Primary Storybook 8.0.0 / @blocks / examples / Button',
     });
     await expect(buttonStory).toBeVisible();
     await buttonStory.click();
@@ -51,13 +55,11 @@ test.describe("composition", () => {
       page
         .locator('iframe[title="storybook-ref-storybook\\@8\\.0\\.0"]')
         .contentFrame()
-        .getByRole("button")
+        .getByRole('button')
     ).toBeVisible({ timeout: 15000 });
   });
 
-  test("should filter and render composed stories on mobile", async ({
-    page,
-  }) => {
+  test('should filter and render composed stories on mobile', async ({ page }) => {
     page.setViewportSize({ width: 320, height: 800 });
     await page.goto(STORYBOOK_URL);
     await new SbPage(page, expect).waitUntilLoaded();
@@ -66,47 +68,41 @@ test.describe("composition", () => {
 
     // scroll down to the bottom of the element getByText('Skip to canvasStorybookSearch')
 
-    await page.getByTitle("Storybook 7.6.18").scrollIntoViewIfNeeded();
+    await page.getByTitle('Storybook 7.6.18').scrollIntoViewIfNeeded();
 
     // Expect that composed Storybooks are visible
-    await expect(page.getByTitle("Storybook 8.0.0")).toBeVisible();
-    await expect(page.getByTitle("Storybook 7.6.18")).toBeVisible();
+    await expect(page.getByTitle('Storybook 8.0.0')).toBeVisible();
+    await expect(page.getByTitle('Storybook 7.6.18')).toBeVisible();
 
     // Expect composed stories to be available in the sidebar
-    await expect(
-      page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]')
-    ).toBeVisible();
+    await expect(page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]')).toBeVisible();
     await page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]').click();
     await expect(
       page.locator('[id="storybook\\@8\\.0\\.0_components-badge--default"]')
     ).toBeVisible();
 
-    await page
-      .locator('[id="storybook\\@7\\.6\\.18_components-badge"]')
-      .click();
-    await page
-      .locator('[id="storybook\\@7\\.6\\.18_components-badge--default"]')
-      .click();
+    await page.locator('[id="storybook\\@7\\.6\\.18_components-badge"]').click();
+    await page.locator('[id="storybook\\@7\\.6\\.18_components-badge--default"]').click();
     await expect(
       page
         .locator('iframe[title="storybook-ref-storybook\\@7\\.6\\.18"]')
         .contentFrame()
-        .locator("#storybook-root")
-        .getByText("Default")
+        .locator('#storybook-root')
+        .getByText('Default')
     ).toBeVisible({ timeout: 15000 });
 
     await page.click('button[aria-label="Open navigation menu"]');
 
     // Expect composed stories `to be available in the search
-    await page.getByPlaceholder("Find components").fill("Button primary");
+    await page.getByPlaceholder('Find components').fill('Button primary');
     await expect(
-      page.getByRole("option", {
-        name: "Primary Storybook 7.6.18 / @components / Button",
+      page.getByRole('option', {
+        name: 'Primary Storybook 7.6.18 / @components / Button',
       })
     ).toBeVisible();
 
-    const buttonStory = page.getByRole("option", {
-      name: "Primary Storybook 8.0.0 / @blocks / examples / Button",
+    const buttonStory = page.getByRole('option', {
+      name: 'Primary Storybook 8.0.0 / @blocks / examples / Button',
     });
     await expect(buttonStory).toBeVisible();
     await buttonStory.click();
@@ -116,7 +112,7 @@ test.describe("composition", () => {
       page
         .locator('iframe[title="storybook-ref-storybook\\@8\\.0\\.0"]')
         .contentFrame()
-        .getByRole("button")
+        .getByRole('button')
     ).toBeVisible({ timeout: 15000 });
   });
 });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The composition E2E test was [timing out](https://app.circleci.com/pipelines/github/storybookjs/storybook/110831/workflows/2c662348-6471-4b70-9889-5e3d82c308b6/jobs/975215/tests) because the Badge component could not be clicked. This seemed to be caused by it taking longer than usual to load the external Storybook. I've added a check with a 15s timeout to wait for the Storybook to load before making further assertions.

Quotes were changed from single to double, consistent with other TS files in the monorepo. My linter insisted and I think it's doing the right thing.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
