### PR TITLE
React: Use self-closing tag for code snippets

### DIFF
--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -50,6 +50,15 @@ function withCSF4(body: string) {
   `;
 }
 
+test('Default', () => {
+  const input = withCSF3(`
+    export const Default: Story = {};
+  `);
+  expect(generateExample(input)).toMatchInlineSnapshot(
+    `"const Default = () => <Button>Click me</Button>;"`
+  );
+});
+
 test('Synthesizes self-closing when no children', () => {
   const input = dedent`
     import type { Meta } from '@storybook/react';
@@ -63,15 +72,6 @@ test('Synthesizes self-closing when no children', () => {
     export const NoChildren: Story = {};
   `;
   expect(generateExample(input)).toMatchInlineSnapshot(`"const NoChildren = () => <Button />;"`);
-});
-
-test('Default', () => {
-  const input = withCSF3(`
-    export const Default: Story = {};
-  `);
-  expect(generateExample(input)).toMatchInlineSnapshot(
-    `"const Default = () => <Button>Click me</Button>;"`
-  );
 });
 
 test('Default satisfies or as', () => {

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -50,6 +50,21 @@ function withCSF4(body: string) {
   `;
 }
 
+test('Synthesizes self-closing when no children', () => {
+  const input = dedent`
+    import type { Meta } from '@storybook/react';
+    import { Button } from '@design-system/button';
+
+    const meta: Meta<typeof Button> = {
+      component: Button,
+    };
+    export default meta;
+
+    export const NoChildren: Story = {};
+  `;
+  expect(generateExample(input)).toMatchInlineSnapshot(`"const NoChildren = () => <Button />;"`);
+});
+
 test('Default', () => {
   const input = withCSF3(`
     export const Default: Story = {};

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
@@ -222,13 +222,15 @@ export function getCodeSnippet(
   const name = t.jsxIdentifier(componentName);
   const openingElAttrs = invalidSpread ? [...injectedAttrs, invalidSpread] : injectedAttrs;
 
+  const children = toJsxChildren(merged.children);
+  const selfClosing = children.length === 0;
   const arrow = t.arrowFunctionExpression(
     [],
     t.jsxElement(
-      t.jsxOpeningElement(name, openingElAttrs, false),
-      t.jsxClosingElement(name),
-      toJsxChildren(merged.children),
-      false
+      t.jsxOpeningElement(name, openingElAttrs, selfClosing),
+      selfClosing ? null : t.jsxClosingElement(name),
+      children,
+      selfClosing
     )
   );
 

--- a/code/renderers/react/src/componentManifest/generator.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.test.ts
@@ -20,222 +20,222 @@ test('componentManifestGenerator generates correct id, name, description and exa
   } as unknown as StoryIndexGenerator);
 
   expect(manifest).toMatchInlineSnapshot(`
-    {
-      "components": {
-        "example-button": {
-          "description": "Primary UI component for user interaction",
-          "error": undefined,
-          "id": "example-button",
-          "import": "import { Button } from "@design-system/components/override";",
-          "jsDocTags": {
-            "import": [
-              "import { Button } from '@design-system/components/override';",
-            ],
-          },
-          "name": "Button",
-          "path": "./src/stories/Button.stories.ts",
-          "reactDocgen": {
-            "actualName": "Button",
-            "definedInFile": "./src/stories/Button.tsx",
-            "description": "Primary UI component for user interaction
-    @import import { Button } from '@design-system/components/override';",
-            "displayName": "Button",
-            "exportName": "Button",
-            "methods": [],
-            "props": {
-              "backgroundColor": {
-                "description": "",
-                "required": false,
-                "tsType": {
-                  "name": "string",
-                },
-              },
-              "label": {
-                "description": "",
-                "required": true,
-                "tsType": {
-                  "name": "string",
-                },
-              },
-              "onClick": {
-                "description": "",
-                "required": false,
-                "tsType": {
-                  "name": "signature",
-                  "raw": "() => void",
-                  "signature": {
-                    "arguments": [],
-                    "return": {
-                      "name": "void",
-                    },
-                  },
-                  "type": "function",
-                },
-              },
-              "primary": {
-                "defaultValue": {
-                  "computed": false,
-                  "value": "false",
-                },
-                "description": "Description of primary",
-                "required": false,
-                "tsType": {
-                  "name": "boolean",
-                },
-              },
-              "size": {
-                "defaultValue": {
-                  "computed": false,
-                  "value": "'medium'",
-                },
-                "description": "",
-                "required": false,
-                "tsType": {
-                  "elements": [
-                    {
-                      "name": "literal",
-                      "value": "'small'",
-                    },
-                    {
-                      "name": "literal",
-                      "value": "'medium'",
-                    },
-                    {
-                      "name": "literal",
-                      "value": "'large'",
-                    },
-                  ],
-                  "name": "union",
-                  "raw": "'small' | 'medium' | 'large'",
-                },
-              },
-            },
-          },
-          "stories": [
-            {
-              "description": undefined,
-              "name": "Primary",
-              "snippet": "const Primary = () => <Button onClick={fn()} primary label="Button"></Button>;",
-              "summary": undefined,
-            },
-            {
-              "description": undefined,
-              "name": "Secondary",
-              "snippet": "const Secondary = () => <Button onClick={fn()} label="Button"></Button>;",
-              "summary": undefined,
-            },
-            {
-              "description": undefined,
-              "name": "Large",
-              "snippet": "const Large = () => <Button onClick={fn()} size="large" label="Button"></Button>;",
-              "summary": undefined,
-            },
-            {
-              "description": undefined,
-              "name": "Small",
-              "snippet": "const Small = () => <Button onClick={fn()} size="small" label="Button"></Button>;",
-              "summary": undefined,
-            },
+  {
+    "components": {
+      "example-button": {
+        "description": "Primary UI component for user interaction",
+        "error": undefined,
+        "id": "example-button",
+        "import": "import { Button } from "@design-system/components/override";",
+        "jsDocTags": {
+          "import": [
+            "import { Button } from '@design-system/components/override';",
           ],
-          "summary": undefined,
         },
-        "example-header": {
-          "description": "Description from meta and very long.",
-          "error": undefined,
-          "id": "example-header",
-          "import": "import { Header } from "some-package";",
-          "jsDocTags": {
-            "summary": [
-              "Component summary",
-            ],
-          },
-          "name": "Header",
-          "path": "./src/stories/Header.stories.ts",
-          "reactDocgen": {
-            "actualName": "",
-            "definedInFile": "./src/stories/Header.tsx",
-            "description": "",
-            "exportName": "default",
-            "methods": [],
-            "props": {
-              "onCreateAccount": {
-                "description": "",
-                "required": false,
-                "tsType": {
-                  "name": "signature",
-                  "raw": "() => void",
-                  "signature": {
-                    "arguments": [],
-                    "return": {
-                      "name": "void",
-                    },
-                  },
-                  "type": "function",
-                },
+        "name": "Button",
+        "path": "./src/stories/Button.stories.ts",
+        "reactDocgen": {
+          "actualName": "Button",
+          "definedInFile": "./src/stories/Button.tsx",
+          "description": "Primary UI component for user interaction
+  @import import { Button } from '@design-system/components/override';",
+          "displayName": "Button",
+          "exportName": "Button",
+          "methods": [],
+          "props": {
+            "backgroundColor": {
+              "description": "",
+              "required": false,
+              "tsType": {
+                "name": "string",
               },
-              "onLogin": {
-                "description": "",
-                "required": false,
-                "tsType": {
-                  "name": "signature",
-                  "raw": "() => void",
-                  "signature": {
-                    "arguments": [],
-                    "return": {
-                      "name": "void",
-                    },
-                  },
-                  "type": "function",
-                },
+            },
+            "label": {
+              "description": "",
+              "required": true,
+              "tsType": {
+                "name": "string",
               },
-              "onLogout": {
-                "description": "",
-                "required": false,
-                "tsType": {
-                  "name": "signature",
-                  "raw": "() => void",
-                  "signature": {
-                    "arguments": [],
-                    "return": {
-                      "name": "void",
-                    },
+            },
+            "onClick": {
+              "description": "",
+              "required": false,
+              "tsType": {
+                "name": "signature",
+                "raw": "() => void",
+                "signature": {
+                  "arguments": [],
+                  "return": {
+                    "name": "void",
                   },
-                  "type": "function",
                 },
+                "type": "function",
               },
-              "user": {
-                "description": "",
-                "required": false,
-                "tsType": {
-                  "name": "User",
-                },
+            },
+            "primary": {
+              "defaultValue": {
+                "computed": false,
+                "value": "false",
+              },
+              "description": "Description of primary",
+              "required": false,
+              "tsType": {
+                "name": "boolean",
+              },
+            },
+            "size": {
+              "defaultValue": {
+                "computed": false,
+                "value": "'medium'",
+              },
+              "description": "",
+              "required": false,
+              "tsType": {
+                "elements": [
+                  {
+                    "name": "literal",
+                    "value": "'small'",
+                  },
+                  {
+                    "name": "literal",
+                    "value": "'medium'",
+                  },
+                  {
+                    "name": "literal",
+                    "value": "'large'",
+                  },
+                ],
+                "name": "union",
+                "raw": "'small' | 'medium' | 'large'",
               },
             },
           },
-          "stories": [
-            {
-              "description": undefined,
-              "name": "LoggedIn",
-              "snippet": "const LoggedIn = () => <Header
-        onLogin={fn()}
-        onLogout={fn()}
-        onCreateAccount={fn()}
-        user={{ name: 'Jane Doe' }}></Header>;",
-              "summary": undefined,
-            },
-            {
-              "description": undefined,
-              "name": "LoggedOut",
-              "snippet": "const LoggedOut = () => <Header onLogin={fn()} onLogout={fn()} onCreateAccount={fn()}></Header>;",
-              "summary": undefined,
-            },
-          ],
-          "summary": "Component summary",
         },
+        "stories": [
+          {
+            "description": undefined,
+            "name": "Primary",
+            "snippet": "const Primary = () => <Button onClick={fn()} primary label="Button" />;",
+            "summary": undefined,
+          },
+          {
+            "description": undefined,
+            "name": "Secondary",
+            "snippet": "const Secondary = () => <Button onClick={fn()} label="Button" />;",
+            "summary": undefined,
+          },
+          {
+            "description": undefined,
+            "name": "Large",
+            "snippet": "const Large = () => <Button onClick={fn()} size="large" label="Button" />;",
+            "summary": undefined,
+          },
+          {
+            "description": undefined,
+            "name": "Small",
+            "snippet": "const Small = () => <Button onClick={fn()} size="small" label="Button" />;",
+            "summary": undefined,
+          },
+        ],
+        "summary": undefined,
       },
-      "v": 0,
-    }
-  `);
+      "example-header": {
+        "description": "Description from meta and very long.",
+        "error": undefined,
+        "id": "example-header",
+        "import": "import { Header } from "some-package";",
+        "jsDocTags": {
+          "summary": [
+            "Component summary",
+          ],
+        },
+        "name": "Header",
+        "path": "./src/stories/Header.stories.ts",
+        "reactDocgen": {
+          "actualName": "",
+          "definedInFile": "./src/stories/Header.tsx",
+          "description": "",
+          "exportName": "default",
+          "methods": [],
+          "props": {
+            "onCreateAccount": {
+              "description": "",
+              "required": false,
+              "tsType": {
+                "name": "signature",
+                "raw": "() => void",
+                "signature": {
+                  "arguments": [],
+                  "return": {
+                    "name": "void",
+                  },
+                },
+                "type": "function",
+              },
+            },
+            "onLogin": {
+              "description": "",
+              "required": false,
+              "tsType": {
+                "name": "signature",
+                "raw": "() => void",
+                "signature": {
+                  "arguments": [],
+                  "return": {
+                    "name": "void",
+                  },
+                },
+                "type": "function",
+              },
+            },
+            "onLogout": {
+              "description": "",
+              "required": false,
+              "tsType": {
+                "name": "signature",
+                "raw": "() => void",
+                "signature": {
+                  "arguments": [],
+                  "return": {
+                    "name": "void",
+                  },
+                },
+                "type": "function",
+              },
+            },
+            "user": {
+              "description": "",
+              "required": false,
+              "tsType": {
+                "name": "User",
+              },
+            },
+          },
+        },
+        "stories": [
+          {
+            "description": undefined,
+            "name": "LoggedIn",
+            "snippet": "const LoggedIn = () => <Header
+      onLogin={fn()}
+      onLogout={fn()}
+      onCreateAccount={fn()}
+      user={{ name: 'Jane Doe' }} />;",
+            "summary": undefined,
+          },
+          {
+            "description": undefined,
+            "name": "LoggedOut",
+            "snippet": "const LoggedOut = () => <Header onLogin={fn()} onLogout={fn()} onCreateAccount={fn()} />;",
+            "summary": undefined,
+          },
+        ],
+        "summary": "Component summary",
+      },
+    },
+    "v": 0,
+  }
+`);
 });
 
 async function getManifestForStory(code: string) {

--- a/code/renderers/react/src/enrichCsf.test.ts
+++ b/code/renderers/react/src/enrichCsf.test.ts
@@ -50,7 +50,7 @@ test('should enrich csf with code parameters', async () => {
       docs: {
         ...Primary.input.parameters?.docs,
         source: {
-          code: "const Primary = () => <Button primary label=\\"Button\\"></Button>;\\n",
+          code: "const Primary = () => <Button primary label=\\"Button\\" />;\\n",
           ...Primary.input.parameters?.docs?.source
         }
       }
@@ -60,7 +60,7 @@ test('should enrich csf with code parameters', async () => {
       docs: {
         ...Secondary.input.parameters?.docs,
         source: {
-          code: "const Secondary = () => <Button label=\\"Button\\"></Button>;\\n",
+          code: "const Secondary = () => <Button label=\\"Button\\" />;\\n",
           ...Secondary.input.parameters?.docs?.source
         }
       }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added self-closing fallback rendering for synthesized snippets with no children in React code snippets, and added a regression test verifying the no-children case now outputs <Button />.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code generation now emits self-closing JSX tags when a component has no children, improving generated snippets and documentation previews.

* **Tests**
  * Added tests to verify components without children produce self-closing JSX output, ensuring consistent snippet formatting.

* **Chores**
  * Updated generated component manifests: story lists, snippets and prop descriptions were refreshed (including a change to the reported size prop format and multi-line description formatting).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->