### PR TITLE
UI: Improve landmark navigation

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -228,6 +228,7 @@
     "@radix-ui/react-scroll-area": "1.2.0-rc.7",
     "@radix-ui/react-slot": "^1.0.2",
     "@react-aria/interactions": "^3.25.5",
+    "@react-aria/landmark": "^3.0.8",
     "@react-aria/overlays": "^3.29.1",
     "@react-aria/tabs": "^3.10.7",
     "@react-aria/toolbar": "3.0.0-beta.20",

--- a/code/core/src/components/components/Card/Card.tsx
+++ b/code/core/src/components/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps, forwardRef } from 'react';
+import React, { type ComponentProps, type DOMAttributes, forwardRef } from 'react';
 
 import type { CSSObject, color } from 'storybook/theming';
 import { keyframes, styled } from 'storybook/theming';
@@ -92,15 +92,16 @@ const CardOutline = styled.div<{
 interface CardProps extends ComponentProps<typeof CardContent> {
   outlineAnimation?: 'none' | 'rainbow' | 'spin';
   outlineColor?: keyof typeof color;
+  outlineProps?: DOMAttributes<HTMLDivElement>;
 }
 
 export const Card = Object.assign(
   forwardRef<HTMLDivElement, CardProps>(function Card(
-    { outlineAnimation = 'none', outlineColor, ...props },
+    { outlineAnimation = 'none', outlineColor, outlineProps = {}, ...props },
     ref
   ) {
     return (
-      <CardOutline animation={outlineAnimation} color={outlineColor} ref={ref}>
+      <CardOutline animation={outlineAnimation} color={outlineColor} ref={ref} {...outlineProps}>
         <CardContent {...props} />
       </CardOutline>
     );

--- a/code/core/src/components/components/Card/Card.tsx
+++ b/code/core/src/components/components/Card/Card.tsx
@@ -92,16 +92,16 @@ const CardOutline = styled.div<{
 interface CardProps extends ComponentProps<typeof CardContent> {
   outlineAnimation?: 'none' | 'rainbow' | 'spin';
   outlineColor?: keyof typeof color;
-  outlineProps?: DOMAttributes<HTMLDivElement>;
+  outlineAttrs?: DOMAttributes<HTMLDivElement>;
 }
 
 export const Card = Object.assign(
   forwardRef<HTMLDivElement, CardProps>(function Card(
-    { outlineAnimation = 'none', outlineColor, outlineProps = {}, ...props },
+    { outlineAnimation = 'none', outlineColor, outlineAttrs: outlineAttrs = {}, ...props },
     ref
   ) {
     return (
-      <CardOutline animation={outlineAnimation} color={outlineColor} ref={ref} {...outlineProps}>
+      <CardOutline animation={outlineAnimation} color={outlineColor} ref={ref} {...outlineAttrs}>
         <CardContent {...props} />
       </CardOutline>
     );

--- a/code/core/src/components/components/Form/styles.ts
+++ b/code/core/src/components/components/Form/styles.ts
@@ -107,8 +107,9 @@ export const styles = (({ theme }: { theme: StorybookTheme }) => ({
     },
   },
 
-  '&[disabled]': {
+  '&[disabled], &[aria-disabled="true"]': {
     background: theme.base === 'light' ? theme.color.lighter : 'transparent',
+    cursor: 'not-allowed',
   },
 
   '&:-webkit-autofill': { WebkitBoxShadow: `0 0 0 3em ${theme.color.lightest} inset` },

--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -117,6 +117,8 @@ export interface API_Shortcuts {
   openInEditor: API_KeyCollection;
   openInIsolation: API_KeyCollection;
   copyStoryLink: API_KeyCollection;
+  goToPreviousLandmark: API_KeyCollection;
+  goToNextLandmark: API_KeyCollection;
   // TODO: bring this back once we want to add shortcuts for this
   // copyStoryName: API_KeyCollection;
 }
@@ -157,6 +159,8 @@ export const defaultShortcuts: API_Shortcuts = Object.freeze({
   openInEditor: ['alt', 'shift', 'E'],
   openInIsolation: ['alt', 'shift', 'I'],
   copyStoryLink: ['alt', 'shift', 'L'],
+  goToPreviousLandmark: ['shift', 'F6'], // hardcoded in react-aria
+  goToNextLandmark: ['F6'], // hardcoded in react-aria
   // TODO: bring this back once we want to add shortcuts for this
   // copyStoryName: ['alt', 'shift', 'C'],
 });
@@ -272,6 +276,11 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
           }
           break;
         }
+
+        // Handled by @react-aria/interactions and useLandmarkIndicator
+        case 'goToNextLandmark':
+        case 'goToPreviousLandmark':
+          break;
 
         case 'focusNav': {
           if (fullAPI.getIsFullscreen()) {

--- a/code/core/src/manager/components/layout/Layout.tsx
+++ b/code/core/src/manager/components/layout/Layout.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useLayoutEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { Match } from 'storybook/internal/router';
 import type { API_Layout, API_ViewMode } from 'storybook/internal/types';
 
 import { type API, useStorybookApi } from 'storybook/manager-api';
-import { styled } from 'storybook/theming';
+import { styled, useTheme } from 'storybook/theming';
 
 import { MEDIA_DESKTOP_BREAKPOINT } from '../../constants';
 import { Notifications } from '../../container/Notifications';
@@ -145,6 +145,8 @@ const OrderedMobileNavigation = styled(MobileNavigation)({
 export const Layout = ({ managerLayoutState, setManagerLayoutState, hasTab, ...slots }: Props) => {
   const { isDesktop, isMobile } = useLayout();
   const api = useStorybookApi();
+  const theme = useTheme();
+  const currentAnimationRef = useRef<Animation | null>(null);
 
   const {
     navSize,
@@ -157,6 +159,66 @@ export const Layout = ({ managerLayoutState, setManagerLayoutState, hasTab, ...s
     showPanel,
     isDragging,
   } = useLayoutSyncingState({ api, managerLayoutState, setManagerLayoutState, isDesktop, hasTab });
+
+  // Global keyboard handler for F6/Shift+F6 landmark navigation
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'F6') {
+        let currentElement: Element | null = document.activeElement;
+        let landmarkElement: HTMLElement | null = null;
+
+        // Walk up from activeElement to find first element with data-sb-landmark
+        while (currentElement) {
+          if (
+            currentElement instanceof HTMLElement &&
+            currentElement.hasAttribute('data-sb-landmark')
+          ) {
+            landmarkElement = currentElement;
+            break;
+          }
+          currentElement = currentElement.parentElement;
+        }
+
+        if (landmarkElement) {
+          console.log('FOUND LANDMARK', landmarkElement);
+
+          // Cancel any existing animation
+          if (currentAnimationRef.current) {
+            currentAnimationRef.current.cancel();
+            currentAnimationRef.current = null;
+          }
+
+          // Start new animation on ::after pseudo-element
+          const animation = landmarkElement.animate(
+            [
+              {
+                border: `2px solid ${theme.color.primary}`,
+              },
+              {
+                border: `2px solid transparent`,
+              },
+            ],
+            {
+              duration: 1500,
+              pseudoElement: '::after',
+            }
+          );
+
+          currentAnimationRef.current = animation;
+
+          // Clear ref when animation finishes
+          animation.onfinish = () => {
+            currentAnimationRef.current = null;
+          };
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, { capture: true });
+    };
+  }, [theme.color.primary]);
 
   return (
     <LayoutContainer

--- a/code/core/src/manager/components/layout/useLandmarkIndicator.ts
+++ b/code/core/src/manager/components/layout/useLandmarkIndicator.ts
@@ -2,6 +2,21 @@ import { useEffect, useRef } from 'react';
 
 import { useTheme } from 'storybook/theming';
 
+function findActiveLandmarkElement() {
+  let currentElement: Element | null = document.activeElement;
+  let landmarkElement: HTMLElement | null = null;
+
+  while (currentElement) {
+    if (currentElement instanceof HTMLElement && currentElement.hasAttribute('data-sb-landmark')) {
+      landmarkElement = currentElement;
+      break;
+    }
+    currentElement = currentElement.parentElement;
+  }
+
+  return landmarkElement;
+}
+
 // Global keyboard handler for F6/Shift+F6 landmark navigation that
 // highlights the landmark containing the current element. This helps
 // users who navigate through landmark shortcuts more quickly visualise
@@ -11,44 +26,33 @@ export function useLandmarkIndicator() {
   const currentAnimationRef = useRef<Animation | null>(null);
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'F6') {
-        let currentElement: Element | null = document.activeElement;
-        let landmarkElement: HTMLElement | null = null;
-
-        // Locate parent landmark by going up the DOM tree.
-        while (currentElement) {
-          if (
-            currentElement instanceof HTMLElement &&
-            currentElement.hasAttribute('data-sb-landmark')
-          ) {
-            landmarkElement = currentElement;
-            break;
-          }
-          currentElement = currentElement.parentElement;
-        }
-
-        // Trigger the highlight animation on the found landmark.
-        if (landmarkElement) {
-          if (currentAnimationRef.current) {
-            currentAnimationRef.current.cancel();
-            currentAnimationRef.current = null;
-          }
-
-          const animation = landmarkElement.animate(
-            [{ border: `2px solid ${theme.color.primary}` }, { border: `2px solid transparent` }],
-            {
-              duration: 1500,
-              pseudoElement: '::after',
-            }
-          );
-
-          currentAnimationRef.current = animation;
-
-          animation.onfinish = () => {
-            currentAnimationRef.current = null;
-          };
-        }
+      if (e.key !== 'F6') {
+        return;
       }
+
+      const landmarkElement = findActiveLandmarkElement();
+      if (!landmarkElement) {
+        return;
+      }
+
+      // Cancel previous landmark animation if user switches fast.
+      if (currentAnimationRef.current) {
+        currentAnimationRef.current.cancel();
+        currentAnimationRef.current = null;
+      }
+
+      const animation = landmarkElement.animate(
+        [{ border: `2px solid ${theme.color.primary}` }, { border: `2px solid transparent` }],
+        {
+          duration: 1500,
+          pseudoElement: '::after',
+        }
+      );
+      currentAnimationRef.current = animation;
+
+      animation.onfinish = () => {
+        currentAnimationRef.current = null;
+      };
     };
 
     document.addEventListener('keydown', handleKeyDown, { capture: true });

--- a/code/core/src/manager/components/layout/useLandmarkIndicator.ts
+++ b/code/core/src/manager/components/layout/useLandmarkIndicator.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+
+import { useTheme } from 'storybook/theming';
+
+// Global keyboard handler for F6/Shift+F6 landmark navigation that
+// highlights the landmark containing the current element. This helps
+// users who navigate through landmark shortcuts more quickly visualise
+// which region of the UI they landed into.
+export function useLandmarkIndicator() {
+  const theme = useTheme();
+  const currentAnimationRef = useRef<Animation | null>(null);
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'F6') {
+        let currentElement: Element | null = document.activeElement;
+        let landmarkElement: HTMLElement | null = null;
+
+        // Locate parent landmark by going up the DOM tree.
+        while (currentElement) {
+          if (
+            currentElement instanceof HTMLElement &&
+            currentElement.hasAttribute('data-sb-landmark')
+          ) {
+            landmarkElement = currentElement;
+            break;
+          }
+          currentElement = currentElement.parentElement;
+        }
+
+        // Trigger the highlight animation on the found landmark.
+        if (landmarkElement) {
+          if (currentAnimationRef.current) {
+            currentAnimationRef.current.cancel();
+            currentAnimationRef.current = null;
+          }
+
+          const animation = landmarkElement.animate(
+            [{ border: `2px solid ${theme.color.primary}` }, { border: `2px solid transparent` }],
+            {
+              duration: 1500,
+              pseudoElement: '::after',
+            }
+          );
+
+          currentAnimationRef.current = animation;
+
+          animation.onfinish = () => {
+            currentAnimationRef.current = null;
+          };
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, { capture: true });
+    };
+  }, [theme.color.primary]);
+}

--- a/code/core/src/manager/components/mobile/navigation/MobileNavigation.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileNavigation.tsx
@@ -80,10 +80,7 @@ export const MobileNavigation: FC<MobileNavigationProps & ComponentProps<typeof 
 
   const sectionRef = useRef<HTMLElement>(null);
   const { landmarkProps } = useLandmark(
-    {
-      'aria-labelledby': headingId,
-      role: 'banner',
-    },
+    { 'aria-labelledby': headingId, role: 'banner' },
     sectionRef
   );
 

--- a/code/core/src/manager/components/mobile/navigation/MobileNavigation.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileNavigation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import type { ComponentProps, FC } from 'react';
 
 import { Button } from 'storybook/internal/components';
@@ -10,6 +10,7 @@ import { useId } from '@react-aria/utils';
 import { useStorybookApi, useStorybookState } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
+import { useLandmark } from '../../../hooks/useLandmark';
 import { useLayout } from '../../layout/LayoutProvider';
 import { MobileAddonsDrawer } from './MobileAddonsDrawer';
 import { MobileMenuDrawer } from './MobileMenuDrawer';
@@ -77,6 +78,15 @@ export const MobileNavigation: FC<MobileNavigationProps & ComponentProps<typeof 
   const fullStoryName = useFullStoryName();
   const headingId = useId();
 
+  const sectionRef = useRef<HTMLElement>(null);
+  const { landmarkProps } = useLandmark(
+    {
+      'aria-labelledby': headingId,
+      role: 'banner',
+    },
+    sectionRef
+  );
+
   return (
     <Container {...props}>
       <MobileMenuDrawer
@@ -96,7 +106,7 @@ export const MobileNavigation: FC<MobileNavigationProps & ComponentProps<typeof 
       </MobileAddonsDrawer>
 
       {!isMobilePanelOpen && (
-        <MobileBottomBar className="sb-bar" aria-labelledby={headingId}>
+        <MobileBottomBar className="sb-bar" {...landmarkProps} ref={sectionRef}>
           <h2 id={headingId} className="sb-sr-only">
             Navigation controls
           </h2>
@@ -132,7 +142,7 @@ export const MobileNavigation: FC<MobileNavigationProps & ComponentProps<typeof 
   );
 };
 
-const Container = styled.div(({ theme }) => ({
+const Container = styled.section(({ theme }) => ({
   bottom: 0,
   left: 0,
   width: '100%',
@@ -141,7 +151,7 @@ const Container = styled.div(({ theme }) => ({
   borderTop: `1px solid ${theme.appBorderColor}`,
 }));
 
-const MobileBottomBar = styled.section({
+const MobileBottomBar = styled.header({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',

--- a/code/core/src/manager/components/panel/Panel.tsx
+++ b/code/core/src/manager/components/panel/Panel.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import React, { Component, useMemo } from 'react';
+import React, { Component, useMemo, useRef } from 'react';
 
 import {
   Button,
@@ -17,6 +17,7 @@ import { BottomBarIcon, CloseIcon, DocumentIcon, SidebarAltIcon } from '@storybo
 import type { State } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
+import { useLandmark } from '../../hooks/useLandmark';
 import { useLayout } from '../layout/LayoutProvider';
 
 export interface SafeTabProps {
@@ -61,7 +62,7 @@ class TabErrorBoundary extends Component<ErrorBoundaryProps, { hasError: boolean
   }
 }
 
-const Section = styled.section({
+const Aside = styled.aside({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
@@ -152,8 +153,14 @@ export const AddonPanel = React.memo<{
     [actions, isDesktop, panelPosition, setMobilePanelOpen, shortcuts]
   );
 
+  const asideRef = useRef<HTMLElement>(null);
+  const { landmarkProps } = useLandmark(
+    { 'aria-labelledby': 'storybook-panel-heading', role: 'region' },
+    asideRef
+  );
+
   return (
-    <Section aria-labelledby="storybook-panel-heading">
+    <Aside ref={asideRef} {...landmarkProps}>
       <h2 id="storybook-panel-heading" className="sb-sr-only">
         Addon panel
       </h2>
@@ -174,7 +181,7 @@ export const AddonPanel = React.memo<{
         </StatelessTabList>
         {Object.keys(panels).length ? <PreRenderAddons panels={panels} /> : null}
       </StatelessTabsView>
-    </Section>
+    </Aside>
   );
 });
 

--- a/code/core/src/manager/components/preview/FramesRenderer.tsx
+++ b/code/core/src/manager/components/preview/FramesRenderer.tsx
@@ -97,7 +97,7 @@ export const FramesRenderer: FC<FramesRendererProps> = ({
           }
           return (
             <SkipToSidebarLink ariaLabel={false} asChild>
-              <a href={`#${selectedStoryId}`} tabIndex={0} title="Skip to sidebar">
+              <a href={`#${selectedStoryId}`} tabIndex={0}>
                 Skip to sidebar
               </a>
             </SkipToSidebarLink>

--- a/code/core/src/manager/components/preview/Preview.tsx
+++ b/code/core/src/manager/components/preview/Preview.tsx
@@ -12,6 +12,7 @@ import type { TabListState } from '@react-stately/tabs';
 import { Helmet } from 'react-helmet-async';
 import { type Combo, Consumer, addons, merge, types } from 'storybook/manager-api';
 
+import { useLandmark } from '../../hooks/useLandmark';
 import { FramesRenderer } from './FramesRenderer';
 import { ToolbarComp } from './Toolbar';
 import { ApplyWrappers } from './Wrappers';
@@ -111,6 +112,12 @@ const Preview = React.memo<PreviewProps>(function Preview(props) {
     }
   }, [entry, viewMode, storyId, api]);
 
+  const mainRef = useRef<HTMLElement>(null);
+  const { landmarkProps } = useLandmark(
+    { 'aria-labelledby': 'main-preview-heading', role: 'main' },
+    mainRef
+  );
+
   return (
     <Fragment>
       {previewId === 'main' && (
@@ -128,7 +135,7 @@ const Preview = React.memo<PreviewProps>(function Preview(props) {
             tools={tools}
             toolsExtra={toolsExtra}
           />
-          <S.FrameWrap aria-labelledby="main-preview-heading">
+          <S.FrameWrap ref={mainRef} {...landmarkProps}>
             <h2 id="main-preview-heading" className="sb-sr-only">
               Main preview area
             </h2>

--- a/code/core/src/manager/components/preview/Toolbar.tsx
+++ b/code/core/src/manager/components/preview/Toolbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { AbstractToolbar, Button, Separator, TabList } from 'storybook/internal/components';
 import { type Addon_BaseType, Addon_TypesEnum } from 'storybook/internal/types';
@@ -18,6 +18,7 @@ import {
 } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
+import { useLandmark } from '../../hooks/useLandmark';
 import { useLayout } from '../layout/LayoutProvider';
 import type { PreviewProps } from './utils/types';
 
@@ -83,12 +84,22 @@ export const ToolbarComp = React.memo<ToolData>(function ToolbarComp({
   tabs,
   tabState,
 }) {
+  const sectionRef = useRef<HTMLElement>(null);
+  const { landmarkProps } = useLandmark(
+    {
+      'aria-labelledby': 'sb-preview-toolbar-title',
+      role: 'region',
+    },
+    sectionRef
+  );
+
   return isShown && (tabs || tools || toolsExtra) ? (
     <StyledSection
       className="sb-bar"
       key="toolbar"
       data-testid="sb-preview-toolbar"
-      aria-labelledby="sb-preview-toolbar-title"
+      ref={sectionRef}
+      {...landmarkProps}
     >
       <h2 id="sb-preview-toolbar-title" className="sb-sr-only">
         Toolbar

--- a/code/core/src/manager/components/preview/Toolbar.tsx
+++ b/code/core/src/manager/components/preview/Toolbar.tsx
@@ -86,10 +86,7 @@ export const ToolbarComp = React.memo<ToolData>(function ToolbarComp({
 }) {
   const sectionRef = useRef<HTMLElement>(null);
   const { landmarkProps } = useLandmark(
-    {
-      'aria-labelledby': 'sb-preview-toolbar-title',
-      role: 'region',
-    },
+    { 'aria-labelledby': 'sb-preview-toolbar-title', role: 'region' },
     sectionRef
   );
 

--- a/code/core/src/manager/components/preview/utils/components.ts
+++ b/code/core/src/manager/components/preview/utils/components.ts
@@ -2,7 +2,7 @@ import { Link } from 'storybook/internal/router';
 
 import { styled } from 'storybook/theming';
 
-export const PreviewContainer = styled.main({
+export const PreviewContainer = styled.div({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
@@ -10,7 +10,7 @@ export const PreviewContainer = styled.main({
   overflow: 'hidden',
 });
 
-export const FrameWrap = styled.section({
+export const FrameWrap = styled.main({
   overflow: 'auto',
   width: '100%',
   zIndex: 3,

--- a/code/core/src/manager/components/sidebar/Explorer.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Explorer.stories.tsx
@@ -83,6 +83,7 @@ export const Simple = () => (
     isLoading={false}
     isBrowsing
     hasEntries={true}
+    isHidden={false}
   />
 );
 
@@ -96,5 +97,6 @@ export const WithRefs = () => (
     isLoading={false}
     isBrowsing
     hasEntries={true}
+    isHidden={false}
   />
 );

--- a/code/core/src/manager/components/sidebar/Explorer.tsx
+++ b/code/core/src/manager/components/sidebar/Explorer.tsx
@@ -11,6 +11,7 @@ export interface ExplorerProps {
   className?: string;
   isLoading: boolean;
   isBrowsing: boolean;
+  isHidden: boolean;
   hasEntries: boolean;
   dataset: CombinedDataset;
   selected: Selection;
@@ -20,11 +21,12 @@ export const Explorer: FC<ExplorerProps> = React.memo(function Explorer({
   hasEntries,
   isLoading,
   isBrowsing,
+  isHidden,
   dataset,
   selected,
   ...restProps
 }) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLElement>(null);
 
   // Track highlighted nodes, keep it in sync with props and enable keyboard navigation
   const [highlighted, setHighlighted, highlightedRef] = useHighlighted({
@@ -35,15 +37,15 @@ export const Explorer: FC<ExplorerProps> = React.memo(function Explorer({
   });
 
   const { landmarkProps } = useLandmark(
-    {
-      'aria-labelledby': 'storybook-explorer-tree-heading',
-      role: 'navigation',
-    },
+    { 'aria-labelledby': 'storybook-explorer-tree-heading', role: 'navigation' },
     containerRef
   );
 
   return (
     <nav
+      hidden={isHidden || undefined}
+      aria-hidden={isHidden || undefined}
+      className={isBrowsing ? undefined : 'sb-sr-only'}
       ref={containerRef}
       id="storybook-explorer-tree"
       data-highlighted-ref-id={highlighted?.refId}

--- a/code/core/src/manager/components/sidebar/Explorer.tsx
+++ b/code/core/src/manager/components/sidebar/Explorer.tsx
@@ -8,6 +8,7 @@ import type { CombinedDataset, Selection } from './types';
 import { useHighlighted } from './useHighlighted';
 
 export interface ExplorerProps {
+  className?: string;
   isLoading: boolean;
   isBrowsing: boolean;
   hasEntries: boolean;
@@ -21,6 +22,7 @@ export const Explorer: FC<ExplorerProps> = React.memo(function Explorer({
   isBrowsing,
   dataset,
   selected,
+  ...restProps
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -47,6 +49,7 @@ export const Explorer: FC<ExplorerProps> = React.memo(function Explorer({
       data-highlighted-ref-id={highlighted?.refId}
       data-highlighted-item-id={highlighted?.itemId}
       {...landmarkProps}
+      {...restProps}
     >
       <h2 id="storybook-explorer-tree-heading" className="sb-sr-only">
         Stories

--- a/code/core/src/manager/components/sidebar/Explorer.tsx
+++ b/code/core/src/manager/components/sidebar/Explorer.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import React, { useRef } from 'react';
 
+import { useLandmark } from '../../hooks/useLandmark';
 import { HighlightStyles } from './HighlightStyles';
 import { Ref } from './Refs';
 import type { CombinedDataset, Selection } from './types';
@@ -31,13 +32,25 @@ export const Explorer: FC<ExplorerProps> = React.memo(function Explorer({
     selected,
   });
 
+  const { landmarkProps } = useLandmark(
+    {
+      'aria-labelledby': 'storybook-explorer-tree-heading',
+      role: 'navigation',
+    },
+    containerRef
+  );
+
   return (
-    <div
+    <nav
       ref={containerRef}
       id="storybook-explorer-tree"
       data-highlighted-ref-id={highlighted?.refId}
       data-highlighted-item-id={highlighted?.itemId}
+      {...landmarkProps}
     >
+      <h2 id="storybook-explorer-tree-heading" className="sb-sr-only">
+        Stories
+      </h2>
       {highlighted && <HighlightStyles {...highlighted} />}
       {dataset.entries.map(([refId, ref]) => (
         <Ref
@@ -51,6 +64,6 @@ export const Explorer: FC<ExplorerProps> = React.memo(function Explorer({
           setHighlighted={setHighlighted}
         />
       ))}
-    </div>
+    </nav>
   );
 });

--- a/code/core/src/manager/components/sidebar/Heading.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Heading.stories.tsx
@@ -236,6 +236,6 @@ export const SkipToCanvasLinkFocused: StoryObj<typeof Heading> = {
   parameters: { layout: 'padded', chromatic: { delay: 300 } },
   play: () => {
     // focus each instance for chromatic/storybook's stacked theme
-    screen.getAllByText('Skip to canvas').forEach((x) => x.focus());
+    screen.getAllByText('Skip to content').forEach((x) => x.focus());
   },
 };

--- a/code/core/src/manager/components/sidebar/Heading.tsx
+++ b/code/core/src/manager/components/sidebar/Heading.tsx
@@ -90,7 +90,7 @@ export const Heading: FC<HeadingProps & ComponentProps<typeof HeadingWrapper>> =
       {skipLinkHref && (
         <SkipToCanvasLink ariaLabel={false} asChild>
           <a href={skipLinkHref} tabIndex={0}>
-            Skip to canvas
+            Skip to content
           </a>
         </SkipToCanvasLink>
       )}

--- a/code/core/src/manager/components/sidebar/Search.tsx
+++ b/code/core/src/manager/components/sidebar/Search.tsx
@@ -442,7 +442,9 @@ export const Search = React.memo<SearchProps>(function Search({
               {children({
                 query: input,
                 results,
-                isBrowsing: !isOpen && document.activeElement !== inputRef.current,
+                isNavVisible: !isOpen && document.activeElement !== inputRef.current,
+                isNavRendered: input.length === 0,
+                isSearchResultRendered: isOpen,
                 closeMenu,
                 getMenuProps,
                 getItemProps,

--- a/code/core/src/manager/components/sidebar/Search.tsx
+++ b/code/core/src/manager/components/sidebar/Search.tsx
@@ -12,6 +12,7 @@ import Fuse from 'fuse.js';
 import { shortcutToHumanString, useStorybookApi } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
+import { useLandmark } from '../../hooks/useLandmark';
 import { getGroupStatus, getMostCriticalStatusValue } from '../../utils/status';
 import { scrollIntoView, searchItem } from '../../utils/tree';
 import { useLayout } from '../layout/LayoutProvider';
@@ -312,6 +313,14 @@ export const Search = React.memo<SearchProps>(function Search({
   );
   const { isMobile } = useLayout();
 
+  const searchLandmarkRef = useRef<HTMLDivElement>(null);
+  const { landmarkProps } = useLandmark(
+    {
+      role: 'search',
+    },
+    searchLandmarkRef
+  );
+
   return (
     // @ts-expect-error (non strict)
     <Downshift<DownshiftItem>
@@ -388,7 +397,7 @@ export const Search = React.memo<SearchProps>(function Search({
         return (
           <>
             <ScreenReaderLabel {...labelProps}>Search for components</ScreenReaderLabel>
-            <SearchBar>
+            <SearchBar ref={searchLandmarkRef} {...landmarkProps}>
               <SearchField
                 {...getRootProps({ refKey: '' }, { suppressRefError: true })}
                 isMobile={isMobile}

--- a/code/core/src/manager/components/sidebar/Search.tsx
+++ b/code/core/src/manager/components/sidebar/Search.tsx
@@ -314,12 +314,7 @@ export const Search = React.memo<SearchProps>(function Search({
   const { isMobile } = useLayout();
 
   const searchLandmarkRef = useRef<HTMLDivElement>(null);
-  const { landmarkProps } = useLandmark(
-    {
-      role: 'search',
-    },
-    searchLandmarkRef
-  );
+  const { landmarkProps } = useLandmark({ role: 'search' }, searchLandmarkRef);
 
   return (
     // @ts-expect-error (non strict)
@@ -443,7 +438,7 @@ export const Search = React.memo<SearchProps>(function Search({
                 query: input,
                 results,
                 isNavVisible: !isOpen && document.activeElement !== inputRef.current,
-                isNavRendered: input.length === 0,
+                isNavReachable: input.length === 0,
                 isSearchResultRendered: isOpen,
                 closeMenu,
                 getMenuProps,

--- a/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
@@ -17,7 +17,6 @@ import {
 } from '../../manager-stores.mock';
 import { LayoutProvider } from '../layout/LayoutProvider';
 import { standardData as standardHeaderData } from './Heading.stories';
-import { IconSymbols } from './IconSymbols';
 import { DEFAULT_REF_ID, Sidebar } from './Sidebar';
 import { mockDataset } from './mockdata';
 import type { RefType } from './types';
@@ -109,7 +108,6 @@ const meta = {
             title.endsWith('scrolled')
           }
         >
-          <IconSymbols />
           {storyFn()}
         </LayoutProvider>
       </ManagerContext.Provider>
@@ -144,7 +142,6 @@ const mobileLayoutDecorator: DecoratorFunction = (storyFn, { globals, title }) =
         title.endsWith('scrolled')
       }
     >
-      <IconSymbols />
       {storyFn()}
     </LayoutProvider>
   </ManagerContext.Provider>

--- a/code/core/src/manager/components/sidebar/Sidebar.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 
 import { Button, ScrollArea } from 'storybook/internal/components';
 import type { API_LoadedRefData, StoryIndex, TagsOptions } from 'storybook/internal/types';
@@ -11,6 +11,7 @@ import { type State, useStorybookApi } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
 import { MEDIA_DESKTOP_BREAKPOINT } from '../../constants';
+import { useLandmark } from '../../hooks/useLandmark';
 import { useLayout } from '../layout/LayoutProvider';
 import { ChecklistWidget } from './ChecklistWidget';
 import { CreateNewStoryFileModal } from './CreateNewStoryFileModal';
@@ -26,7 +27,7 @@ import { useLastViewed } from './useLastViewed';
 
 export const DEFAULT_REF_ID = 'storybook_internal';
 
-const Container = styled.nav(({ theme }) => ({
+const Container = styled.header(({ theme }) => ({
   position: 'absolute',
   zIndex: 1,
   left: 0,
@@ -153,8 +154,20 @@ export const Sidebar = React.memo(function Sidebar({
     []
   );
 
+  const headerRef = useRef<HTMLElement>(null);
+  const { landmarkProps } = useLandmark(
+    {
+      'aria-labelledby': 'global-site-h1',
+      role: 'banner',
+    },
+    headerRef
+  );
+
   return (
-    <Container className="container sidebar-container" aria-label="Global">
+    <Container className="container sidebar-container" ref={headerRef} {...landmarkProps}>
+      <h1 id="global-site-h1" className="sb-sr-only">
+        Storybook
+      </h1>
       <ScrollArea vertical offset={3} scrollbarSize={6} scrollPadding="4rem">
         <Stack>
           <div>

--- a/code/core/src/manager/components/sidebar/Sidebar.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.tsx
@@ -18,6 +18,7 @@ import { CreateNewStoryFileModal } from './CreateNewStoryFileModal';
 import { Explorer } from './Explorer';
 import type { HeadingProps } from './Heading';
 import { Heading } from './Heading';
+import { IconSymbols } from './IconSymbols';
 import { Search } from './Search';
 import { SearchResults } from './SearchResults';
 import { SidebarBottom } from './SidebarBottom';
@@ -58,22 +59,6 @@ const CreateNewStoryButton = styled(Button)<{ isMobile: boolean }>(({ theme, isM
   height: isMobile ? 36 : 32,
   borderRadius: theme.appBorderRadius + 2,
 }));
-
-const Swap = React.memo(function Swap({
-  children,
-  condition,
-}: {
-  children: React.ReactNode;
-  condition: boolean;
-}) {
-  const [a, b] = React.Children.toArray(children);
-  return (
-    <>
-      <div style={{ display: condition ? 'block' : 'none' }}>{a}</div>
-      <div style={{ display: condition ? 'none' : 'block' }}>{b}</div>
-    </>
-  );
-});
 
 const useCombination = (
   index: SidebarProps['index'],
@@ -168,6 +153,7 @@ export const Sidebar = React.memo(function Sidebar({
       <h1 id="global-site-h1" className="sb-sr-only">
         Storybook
       </h1>
+      <IconSymbols />
       <ScrollArea vertical offset={3} scrollbarSize={6} scrollPadding="4rem">
         <Stack>
           <div>
@@ -215,32 +201,39 @@ export const Sidebar = React.memo(function Sidebar({
             {({
               query,
               results,
-              isBrowsing,
+              isNavVisible,
+              isNavRendered,
+              isSearchResultRendered,
               closeMenu,
               getMenuProps,
               getItemProps,
               highlightedIndex,
             }) => (
-              <Swap condition={isBrowsing}>
-                <Explorer
-                  dataset={dataset}
-                  selected={selected}
-                  isLoading={isLoading}
-                  isBrowsing={isBrowsing}
-                  hasEntries={hasEntries}
-                />
-                <SearchResults
-                  query={query}
-                  results={results}
-                  closeMenu={closeMenu}
-                  getMenuProps={getMenuProps}
-                  getItemProps={getItemProps}
-                  highlightedIndex={highlightedIndex}
-                  enableShortcuts={enableShortcuts}
-                  isLoading={isLoading}
-                  clearLastViewed={lastViewedProps.clearLastViewed}
-                />
-              </Swap>
+              <>
+                {isNavRendered && (
+                  <Explorer
+                    className={isNavVisible ? undefined : 'sb-sr-only'}
+                    dataset={dataset}
+                    selected={selected}
+                    isLoading={isLoading}
+                    isBrowsing={isNavVisible}
+                    hasEntries={hasEntries}
+                  />
+                )}
+                {isSearchResultRendered && (
+                  <SearchResults
+                    query={query}
+                    results={results}
+                    closeMenu={closeMenu}
+                    getMenuProps={getMenuProps}
+                    getItemProps={getItemProps}
+                    highlightedIndex={highlightedIndex}
+                    enableShortcuts={enableShortcuts}
+                    isLoading={isLoading}
+                    clearLastViewed={lastViewedProps.clearLastViewed}
+                  />
+                )}
+              </>
             )}
           </Search>
         </Stack>

--- a/code/core/src/manager/components/sidebar/Sidebar.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.tsx
@@ -141,10 +141,7 @@ export const Sidebar = React.memo(function Sidebar({
 
   const headerRef = useRef<HTMLElement>(null);
   const { landmarkProps } = useLandmark(
-    {
-      'aria-labelledby': 'global-site-h1',
-      role: 'banner',
-    },
+    { 'aria-labelledby': 'global-site-h1', role: 'banner' },
     headerRef
   );
 
@@ -202,7 +199,7 @@ export const Sidebar = React.memo(function Sidebar({
               query,
               results,
               isNavVisible,
-              isNavRendered,
+              isNavReachable,
               isSearchResultRendered,
               closeMenu,
               getMenuProps,
@@ -210,16 +207,16 @@ export const Sidebar = React.memo(function Sidebar({
               highlightedIndex,
             }) => (
               <>
-                {isNavRendered && (
+                {
                   <Explorer
-                    className={isNavVisible ? undefined : 'sb-sr-only'}
                     dataset={dataset}
                     selected={selected}
                     isLoading={isLoading}
                     isBrowsing={isNavVisible}
+                    isHidden={!isNavReachable}
                     hasEntries={hasEntries}
                   />
-                )}
+                }
                 {isSearchResultRendered && (
                   <SearchResults
                     query={query}

--- a/code/core/src/manager/components/sidebar/TestingWidget.tsx
+++ b/code/core/src/manager/components/sidebar/TestingWidget.tsx
@@ -250,18 +250,15 @@ export const TestingWidget = ({
               : undefined
   );
 
+  const cardRef = useRef<HTMLDivElement>(null);
+  const { landmarkProps } = useLandmark(
+    { 'aria-labelledby': 'storybook-testing-widget-heading', role: 'region' },
+    cardRef
+  );
+
   if (!hasTestProviders && !errorCount && !warningCount) {
     return null;
   }
-
-  const cardRef = useRef<HTMLDivElement>(null);
-  const { landmarkProps } = useLandmark(
-    {
-      'aria-labelledby': 'storybook-testing-widget-heading',
-      role: 'region',
-    },
-    cardRef
-  );
 
   return (
     <HoverCard
@@ -272,7 +269,7 @@ export const TestingWidget = ({
         isCrashed || (isRunning && errorCount > 0) ? 'negative' : isUpdated ? 'positive' : undefined
       }
       ref={cardRef}
-      outlineProps={landmarkProps}
+      outlineAttrs={landmarkProps}
     >
       <h2 id="storybook-testing-widget-heading" className="sb-sr-only">
         Component tests

--- a/code/core/src/manager/components/sidebar/TestingWidget.tsx
+++ b/code/core/src/manager/components/sidebar/TestingWidget.tsx
@@ -21,6 +21,7 @@ import { ChevronSmallUpIcon, PlayAllHollowIcon, SweepIcon } from '@storybook/ico
 import { internal_fullTestProviderStore } from '#manager-stores';
 import { styled } from 'storybook/theming';
 
+import { useLandmark } from '../../hooks/useLandmark';
 import { Optional } from '../Optional/Optional';
 import { useDynamicFavicon } from './useDynamicFavicon';
 
@@ -253,6 +254,15 @@ export const TestingWidget = ({
     return null;
   }
 
+  const cardRef = useRef<HTMLDivElement>(null);
+  const { landmarkProps } = useLandmark(
+    {
+      'aria-labelledby': 'storybook-testing-widget-heading',
+      role: 'region',
+    },
+    cardRef
+  );
+
   return (
     <HoverCard
       id="storybook-testing-module"
@@ -261,7 +271,12 @@ export const TestingWidget = ({
       outlineColor={
         isCrashed || (isRunning && errorCount > 0) ? 'negative' : isUpdated ? 'positive' : undefined
       }
+      ref={cardRef}
+      outlineProps={landmarkProps}
     >
+      <h2 id="storybook-testing-widget-heading" className="sb-sr-only">
+        Component tests
+      </h2>
       <Bar {...(hasTestProviders ? { onClick: (e) => toggleCollapsed(e) } : {})}>
         <Action>
           {hasTestProviders && (

--- a/code/core/src/manager/components/sidebar/Tree.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.stories.tsx
@@ -12,6 +12,7 @@ import { action } from 'storybook/actions';
 import { type ComponentEntry, type IndexHash, ManagerContext } from 'storybook/manager-api';
 import { expect, fn, screen, userEvent, within } from 'storybook/test';
 
+import { IconSymbols } from './IconSymbols';
 import { DEFAULT_REF_ID } from './Sidebar';
 import { Tree } from './Tree';
 import { index } from './mockdata.large';
@@ -77,7 +78,10 @@ const meta = {
   },
   decorators: [
     (storyFn) => (
-      <ManagerContext.Provider value={managerContext}>{storyFn()}</ManagerContext.Provider>
+      <ManagerContext.Provider value={managerContext}>
+        <IconSymbols />
+        {storyFn()}
+      </ManagerContext.Provider>
     ),
   ],
 } as Meta<typeof Tree>;

--- a/code/core/src/manager/components/sidebar/Tree.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.stories.tsx
@@ -276,7 +276,7 @@ export const SkipToCanvasLinkFocused: Story = {
   },
   play: async ({ canvasElement }) => {
     const screen = await within(canvasElement);
-    const link = await screen.findByText('Skip to canvas');
+    const link = await screen.findByText('Skip to content');
 
     await link.focus();
 

--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -751,10 +751,7 @@ export const Tree = React.memo<{
   ]);
   return (
     <StatusContext.Provider value={{ data, allStatuses, groupStatus }}>
-      <div ref={containerRef}>
-        <IconSymbols />
-        {treeItems}
-      </div>
+      <div ref={containerRef}>{treeItems}</div>
     </StatusContext.Provider>
   );
 });

--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -302,7 +302,7 @@ const Node = React.memo<NodeProps>(function Node(props) {
         </LeafNode>
         {isSelected && (
           <SkipToContentLink asChild ariaLabel={false}>
-            <a href="#storybook-preview-wrapper">Skip to canvas</a>
+            <a href="#storybook-preview-wrapper">Skip to content</a>
           </SkipToContentLink>
         )}
         {contextMenu.node}
@@ -443,7 +443,7 @@ const Node = React.memo<NodeProps>(function Node(props) {
         </BranchNode>
         {isSelected && (
           <SkipToContentLink asChild ariaLabel={false}>
-            <a href="#storybook-preview-wrapper">Skip to canvas</a>
+            <a href="#storybook-preview-wrapper">Skip to content</a>
           </SkipToContentLink>
         )}
         {contextMenu.node}
@@ -501,7 +501,7 @@ const Node = React.memo<NodeProps>(function Node(props) {
       </LeafNode>
       {isSelected && (
         <SkipToContentLink ariaLabel={false} asChild>
-          <a href="#storybook-preview-wrapper">Skip to canvas</a>
+          <a href="#storybook-preview-wrapper">Skip to content</a>
         </SkipToContentLink>
       )}
       {contextMenu.node}

--- a/code/core/src/manager/components/sidebar/types.ts
+++ b/code/core/src/manager/components/sidebar/types.ts
@@ -54,7 +54,16 @@ export type DownshiftItem = SearchResult | ExpandType;
 export type SearchChildrenFn = (args: {
   query: string;
   results: DownshiftItem[];
-  isBrowsing: boolean;
+  // Whether the nav explorer should be visible in the UI. When the search input is
+  // focused, it gets replaced with a list of recently viewed stories. When there
+  // is a search query, it gets replaced by the search results.
+  isNavVisible: boolean;
+  // Whether the nav explorer should be reachable in the document. When the search
+  // input is focused, we keep the nav rendered in the document and reachable by
+  // keyboard, so keyboard shortcuts to navigate to it still work.
+  isNavRendered: boolean;
+  // Whether the UI with search results or recently viewed pages is visible.
+  isSearchResultRendered: boolean;
   closeMenu: (cb?: () => void) => void;
   getMenuProps: ControllerStateAndHelpers<DownshiftItem>['getMenuProps'];
   getItemProps: ControllerStateAndHelpers<DownshiftItem>['getItemProps'];

--- a/code/core/src/manager/components/sidebar/types.ts
+++ b/code/core/src/manager/components/sidebar/types.ts
@@ -61,7 +61,7 @@ export type SearchChildrenFn = (args: {
   // Whether the nav explorer should be reachable in the document. When the search
   // input is focused, we keep the nav rendered in the document and reachable by
   // keyboard, so keyboard shortcuts to navigate to it still work.
-  isNavRendered: boolean;
+  isNavReachable: boolean;
   // Whether the UI with search results or recently viewed pages is visible.
   isSearchResultRendered: boolean;
   closeMenu: (cb?: () => void) => void;

--- a/code/core/src/manager/hooks/useLandmark.ts
+++ b/code/core/src/manager/hooks/useLandmark.ts
@@ -1,0 +1,22 @@
+import { type RefObject } from 'react';
+
+import {
+  type AriaLandmarkProps,
+  type LandmarkAria,
+  useLandmark as useUpstream,
+} from '@react-aria/landmark';
+import type { FocusableElement } from '@react-types/shared';
+
+export function useLandmark(
+  props: AriaLandmarkProps,
+  ref: RefObject<FocusableElement | null>
+): LandmarkAria & { landmarkProps: { 'data-sb-landmark': true } } {
+  const { landmarkProps } = useUpstream(props, ref);
+
+  return {
+    landmarkProps: {
+      ...landmarkProps,
+      'data-sb-landmark': true,
+    },
+  };
+}

--- a/code/core/src/manager/settings/defaultShortcuts.tsx
+++ b/code/core/src/manager/settings/defaultShortcuts.tsx
@@ -23,6 +23,8 @@ export const defaultShortcuts: State['shortcuts'] = {
   openInEditor: ['alt', 'shift', 'E'],
   openInIsolation: ['alt', 'shift', 'I'],
   copyStoryLink: ['alt', 'shift', 'L'],
+  goToPreviousLandmark: ['shift', 'F6'], // hardcoded in react-aria
+  goToNextLandmark: ['F6'], // hardcoded in react-aria
   // TODO: bring this back once we want to add shortcuts for this
   // copyStoryName: ['alt', 'shift', 'C'],
 };

--- a/code/core/src/manager/settings/shortcuts.tsx
+++ b/code/core/src/manager/settings/shortcuts.tsx
@@ -150,8 +150,7 @@ type ConfiguredShortcut = { shortcut: API_KeyCollection; error: boolean; hardcod
 const fixedShortcuts = ['escape'];
 
 // Shortcuts that cannot be changed by the user (imposed by third-party libraries).
-const hardcodedShortcuts = ['gotoPreviousLandmark', 'goToNextLandmark'];
-
+const hardcodedShortcuts = ['goToPreviousLandmark', 'goToNextLandmark'];
 function toShortcutState(
   shortcutKeys: ShortcutsScreenProps['shortcutKeys']
 ): Record<Feature, ConfiguredShortcut> {

--- a/code/core/src/manager/settings/shortcuts.tsx
+++ b/code/core/src/manager/settings/shortcuts.tsx
@@ -1,11 +1,12 @@
 import type { ComponentProps, FC } from 'react';
 import React, { Component } from 'react';
 
-import { Button, Form } from 'storybook/internal/components';
+import { Button, Form, Tooltip, TooltipProvider } from 'storybook/internal/components';
 
 import { CheckIcon } from '@storybook/icons';
 
 import {
+  type API_KeyCollection,
   eventToShortcut,
   shortcutMatchesShortcut,
   shortcutToHumanString,
@@ -135,22 +136,35 @@ const shortcutLabels = {
   openInEditor: 'Open story in editor',
   openInIsolation: 'Open story in isolation',
   copyStoryLink: 'Copy story link to clipboard',
+  goToPreviousLandmark: 'Go to previous landmark',
+  goToNextLandmark: 'Go to next landmark',
   // TODO: bring this back once we want to add shortcuts for this
   // copyStoryName: 'Copy story name to clipboard',
 };
 
 export type Feature = keyof typeof shortcutLabels;
 
+type ConfiguredShortcut = { shortcut: API_KeyCollection; error: boolean; hardcoded?: boolean };
+
 // Shortcuts that cannot be configured
 const fixedShortcuts = ['escape'];
 
-function toShortcutState(shortcutKeys: ShortcutsScreenProps['shortcutKeys']) {
-  return Object.entries(shortcutKeys).reduce(
-    // @ts-expect-error (non strict)
-    (acc, [feature, shortcut]: [Feature, string]) =>
-      fixedShortcuts.includes(feature) ? acc : { ...acc, [feature]: { shortcut, error: false } },
-    {} as Record<Feature, any>
-  );
+// Shortcuts that cannot be changed by the user (imposed by third-party libraries).
+const hardcodedShortcuts = ['gotoPreviousLandmark', 'goToNextLandmark'];
+
+function toShortcutState(
+  shortcutKeys: ShortcutsScreenProps['shortcutKeys']
+): Record<Feature, ConfiguredShortcut> {
+  const state: Record<string, ConfiguredShortcut> = {};
+  for (const key of Object.keys(shortcutKeys).filter((k) => !fixedShortcuts.includes(k))) {
+    state[key] = {
+      shortcut: shortcutKeys[key as Feature],
+      error: false,
+      hardcoded: hardcodedShortcuts.includes(key),
+    };
+  }
+
+  return state;
 }
 
 export interface ShortcutsScreenState {
@@ -179,7 +193,6 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
       // The initial shortcutKeys that come from props are the defaults/what was saved
       // As the user interacts with the page, the state stores the temporary, unsaved shortcuts
       // This object also includes the error attached to each shortcut
-      // @ts-expect-error (non strict)
       shortcutKeys: toShortcutState(props.shortcutKeys),
       addonsShortcutLabels: props.addonsShortcutLabels,
     };
@@ -254,7 +267,6 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
     const { restoreAllDefaultShortcuts } = this.props;
 
     const defaultShortcuts = await restoreAllDefaultShortcuts();
-    // @ts-expect-error (non strict)
     return this.setState({ shortcutKeys: toShortcutState(defaultShortcuts) });
   };
 
@@ -295,28 +307,46 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
         (addonsShortcutLabels && addonsShortcutLabels[feature])
     );
 
-    const arr = availableShortcuts.map(([feature, { shortcut }]: [Feature, any]) => (
-      <Row key={feature}>
-        {/* @ts-expect-error (non strict) */}
-        <Description>{shortcutLabels[feature] || addonsShortcutLabels[feature]}</Description>
+    const arr = availableShortcuts.map(
+      ([feature, { shortcut, hardcoded }]: [Feature, ConfiguredShortcut]) => (
+        <Row key={feature}>
+          {/* @ts-expect-error (non strict) */}
+          <Description>{shortcutLabels[feature] || addonsShortcutLabels[feature]}</Description>
 
-        <TextInput
-          spellCheck="false"
-          valid={this.displayError(feature)}
-          className="modalInput"
-          onBlur={this.onBlur}
-          onFocus={this.onFocus(feature)}
-          // @ts-expect-error (Converted from ts-ignore)
-          onKeyDown={this.onKeyDown}
-          value={shortcut ? shortcutToHumanString(shortcut) : ''}
-          placeholder="Type keys"
-          readOnly
-        />
+          {hardcoded ? (
+            <>
+              <TooltipProvider
+                tooltip={<Tooltip hasChrome>This shortcut cannot be changed.</Tooltip>}
+                placement="right"
+              >
+                <TextInput
+                  aria-disabled
+                  readOnly
+                  valid={undefined}
+                  value={shortcut ? shortcutToHumanString(shortcut) : ''}
+                />
+              </TooltipProvider>
+            </>
+          ) : (
+            <TextInput
+              spellCheck="false"
+              valid={this.displayError(feature)}
+              className="modalInput"
+              onBlur={this.onBlur}
+              onFocus={this.onFocus(feature)}
+              // @ts-expect-error (Converted from ts-ignore)
+              onKeyDown={this.onKeyDown}
+              value={shortcut ? shortcutToHumanString(shortcut) : ''}
+              placeholder="Type keys"
+              readOnly
+            />
+          )}
 
-        {/* @ts-expect-error (non strict) */}
-        <SuccessIcon valid={this.displaySuccessMessage(feature)} />
-      </Row>
-    ));
+          {/* @ts-expect-error (non strict) */}
+          <SuccessIcon valid={this.displaySuccessMessage(feature)} />
+        </Row>
+      )
+    );
 
     return arr;
   };
@@ -347,7 +377,6 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
         >
           Restore defaults
         </Button>
-
         <SettingsFooter />
       </Container>
     );

--- a/code/core/src/theming/global.ts
+++ b/code/core/src/theming/global.ts
@@ -134,6 +134,26 @@ export const createGlobal = memoize(1)(({
       opacity: 1,
     },
 
+    '[data-sb-landmark]': {
+      position: 'relative',
+    },
+
+    '[data-sb-landmark]:focus-visible': {
+      outline: 'none',
+    },
+
+    '[data-sb-landmark]:focus-visible::after': {
+      outline: `2px solid ${color.primary}`,
+      outlineOffset: '-2px',
+    },
+
+    '[data-sb-landmark]::after': {
+      content: "''",
+      position: 'absolute',
+      inset: 0,
+      pointerEvents: 'none',
+    },
+
     '.react-aria-Popover:focus-visible': {
       outline: 'none',
     },

--- a/docs/get-started/browse-stories.mdx
+++ b/docs/get-started/browse-stories.mdx
@@ -8,17 +8,21 @@ sidebar:
 
 Last chapter, we learned that stories correspond with discrete component states. This chapter demonstrates how to use Storybook as a workshop for building components.
 
-## Sidebar and Canvas
+## Sidebar and Preview
 
-A `*.stories.js|ts|svelte` file defines all the stories for a component. Each story has a corresponding sidebar item. When you click on a story, it renders in the Canvas an isolated preview iframe.
+A `*.stories.js|ts|svelte` file defines all the stories for a component. Each story has a corresponding sidebar item. When you click on a story, it renders in an isolated preview iframe.
 
 <Video src="../_assets/get-started/example-browse-all-stories-optimized.mp4" />
 
-Navigate between stories by clicking on them in the sidebar. Try the sidebar search to find a story by name.
+The sidebar contains three areas: the sidebar search, the story explorer, and the component test widget. Try the sidebar search to find a story by name. Navigate between stories by clicking on them in the sidebar. Run component tests for all stories using the widget at the bottom of the sidebar.
 
-Or use keyboard shortcuts. Click on the Storybook's menu to see the list of shortcuts available.
+Or use keyboard shortcuts. Click on the Storybook menu to see a list of available shortcuts.
 
 ![Storybook keyboard shortcuts examples](../_assets/get-started/storybook-keyboard-shortcuts.png)
+
+<Callout variant="info" icon="♿">
+  Storybook supports fast keyboard navigation between landmark regions. Press <kbd>F6</kbd> and <kbd>Shift+F6</kbd> to navigate between the sidebar, toolbar, preview, and addons panel.
+</Callout>
 
 ## Toolbar
 

--- a/docs/get-started/browse-stories.mdx
+++ b/docs/get-started/browse-stories.mdx
@@ -14,7 +14,7 @@ A `*.stories.js|ts|svelte` file defines all the stories for a component. Each st
 
 <Video src="../_assets/get-started/example-browse-all-stories-optimized.mp4" />
 
-The sidebar contains three areas: the sidebar search, the story explorer, and the component test widget. Try the sidebar search to find a story by name. Navigate between stories by clicking on them in the sidebar. Run component tests for all stories using the widget at the bottom of the sidebar.
+The sidebar contains three areas: sidebar search, story explorer, and [testing widget](../writing-tests/index.mdx). Try the sidebar search to find a story by name. Navigate between stories by clicking on them in the explorer. Run component tests for all stories using the widget at the bottom of the sidebar.
 
 Or use keyboard shortcuts. Click on the Storybook menu to see a list of available shortcuts.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5866,22 +5866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/landmark@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@react-aria/landmark@npm:3.0.7"
-  dependencies:
-    "@react-aria/utils": "npm:^3.31.0"
-    "@react-types/shared": "npm:^3.32.1"
-    "@swc/helpers": "npm:^0.5.0"
-    use-sync-external-store: "npm:^1.4.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10c0/581692703e20d351431d99025aca1e5ce06c8fb4b034dc283cf04d9cb86063780c0022f8e2a7948845a4bd90c891251f7549146bb07e845a5c287b739ad46f7d
-  languageName: node
-  linkType: hard
-
-"@react-aria/landmark@npm:^3.0.8":
+"@react-aria/landmark@npm:^3.0.7, @react-aria/landmark@npm:^3.0.8":
   version: 3.0.8
   resolution: "@react-aria/landmark@npm:3.0.8"
   dependencies:
@@ -6392,24 +6377,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/utils@npm:^3.30.1, @react-aria/utils@npm:^3.31.0":
-  version: 3.31.0
-  resolution: "@react-aria/utils@npm:3.31.0"
-  dependencies:
-    "@react-aria/ssr": "npm:^3.9.10"
-    "@react-stately/flags": "npm:^3.1.2"
-    "@react-stately/utils": "npm:^3.10.8"
-    "@react-types/shared": "npm:^3.32.1"
-    "@swc/helpers": "npm:^0.5.0"
-    clsx: "npm:^2.0.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10c0/a6b5c6b85a51fa9ca204f045f70d36a55e16b56b85141d556eaacb7b74c4c0915189f6d2baea06df59bdd2926dcca08c2313c98478dbb50ed8e59f9b6754735c
-  languageName: node
-  linkType: hard
-
-"@react-aria/utils@npm:^3.32.0":
+"@react-aria/utils@npm:^3.30.1, @react-aria/utils@npm:^3.31.0, @react-aria/utils@npm:^3.32.0":
   version: 3.32.0
   resolution: "@react-aria/utils@npm:3.32.0"
   dependencies:
@@ -6876,18 +6844,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/utils@npm:^3.10.8":
-  version: 3.10.8
-  resolution: "@react-stately/utils@npm:3.10.8"
-  dependencies:
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10c0/a97cc292986e3eeb2ceb1626671ce60e8342a3ff35ab92bcfcb94bd6b28729836cc592e3fe4df2fba603e5fdd26291be77b7f60441920298c282bb93f424feba
-  languageName: node
-  linkType: hard
-
-"@react-stately/utils@npm:^3.11.0":
+"@react-stately/utils@npm:^3.10.8, @react-stately/utils@npm:^3.11.0":
   version: 3.11.0
   resolution: "@react-stately/utils@npm:3.11.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5881,6 +5881,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-aria/landmark@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@react-aria/landmark@npm:3.0.8"
+  dependencies:
+    "@react-aria/utils": "npm:^3.32.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/13a81bbc37121eb1a1019608a20e97c72e5d7fa338550011052ba2230310002bf6d87aec31ae74e44ac622b473b8830108571787ca1edffd4f0df84f17b002ca
+  languageName: node
+  linkType: hard
+
 "@react-aria/link@npm:^3.8.6":
   version: 3.8.6
   resolution: "@react-aria/link@npm:3.8.6"
@@ -6394,6 +6409,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-aria/utils@npm:^3.32.0":
+  version: 3.32.0
+  resolution: "@react-aria/utils@npm:3.32.0"
+  dependencies:
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-stately/flags": "npm:^3.1.2"
+    "@react-stately/utils": "npm:^3.11.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+    clsx: "npm:^2.0.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/10fd9b162f8c752bf70070f5e091eaf3bd2c163b0a86e1f29c306c766b6b1acbbefa85c1ed6c28973b858afeafd638faa783361440c679890698c3d78bb50121
+  languageName: node
+  linkType: hard
+
 "@react-aria/virtualizer@npm:^4.1.9":
   version: 4.1.10
   resolution: "@react-aria/virtualizer@npm:4.1.10"
@@ -6852,6 +6884,17 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10c0/a97cc292986e3eeb2ceb1626671ce60e8342a3ff35ab92bcfcb94bd6b28729836cc592e3fe4df2fba603e5fdd26291be77b7f60441920298c282bb93f424feba
+  languageName: node
+  linkType: hard
+
+"@react-stately/utils@npm:^3.11.0":
+  version: 3.11.0
+  resolution: "@react-stately/utils@npm:3.11.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/09b38438df19fd8ff14d3147b2f9e5d42869b3ee637b0e33d6f2ab5cba93612e640c6de339b766b8c825d7bef828851fd551d5a197a037eb1331913546b8516c
   languageName: node
   linkType: hard
 
@@ -28416,6 +28459,7 @@ __metadata:
     "@radix-ui/react-scroll-area": "npm:1.2.0-rc.7"
     "@radix-ui/react-slot": "npm:^1.0.2"
     "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/landmark": "npm:^3.0.8"
     "@react-aria/overlays": "npm:^3.29.1"
     "@react-aria/tabs": "npm:^3.10.7"
     "@react-aria/toolbar": "npm:3.0.0-beta.20"


### PR DESCRIPTION
Closes #32271

## What I did


[Peek 2026-01-09 19-27.webm](https://github.com/user-attachments/assets/22d5de78-2f03-4f2f-9fa6-5540cdc3e00f)

* [x] Aligned site structure with feedback from accessibility experts who audited our recent a11y changes
* [x] Applied landmarks to
 * Sidebar (`header` element, `banner` role, was previously a nav)
 * Search (`search` role)
 * Explorer (`nav` role)
 * Preview (`main` role)
 * Toolbar (`region` role)
 * Addon panel (`aside` role)
* [x] In mobile, applied `header`/`banner` to the MobileNavigation bottom bar
* [x] Added global keyboard shortcuts for landmark nav (F6 / Shift+F6) based on React Aria, so that everyone can keyboard nav like a pro
* [x] Added focus outline specific to landmark regions so they can be spotted (reviewed with @MichaelArestad)
* [x] Fixed focus outline visibility on preview region
* [x] Fix issue with nav being unreachable when Search is focused
* [ ] ~Fix preview iframe eating up F6 key events~ (can't find a way)

Still gotta handle a few focus / keyboard handling edge cases.

## Checklist for Contributors

### Testing

Not tested

#### Manual testing

##### With screen reader
1. Run Storybook with NVDA or VoiceOver on
2. Use your screen reader's landmark navigation shortcuts (NVDA: D and Shift+D, when in browse mode)
3. NVDA will show a decorative outline (NVDA baked-in feature), VoiceOver won't

##### Without screen reader
1. Run Storybook in your favourite browser
2. Press F6 and Shift+F6 to quick nav between landmarks, using [React Aria's hook](https://react-aria.adobe.com/useLandmark)
3. Notice the highlight that helps you spot in which region you are
4. Notice the quick nav remembers which element of the landmark region you were last on, and returns to that element
5. This quick nav also does not suffer from limitations between browse mode and focus mode in screen readers

### Limitations

* Can't quick nav from within the preview iframe with React Aria shortcut
* Can't change the keyboard shortcut, it is hardcoded by React Aria, so we can't show it in the shortcuts UI for it to be customised
* Quicknav feature is undocumented at the moment

### Documentation

@kylegach @jonniebigodes @MichaelArestad I'd like to get your opinions on how to make this feature discoverable to users. Should we add it in the shortcuts page, even though it can't be edited, just for visibility? Is there a best page to document it in the docs website?

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard landmark navigation (F6 / Shift+F6) with temporary visual border highlighting; new shortcut labels and defaults added.
  * Card accepts custom outline attributes.
  * Semantic landmarks added across sidebar, toolbar, preview, panel, mobile nav, and widgets to improve accessibility.

* **Bug Fixes**
  * Skip link label changed from "Skip to canvas" to "Skip to content" for clarity.

* **Style**
  * Global styles added to support landmark focus indicators.

* **Documentation**
  * Getting-started guide updated to document landmark navigation and sidebar/preview changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->