### PR TITLE
Docs: Support Rolldown bundler module namespace objects

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.test.ts
@@ -80,6 +80,40 @@ describe('attachCSFFile', () => {
   });
 });
 
+describe('referenceMeta', () => {
+  it('works with different module namespace object but same default export (Rolldown compatibility)', () => {
+    // This test simulates what happens with Rolldown bundler:
+    // The module namespace object from MDX import differs from the one stored in CSFFile,
+    // but the .default property (meta export) is the same object reference
+    const { story, csfFile, metaExport, storyExport } = csfFileParts();
+    const store = {
+      componentStoriesFromCSFFile: () => [story],
+    } as unknown as StoryStore<Renderer>;
+    const context = new DocsContext(channel, store, renderStoryToElement, [csfFile]);
+
+    // Create a different namespace object with the same default export
+    // This simulates Rolldown's behavior where namespace objects are not singletons
+    const differentModuleExports = { default: metaExport, story: storyExport };
+
+    // This should NOT throw, as we can resolve via the .default property
+    expect(() => context.referenceMeta(differentModuleExports, true)).not.toThrow();
+    expect(context.storyById()).toEqual(story);
+  });
+
+  it('throws for non-module objects (components)', () => {
+    const { story, csfFile, component } = csfFileParts();
+    const store = {
+      componentStoriesFromCSFFile: () => [story],
+    } as unknown as StoryStore<Renderer>;
+    const context = new DocsContext(channel, store, renderStoryToElement, [csfFile]);
+
+    // Passing a component directly should throw
+    expect(() => context.referenceMeta(component, true)).toThrow(
+      '<Meta of={} /> must reference a CSF file module export or meta export'
+    );
+  });
+});
+
 describe('resolveOf', () => {
   const { story, csfFile, storyExport, metaExport, moduleExports, component } = csfFileParts();
 
@@ -107,6 +141,16 @@ describe('resolveOf', () => {
 
     it('works for full module exports', () => {
       expect(context.resolveOf(moduleExports)).toEqual({
+        type: 'meta',
+        csfFile,
+        preparedMeta: expect.any(Object),
+      });
+    });
+
+    it('works for module exports with different object identity but same default (Rolldown compatibility)', () => {
+      // Simulate what happens in Rolldown: different namespace object but same default export
+      const differentModuleExports = { default: metaExport, story: storyExport };
+      expect(context.resolveOf(differentModuleExports)).toEqual({
         type: 'meta',
         csfFile,
         preparedMeta: expect.any(Object),

--- a/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.test.ts
@@ -109,7 +109,7 @@ describe('referenceMeta', () => {
 
     // Passing a component directly should throw
     expect(() => context.referenceMeta(component, true)).toThrow(
-      '<Meta of={} /> must reference a CSF file module export or meta export'
+      '<Meta of={} /> must reference a CSF file module export or meta export. Did you mistakenly reference your component instead of your CSF file?'
     );
   });
 });

--- a/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.ts
@@ -157,7 +157,19 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
   ): ResolvedModuleExportFromType<TType, TRenderer> {
     type TResolvedExport = ResolvedModuleExportFromType<TType, TRenderer>;
 
-    const csfFile = this.exportsToCSFFile.get(moduleExportOrType);
+    let csfFile = this.exportsToCSFFile.get(moduleExportOrType);
+
+    // If direct lookup fails and the object has a .default property,
+    // try looking up by the default export. This handles bundlers like Rolldown
+    // that don't preserve module namespace object identity across imports.
+    if (
+      !csfFile &&
+      moduleExportOrType &&
+      typeof moduleExportOrType === 'object' &&
+      'default' in moduleExportOrType
+    ) {
+      csfFile = this.exportsToCSFFile.get((moduleExportOrType as ModuleExports).default);
+    }
 
     if (csfFile) {
       return { type: 'meta', csfFile } as TResolvedExport;


### PR DESCRIPTION
## What I did

When using vite-rolldown, bundled code creates different object references for the same module imported from multiple files. This caused Map.get() lookups to fail since Maps use object identity.

- Add fallback lookup by .default property in resolveModuleExport()
- Handles bundlers that don't preserve ES module namespace identity
- Add tests for Rolldown compatibility scenarios

Closes #31879

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Cloned the repro repo posted in the GitHub issue: https://github.com/beaussan/repro-storybook-rolldown-story-of

- Installed Storybook from my local tarball created after the update
- Reinstalled dependencies, built project, ran Storybook, confirmed fix validity (tarball attached to this comment) 

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers
[storybook-10.2.0-alpha.3.tgz](https://github.com/user-attachments/files/23935646/storybook-10.2.0-alpha.3.tgz)

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility with bundlers that don't preserve module namespace identity (e.g., Rolldown) by improving module export resolution, ensuring correct default export handling.

* **Tests**
  * Added comprehensive tests to verify proper reference and module resolution in bundler compatibility scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->