### PR TITLE
CSF-Factories: Export WebComponentsTypes and VueTypes

### DIFF
--- a/code/renderers/vue3/src/index.ts
+++ b/code/renderers/vue3/src/index.ts
@@ -5,3 +5,5 @@ export * from './public-types';
 export * from './portable-stories';
 
 export * from './preview';
+
+export type { VueTypes } from './types';

--- a/code/renderers/web-components/src/index.ts
+++ b/code/renderers/web-components/src/index.ts
@@ -9,6 +9,8 @@ export * from './framework-api';
 export * from './portable-stories';
 export * from './preview';
 
+export type { WebComponentsTypes } from './types';
+
 // TODO: disable HMR and do full page loads because of customElements.define
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Export `WebComponentsTypes` from `@storybook/web-components` and `VueTypes` from `@storybook/vue3`.

When using CSF factories with `meta.story()`, the return type references these type constraints, but they were not exported from the package's public API, causing TS4023 errors:

```
TS4023: Exported variable 'Default' has or is using name 'WebComponentsTypes'
```

This follows the existing pattern from `@storybook/react` which already exports `ReactTypes` (added in #30601).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

This is a TypeScript types-only change. To test:
1. Use the canary release in a project using `@storybook/web-components` or `@storybook/vue3` with CSF factories
2. Verify that `meta.story()` no longer produces TS4023 errors about unexported types

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation changes needed - this is a bugfix for missing type exports.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33521-sha-610a6294`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33521-sha-610a6294 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33521-sha-610a6294 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33521-sha-610a6294`](https://npmjs.com/package/storybook/v/0.0.0-pr-33521-sha-610a6294) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/fix-ts4023-types-export`](https://github.com/storybookjs/storybook/tree/kasper/fix-ts4023-types-export) |
| **Commit** | [`610a6294`](https://github.com/storybookjs/storybook/commit/610a62946d8e093fcae67dc8bb1af4d93e0fb1ad) |
| **Datetime** | Tue Jan 13 10:11:23 UTC 2026 (`1768299083`) |
| **Workflow run** | [20952819137](https://github.com/storybookjs/storybook/actions/runs/20952819137) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33521`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->