### PR TITLE
CSF-Factories: Allow kebab-case HTML attribute names in web components args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ code/core/report
 
 .junie
 CLAUDE.local.md
+.claude

--- a/code/renderers/web-components/src/csf-factories.test.ts
+++ b/code/renderers/web-components/src/csf-factories.test.ts
@@ -205,3 +205,23 @@ it('Components without Props can be used', () => {
 
   const Basic = meta.story();
 });
+
+// https://github.com/storybookjs/storybook/issues/33524
+it('✅ Kebab-case HTML attribute names are allowed in args', () => {
+  const meta = preview.meta({
+    component: 'my-button',
+    args: {
+      label: 'hello',
+      'aria-label': 'my button', // kebab-case attribute
+    },
+  });
+
+  const Basic = meta.story({
+    args: {
+      'data-testid': 'button-1', // kebab-case attribute
+    },
+  });
+
+  expect(meta.input.args?.['aria-label']).toBe('my button');
+  expect(Basic.input.args?.['data-testid']).toBe('button-1');
+});

--- a/code/renderers/web-components/src/preview.ts
+++ b/code/renderers/web-components/src/preview.ts
@@ -60,6 +60,15 @@ type InferWebComponentsTypes<T, TArgs, Decorators> = WebComponentsTypes &
   T & { args: Simplify<InferArgs<TArgs, T, Decorators>> };
 
 /**
+ * Infers args from a web component's HTMLElement type, allowing both camelCase properties and
+ * kebab-case HTML attribute names (e.g., 'aria-label', 'data-testid', 'static-color').
+ */
+type InferArgsFromComponent<C extends keyof HTMLElementTagNameMap> = Partial<
+  HTMLElementTagNameMap[C]
+> &
+  Record<`${string}-${string}`, unknown>;
+
+/**
  * Web Components-specific Preview interface that provides type-safe CSF factory methods.
  *
  * Use `preview.meta()` to create a meta configuration for a component, and then `meta.story()` to
@@ -94,22 +103,20 @@ export interface WebComponentsPreview<T extends AddonTypes> extends Preview<
     C extends keyof HTMLElementTagNameMap,
     Decorators extends DecoratorFunction<WebComponentsTypes & T, any>,
     // Try to make Exact<Partial<TArgs>, TMetaArgs> work
-    TMetaArgs extends Partial<HTMLElementTagNameMap[C] & T['args']>,
+    TMetaArgs extends InferArgsFromComponent<C> & Partial<T['args']>,
   >(
     meta: {
       component?: C;
       args?: TMetaArgs;
       decorators?: Decorators | Decorators[];
     } & Omit<
-      ComponentAnnotations<WebComponentsTypes & T, Partial<HTMLElementTagNameMap[C]> & T['args']>,
+      ComponentAnnotations<WebComponentsTypes & T, InferArgsFromComponent<C> & T['args']>,
       'decorators' | 'component' | 'args'
     >
   ): WebComponentsMeta<
-    InferWebComponentsTypes<T, Partial<HTMLElementTagNameMap[C]>, Decorators>,
+    InferWebComponentsTypes<T, InferArgsFromComponent<C>, Decorators>,
     Omit<
-      ComponentAnnotations<
-        InferWebComponentsTypes<T, Partial<HTMLElementTagNameMap[C]>, Decorators>
-      >,
+      ComponentAnnotations<InferWebComponentsTypes<T, InferArgsFromComponent<C>, Decorators>>,
       'args'
     > & {
       args: {} extends TMetaArgs ? {} : TMetaArgs;


### PR DESCRIPTION
closes #33524

## What I did

When using `@wc-toolkit/storybook-helpers` or similar libraries that generate args with kebab-case attribute names (e.g., `'static-color'`), TypeScript would error because our types only allowed camelCase property names.

This adds `InferArgsFromComponent<C>` which allows both:
- **camelCase properties** from `HTMLElementTagNameMap` (type-checked)
- **kebab-case strings** containing `-` (for HTML attributes)

Since JavaScript property names cannot contain `-`, any string with a dash is definitively an HTML attribute name, making this a safe heuristic.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Clone the reproduction repo: `git clone https://github.com/kasperpeulen/spectrum-web-components.git`
2. Checkout the branch: `git checkout storybook-csf-factories-kebab-case-issue`
3. Install the canary: `npx storybook@<CANARY_VERSION> upgrade`
4. Run TypeScript check: `cd 2nd-gen/packages/swc && npx tsc --noEmit`
5. Verify no errors for kebab-case args like `'static-color'` or `'icon-slot'`

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation changes needed - this is a bugfix for type inference.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web component arguments now support kebab-case HTML attribute names (e.g., aria-label, data-testid) alongside camelCase properties.

* **Tests**
  * Added test coverage for kebab-case attribute naming conventions in web component arguments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->