### PR TITLE
Initiate: Fix used port flag handling

### DIFF
--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -201,7 +201,7 @@ async function runStorybookDev(result: {
     const availablePort = await getServerPort(defaultPort);
     const useAlternativePort = availablePort !== defaultPort;
 
-    const portFlag = flags.findIndex((flag) => flag.startsWith('-p'));
+    const portFlag = flags.findIndex((flag) => flag.startsWith('-p '));
 
     if (useAlternativePort && portFlag === -1) {
       flags.push(`-p ${availablePort}`);

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -201,8 +201,12 @@ async function runStorybookDev(result: {
     const availablePort = await getServerPort(defaultPort);
     const useAlternativePort = availablePort !== defaultPort;
 
-    if (useAlternativePort) {
-      flags.push(`--port=${availablePort}`);
+    const portFlag = flags.findIndex((flag) => flag.startsWith('-p'));
+
+    if (useAlternativePort && portFlag === -1) {
+      flags.push(`-p ${availablePort}`);
+    } else if (useAlternativePort && portFlag !== -1) {
+      flags[portFlag] = `-p ${availablePort}`;
     }
 
     flags.push('--quiet');


### PR DESCRIPTION
## What I did

@yannbf found out that the previous fix causes this to happen:
<img width="788" height="330" alt="image" src="https://github.com/user-attachments/assets/82900e62-df00-4ef9-99b6-3813d16ea07e" />

I'm trying to fix this, so the existing flag gets replaced, if it's there, and the shorthand is always used for consistency

I'm releasing a canary of this, to test it.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Ensure you have a storybook running on the default port `6006`, then run `npx storybook@next init`.

You should see that storybook starts without asking you for which port, and it should start on the next available port automatically.

I've manually tested this.

<img width="1302" height="512" alt="Screenshot 2026-01-15 at 10 21 36" src="https://github.com/user-attachments/assets/d6ab41d4-b0cd-4c98-8b05-53e6b772703d" />


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33544-sha-f7e9934d`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33544-sha-f7e9934d sandbox` or in an existing project with `npx storybook@0.0.0-pr-33544-sha-f7e9934d upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33544-sha-f7e9934d`](https://npmjs.com/package/storybook/v/0.0.0-pr-33544-sha-f7e9934d) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/more-fallbacks-to-init-port-fix`](https://github.com/storybookjs/storybook/tree/norbert/more-fallbacks-to-init-port-fix) |
| **Commit** | [`f7e9934d`](https://github.com/storybookjs/storybook/commit/f7e9934d7313e144df6523a8f1d74e569589a567) |
| **Datetime** | Thu Jan 15 08:53:51 UTC 2026 (`1768467231`) |
| **Workflow run** | [21025302565](https://github.com/storybookjs/storybook/actions/runs/21025302565) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33544`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port flag handling in Storybook development startup. The dev server now properly detects and updates existing port configurations instead of unconditionally appending duplicate port flags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->