### PR TITLE
CLI: Detect free port when running dev during initiate

### DIFF
--- a/code/core/src/core-server/index.ts
+++ b/code/core/src/core-server/index.ts
@@ -30,3 +30,5 @@ export {
   fullTestProviderStore as internal_fullTestProviderStore,
   universalTestProviderStore as internal_universalTestProviderStore,
 } from './stores/test-provider';
+
+export { getServerPort } from './utils/server-address';

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -4,11 +4,8 @@ import {
   PackageManagerName,
   executeCommand,
 } from 'storybook/internal/common';
-import { withTelemetry } from 'storybook/internal/core-server';
+import { getServerPort, withTelemetry } from 'storybook/internal/core-server';
 import { logTracker, logger } from 'storybook/internal/node-logger';
-import { ErrorCollector } from 'storybook/internal/telemetry';
-
-import detectFreePort from 'detect-port';
 
 import {
   executeAddonConfiguration,
@@ -187,7 +184,7 @@ async function runStorybookDev(result: {
 
     // Check if default port 6006 is available
     const defaultPort = 6006;
-    const availablePort = await detectFreePort(defaultPort);
+    const availablePort = await getServerPort(defaultPort);
     const useAlternativePort = availablePort !== defaultPort;
 
     if (useAlternativePort) {

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -182,15 +182,6 @@ async function runStorybookDev(result: {
       flags.push('--silent');
     }
 
-    // Check if default port 6006 is available
-    const defaultPort = 6006;
-    const availablePort = await getServerPort(defaultPort);
-    const useAlternativePort = availablePort !== defaultPort;
-
-    if (useAlternativePort) {
-      flags.push(`--port=${availablePort}`);
-    }
-
     // npm needs extra -- to pass flags to the command
     // in the case of Angular, we are calling `ng run` which doesn't need the extra `--`
     const doesNeedExtraDash =
@@ -203,6 +194,15 @@ async function runStorybookDev(result: {
 
     if (supportsOnboarding && shouldOnboard) {
       flags.push('--initial-path=/onboarding');
+    }
+
+    // Check if default port 6006 is available
+    const defaultPort = 6006;
+    const availablePort = await getServerPort(defaultPort);
+    const useAlternativePort = availablePort !== defaultPort;
+
+    if (useAlternativePort) {
+      flags.push(`--port=${availablePort}`);
     }
 
     flags.push('--quiet');


### PR DESCRIPTION
## What I did

Discovered during QA: when runnign storybook initiate whilst another storybook is running on the default port, the user is asked if another port should be used.

This hinders the ease of onboarding, so it's better to detect if the port is open beforehand and set an alternative one (that's free) if that's the case.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Storybook dev server now automatically detects port availability and selects an alternative port if the default port (6006) is already in use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->