### PR TITLE
React: Add jsxOnly option to experimentalCodeExamples

### DIFF
--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -512,13 +512,13 @@ export interface StorybookConfigRaw {
      * ```ts
      * // Enable with default options (includes wrapper function)
      * features: {
-     *   experimentalCodeExamples: true;
+     *   experimentalCodeExamples: true,
      * }
      *
      * // Enable with JSX-only output
      * features: {
      *   experimentalCodeExamples: {
-     *     jsxOnly: true;
+     *     jsxOnly: true,
      *   }
      * }
      * ```

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -502,10 +502,31 @@ export interface StorybookConfigRaw {
      * examples a lot faster, more readable and more accurate. They are not dynamic though, it won't
      * change if you change when using the control panel.
      *
+     * Can be set to `true` to enable with default options, or an object to configure:
+     *
+     * - `jsxOnly`: When true, outputs only the JSX element without the wrapper function. For example,
+     *   `<Button primary />` instead of `const Story = () => <Button primary />`
+     *
+     * @example
+     *
+     * ```ts
+     * // Enable with default options (includes wrapper function)
+     * features: {
+     *   experimentalCodeExamples: true;
+     * }
+     *
+     * // Enable with JSX-only output
+     * features: {
+     *   experimentalCodeExamples: {
+     *     jsxOnly: true;
+     *   }
+     * }
+     * ```
+     *
      * @default false
      * @experimental This feature is in early development and may change significantly in future releases.
      */
-    experimentalCodeExamples?: boolean;
+    experimentalCodeExamples?: boolean | { jsxOnly?: boolean };
   };
 
   build?: TestBuildConfig;

--- a/code/renderers/react/src/enrichCsf.ts
+++ b/code/renderers/react/src/enrichCsf.ts
@@ -12,6 +12,12 @@ export const enrichCsf: PresetPropertyFn<'experimental_enrichCsf'> = async (inpu
   if (!features.experimentalCodeExamples) {
     return;
   }
+
+  // Parse experimentalCodeExamples config
+  const codeExamplesConfig =
+    typeof features.experimentalCodeExamples === 'object' ? features.experimentalCodeExamples : {};
+  const jsxOnly = codeExamplesConfig.jsxOnly ?? false;
+
   return async (csf: CsfFile, csfSource: CsfFile) => {
     const promises = Object.keys(csf._stories).map(async (key) => {
       if (!csfSource._meta?.component) {
@@ -21,7 +27,7 @@ export const enrichCsf: PresetPropertyFn<'experimental_enrichCsf'> = async (inpu
       let node;
       let snippet;
       try {
-        node = getCodeSnippet(csfSource, key, csfSource._meta?.component);
+        node = getCodeSnippet(csfSource, key, csfSource._meta?.component, { jsxOnly });
       } catch (e) {
         if (!(e instanceof Error)) {
           return;


### PR DESCRIPTION
  Closes #33473                                                                                                                                                        
                                                                                                                                                                       
  ## What I did                                                                                                                                                        
                                                                                                                                                                       
  Added a `jsxOnly` option to `experimentalCodeExamples` to output clean JSX without wrapper functions.                                                                
                                                                                                                                                                       
  ### Background                                                                                                                                                       
  Issue #33473 reports that compound components lose dot notation in "Show Code".                                                                                      
  - In **legacy mode** (`type: 'dynamic'`): `<Card.Header>` → `<Header>` ❌                                                                                            
  - In **experimentalCodeExamples**: `<Card.Header>` is preserved ✅ but wrapped in function                                                                           
                                                                                                                                                                       
  This PR adds flexibility to `experimentalCodeExamples` by allowing JSX-only output.                                                                                  
                                                                                                                                                                       
  ### Usage                                                                                                                                                            
  ```ts                                                                                                                                                                
  // .storybook/main.ts                                                                                                                                                
  features: {                                                                                                                                                          
    experimentalCodeExamples: { jsxOnly: true }                                                                                                                        
  }
```                                                                                                                                                                    
                                                                                                                                                                       
### Output comparison
| Setting | Show Code output |
|---------|------------------|
| `experimentalCodeExamples: true` | `const Story = () => <Card.Header />` |
| `experimentalCodeExamples: { jsxOnly: true }` | `<Card.Header />` |
                                                                
###  Why this helps with #33473                                                                                                                                           
                                                                                                                                                                       
  Users experiencing the compound component issue can now:                                                                                                             
  1. Enable experimentalCodeExamples (fixes dot notation)                                                                                                              
  2. Add jsxOnly: true (removes verbose wrapper)                                                                                                                       
  3. Get clean, copy-pasteable JSX: <Card.Header>...</Card.Header>                                                                                                     
                                                                                                                                                                       
  This provides a better DX than the current workaround of manually setting displayName.                                                                               
                                                                                                                                                                       
  ---                                                                                                                                                                  
##  Checklist for Contributors                                                                                                                                           
                                                                                                                                                                       
###  Testing                                                                                                                                                              
                                                                                                                                                                       
The changes in this PR are covered in the following automated tests:

- [x] Unit tests (added tests for both wrapper and jsxOnly modes)
- [x] Integration tests with compound components
- [ ] stories
- [ ] end-to-end tests                                                                                                                                            
                                                                                                                                                                       
###  Manual testing                                                                                                                                                       
                                                                                                                                                                       
  1. Run sandbox: yarn task --task sandbox --start-from auto --template react-vite/default-ts                                                                          
  2. Create compound component story                                                                                                                                   
  3. Test both modes:                                                                                                                                                  
    - Default: Shows const Default = () => <Card.Header>...                                                                                                            
    - jsxOnly: true: Shows <Card.Header>... only                                                                                                                       
  4. Verify dot notation is preserved in both modes ✅                                                                                                                 
                                                                                                                                                                       
###  Documentation                                                                                                                                                        
                                                                                                                                                                       
  - Add or update documentation reflecting your changes                                                                                                                
  - If you are deprecating/removing a feature, make sure to update MIGRATION.MD                     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental code examples config now accepts an object with a jsxOnly option to render snippets as pure JSX elements.
* **Behavior**
  * Code snippet generation can emit plain JSX instead of wrapped story functions when jsxOnly is enabled.
* **Tests**
  * Coverage expanded to validate jsxOnly scenarios.
* **Documentation**
  * Examples and docs updated to show the new jsxOnly usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->