### PR TITLE
Revert "ReactDocgen: Try using the latest version of the original"

### DIFF
--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -428,9 +428,6 @@ export const baseTemplates = {
         features: {
           experimentalTestSyntax: true,
         },
-        typescript: {
-          reactDocgen: 'react-docgen-typescript',
-        } as any, // the generic type does not contain the reactDocgen property
       },
     },
     skipTasks: ['e2e-tests', 'bench', 'vitest-integration'],

--- a/code/presets/create-react-app/package.json
+++ b/code/presets/create-react-app/package.json
@@ -34,9 +34,9 @@
   ],
   "dependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
+    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
     "@types/semver": "^7.7.1",
     "pnp-webpack-plugin": "^1.7.0",
-    "react-docgen-typescript-plugin": "^1.0.8",
     "semver": "^7.7.3"
   },
   "devDependencies": {

--- a/code/presets/create-react-app/src/types.ts
+++ b/code/presets/create-react-app/src/types.ts
@@ -1,6 +1,6 @@
 import type { Options } from 'storybook/internal/types';
 
-import type { PluginOptions as RDTSPluginOptions } from 'react-docgen-typescript-plugin';
+import type { PluginOptions as RDTSPluginOptions } from '@storybook/react-docgen-typescript-plugin';
 
 export interface PluginOptions extends Options {
   /**

--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -39,10 +39,10 @@
   ],
   "dependencies": {
     "@storybook/core-webpack": "workspace:*",
+    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
     "@types/semver": "^7.7.1",
     "magic-string": "^0.30.5",
     "react-docgen": "^7.1.1",
-    "react-docgen-typescript-plugin": "^1.0.8",
     "resolve": "^1.22.8",
     "semver": "^7.7.3",
     "tsconfig-paths": "^4.2.0",

--- a/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
+++ b/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { TypescriptOptions } from '@storybook/core-webpack';
+import ReactDocgenTypescriptPlugin from '@storybook/react-docgen-typescript-plugin';
 
-import ReactDocgenTypescriptPlugin from 'react-docgen-typescript-plugin';
 import type { Configuration } from 'webpack';
 
 import * as preset from './framework-preset-react-docs';

--- a/code/presets/react-webpack/src/framework-preset-react-docs.ts
+++ b/code/presets/react-webpack/src/framework-preset-react-docs.ts
@@ -40,7 +40,7 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (
     };
   }
 
-  const { ReactDocgenTypeScriptPlugin } = await import('react-docgen-typescript-plugin');
+  const { ReactDocgenTypeScriptPlugin } = await import('@storybook/react-docgen-typescript-plugin');
 
   return {
     ...config,

--- a/code/presets/react-webpack/src/types.ts
+++ b/code/presets/react-webpack/src/types.ts
@@ -3,8 +3,7 @@ import type {
   TypescriptOptions as TypescriptOptionsBase,
   WebpackConfiguration as WebpackConfigurationBase,
 } from '@storybook/core-webpack';
-
-import type { PluginOptions as ReactDocgenTypescriptOptions } from 'react-docgen-typescript-plugin';
+import type { PluginOptions as ReactDocgenTypescriptOptions } from '@storybook/react-docgen-typescript-plugin';
 
 export type { BuilderResult } from '@storybook/core-webpack';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8264,10 +8264,10 @@ __metadata:
   resolution: "@storybook/preset-create-react-app@workspace:code/presets/create-react-app"
   dependencies:
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.1"
+    "@storybook/react-docgen-typescript-plugin": "npm:1.0.6--canary.9.0c3f3b7.0"
     "@types/node": "npm:^22.19.1"
     "@types/semver": "npm:^7.7.1"
     pnp-webpack-plugin: "npm:^1.7.0"
-    react-docgen-typescript-plugin: "npm:^1.0.8"
     semver: "npm:^7.7.3"
     typescript: "npm:^5.9.3"
   peerDependencies:
@@ -8281,12 +8281,12 @@ __metadata:
   resolution: "@storybook/preset-react-webpack@workspace:code/presets/react-webpack"
   dependencies:
     "@storybook/core-webpack": "workspace:*"
+    "@storybook/react-docgen-typescript-plugin": "npm:1.0.6--canary.9.0c3f3b7.0"
     "@types/node": "npm:^22.19.1"
     "@types/semver": "npm:^7.7.1"
     empathic: "npm:^2.0.0"
     magic-string: "npm:^0.30.5"
     react-docgen: "npm:^7.1.1"
-    react-docgen-typescript-plugin: "npm:^1.0.8"
     resolve: "npm:^1.22.8"
     semver: "npm:^7.7.3"
     tsconfig-paths: "npm:^4.2.0"
@@ -8317,6 +8317,24 @@ __metadata:
     storybook: "workspace:^"
   languageName: unknown
   linkType: soft
+
+"@storybook/react-docgen-typescript-plugin@npm:1.0.6--canary.9.0c3f3b7.0":
+  version: 1.0.6--canary.9.0c3f3b7.0
+  resolution: "@storybook/react-docgen-typescript-plugin@npm:1.0.6--canary.9.0c3f3b7.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    endent: "npm:^2.0.1"
+    find-cache-dir: "npm:^3.3.1"
+    flat-cache: "npm:^3.0.4"
+    micromatch: "npm:^4.0.2"
+    react-docgen-typescript: "npm:^2.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    typescript: ">= 4.x"
+    webpack: ">= 4"
+  checksum: 10c0/505a728f36df3f519f4985bdf18f2078ea18a1a8f7f837fc831f971363fb7643a182f01a6857a9729ac5a1246d370526fca5a19017f82e7493af4ca945cb7235
+  languageName: node
+  linkType: hard
 
 "@storybook/react-dom-shim@workspace:*, @storybook/react-dom-shim@workspace:code/lib/react-dom-shim":
   version: 0.0.0-use.local
@@ -14637,6 +14655,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dedent@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "dedent@npm:0.7.0"
+  checksum: 10c0/7c3aa00ddfe3e5fcd477958e156156a5137e3bb6ff1493ca05edff4decf29a90a057974cc77e75951f8eb801c1816cb45aea1f52d628cdd000b82b36ab839d1b
+  languageName: node
+  linkType: hard
+
 "deep-diff@npm:^1.0.2":
   version: 1.0.2
   resolution: "deep-diff@npm:1.0.2"
@@ -15532,6 +15557,17 @@ __metadata:
   dependencies:
     once: "npm:^1.4.0"
   checksum: 10c0/870b423afb2d54bb8d243c63e07c170409d41e20b47eeef0727547aea5740bd6717aca45597a9f2745525667a6b804c1e7bede41f856818faee5806dd9ff3975
+  languageName: node
+  linkType: hard
+
+"endent@npm:^2.0.1":
+  version: 2.1.0
+  resolution: "endent@npm:2.1.0"
+  dependencies:
+    dedent: "npm:^0.7.0"
+    fast-json-parse: "npm:^1.0.3"
+    objectorarray: "npm:^1.0.5"
+  checksum: 10c0/8cd6dae45e693ae2b2cbff2384348d3a5e2a06cc0396dddca8165e46bd2fd8d5394d44d338ba653bbfce4aead90eca1ec1abe7203843c84155c645d283b6b884
   languageName: node
   linkType: hard
 
@@ -17092,6 +17128,13 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.8"
   checksum: 10c0/f6aaa141d0d3384cf73cbcdfc52f475ed293f6d5b65bfc5def368b09163a9f7e5ec2b3014d80f733c405f58e470ee0cc451c2937685045cddcdeaa24199c43fe
+  languageName: node
+  linkType: hard
+
+"fast-json-parse@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "fast-json-parse@npm:1.0.3"
+  checksum: 10c0/2c58c7a0f7f1725c9da1272839f9bee3ccc13b77672b18ab4ac470c707999bca39828cd7e79b87c73017f21c3ddff37992d03fa2fd2da124d9bd06c1d02c9b7e
   languageName: node
   linkType: hard
 
@@ -23470,6 +23513,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"objectorarray@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "objectorarray@npm:1.0.5"
+  checksum: 10c0/3d3db66e2052df85617ac31b98f8e51a7a883ebce24123018dacf286712aa513a0a84e82b4a6bef68889d5fc39cf08e630ee78df013023fc5161e1fdf3eaaa5a
+  languageName: node
+  linkType: hard
+
 "obuf@npm:^1.0.0, obuf@npm:^1.1.2":
   version: 1.1.2
   resolution: "obuf@npm:1.1.2"
@@ -25758,23 +25808,6 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 10c0/48eb73cf71e10841c2a61b6b06ab81da9fffa9876134c239bfdebcf348ce2a47e56b146338e35dfb03512c85966bfc9a53844fc56bc50154e71f8daee59ff6f0
-  languageName: node
-  linkType: hard
-
-"react-docgen-typescript-plugin@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "react-docgen-typescript-plugin@npm:1.0.8"
-  dependencies:
-    debug: "npm:^4.1.1"
-    find-cache-dir: "npm:^3.3.1"
-    flat-cache: "npm:^3.0.4"
-    micromatch: "npm:^4.0.2"
-    react-docgen-typescript: "npm:^2.2.2"
-    tslib: "npm:^2.6.2"
-  peerDependencies:
-    typescript: ">= 4.x"
-    webpack: ">= 4"
-  checksum: 10c0/9abd1e7c71e2ba7fad080ef17fd262c89aa59509c69a5d34f2a8b63f7e33271e49ab82274c79393f704f387eb09247de6f32605439835237dacf4e31de6859a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts storybookjs/storybook#33454

I have found a major regression when react components are exported directly like so:
```ts
export default function Header(){};
```

When users change their code to be like so:
```ts
function header(){};
export default Header
```

Everything functions correctly.

For now, I'll revert the change, and I'll seek a way to improve the upstream package so that it supports this use-case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React Docgen TypeScript plugin integration across Create React App and React Webpack presets to use Storybook's maintained variant, improving long-term dependency management and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->