### PR TITLE
Telemetry: Add `packageJson.type`

### DIFF
--- a/code/core/src/telemetry/storybook-metadata.ts
+++ b/code/core/src/telemetry/storybook-metadata.ts
@@ -222,6 +222,7 @@ export const computeStorybookMetadata = async ({
     storybookPackages,
     addons,
     hasStorybookEslint,
+    packageJsonType: packageJson.type ?? 'unknown',
   };
 };
 

--- a/code/core/src/telemetry/types.ts
+++ b/code/core/src/telemetry/types.ts
@@ -78,6 +78,7 @@ export type StorybookMetadata = {
     packageName: string;
     version: string;
   };
+  packageJsonType?: 'unknown' | 'module' | 'commonjs';
   knownPackages?: KnownPackagesList;
   hasRouterPackage?: boolean;
   hasStorybookEslint?: boolean;


### PR DESCRIPTION
## What I did

We had a conversation about a bug, where users are presented with a warning from NodeJS about the fact that `main.js` is a ESM formatted file, but it's assumed to be CJS in the case where users have `packageJson.type` as `commonjs` (default).

We do not know how common this situation is, we do know that about 15% of `init` do not use TypeScipt.

We internally debated how important it is to address the bug, and agrees, we should investigate the data a bit more, and determine how many users are affected.

For this we need to know the user's `packageJson.type` field.
If it turns out a significant portion has `none` or `commonjs` we deem it important to figure out a fix.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I suspect, no manual testing is required; since all the code to load `packageJson` was already present, we're only adding 1 additional field to an pre-existing system.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced telemetry data collection to track your project's module type configuration, capturing whether your package uses ESM (module) or CommonJS format for improved analytics and diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->