### PR TITLE
AddonVitest: Improve perf & fix loading incorrect `.env` file

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -146,7 +146,6 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
   const [
     { storiesGlobs },
     framework,
-    storybookEnv,
     viteConfigFromStorybook,
     staticDirs,
     previewLevelTags,
@@ -156,7 +155,6 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
   ] = await Promise.all([
     getStoryGlobsAndFiles(presets, directories),
     presets.apply('framework', undefined),
-    presets.apply('env', {}),
     presets.apply<{ plugins?: Plugin[]; root: string }>('viteFinal', commonConfig),
     presets.apply('staticDirs', []),
     extractTagsFromPreview(finalOptions.configDir),
@@ -195,7 +193,11 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
         .replace('</head>', `${headHtmlSnippet ?? ''}</head>`)
         .replace('<body>', `<body>${bodyHtmlSnippet ?? ''}`);
     },
-    async config(nonMutableInputConfig) {
+    async config(nonMutableInputConfig, { mode }) {
+      if (mode) {
+        // Needed for `preset.apply('env')` to work correctly
+        process.env.BUILD_MODE = mode;
+      }
       // ! We're not mutating the input config, instead we're returning a new partial config
       // ! see https://vite.dev/guide/api-plugin.html#config
       try {
@@ -258,7 +260,15 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
             : {}),
 
           env: {
-            ...storybookEnv,
+            /**
+             * We do this late, because we need vitest's --mode to be available and set to
+             * BUILD_MODE. Unfortunately, the dependencies we use to load .env files can only be
+             * configured using that environment variable. We need it to be synced up with the mode
+             * that vitest is running in, or risk leaking envs from the wrong file.
+             *
+             * @see https://github.com/storybookjs/storybook/issues/33101
+             */
+            ...(await presets.apply('env', {})),
             // To be accessed by the setup file
             __STORYBOOK_URL__: finalOptions.storybookUrl,
 

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -412,10 +412,6 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
       }
     },
     async transform(code, id) {
-      if (!optionalEnvToBoolean(process.env.VITEST)) {
-        return code;
-      }
-
       const relativeId = relative(finalOptions.vitestRoot, id);
 
       if (match([relativeId], finalOptions.includeStories).length > 0) {

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -196,7 +196,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
     async config(nonMutableInputConfig, { mode }) {
       if (mode) {
         // Needed for `preset.apply('env')` to work correctly
-        process.env.BUILD_MODE = mode;
+        process.env.BUILD_TARGET = mode;
       }
       // ! We're not mutating the input config, instead we're returning a new partial config
       // ! see https://vite.dev/guide/api-plugin.html#config

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -98,6 +98,10 @@ const mdxStubPlugin: Plugin = {
 };
 
 export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> => {
+  if (!optionalEnvToBoolean(process.env.VITEST)) {
+    return [];
+  }
+
   const finalOptions = {
     ...defaultOptions,
     ...options,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/33101

## What I did

I am doing 2 things in this PR:

1: I'm improving the performance of the addon-vitest package, by only evaluating what config to add/change when the code is being called in a vitest environment.
2: Fix a bug where the incorrect .env file is loaded

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I discussed with @JReinhold about how to approach testing this, and though we discussed options like, extending a sandbox in some way or writing a unit-test for the function, both would be rather hard to do.

So I'm going to do a manual test using a canary release.
Here's my plan:

- I'm going to take the repro: https://stackblitz.com/edit/github-szu539pq?file=vite.config.ts
- Upgrade/switch it to my canary
- Ensure the .env files exist
- Run npm run build (executes vite build --mode=uat)
- Check if the built JS (in /dist/client/assets/index-*.js) contains the wrong environment variable (VITE_ENV_EXAMPLE=PRODUCTION instead of VITE_ENV_EXAMPLE=UAT)

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33469-sha-4021d8de`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33469-sha-4021d8de sandbox` or in an existing project with `npx storybook@0.0.0-pr-33469-sha-4021d8de upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33469-sha-4021d8de`](https://npmjs.com/package/storybook/v/0.0.0-pr-33469-sha-4021d8de) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/improve-vitest-addon-plugin`](https://github.com/storybookjs/storybook/tree/norbert/improve-vitest-addon-plugin) |
| **Commit** | [`4021d8de`](https://github.com/storybookjs/storybook/commit/4021d8dee40df375b3909274607beed8227fd5f1) |
| **Datetime** | Tue Jan  6 10:32:21 UTC 2026 (`1767695541`) |
| **Workflow run** | [20745609634](https://github.com/storybookjs/storybook/actions/runs/20745609634) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33469`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Vitest plugin initialization to better handle environment configuration and build mode setup.
  * Streamlined configuration resolution for improved Vitest integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->