### PR TITLE
Docs: Add missing copyEvent on a create command

### DIFF
--- a/docs/get-started/install.mdx
+++ b/docs/get-started/install.mdx
@@ -59,12 +59,12 @@ You can use Storybook with older browsers in two ways:
 
 Run this command inside your project's root directory to install the latest version of Storybook:
 
-<CodeSnippets path="create-command.md" />
+<CodeSnippets path="create-command.md" variant="new-users" copyEvent="CreateCommandCopy" />
 
 <details id="custom-storybook-version">
   <summary>Install a specific version</summary>
 
-  For installing Storybook 8.3 or newer, you can use the `create` command with a specific version:
+  To install Storybook 8.3 or newer, you can use the `create` command with a specific version:
 
   {/* prettier-ignore-start */}
 


### PR DESCRIPTION
Adds a copy event to the second create command on the install page.

@shilman note that there is still an issue with the deployment. The first create command on the page was correctly updated in the codebase but is not updated in the website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced installation guides with improved code snippet display and formatting options
  * Clarified installation instructions for Storybook 8.3 and newer versions with refined guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->