### PR TITLE
Manifests: Support `!manifest` tag in preview files

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -92,6 +92,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                 ],
@@ -141,6 +142,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "F",
@@ -156,6 +158,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "F",
@@ -189,6 +192,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "stories",
@@ -204,6 +208,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "stories",
@@ -239,6 +244,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "componentPath/extension",
                 "type": "story",
@@ -253,6 +259,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "componentPath/noExtension",
                 "type": "story",
@@ -267,6 +274,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "componentPath/package",
                 "type": "story",
@@ -281,6 +289,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                 ],
                 "title": "nested/Button",
@@ -296,6 +305,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "second-nested/G",
                 "type": "story",
@@ -330,6 +340,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                 ],
@@ -344,6 +355,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -359,6 +371,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -374,6 +387,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "componentPath/extension",
                 "type": "story",
@@ -388,6 +402,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "componentPath/noExtension",
                 "type": "story",
@@ -402,6 +417,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "componentPath/package",
                 "type": "story",
@@ -414,6 +430,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "D",
@@ -429,6 +446,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "D",
@@ -444,6 +462,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "foobar",
                 ],
                 "title": "Example/Button",
@@ -459,6 +478,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "first-nested/deeply/F",
                 "type": "story",
@@ -473,6 +493,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "first-nested/deeply/Features",
                 "type": "story",
@@ -487,6 +508,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "play-fn",
                 ],
                 "title": "first-nested/deeply/Features",
@@ -502,6 +524,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "first-nested/deeply/Features",
                 "type": "story",
@@ -516,6 +539,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "first-nested/deeply/Features",
                 "type": "story",
@@ -530,6 +554,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "play-fn",
                 ],
                 "title": "first-nested/deeply/Features",
@@ -543,6 +568,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "H",
@@ -558,6 +584,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "H",
@@ -573,6 +600,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                 ],
                 "title": "nested/Button",
@@ -588,6 +616,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "second-nested/G",
                 "type": "story",
@@ -642,6 +671,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                 ],
@@ -656,6 +686,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -671,6 +702,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -686,6 +718,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "componentPath/extension",
                 "type": "story",
@@ -700,6 +733,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "componentPath/noExtension",
                 "type": "story",
@@ -714,6 +748,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "componentPath/package",
                 "type": "story",
@@ -726,6 +761,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "D",
@@ -741,6 +777,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "D",
@@ -756,6 +793,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "foobar",
                 ],
                 "title": "Example/Button",
@@ -771,6 +809,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "first-nested/deeply/F",
                 "type": "story",
@@ -785,6 +824,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "first-nested/deeply/Features",
                 "type": "story",
@@ -799,6 +839,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "play-fn",
                 ],
                 "title": "first-nested/deeply/Features",
@@ -814,6 +855,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "first-nested/deeply/Features",
                 "type": "story",
@@ -828,6 +870,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "first-nested/deeply/Features",
                 "type": "story",
@@ -842,6 +885,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "play-fn",
                 ],
                 "title": "first-nested/deeply/Features",
@@ -855,6 +899,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "H",
@@ -870,6 +915,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "H",
@@ -885,6 +931,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                 ],
                 "title": "nested/Button",
@@ -900,6 +947,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "second-nested/G",
                 "type": "story",
@@ -1090,6 +1138,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -1105,6 +1154,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                   "attached-mdx",
                 ],
@@ -1121,6 +1171,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -1157,6 +1208,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -1172,6 +1224,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                   "attached-mdx",
                 ],
@@ -1188,6 +1241,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -1230,6 +1284,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                   "attached-mdx",
@@ -1247,6 +1302,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                 ],
@@ -1342,6 +1398,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "duplicate/A",
@@ -1357,6 +1414,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "duplicate/A",
@@ -1372,6 +1430,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "duplicate/A",
@@ -1423,6 +1482,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "A",
@@ -1438,6 +1498,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "A",
@@ -1469,6 +1530,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                   "attached-mdx",
@@ -1486,6 +1548,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                   "attached-mdx",
@@ -1503,6 +1566,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                 ],
@@ -1517,6 +1581,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "unattached-mdx",
                 ],
                 "title": "ComponentReference",
@@ -1530,6 +1595,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "unattached-mdx",
                 ],
                 "title": "docs2/Yabbadabbadooo",
