### PR TITLE
CSF-Factories: Skip non-factory exports instead of throwing error

### DIFF
--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -552,24 +552,13 @@ export class CsfFile {
               const id = declPath.node.id;
 
               if (t.isIdentifier(id)) {
-                let storyIsFactory = false;
                 const { name: exportName } = id;
                 if (exportName === '__namedExportsOrder' && declPath.isVariableDeclarator()) {
                   self._namedExportsOrder = parseExportsOrder(declPath.node.init as t.Expression);
                   return;
                 }
-                self._storyExports[exportName] = decl;
-                self._storyDeclarationPath[exportName] = declPath;
-                self._storyPaths[exportName] = path;
-                self._storyStatements[exportName] = node;
-                let name = storyNameFromExport(exportName);
-                if (self._storyAnnotations[exportName]) {
-                  logger.warn(
-                    `Unexpected annotations for "${exportName}" before story declaration`
-                  );
-                } else {
-                  self._storyAnnotations[exportName] = {};
-                }
+
+                // Determine the story node, unwrapping TS expressions
                 let storyNode;
                 if (t.isVariableDeclarator(decl)) {
                   if (
@@ -591,6 +580,9 @@ export class CsfFile {
                 } else {
                   storyNode = decl;
                 }
+
+                // Check if this is a factory story (meta.story() or meta.extend())
+                let storyIsFactory = false;
                 if (
                   t.isCallExpression(storyNode) &&
                   t.isMemberExpression(storyNode.callee) &&
@@ -601,13 +593,13 @@ export class CsfFile {
                   storyIsFactory = true;
                   storyNode = storyNode.arguments[0];
                 }
+
+                // Skip non-factory exports in factory files
                 if (self._metaIsFactory && !storyIsFactory) {
-                  throw new MixedFactoryError(
-                    'expected factory story',
-                    storyNode as t.Node,
-                    self._options.fileName
-                  );
-                } else if (!self._metaIsFactory && storyIsFactory) {
+                  return;
+                }
+
+                if (!self._metaIsFactory && storyIsFactory) {
                   if (self._metaNode) {
                     throw new MixedFactoryError(
                       'expected non-factory story',
@@ -622,6 +614,21 @@ export class CsfFile {
                     );
                   }
                 }
+
+                // Now we know this is a valid story, register it
+                self._storyExports[exportName] = decl;
+                self._storyDeclarationPath[exportName] = declPath;
+                self._storyPaths[exportName] = path;
+                self._storyStatements[exportName] = node;
+                let name = storyNameFromExport(exportName);
+                if (self._storyAnnotations[exportName]) {
+                  logger.warn(
+                    `Unexpected annotations for "${exportName}" before story declaration`
+                  );
+                } else {
+                  self._storyAnnotations[exportName] = {};
+                }
+
                 const parameters: { [key: string]: any } = {};
                 if (t.isObjectExpression(storyNode)) {
                   parameters.__isArgsStory = true; // assume default render is an args story


### PR DESCRIPTION
Closes #33549

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Previously, CSF factory files would throw a `MixedFactoryError` if any named export was not a factory story. This caused issues when files had helper exports or utility functions alongside stories.

Now, non-factory exports in factory files are simply skipped during indexing. This means:
- Helper exports no longer need `excludeStories` to avoid errors
- `excludeStories`/`includeStories` still work for factory stories
- Only actual factory stories (`meta.story()` / `meta.extend()`) are indexed

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Add non-factory exports to a story file:
   ```ts
   // In Button.stories.ts, add at the end:
   export const mockData = { foo: 'bar' };
   export const helperFunction = () => console.log('helper');
   ```
3. Run `yarn storybook`
4. **Before fix**: Would fail with `CSF: expected factory story` error
5. **After fix**: Storybook starts successfully, only factory stories are indexed

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33550-sha-bd642744`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33550-sha-bd642744 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33550-sha-bd642744 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33550-sha-bd642744`](https://npmjs.com/package/storybook/v/0.0.0-pr-33550-sha-bd642744) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/fix-csf-factories-exclude-stories`](https://github.com/storybookjs/storybook/tree/kasper/fix-csf-factories-exclude-stories) |
| **Commit** | [`bd642744`](https://github.com/storybookjs/storybook/commit/bd642744949a786d071296306aabef8b3581aac7) |
| **Datetime** | Thu Jan 15 13:53:17 UTC 2026 (`1768485197`) |
| **Workflow run** | [21033721817](https://github.com/storybookjs/storybook/actions/runs/21033721817) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33550`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->