### PR TITLE
Docs: add dedicated Globals API page

### DIFF
--- a/docs/_snippets/addon-consume-and-update-globaltype.md
+++ b/docs/_snippets/addon-consume-and-update-globaltype.md
@@ -1,8 +1,8 @@
 ```js filename="your-addon-register-file.js" renderer="common" language="js"
 import React, { useCallback } from 'react';
 import { OutlineIcon } from '@storybook/icons';
-import { useGlobals } from 'storybook/manager-api';
-import { addons } from 'storybook/preview-api';
+import { useGlobals } from '@storybook/manager-api';
+import { addons } from '@storybook/preview-api';
 import { ToggleButton } from 'storybook/internal/components';
 import { FORCE_RE_RENDER } from 'storybook/internal/core-events';
 

--- a/docs/_snippets/addon-consume-globaltype.md
+++ b/docs/_snippets/addon-consume-globaltype.md
@@ -1,7 +1,7 @@
 ```js filename="your-addon-register-file.js" renderer="common" language="js"
 import React from 'react';
 
-import { useGlobals } from 'storybook/manager-api';
+import { useGlobals } from '@storybook/manager-api';
 
 import {
   AddonPanel,

--- a/docs/_snippets/globals-in-mdx-via-stories.md
+++ b/docs/_snippets/globals-in-mdx-via-stories.md
@@ -1,0 +1,40 @@
+```mdx filename="Component.mdx" renderer="common" language="mdx"
+import { Meta, Story } from '@storybook/blocks';
+import * as ComponentStories from './Component.stories';
+
+<Meta of={ComponentStories} />
+
+# Component Documentation
+
+This component supports multiple themes. The stories below demonstrate how it looks in different themes.
+
+Change the theme using the toolbar to see how the component adapts. The stories will automatically update.
+
+<Story of={ComponentStories.LightTheme} />
+<Story of={ComponentStories.DarkTheme} />
+```
+
+```tsx filename="Component.stories.tsx" renderer="react" language="ts"
+import type { Meta, StoryObj } from '@storybook/react';
+import { Component } from './Component';
+
+const meta = {
+  component: Component,
+} satisfies Meta<typeof Component>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LightTheme: Story = {
+  globals: {
+    theme: 'light',
+  },
+};
+
+export const DarkTheme: Story = {
+  globals: {
+    theme: 'dark',
+  },
+};
+```
+

--- a/docs/_snippets/globals-in-mdx-with-doc-blocks.md
+++ b/docs/_snippets/globals-in-mdx-with-doc-blocks.md
@@ -1,0 +1,15 @@
+```mdx filename="Component.mdx" renderer="common" language="mdx"
+import { Meta, Story } from '@storybook/blocks';
+import * as ComponentStories from './Component.stories';
+
+<Meta of={ComponentStories} />
+
+# Component Documentation
+
+This component responds to the theme global. Use the toolbar to change themes and see how it adapts.
+
+<Story of={ComponentStories.Default} />
+
+The Story block above will automatically reflect global changes, including theme updates.
+```
+

--- a/docs/_snippets/globals-in-mdx-with-wrapper.md
+++ b/docs/_snippets/globals-in-mdx-with-wrapper.md
@@ -1,0 +1,26 @@
+```tsx filename="src/components/ThemeAwareComponent.tsx" renderer="react" language="ts"
+import React from 'react';
+import { useGlobals } from '@storybook/preview-api';
+
+export const ThemeAwareComponent: React.FC = () => {
+  const [globals] = useGlobals();
+  const theme = globals.theme || 'light';
+
+  return (
+    <div style={{ padding: '1rem', background: theme === 'dark' ? '#333' : '#fff' }}>
+      Current theme: {theme}
+    </div>
+  );
+};
+```
+
+```mdx filename="Component.mdx" renderer="common" language="mdx"
+import { ThemeAwareComponent } from '../src/components/ThemeAwareComponent';
+
+# Component Documentation
+
+<ThemeAwareComponent />
+
+This component uses the `useGlobals` hook internally and will update when globals change.
+```
+

--- a/docs/_snippets/globals-mutation-example.md
+++ b/docs/_snippets/globals-mutation-example.md
@@ -1,0 +1,8 @@
+```ts filename="example.ts" renderer="common" language="ts"
+// ❌ Wrong - Direct mutation won't trigger re-renders
+globals.theme = 'dark';
+
+// ✅ Correct - Use updateGlobals function
+updateGlobals({ theme: 'dark' });
+```
+

--- a/docs/_snippets/globals-toolbar-menuitem-type.md
+++ b/docs/_snippets/globals-toolbar-menuitem-type.md
@@ -1,0 +1,9 @@
+```ts filename="types.ts" renderer="common" language="ts"
+type MenuItem = {
+  value: string;
+  title: string;
+  right?: string;
+  icon?: string;
+};
+```
+

--- a/docs/_snippets/globals-typescript-typing.md
+++ b/docs/_snippets/globals-typescript-typing.md
@@ -1,0 +1,33 @@
+```ts filename=".storybook/preview.ts" renderer="common" language="ts"
+import type { Preview } from '@storybook/your-framework';
+
+type Globals = {
+  theme: 'light' | 'dark';
+  locale: 'en' | 'es' | 'fr';
+};
+
+const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: 'Global theme for components',
+      toolbar: {
+        title: 'Theme',
+        icon: 'circlehollow',
+        items: ['light', 'dark'],
+        dynamicTitle: true,
+      },
+    },
+    locale: {
+      description: 'Global locale for components',
+      toolbar: {
+        title: 'Locale',
+        items: ['en', 'es', 'fr'],
+        dynamicTitle: true,
+      },
+    },
+  },
+};
+
+export default preview;
+```
+

--- a/docs/_snippets/preview-globaltypes-definition.md
+++ b/docs/_snippets/preview-globaltypes-definition.md
@@ -1,0 +1,91 @@
+```js filename=".storybook/preview.js" renderer="common" language="js" tabTitle="CSF 3"
+const preview = {
+  globalTypes: {
+    theme: {
+      description: 'Global theme for components',
+      toolbar: {
+        // The label to show for this toolbar item
+        title: 'Theme',
+        icon: 'circlehollow',
+        // Array of plain string values or MenuItem shape (see below)
+        items: ['light', 'dark'],
+        // Change title based on selected value
+        dynamicTitle: true,
+      },
+    },
+  },
+};
+
+export default preview;
+```
+
+```ts filename=".storybook/preview.ts" renderer="common" language="ts" tabTitle="CSF 3"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+import type { Preview } from '@storybook/your-framework';
+
+const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: 'Global theme for components',
+      toolbar: {
+        // The label to show for this toolbar item
+        title: 'Theme',
+        icon: 'circlehollow',
+        // Array of plain string values or MenuItem shape (see below)
+        items: ['light', 'dark'],
+        // Change title based on selected value
+        dynamicTitle: true,
+      },
+    },
+  },
+};
+
+export default preview;
+```
+
+```ts filename=".storybook/preview.ts" renderer="react" language="ts" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { definePreview } from '@storybook/your-framework';
+
+export default definePreview({
+  globalTypes: {
+    theme: {
+      description: 'Global theme for components',
+      toolbar: {
+        // The label to show for this toolbar item
+        title: 'Theme',
+        icon: 'circlehollow',
+        // Array of plain string values or MenuItem shape (see below)
+        items: ['light', 'dark'],
+        // Change title based on selected value
+        dynamicTitle: true,
+      },
+    },
+  },
+});
+```
+
+<!-- JS snippets still needed while providing both CSF 3 & Next -->
+
+```js filename=".storybook/preview.js" renderer="react" language="js" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { definePreview } from '@storybook/your-framework';
+
+export default definePreview({
+  globalTypes: {
+    theme: {
+      description: 'Global theme for components',
+      toolbar: {
+        // The label to show for this toolbar item
+        title: 'Theme',
+        icon: 'circlehollow',
+        // Array of plain string values or MenuItem shape (see below)
+        items: ['light', 'dark'],
+        // Change title based on selected value
+        dynamicTitle: true,
+      },
+    },
+  },
+});
+```
+

--- a/docs/_snippets/preview-initial-globals.md
+++ b/docs/_snippets/preview-initial-globals.md
@@ -1,0 +1,91 @@
+```js filename=".storybook/preview.js" renderer="common" language="js" tabTitle="CSF 3"
+const preview = {
+  globalTypes: {
+    theme: {
+      description: 'Global theme for components',
+      toolbar: {
+        title: 'Theme',
+        icon: 'circlehollow',
+        items: ['light', 'dark'],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: 'light',
+  },
+};
+
+export default preview;
+```
+
+```ts filename=".storybook/preview.ts" renderer="common" language="ts" tabTitle="CSF 3"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+import type { Preview } from '@storybook/your-framework';
+
+const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: 'Global theme for components',
+      toolbar: {
+        title: 'Theme',
+        icon: 'circlehollow',
+        items: ['light', 'dark'],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: 'light',
+  },
+};
+
+export default preview;
+```
+
+```ts filename=".storybook/preview.ts" renderer="react" language="ts" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { definePreview } from '@storybook/your-framework';
+
+export default definePreview({
+  globalTypes: {
+    theme: {
+      description: 'Global theme for components',
+      toolbar: {
+        title: 'Theme',
+        icon: 'circlehollow',
+        items: ['light', 'dark'],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: 'light',
+  },
+});
+```
+
+<!-- JS snippets still needed while providing both CSF 3 & Next -->
+
+```js filename=".storybook/preview.js" renderer="react" language="js" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { definePreview } from '@storybook/your-framework';
+
+export default definePreview({
+  globalTypes: {
+    theme: {
+      description: 'Global theme for components',
+      toolbar: {
+        title: 'Theme',
+        icon: 'circlehollow',
+        items: ['light', 'dark'],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: 'light',
+  },
+});
+```
+

--- a/docs/_snippets/storybook-addon-use-global.md
+++ b/docs/_snippets/storybook-addon-use-global.md
@@ -5,7 +5,7 @@ import type {
   StoryContext,
 } from 'storybook/internal/types';
 
-import { useEffect, useMemo, useGlobals } from 'storybook/preview-api';
+import { useEffect, useMemo, useGlobals } from '@storybook/preview-api';
 import { PARAM_KEY } from './constants';
 
 import { clearStyles, addOutlineStyles } from './helpers';

--- a/docs/api/globals.mdx
+++ b/docs/api/globals.mdx
@@ -1,0 +1,276 @@
+---
+title: 'Globals'
+sidebar:
+  order: 5
+  title: Globals
+---
+
+Globals are dynamic, user-controlled values that persist across stories in Storybook. Unlike [parameters](./parameters.mdx), which are static metadata, globals can be changed interactively through the Storybook UI (typically via toolbar menus) and affect how stories are rendered.
+
+## Globals vs Parameters
+
+While both globals and parameters are used to configure Storybook, they serve different purposes:
+
+| Feature | Globals | Parameters |
+|---------|---------|------------|
+| **Mutability** | Dynamic, can be changed by users | Static, defined at build time |
+| **Scope** | Storybook-wide, persist across navigation | Story-specific, can be overridden per story |
+| **Use case** | User preferences (themes, locales, viewports) | Configuration metadata (addon settings, layout) |
+| **Access** | Via `context.globals` or `useGlobals()` hook | Via `context.parameters` or `useParameter()` hook |
+| **Definition** | `globalTypes` in preview config | `parameters` in preview, meta, or story |
+
+<Callout variant="info">
+  Use **globals** when you want users to interactively control values that affect story rendering (e.g., switching themes). Use **parameters** for static configuration that doesn't change during a session (e.g., addon settings).
+</Callout>
+
+## Defining globals
+
+Globals are defined using `globalTypes` in your `.storybook/preview.js|ts` file. Each global must have a unique key and can optionally include a toolbar configuration to make it interactive.
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="preview-globaltypes-definition.md" />
+
+{/* prettier-ignore-end */}
+
+<Callout variant="info">
+  As globals are *global*, you can *only* define `globalTypes` and `initialGlobals` in [`.storybook/preview.js|ts`](../configure/index.mdx#configure-story-rendering). They cannot be defined at the story or component level.
+</Callout>
+
+### Global type configuration
+
+Each global type can include the following properties:
+
+#### `description`
+
+Type: `string`
+
+A description of what this global controls. Used for documentation and accessibility.
+
+#### `toolbar`
+
+Type: `object`
+
+Configuration for displaying this global in the Storybook toolbar. If omitted, the global will not appear in the toolbar but can still be accessed programmatically.
+
+##### `toolbar.title`
+
+Type: `string`
+
+The label displayed in the toolbar menu.
+
+##### `toolbar.icon`
+
+Type: `string`
+
+An icon identifier from `@storybook/icons` to display in the toolbar. See the [available icons](../faq.mdx#what-icons-are-available-for-my-toolbar-or-my-addon) for options.
+
+##### `toolbar.items`
+
+Type: `string[] | MenuItem[]`
+
+An array of values that can be selected. Can be plain strings or `MenuItem` objects with additional configuration:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="globals-toolbar-menuitem-type.md" />
+
+{/* prettier-ignore-end */}
+
+##### `toolbar.dynamicTitle`
+
+Type: `boolean`
+
+Default: `false`
+
+When `true`, the toolbar button title changes to reflect the currently selected value.
+
+### Initial globals
+
+You can set default values for globals using `initialGlobals`:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="preview-initial-globals.md" />
+
+{/* prettier-ignore-end */}
+
+## Reading globals in Preview
+
+In the preview context (decorators, render functions, stories), you can access globals via the `context` object or using the `useGlobals` hook from `@storybook/preview-api`.
+
+### Using context.globals
+
+The simplest way to access globals is through the `context` parameter passed to render functions and decorators:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="my-component-story-use-globaltype.md" />
+
+{/* prettier-ignore-end */}
+
+### Using useGlobals hook
+
+For more complex scenarios, such as in decorators that need to react to global changes, use the `useGlobals` hook:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="storybook-addon-use-global.md" />
+
+{/* prettier-ignore-end */}
+
+<Callout variant="warning">
+  The `useGlobals` hook from `@storybook/preview-api` can only be used within React components (e.g., decorators). It cannot be used directly in story render functions or non-React contexts.
+</Callout>
+
+## Reading and updating globals in Manager
+
+In the manager context (addons, panels, toolbars), use `useGlobals` from `@storybook/manager-api` to both read and update globals.
+
+### Reading globals
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="addon-consume-globaltype.md" />
+
+{/* prettier-ignore-end */}
+
+### Updating globals
+
+The `useGlobals` hook returns a tuple where the second element is an `updateGlobals` function:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="addon-consume-and-update-globaltype.md" />
+
+{/* prettier-ignore-end */}
+
+<Callout variant="info">
+  When updating globals from the manager, the preview will automatically re-render affected stories. If you need to force a re-render explicitly, you can emit the `FORCE_RE_RENDER` event via the addons channel.
+</Callout>
+
+## Working with globals in MDX
+
+MDX files have some limitations when working with globals due to their rendering context.
+
+### Limitations
+
+1. **Hooks are not always available**: The `useGlobals` hook from `@storybook/preview-api` cannot be used directly in MDX files because MDX renders in a React context that doesn't have access to the preview API.
+
+2. **Context access**: You cannot directly access `context.globals` in MDX files since they don't receive a context parameter.
+
+3. **Reactive updates**: MDX files don't automatically re-render when globals change, unlike stories.
+
+### Recommended patterns
+
+#### Pattern 1: Use Doc Blocks
+
+The recommended approach is to use Storybook's Doc Blocks, which handle globals automatically:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="globals-in-mdx-with-doc-blocks.md" />
+
+{/* prettier-ignore-end */}
+
+#### Pattern 2: Create a wrapper component
+
+If you need direct access to globals in MDX, create a React component that uses the hook and import it:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="globals-in-mdx-with-wrapper.md" />
+
+{/* prettier-ignore-end */}
+
+#### Pattern 3: Reference stories that use globals
+
+Instead of accessing globals directly in MDX, reference stories that already consume globals:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="globals-in-mdx-via-stories.md" />
+
+{/* prettier-ignore-end */}
+
+<Callout variant="warning">
+  Avoid trying to use `useGlobals` directly in MDX files. It will not work and may cause runtime errors. Always use one of the recommended patterns above.
+</Callout>
+
+## Setting globals on stories
+
+While globals are typically controlled via the toolbar, you can override them for specific stories using the `globals` property:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="addon-backgrounds-define-globals.md" />
+
+{/* prettier-ignore-end */}
+
+<Callout variant="info">
+  When you set `globals` on a story or component, the toolbar control for that global will be disabled for those stories, preventing users from changing the value interactively. Use this sparingly, as it reduces the explorability of your Storybook.
+</Callout>
+
+## Common pitfalls
+
+### Pitfall 1: Defining globalTypes in stories
+
+**Problem**: Trying to define `globalTypes` in a story file or component meta.
+
+**Solution**: `globalTypes` can only be defined in `.storybook/preview.js|ts`. If you need story-specific behavior, use the `globals` property on the story instead.
+
+### Pitfall 2: Using manager-api hooks in preview
+
+**Problem**: Importing `useGlobals` from `@storybook/manager-api` in preview code (decorators, stories).
+
+**Solution**: Use `useGlobals` from `@storybook/preview-api` in preview code, and `@storybook/manager-api` only in manager code (addons).
+
+### Pitfall 3: Expecting globals to update MDX
+
+**Problem**: Expecting MDX documentation to automatically update when globals change.
+
+**Solution**: MDX files don't reactively update. Use Doc Blocks or reference stories that consume globals instead.
+
+### Pitfall 4: Mutating globals directly
+
+**Problem**: Trying to mutate the globals object directly instead of using `updateGlobals`.
+
+**Solution**: Always use the `updateGlobals` function returned by `useGlobals`. Direct mutation won't trigger re-renders.
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="globals-mutation-example.md" />
+
+{/* prettier-ignore-end */}
+
+## Best practices
+
+1. **Use globals for user preferences**: Globals are ideal for values that users should control, such as themes, locales, or viewport sizes.
+
+2. **Use parameters for configuration**: Use parameters for static configuration that doesn't change during a session, such as addon settings or layout preferences.
+
+3. **Define globalTypes once**: Define all `globalTypes` in your preview configuration file. Don't scatter them across multiple files.
+
+4. **Provide sensible defaults**: Always set `initialGlobals` to provide a good default experience.
+
+5. **Document your globals**: Use the `description` property to document what each global controls.
+
+6. **Use decorators for global effects**: When globals need to affect rendering (e.g., applying themes), use decorators rather than accessing globals in every story.
+
+7. **Avoid story-level globals**: Use story-level `globals` sparingly. Prefer letting users control globals via the toolbar for better explorability.
+
+8. **Type your globals**: In TypeScript projects, consider creating a type for your globals to ensure type safety:
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="globals-typescript-typing.md" />
+
+{/* prettier-ignore-end */}
+
+## Related APIs
+
+- [Parameters](./parameters.mdx) - Static metadata for stories and addons
+- [Args](../writing-stories/args.mdx) - Dynamic story inputs
+- [Decorators](../writing-stories/decorators.mdx) - Wrapper functions for stories
+- [Toolbars & Globals](../essentials/toolbars-and-globals.mdx) - User guide for working with globals
+

--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -102,6 +102,14 @@ An overview of all available API references for Storybook.
         Parameters are static metadata used to configure your <a href="./get-started/whats-a-story">stories</a> <a href="./addons">addons</a> in Storybook. They are specified at the story, meta (component), project (global) levels.
       </Td>
     </Tr>
+
+    <Tr>
+      <Td><A href="./api/globals">Globals</A></Td>
+
+      <Td>
+        Globals are dynamic, user-controlled values that persist across stories in Storybook. Unlike parameters, globals can be changed interactively through the Storybook UI and affect how stories are rendered.
+      </Td>
+    </Tr>
   </tbody>
 </Table>
 


### PR DESCRIPTION
Closes #32380

## What I did

Added a dedicated **Globals** page to the API documentation to give globals first-class visibility alongside parameters.

The new page explains what globals are, how they differ from parameters, and how to use them across preview, manager, and MDX contexts, with guidance on common pitfalls.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [x] integration tests
- [x] end-to-end tests

#### Manual testing

No manual testing required.  
This PR is documentation-only and does not affect runtime behavior.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Notes

- Adds a dedicated Globals page to the API section
- Documents globals usage in preview, manager, and MDX contexts
- Uses `CodeSnippets` for all examples (no inline code blocks)
- Improves clarity and discoverability compared to existing docs

Thanks!
