### PR TITLE
UI: Fix React error 300 on some addons

### DIFF
--- a/code/core/src/manager/components/panel/Panel.tsx
+++ b/code/core/src/manager/components/panel/Panel.tsx
@@ -67,11 +67,17 @@ const Section = styled.section({
   flexDirection: 'column',
 });
 
+// Ensures we don't cause difficult-to-debug hooks violations
+// whether addon authors pass a React component ctor or anonymous function.
+function renderChild(RenderProp: Addon_BaseType['render']) {
+  return <RenderProp active={true} />;
+}
+
 // Avoids crashes due to rules of hooks.
 const PreRenderAddons = ({ panels }: { panels: Record<string, Addon_BaseType> }) => {
   return Object.entries(panels).map(([k, v]) => (
     <StatelessTabPanel key={k} name={k} hasScrollbar={false}>
-      <TabErrorBoundary key={k}>{v.render({ active: true })}</TabErrorBoundary>
+      <TabErrorBoundary key={k}>{renderChild(v.render)}</TabErrorBoundary>
     </StatelessTabPanel>
   ));
 };


### PR DESCRIPTION
Closes #33352

## What I did

Accounted for React elements passed to the `render` prop for addon tools. If the prop is not a function, I'm now using `cloneElement` instead of directly rendering it as a function. This fixes the bug as far as I can tell.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

ø

#### Manual testing

> [!CAUTION]
> I could not repro on our own SB instance so I ended up having to code a fix in the built SB manager in the repro repo's `node_modules`.

1. Fork https://github.com/US-CBP/design-system/tree/develop/packages/web-components
2. Run the SB instance in `packages/web-components`
3. Go to any page, press F5 and notice the crash
2. Replace the Storybook instance it contains with the code on this branch
3. Rinse and repeat, it should no longer crash

### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33381-sha-f3410369`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33381-sha-f3410369 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33381-sha-f3410369 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33381-sha-f3410369`](https://npmjs.com/package/storybook/v/0.0.0-pr-33381-sha-f3410369) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`sidnioulz/issue-33352`](https://github.com/storybookjs/storybook/tree/sidnioulz/issue-33352) |
| **Commit** | [`f3410369`](https://github.com/storybookjs/storybook/commit/f3410369066852d20a86d93248b750544c9dea62) |
| **Datetime** | Wed Dec 17 11:48:20 UTC 2025 (`1765972100`) |
| **Workflow run** | [20301772924](https://github.com/storybookjs/storybook/actions/runs/20301772924) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33381`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed panel addon rendering so the active state is applied consistently across different render types.
  * Improved addon rendering support to handle both element and function renderers reliably, preventing potential hook-related issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->