### PR TITLE
Controls: Force object control JSON mode to reset

### DIFF
--- a/code/addons/docs/src/blocks/controls/Object.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.tsx
@@ -207,6 +207,11 @@ export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange, argType 
     }
   }, [forceVisible]);
 
+  // Use string value as key to force re-render on Arg value reset.
+  const jsonString = useMemo(() => {
+    return JSON.stringify(data ?? '', null, 2);
+  }, [data]);
+
   if (!hasData) {
     return (
       <Button
@@ -226,7 +231,8 @@ export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange, argType 
       id={getControlId(name)}
       minRows={3}
       name={name}
-      defaultValue={value === null ? '' : JSON.stringify(value, null, 2)}
+      key={jsonString}
+      defaultValue={jsonString}
       onBlur={(event: FocusEvent<HTMLTextAreaElement>) => updateRaw(event.target.value)}
       placeholder="Edit JSON string..."
       autoFocus={forceVisible}


### PR DESCRIPTION
Closes #24316

## What I did

Forced JSON mode Object control to re-render when upstream changes value, as the underlying textarea doesn't seem to want to behave in controlled mode, and we can't rely on the ref being mounted to programmatically update it.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

I could not find a way to automate tests. I've tried setting up an ArgsTable story with a mocked Docs context and a functioning `resetArgs` function but did not manage.

#### Manual testing

1. Go to http://localhost:6006/?path=/story/addons-docs-blocks-controls-object--object
2. Switch the object to JSON mode
3. Replace "Michael" with "Vanessa"
4. Click the reset button; on this branch, the string will be reset, but not on `next`

### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the JSON object editor to properly update its display when underlying data changes, ensuring the textarea reliably reflects the current content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->