### PR TITLE
Interactions: Fix state reset bug when switching stories with date mocks

### DIFF
--- a/code/core/src/component-testing/components/Panel.tsx
+++ b/code/core/src/component-testing/components/Panel.tsx
@@ -273,8 +273,16 @@ export const Panel = memo<{ refId?: string; storyId: string; storyUrl: string }>
             return;
           }
 
+          // Update lastRenderId. When we switch stories, this value might decrease if our
+          // users have mocked Date.now() via addons or manually in their code, so we must
+          // reset lastRenderId.
+          if (lastStoryId.current === event.storyId) {
+            lastRenderId.current = Math.max(lastRenderId.current, event.renderId || 0);
+          } else {
+            lastRenderId.current = event.renderId || 0;
+          }
+
           lastStoryId.current = event.storyId;
-          lastRenderId.current = Math.max(lastRenderId.current, event.renderId || 0);
           if (lastRenderId.current !== event.renderId) {
             return;
           }

--- a/code/core/src/component-testing/components/Panel.tsx
+++ b/code/core/src/component-testing/components/Panel.tsx
@@ -250,7 +250,7 @@ export const Panel = memo<{ refId?: string; storyId: string; storyUrl: string }>
     }, []);
 
     const lastStoryId = useRef<string>(undefined);
-    const lastRenderId = useRef<number>(0);
+    const latestRenderId = useRef<number>(0);
     const emit = useChannel(
       {
         [EVENTS.CALL]: setCall,
@@ -273,17 +273,18 @@ export const Panel = memo<{ refId?: string; storyId: string; storyUrl: string }>
             return;
           }
 
-          // Update lastRenderId. When we switch stories, this value might decrease if our
-          // users have mocked Date.now() via addons or manually in their code, so we must
-          // reset lastRenderId.
+          // Update lastRenderId and lastStoryId. When we switch stories, lastRenderId's
+          // value might decrease if our users have mocked Date.now() via addons or
+          // manually in their code, so we must reset it.
           if (lastStoryId.current === event.storyId) {
-            lastRenderId.current = Math.max(lastRenderId.current, event.renderId || 0);
+            latestRenderId.current = Math.max(latestRenderId.current, event.renderId || 0);
           } else {
-            lastRenderId.current = event.renderId || 0;
+            latestRenderId.current = event.renderId || 0;
+            lastStoryId.current = event.storyId;
           }
 
-          lastStoryId.current = event.storyId;
-          if (lastRenderId.current !== event.renderId) {
+          // Bail out if concurrent renders are ongoing for the same story (only keep the latest one).
+          if (latestRenderId.current !== event.renderId) {
             return;
           }
 


### PR DESCRIPTION
Closes #32834 

## What I did

Forced a reset of `lastRenderId` when switching stories, to ensure we account for the fact that `Date.now()` can be mocked in a story.

## Checklist for Contributors

### Testing

#### Manual testing

1. Build a canary for this PR
2. Install it on https://github.com/Sidnioulz/storybook-play-function-error-state-persistence-repro
3. Launch Storybook
4. Go to http://localhost:6006/?path=/story/example-frog--late which triggers a caught exception state
5. Navigate to http://localhost:6006/?path=/story/example-frog--on-time-too and see the state is cleared

Without the canary, the state will not be properly cleared.

### Documentation
ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved render tracking so component testing more reliably handles switching between stories, preventing stale or concurrent render updates.
  * Added per-story update logic and an early bailout to ensure only the relevant render advances, reducing incorrect state transitions during rapid story changes or mocked-time scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->