### PR TITLE
Core: Fix internal yarn build command

### DIFF
--- a/docs/contribute/code.mdx
+++ b/docs/contribute/code.mdx
@@ -102,6 +102,19 @@ Otherwise, if it affects the `Manager` (the outermost Storybook `iframe` where t
 
 ![Storybook manager preview](../_assets/addons/manager-preview.png)
 
+The `yarn build` commands accepts arguments to help speed up your development workflow:
+* `--all` will cause all packages to be built
+* `--watch` will enable watch mode (and skip the watch mode prompt)
+* `--prod` will build for production (and skip the production mode prompt)
+* individual package names can be passed, without the `@storybook/` prefix, e.g. `storybook`, `addon-docs`, etc.
+
+For example, to build Storybook and the docs addon in watch mode, run:
+
+```shell
+yarn build --watch storybook addon-docs
+```
+
+
 ## Check your work
 
 When you're done coding, add documentation and tests as appropriate. That simplifies the PR review process, which means your code will get merged faster.

--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -101,7 +101,7 @@ async function run() {
   }
 
   if (hasInvalidName) {
-    process.exit(0);
+    process.exit(1);
   }
 
   if (!selection.length) {

--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -11,8 +11,6 @@
  *
  * When you pass no package names, you will be prompted to select which packages to build.
  */
-// FIXME --all not working
-// FIXME --no-watch and --no-prod needed
 import { join } from 'node:path';
 
 import { exec } from 'child_process';

--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -5,12 +5,14 @@
  *
  * You can pass a list of package names to build, or use the `--all` flag to build all packages.
  *
- * You can also pass the `--watch` flag to build in watch mode.
+ * Pass the `--watch` flag to build in watch mode or `--no-watch` to skip the watch mode prompt.
  *
- * You can also pass the `--prod` flag to build in production mode.
+ * Pass the `--prod` flag to build in production mode or `--no-prod` to skip the production prompt.
  *
  * When you pass no package names, you will be prompted to select which packages to build.
  */
+// FIXME --all not working
+// FIXME --no-watch and --no-prod needed
 import { join } from 'node:path';
 
 import { exec } from 'child_process';
@@ -25,8 +27,20 @@ import { findMostMatchText } from './utils/diff';
 import { getCodeWorkspaces } from './utils/workspace';
 
 async function run() {
-  const packages = (await getCodeWorkspaces()).filter(({ name }) => name !== '@storybook/code');
-  const packageTasks = packages
+  const packages = (await getCodeWorkspaces())
+    .filter(({ name }) => name !== '@storybook/code')
+    .sort((a) => (a.name === 'storybook' ? -1 : 0)); // Place main package first in option list
+
+  const tasks: Record<
+    string,
+    {
+      name: string;
+      defaultValue: boolean;
+      suffix: string;
+      value?: unknown;
+      location?: string;
+    }
+  > = packages
     .map((pkg) => {
       let suffix = pkg.name.replace('@storybook/', '');
       if (pkg.name === '@storybook/cli') {
@@ -36,7 +50,6 @@ async function run() {
         ...pkg,
         suffix,
         defaultValue: false,
-        helpText: `build only the ${pkg.name} package`,
       };
     })
     .reduce(
@@ -44,86 +57,59 @@ async function run() {
         acc[next.name] = next;
         return acc;
       },
-      {} as Record<
-        string,
-        { name: string; defaultValue: boolean; suffix: string; helpText: string }
-      >
+      {} as Record<string, { name: string; defaultValue: boolean; suffix: string }>
     );
-
-  const tasks: Record<
-    string,
-    {
-      name: string;
-      defaultValue: boolean;
-      suffix: string;
-      helpText: string;
-      value?: any;
-      location?: string;
-    }
-  > = {
-    watch: {
-      name: `watch`,
-      defaultValue: false,
-      suffix: '--watch',
-      helpText: 'build on watch mode',
-    },
-    prod: {
-      name: `prod`,
-      defaultValue: false,
-      suffix: '--prod',
-      helpText: 'build on production mode',
-    },
-    ...packageTasks,
-  };
 
   const main = program
     .version('5.0.0')
-    .option('--all', `build everything ${picocolors.gray('(all)')}`);
+    .allowExcessArguments(true)
+    .option('--all', `build everything ${picocolors.gray('(all)')}`, false)
+    .option('--watch', `build in watch mode`)
+    .option('--prod', `build in production mode`)
+    .option('--no-watch', `do not build in watch mode`)
+    .option('--no-prod', `do not build in production mode`);
 
-  Object.keys(tasks)
-    .reduce((acc, key) => acc.option(tasks[key].suffix, tasks[key].helpText), main)
-    .parse(process.argv);
+  main.parse(process.argv);
+
+  const opts = main.opts();
+  let watchMode = opts.watch;
+  let prodMode = opts.prod;
 
   Object.keys(tasks).forEach((key) => {
-    const opts = program.opts();
-    // checks if a flag is passed e.g. yarn build --@storybook/addon-docs --watch
-    const containsFlag = program.args.includes(tasks[key].suffix);
+    // checks if a flag is passed e.g. yarn build addon-docs --watch
+    const containsFlag = main.args.includes(tasks[key].suffix);
     tasks[key].value = containsFlag || opts.all;
   });
 
-  let watchMode = process.argv.includes('--watch');
-  let prodMode = process.argv.includes('--prod');
-  let selection = Object.keys(tasks)
-    .map((key) => tasks[key])
-    .filter((item) => !['watch', 'prod'].includes(item.name) && item.value === true);
+  let selection = Object.values(tasks).filter((item) => item.value === true);
 
-  // user has passed invalid package name(s) - try to guess the correct package name(s)
-  if ((!selection.length && main.args.length >= 1) || selection.length !== main.args.length) {
-    const suffixList = Object.values(tasks)
-      .filter((t) => t.name.includes('@storybook'))
-      .map((t) => t.suffix);
+  // check for invalid package name(s) and try to guess the correct package name(s)
+  const suffixList = Object.values(tasks).map((t) => t.suffix);
+  let hasInvalidName = false;
 
-    for (const arg of main.args) {
-      if (!suffixList.includes(arg)) {
-        const matchText = findMostMatchText(suffixList, arg);
+  for (const arg of main.args) {
+    if (!suffixList.includes(arg)) {
+      const matchText = findMostMatchText(suffixList, arg);
 
-        if (matchText) {
-          console.log(
-            `${picocolors.red('Error')}: ${picocolors.cyan(
-              arg
-            )} is not a valid package name, Did you mean ${picocolors.cyan(matchText)}?`
-          );
-        }
+      if (matchText) {
+        hasInvalidName = true;
+        process.stderr.write(
+          `${picocolors.red('Error')}: ${picocolors.cyan(
+            arg
+          )} is not a valid package name, Did you mean ${picocolors.cyan(matchText)}?\n`
+        );
       }
     }
+  }
 
+  if (hasInvalidName) {
     process.exit(0);
   }
 
   if (!selection.length) {
     selection = await prompts(
       [
-        {
+        watchMode === undefined && {
           type: 'toggle',
           name: 'watch',
           message: 'Start in watch mode',
@@ -131,7 +117,7 @@ async function run() {
           active: 'yes',
           inactive: 'no',
         },
-        {
+        prodMode === undefined && {
           type: 'toggle',
           name: 'prod',
           message: 'Start in production mode',
@@ -144,7 +130,7 @@ async function run() {
           message: 'Select the packages to build',
           name: 'todo',
           min: 1,
-          hint: 'You can also run directly with package name like `yarn build core`, or `yarn build --all` for all packages!',
+          hint: 'You can also run directly with package name like `yarn build storybook`, or `yarn build --all` for all packages!',
           // @ts-expect-error @types incomplete
           optionsPerPage: windowSize.height - 3, // 3 lines for extra info
           choices: packages.map(({ name: key }) => ({
@@ -162,7 +148,7 @@ async function run() {
     });
   }
 
-  console.log('Building selected packages...');
+  process.stdout.write('Building selected packages...\n');
   let lastName = '';
 
   selection.forEach(async (v) => {


### PR DESCRIPTION
Closes #33432 


## What I did

* Fixed regression caused by an upgrade to the commander dependency (thanks @ia319 for diagnosing it)
* Repaired `yarn build --all` which incorrectly caused the script to exit
* Fixed bug when passing `--all storybook` which incorrectly assumed `storybook` is an invalid package name due to incorrect package name filtering
* Restored old package order with the main `storybook` package appearing first, as it's the most useful
* Made `--watch` and `--prod` flags skip relevant prompts when passed without package name
* Added `--no-watch` and `--no-prod` counterparts with the same effect
* Documented `yarn build` flags

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing
ø

#### Manual testing

Run commands:

* `yarn build`, you will get fully prompted (watch + prod + packages, `storybook appears first)
* `yarn build --all`, build will start
* `yarn build --all storybook`, build will start
* `yarn build --all addon-a11y`, build will start
* `yarn build storybook addon-a11y`, build will start with only 2 packages
* `yarn build --all --watch`, build will start in watch mode
* `yarn build --watch --no-prod`, you will be prompted only package names, and build will start in watch mode and development mode

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the yarn build command, covering --all, --watch, --prod (and examples for building specific packages).

* **Chores**
  * Improved the build CLI: clearer package selection ordering, explicit disable options, better validation and error messages, conditional prompts, and clearer build/output messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->