### PR TITLE
CircleCI: Fix artifact paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,10 +412,10 @@ jobs:
             - report-workflow-on-failure:
                 template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests-dev)
             - store_test_results:
-                path: storybook/test-results
+                path: test-results
             - store_artifacts:
                 destination: playwright
-                path: storybook/code/playwright-results/
+                path: code/playwright-results/
     e2e-production:
         executor:
             class: medium
@@ -443,10 +443,10 @@ jobs:
             - report-workflow-on-failure:
                 template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests)
             - store_test_results:
-                path: storybook/test-results
+                path: test-results
             - store_artifacts:
                 destination: playwright
-                path: storybook/code/playwright-results/
+                path: code/playwright-results/
     e2e-ui:
         executor:
             class: medium

--- a/.circleci/src/jobs/e2e-dev.yml
+++ b/.circleci/src/jobs/e2e-dev.yml
@@ -30,7 +30,7 @@ steps:
   - report-workflow-on-failure:
       template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests-dev)
   - store_test_results:
-      path: storybook/test-results
+      path: test-results
   - store_artifacts: # this is where playwright puts more complex stuff
-      path: storybook/code/playwright-results/
+      path: code/playwright-results/
       destination: playwright

--- a/.circleci/src/jobs/e2e-production.yml
+++ b/.circleci/src/jobs/e2e-production.yml
@@ -30,7 +30,7 @@ steps:
   - report-workflow-on-failure:
       template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task e2e-tests)
   - store_test_results:
-      path: storybook/test-results
+      path: test-results
   - store_artifacts: # this is where playwright puts more complex stuff
-      path: storybook/code/playwright-results/
+      path: code/playwright-results/
       destination: playwright


### PR DESCRIPTION
## What I did

I was alerted by @JReinhold that CircleCI was not actually storing artifacts anymore.
I investigated and found that the paths was wrong.

I corrected the path, and verified that artifacts are actually stored now.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual testing needed, I manually verified this.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
