### PR TITLE
UI: Ensure consistent right padding in TreeNode

### DIFF
--- a/code/core/src/manager/components/sidebar/TreeNode.tsx
+++ b/code/core/src/manager/components/sidebar/TreeNode.tsx
@@ -60,6 +60,7 @@ const commonNodeStyles: FunctionInterpolation<{ depth?: number; isExpandable?: b
   paddingLeft: `${(isExpandable ? 8 : 22) + depth * 18}px`,
   paddingTop: 5,
   paddingBottom: 4,
+  paddingRight: 6,
   overflowWrap: 'break-word',
   wordWrap: 'break-word',
   wordBreak: 'break-word',


### PR DESCRIPTION
## What I did

Fixed a layout issue in Sidebar TreeNode that affects positioning of labels with `renderLabel`.

MDX are HTML anchors whereas stories are buttons. This causes a different default padding to apply, resulting in a 6px right padding for stories but not for links. Now that we have ContextMenu and test statuses, this makes it difficult for `renderLabel` users to compute margins.

### Before
<img width="309" height="82" alt="image" src="https://github.com/user-attachments/assets/4f8b3177-21e8-4947-9c2e-737e75336372" />
<img width="302" height="93" alt="image" src="https://github.com/user-attachments/assets/d06864ed-f97e-45d0-91c5-ff9f4a3455ea" />


### After
<img width="306" height="117" alt="image" src="https://github.com/user-attachments/assets/0b7c4eb1-4cbe-4f56-99fc-463e3ff438fe" />
<img width="299" height="90" alt="image" src="https://github.com/user-attachments/assets/26e19c58-b6d3-4359-8ba2-5cbfc558db6e" />


## Checklist for Contributors

### Testing

#### Manual testing

Verify that the padding is now consistent between docs and story entries in your sidebar.

### Documentation
ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in the sidebar tree nodes for better visual layout and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->