@@ -1543,6 +1609,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "unattached-mdx",
                 ],
                 "title": "NoTitle",
@@ -1556,6 +1623,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "foo",
                   "bar",
                   "unattached-mdx",
@@ -1622,6 +1690,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                   "attached-mdx",
@@ -1639,6 +1708,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                   "attached-mdx",
@@ -1656,6 +1726,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                 ],
@@ -1670,6 +1741,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "unattached-mdx",
                 ],
                 "title": "ComponentReference",
@@ -1683,6 +1755,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "unattached-mdx",
                 ],
                 "title": "docs2/Yabbadabbadooo",
@@ -1696,6 +1769,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "unattached-mdx",
                 ],
                 "title": "NoTitle",
@@ -1709,6 +1783,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "foo",
                   "bar",
                   "unattached-mdx",
@@ -1746,6 +1821,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "component-tag",
                   "story-tag",
                 ],
@@ -1760,6 +1836,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -1775,6 +1852,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                 ],
                 "title": "B",
@@ -1791,6 +1869,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "autodocs",
                   "attached-mdx",
                 ],
@@ -1831,6 +1910,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                   "attached-mdx",
                 ],
                 "title": "B",
@@ -1846,6 +1926,7 @@ describe('StoryIndexGenerator', () => {
                 "tags": [
                   "dev",
                   "test",
+                  "manifest",
                 ],
                 "title": "B",
                 "type": "story",

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -875,7 +875,7 @@ export class StoryIndexGenerator {
 
   getProjectTags(previewCode?: string) {
     let projectTags = [] as Tag[];
-    const defaultTags = ['dev', 'test'];
+    const defaultTags = ['dev', 'test', 'manifest'];
     if (previewCode) {
       try {
         const projectAnnotations = loadConfig(previewCode).parse();

--- a/code/core/src/core-server/utils/index-json.test.ts
+++ b/code/core/src/core-server/utils/index-json.test.ts
@@ -123,6 +123,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "component-tag",
                 "story-tag",
                 "attached-mdx",
@@ -140,6 +141,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "component-tag",
                 "story-tag",
                 "attached-mdx",
@@ -156,6 +158,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "component-tag",
                 "story-tag",
               ],
@@ -170,6 +173,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "autodocs",
               ],
               "title": "B",
@@ -184,6 +188,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "autodocs",
               ],
               "title": "B",
@@ -199,6 +204,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
               ],
               "title": "componentPath/extension",
               "type": "story",
@@ -213,6 +219,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
               ],
               "title": "componentPath/noExtension",
               "type": "story",
@@ -227,6 +234,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
               ],
               "title": "componentPath/package",
               "type": "story",
@@ -239,6 +247,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "autodocs",
               ],
               "title": "D",
@@ -253,6 +262,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "autodocs",
               ],
               "title": "D",
@@ -266,6 +276,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "unattached-mdx",
               ],
               "title": "docs2/ComponentReference",
@@ -279,6 +290,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "unattached-mdx",
               ],
               "title": "docs2/NoTitle",
@@ -292,6 +304,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "foo",
                 "bar",
                 "unattached-mdx",
@@ -307,6 +320,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "unattached-mdx",
               ],
               "title": "docs2/Yabbadabbadooo",
@@ -321,6 +335,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "foobar",
               ],
               "title": "Example/Button",
@@ -335,6 +350,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
               ],
               "title": "first-nested/deeply/F",
               "type": "story",
@@ -348,6 +364,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
               ],
               "title": "first-nested/deeply/Features",
               "type": "story",
@@ -361,6 +378,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "play-fn",
               ],
               "title": "first-nested/deeply/Features",
@@ -375,6 +393,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
               ],
               "title": "first-nested/deeply/Features",
               "type": "story",
@@ -388,6 +407,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
               ],
               "title": "first-nested/deeply/Features",
               "type": "story",
@@ -401,6 +421,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "play-fn",
               ],
               "title": "first-nested/deeply/Features",
@@ -414,6 +435,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "autodocs",
               ],
               "title": "H",
@@ -428,6 +450,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "autodocs",
               ],
               "title": "H",
@@ -442,6 +465,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
                 "component-tag",
               ],
               "title": "nested/Button",
