### PR TITLE
UI: Fix regression in select close handler focus

### DIFF
--- a/code/core/src/components/components/Select/Select.stories.tsx
+++ b/code/core/src/components/components/Select/Select.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button } from 'storybook/internal/components';
+import { Button, Toolbar } from 'storybook/internal/components';
 
 import { LinuxIcon } from '@storybook/icons';
 
@@ -199,6 +199,113 @@ export const WithSiblings = meta.story({
       <Button ariaLabel={false}>After</Button>
     </Row>
   ),
+  play: async ({ canvas, step }) => {
+    const user = userEvent.setup();
+
+    await step('Open select and select an option', async () => {
+      const select = canvas.getByRole('button', { name: /Animal/i });
+      await user.click(select);
+
+      const listbox = await screen.findByRole('listbox');
+      expect(listbox).toBeInTheDocument();
+
+      const option = within(listbox).getByRole('option', { name: 'Frog' });
+      await user.click(option);
+    });
+
+    await step('Tab should land on sibling after select', async () => {
+      const select = canvas.getByRole('button', { name: /Frog/i });
+      expect(select).toHaveFocus();
+
+      await user.tab();
+
+      const afterButton = canvas.getByRole('button', { name: 'After' });
+      expect(afterButton).toHaveFocus();
+    });
+
+    await step('Navigate back and reopen select', async () => {
+      await user.tab({ shift: true });
+
+      const select = canvas.getByRole('button', { name: /Frog/i });
+      expect(select).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+
+      const listbox = await screen.findByRole('listbox');
+      expect(listbox).toBeInTheDocument();
+    });
+
+    await step('Escape should return to select trigger', async () => {
+      await user.keyboard('{Escape}');
+
+      const select = canvas.getByRole('button', { name: /Frog/i });
+      expect(select).toHaveFocus();
+    });
+  },
+});
+
+export const WithSiblingsInToolbar = meta.story({
+  name: 'With Siblings in Toolbar',
+  render: (args) => (
+    <Toolbar aria-label="Test toolbar">
+      <Button ariaLabel="Before button">Before</Button>
+      <Select {...args} />
+      <Button ariaLabel="After button">After</Button>
+    </Toolbar>
+  ),
+  play: async ({ canvas, step }) => {
+    const user = userEvent.setup();
+
+    await step('Navigate to select with ArrowRight', async () => {
+      const beforeButton = canvas.getByRole('button', { name: 'Before button' });
+      beforeButton.focus();
+      expect(beforeButton).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+
+      const select = canvas.getByRole('button', { name: /Animal/i });
+      expect(select).toHaveFocus();
+    });
+
+    await step('Open select and select an option', async () => {
+      await user.keyboard('{Enter}');
+
+      const listbox = await screen.findByRole('listbox');
+      expect(listbox).toBeInTheDocument();
+
+      const option = within(listbox).getByRole('option', { name: 'Frog' });
+      await user.click(option);
+    });
+
+    await step('ArrowRight should land on sibling after select', async () => {
+      const select = canvas.getByRole('button', { name: /Frog/i });
+      expect(select).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+
+      const afterButton = canvas.getByRole('button', { name: 'After button' });
+      expect(afterButton).toHaveFocus();
+    });
+
+    await step('Navigate back with ArrowLeft and reopen select', async () => {
+      await user.keyboard('{ArrowLeft}');
+
+      const select = canvas.getByRole('button', { name: /Frog/i });
+      expect(select).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+
+      const listbox = await screen.findByRole('listbox');
+      expect(listbox).toBeInTheDocument();
+    });
+
+    await step('Escape should return to select trigger', async () => {
+      await user.keyboard('{Escape}');
+
+      const select = canvas.getByRole('button', { name: /Frog/i });
+      expect(select).toHaveFocus();
+    });
+  },
 });
 
 export const DefaultOption = meta.story({

--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -213,6 +213,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
     ref
   ) => {
     const [isOpen, setIsOpen] = useState(props.defaultOpen || false);
+    const [shouldRefocusTrigger, setShouldRefocusTrigger] = useState(false);
     const triggerRef = useObjectRef(ref);
 
     const id = useMemo(() => {
@@ -228,8 +229,17 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
 
     const handleClose = useCallback(() => {
       setIsOpen(false);
-      triggerRef.current?.focus();
-    }, [triggerRef]);
+      setShouldRefocusTrigger(true);
+    }, []);
+
+    // We must delay refocusing the trigger because we first need the listbox to close,
+    // and @react-aria/overlays to remove the inert attribute set up by MinimalistPopover.
+    useEffect(() => {
+      if (!otState.isOpen && shouldRefocusTrigger) {
+        triggerRef.current?.focus();
+        setShouldRefocusTrigger(false);
+      }
+    }, [otState.isOpen, shouldRefocusTrigger, triggerRef]);
 
     // The last selected option(s), which will be used by the app.
     const [selectedOptions, setSelectedOptions] = useState<InternalOption[]>(


### PR DESCRIPTION
Closes #33467

## What I did

Fixed a nasty regression on keyboard handling in the toolbar (and all other Selects) introduced by https://github.com/storybookjs/storybook/pull/33186.

The `inert` attribute that prevents other components from installing focus traps whilst a Select is opened caused a race condition with the refocusing of the Select trigger when closing Select.

I've changed the close handler to ensure that the intermediary popover that sets up the hook with the inert attribute is unmounted (and its hook's cleanup function called) before actually attempting to refocus the trigger.

I've also reinforced stories to have a NRT for this use case.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Kb nav to toolbar background button
2. Press ArrowDown to enter
3. Press Esc to exit
4. Press Tab, notice you land on the next toolbar item

### Documentation
ø
## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling in the Select so the trigger reliably regains focus after the dropdown closes.

* **Tests**
  * Added interactive stories that exercise keyboard and mouse navigation for the Select, including sibling focus transitions.

* **New Features**
  * Added a new interactive story demonstrating the Select inside a toolbar with enhanced interaction coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->