### PR TITLE
Controls: Allow resetting the Select control

### DIFF
--- a/code/addons/docs/src/blocks/controls/options/Select.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Select.tsx
@@ -120,7 +120,7 @@ const SingleSelect: FC<SelectProps> = ({ name, value, options, onChange, argType
         {name}
       </label>
       <OptionsSelect disabled={readonly} id={controlId} value={selection} onChange={handleChange}>
-        <option key="no-selection" disabled>
+        <option disabled={selection === NO_SELECTION} key="no-selection">
           {NO_SELECTION}
         </option>
         {Object.keys(options).map((key) => (

--- a/code/addons/docs/src/blocks/controls/options/SelectOptions.stories.tsx
+++ b/code/addons/docs/src/blocks/controls/options/SelectOptions.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { fn } from 'storybook/test';
+import { expect, fn, userEvent } from 'storybook/test';
 
 import { OptionsControl } from './Options';
 
@@ -67,6 +67,28 @@ export const ArrayMulti: Story = {
 export const ArrayUndefined: Story = {
   args: {
     value: undefined,
+  },
+};
+
+export const ArrayResettable: Story = {
+  args: {
+    value: undefined,
+  },
+  play: async ({ canvas, args }) => {
+    const select = canvas.getByRole('combobox');
+    expect(select).toHaveValue('Choose option...');
+
+    await userEvent.click(select);
+    await userEvent.selectOptions(select, arrayOptions[2]);
+
+    expect(args.onChange).toHaveBeenCalledWith(arrayOptions[2]);
+    expect(select).toHaveValue(arrayOptions[2]);
+
+    await userEvent.click(select);
+    await userEvent.selectOptions(select, 'Choose option...');
+
+    expect(args.onChange).toHaveBeenCalledWith(undefined);
+    expect(select).toHaveValue('Choose option...');
   },
 };
 


### PR DESCRIPTION
Partially fixes https://github.com/storybookjs/storybook/issues/12641

## What I did

Issue #12641 reported that controls would sometimes display as enums instead of selects, _and_ and that select controls could not be reset.

PR #33200 addresses the first reported issue. This PR addresses the second one so we don't accidentally lose track of it.

Both PRs must be merged before the issue can be closed.

This PR addresses the reset issue by allowing users to re-select the "Select option..." `option` in the `select`, which correctly calls `onChange` with the `undefined` value.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Go to http://localhost:6006/?path=/story/addons-docs-blocks-controls-options-select--array-resettable
2. Run the play function

### Documentation

N/A

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved placeholder option behavior in select controls to be conditionally disabled based on current selection state.

* **Tests**
  * Enhanced test coverage for resettable select control behavior, including interactive reset scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->