### PR TITLE
CLIInitiate: Simplify the CLI init port flag detection

### DIFF
--- a/code/lib/create-storybook/src/initiate.test.ts
+++ b/code/lib/create-storybook/src/initiate.test.ts
@@ -18,6 +18,10 @@ const getCliIntegrationFromAncestry =
 
 vi.mock('storybook/internal/telemetry');
 
+vi.mock('storybook/internal/core-server', () => ({
+  getServerPort: vi.fn().mockResolvedValue(6006),
+}));
+
 describe('getStorybookVersionFromAncestry', () => {
   it('possible storybook path', () => {
     const ancestry = [{ command: 'node' }, { command: 'storybook@7.0.0' }, { command: 'npm' }];

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -156,17 +156,6 @@ export async function initiate(options: CommandOptions): Promise<void> {
   });
 
   if (initiateResult?.shouldRunDev) {
-    const defaultPort = 6006;
-    const availablePort = await getServerPort(defaultPort);
-    const useAlternativePort = availablePort !== defaultPort;
-
-    if (useAlternativePort) {
-      initiateResult.storybookCommand = initiateResult.storybookCommand?.replace(
-        `-p ${defaultPort}`,
-        `-p ${availablePort}`
-      );
-    }
-
     await runStorybookDev(initiateResult);
   }
 }
@@ -206,17 +195,27 @@ async function runStorybookDev(result: {
         parts.push('--');
       }
 
-      if (supportsOnboarding && shouldOnboard) {
-        parts.push('--initial-path=/onboarding');
-      }
+      const defaultPort = 6006;
+      const availablePort = await getServerPort(defaultPort);
+      const useAlternativePort = availablePort !== defaultPort;
 
-      parts.push('--quiet');
+      if (useAlternativePort) {
+        parts.push(`-p ${availablePort}`);
+
+        if (supportsOnboarding && shouldOnboard) {
+          parts.push('--initial-path=/onboarding');
+        }
+
+        parts.push('--quiet');
+      }
     }
 
     // instead of calling 'dev' automatically, we spawn a subprocess so that it gets
     // executed directly in the user's project directory. This avoid potential issues
     // with packages running in npxs' node_modules
     const [command, ...args] = [...parts];
+
+    console.log({ args });
     await executeCommand({
       command: command,
       args,

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -215,7 +215,6 @@ async function runStorybookDev(result: {
     // with packages running in npxs' node_modules
     const [command, ...args] = [...parts];
 
-    console.log({ args });
     await executeCommand({
       command: command,
       args,

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -200,7 +200,7 @@ async function runStorybookDev(result: {
       const useAlternativePort = availablePort !== defaultPort;
 
       if (useAlternativePort) {
-        parts.push(`-p ${availablePort}`);
+        parts.push(`-p`, `${availablePort}`);
 
         if (supportsOnboarding && shouldOnboard) {
           parts.push('--initial-path=/onboarding');


### PR DESCRIPTION
## What I did

We discovered that the previous fix does functionally work, but it's still adding the `-p`-flag twice.

This is supported by commander (the underlaying library used for storybook CLI, so functionally we're okay.
This PR is meant to cleanup so the `-p` argument is replaced properly.

When using `pnpm` the command is shown to the user, and we want it to be displayed correctly.

This is wrong:
<img width="1254" height="260" alt="image (1)" src="https://github.com/user-attachments/assets/90bfc00a-5af3-417f-9e68-7906c578de50" />

In my canary testing is discovered that a sbFlag was added to angular empty init, which isn't supported, so I added a clear guard against this happening again in the future.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I'm releasing another canary on this PR, and testing with `pnpm`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33546-sha-66ad959a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33546-sha-66ad959a sandbox` or in an existing project with `npx storybook@0.0.0-pr-33546-sha-66ad959a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33546-sha-66ad959a`](https://npmjs.com/package/storybook/v/0.0.0-pr-33546-sha-66ad959a) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/improve-cli-init-port`](https://github.com/storybookjs/storybook/tree/norbert/improve-cli-init-port) |
| **Commit** | [`66ad959a`](https://github.com/storybookjs/storybook/commit/66ad959a8c56e9ae1110332d49da93d59567385b) |
| **Datetime** | Thu Jan 15 11:09:11 UTC 2026 (`1768475351`) |
| **Workflow run** | [21029184749](https://github.com/storybookjs/storybook/actions/runs/21029184749) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33546`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storybook now picks an available port automatically when remapping is needed.
  * Onboarding mode adds an initial onboarding path when enabled.

* **Refactor**
  * Internal command argument assembly and process invocation streamlined; no public APIs changed.

* **Bug Fixes**
  * Reduced noisy output by adding a quiet mode when port remapping occurs.

* **Tests**
  * Added a mock to stabilize server-port behavior in tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->