### PR TITLE
A11y: Ensure popover dialogs have an ARIA label

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -627,6 +627,20 @@ The PopoverProvider component acts as a counterpoint to WithTooltip. When you wa
 
 PopoverProvider is based on react-aria. It must have a single child that acts as a trigger. This child must have a pressable role (can be clicked or pressed) and must be able to receive React refs. Wrap your trigger component in `forwardRef` if you notice placement issues for your popover.
 
+##### Added: ariaLabel
+
+The `ariaLabel` prop was added to provide an accessible label for the popover dialog. This label is announced by screen readers when the popover opens. **This prop will become mandatory in Storybook 11.** Provide a concise description of the popover's purpose.
+
+```tsx
+<PopoverProvider ariaLabel="Share options" popover={<ShareMenu />}>
+  <Button ariaLabel="Share">Share</Button>
+</PopoverProvider>
+```
+
+##### Automatic aria-haspopup
+
+PopoverProvider now automatically sets `aria-haspopup="dialog"` on the trigger element. You no longer need to manually add this attribute to your trigger buttons.
+
 #### WithTooltip Component API Changes
 
 The WithTooltip component has been reimplemented from the ground up, under the new name `TooltipProvider`. The new implementation will replace `WithTooltip` entirely in Storybook 11. Below is a summary of the changes between both APIs, which will take full effect in Storybook 11.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -629,7 +629,7 @@ PopoverProvider is based on react-aria. It must have a single child that acts as
 
 ##### Added: ariaLabel
 
-The `ariaLabel` prop was added to provide an accessible label for the popover dialog. This label is announced by screen readers when the popover opens. **This prop will become mandatory in Storybook 11.** Provide a concise description of the popover's purpose.
+The `ariaLabel` prop was added in Storybook 10.2 to provide an accessible label for the popover dialog. This label is announced by screen readers when the popover opens. `ariaLabel` will become mandatory in Storybook 11.
 
 ```tsx
 <PopoverProvider ariaLabel="Share options" popover={<ShareMenu />}>

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -637,10 +637,6 @@ The `ariaLabel` prop was added to provide an accessible label for the popover di
 </PopoverProvider>
 ```
 
-##### Automatic aria-haspopup
-
-PopoverProvider now automatically sets `aria-haspopup="dialog"` on the trigger element. You no longer need to manually add this attribute to your trigger buttons.
-
 #### WithTooltip Component API Changes
 
 The WithTooltip component has been reimplemented from the ground up, under the new name `TooltipProvider`. The new implementation will replace `WithTooltip` entirely in Storybook 11. Below is a summary of the changes between both APIs, which will take full effect in Storybook 11.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -629,7 +629,7 @@ PopoverProvider is based on react-aria. It must have a single child that acts as
 
 ##### Added: ariaLabel
 
