### PR TITLE
Core: Add support for wrapped components in component transformer

### DIFF
--- a/code/core/src/csf-tools/vitest-plugin/component-transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/component-transformer.test.ts
@@ -99,6 +99,139 @@ describe('component transformer', () => {
     `);
   });
 
+  it('generates tests for wrapped exports', async () => {
+    const code = `
+      import { someWrapper } from '../lib/util';
+      function Component() {}
+
+      export default someWrapper(Component);
+
+      export function withErrorBoundary<P extends object, R>(
+        Component: ComponentType<P>,
+      ) {
+        return forwardRef<R, P>(function WithErrorBoundary(props, ref) {
+          return (
+            <ErrorBoundary>
+              <Component {...props} ref={ref} />
+            </ErrorBoundary>
+          )
+        })
+      }
+      
+      export const FancyButton = React.forwardRef((props, ref) => (
+        <button ref={ref}>
+          {props.children}
+        </button>
+      ));
+
+      export const Label = memo(() => <div />);
+      
+      export {
+        Label,
+      };
+    `;
+
+    const result = await transform({ code, fileName: 'src/components/Spinner.tsx' });
+
+    expect(result.code).toContain('const _Spinner = someWrapper(Component);');
+    expect(result.code).toContain('export default _Spinner;');
+    expect(result.code).toContain('_test("Spinner", _testStory({');
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+      import { test as _test, expect as _expect } from "vitest";
+      import { someWrapper } from '../lib/util';
+      function Component() {}
+      const _Spinner = someWrapper(Component);
+      export default _Spinner;
+      export function withErrorBoundary<P extends object, R>(Component: ComponentType<P>) {
+        return forwardRef<R, P>(function WithErrorBoundary(props, ref) {
+          return <ErrorBoundary>
+                    <Component {...props} ref={ref} />
+                  </ErrorBoundary>;
+        });
+      }
+      export const FancyButton = React.forwardRef((props, ref) => <button ref={ref}>
+                {props.children}
+              </button>);
+      export const Label = memo(() => <div />);
+      export { Label };
+      const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+      if (_isRunningFromThisFile) {
+        _test("Spinner", _testStory({
+          exportName: "Spinner",
+          story: {
+            args: {}
+          },
+          meta: {
+            title: "generated/tests/Spinner",
+            component: _Spinner
+          },
+          skipTags: [],
+          storyId: "generated-Spinner",
+          componentPath: "src/components/Spinner.tsx",
+          componentName: "_Spinner"
+        }));
+        _test("withErrorBoundary", _testStory({
+          exportName: "withErrorBoundary",
+          story: {
+            args: {}
+          },
+          meta: {
+            title: "generated/tests/withErrorBoundary",
+            component: withErrorBoundary
+          },
+          skipTags: [],
+          storyId: "generated-withErrorBoundary",
+          componentPath: "src/components/Spinner.tsx",
+          componentName: "withErrorBoundary"
+        }));
+        _test("FancyButton", _testStory({
+          exportName: "FancyButton",
+          story: {
+            args: {}
+          },
+          meta: {
+            title: "generated/tests/FancyButton",
+            component: FancyButton
+          },
+          skipTags: [],
+          storyId: "generated-FancyButton",
+          componentPath: "src/components/Spinner.tsx",
+          componentName: "FancyButton"
+        }));
+        _test("Label", _testStory({
+          exportName: "Label",
+          story: {
+            args: {}
+          },
+          meta: {
+            title: "generated/tests/Label",
+            component: Label
+          },
+          skipTags: [],
+          storyId: "generated-Label",
+          componentPath: "src/components/Spinner.tsx",
+          componentName: "Label"
+        }));
+        _test("Label", _testStory({
+          exportName: "Label",
+          story: {
+            args: {}
+          },
+          meta: {
+            title: "generated/tests/Label",
+            component: Label
+          },
+          skipTags: [],
+          storyId: "generated-Label",
+          componentPath: "src/components/Spinner.tsx",
+          componentName: "Label"
+        }));
+      }"
+    `);
+  });
+
   it('generates tests for every exported component', async () => {
     const code = `
       export const Label = () => <div />;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The component transformer was not account for components like `memo(() => </>)` so this PR fixes that.
See tests for example cases.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

See tests

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for wrapped component default exports (e.g., components exported via wrapper functions).
  * Improved test generation for wrapped exports with proper metadata handling.

* **Tests**
  * Added comprehensive test coverage for wrapped export scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->