### PR TITLE
Build: Apply vite base config to manager build output

### DIFF
--- a/code/core/assets/server/template.ejs
+++ b/code/core/assets/server/template.ejs
@@ -7,9 +7,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <% if (favicon.endsWith('.svg')) {%>
-    <link rel="icon" type="image/svg+xml" href="./<%= favicon %>" />
+    <link rel="icon" type="image/svg+xml" href="<%= base %><%= favicon %>" />
     <% } else if (favicon.endsWith('.ico')) { %>
-    <link rel="icon" type="image/x-icon" href="./<%= favicon %>" />
+    <link rel="icon" type="image/x-icon" href="<%= base %><%= favicon %>" />
     <% } %>
     <style>
       @font-face {
@@ -17,7 +17,7 @@
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url('./sb-common-assets/nunito-sans-regular.woff2') format('woff2');
+        src: url('<%= base %>sb-common-assets/nunito-sans-regular.woff2') format('woff2');
       }
 
       @font-face {
@@ -25,7 +25,7 @@
         font-style: italic;
         font-weight: 400;
         font-display: swap;
-        src: url('./sb-common-assets/nunito-sans-italic.woff2') format('woff2');
+        src: url('<%= base %>sb-common-assets/nunito-sans-italic.woff2') format('woff2');
       }
 
       @font-face {
@@ -33,7 +33,7 @@
         font-style: normal;
         font-weight: 700;
         font-display: swap;
-        src: url('./sb-common-assets/nunito-sans-bold.woff2') format('woff2');
+        src: url('<%= base %>sb-common-assets/nunito-sans-bold.woff2') format('woff2');
       }
 
       @font-face {
@@ -41,11 +41,11 @@
         font-style: italic;
         font-weight: 700;
         font-display: swap;
-        src: url('./sb-common-assets/nunito-sans-bold-italic.woff2') format('woff2');
+        src: url('<%= base %>sb-common-assets/nunito-sans-bold-italic.woff2') format('woff2');
       }
     </style>
 
-    <link href="./sb-manager/runtime.js" rel="modulepreload" />
+    <link href="<%= base %>sb-manager/runtime.js" rel="modulepreload" />
 
     <% files.js.forEach(file => { %>
     <link href="<%= file %>" rel="modulepreload" />
@@ -75,13 +75,13 @@
     <% } %>
 
     <script type="module">
-      import './sb-manager/globals-runtime.js';
+      import '<%= base %>sb-manager/globals-runtime.js';
 
       <% files.js.forEach(file => { %>
         import '<%= file %>';
       <% }); %>
 
-      import './sb-manager/runtime.js';
+      import '<%= base %>sb-manager/runtime.js';
     </script>
   </body>
 </html>

--- a/code/core/src/builder-manager/index.ts
+++ b/code/core/src/builder-manager/index.ts
@@ -154,6 +154,7 @@ const starter: StarterFunction = async function* starterGeneratorFn({
     logLevel,
     docsOptions,
     tagsOptions,
+    base,
   } = await getData(options);
 
   yield;
@@ -188,7 +189,7 @@ const starter: StarterFunction = async function* starterGeneratorFn({
     })
   );
 
-  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation?.outputFiles);
+  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation?.outputFiles, base);
 
   if (compilation.metafile && options.outputDir) {
     await writeFile(
@@ -215,7 +216,8 @@ const starter: StarterFunction = async function* starterGeneratorFn({
     docsOptions,
     tagsOptions,
     options,
-    globals
+    globals,
+    base
   );
 
   yield;
@@ -269,6 +271,7 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
     logLevel,
     docsOptions,
     tagsOptions,
+    base,
   } = await getData(options);
   yield;
 
@@ -293,7 +296,7 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
     },
     recursive: true,
   });
-  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation?.outputFiles);
+  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation?.outputFiles, base);
 
   // Build additional global values
   const globals: Record<string, any> = await buildFrameworkGlobalsFromOptions(options);
@@ -313,7 +316,8 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
     docsOptions,
     tagsOptions,
     options,
-    globals
+    globals,
+    base
   );
 
   await Promise.all([writeFile(join(options.outputDir, 'index.html'), html), managerFiles]);

--- a/code/core/src/builder-manager/utils/data.ts
+++ b/code/core/src/builder-manager/utils/data.ts
@@ -6,6 +6,30 @@ import type { Options } from 'storybook/internal/types';
 import { executor, getConfig } from '../index';
 import { readTemplate } from './template';
 