-The `ariaLabel` prop was added in Storybook 10.2 to provide an accessible label for the popover dialog. This label is announced by screen readers when the popover opens. `ariaLabel` will become mandatory in Storybook 11.
+The `ariaLabel` prop was added in Storybook 10.3 to provide an accessible label for the popover dialog. This label is announced by screen readers when the popover opens. `ariaLabel` will become mandatory in Storybook 11.
 
 ```tsx
 <PopoverProvider ariaLabel="Share options" popover={<ShareMenu />}>

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
@@ -203,6 +203,7 @@ const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
 
   return (
     <PopoverProvider
+      ariaLabel="Argument value details"
       placement="bottom"
       visible={isOpen}
       onVisibleChange={(isVisible) => {

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgValue.tsx
@@ -203,7 +203,7 @@ const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
 
   return (
     <PopoverProvider
-      ariaLabel="Argument value details"
+      ariaLabel="Arg value details"
       placement="bottom"
       visible={isOpen}
       onVisibleChange={(isVisible) => {

--- a/code/addons/docs/src/blocks/controls/Color.tsx
+++ b/code/addons/docs/src/blocks/controls/Color.tsx
@@ -393,6 +393,7 @@ export const ColorControl: FC<ColorControlProps> = ({
         placeholder="Choose color..."
       />
       <PopoverProvider
+        ariaLabel="Color picker"
         defaultVisible={startOpen}
         visible={readOnly ? false : undefined}
         onVisibleChange={() => color && addPreset(color)}

--- a/code/core/src/components/components/Popover/PopoverProvider.stories.tsx
+++ b/code/core/src/components/components/Popover/PopoverProvider.stories.tsx
@@ -28,6 +28,7 @@ const meta = preview.meta({
   title: 'Overlay/PopoverProvider',
   component: PopoverProvider,
   args: {
+    ariaLabel: 'Sample popover',
     hasChrome: true,
     offset: 8,
     placement: 'top',

--- a/code/core/src/components/components/Popover/PopoverProvider.tsx
+++ b/code/core/src/components/components/Popover/PopoverProvider.tsx
@@ -104,9 +104,11 @@ export const PopoverProvider = ({
     >
       <Pressable>
         {
+          // React-aria does not inject aria-haspopup='dialog' to support legacy screen readers, so we do it ourselves.
+          // @ts-expect-error react-aria does not allow passing valid ARIA attributes to Pressable children
           cloneElement(children, {
             'aria-haspopup': 'dialog',
-          } as DOMAttributes<Element>) as ReactElement<DOMAttributes<FocusableElement>, string>
+          })
         }
       </Pressable>
       <PopoverUpstream

--- a/code/core/src/components/components/Popover/PopoverProvider.tsx
+++ b/code/core/src/components/components/Popover/PopoverProvider.tsx
@@ -1,6 +1,5 @@
 import type { DOMAttributes, ReactElement, ReactNode } from 'react';
 import React, { cloneElement, useCallback, useState } from 'react';
-import type { FocusableElement } from '@react-types/shared';
 
 import { deprecate } from 'storybook/internal/client-logger';
 

--- a/code/core/src/components/components/Popover/PopoverProvider.tsx
+++ b/code/core/src/components/components/Popover/PopoverProvider.tsx
@@ -104,11 +104,12 @@ export const PopoverProvider = ({
     >
       <Pressable>
         {
-          // React-aria does not inject aria-haspopup='dialog' to support legacy screen readers, so we do it ourselves.
-          // @ts-expect-error react-aria does not allow passing valid ARIA attributes to Pressable children
-          cloneElement(children, {
-            'aria-haspopup': 'dialog',
-          })
+          /* React-aria does not inject aria-haspopup='dialog' to support legacy screen readers, so we do it ourselves. */
+          cloneElement(
+            children,
+            // @ts-expect-error aria-haspopup is a valid ARIA attribute but cloneElement types are too strict
+            { 'aria-haspopup': 'dialog' }
+          )
         }
       </Pressable>
       <PopoverUpstream

--- a/code/core/src/components/components/Tabs/Tabs.hooks.tsx
+++ b/code/core/src/components/components/Tabs/Tabs.hooks.tsx
@@ -69,7 +69,7 @@ export function useList(list: ChildrenListComplete) {
       return (
         <>
           <PopoverProvider
-            ariaLabel="More tabs"
+            ariaLabel="Additional tabs"
             visible={isTooltipVisible}
             onVisibleChange={setTooltipVisible}
             placement="bottom"

--- a/code/core/src/components/components/Tabs/Tabs.hooks.tsx
+++ b/code/core/src/components/components/Tabs/Tabs.hooks.tsx
@@ -69,6 +69,7 @@ export function useList(list: ChildrenListComplete) {
       return (
         <>
           <PopoverProvider
+            ariaLabel="More tabs"
             visible={isTooltipVisible}
             onVisibleChange={setTooltipVisible}
             placement="bottom"

--- a/code/core/src/components/components/tooltip/TooltipMessage.stories.tsx
+++ b/code/core/src/components/components/tooltip/TooltipMessage.stories.tsx
@@ -27,7 +27,13 @@ const WithPopoverDecorator: DecoratorFunction = (storyFn) => (
       height: '300px',
     }}
   >
-    <PopoverProvider ariaLabel="Tooltip message" placement="top" visible padding={0} popover={storyFn()}>
+    <PopoverProvider
+      ariaLabel="Tooltip message"
+      placement="top"
+      visible
+      padding={0}
+      popover={storyFn()}
+    >
       <Button ariaLabel={false}>Popover</Button>
     </PopoverProvider>
   </div>

--- a/code/core/src/components/components/tooltip/TooltipMessage.stories.tsx
+++ b/code/core/src/components/components/tooltip/TooltipMessage.stories.tsx
@@ -27,7 +27,7 @@ const WithPopoverDecorator: DecoratorFunction = (storyFn) => (
       height: '300px',
     }}
   >
-    <PopoverProvider placement="top" visible padding={0} popover={storyFn()}>
+    <PopoverProvider ariaLabel="Tooltip message" placement="top" visible padding={0} popover={storyFn()}>
       <Button ariaLabel={false}>Popover</Button>
     </PopoverProvider>
   </div>

--- a/code/core/src/manager/components/preview/tools/share.tsx
+++ b/code/core/src/manager/components/preview/tools/share.tsx
@@ -146,6 +146,7 @@ export const shareTool: Addon_BaseType = {
       {({ api, storyId, refId }) =>
         storyId ? (
           <PopoverProvider
+            ariaLabel="Share this story"
             hasChrome
             placement="bottom"
             padding={0}

--- a/code/core/src/manager/components/sidebar/ChecklistWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ChecklistWidget.tsx
@@ -247,7 +247,7 @@ export const ChecklistWidget = () => {
                   <CollapseToggle
                     {...toggleProps}
                     id="checklist-module-collapse-toggle"
-                    ariaLabel={`${isCollapsed ? 'Expand' : 'Collapse'} onboarding checklist`}
+                    ariaLabel={`${isCollapsed ? 'Expand' : 'Collapse'} onboarding guide`}
                   >
                     <ChevronSmallUpIcon
                       style={{

--- a/code/core/src/manager/components/sidebar/ChecklistWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ChecklistWidget.tsx
@@ -259,7 +259,7 @@ export const ChecklistWidget = () => {
                   </CollapseToggle>
                   {loaded && (
                     <PopoverProvider
-                      ariaLabel="Checklist options"
+                      ariaLabel="Onboarding guide menu"
                       padding={0}
                       popover={({ onHide }) => (
                         <ActionList>

--- a/code/core/src/manager/components/sidebar/ChecklistWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ChecklistWidget.tsx
@@ -259,6 +259,7 @@ export const ChecklistWidget = () => {
                   </CollapseToggle>
                   {loaded && (
                     <PopoverProvider
+                      ariaLabel="Checklist options"
                       padding={0}
                       popover={({ onHide }) => (
                         <ActionList>

--- a/code/core/src/manager/components/sidebar/ContextMenu.tsx
+++ b/code/core/src/manager/components/sidebar/ContextMenu.tsx
@@ -196,6 +196,7 @@ export const useContextMenu = (context: API_HashEntry, links: Link[], api: API) 
       onMouseEnter: handlers.onMouseEnter,
       node: shouldRender ? (
         <PopoverProvider
+          ariaLabel="Story actions"
           placement="bottom-end"
           defaultVisible={false}
           visible={isOpen}

--- a/code/core/src/manager/components/sidebar/ContextMenu.tsx
+++ b/code/core/src/manager/components/sidebar/ContextMenu.tsx
@@ -196,7 +196,7 @@ export const useContextMenu = (context: API_HashEntry, links: Link[], api: API) 
       onMouseEnter: handlers.onMouseEnter,
       node: shouldRender ? (
         <PopoverProvider
-          ariaLabel="Story actions"
+          ariaLabel="Context menu"
           placement="bottom-end"
           defaultVisible={false}
           visible={isOpen}

--- a/code/core/src/manager/components/sidebar/Menu.tsx
+++ b/code/core/src/manager/components/sidebar/Menu.tsx
@@ -199,6 +199,7 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick
 
   return (
     <PopoverProvider
+      ariaLabel="Storybook menu"
       placement={'bottom-start'}
       padding={0}
       popover={({ onHide }) => <SidebarMenuList onHide={onHide} menu={menu} />}

--- a/code/core/src/manager/components/sidebar/RefBlocks.tsx
+++ b/code/core/src/manager/components/sidebar/RefBlocks.tsx
@@ -127,6 +127,7 @@ export const ErrorBlock: FC<{ error: Error }> = ({ error }) => {
           Oh no! Something went wrong loading this Storybook.
           <br />
           <PopoverProvider
+            ariaLabel="Error details"
             hasCloseButton
             offset={isMobile ? 0 : 8}
             placement={isMobile ? 'bottom-end' : 'bottom-start'}

--- a/code/core/src/manager/components/sidebar/RefIndicator.tsx
+++ b/code/core/src/manager/components/sidebar/RefIndicator.tsx
@@ -155,6 +155,7 @@ export const RefIndicator = React.memo(
       return (
         <IndicatorPlacement ref={forwardedRef}>
           <PopoverProvider
+            ariaLabel="Storybook status"
             placement={isMobile ? 'bottom' : 'bottom-start'}
             padding={0}
             popover={() => (

--- a/code/core/src/manager/components/sidebar/RefIndicator.tsx
+++ b/code/core/src/manager/components/sidebar/RefIndicator.tsx
@@ -155,7 +155,7 @@ export const RefIndicator = React.memo(
       return (
         <IndicatorPlacement ref={forwardedRef}>
           <PopoverProvider
-            ariaLabel="Storybook status"
+            ariaLabel="Composed Storybook status"
             placement={isMobile ? 'bottom' : 'bottom-start'}
             padding={0}
             popover={() => (

--- a/code/core/src/manager/components/sidebar/TagsFilter.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilter.tsx
@@ -212,6 +212,7 @@ export const TagsFilter = ({ api, indexJson, tagPresets }: TagsFilterProps) => {
 
   return (
     <PopoverProvider
+      ariaLabel="Tag filters"
       placement="bottom"
       onVisibleChange={setExpanded}
       offset={8}
@@ -236,7 +237,6 @@ export const TagsFilter = ({ api, indexJson, tagPresets }: TagsFilterProps) => {
         key="tags"
         ariaLabel="Tag filters"
         ariaDescription="Filter the items shown in a sidebar based on the tags applied to them."
-        aria-haspopup="dialog"
         variant="ghost"
         padding="small"
         isHighlighted={tagsActive}

--- a/code/core/src/manager/container/Menu.stories.tsx
+++ b/code/core/src/manager/container/Menu.stories.tsx
@@ -21,7 +21,7 @@ export default {
           height: '300px',
         }}
       >
-        <PopoverProvider placement="top" defaultVisible padding={0} popover={storyFn()}>
+        <PopoverProvider ariaLabel="Menu" placement="top" defaultVisible padding={0} popover={storyFn()}>
           <Button ariaLabel={false}>Click me</Button>
         </PopoverProvider>
       </div>

--- a/code/core/src/manager/container/Menu.stories.tsx
+++ b/code/core/src/manager/container/Menu.stories.tsx
@@ -21,7 +21,13 @@ export default {
           height: '300px',
         }}
       >
-        <PopoverProvider ariaLabel="Menu" placement="top" defaultVisible padding={0} popover={storyFn()}>
+        <PopoverProvider
+          ariaLabel="Menu"
+          placement="top"
+          defaultVisible
+          padding={0}
+          popover={storyFn()}
+        >
           <Button ariaLabel={false}>Click me</Button>
         </PopoverProvider>
       </div>


### PR DESCRIPTION
Closes #33494

  ## What I did

  Added accessibility improvements to `PopoverProvider` component:

  - Added `ariaLabel` prop that provides an accessible label for the popover dialog, announced by screen readers when the popover opens
  - Added deprecation warning when `ariaLabel` is not provided (will become mandatory in Storybook 11)
  - Automatically injects `aria-haspopup="dialog"` to trigger elements, informing assistive technology that the button opens a dialog
  - Updated all existing `PopoverProvider` usages in the codebase with appropriate aria labels
  - Updated MIGRATION.md with documentation for the new prop and behavior

  ## Checklist for Contributors

  ### Testing

  #### The changes in this PR are covered in the following automated tests:

  - [x] stories
  - [ ] unit tests
  - [ ] integration tests
  - [ ] end-to-end tests

  #### Manual testing

  1. Run `yarn storybook:ui` in the `code` directory
  2. Navigate to **Overlay/PopoverProvider** stories
  3. Open browser DevTools and inspect a trigger button
  4. Verify `aria-haspopup="dialog"` is present on the trigger
  5. Click the trigger to open the popover
  6. Verify `aria-expanded="true"` appears on the trigger when open
  7. Inspect the popover element and verify `aria-label` is set

  ### Documentation

  - [ ] Add or update documentation reflecting your changes
  - [x] If you are deprecating/removing a feature, make sure to update
        [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

  ## Checklist for Maintainers

  - [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
  - [ ] Make sure this PR contains **one** of the labels below:
     <details>
       <summary>Available labels</summary>

    - `bug`: Internal changes that fixes incorrect behavior.
    - `maintenance`: User-facing maintenance tasks.
    - `dependencies`: Upgrading (sometimes downgrading) dependencies.
    - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
    - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
    - `documentation`: Documentation **only** changes. Will not show up in release changelog.
    - `feature request`: Introducing a new feature.
    - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
    - `other`: Changes that don't fit in the above categories.

     </details>
     
     
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popovers now support an ariaLabel for improved accessibility; many popovers and stories include example labels.
  * Tooltip system reimplemented as TooltipProvider with a new triggerOnFocusOnly option and defaultVisible control.

* **Breaking Changes**
  * WithTooltip public API simplified: removed trigger, interactive, followCursor, closeOnOutsideClick, closeOnTriggerHidden, withArrows, strategy, mutationObserverOptions, hasChrome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=132382032