### PR TITLE
Core: Ensure /project.json route is up before builders serve local FS

### DIFF
--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -17,6 +17,7 @@ import { getCachingMiddleware } from './utils/get-caching-middleware';
 import { getServerChannel } from './utils/get-server-channel';
 import { getAccessControlMiddleware } from './utils/getAccessControlMiddleware';
 import { getStoryIndexGenerator } from './utils/getStoryIndexGenerator';
+import { useStorybookMetadata } from './utils/metadata';
 import { getMiddleware } from './utils/middleware';
 import { openInBrowser } from './utils/open-browser/open-in-browser';
 import { getServerAddresses } from './utils/server-address';
@@ -78,6 +79,12 @@ export async function storybookDevServer(options: Options) {
 
   if (options.debugWebpack) {
     logConfig('Preview webpack config', await previewBuilder.getConfig(options));
+  }
+
+  // Boot up the `/project.json` route handler early to avoid Vite Dev Server
+  // serving a NX monorepo `project.json` file instead.
+  if (!core?.disableProjectJson) {
+    useStorybookMetadata(app, options.configDir);
   }
 
   const managerResult = options.previewOnly

--- a/code/core/src/core-server/utils/doTelemetry.ts
+++ b/code/core/src/core-server/utils/doTelemetry.ts
@@ -6,7 +6,6 @@ import invariant from 'tiny-invariant';
 
 import { sendTelemetryError } from '../withTelemetry';
 import type { StoryIndexGenerator } from './StoryIndexGenerator';
-import { useStorybookMetadata } from './metadata';
 import { summarizeIndex } from './summarizeIndex';
 import { versionStatus } from './versionStatus';
 
@@ -50,9 +49,5 @@ export async function doTelemetry(
       }
       telemetry('dev', payload, { configDir: options.configDir });
     });
-  }
-
-  if (!core?.disableProjectJson) {
-    useStorybookMetadata(app, options.configDir);
   }
 }


### PR DESCRIPTION
## What I did

I noticed that the `/project.json` route has started serving our new NX monorepo `project.json` file. Jeppe correctly identified that this is caused by Vite Dev Server's serving of local files. The route handler was set up after Vite's server was started, allowing the route to be intercepted.

Switching up the route order fixes the issue.

### Manual testing

Visit http://localhost:6006/project.json and inspect the content on the monorepo `next` vs on this branch.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized server initialization by reorganizing when project metadata is loaded. Project information endpoints now initialize earlier during the startup sequence, enhancing initialization timing. This optimization can be disabled through configuration settings if needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->