+/**
+ * Extracts the base path from viteFinal configuration. Only returns a custom base if explicitly set
+ * and not default values. This ensures backward compatibility for users who don't set a base.
+ */
+async function getManagerBase(options: Options): Promise<string> {
+  try {
+    // Try to get the viteFinal configuration to extract the base
+    const viteConfig = (await options.presets.apply('viteFinal', {}, options)) as
+      | { base?: string }
+      | undefined;
+    const viteBase = viteConfig?.base;
+
+    // Only use custom base if it's explicitly set and not a default value
+    if (viteBase && viteBase !== '/' && viteBase !== './') {
+      // Ensure base ends with a trailing slash for proper path concatenation
+      return viteBase.endsWith('/') ? viteBase : `${viteBase}/`;
+    }
+  } catch {
+    // viteFinal may not be available (e.g., webpack builder), fall back to default
+  }
+
+  return './';
+}
+
 export const getData = async (options: Options) => {
   const refs = getRefs(options);
   const favicon = options.presets.apply<string>('favicon').then((p) => basename(p));
@@ -19,10 +43,11 @@ export const getData = async (options: Options) => {
   const customHead = options.presets.apply<string>('managerHead');
 
   // we await these, because crucially if these fail, we want to bail out asap
-  const [instance, config] = await Promise.all([
+  const [instance, config, base] = await Promise.all([
     //
     executor.get(),
     getConfig(options),
+    getManagerBase(options),
   ]);
 
   return {
@@ -37,5 +62,6 @@ export const getData = async (options: Options) => {
     logLevel,
     favicon,
     tagsOptions,
+    base,
   };
 };

--- a/code/core/src/builder-manager/utils/files.ts
+++ b/code/core/src/builder-manager/utils/files.ts
@@ -10,12 +10,13 @@ import type { Compilation } from '../types';
 
 export async function readOrderedFiles(
   addonsDir: string,
-  outputFiles: Compilation['outputFiles'] | undefined
+  outputFiles: Compilation['outputFiles'] | undefined,
+  base: string = './'
 ) {
   const files = await Promise.all(
     outputFiles?.map(async (file) => {
       // convert deeply nested paths to a single level, also remove special characters
-      const { location, url } = sanitizePath(file, addonsDir);
+      const { location, url } = sanitizePath(file, addonsDir, base);
 
       if (!existsSync(location)) {
         const directory = dirname(location);
@@ -31,10 +32,10 @@ export async function readOrderedFiles(
   return { cssFiles, jsFiles };
 }
 
-export function sanitizePath(file: OutputFile, addonsDir: string) {
+export function sanitizePath(file: OutputFile, addonsDir: string, base: string = './') {
   const filePath = relative(addonsDir, file.path);
   const location = normalize(join(addonsDir, filePath));
-  const url = `./sb-addons/${slash(filePath).split('/').map(encodeURIComponent).join('/')}`;
+  const url = `${base}sb-addons/${slash(filePath).split('/').map(encodeURIComponent).join('/')}`;
 
   return { location, url };
 }

--- a/code/core/src/builder-manager/utils/template.ts
+++ b/code/core/src/builder-manager/utils/template.ts
@@ -34,7 +34,8 @@ export const renderHTML = async (
   docsOptions: Promise<DocsOptions>,
   tagsOptions: Promise<TagsOptions>,
   { versionCheck, previewUrl, configType, ignorePreview }: Options,
-  globals: Record<string, any>
+  globals: Record<string, any>,
+  base: string = './'
 ) => {
   const titleRef = await title;
   const templateRef = await template;
@@ -47,6 +48,7 @@ export const renderHTML = async (
     title: titleRef ? `${titleRef} - Storybook` : 'Storybook',
     files: { js: jsFiles, css: cssFiles },
     favicon: await favicon,
+    base,
     globals: {
       FEATURES: JSON.stringify(await features, null, 2),
       REFS: JSON.stringify(await refs, null, 2),


### PR DESCRIPTION
Closes #30434

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did
apply the resolved vite base config to the manager builder and remove hardcoded relative paths

- extract base path from viteFinal configuration in getManagerBase
- update template.ejs to use dynamic base for assets, fonts, and scripts
- pass base parameter through builder-manager core logic and rendering
- adjust addon asset url generation to respect the base path
- update readOrderedFiles and sanitizePath to handle custom base

default to ./ when no custom base is configured
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing
Create a React Vite default TypeScript sandbox.
Copy the two configuration files from https://github.com/ia319/Storybook-PR-Preview-Sandbox/tree/main/Manager-Builder-ignoring-Vite-Base into `.storybook`.
### 1. Install & Build

```bash
yarn install
yarn build-storybook
```

### 2. Verify Output

Check if the generated `index.html` uses the configured base path (`/design-system/`).

```bash
grep -E "sb-manager|sb-addons" storybook-static/index.html | head -5
```

**Output should contain absolute paths:**
```html
<link href="/design-system/sb-manager/runtime.js" rel="modulepreload" />
<link  href="/design-system/sb-addons/..." rel="modulepreload" />
```
<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset path resolution to properly support configurable base paths throughout the application, ensuring all resources including favicons, fonts, and runtime modules load correctly in all deployment scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->