### PR TITLE
Core: Add try-catch for cross-origin access in Storybook hooks

### DIFF
--- a/code/core/template/stories/preview.ts
+++ b/code/core/template/stories/preview.ts
@@ -9,15 +9,30 @@ declare global {
   }
 }
 
-// This is used to test the hooks in our E2E tests (look for storybook-hooks.spec.ts)
-globalThis.parent.__STORYBOOK_BEFORE_ALL_CALLS__ = 0;
-globalThis.parent.__STORYBOOK_BEFORE_ALL_CLEANUP_CALLS__ = 0;
+try {
+  // This is used to test the hooks in our E2E tests (look for storybook-hooks.spec.ts)
+
+  /**
+   * Wrapped in a try-catch, because accessing properties on globalThis.parent may throw if the
+   * parent is cross-origin.
+   */
+  globalThis.parent.__STORYBOOK_BEFORE_ALL_CALLS__ = 0;
+  globalThis.parent.__STORYBOOK_BEFORE_ALL_CLEANUP_CALLS__ = 0;
+} catch {
+  // ignore
+}
 
 export const beforeAll = async () => {
-  globalThis.parent.__STORYBOOK_BEFORE_ALL_CALLS__ += 1;
-  return () => {
-    globalThis.parent.__STORYBOOK_BEFORE_ALL_CLEANUP_CALLS__ += 1;
-  };
+  let cleanup: () => void = () => {};
+  try {
+    globalThis.parent.__STORYBOOK_BEFORE_ALL_CALLS__ += 1;
+    cleanup = () => {
+      globalThis.parent.__STORYBOOK_BEFORE_ALL_CLEANUP_CALLS__ += 1;
+    };
+  } catch {
+    // ignore
+  }
+  return cleanup;
 };
 
 export const parameters = {


### PR DESCRIPTION
## What I did

I noticed chromatic canvas failing due to a parent.[property] access being denied, due to cross origin.

I suspect this is the culpit of the error, so I'm wrapping the code with a try-catch for now.

I do wonder why this is production code, since the comments imply it's only there for internal e2e testing purposes.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I'll manually check the UI review canvas in chromatic.

This was where I found the error before:
https://www.chromatic.com/component?appId=635781f3500dd2c49e189caf&csfId=manager-sidebar-treenode&specName=Types&buildNumber=24086&k=69499185f7f68d66d9516994-1200px-interactive-true&h=3&b=-1

After this change I can see the canvas corectly, see here:
https://www.chromatic.com/component?appId=635781f3500dd2c49e189caf&csfId=manager-sidebar-treenode&specName=Types&buildNumber=24180&k=69499185f7f68d66d9516994-1200px-interactive-true&h=8&b=-2

So that should no longer happen after this change.

I think we should patch this back, it may also be affecting storybook composition?

If I understand the comment correctly, this code only exists for internal e2e testing purposes.
I suggest we try to find another way to test the behavior without introducing globalThis.parent hooks in the preview runtime code.

<!-- CANARY_RELEASE_SECTION -->
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
