### PR TITLE
CI: Make missing manual testing section a CI failure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,8 @@ Thank you for contributing to Storybook! Please submit all PRs to the `next` bra
 
 #### Manual testing
 
-_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_
+> [!CAUTION]
+> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!
 
 <!-- Please include the steps to test your changes here. For example:
 

--- a/scripts/dangerfile.js
+++ b/scripts/dangerfile.js
@@ -98,7 +98,55 @@ Bad examples:
   }
 };
 
+/** @param {string} body */
+const checkManualTestingSection = (body) => {
+  // Check if author is a core team member or maintainer
+  const author = danger.github.pr.user;
+  const authorAssociation = danger.github.pr.author_association;
+
+  // Bypass check for OWNER, MEMBER roles (but never for bots e.g. Copilot)
+  if (['OWNER', 'MEMBER'].includes(authorAssociation) && author.type !== 'Bot') {
+    return;
+  }
+
+  // Check if manual testing section exists
+  const manualTestingMatch = body.match(/####\s*Manual testing/i);
+  if (!manualTestingMatch || manualTestingMatch.index === undefined) {
+    fail(
+      'PR description is missing the mandatory "#### Manual testing" section. Please add it so that reviewers know how to manually test your changes.'
+    );
+    return;
+  }
+
+  // Extract content after the manual testing section
+  const manualTestingSectionStart = manualTestingMatch.index + manualTestingMatch[0].length;
+  const restOfBody = body.substring(manualTestingSectionStart);
+
+  // Find the next section
+  const nextSectionMatch = restOfBody.match(/\n#+[^#]/);
+  const manualTestingContent = nextSectionMatch
+    ? restOfBody.substring(0, nextSectionMatch.index)
+    : restOfBody;
+
+  // Remove the initial message and check if there's any meaningful content left
+  const contentWithoutInitialMessage = manualTestingContent
+    .replace(/>\s*\[!CAUTION\][^]*?This section is mandatory[^]*?Thanks!/i, '')
+    .trim();
+
+  // Check if there's any substantial content (ignoring whitespace and template comments)
+  const contentWithoutComments = contentWithoutInitialMessage
+    .replace(/<!--[^]*?-->/g, '') // Remove HTML comments
+    .replace(/\s+/g, ''); // Remove all whitespace
+
+  if (!contentWithoutComments) {
+    fail(
+      'The "#### Manual testing" section must be filled in. Please describe how to test the changes you\'ve made, step by step, so that reviewers can confirm your PR works as intended.'
+    );
+  }
+};
+
 if (prLogConfig) {
   checkRequiredLabels(labels.map((l) => l.name));
   checkPrTitle(danger.github.pr.title);
+  checkManualTestingSection(danger.github.pr.body);
 }


### PR DESCRIPTION
## What I did

A little experiment because I keep having to tell LLMs disguised as humans to respect our PR template. I'm hoping causing an explicit CI failure will cause more agents to output repro steps we need to speed up reviews.

This is tested via child PRs targeting this branch.

## Checklist for Contributors

### Testing

Tested through mock PRs targeting this branch.

#### Manual testing

See:
* https://github.com/storybookjs/storybook/pull/33372
* https://github.com/storybookjs/storybook/pull/33373

### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced PR template with improved visual formatting for manual testing guidance.

* **Chores**
  * Added automated validation to enforce manual testing documentation in pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->