### PR TITLE
Addon Pseudo States: Fix stylesheet rewrite for `:not()` with parenthesis in inner selector

### DIFF
--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -390,11 +390,11 @@ describe('rewriteStyleSheet', () => {
     );
   });
 
-  it('supports ":has" inside of ":not"', () => {
-    const sheet = new Sheet(':not(:hover, :has(:focus), :has(:active)) { color: red }');
+  it('supports ":has" inside and outside of ":not"', () => {
+    const sheet = new Sheet(':has(:not(:hover, :has(:focus), :has(:active))) { color: red }');
     rewriteStyleSheet(sheet as any);
     expect(sheet.cssRules[0].cssText).toEqual(
-      ':not(:hover, :has(:focus), :has(:active)), :not(.pseudo-hover, :has(.pseudo-focus), :has(.pseudo-active)), :not(.pseudo-hover-all *, .pseudo-focus-all :has(*), .pseudo-active-all :has(*)) { color: red }'
+      ':has(:not(:hover, :has(:focus), :has(:active))), :has(:not(.pseudo-hover, :has(.pseudo-focus), :has(.pseudo-active))), :has(:not(.pseudo-hover-all *, .pseudo-focus-all :has(*), .pseudo-active-all :has(*))) { color: red }'
     );
   });
 

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -391,10 +391,10 @@ describe('rewriteStyleSheet', () => {
   });
 
   it('supports ":has" inside of ":not"', () => {
-    const sheet = new Sheet(':not(:hover, :has(:focus), :active) { color: red }');
+    const sheet = new Sheet(':not(:hover, :has(:focus), :has(:active)) { color: red }');
     rewriteStyleSheet(sheet as any);
     expect(sheet.cssRules[0].cssText).toEqual(
-      ':not(:hover, :has(:focus), :active), :not(.pseudo-hover, :has(.pseudo-focus), .pseudo-active), :not(.pseudo-hover-all *, .pseudo-focus-all :has(*), .pseudo-active-all *) { color: red }'
+      ':not(:hover, :has(:focus), :has(:active)), :not(.pseudo-hover, :has(.pseudo-focus), :has(.pseudo-active)), :not(.pseudo-hover-all *, .pseudo-focus-all :has(*), .pseudo-active-all :has(*)) { color: red }'
     );
   });
 

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -390,6 +390,14 @@ describe('rewriteStyleSheet', () => {
     );
   });
 
+  it('supports ":has" inside of ":not"', () => {
+    const sheet = new Sheet(':not(:hover, :has(:focus), :active) { color: red }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].cssText).toEqual(
+      ':not(:hover, :has(:focus), :active), :not(.pseudo-hover, :has(.pseudo-focus), .pseudo-active), :not(.pseudo-hover-all *, .pseudo-focus-all :has(*), .pseudo-active-all *) { color: red }'
+    );
+  });
+
   it('skips escaped pseudo-selectors "\\:hover"', () => {
     const sheet = new Sheet('a\\:hover { color: red }');
     rewriteStyleSheet(sheet as any);

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
@@ -79,12 +79,15 @@ const extractPseudoStates = (selector: string) => {
 };
 
 const rewriteNotSelectors = (selector: string, forShadowDOM: boolean) => {
-  return [...selector.matchAll(/:not\(([^)]+)\)/g)].reduce((acc, match) => {
-    const originalNot = match[0];
-    const selectorList = match[1];
-    const rewrittenNot = rewriteNotSelector(selectorList, forShadowDOM);
-    return acc.replace(originalNot, rewrittenNot);
-  }, selector);
+  // Accept up to 3 levels of nested parentheses.
+  return [...selector.matchAll(/:not\((?:[^()]|\([^()]+\)|\((?:[^()]|\([^()]+\))+\))+\)/g)].reduce(
+    (acc, [originalNot]) => {
+      const selectorList = originalNot.match(/^:not\((.+)\)$/)?.[1] ?? '';
+      const rewrittenNot = rewriteNotSelector(selectorList, forShadowDOM);
+      return acc.replace(originalNot, rewrittenNot);
+    },
+    selector
+  );
 };
 
 const rewriteNotSelector = (negatedSelectorList: string, forShadowDOM: boolean) => {


### PR DESCRIPTION
## What I did

Fixed the below runtime error, which was caused by a styled component using a CSS selector shaped like `:not(:has(...))`. The way `:not` got rewritten did not take into account nested parenthesis. Now it does, up to 3 levels deep (seems sufficient for CSS).

<img width="833" height="175" alt="Screenshot 2026-01-09 at 08 47 54" src="https://github.com/user-attachments/assets/b06b428b-fc81-4978-8b99-5a2312fff354" />

The problem here is the last `:has()` does not have an argument, which is invalid. The solution is to pass `*` which we already did in other scenarios, just not this one.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Open the "Checklist" stories. They no longer cause a CSS parsing error.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS selector rewriting to correctly handle deeper nesting in :not(...) arguments and combinations with :has(), ensuring complex pseudo-selector expansions are applied reliably.

* **Tests**
  * Added a test verifying correct expansion and rewriting of complex nested pseudo-selectors, including :not with :has variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->