### PR TITLE
Addon-Vitest: Isolate error reasons during postinstall

### DIFF
--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -11,6 +11,7 @@ import {
   getStorybookInfo,
 } from 'storybook/internal/common';
 import { CLI_COLORS } from 'storybook/internal/node-logger';
+import type { StorybookError } from 'storybook/internal/server-errors';
 import {
   AddonVitestPostinstallConfigUpdateError,
   AddonVitestPostinstallError,
@@ -26,7 +27,6 @@ import { dirname, relative, resolve } from 'pathe';
 import { satisfies } from 'semver';
 import { dedent } from 'ts-dedent';
 
-import type { StorybookError } from '../../../core/src/storybook-error';
 import { type PostinstallOptions } from '../../../lib/cli-storybook/src/add';
 import { DOCUMENTATION_LINK } from './constants';
 import { loadTemplate, updateConfigFile, updateWorkspaceFile } from './updateVitestFile';
@@ -37,7 +37,7 @@ const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.cts', '.mts', '.cjs', '.mjs'
 const addonA11yName = '@storybook/addon-a11y';
 
 export default async function postInstall(options: PostinstallOptions) {
-  const errors: StorybookError[] = [];
+  const errors: InstanceType<typeof StorybookError>[] = [];
   const { logger, prompt } = options;
 
   const packageManager = JsPackageManagerFactory.getPackageManager({

--- a/code/core/src/core-server/withTelemetry.ts
+++ b/code/core/src/core-server/withTelemetry.ts
@@ -90,7 +90,8 @@ export async function sendTelemetryError(
   _error: unknown,
   eventType: EventType,
   options: TelemetryOptions,
-  blocking = true
+  blocking = true,
+  parent?: StorybookError
 ) {
   try {
     let errorLevel = 'error';
@@ -125,6 +126,8 @@ export async function sendTelemetryError(
           errorHash,
           // if we ever end up sending a non-error instance, we'd like to know
           isErrorInstance: error instanceof Error,
+          // Include parent error information if this is a sub-error
+          ...(parent ? { parent: parent.fullErrorCode } : {}),
         },
         {
           immediate: true,
@@ -132,6 +135,15 @@ export async function sendTelemetryError(
           enableCrashReports: errorLevel === 'full',
         }
       );
+
+      // If this is a StorybookError with sub-errors, send telemetry for each sub-error separately
+      if (error instanceof StorybookError && error.subErrors.length > 0) {
+        for (const subError of error.subErrors) {
+          if (subError instanceof StorybookError) {
+            await sendTelemetryError(subError, eventType, options, blocking, error);
+          }
+        }
+      }
     }
   } catch (err) {
     // if this throws an error, we just move on

--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -5,6 +5,8 @@ import type { Status } from './shared/status-store';
 import type { StatusTypeId } from './shared/status-store';
 import { StorybookError } from './storybook-error';
 
+export { StorybookError } from './storybook-error';
+
 /**
  * If you can't find a suitable category for your error, create one based on the package name/file
  * path of which the error is thrown. For instance: If it's from `@storybook/node-logger`, then

--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -468,14 +468,75 @@ export class AddonVitestPostinstallPrerequisiteCheckError extends StorybookError
   }
 }
 
+export class AddonVitestPostinstallFailedAddonA11yError extends StorybookError {
+  constructor(public data: { error: unknown | Error }) {
+    super({
+      name: 'AddonVitestPostinstallFailedAddonA11yError',
+      message: "The @storybook/addon-a11y couldn't be set up for the Vitest addon",
+      category: Category.CLI_INIT,
+      isHandledError: true,
+      code: 6,
+    });
+  }
+}
+
+export class AddonVitestPostinstallExistingSetupFileError extends StorybookError {
+  constructor(public data: { filePath: string }) {
+    super({
+      name: 'AddonVitestPostinstallExistingSetupFileError',
+      category: Category.CLI_INIT,
+      isHandledError: true,
+      code: 7,
+      documentation: `https://storybook.js.org/docs/writing-tests/integrations/vitest-addon#manual-setup`,
+      message: dedent`
+        Found an existing Vitest setup file: ${data.filePath}
+        Please refer to the documentation to complete the setup manually.
+      `,
+    });
+  }
+}
+
+export class AddonVitestPostinstallWorkspaceUpdateError extends StorybookError {
+  constructor(public data: { filePath: string }) {
+    super({
+      name: 'AddonVitestPostinstallWorkspaceUpdateError',
+      category: Category.CLI_INIT,
+      isHandledError: true,
+      code: 8,
+      documentation: `https://storybook.js.org/docs/writing-tests/integrations/vitest-addon#manual-setup`,
+      message: dedent`
+        Could not update existing Vitest workspace file: ${data.filePath}
+        Please refer to the documentation to complete the setup manually.
+      `,
+    });
+  }
+}
+
+export class AddonVitestPostinstallConfigUpdateError extends StorybookError {
+  constructor(public data: { filePath: string }) {
+    super({
+      name: 'AddonVitestPostinstallConfigUpdateError',
+      category: Category.CLI_INIT,
+      isHandledError: true,
+      code: 9,
+      documentation: `https://storybook.js.org/docs/writing-tests/integrations/vitest-addon#manual-setup`,
+      message: dedent`
+        Unable to update existing Vitest config file: ${data.filePath}
+        Please refer to the documentation to complete the setup manually.
+      `,
+    });
+  }
+}
+
 export class AddonVitestPostinstallError extends StorybookError {
-  constructor(public data: { errors: string[] }) {
+  constructor(public data: { errors: StorybookError[] }) {
     super({
       name: 'AddonVitestPostinstallError',
       category: Category.CLI_INIT,
       isHandledError: true,
       code: 5,
       message: 'The Vitest addon setup failed.',
+      subErrors: data.errors,
     });
   }
 }

--- a/code/core/src/storybook-error.ts
+++ b/code/core/src/storybook-error.ts
@@ -71,6 +71,26 @@ export abstract class StorybookError extends Error {
     this._name = name;
   }
 
+  /**
+   * A collection of sub errors which relate to a parent error.
+   *
+   * Sub-errors are used to represent multiple related errors that occurred together. When a
+   * StorybookError with sub-errors is sent to telemetry, both the parent error and each sub-error
+   * are sent as separate telemetry events. This allows for better error tracking and debugging.
+   *
+   * @example
+   *
+   * ```ts
+   * const error1 = new SomeError();
+   * const error2 = new AnotherError();
+   * const parentError = new ParentError({
+   *   // ... other props
+   *   subErrors: [error1, error2],
+   * });
+   * ```
+   */
+  subErrors: StorybookError[] = [];
+
   constructor(props: {
     category: string;
     code: number;
@@ -78,6 +98,11 @@ export abstract class StorybookError extends Error {
     documentation?: boolean | string | string[];
     isHandledError?: boolean;
     name: string;
+    /**
+     * Optional array of sub-errors that are related to this error. When this error is sent to
+     * telemetry, each sub-error will be sent as a separate event.
+     */
+    subErrors?: StorybookError[];
   }) {
     super(StorybookError.getFullMessage(props));
     this.category = props.category;
@@ -85,6 +110,7 @@ export abstract class StorybookError extends Error {
     this.code = props.code;
     this.isHandledError = props.isHandledError ?? false;
     this.name = props.name;
+    this.subErrors = props.subErrors ?? [];
   }
 
   /** Generates the error message along with additional documentation link (if applicable). */

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -117,7 +117,7 @@ export async function doInitiate(options: CommandOptions): Promise<
       !!options.dev &&
       !options.skipInstall &&
       shouldRunDev !== false &&
-      ErrorCollector.getErrors().length === 0,
+      dependencyInstallationResult.status === 'success',
     shouldOnboard: newUser,
     projectType,
     packageManager,


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When AddonVitestPostinstallError is thrown with sub-errors, telemetry sends separate events for the parent and each sub-error, improving error tracking and debugging.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, more specific error reporting during Vitest addon setup with structured failure messages and improved telemetry for multi-part failures.
  * Fixes to when Playwright-related failures are surfaced so only relevant errors are reported.

* **Chores**
  * Internal error handling reworked for consistent aggregation and reporting.
  * Dev startup now respects dependency installation outcome rather than global error state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->