### PR TITLE
UI: Add accessibility statement page

### DIFF
--- a/code/core/src/manager/App.tsx
+++ b/code/core/src/manager/App.tsx
@@ -8,7 +8,6 @@ import { addons } from 'storybook/manager-api';
 import { Global, createGlobal } from 'storybook/theming';
 
 import { Layout } from './components/layout/Layout';
-import { useLayout } from './components/layout/LayoutProvider';
 import Panel from './container/Panel';
 import Preview from './container/Preview';
 import Sidebar from './container/Sidebar';
@@ -21,8 +20,6 @@ type Props = {
 };
 
 export const App = ({ managerLayoutState, setManagerLayoutState, pages, hasTab }: Props) => {
-  const { setMobileAboutOpen } = useLayout();
-
   /**
    * Lets us tell the UI whether or not keyboard shortcuts are enabled, in places where it's not
    * convenient to load the addons singleton to figure it out.
@@ -67,7 +64,7 @@ export const App = ({ managerLayoutState, setManagerLayoutState, pages, hasTab }
         managerLayoutState={managerLayoutState}
         setManagerLayoutState={setManagerLayoutState}
         slotMain={<Preview id="main" withLoader />}
-        slotSidebar={<Sidebar onMenuClick={() => setMobileAboutOpen((state) => !state)} />}
+        slotSidebar={<Sidebar />}
         slotPanel={<Panel />}
         slotPages={pages.map(({ id, render: Content }) => (
           <Content key={id} />

--- a/code/core/src/manager/components/a11y/A11yStatement.tsx
+++ b/code/core/src/manager/components/a11y/A11yStatement.tsx
@@ -1,0 +1,188 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import { H2, H3, H4, H5, Link } from 'storybook/internal/components';
+
+import { shortcutToHumanString } from 'storybook/manager-api';
+import { styled } from 'storybook/theming';
+
+const Container = styled.div(({ theme }) => ({
+  fontSize: theme.typography.size.s2,
+}));
+
+const Kbd = styled.kbd(({ theme }) => ({
+  background: theme.base === 'light' ? 'rgba(0,0,0,0.05)' : 'rgba(255,255,255,0.05)',
+  borderRadius: theme.appBorderRadius,
+  border: `1px solid ${theme.appBorderColor}`,
+  display: 'inline-block',
+  padding: '2px 6px',
+  fontFamily: theme.typography.fonts.mono,
+}));
+
+const Shortcut: FC<{ shortcut: string }> = ({ shortcut }) => {
+  const human = shortcutToHumanString([shortcut]);
+  return <Kbd aria-label={shortcut}>{human}</Kbd>;
+};
+const Code = styled.pre(({ theme }) => ({
+  background: theme.base === 'light' ? 'rgba(0, 0, 0, 0.05)' : theme.appBorderColor,
+  fontSize: theme.typography.size.s2 - 1,
+  margin: '4px 0 16px',
+}));
+
+const A11yStatement: FC = () => (
+  <Container>
+    <H2>Accessibility Statement for Storybook</H2>
+    <p>This is an accessibility statement for the Storybook application.</p>
+
+    <H3>Conformance status</H3>
+    <p>
+      The{' '}
+      <Link href="https://www.w3.org/WAI/standards-guidelines/wcag/">
+        Web Content Accessibility Guidelines (WCAG)
+      </Link>{' '}
+      defines requirements for designers and developers to improve accessibility for people with
+      disabilities. It defines three levels of conformance: Level A, Level AA, and Level AAA.
+    </p>
+    <p>
+      Storybook is <strong>partially conformant</strong> with <strong>WCAG 2.2 level AA</strong>.
+      Partially conformant means that some parts of the content do not fully conform to the
+      accessibility standard.
+    </p>
+
+    <H3>Measures to support accessibility</H3>
+    <p>
+      The Storybook maintainers take the following measures to ensure the accessibility of
+      Storybook:
+    </p>
+    <ul>
+      <li>Include accessibility throughout our development workflow</li>
+      <li>Test new features for accessibility issues</li>
+      <li>Monitor Storybook automatically for accessibility regressions</li>
+      <li>Request review from external accessibility experts on specific features</li>
+    </ul>
+
+    <H3>Feedback</H3>
+    <p>
+      We welcome your feedback on the accessibility of Storybook. Please let us know if you
+      encounter accessibility barriers on Storybook by{' '}
+      <Link href="https://github.com/storybookjs/storybook/issues/new?template=bug_report.yml">
+        filling a bug report
+      </Link>
+      .
+    </p>
+    <p>We try to respond to feedback within one to two weeks.</p>
+
+    <H3>Compatibility</H3>
+    <p>Storybook is designed to be compatible with the following assistive technologies:</p>
+    <ul>
+      <li>Chrome with NVDA on Windows</li>
+      <li>Firefox with NVDA on Windows</li>
+      <li>Safari with VoiceOver on Mac</li>
+      {/* <li>Firefox with Orca on ArchLinux</li> TODO */}
+    </ul>
+    <p>
+      Storybook is not tested with the following technologies and may not be compatible with them:
+    </p>
+    <ul>
+      <li>Browsers older than Chrome 131, Edge 134, Firefox 136, Safari 18.3, and Opera 117</li>
+      <li>The Narrator and JAWS screen readers</li>
+    </ul>
+
+    <H3>Technical specifications</H3>
+    <p>
+      Accessibility of Storybook relies on the following technologies to work with the particular
+      combination of web browser and any assistive technologies or plugins installed on your
+      computer:
+    </p>
+    <ul>
+      <li>HTML</li>
+      <li>WAI-ARIA</li>
+      <li>CSS</li>
+      <li>JavaScript</li>
+    </ul>
+    <p>These technologies are relied upon for conformance with the accessibility standards used.</p>
+
+    <H3>Limitations and alternatives</H3>
+    <p>
+      Despite our best efforts to ensure the accessibility of Storybook, there are some limitations.
+      Below is a description of the most impactful limitations, and potential solutions.
+    </p>
+    <p>
+      Please{' '}
+      <Link href="https://github.com/storybookjs/storybook/issues/new?template=bug_report.yml">
+        fill a bug report
+      </Link>{' '}
+      if you observe an issue not listed below or on our{' '}
+      <Link href="https://github.com/orgs/storybookjs/projects/23/views/1">
+        accessibility bug tracker
+      </Link>
+      .
+    </p>
+
+    <H4>Sidebar navigation is not accessible with the keyboard</H4>
+    <p>
+      Navigating through stories in the sidebar is difficult, and the context menus next to each
+      component (which let you run tests for that specific component) are not reachable by keyboard.
+      We are currently testing an alternative design of the sidebar that works well with keyboards
+      and major screen readers.
+    </p>
+    <p>
+      If you use the search bar to find specific stories, press the <Shortcut shortcut="ArrowUp" />{' '}
+      and <Shortcut shortcut="ArrowDown" /> keys from the search input to navigate to search
+      results.
+    </p>
+    <p>
+      If you use the sidebar directly, press <Shortcut shortcut="Tab" /> to navigate between content
+      sections, and press <Shortcut shortcut="ArrowUp" /> and <Shortcut shortcut="ArrowDown" /> to
+      enter a content section when on the title of a section. Each section is immediately followed
+      by a button to expand all items within the section. Make sure to expand all items before
+      navigating in the section, as expanding and collapsing individual items is not currently
+      possible with the keyboard alone.
+    </p>
+
+    <H4>Storybook Vitest addon limitations</H4>
+    <H5>Test result are not announced</H5>
+    <p>
+      The test widget provided by the{' '}
+      <Link href="https://storybook.js.org/docs/writing-tests/integrations/vitest-addon">
+        Vitest addon
+      </Link>{' '}
+      at the bottom of the sidebar allows you to run tests on all stories, but it does not report
+      when tests are done running. We will implement live announcements in a future update to
+      address this issue. If you have few tests to run, results will be available after
+      approximately ten seconds. If you have hundreds of tests, it can take a few minutes for tests
+      to complete. Please wait and recheck the test widget manually for results.
+    </p>
+    <H5>Tests cannot be run per component</H5>
+    <p>
+      It is not currently possible to run tests on a specific component with the keyboard only. We
+      will fix this issue alongside the sidebar navigation improvements. In the meantime, you can
+      run tests in your terminal application via Vitest, which can{' '}
+      <Link href="https://vitest.dev/guide/filtering">run tests for specific files</Link>:
+    </p>
+    <Code>vitest --project=storybook</Code>
+
+    <H4>Interactive stories always auto-play</H4>
+    <p>
+      Interactive stories on Storybook play automatically as you navigate to them. This is harmful
+      to some users, but disabling that feature requires a few underlying changes to how Storybook
+      functions.. We are working on a solution to disable autoplay based on user motion preferences.
+      In the meantime, please ask your Storybook administrator to follow the{' '}
+      <Link href="https://github.blog/engineering/user-experience/how-to-make-storybook-interactions-respect-user-motion-preferences/">
+        workaround
+      </Link>{' '}
+      kindly provided by the GitHub Design System team.
+    </p>
+
+    <H3>Assessment approach</H3>
+    <p>Storybook assessed the accessibility of Storybook by the following approaches:</p>
+    <ul>
+      <li>Self-evaluation</li>
+    </ul>
+
+    <H3>Date</H3>
+    <p>This statement was created on 2 January 2026.</p>
+  </Container>
+);
+
+export { A11yStatement };

