### PR TITLE
Docs: Mention Vite publicDir interference

### DIFF
--- a/docs/api/main-config/main-config-static-dirs.mdx
+++ b/docs/api/main-config/main-config-static-dirs.mdx
@@ -17,6 +17,10 @@ Sets a list of directories of [static files](../../configure/integration/images-
 
 {/* prettier-ignore-end */}
 
+<Callout variant="info">
+When using Vite-based frameworks, additional directories may be copied to your build directory because of Vite's own [static asset handling](https://vite.dev/guide/assets#the-public-directory). You can set Vite's `publicDir` option to `false` to disable this behavior.
+</Callout>
+
 ## With configuration objects
 
 You can also use a configuration object to define the directories:

--- a/docs/configure/integration/images-and-assets.mdx
+++ b/docs/configure/integration/images-and-assets.mdx
@@ -55,6 +55,10 @@ Or even use a configuration object to define the directories:
 
 {/* prettier-ignore-end */}
 
+<Callout variant="info">
+When using Vite-based frameworks, additional directories may be copied to your build directory because of Vite's own [static asset handling](https://vite.dev/guide/assets#the-public-directory). You can set Vite's `publicDir` option to `false` to disable this behavior.
+</Callout>
+
 ## Reference assets from a CDN
 
 Upload your files to an online CDN and reference them. In this example, we’re using a placeholder image service.


### PR DESCRIPTION
## What I did

Short term fix for #24627 until the issue can be addressed, as it could involve breaking changes.

## Checklist for Contributors

### Testing
N/A

#### Manual testing

N/A, docs. Visit http://localhost:3000/docs/api/main-config/main-config-static-dirs for outcome:

<img width="810" height="1026" alt="image" src="https://github.com/user-attachments/assets/88523dea-f92f-41e5-b50c-126d100dfde3" />



### Documentation

N/A

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how Vite-based frameworks may copy extra static directories into build output and added informational callouts explaining this behavior.
  * Explained how to disable the behavior by setting Vite's publicDir to false, and preserved existing configuration guidance for static assets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->