### PR TITLE
Core: Fix manual zoom input field UX

### DIFF
--- a/code/core/src/components/components/Form/Input.stories.tsx
+++ b/code/core/src/components/components/Form/Input.stories.tsx
@@ -14,3 +14,7 @@ type Story = StoryObj<typeof meta>;
 export const Input: Story = {
   render: (args) => <Component aria-label="Sample input" {...args} />,
 };
+
+export const WithSuffix: Story = {
+  render: (args) => <Component aria-label="Sample input" suffix="px" value="10" {...args} />,
+};

--- a/code/core/src/components/components/Form/Input.tsx
+++ b/code/core/src/components/components/Form/Input.tsx
@@ -1,6 +1,7 @@
 import React, { type HTMLProps } from 'react';
 import { forwardRef } from 'react';
 
+import { useId } from '@react-aria/utils';
 import { styled } from 'storybook/theming';
 
 import {
@@ -62,13 +63,19 @@ export const Input = Object.assign(
       { size, valid, align, value, suffix, ...props },
       ref
     ) {
+      const suffixId = useId();
       return (
         <Wrapper>
-          <input {...props} value={value} ref={ref} />
+          <input
+            {...props}
+            value={value}
+            ref={ref}
+            aria-describedby={suffix ? suffixId : undefined}
+          />
           {suffix && (
             <Mask aria-hidden>
               <span>{value}</span>
-              <span>{suffix}</span>
+              <span id={suffixId}>{suffix}</span>
             </Mask>
           )}
         </Wrapper>

--- a/code/core/src/components/components/Form/Input.tsx
+++ b/code/core/src/components/components/Form/Input.tsx
@@ -13,6 +13,33 @@ import {
   validation,
 } from './styles';
 
+const Wrapper = styled.div({
+  position: 'relative',
+  width: '100%',
+});
+
+const Mask = styled.div(
+  ({ theme }) => ({
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    display: 'flex',
+    alignItems: 'center',
+    pointerEvents: 'none',
+    overflow: 'hidden',
+    color: theme.textMutedColor,
+    'span:first-of-type': {
+      opacity: 0,
+    },
+  }),
+  (props) => {
+    const { fontSize, lineHeight, padding } = styles(props);
+    return { fontSize, lineHeight, padding };
+  }
+);
+
 type InputProps = Omit<
   HTMLProps<HTMLInputElement>,
   keyof {
@@ -26,12 +53,26 @@ type InputProps = Omit<
   align?: Alignments;
   valid?: ValidationStates;
   height?: number;
+  suffix?: string;
 };
 
 export const Input = Object.assign(
   styled(
-    forwardRef<any, InputProps>(function Input({ size, valid, align, ...props }, ref) {
-      return <input {...props} ref={ref} />;
+    forwardRef<any, InputProps>(function Input(
+      { size, valid, align, value, suffix, ...props },
+      ref
+    ) {
+      return (
+        <Wrapper>
+          <input {...props} value={value} ref={ref} />
+          {suffix && (
+            <Mask aria-hidden>
+              <span>{value}</span>
+              <span>{suffix}</span>
+            </Mask>
+          )}
+        </Wrapper>
+      );
     })
   )<InputProps>(styles, sizes, alignment, validation, {
     minHeight: 32,

--- a/code/core/src/manager/components/preview/NumericInput.stories.tsx
+++ b/code/core/src/manager/components/preview/NumericInput.stories.tsx
@@ -1,4 +1,6 @@
-import { expect, fireEvent, fn } from 'storybook/test';
+import { useState } from 'react';
+
+import { expect, fireEvent, fn, mocked } from 'storybook/test';
 
 import preview from '../../../../../.storybook/preview';
 import { NumericInput } from './NumericInput';
@@ -8,6 +10,12 @@ const meta = preview.meta({
   tags: ['autodocs'],
   args: {
     setValue: fn(),
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    args.value = value;
+    args.setValue = mocked(args.setValue).mockImplementation(setValue);
+    return <NumericInput {...args} />;
   },
 });
 
@@ -55,7 +63,7 @@ export const WithExplicitUnit = meta.story({
     fireEvent.keyDown(input, { key: 'ArrowUp' });
     fireEvent.keyDown(input, { key: 'ArrowUp' });
     fireEvent.keyDown(input, { key: 'ArrowDown' });
-    expect(input).toHaveValue('11vw');
+    expect(input).toHaveValue('11');
     expect(args.setValue).toHaveBeenNthCalledWith(1, '11vw');
     expect(args.setValue).toHaveBeenNthCalledWith(2, '12vw');
     expect(args.setValue).toHaveBeenNthCalledWith(3, '11vw');

--- a/code/core/src/manager/components/preview/NumericInput.tsx
+++ b/code/core/src/manager/components/preview/NumericInput.tsx
@@ -46,6 +46,10 @@ const Wrapper = styled.div<{ after?: ReactNode; before?: ReactNode }>(
         outline: 'none',
       },
     },
+    'input + div': {
+      paddingInline: 0,
+      fontSize: 'inherit',
+    },
     '&:has(input:focus-visible)': {
       outline: `2px solid ${theme.color.secondary}`,
       outlineOffset: -2,
@@ -76,8 +80,8 @@ export const NumericInput = forwardRef<HTMLInputElement, NumericInputProps>(func
     setValue,
     minValue = -Infinity,
     maxValue = Infinity,
-    unit,
-    baseUnit,
+    unit: fixedUnit,
+    baseUnit = fixedUnit,
     className,
     style,
     ...props
@@ -96,12 +100,12 @@ export const NumericInput = forwardRef<HTMLInputElement, NumericInputProps>(func
 
   const parseValue = useCallback(
     (value: string) => {
-      const [, inputValue, inputUnit = unit || baseUnit || ''] =
-        value.match(/(-?\d+(?:\.\d+)?)(\%|[a-z]{0,4})?$/) || [];
+      const [, inputValue, unit = fixedUnit || baseUnit || ''] =
+        value.match(/(-?\d+(?:\.\d+)?)(\%|[a-z]{1,4})?$/) || [];
       const number = Math.max(minValue, Math.min(parseFloat(inputValue), maxValue));
-      return { number, unit: inputUnit };
+      return { number, unit };
     },
-    [minValue, maxValue, unit, baseUnit]
+    [minValue, maxValue, fixedUnit, baseUnit]
   );
 
   const updateValue = useCallback(
@@ -177,6 +181,7 @@ export const NumericInput = forwardRef<HTMLInputElement, NumericInputProps>(func
         id={id}
         ref={inputRef}
         value={inputValue}
+        suffix={fixedUnit ? fixedUnit : inputValue && baseUnit}
         onChange={onChange}
         onFocus={setInputSelection}
         onBlur={updateInputValue}


### PR DESCRIPTION
## What I did

Instead of having the `%` "unit" as part of the input value, keep just the number as the input value and show the unit as a non-selectable, non-editable suffix. This avoids parsing issues, specifically when a number is appended after the unit (e.g. `100%1`), which is syntactically invalid.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inputs can show an optional suffix (e.g., units) alongside entered values.
  * Numeric input now consistently displays a unified suffix derived from its unit settings.

* **Bug Fixes / Improvements**
  * Arrow-key stepping and value updates for unit-aware inputs made more consistent.

* **Tests**
  * Storybook updated with a WithSuffix example and a render wrapper to reflect display vs stored-value behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->