### PR TITLE
Manager: Fix system query parameters being overridable

### DIFF
--- a/code/core/src/manager-api/modules/url.ts
+++ b/code/core/src/manager-api/modules/url.ts
@@ -12,6 +12,7 @@ import type { API_Layout, API_UI, API_ViewMode, Args } from 'storybook/internal/
 import { global } from '@storybook/global';
 
 import { dequal as deepEqual } from 'dequal';
+import { omit } from 'es-toolkit/object';
 import { stringify } from 'picoquery';
 
 import type { ModuleArgs, ModuleFn } from '../lib/types';
@@ -261,18 +262,23 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
       let globalsParam = inheritGlobals
         ? mergeSerializedParams(customQueryParams?.globals ?? '', globals)
         : globals;
-      let customParams = stringify(otherParams, {
+      let customManagerParams = stringify(otherParams, {
+        nesting: true,
+        nestingSyntax: 'js',
+      });
+      let customPreviewParams = stringify(omit(otherParams, ['id', 'viewMode']), {
         nesting: true,
         nestingSyntax: 'js',
       });
 
       argsParam = argsParam && `&args=${argsParam}`;
       globalsParam = globalsParam && `&globals=${globalsParam}`;
-      customParams = customParams && `&${customParams}`;
+      customManagerParams = customManagerParams && `&${customManagerParams}`;
+      customPreviewParams = customPreviewParams && `&${customPreviewParams}`;
 
       return {
-        managerHref: `${managerBase}?path=/${viewMode}/${refId ? `${refId}_` : ''}${storyId}${argsParam}${globalsParam}${customParams}`,
-        previewHref: `${previewBase}?id=${storyId}&viewMode=${viewMode}${refParam}${argsParam}${refId ? '' : globalsParam}${customParams}`,
+        managerHref: `${managerBase}?path=/${viewMode}/${refId ? `${refId}_` : ''}${storyId}${argsParam}${globalsParam}${customManagerParams}`,
+        previewHref: `${previewBase}?id=${storyId}&viewMode=${viewMode}${refParam}${argsParam}${refId ? '' : globalsParam}${customPreviewParams}`,
       };
     },
     getQueryParam(key) {

--- a/code/core/src/manager-api/tests/url.test.js
+++ b/code/core/src/manager-api/tests/url.test.js
@@ -364,10 +364,21 @@ describe('getStoryHrefs', () => {
     store.setState(state);
 
     const { managerHref, previewHref } = api.getStoryHrefs('test--story', {
-      queryParams: { one: 1, foo: { bar: 'baz' } },
+      queryParams: {
+        one: 1,
+        foo: { bar: 'baz' },
+        id: 'not-allowed-in-preview',
+        viewMode: 'not-allowed-in-preview',
+      },
     });
     expect(managerHref).toContain('&args=a:1&globals=b:2&one=1&foo.bar=baz');
     expect(previewHref).toContain('&args=a:1&globals=b:2&one=1&foo.bar=baz');
+
+    expect(managerHref).toContain('id=not-allowed-in-preview');
+    expect(previewHref).not.toContain('id=not-allowed-in-preview');
+
+    expect(managerHref).toContain('viewMode=not-allowed-in-preview');
+    expect(previewHref).not.toContain('viewMode=not-allowed-in-preview');
   });
 
   it('correctly preserves args and globals encoding', () => {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed a case where eg. having `?id=bla-bla` in the manager URL would propagate down into the preview URL, resulting in the preview having `iframe?id=story-id&id=blabla` which caused everything to fail.

This is specifically a problem in VSCode's new Simple Browser (in preview), that sets an `id` query param on all pages it visits.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Open a Storybook with any story
2. Add the following to the URL: `&id=bla-di-bloops` and navigate
3. The story should _not_ render with a _"Couldn't find story matching 'bla-di-bloops'"_ error, it should render fine.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
4. Open Storybook in your browser
5. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL parameter handling to ensure internal parameters are properly excluded from preview URLs while retained in manager URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->