### PR TITLE
CI: Skip nx workflow on forks due to missing secrets

### DIFF
--- a/.github/workflows/nx.yml
+++ b/.github/workflows/nx.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - next
+  # TODO use pull_request_target in the future to also run on forks
   pull_request:
     types: [opened, synchronize, labeled, reopened]
   schedule:
@@ -21,6 +22,7 @@ jobs:
   nx:
     if: >
       (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         (contains(github.event.pull_request.labels.*.name, 'ci:normal') ||
          contains(github.event.pull_request.labels.*.name, 'ci:merged') ||
          contains(github.event.pull_request.labels.*.name, 'ci:daily'))


### PR DESCRIPTION
## What I did

Forks don't have access to repository secrets (NX_CLOUD_ACCESS_TOKEN), so the nx workflow would fail. This change ensures the workflow only runs on PRs from the main repository.

In the future, we plan to use `pull_request_target` to safely run on forks while still having access to secrets.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

This is a CI workflow change. No manual testing is necessary - the workflow will simply be skipped for fork PRs.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>
  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
