### PR TITLE
Next.js: Handle v14 compatibility for draftMode import

### DIFF
--- a/code/frameworks/nextjs/src/export-mocks/headers/index.ts
+++ b/code/frameworks/nextjs/src/export-mocks/headers/index.ts
@@ -1,4 +1,3 @@
-import { draftMode as originalDraftMode } from 'next/dist/server/request/draft-mode';
 import * as headers from 'next/dist/server/request/headers';
 import { fn } from 'storybook/test';
 
@@ -10,5 +9,18 @@ export { headers } from './headers';
 export { cookies } from './cookies';
 
 // passthrough mocks - keep original implementation but allow for spying
-const draftMode = fn(originalDraftMode ?? (headers as any).draftMode).mockName('draftMode');
+// In Next.js 14, draftMode is exported from 'next/dist/client/components/headers'
+// In Next.js 15+, draftMode is exported from 'next/dist/server/request/draft-mode'
+// The webpack alias handles this, but we need to avoid the top-level import
+// to prevent build errors when the module doesn't exist
+let originalDraftMode: any;
+try {
+  // This will be resolved by webpack alias to the correct location based on Next.js version
+  originalDraftMode = require('next/dist/server/request/draft-mode').draftMode;
+} catch {
+  // Fallback to the location in the headers module (Next.js 14)
+  originalDraftMode = (headers as any).draftMode;
+}
+
+const draftMode = fn(originalDraftMode).mockName('draftMode');
 export { draftMode };


### PR DESCRIPTION
## Summary

Fixes #32950 - Build errors when using Storybook v10 with Next.js 14

The issue occurred because `next/dist/server/request/draft-mode` doesn't exist in Next.js 14, causing build failures. While webpack aliases were configured to handle this version difference, the static top-level import was failing before webpack could apply the aliases.

## Changes

- Replaced static import with dynamic `require()` in try-catch block
- Added fallback to Next.js 14 location when the Next.js 15+ path doesn't exist
- Preserved existing webpack alias functionality for proper path resolution

## Technical Details

**Next.js 14**: `draftMode` is exported from `next/dist/client/components/headers`
**Next.js 15+**: `draftMode` is exported from `next/dist/server/request/draft-mode`

The webpack compatibility map already handles this via aliases, but we needed to defer the import to runtime to prevent build-time resolution errors.

## Test plan

- [ ] Verify builds succeed with Next.js 14
- [ ] Verify builds succeed with Next.js 15+
- [ ] Confirm webpack aliases still work correctly
- [ ] Test that draftMode mocking functionality is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draft mode initialization to handle varying module locations and enhance compatibility across different environments through better fallback mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->