### PR TITLE
Vitest: Fallback detecting vitest version in postinstall

### DIFF
--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -50,7 +50,14 @@ export default async function postInstall(options: PostinstallOptions) {
       { last: getProjectRoot(), cwd: options.configDir }
     );
 
-  const vitestVersionSpecifier = await packageManager.getInstalledVersion('vitest');
+  const allDeps = packageManager.getAllDependencies();
+
+  // Determine Vitest version/range from installed or declared dependency to avoid pulling
+  // incompatible majors by default.
+  let vitestVersionSpecifier = await packageManager.getInstalledVersion('vitest');
+  if (!vitestVersionSpecifier && allDeps['vitest']) {
+    vitestVersionSpecifier = allDeps['vitest'];
+  }
   logger.debug(`Vitest version specifier: ${vitestVersionSpecifier}`);
   const isVitest3_2To4 = vitestVersionSpecifier
     ? satisfies(vitestVersionSpecifier, '>=3.2.0 <4.0.0')
@@ -60,7 +67,6 @@ export default async function postInstall(options: PostinstallOptions) {
     : true;
 
   const info = await getStorybookInfo(options.configDir);
-  const allDeps = packageManager.getAllDependencies();
   // only install these dependencies if they are not already installed
 
   const addonVitestService = new AddonVitestService(packageManager);

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -24,7 +24,7 @@ import { SupportedFramework } from 'storybook/internal/types';
 
 import * as find from 'empathic/find';
 import { dirname, relative, resolve } from 'pathe';
-import { satisfies } from 'semver';
+import { coerce, satisfies } from 'semver';
 import { dedent } from 'ts-dedent';
 
 import { type PostinstallOptions } from '../../../lib/cli-storybook/src/add';
@@ -58,10 +58,20 @@ export default async function postInstall(options: PostinstallOptions) {
   if (!vitestVersionSpecifier && allDeps['vitest']) {
     vitestVersionSpecifier = allDeps['vitest'];
   }
+
+  /**
+   * Coerce the version specifier to a version string
+   *
+   * This removed any version range specifiers like ^, ~, etc. which is needed to check with
+   * semver.satisfies.
+   */
+  vitestVersionSpecifier = coerce(vitestVersionSpecifier)?.version ?? null;
+
   logger.debug(`Vitest version specifier: ${vitestVersionSpecifier}`);
   const isVitest3_2To4 = vitestVersionSpecifier
     ? satisfies(vitestVersionSpecifier, '>=3.2.0 <4.0.0')
     : false;
+
   const isVitest4OrNewer = vitestVersionSpecifier
     ? satisfies(vitestVersionSpecifier, '>=4.0.0')
     : true;

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -631,6 +631,7 @@ export abstract class JsPackageManager {
       logger.debug(`Getting installed version for ${packageName}...`);
       const installations = await this.findInstallations([packageName]);
       if (!installations) {
+        logger.debug(`No installations found for ${packageName}`);
         // Cache the null result
         JsPackageManager.installedVersionCache.set(cacheKey, null);
         return null;
@@ -646,6 +647,7 @@ export abstract class JsPackageManager {
 
       return coercedVersion;
     } catch (e) {
+      logger.error(`Error getting installed version for ${packageName}: ${String(e)}`);
       JsPackageManager.installedVersionCache.set(cacheKey, null);
       return null;
     }

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -144,7 +144,7 @@ export class NPMProxy extends JsPackageManager {
       const parsedOutput = JSON.parse(commandResult);
 
       return this.mapDependencies(parsedOutput, pattern);
-    } catch (e) {
+    } catch {
       // when --depth is higher than 0, npm can return a non-zero exit code
       // in case the user's project has peer dependency issues. So we try again with no depth
       try {
@@ -153,10 +153,8 @@ export class NPMProxy extends JsPackageManager {
         const parsedOutput = JSON.parse(commandResult);
 
         return this.mapDependencies(parsedOutput, pattern);
-      } catch (err) {
-        logger.debug(
-          `An issue occurred while trying to find dependencies metadata using npm: ${err}`
-        );
+      } catch (e) {
+        logger.debug(`Error finding installations for ${pattern.join(', ')}: ${String(e)}`);
         return undefined;
       }
     }

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import process from 'node:process';
 
-import { prompt } from 'storybook/internal/node-logger';
+import { logger, prompt } from 'storybook/internal/node-logger';
 import { FindPackageVersionsError } from 'storybook/internal/server-errors';
 
 import * as find from 'empathic/find';
@@ -115,6 +115,7 @@ export class Yarn1Proxy extends JsPackageManager {
       const process = executeCommand({
         command: 'yarn',
         args: yarnArgs.concat(pattern),
+        shell: true,
         env: {
           FORCE_COLOR: 'false',
         },
@@ -126,6 +127,7 @@ export class Yarn1Proxy extends JsPackageManager {
       const parsedOutput = JSON.parse(commandResult);
       return this.mapDependencies(parsedOutput, pattern);
     } catch (e) {
+      logger.debug(`Error finding installations for ${pattern.join(', ')}: ${String(e)}`);
       return undefined;
     }
   }

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.ts
@@ -145,6 +145,7 @@ export class Yarn2Proxy extends JsPackageManager {
 
       return this.mapDependencies(commandResult, pattern);
     } catch (e) {
+      logger.debug(`Error finding installations for ${pattern.join(', ')}: ${String(e)}`);
       return undefined;
     }
   }


### PR DESCRIPTION
Closes #33410

## What I did

I copied the fallback mechanism found in `AddonVitestService` to the postinstall. Though this is no longer really needed due to the second fix in this PR:

I have figured out why the `packageManager.getInstalledVersion('vitest')` is failing:

When this command is executed:
```sh
pnpm list "vitest" --json --depth=99
```
`pnpm` exits with code=1, with this error:
```
"code": "EINVALIDTAGNAME",
"message": "Invalid tag name \"\"vitest\"\": Tags may not have any characters that encodeURIComponent encodes."
```

Running the command with `shell:true` resolves the problem.

It seemed both `pnpm` and `yarn1` `PackageManager`-instances were affected by this.

I've added additional debug logging to make the errors easier to find in the future.

Another discovery was that the config-file getting edited/generated for addon-vitest can get out of sync with the version getting add/installed due to a missing `semver.coerce`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I've tested a canary with just the fallback addition.

Then I switched to running the bin directly off a development branch, as suggested by the issue.
Adding debug logging until I was able to figure out why the installed version was not correctly detected.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33415-sha-8542def9`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33415-sha-8542def9 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33415-sha-8542def9 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33415-sha-8542def9`](https://npmjs.com/package/storybook/v/0.0.0-pr-33415-sha-8542def9) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/vitest-version-detection-fallback`](https://github.com/storybookjs/storybook/tree/norbert/vitest-version-detection-fallback) |
| **Commit** | [`8542def9`](https://github.com/storybookjs/storybook/commit/8542def9bc4626d7289dd514d5bd2818ebb02c80) |
| **Datetime** | Tue Dec 23 10:58:13 UTC 2025 (`1766487493`) |
| **Workflow run** | [20458859104](https://github.com/storybookjs/storybook/actions/runs/20458859104) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33415`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
