### PR TITLE
CLI: Remove REACT_PROJECT projectType

### DIFF
--- a/code/core/src/cli/projectTypes.ts
+++ b/code/core/src/cli/projectTypes.ts
@@ -11,7 +11,6 @@ export enum ProjectType {
   REACT_NATIVE = 'react_native',
   REACT_NATIVE_AND_RNW = 'react_native_and_rnw',
   REACT_NATIVE_WEB = 'react_native_web',
-  REACT_PROJECT = 'react_project',
   REACT_SCRIPTS = 'react_scripts',
   SERVER = 'server',
   SOLID = 'solid',

--- a/code/lib/create-storybook/src/services/FeatureCompatibilityService.ts
+++ b/code/lib/create-storybook/src/services/FeatureCompatibilityService.ts
@@ -7,7 +7,6 @@ const ONBOARDING_PROJECT_TYPES: ProjectType[] = [
   ProjectType.REACT,
   ProjectType.REACT_SCRIPTS,
   ProjectType.REACT_NATIVE_WEB,
-  ProjectType.REACT_PROJECT,
   ProjectType.NEXTJS,
   ProjectType.VUE3,
   ProjectType.ANGULAR,

--- a/code/lib/create-storybook/src/services/ProjectTypeService.test.ts
+++ b/code/lib/create-storybook/src/services/ProjectTypeService.test.ts
@@ -68,17 +68,6 @@ describe('ProjectTypeService', () => {
       expect(result).toBe(ProjectType.NEXTJS);
     });
 
-    it('detects REACT_PROJECT via peerDependencies', async () => {
-      (pm as any).primaryPackageJson.packageJson = {
-        peerDependencies: { react: '^18.0.0' },
-      };
-      const service = new ProjectTypeService(pm);
-      // @ts-expect-error private method spy
-      vi.spyOn(service, 'isNxProject').mockReturnValue(false);
-      const result = await service.autoDetectProjectType({ html: false } as CommandOptions);
-      expect(result).toBe(ProjectType.REACT_PROJECT);
-    });
-
     it('detects VUE3 when vue major is 3', async () => {
       (pm as any).primaryPackageJson.packageJson = {
         dependencies: { vue: '^3.2.0' },

--- a/code/lib/create-storybook/src/services/ProjectTypeService.ts
+++ b/code/lib/create-storybook/src/services/ProjectTypeService.ts
@@ -75,13 +75,6 @@ export class ProjectTypeService {
         },
       },
       {
-        preset: ProjectType.REACT_PROJECT,
-        peerDependencies: ['react'],
-        matcherFunction: ({ peerDependencies }) => {
-          return peerDependencies?.every(Boolean) ?? true;
-        },
-      },
-      {
         preset: ProjectType.REACT_NATIVE,
         dependencies: ['react-native', 'react-native-scripts'],
         matcherFunction: ({ dependencies }) => {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

As part of the CLI revamp project, the generator for the project type "REACT_PROJECT" was removed because it was identical to the one for the project type "REACT". I forgot to clean up the related `projectType` detection logic, which is now done in this PR!

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed support for React project type detection and onboarding. React projects will no longer be recognized or supported through the automatic detection flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->