### PR TITLE
Fix ArgTypes table types to allow summary/detail undefined

### DIFF
--- a/code/core/src/csf/story.ts
+++ b/code/core/src/csf/story.ts
@@ -126,13 +126,13 @@ export interface InputType {
     /** @see https://storybook.js.org/docs/api/arg-types#tablecategory */
     category?: string;
     /** @see https://storybook.js.org/docs/api/arg-types#tabledefaultvalue */
-    defaultValue?: { summary?: string; detail?: string };
+    defaultValue?: { summary?: string | undefined; detail?: string | undefined };
     /** @see https://storybook.js.org/docs/api/arg-types#tabledisable */
     disable?: boolean;
     /** @see https://storybook.js.org/docs/api/arg-types#tablesubcategory */
     subcategory?: string;
     /** @see https://storybook.js.org/docs/api/arg-types#tabletype */
-    type?: { summary?: string; detail?: string };
+    type?: { summary?: string | undefined; detail?: string | undefined };
   };
   /** @see https://storybook.js.org/docs/api/arg-types#type */
   type?: SBType | SBScalarType['name'];

--- a/code/core/src/docs-tools/argTypes/docgen/PropDef.ts
+++ b/code/core/src/docs-tools/argTypes/docgen/PropDef.ts
@@ -15,8 +15,8 @@ export interface JsDocTags {
 }
 
 export interface PropSummaryValue {
-  summary?: string;
-  detail?: string;
+  summary?: string | undefined;
+  detail?: string | undefined;
 }
 
 export type PropType = PropSummaryValue;

--- a/docs/api/arg-types.mdx
+++ b/docs/api/arg-types.mdx
@@ -75,7 +75,7 @@ Type:
       defaultValue?: { summary: string; detail?: string };
       disable?: boolean;
       subcategory?: string;
-      type?: { summary?: string; detail?: string };
+      type?: { summary?: string | undefined; detail?: string | undefined};
     },
     type?: SBType | SBScalarType['name'];
   }


### PR DESCRIPTION
Fixes typing so table.type.summary / detail can be set to undefined (helps with exactOptionalPropertyTypes).

Closes #27129