### PR TITLE
NextJS: Import `next/dist` with `.js`-extension for ESM compat

### DIFF
--- a/code/frameworks/nextjs-vite/src/export-mocks/headers/cookies.ts
+++ b/code/frameworks/nextjs-vite/src/export-mocks/headers/cookies.ts
@@ -5,7 +5,7 @@
 // @ts-ignore we must ignore types here as during compilation they are not generated yet
 import { headers } from '@storybook/nextjs-vite/headers.mock';
 
-import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies';
+import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies/index.js';
 import { fn } from 'storybook/test';
 
 class RequestCookiesMock extends RequestCookies {

--- a/code/frameworks/nextjs-vite/src/export-mocks/headers/headers.ts
+++ b/code/frameworks/nextjs-vite/src/export-mocks/headers/headers.ts
@@ -1,4 +1,4 @@
-import { HeadersAdapter } from 'next/dist/server/web/spec-extension/adapters/headers';
+import { HeadersAdapter } from 'next/dist/server/web/spec-extension/adapters/headers.js';
 import { fn } from 'storybook/test';
 
 class HeadersAdapterMock extends HeadersAdapter {

--- a/code/frameworks/nextjs-vite/src/export-mocks/headers/index.ts
+++ b/code/frameworks/nextjs-vite/src/export-mocks/headers/index.ts
@@ -1,9 +1,9 @@
-import { draftMode as originalDraftMode } from 'next/dist/server/request/draft-mode';
-import * as headers from 'next/dist/server/request/headers';
+import { draftMode as originalDraftMode } from 'next/dist/server/request/draft-mode.js';
+import * as headers from 'next/dist/server/request/headers.js';
 import { fn } from 'storybook/test';
 
 // re-exports of the actual module
-export * from 'next/dist/server/request/headers';
+export * from 'next/dist/server/request/headers.js';
 
 // mock utilities/overrides (as of Next v14.2.0)
 export { headers } from './headers';

--- a/code/frameworks/nextjs-vite/src/export-mocks/navigation/index.ts
+++ b/code/frameworks/nextjs-vite/src/export-mocks/navigation/index.ts
@@ -1,8 +1,8 @@
 import { NextjsRouterMocksNotAvailable } from 'storybook/internal/preview-errors';
 
-import * as actual from 'next/dist/client/components/navigation';
-import { getRedirectError } from 'next/dist/client/components/redirect';
-import { RedirectStatusCode } from 'next/dist/client/components/redirect-status-code';
+import * as actual from 'next/dist/client/components/navigation.js';
+import { RedirectStatusCode } from 'next/dist/client/components/redirect-status-code.js';
+import { getRedirectError } from 'next/dist/client/components/redirect.js';
 import type { Mock } from 'storybook/test';
 import { fn } from 'storybook/test';
 
@@ -57,7 +57,7 @@ export const getRouter = () => {
 };
 
 // re-exports of the actual module
-export * from 'next/dist/client/components/navigation';
+export * from 'next/dist/client/components/navigation.js';
 
 // mock utilities/overrides (as of Next v14.2.0)
 export const redirect = fn(

--- a/code/frameworks/nextjs-vite/src/export-mocks/router/index.ts
+++ b/code/frameworks/nextjs-vite/src/export-mocks/router/index.ts
@@ -1,6 +1,6 @@
 import { NextjsRouterMocksNotAvailable } from 'storybook/internal/preview-errors';
 
-import singletonRouter, * as originalRouter from 'next/dist/client/router';
+import singletonRouter, * as originalRouter from 'next/dist/client/router.js';
 import type { NextRouter, SingletonRouter } from 'next/router';
 import type { Mock } from 'storybook/test';
 import { fn } from 'storybook/test';
@@ -108,7 +108,7 @@ export const getRouter = () => {
 };
 
 // re-exports of the actual module
-export * from 'next/dist/client/router';
+export * from 'next/dist/client/router.js';
 export default singletonRouter;
 
 // mock utilities/overrides (as of Next v14.2.0)

--- a/code/frameworks/nextjs-vite/src/head-manager/head-manager-provider.tsx
+++ b/code/frameworks/nextjs-vite/src/head-manager/head-manager-provider.tsx
@@ -1,8 +1,8 @@
 import type { PropsWithChildren } from 'react';
 import React, { useMemo } from 'react';
 
-import initHeadManager from 'next/dist/client/head-manager';
-import { HeadManagerContext } from 'next/dist/shared/lib/head-manager-context.shared-runtime';
+import initHeadManager from 'next/dist/client/head-manager.js';
+import { HeadManagerContext } from 'next/dist/shared/lib/head-manager-context.shared-runtime.js';
 
 type HeadManagerValue = {
   updateHead?: ((state: JSX.Element[]) => void) | undefined;

--- a/code/frameworks/nextjs-vite/src/preview.tsx
+++ b/code/frameworks/nextjs-vite/src/preview.tsx
@@ -11,7 +11,7 @@ import { createNavigation } from '@storybook/nextjs-vite/navigation.mock';
 // @ts-ignore we must ignore types here as during compilation they are not generated yet
 import { createRouter } from '@storybook/nextjs-vite/router.mock';
 
-import { isNextRouterError } from 'next/dist/client/components/is-next-router-error';
+import { isNextRouterError } from 'next/dist/client/components/is-next-router-error.js';
 
 import { HeadManagerDecorator } from './head-manager/decorator';
 import { ImageDecorator } from './images/decorator';

--- a/code/frameworks/nextjs-vite/src/routing/app-router-provider.tsx
+++ b/code/frameworks/nextjs-vite/src/routing/app-router-provider.tsx
@@ -12,13 +12,13 @@ import {
   AppRouterContext,
   GlobalLayoutRouterContext,
   LayoutRouterContext,
-} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+} from 'next/dist/shared/lib/app-router-context.shared-runtime.js';
 import {
   PathParamsContext,
   PathnameContext,
   SearchParamsContext,
-} from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
-import { PAGE_SEGMENT_KEY } from 'next/dist/shared/lib/segment';
+} from 'next/dist/shared/lib/hooks-client-context.shared-runtime.js';
+import { PAGE_SEGMENT_KEY } from 'next/dist/shared/lib/segment.js';
 
 import type { RouteParams } from './types';
 

--- a/code/frameworks/nextjs-vite/src/routing/decorator.tsx
+++ b/code/frameworks/nextjs-vite/src/routing/decorator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import type { Addon_StoryContext } from 'storybook/internal/types';
 
-import { RedirectBoundary } from 'next/dist/client/components/redirect-boundary';
+import { RedirectBoundary } from 'next/dist/client/components/redirect-boundary.js';
 
 import { AppRouterProvider } from './app-router-provider';
 import { PageRouterProvider } from './page-router-provider';

--- a/code/frameworks/nextjs-vite/src/routing/page-router-provider.tsx
+++ b/code/frameworks/nextjs-vite/src/routing/page-router-provider.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 // @ts-ignore we must ignore types here as during compilation they are not generated yet
 import { getRouter } from '@storybook/nextjs-vite/router.mock';
 
-import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime.js';
 
 export const PageRouterProvider: React.FC<PropsWithChildren> = ({ children }) => (
   <RouterContext.Provider value={getRouter()}>{children}</RouterContext.Provider>

--- a/code/frameworks/nextjs/src/compatibility/draft-mode.compat.ts
+++ b/code/frameworks/nextjs/src/compatibility/draft-mode.compat.ts
@@ -1,2 +1,2 @@
 // @ts-expect-error Compatibility for Next 14
-export { draftMode } from 'next/dist/client/components/headers';
+export { draftMode } from 'next/dist/client/components/headers.js';

--- a/code/frameworks/nextjs/src/export-mocks/cache/index.ts
+++ b/code/frameworks/nextjs/src/export-mocks/cache/index.ts
@@ -1,5 +1,5 @@
-import { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache';
-import { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store';
+import { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache.js';
+import { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store.js';
 import { fn } from 'storybook/test';
 
 // mock utilities/overrides (as of Next v14.2.0)

--- a/code/frameworks/nextjs/src/export-mocks/headers/cookies.ts
+++ b/code/frameworks/nextjs/src/export-mocks/headers/cookies.ts
@@ -5,7 +5,7 @@
 // @ts-ignore we must ignore types here as during compilation they are not generated yet
 import { headers } from '@storybook/nextjs/headers.mock';
 
-import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies';
+import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies/index.js';
 import { fn } from 'storybook/test';
 
 class RequestCookiesMock extends RequestCookies {

--- a/code/frameworks/nextjs/src/export-mocks/headers/headers.ts
+++ b/code/frameworks/nextjs/src/export-mocks/headers/headers.ts
@@ -1,4 +1,4 @@
-import { HeadersAdapter } from 'next/dist/server/web/spec-extension/adapters/headers';
+import { HeadersAdapter } from 'next/dist/server/web/spec-extension/adapters/headers.js';
 import { fn } from 'storybook/test';
 
 class HeadersAdapterMock extends HeadersAdapter {

--- a/code/frameworks/nextjs/src/export-mocks/headers/index.ts
+++ b/code/frameworks/nextjs/src/export-mocks/headers/index.ts
@@ -1,8 +1,8 @@
-import * as headers from 'next/dist/server/request/headers';
+import * as headers from 'next/dist/server/request/headers.js';
 import { fn } from 'storybook/test';
 
 // re-exports of the actual module
-export * from 'next/dist/server/request/headers';
+export * from 'next/dist/server/request/headers.js';
 
 // mock utilities/overrides (as of Next v14.2.0)
 export { headers } from './headers';

--- a/code/frameworks/nextjs/src/export-mocks/navigation/index.ts
+++ b/code/frameworks/nextjs/src/export-mocks/navigation/index.ts
@@ -1,8 +1,8 @@
 import { NextjsRouterMocksNotAvailable } from 'storybook/internal/preview-errors';
 
-import * as actual from 'next/dist/client/components/navigation';
-import { getRedirectError } from 'next/dist/client/components/redirect';
-import { RedirectStatusCode } from 'next/dist/client/components/redirect-status-code';
+import * as actual from 'next/dist/client/components/navigation.js';
+import { RedirectStatusCode } from 'next/dist/client/components/redirect-status-code.js';
+import { getRedirectError } from 'next/dist/client/components/redirect.js';
 import type { Mock } from 'storybook/test';
 import { fn } from 'storybook/test';
 
@@ -57,7 +57,7 @@ export const getRouter = () => {
 };
 
 // re-exports of the actual module
-export * from 'next/dist/client/components/navigation';
+export * from 'next/dist/client/components/navigation.js';
 
 // mock utilities/overrides (as of Next v14.2.0)
 export const redirect = fn(

--- a/code/frameworks/nextjs/src/export-mocks/router/index.ts
+++ b/code/frameworks/nextjs/src/export-mocks/router/index.ts
@@ -1,6 +1,6 @@
 import { NextjsRouterMocksNotAvailable } from 'storybook/internal/preview-errors';
 
-import singletonRouter, * as originalRouter from 'next/dist/client/router';
+import singletonRouter, * as originalRouter from 'next/dist/client/router.js';
 import type { NextRouter, SingletonRouter } from 'next/router';
 import type { Mock } from 'storybook/test';
 import { fn } from 'storybook/test';
@@ -108,7 +108,7 @@ export const getRouter = () => {
 };
 
 // re-exports of the actual module
-export * from 'next/dist/client/router';
+export * from 'next/dist/client/router.js';
 export default singletonRouter;
 
 // mock utilities/overrides (as of Next v14.2.0)

--- a/code/frameworks/nextjs/src/head-manager/head-manager-provider.tsx
+++ b/code/frameworks/nextjs/src/head-manager/head-manager-provider.tsx
@@ -1,8 +1,8 @@
 import type { PropsWithChildren } from 'react';
 import React, { useMemo } from 'react';
 
-import initHeadManager from 'next/dist/client/head-manager';
-import { HeadManagerContext } from 'next/dist/shared/lib/head-manager-context.shared-runtime';
+import initHeadManager from 'next/dist/client/head-manager.js';
+import { HeadManagerContext } from 'next/dist/shared/lib/head-manager-context.shared-runtime.js';
 
 type HeadManagerValue = {
   updateHead?: ((state: JSX.Element[]) => void) | undefined;

--- a/code/frameworks/nextjs/src/preview.tsx
+++ b/code/frameworks/nextjs/src/preview.tsx
@@ -12,7 +12,7 @@ import { createNavigation } from '@storybook/nextjs/navigation.mock';
 // @ts-ignore we must ignore types here as during compilation they are not generated yet
 import { createRouter } from '@storybook/nextjs/router.mock';
 
-import { isNextRouterError } from 'next/dist/client/components/is-next-router-error';
+import { isNextRouterError } from 'next/dist/client/components/is-next-router-error.js';
 
 import { HeadManagerDecorator } from './head-manager/decorator';
 import { ImageDecorator } from './images/decorator';

--- a/code/frameworks/nextjs/src/routing/app-router-provider.tsx
+++ b/code/frameworks/nextjs/src/routing/app-router-provider.tsx
@@ -12,13 +12,13 @@ import {
   AppRouterContext,
   GlobalLayoutRouterContext,
   LayoutRouterContext,
-} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+} from 'next/dist/shared/lib/app-router-context.shared-runtime.js';
 import {
   PathParamsContext,
   PathnameContext,
   SearchParamsContext,
-} from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
-import { PAGE_SEGMENT_KEY } from 'next/dist/shared/lib/segment';
+} from 'next/dist/shared/lib/hooks-client-context.shared-runtime.js';
+import { PAGE_SEGMENT_KEY } from 'next/dist/shared/lib/segment.js';
 
 import type { RouteParams } from './types';
 

--- a/code/frameworks/nextjs/src/routing/decorator.tsx
+++ b/code/frameworks/nextjs/src/routing/decorator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import type { Addon_StoryContext } from 'storybook/internal/types';
 
-import { RedirectBoundary } from 'next/dist/client/components/redirect-boundary';
+import { RedirectBoundary } from 'next/dist/client/components/redirect-boundary.js';
 
 import { AppRouterProvider } from './app-router-provider';
 import { PageRouterProvider } from './page-router-provider';

--- a/code/frameworks/nextjs/src/routing/page-router-provider.tsx
+++ b/code/frameworks/nextjs/src/routing/page-router-provider.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { getRouter } from '@storybook/nextjs/router.mock';
 
-import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime.js';
 
 export const PageRouterProvider: React.FC<PropsWithChildren> = ({ children }) => (
   <RouterContext.Provider value={getRouter()}>{children}</RouterContext.Provider>


### PR DESCRIPTION
Closes #33379
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

fix imports with `.js` extensions

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Build packages locally
2. Link built package to https://github.com/lab-yue/reproduction-portable-stories-next
3. Tests run successfully

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
4. Open Storybook in your browser
5. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported a cookies helper from the Next.js integration layer.

* **Chores**
  * Normalized Next.js module specifiers to explicit .js entry points across integration layers to align with current module resolution. No runtime behavior or public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->