@@ -456,6 +480,7 @@ describe('registerIndexJsonRoute', () => {
               "tags": [
                 "dev",
                 "test",
+                "manifest",
               ],
               "title": "second-nested/G",
               "type": "story",

--- a/code/core/src/core-server/utils/manifests/manifests.ts
+++ b/code/core/src/core-server/utils/manifests/manifests.ts
@@ -17,9 +17,11 @@ async function getManifests(presets: Presets) {
     (entry) => entry.tags?.includes('manifest') ?? false
   );
 
-  return await presets.apply<Manifests>('experimental_manifests', undefined, {
-    manifestEntries,
-  });
+  return (
+    (await presets.apply<Manifests>('experimental_manifests', undefined, {
+      manifestEntries,
+    })) ?? {}
+  );
 }
 
 export async function writeManifests(outputDir: string, presets: Presets) {

--- a/code/renderers/react/src/componentManifest/fixtures.ts
+++ b/code/renderers/react/src/componentManifest/fixtures.ts
@@ -8,6 +8,7 @@ export const fsMocks = {
         import { Button } from './Button';
         
         const meta = {
+          title: 'Example/Button',
           component: Button,
           args: { onClick: fn() },
         } satisfies Meta<typeof Button>;
@@ -62,6 +63,7 @@ export const fsMocks = {
           * @summary Component summary
           */
         const meta = {
+          title: 'Example/Header',
           component: Header,
           args: {
             onLogin: fn(),
@@ -118,7 +120,7 @@ export const indexJson = {
       title: 'Example/Button',
       importPath: './src/stories/Button.stories.ts',
       componentPath: './src/stories/Button.tsx',
-      tags: ['dev', 'test', 'vitest', 'autodocs'],
+      tags: ['dev', 'test', 'vitest', 'autodocs', 'manifest'],
       exportName: 'Primary',
     },
     'example-button--secondary': {
@@ -129,7 +131,7 @@ export const indexJson = {
       title: 'Example/Button',
       importPath: './src/stories/Button.stories.ts',
       componentPath: './src/stories/Button.tsx',
-      tags: ['dev', 'test', 'vitest', 'autodocs'],
+      tags: ['dev', 'test', 'vitest', 'autodocs', 'manifest'],
       exportName: 'Secondary',
     },
     'example-button--large': {
@@ -140,7 +142,7 @@ export const indexJson = {
       title: 'Example/Button',
       importPath: './src/stories/Button.stories.ts',
       componentPath: './src/stories/Button.tsx',
-      tags: ['dev', 'test', 'vitest', 'autodocs'],
+      tags: ['dev', 'test', 'vitest', 'autodocs', 'manifest'],
       exportName: 'Large',
     },
     'example-button--small': {
@@ -151,7 +153,7 @@ export const indexJson = {
       title: 'Example/Button',
       importPath: './src/stories/Button.stories.ts',
       componentPath: './src/stories/Button.tsx',
-      tags: ['dev', 'test', 'vitest', 'autodocs'],
+      tags: ['dev', 'test', 'vitest', 'autodocs', 'manifest'],
       exportName: 'Small',
     },
     'example-header--docs': {
@@ -171,7 +173,7 @@ export const indexJson = {
       title: 'Example/Header',
       importPath: './src/stories/Header.stories.ts',
       componentPath: './src/stories/Header.tsx',
-      tags: ['dev', 'test', 'vitest', 'autodocs'],
+      tags: ['dev', 'test', 'vitest', 'autodocs', 'manifest'],
       exportName: 'LoggedIn',
     },
     'example-header--logged-out': {
@@ -182,7 +184,7 @@ export const indexJson = {
       title: 'Example/Header',
       importPath: './src/stories/Header.stories.ts',
       componentPath: './src/stories/Header.tsx',
-      tags: ['dev', 'test', 'vitest', 'autodocs'],
+      tags: ['dev', 'test', 'vitest', 'autodocs', 'manifest'],
       exportName: 'LoggedOut',
     },
   },

--- a/code/renderers/react/src/componentManifest/generator.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.test.ts
@@ -12,7 +12,10 @@ beforeEach(() => {
 });
 
 test('manifests generates correct id, name, description and examples ', async () => {
-  const result = await manifests(undefined, { index: indexJson } as any);
+  const manifestEntries = Object.values(indexJson.entries).filter(
+    (entry) => entry.tags?.includes('manifest') ?? false
+  );
+  const result = await manifests(undefined, { manifestEntries } as any);
 
   expect(result?.components).toMatchInlineSnapshot(`
   {
@@ -260,24 +263,21 @@ async function getManifestForStory(code: string) {
     '/app'
   );
 
-  const indexJson = {
-    v: 5,
-    entries: {
-      'example-button--primary': {
-        type: 'story',
-        subtype: 'story',
-        id: 'example-button--primary',
-        name: 'Primary',
-        title: 'Example/Button',
-        importPath: './src/stories/Button.stories.ts',
-        componentPath: './src/stories/Button.tsx',
-        tags: ['dev', 'test', 'vitest', 'autodocs'],
-        exportName: 'Primary',
-      },
+  const manifestEntries = [
+    {
+      type: 'story',
+      subtype: 'story',
+      id: 'example-button--primary',
+      name: 'Primary',
+      title: 'Example/Button',
+      importPath: './src/stories/Button.stories.ts',
+      componentPath: './src/stories/Button.tsx',
+      tags: ['dev', 'test', 'vitest', 'autodocs', 'manifest'],
+      exportName: 'Primary',
     },
-  };
+  ];
 
-  const result = await manifests(undefined, { index: indexJson } as any);
+  const result = await manifests(undefined, { manifestEntries } as any);
 
   return result?.components?.components?.['example-button'];
 }
@@ -288,6 +288,7 @@ function withCSF3(body: string) {
     import { Button } from './Button';
 
     const meta = {
+      title: 'Example/Button',
       component: Button,
       args: { onClick: fn() },
     } satisfies Meta<typeof Button>;
@@ -303,7 +304,9 @@ test('fall back to index title when no component name', async () => {
     import { Button } from './Button';
 
     export default {
+      title: 'Example/Button',
       args: { onClick: fn() },
+      tags: ['manifest'],
     };
     
     export const Primary = () => <Button csf1="story" />;
@@ -313,7 +316,7 @@ test('fall back to index title when no component name', async () => {
       "description": "Primary UI component for user interaction",
       "error": undefined,
       "id": "example-button",
-      "import": "import { Button } from \"some-package\";",
+      "import": "import { Button } from "some-package";",
       "jsDocTags": {},
       "name": "Button",
       "path": "./src/stories/Button.stories.ts",
@@ -389,9 +392,9 @@ test('component exported from other file', async () => {
         {
           "error": {
             "message": "Expected story to be a function or variable declaration
-       8 | export default meta;
-       9 |
-    > 10 | export { Primary } from './other-file';
+       9 | export default meta;
+      10 |
+    > 11 | export { Primary } from './other-file';
          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
             "name": "SyntaxError",
           },
@@ -441,9 +444,9 @@ test('unknown expressions', async () => {
         {
           "error": {
             "message": "Expected story to be csf factory, function or an object expression
-       8 | export default meta;
-       9 |
-    > 10 | export const Primary = someWeirdExpression;
+       9 | export default meta;
+      10 |
+    > 11 | export const Primary = someWeirdExpression;
          |                        ^^^^^^^^^^^^^^^^^^^",
             "name": "SyntaxError",
           },

--- a/code/renderers/react/src/componentManifest/generator.ts
+++ b/code/renderers/react/src/componentManifest/generator.ts
@@ -54,10 +54,11 @@ function extractStories(
   componentName: string | undefined,
   manifestEntries: IndexEntry[]
 ) {
+  const manifestEntryIds = new Set(manifestEntries.map((entry) => entry.id));
   return Object.entries(csf._stories)
     .filter(([, story]) =>
       // Only include stories that are in the list of entries already filtered for the 'manifest' tag
-      manifestEntries.some((entry) => entry.id === story.id)
+      manifestEntryIds.has(story.id)
     )
     .map(([storyName]) => {
       try {

--- a/code/renderers/react/src/componentManifest/generator.ts
+++ b/code/renderers/react/src/componentManifest/generator.ts
@@ -1,11 +1,10 @@
 import { recast } from 'storybook/internal/babel';
-import { combineTags } from 'storybook/internal/csf';
 import { extractDescription, loadCsf } from 'storybook/internal/csf-tools';
 import { logger } from 'storybook/internal/node-logger';
+import type { IndexEntry } from 'storybook/internal/types';
 import {
   type ComponentManifest,
   type PresetPropertyFn,
-  type StoryIndex,
   type StorybookConfigRaw,
 } from 'storybook/internal/types';
 
@@ -52,17 +51,15 @@ function getPackageInfo(componentPath: string | undefined, fallbackPath: string)
 
 function extractStories(
   csf: ReturnType<ReturnType<typeof loadCsf>['parse']>,
-  componentName: string | undefined
+  componentName: string | undefined,
+  manifestEntries: IndexEntry[]
 ) {
-  return Object.keys(csf._stories)
-    .filter((storyName) =>
-      combineTags(
-        'manifest',
-        ...(csf.meta.tags ?? []),
-        ...(csf._stories[storyName].tags ?? [])
-      ).includes('manifest')
+  return Object.entries(csf._stories)
+    .filter(([, story]) =>
+      // Only include stories that are in the list of entries already filtered for the 'manifest' tag
+      manifestEntries.some((entry) => entry.id === story.id)
     )
-    .map((storyName) => {
+    .map(([storyName]) => {
       try {
         const jsdocComment = extractDescription(csf._storyStatements[storyName]);
         const { tags = {}, description } = jsdocComment ? extractJSDocInfo(jsdocComment) : {};
@@ -100,16 +97,14 @@ function extractComponentDescription(
 export const manifests: PresetPropertyFn<
   'experimental_manifests',
   StorybookConfigRaw,
-  { index: StoryIndex }
-> = async (existingManifests = {}, { index }) => {
+  { manifestEntries: IndexEntry[] }
+> = async (existingManifests = {}, { manifestEntries }) => {
   invalidateCache();
 
   const startPerformance = performance.now();
 
   const entriesByUniqueComponent = uniqBy(
-    Object.values(index.entries).filter(
-      (entry) => entry.type === 'story' && entry.subtype === 'story'
-    ),
+    manifestEntries.filter((entry) => entry.type === 'story' && entry.subtype === 'story'),
     (entry) => entry.id.split('--')[0]
   );
 
@@ -118,14 +113,6 @@ export const manifests: PresetPropertyFn<
       const absoluteImportPath = path.join(process.cwd(), entry.importPath);
       const storyFile = cachedReadFileSync(absoluteImportPath, 'utf-8') as string;
       const csf = loadCsf(storyFile, { makeTitle: (title) => title ?? 'No title' }).parse();
-
-      const hasManifestTag = csf.stories
-        .map((it) => combineTags('manifest', ...(csf.meta.tags ?? []), ...(it.tags ?? [])))
-        .some((it) => it.includes('manifest'));
-
-      if (!hasManifestTag) {
-        return;
-      }
 
       const componentName = csf._meta?.component;
       const id = entry.id.split('--')[0];
@@ -144,7 +131,7 @@ export const manifests: PresetPropertyFn<
       const imports =
         getImports({ components: allComponents, packageName }).join('\n').trim() || fallbackImport;
 
-      const stories = extractStories(csf, component?.componentName);
+      const stories = extractStories(csf, component?.componentName, manifestEntries);
 
       const base = {
         id,


### PR DESCRIPTION
Originally proposed by @cdedreuille 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Refactored the way the manifest logic filters entries by the `manifest` tag, so that now the `manifest` tag actually exists in the index instead of being synthetically applied during manifest creation. This enables support for users disabling manifests globally with the `!manifest` tag in a preview file, and then selectively _opting-in_ stories/docs afterwards, instead of the default worklfow of _opting-out_ stories/docs.

It also includes a small change to the API of the `experimental_manifests` preset. It no longer takes in the raw index as input, but instead a pre-filtered list of entries, as I assume all manifest generators will want to filter by the `manifest` tag anyway.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default "manifest" tag to project/story tags to mark entries for manifest processing.

* **Refactor**
  * Centralized manifest retrieval so all manifest endpoints use a single source of truth, reducing duplication.

* **Tests**
  * Updated and added tests and snapshots to cover manifest-tagged entries and manifest filtering behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->