### PR TITLE
Vue: Make globals reactive in decorators

### DIFF
--- a/code/e2e-tests/framework-vue3.spec.ts
+++ b/code/e2e-tests/framework-vue3.spec.ts
@@ -31,7 +31,7 @@ test.describe('Vue 3', () => {
     await expect(previewRoot).toContainText('2');
   });
 
-  test('Decorators can inject reactive globals', async ({ page }) => {
+  test('Decorators can consume reactive globals', async ({ page }) => {
     const sbPage = new SbPage(page, expect);
 
     await sbPage.navigateToStory(

--- a/code/e2e-tests/framework-vue3.spec.ts
+++ b/code/e2e-tests/framework-vue3.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+import process from 'process';
+
+import { SbPage } from './util';
+
+const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:6006';
+const templateName = process.env.STORYBOOK_TEMPLATE_NAME;
+
+test.describe('Vue 3', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(storybookUrl);
+    await new SbPage(page, expect).waitUntilLoaded();
+  });
+
+  test.skip(!templateName?.includes('vue3'), 'Only run these tests on Vue 3');
+
+  test('updateArgs works in decorators', async ({ page }) => {
+    const sbPage = new SbPage(page, expect);
+
+    await sbPage.navigateToStory(
+      'stories/renderers/vue3_vue3-vite-default-ts/decorators',
+      'update-args'
+    );
+    const previewRoot = sbPage.previewRoot();
+    const button = previewRoot.getByRole('button', { name: 'Add 1' });
+
+    await expect(previewRoot).toContainText('0');
+    await button.click();
+    await expect(previewRoot).toContainText('1');
+    await button.click();
+    await expect(previewRoot).toContainText('2');
+  });
+
+  test('Decorators can inject reactive globals', async ({ page }) => {
+    const sbPage = new SbPage(page, expect);
+
+    await sbPage.navigateToStory(
+      'stories/renderers/vue3_vue3-vite-default-ts/decorators',
+      'reactive-global-decorator'
+    );
+
+    // Check the original language
+    await expect(sbPage.previewRoot()).toContainText('Hello');
+
+    // Select spanish in the locale toolbar and check that the text changes
+    await sbPage.selectToolbar('[aria-label^="Internationalization locale"]', 'text=/Español/');
+    await expect(sbPage.previewRoot()).toContainText('Hola');
+  });
+});

--- a/code/renderers/vue3/src/render.test.ts
+++ b/code/renderers/vue3/src/render.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import type { Args, Globals } from 'storybook/internal/types';
+
 import { expectTypeOf } from 'expect-type';
-import { reactive } from 'vue';
+import { computed, reactive } from 'vue';
 
 import { updateArgs } from './render';
 
@@ -23,7 +25,7 @@ describe('Render Story', () => {
     expectTypeOf(reactiveArgs).toEqualTypeOf<{ objectArg: { argFoo: string; argBar: string } }>();
 
     const newArgs = { argFoo: 'foo2', argBar: 'bar2' };
-    updateArgs(reactiveArgs, newArgs);
+    updateArgs<Args>(reactiveArgs, newArgs);
     expectTypeOf(reactiveArgs).toEqualTypeOf<{ objectArg: { argFoo: string; argBar: string } }>();
     expect(reactiveArgs).toEqual({
       argFoo: 'foo2',
@@ -37,7 +39,7 @@ describe('Render Story', () => {
     expectTypeOf(reactiveArgs).toEqualTypeOf<{ objectArg: { argFoo: string } }>();
 
     const newArgs = { argFoo: 'foo2', argBar: 'bar2' };
-    updateArgs(reactiveArgs, newArgs);
+    updateArgs<Args>(reactiveArgs, newArgs);
     expect(reactiveArgs).toEqual({ argFoo: 'foo2', argBar: 'bar2' });
   });
 
@@ -53,7 +55,7 @@ describe('Render Story', () => {
     }>();
 
     const newArgs = { argFoo: 'foo2', argBar: 'bar2' };
-    updateArgs(reactiveArgs, newArgs);
+    updateArgs<Args>(reactiveArgs, newArgs);
 
     expect(reactiveArgs).toEqual({
       argFoo: 'foo2',
@@ -87,5 +89,24 @@ describe('Render Story', () => {
     updateArgs(reactiveArgs, newArgs);
 
     expect(reactiveArgs).toEqual({ objectArg: { argFoo: 'bar' } });
+  });
+
+  it('update reactive Globals', async () => {
+    const reactiveGlobals = reactive<Globals>({ theme: 'light', locale: 'en' });
+
+    let observedTheme: string | undefined;
+    const watcher = computed(() => {
+      observedTheme = reactiveGlobals.theme as string;
+      return reactiveGlobals.theme;
+    });
+
+    expect(watcher.value).toBe('light');
+    expect(observedTheme).toBe('light');
+
+    updateArgs<Globals>(reactiveGlobals, { theme: 'dark', locale: 'en' });
+
+    expect(watcher.value).toBe('dark');
+    expect(observedTheme).toBe('dark');
+    expect(reactiveGlobals).toEqual({ theme: 'dark', locale: 'en' });
   });
 });

--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -9,7 +9,7 @@ import {
 
 import type { PreviewWeb } from 'storybook/preview-api';
 import type { App } from 'vue';
-import { createApp, h, isReactive, isVNode, provide, reactive } from 'vue';
+import { createApp, h, isReactive, isVNode, reactive } from 'vue';
 
 import type { StoryFnVueReturnType, StoryID, VueRenderer } from './types';
 
@@ -87,7 +87,6 @@ export async function renderToCanvas(
         reactiveGlobals: storyContext.globals,
       };
       map.set(canvasElement, appState);
-      provide('globals', storyContext.globals);
       return () => {
         // not passing args here as props
         // treat the rootElement as a component without props

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/decorators.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/decorators.stories.ts
@@ -3,7 +3,9 @@ import type { DecoratorFunction } from 'storybook/internal/types';
 import { global as globalThis } from '@storybook/global';
 import type { Meta, StoryObj, VueRenderer } from '@storybook/vue3';
 
+import { useArgs } from 'storybook/preview-api';
 import { h } from 'vue';
+import { computed } from 'vue';
 
 const { Button, Pre } = (globalThis as any).__TEMPLATE_COMPONENTS__;
 
@@ -47,6 +49,63 @@ const DynamicWrapperWrapper: DecoratorFunction<VueRenderer> = (storyFn, { args }
   computed: { level: () => `${args.level}px` },
 });
 
+const getCaptionForLocale = (locale: string) => {
+  switch (locale) {
+    case 'es':
+      return 'Hola!';
+    case 'kr':
+      return '안녕하세요!';
+    case 'zh':
+      return '你好!';
+    case 'en':
+      return 'Hello!';
+    default:
+      return undefined;
+  }
+};
+
+const updateArgsDecorator: DecoratorFunction<VueRenderer> = (story, { args }) => {
+  const [, updateArgs] = useArgs();
+  return {
+    components: { story },
+    setup() {
+      return {
+        args,
+        updateArgs,
+      };
+    },
+    template: `
+      <div>
+        <button @click="() => updateArgs({ label: Number(args.label) + 1 })">Add 1</button>
+        <hr />
+        <story />
+      </div>
+    `,
+  };
+};
+
+const localeDecorator: DecoratorFunction<VueRenderer> = (story, { globals }) => {
+  return {
+    components: { story },
+    inject: ['globals'],
+    setup() {
+      const ctxGreeting = computed(() => getCaptionForLocale(globals?.locale) || 'Hello!');
+
+      return {
+        ctxGreeting,
+        globals,
+      };
+    },
+    template: `
+      <div>
+        <p>Greeting: {{ctxGreeting}}</p>
+        <p>Locale: {{globals?.locale}}</p>
+        <story />
+      </div>
+    `,
+  };
+};
+
 export const ComponentTemplate: Story = {
   args: { label: 'With component' },
   decorators: [ComponentTemplateWrapper],
@@ -83,4 +142,14 @@ export const MultipleWrappers = {
     VueWrapperWrapper,
     DynamicWrapperWrapper,
   ],
+};
+
+export const UpdateArgs = {
+  args: { label: '0' },
+  decorators: [updateArgsDecorator],
+};
+
+export const ReactiveGlobalDecorator = {
+  args: { label: 'With reactive global decorator' },
+  decorators: [localeDecorator],
 };

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/decorators.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/decorators.stories.ts
@@ -87,7 +87,6 @@ const updateArgsDecorator: DecoratorFunction<VueRenderer> = (story, { args }) =>
 const localeDecorator: DecoratorFunction<VueRenderer> = (story, { globals }) => {
   return {
     components: { story },
-    inject: ['globals'],
     setup() {
       const ctxGreeting = computed(() => getCaptionForLocale(globals?.locale) || 'Hello!');
 

--- a/docs/_snippets/decorator-with-reactive-globals.md
+++ b/docs/_snippets/decorator-with-reactive-globals.md
@@ -1,0 +1,52 @@
+```js filename=".storybook/preview.js" renderer="vue" language="js"
+import { computed } from 'vue';
+
+export default {
+  decorators: [
+    (story, { globals }) => {
+      return {
+        components: { story },
+        setup() {
+          const greeting = computed(() => globals?.locale === 'en' ? 'Hello!' : '¡Hola!');
+
+          return { greeting, globals };
+        },
+        template: `
+          <div lang={{globals?.locale || 'en'}}>
+            <p>Greeting: {{greeting}}</p>
+            <story />
+          </div>
+        `,
+      };
+    },
+  ],
+};
+```
+
+```ts filename=".storybook/preview.ts" renderer="vue" language="ts"
+import { computed } from 'vue';
+import type { Preview } from '@storybook/vue3-vite';
+
+const preview: Preview = {
+  decorators: [
+    (story, { globals }) => {
+      return {
+        components: { story },
+        setup() {
+          const greeting = computed(() => globals?.locale === 'en' ? 'Hello!' : '¡Hola!');
+
+          return { greeting, globals };
+        },
+        template: `
+          <div lang={{globals?.locale || 'en'}}>
+            <p>Greeting: {{greeting}}</p>
+            <story />
+          </div>
+        `,
+      };
+    },
+  ],
+};
+
+export default preview;
+```

--- a/docs/_snippets/decorator-with-reactive-globals.md
+++ b/docs/_snippets/decorator-with-reactive-globals.md
@@ -12,7 +12,7 @@ export default {
           return { greeting, globals };
         },
         template: `
-          <div lang={{globals?.locale || 'en'}}>
+          <div :lang={{globals?.locale || 'en'}}>
             <p>Greeting: {{greeting}}</p>
             <story />
           </div>
@@ -38,7 +38,7 @@ const preview: Preview = {
           return { greeting, globals };
         },
         template: `
-          <div lang={{globals?.locale || 'en'}}>
+          <div :lang={{globals?.locale || 'en'}}>
             <p>Greeting: {{greeting}}</p>
             <story />
           </div>

--- a/docs/_snippets/decorator-with-updateArgs.md
+++ b/docs/_snippets/decorator-with-updateArgs.md
@@ -1,0 +1,58 @@
+```js filename=".storybook/preview.js" renderer="vue" language="js"
+import { useArgs } from 'storybook/preview-api';
+
+const WithIncrementDecorator = {
+  args: {
+    counter: 0,
+  },
+  decorators: [
+    (story, { args }) => {
+      const [, updateArgs] = useArgs();
+      return {
+        components: { story },
+        setup() {
+          return { args, updateArgs };
+        },
+        template: `
+          <div>
+            <button @click="() => updateArgs({ counter: args.counter + 1 })">
+              Increment
+            </button>
+            <story />
+          </div>
+        `,
+      };
+    },
+  ],
+};
+```
+
+```ts filename=".storybook/preview.ts" renderer="vue" language="ts"
+import { useArgs } from 'storybook/preview-api';
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+const WithIncrementDecorator: StoryObj<Meta<typeof MyComponent>> = {
+  args: {
+    counter: 0,
+  },
+  decorators: [
+    (story, { args }) => {
+      const [, updateArgs] = useArgs();
+      return {
+        components: { story },
+        setup() {
+          return { args, updateArgs };
+        },
+        template: `
+          <div>
+            <button @click="() => updateArgs({ counter: args.counter + 1 })">
+              Increment
+            </button>
+            <story />
+          </div>
+        `,
+      };
+    },
+  ],
+};
+```

--- a/docs/writing-stories/decorators.mdx
+++ b/docs/writing-stories/decorators.mdx
@@ -79,6 +79,30 @@ This context can be used to adjust the behavior of your decorator based on the s
   For another example, see the section on [configuring the mock provider](./mocking-data-and-modules/mocking-providers.mdx#configuring-the-mock-provider), which demonstrates how to use the same technique to change which theme is provided to the component.
 </Callout>
 
+<IfRenderer renderer="vue">
+
+### Reactive globals
+
+To ensure `globals` in Vue decorators are fully reactive, you must pass them through the `setup` function. You can also compute derived values with Vue's `computed` function.
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="decorator-with-reactive-globals.md" />
+
+{/* prettier-ignore-end */}
+
+### Preview API hooks
+
+The same applies to Storybook hooks you want to call in your decorator. For instance, this decorator increments a counter used by its decorated story.
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="decorator-with-updateArgs.md" />
+
+{/* prettier-ignore-end */}
+
+</IfRenderer>
+
 ### Using decorators to provide data
 
 If your components are “connected” and require side-loaded data to render, you can use decorators to provide that data in a mocked way without having to refactor your components to take that data as an arg. There are several techniques to achieve this. Depending on exactly how you are loading that data. Read more in the [building pages in Storybook](./build-pages-with-storybook.mdx) section.


### PR DESCRIPTION
Closes #23655

## What I did

* Allowed globals to be reactive
* Added stories and E2E tests to avoid regressions
* Documented code patterns for Vue decorators with reactivity

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

Unit tests are very low quality. Really, we're testing the underlying update function used to update globals, rather than the whole setup. I'd want a dedicated story instead.

- [x] stories
- [x] unit tests
- [x] E2E tests

#### Manual testing

1. Create a fresh Vue sandbox
2. Add the code snippet below to your `.storybook/preview.ts`
3. Open a [component story with the mood global set](http://localhost:6006/?path=/story/example-button--secondary&globals=mood:!hex(56db96))
4. Change the mood value in the toolbar

```ts
import { sb } from 'storybook/test';

sb.mock('../template-stories/core/test/ModuleMocking.utils.ts');
sb.mock('../template-stories/core/test/ModuleSpyMocking.utils.ts', { spy: true });
sb.mock('../template-stories/core/test/ModuleAutoMocking.utils.ts');
sb.mock(import('lodash-es'));
sb.mock(import('lodash-es/add'));
sb.mock(import('lodash-es/sum'));
sb.mock(import('uuid'));

import * as templateAnnotations from "../template-stories/core/preview";
import "../src/stories/renderers/vue3/preview.js";
import "../src/stories/components";
import addonDocs from "@storybook/addon-docs";
import addonA11y from "@storybook/addon-a11y";
import { definePreview } from "@storybook/vue3-vite";


import { type DecoratorFunction, type Globals } from 'storybook/internal/types';
import { computed, inject } from 'vue';

export const MOODS = [
  { color: '#eee', id: 'base', name: 'Base color' },
  { color: '#111', id: 'inverse', name: 'Inverse' },
  { color: '#56db96', id: 'emerald', name: 'Emerald' },
]

const globalTypes = {
  mood: {
    defaultValue: 'base',
    description: 'Change this global and watch the background colour change',
    name: 'mood',
    toolbar: {
      dynamicTitle: true,
      icon: 'paintbrush',
      items: MOODS.map((mood) => ({
        title: mood.name,
        value: mood.color,
      })),
      title: 'Mood',
    },
  },
}

const withMoodRootClass: DecoratorFunction = (story, { globals }) => {
  return {
    components: { story },
    inheritAttrs: false,
    setup() {
      const mood = computed(() => `width: 100%; height: 60vh; margin: -20px; padding: 20px; background-color: ${globals?.mood};`)
      return {
        globals,
        mood,
      };
    },
    template: `<div :style="mood" :data-mood="globals.mood"><story /></div>`,
  }
}

export default definePreview({
  decorators: [withMoodRootClass],
  globalTypes,
  // ...
});
```

### Documentation


- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Vue 3 renderer now keeps globals reactive so UI updates immediately when args or globals change.
  * Arg-update API is more type-safe and generalized for reliable dynamic updates.

* **New Features**
  * Added example stories and decorators demonstrating dynamic arg updates and reactive globals.
  * Added preview configuration examples to enable locale-aware rendering.

* **Tests**
  * New unit and end-to-end tests cover reactive globals, decorator behavior, and arg-update flows.

* **Documentation**
  * Added snippets and docs showing decorators that use reactive globals and update args.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->