--- a/code/core/src/manager/components/layout/LayoutProvider.tsx
+++ b/code/core/src/manager/components/layout/LayoutProvider.tsx
@@ -7,6 +7,8 @@ import { useMediaQuery } from '../../hooks/useMedia';
 type LayoutContextType = {
   isMobileMenuOpen: boolean;
   setMobileMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isMobileA11yStatementOpen: boolean;
+  setMobileA11yStatementOpen: React.Dispatch<React.SetStateAction<boolean>>;
   isMobileAboutOpen: boolean;
   setMobileAboutOpen: React.Dispatch<React.SetStateAction<boolean>>;
   isMobilePanelOpen: boolean;
@@ -18,6 +20,8 @@ type LayoutContextType = {
 const LayoutContext = createContext<LayoutContextType>({
   isMobileMenuOpen: false,
   setMobileMenuOpen: () => {},
+  isMobileA11yStatementOpen: false,
+  setMobileA11yStatementOpen: () => {},
   isMobileAboutOpen: false,
   setMobileAboutOpen: () => {},
   isMobilePanelOpen: false,
@@ -28,10 +32,12 @@ const LayoutContext = createContext<LayoutContextType>({
 
 export const LayoutProvider: FC<
   PropsWithChildren & {
+    /* Helps with testing components that depend on LayoutProvider */
     forceDesktop?: boolean;
   }
 > = ({ children, forceDesktop }) => {
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [isMobileA11yStatementOpen, setMobileA11yStatementOpen] = useState(false);
   const [isMobileAboutOpen, setMobileAboutOpen] = useState(false);
   const [isMobilePanelOpen, setMobilePanelOpen] = useState(false);
   const isDesktop = forceDesktop ?? useMediaQuery(`(min-width: ${BREAKPOINT}px)`);
@@ -41,6 +47,8 @@ export const LayoutProvider: FC<
     () => ({
       isMobileMenuOpen,
       setMobileMenuOpen,
+      isMobileA11yStatementOpen,
+      setMobileA11yStatementOpen,
       isMobileAboutOpen,
       setMobileAboutOpen,
       isMobilePanelOpen,
@@ -51,6 +59,8 @@ export const LayoutProvider: FC<
     [
       isMobileMenuOpen,
       setMobileMenuOpen,
+      isMobileA11yStatementOpen,
+      setMobileA11yStatementOpen,
       isMobileAboutOpen,
       setMobileAboutOpen,
       isMobilePanelOpen,

--- a/code/core/src/manager/components/mobile/a11y/MobileA11yStatement.stories.tsx
+++ b/code/core/src/manager/components/mobile/a11y/MobileA11yStatement.stories.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ManagerContext } from 'storybook/manager-api';
+import { within } from 'storybook/test';
+
+import { LayoutProvider, useLayout } from '../../layout/LayoutProvider';
+import { MobileA11yStatement } from './MobileA11yStatement';
+
+/** A helper component to open the about page via the MobileLayoutContext */
+const OpenAboutHelper = ({ children }: { children: any }) => {
+  const { setMobileA11yStatementOpen } = useLayout();
+  useEffect(() => {
+    setMobileA11yStatementOpen(true);
+  }, [setMobileA11yStatementOpen]);
+  return children;
+};
+
+const meta = {
+  component: MobileA11yStatement,
+  title: 'Mobile/AccessibilityStatement',
+  globals: { sb_theme: 'light' },
+  parameters: {
+    layout: 'fullscreen',
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+    chromatic: { viewports: [320] },
+  },
+  decorators: [
+    (storyFn) => {
+      return (
+        <ManagerContext.Provider
+          value={
+            {
+              api: {
+                getCurrentVersion: () => ({
+                  version: '7.2.0',
+                }),
+              },
+            } as any
+          }
+        >
+          <LayoutProvider>
+            <OpenAboutHelper>{storyFn()}</OpenAboutHelper>
+          </LayoutProvider>
+        </ManagerContext.Provider>
+      );
+    },
+  ],
+} satisfies Meta<typeof MobileA11yStatement>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Dark: Story = {
+  globals: { sb_theme: 'dark' },
+};
+
+export const Closed: Story = {
+  play: async ({ canvasElement }) => {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const closeButton = within(canvasElement).getByText('Back');
+    closeButton.click();
+  },
+};

--- a/code/core/src/manager/components/mobile/a11y/MobileA11yStatement.tsx
+++ b/code/core/src/manager/components/mobile/a11y/MobileA11yStatement.tsx
@@ -1,0 +1,106 @@
+import type { FC } from 'react';
+import React, { useEffect, useRef } from 'react';
+
+import { Button, ScrollArea } from 'storybook/internal/components';
+
+import { ArrowLeftIcon } from '@storybook/icons';
+
+import { useTransitionState } from 'react-transition-state';
+import { keyframes, styled } from 'storybook/theming';
+
+import { MOBILE_TRANSITION_DURATION } from '../../../constants';
+import { A11yStatement } from '../../a11y/A11yStatement';
+import { useLayout } from '../../layout/LayoutProvider';
+
+export const MobileA11yStatement: FC = () => {
+  const { isMobileA11yStatementOpen, setMobileA11yStatementOpen } = useLayout();
+  const pageRef = useRef(null);
+
+  const [state, toggle] = useTransitionState({
+    timeout: MOBILE_TRANSITION_DURATION,
+    mountOnEnter: true,
+    unmountOnExit: true,
+  });
+
+  // Update transition state when isMobileA11yStatementOpen changes
+  useEffect(() => {
+    toggle(isMobileA11yStatementOpen);
+  }, [isMobileA11yStatementOpen, toggle]);
+
+  if (!state.isMounted) {
+    return null;
+  }
+
+  return (
+    <Container
+      ref={pageRef}
+      $status={state.status}
+      $transitionDuration={MOBILE_TRANSITION_DURATION}
+    >
+      <ScrollArea vertical offset={3} scrollbarSize={6}>
+        <InnerArea>
+          <CloseButton
+            onClick={() => setMobileA11yStatementOpen(false)}
+            ariaLabel="Close accessibility statement"
+            variant="ghost"
+          >
+            <ArrowLeftIcon />
+            Back
+          </CloseButton>
+          <A11yStatement />
+        </InnerArea>
+      </ScrollArea>
+    </Container>
+  );
+};
+
+const slideFromRight = keyframes({
+  from: {
+    opacity: 0,
+    transform: 'translate(20px, 0)',
+  },
+  to: {
+    opacity: 1,
+    transform: 'translate(0, 0)',
+  },
+});
+
+const slideToRight = keyframes({
+  from: {
+    opacity: 1,
+    transform: 'translate(0, 0)',
+  },
+  to: {
+    opacity: 0,
+    transform: 'translate(20px, 0)',
+  },
+});
+
+const Container = styled.div<{ $status: string; $transitionDuration: number }>(
+  ({ theme, $status, $transitionDuration }) => ({
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    top: 0,
+    left: 0,
+    zIndex: 11,
+    overflow: 'auto',
+    color: theme.color.defaultText,
+    background: theme.background.content,
+    animation:
+      $status === 'exiting'
+        ? `${slideToRight} ${$transitionDuration}ms`
+        : `${slideFromRight} ${$transitionDuration}ms`,
+  })
+);
+
+const InnerArea = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 20,
+  padding: '25px 12px 20px',
+});
+
+const CloseButton = styled(Button)({
+  alignSelf: 'start',
+});

--- a/code/core/src/manager/components/mobile/navigation/MobileMenuDrawer.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileMenuDrawer.tsx
@@ -6,6 +6,7 @@ import { Modal } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
 import { MOBILE_TRANSITION_DURATION } from '../../../constants';
+import { MobileA11yStatement } from '../a11y/MobileA11yStatement';
 import { MobileAbout } from '../about/MobileAbout';
 
 interface MobileMenuDrawerProps {
@@ -38,6 +39,7 @@ export const MobileMenuDrawer: FC<MobileMenuDrawerProps> = ({
       onOpenChange={onOpenChange}
     >
       {children}
+      <MobileA11yStatement />
       <MobileAbout />
     </StyledModal>
   );

--- a/code/core/src/manager/components/sidebar/Heading.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Heading.stories.tsx
@@ -239,3 +239,17 @@ export const SkipToCanvasLinkFocused: StoryObj<typeof Heading> = {
     screen.getAllByText('Skip to canvas').forEach((x) => x.focus());
   },
 };
+
+export const AccessibilityStatementLinkFocused: StoryObj<typeof Heading> = {
+  args: {
+    menu: menuItems,
+    a11yStatementHref: './?path=/settings/accessibility-statement',
+    isLoading: false,
+  },
+  globals: { sb_theme: 'light' },
+  parameters: { layout: 'padded', chromatic: { delay: 300 } },
+  play: () => {
+    // focus each instance for chromatic/storybook's stacked theme
+    screen.getAllByText('Accessibility Statement').forEach((x) => x.focus());
+  },
+};

--- a/code/core/src/manager/components/sidebar/Heading.tsx
+++ b/code/core/src/manager/components/sidebar/Heading.tsx
@@ -6,15 +6,15 @@ import { Button } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
 import { Brand } from './Brand';
-import type { MenuList, SidebarMenuProps } from './Menu';
+import type { MenuList } from './Menu';
 import { SidebarMenu } from './Menu';
 
 export interface HeadingProps {
   menuHighlighted?: boolean;
   menu: MenuList;
   skipLinkHref?: string;
+  a11yStatementHref?: string;
   isLoading: boolean;
-  onMenuClick?: SidebarMenuProps['onClick'];
 }
 
 const BrandArea = styled.div(({ theme }) => ({
@@ -81,8 +81,7 @@ export const Heading: FC<HeadingProps & ComponentProps<typeof HeadingWrapper>> =
   menuHighlighted = false,
   menu,
   skipLinkHref,
-  isLoading,
-  onMenuClick,
+  a11yStatementHref,
   ...props
 }) => {
   return (
@@ -95,11 +94,19 @@ export const Heading: FC<HeadingProps & ComponentProps<typeof HeadingWrapper>> =
         </SkipToCanvasLink>
       )}
 
+      {a11yStatementHref && (
+        <SkipToCanvasLink ariaLabel={false} asChild>
+          <a href={a11yStatementHref} rel="canonical" tabIndex={0}>
+            Accessibility Statement
+          </a>
+        </SkipToCanvasLink>
+      )}
+
       <BrandArea>
         <Brand />
       </BrandArea>
 
-      <SidebarMenu menu={menu} isHighlighted={menuHighlighted} onClick={onMenuClick} />
+      <SidebarMenu menu={menu} isHighlighted={menuHighlighted} />
     </HeadingWrapper>
   );
 };

--- a/code/core/src/manager/components/sidebar/Menu.tsx
+++ b/code/core/src/manager/components/sidebar/Menu.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import { ActionList, Button, PopoverProvider, ToggleButton } from 'storybook/internal/components';
 
-import { CloseIcon, CogIcon } from '@storybook/icons';
+import { AccessibilityIcon, CloseIcon, CogIcon } from '@storybook/icons';
 
 import { transparentize } from 'polished';
 import { type Theme, css, styled } from 'storybook/theming';
@@ -133,12 +133,12 @@ const SidebarMenuList: FC<{
 export interface SidebarMenuProps {
   menu: MenuList;
   isHighlighted?: boolean;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick }) => {
+export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted }) => {
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
-  const { isMobile, setMobileMenuOpen } = useLayout();
+  const { isMobile, setMobileAboutOpen, setMobileA11yStatementOpen, setMobileMenuOpen } =
+    useLayout();
 
   if (isMobile) {
     return (
@@ -146,9 +146,19 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick
         <SidebarButton
           padding="small"
           variant="ghost"
+          ariaLabel="Accessibility statement"
+          highlighted={!!isHighlighted}
+          onClick={() => setMobileA11yStatementOpen(true)}
+          isMobile={true}
+        >
+          <AccessibilityIcon />
+        </SidebarButton>
+        <SidebarButton
+          padding="small"
+          variant="ghost"
           ariaLabel="About Storybook"
           highlighted={!!isHighlighted}
-          onClick={onClick}
+          onClick={() => setMobileAboutOpen(true)}
           isMobile={true}
         >
           <CogIcon />

--- a/code/core/src/manager/components/sidebar/Sidebar.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.tsx
@@ -15,7 +15,6 @@ import { useLayout } from '../layout/LayoutProvider';
 import { ChecklistWidget } from './ChecklistWidget';
 import { CreateNewStoryFileModal } from './CreateNewStoryFileModal';
 import { Explorer } from './Explorer';
-import type { HeadingProps } from './Heading';
 import { Heading } from './Heading';
 import { Search } from './Search';
 import { SearchResults } from './SearchResults';
@@ -111,7 +110,6 @@ export interface SidebarProps extends API_LoadedRefData {
   refId?: string;
   menuHighlighted?: boolean;
   enableShortcuts?: boolean;
-  onMenuClick?: HeadingProps['onMenuClick'];
   showCreateStoryButton?: boolean;
   indexJson?: StoryIndex;
   isDevelopment?: boolean;
@@ -130,7 +128,6 @@ export const Sidebar = React.memo(function Sidebar({
   enableShortcuts = true,
   isDevelopment = global.CONFIG_TYPE === 'DEVELOPMENT',
   refs = {},
-  onMenuClick,
   showCreateStoryButton = isDevelopment && isRendererReact,
 }: SidebarProps) {
   const [isFileSearchModalOpen, setIsFileSearchModalOpen] = useState(false);
@@ -163,8 +160,8 @@ export const Sidebar = React.memo(function Sidebar({
               menuHighlighted={menuHighlighted}
               menu={menu}
               skipLinkHref="#storybook-preview-wrapper"
+              a11yStatementHref="./?path=/settings/accessibility-statement"
               isLoading={isLoading}
-              onMenuClick={onMenuClick}
             />
             {!isLoading && global.CONFIG_TYPE === 'DEVELOPMENT' && <ChecklistWidget />}
           </div>

--- a/code/core/src/manager/container/Menu.tsx
+++ b/code/core/src/manager/container/Menu.tsx
@@ -6,6 +6,7 @@ import { STORIES_COLLAPSE_ALL } from 'storybook/internal/core-events';
 
 import { global } from '@storybook/global';
 import {
+  AccessibilityIcon,
   CheckIcon,
   CommandIcon,
   DocumentIcon,
@@ -84,6 +85,17 @@ export const useMenu = ({
       onClick: () => api.changeSettingsTab('about'),
       closeOnClick: true,
       icon: <InfoIcon />,
+    }),
+    [api]
+  );
+
+  const a11yStatement = useMemo(
+    () => ({
+      id: 'accessibility-statement',
+      title: 'Accessibility statement',
+      onClick: () => api.changeSettingsTab('accessibility-statement'),
+      closeOnClick: true,
+      icon: <AccessibilityIcon />,
     }),
     [api]
   );
@@ -249,10 +261,11 @@ export const useMenu = ({
         ],
         [sidebarToggle, toolbarToogle, addonsToggle, up, down, prev, next, collapse],
         getAddonsShortcuts(),
-        [documentation],
+        [a11yStatement, documentation],
       ] satisfies NormalLink[][],
     [
       about,
+      a11yStatement,
       guide,
       documentation,
       shortcuts,

--- a/code/core/src/manager/container/Sidebar.tsx
+++ b/code/core/src/manager/container/Sidebar.tsx
@@ -3,17 +3,12 @@ import React from 'react';
 import type { Combo, StoriesHash } from 'storybook/manager-api';
 import { Consumer, experimental_useStatusStore } from 'storybook/manager-api';
 
-import type { SidebarProps as SidebarComponentProps } from '../components/sidebar/Sidebar';
 import { Sidebar as SidebarComponent } from '../components/sidebar/Sidebar';
 import { useMenu } from './Menu';
 
 export type Item = StoriesHash[keyof StoriesHash];
 
-interface SidebarProps {
-  onMenuClick?: SidebarComponentProps['onMenuClick'];
-}
-
-const Sidebar = React.memo(function Sideber({ onMenuClick }: SidebarProps) {
+const Sidebar = React.memo(function SidebarContainer() {
   const mapper = ({ state, api }: Combo) => {
     const {
       ui: { name, url, enableShortcuts },
@@ -63,7 +58,6 @@ const Sidebar = React.memo(function Sideber({ onMenuClick }: SidebarProps) {
           <SidebarComponent
             {...state}
             menu={menu}
-            onMenuClick={onMenuClick}
             allStatuses={allStatuses}
             enableShortcuts={enableShortcuts}
           />

--- a/code/core/src/manager/settings/A11yStatementPage.tsx
+++ b/code/core/src/manager/settings/A11yStatementPage.tsx
@@ -1,0 +1,21 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import { styled } from 'storybook/theming';
+
+import { A11yStatement } from '../components/a11y/A11yStatement';
+
+const MainWrapper = styled.main(({ theme }) => ({
+  fontSize: theme.typography.size.s2,
+  padding: `3rem 20px`,
+  maxWidth: 600,
+  margin: '0 auto',
+}));
+
+const A11yStatementPage: FC = () => (
+  <MainWrapper>
+    <A11yStatement />
+  </MainWrapper>
+);
+
+export { A11yStatementPage };

--- a/code/core/src/manager/settings/index.tsx
+++ b/code/core/src/manager/settings/index.tsx
@@ -12,6 +12,7 @@ import { types, useStorybookApi, useStorybookState } from 'storybook/manager-api
 import { styled } from 'storybook/theming';
 
 import { matchesKeyCode, matchesModifiers } from '../keybinding';
+import { A11yStatementPage } from './A11yStatementPage';
 import { AboutPage } from './AboutPage';
 import { GuidePage } from './GuidePage';
 import { ShortcutsPage } from './ShortcutsPage';
@@ -82,6 +83,16 @@ const Pages: FC<{
       children: (
         <RouteWrapper path="shortcuts">
           <ShortcutsPage key="shortcuts" />
+        </RouteWrapper>
+      ),
+    });
+
+    tabsToInclude.push({
+      id: 'accessibility-statement',
+      title: 'Accessibility statement',
+      children: (
+        <RouteWrapper path="accessibility-statement">
+          <A11yStatementPage key="a11y" />
         </RouteWrapper>
       ),
     });


### PR DESCRIPTION
Closes #33453 

## What I did

Created an accessibility statement page, ahead of the blog post on accessibility, so we can reference it.

* Added an accessibility statement page
* Added a link to the page in the settings menu and tablist
* Added a link to the page in the mobile sidebar heading
* Cleaned up some mobile sidebar prop drilling in favour of already-in-use `useLayout` hook
* Added stories for mobile version of the sidebar Menu

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Open Storybook
2. In desktop mode, in sidebar settings menu, click Accessibility statement
3. In mobile mode, open the sidebar and click the accessibility icon

<img width="336" height="520" alt="image" src="https://github.com/user-attachments/assets/e1dff858-0fc2-4be4-a83c-7e4a120448b3" />

<img width="1130" height="690" alt="image" src="https://github.com/user-attachments/assets/85fc116f-d162-4017-ad00-371606d92c59" />

<img width="501" height="216" alt="image" src="https://github.com/user-attachments/assets/9d05a9e9-7825-4bc9-9dbf-3012d54d2d80" />

<img width="499" height="824" alt="image" src="https://github.com/user-attachments/assets/036d6e59-e886-4b37-84db-e83198a2d1ff" />



### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a comprehensive accessibility statement detailing conformance, accessibility measures, feedback channels, compatibility information, and technical specifications.
  * Accessibility statement now accessible via a new link in the sidebar and a dedicated button in the mobile menu.
  * New settings tab for quick access to the accessibility statement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->