### PR TITLE
Nextjs-Vite: Install `vite` during migration if not installed yet

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.test.ts
@@ -47,7 +47,7 @@ describe('nextjs-to-nextjs-vite', () => {
     vi.clearAllMocks();
     vi.mocked(mockPackageManager.removeDependencies).mockResolvedValue(undefined);
     vi.mocked(mockPackageManager.addDependencies).mockResolvedValue(undefined);
-    vi.mocked(mockPackageManager.getDependencyVersion).mockReturnValue(undefined);
+    vi.mocked(mockPackageManager.getDependencyVersion).mockReturnValue(null);
   });
 
   describe('check function', () => {

--- a/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.test.ts
@@ -7,6 +7,8 @@ import type { JsPackageManager } from 'storybook/internal/common';
 import type { CheckOptions } from '.';
 import { nextjsToNextjsVite } from './nextjs-to-nextjs-vite';
 
+const VITE_DEFAULT_VERSION = '^7.0.0';
+
 // Mock dependencies
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
@@ -142,7 +144,8 @@ describe('nextjs-to-nextjs-vite', () => {
         })
       );
 
-      // Mock getDependencyVersion to return undefined (vite not installed)
+      // Explicitly set getDependencyVersion to return undefined for this test scenario
+      // Even though beforeEach sets it, we keep this for clarity and test documentation
       vi.mocked(mockPackageManager.getDependencyVersion).mockReturnValue(undefined);
 
       await nextjsToNextjsVite.run!({
@@ -158,7 +161,7 @@ describe('nextjs-to-nextjs-vite', () => {
       expect(mockPackageManager.removeDependencies).toHaveBeenCalledWith(['@storybook/nextjs']);
       expect(mockPackageManager.addDependencies).toHaveBeenCalledWith(
         { type: 'devDependencies', skipInstall: true },
-        ['@storybook/nextjs-vite@9.0.0', 'vite@^7.0.0']
+        [`@storybook/nextjs-vite@9.0.0`, `vite@${VITE_DEFAULT_VERSION}`]
       );
     });
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.test.ts
@@ -5,9 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { JsPackageManager } from 'storybook/internal/common';
 
 import type { CheckOptions } from '.';
-import { nextjsToNextjsVite } from './nextjs-to-nextjs-vite';
-
-const VITE_DEFAULT_VERSION = '^7.0.0';
+import { VITE_DEFAULT_VERSION, nextjsToNextjsVite } from './nextjs-to-nextjs-vite';
 
 // Mock dependencies
 vi.mock('node:fs/promises', () => ({
@@ -143,10 +141,6 @@ describe('nextjs-to-nextjs-vite', () => {
           },
         })
       );
-
-      // Explicitly set getDependencyVersion to return undefined for this test scenario
-      // Even though beforeEach sets it, we keep this for clarity and test documentation
-      vi.mocked(mockPackageManager.getDependencyVersion).mockReturnValue(undefined);
 
       await nextjsToNextjsVite.run!({
         result,

--- a/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.ts
@@ -5,6 +5,8 @@ import { logger } from 'storybook/internal/node-logger';
 
 import type { Fix } from '../types';
 
+const VITE_DEFAULT_VERSION = '^7.0.0';
+
 interface NextjsToNextjsViteOptions {
   hasNextjsPackage: boolean;
   packageJsonFiles: string[];
@@ -102,7 +104,7 @@ export const nextjsToNextjsVite: Fix<NextjsToNextjsViteOptions> = {
       await packageManager.removeDependencies(['@storybook/nextjs']);
       await packageManager.addDependencies({ type: 'devDependencies', skipInstall: true }, [
         `@storybook/nextjs-vite@${storybookVersion}`,
-        ...(viteVersion ? [] : ['vite@^7.0.0']), // Add vite if it's not installed yet
+        ...(viteVersion ? [] : [`vite@${VITE_DEFAULT_VERSION}`]), // Add vite if it's not installed yet
       ]);
     }
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.ts
@@ -98,9 +98,11 @@ export const nextjsToNextjsVite: Fix<NextjsToNextjsViteOptions> = {
       logger.debug('Dry run: Skipping package.json updates.');
     } else {
       logger.debug('Updating package.json files...');
+      const viteVersion = packageManager.getDependencyVersion('vite');
       await packageManager.removeDependencies(['@storybook/nextjs']);
       await packageManager.addDependencies({ type: 'devDependencies', skipInstall: true }, [
         `@storybook/nextjs-vite@${storybookVersion}`,
+        ...(viteVersion ? [] : ['vite@^7.0.0']), // Add vite if it's not installed yet
       ]);
     }
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.ts
@@ -5,7 +5,7 @@ import { logger } from 'storybook/internal/node-logger';
 
 import type { Fix } from '../types';
 
-const VITE_DEFAULT_VERSION = '^7.0.0';
+export const VITE_DEFAULT_VERSION = '^7.0.0';
 
 interface NextjsToNextjsViteOptions {
   hasNextjsPackage: boolean;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

In the automigration from Nextjs to Nextjs-Vite, add `vite` as a devDependency if it isn't installed yet. This prevents the project from breaking in case it wasn't previously using Vite yet.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33316-sha-bb47faf7`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33316-sha-bb47faf7 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33316-sha-bb47faf7 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33316-sha-bb47faf7`](https://npmjs.com/package/storybook/v/0.0.0-pr-33316-sha-bb47faf7) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`nextjs-vite-automigration-add-vite`](https://github.com/storybookjs/storybook/tree/nextjs-vite-automigration-add-vite) |
| **Commit** | [`bb47faf7`](https://github.com/storybookjs/storybook/commit/bb47faf73d100dd45c1b1fb68921ab4b13f68de5) |
| **Datetime** | Wed Dec 10 14:40:14 UTC 2025 (`1765377614`) |
| **Workflow run** | [20102391382](https://github.com/storybookjs/storybook/actions/runs/20102391382) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33316`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Next.js to Vite migration with improved dependency management. The migration now automatically installs Vite (^7.0.0) when it's not already present in your project, while intelligently detecting and skipping reinstallation if Vite is already installed. This streamlines the setup process and reduces manual configuration requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->