### PR TITLE
UI: Handle kb nav edge cases when preview and panel are hidden

### DIFF
--- a/code/core/src/manager/components/layout/Drag.tsx
+++ b/code/core/src/manager/components/layout/Drag.tsx
@@ -1,0 +1,65 @@
+import { styled } from 'storybook/theming';
+
+/**
+ * Drag handle for the sidebar and panel resizers. Can be horizontal (bottom panel) or vertical
+ * (sidebar or right panel). Can optionally be set to not overlap the content area (only render
+ * outside of it), which is necessary when the panel is collapsed to prevent a layout shift when
+ * scrollIntoView is used.
+ */
+export const Drag = styled.div<{
+  orientation?: 'horizontal' | 'vertical';
+  overlapping?: boolean;
+  position?: 'left' | 'right';
+}>(
+  ({ theme }) => ({
+    position: 'absolute',
+    opacity: 0,
+    transition: 'opacity 0.2s ease-in-out',
+    zIndex: 100,
+
+    '&:after': {
+      content: '""',
+      display: 'block',
+      backgroundColor: theme.color.secondary,
+    },
+
+    '&:hover': {
+      opacity: 1,
+    },
+  }),
+  ({ orientation = 'vertical', overlapping = true, position = 'left' }) =>
+    orientation === 'vertical'
+      ? {
+          width: overlapping ? (position === 'left' ? 10 : 13) : 7,
+          height: '100%',
+          top: 0,
+          right: position === 'left' ? -7 : undefined,
+          left: position === 'right' ? -7 : undefined,
+
+          '&:after': {
+            width: 1,
+            height: '100%',
+            marginLeft: position === 'left' ? 3 : 6,
+          },
+
+          '&:hover': {
+            cursor: 'col-resize',
+          },
+        }
+      : {
+          width: '100%',
+          height: overlapping ? 13 : 7,
+          top: -7,
+          left: 0,
+
+          '&:after': {
+            width: '100%',
+            height: 1,
+            marginTop: 6,
+          },
+
+          '&:hover': {
+            cursor: 'row-resize',
+          },
+        }
+);

--- a/code/core/src/manager/components/layout/Layout.stories.tsx
+++ b/code/core/src/manager/components/layout/Layout.stories.tsx
@@ -189,7 +189,7 @@ export const DesktopDocs: Story = {
       const pagesMain = canvas.queryByRole('main', { name: 'Main content' });
       expect(pagesMain).not.toBeInTheDocument();
     });
-    await step('Verify preview area is  rendered', async () => {
+    await step('Verify preview area is rendered', async () => {
       const preview = canvas.getByTestId('preview');
       expect(preview).toBeInTheDocument();
     });

--- a/code/core/src/manager/components/layout/MainAreaContainer.tsx
+++ b/code/core/src/manager/components/layout/MainAreaContainer.tsx
@@ -66,9 +66,8 @@ interface MainAreaContainerProps {
 }
 
 /**
- * Shows Router-controlled pages (e.g. settings/about), inside a landmark for navigability. Assumes
- * that the main preview area is not concurrently reachable by assistive technologies, since these
- * components both define a `main` role.
+ * Shows Router-controlled pages (e.g. settings/about), inside a landmark for navigability, OR shows
+ * the preview area. Ensures a single `main` landmark exists at a time.
  */
 const MainAreaContainer = React.memo<MainAreaContainerProps>(function MainAreaContainer({
   showPages,
@@ -77,19 +76,13 @@ const MainAreaContainer = React.memo<MainAreaContainerProps>(function MainAreaCo
 }) {
   return (
     <>
-      {showPages && <PagesContainer>{slotPages}</PagesContainer>}
-      <Match path={/(^\/story|docs|onboarding\/|^\/$)/} startsWith={false}>
-        {({ match }) => (
-          <MainInnerContainer
-            shown={!!match}
-            // Ensures only one main landmark is in the Accessibility Object Model at any given time
-            hidden={showPages ? true : undefined}
-            aria-hidden={showPages ? true : undefined}
-          >
-            {slotMain}
-          </MainInnerContainer>
-        )}
-      </Match>
+      {showPages ? (
+        <PagesContainer>{slotPages}</PagesContainer>
+      ) : (
+        <Match path={/(^\/story|docs|onboarding\/|^\/$)/} startsWith={false}>
+          {({ match }) => <MainInnerContainer shown={!!match}>{slotMain}</MainInnerContainer>}
+        </Match>
+      )}
     </>
   );
 });

--- a/code/core/src/manager/components/layout/MainAreaContainer.tsx
+++ b/code/core/src/manager/components/layout/MainAreaContainer.tsx
@@ -1,0 +1,97 @@
+import React, { useRef } from 'react';
+
+import { Match } from 'storybook/internal/router';
+
+import { styled } from 'storybook/theming';
+
+import { MEDIA_DESKTOP_BREAKPOINT } from '../../constants';
+import { useLandmark } from '../../hooks/useLandmark';
+
+interface PagesContainerProps {
+  children: React.ReactNode;
+}
+
+const PagesInnerContainer = styled.main(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gridRowStart: 'sidebar-start',
+  gridRowEnd: '-1',
+  gridColumnStart: 'sidebar-end',
+  gridColumnEnd: '-1',
+  backgroundColor: theme.appContentBg,
+  zIndex: 1,
+}));
+
+/**
+ * Shows Router-controlled pages (e.g. settings/about), inside a landmark for navigability. Assumes
+ * that the main preview area is not concurrently reachable by assistive technologies, since these
+ * components both define a `main` role.
+ */
+const PagesContainer = React.memo<PagesContainerProps>(function PagesContainer(props) {
+  const { children } = props;
+
+  const mainRef = useRef<HTMLElement>(null);
+  const { landmarkProps } = useLandmark(
+    { 'aria-labelledby': 'main-content-heading', role: 'main' },
+    mainRef
+  );
+
+  return (
+    <PagesInnerContainer id="main-content-wrapper" ref={mainRef} {...landmarkProps}>
+      <h2 id="main-content-heading" className="sb-sr-only">
+        Main content
+      </h2>
+      {children}
+    </PagesInnerContainer>
+  );
+});
+
+const MainInnerContainer = styled.div<{ shown: boolean }>(({ theme, shown }) => ({
+  flex: 1,
+  position: 'relative',
+  backgroundColor: theme.appContentBg,
+  display: shown ? 'grid' : 'none', // This is needed to make the content container fill the available space
+  overflow: 'auto',
+
+  [MEDIA_DESKTOP_BREAKPOINT]: {
+    flex: 'auto',
+    gridArea: 'content',
+  },
+}));
+
+interface MainAreaContainerProps {
+  showPages: boolean;
+  slotMain: React.ReactNode;
+  slotPages: React.ReactNode;
+}
+
+/**
+ * Shows Router-controlled pages (e.g. settings/about), inside a landmark for navigability. Assumes
+ * that the main preview area is not concurrently reachable by assistive technologies, since these
+ * components both define a `main` role.
+ */
+const MainAreaContainer = React.memo<MainAreaContainerProps>(function MainAreaContainer({
+  showPages,
+  slotMain,
+  slotPages,
+}) {
+  return (
+    <>
+      {showPages && <PagesContainer>{slotPages}</PagesContainer>}
+      <Match path={/(^\/story|docs|onboarding\/|^\/$)/} startsWith={false}>
+        {({ match }) => (
+          <MainInnerContainer
+            shown={!!match}
+            // Ensures only one main landmark is in the Accessibility Object Model at any given time
+            hidden={showPages ? true : undefined}
+            aria-hidden={showPages ? true : undefined}
+          >
+            {slotMain}
+          </MainInnerContainer>
+        )}
+      </Match>
+    </>
+  );
+});
+
+export { MainAreaContainer };

--- a/code/core/src/manager/components/layout/PanelContainer.tsx
+++ b/code/core/src/manager/components/layout/PanelContainer.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import { styled } from 'storybook/theming';
+
+import type { API_Layout } from '../../../types';
+import { Drag } from './Drag';
+
+interface PagesContainerProps {
+  children: React.ReactNode;
+  bottomPanelHeight: number;
+  rightPanelWidth: number;
+  panelResizerRef: React.Ref<HTMLDivElement>;
+  position: API_Layout['panelPosition'];
+}
+
+const Container = styled.div<{ position: API_Layout['panelPosition'] }>(({ theme, position }) => ({
+  gridArea: 'panel',
+  position: 'relative',
+  backgroundColor: theme.appContentBg,
+  borderTop: position === 'bottom' ? `1px solid ${theme.appBorderColor}` : undefined,
+  borderLeft: position === 'right' ? `1px solid ${theme.appBorderColor}` : undefined,
+  '& > aside': {
+    overflow: 'hidden',
+  },
+}));
+
+const PanelSlot = styled.div({
+  height: '100%',
+});
+
+/**
+ * Shows the addon panel and its resize drag handle. The drag handle is always rendered so users can
+ * reopen the panel. The panel is always rendered (to preserve internal state), but it's excluded
+ * from the Accessibility Object Model when effectively collapsed.
+ */
+const PanelContainer = React.memo<PagesContainerProps>(function PagesContainer(props) {
+  const { children, bottomPanelHeight, rightPanelWidth, panelResizerRef, position } = props;
+
+  const shouldHidePanelContent =
+    position === 'bottom' ? bottomPanelHeight === 0 : rightPanelWidth === 0;
+
+  return (
+    <Container position={position}>
+      <Drag
+        orientation={position === 'bottom' ? 'horizontal' : 'vertical'}
+        overlapping={position === 'bottom' ? !!bottomPanelHeight : !!rightPanelWidth}
+        position={position === 'bottom' ? 'left' : 'right'}
+        ref={panelResizerRef}
+      />
+      <PanelSlot
+        // This ensures that the panel content is not reachable by keyboard or assistive
+        // tech when actually collapsed.
+        hidden={shouldHidePanelContent ? true : undefined}
+        aria-hidden={shouldHidePanelContent ? true : undefined}
+      >
+        {children}
+      </PanelSlot>
+    </Container>
+  );
+});
+
+export { PanelContainer };

--- a/code/core/src/manager/components/layout/PanelContainer.tsx
+++ b/code/core/src/manager/components/layout/PanelContainer.tsx
@@ -5,7 +5,7 @@ import { styled } from 'storybook/theming';
 import type { API_Layout } from '../../../types';
 import { Drag } from './Drag';
 
-interface PagesContainerProps {
+interface PanelContainerProps {
   children: React.ReactNode;
   bottomPanelHeight: number;
   rightPanelWidth: number;
@@ -33,7 +33,7 @@ const PanelSlot = styled.div({
  * reopen the panel. The panel is always rendered (to preserve internal state), but it's excluded
  * from the Accessibility Object Model when effectively collapsed.
  */
-const PanelContainer = React.memo<PagesContainerProps>(function PagesContainer(props) {
+const PanelContainer = React.memo<PanelContainerProps>(function PanelContainer(props) {
   const { children, bottomPanelHeight, rightPanelWidth, panelResizerRef, position } = props;
 
   const shouldHidePanelContent =

--- a/code/core/src/manager/components/layout/PanelContainer.tsx
+++ b/code/core/src/manager/components/layout/PanelContainer.tsx
@@ -19,9 +19,6 @@ const Container = styled.div<{ position: API_Layout['panelPosition'] }>(({ theme
   backgroundColor: theme.appContentBg,
   borderTop: position === 'bottom' ? `1px solid ${theme.appBorderColor}` : undefined,
   borderLeft: position === 'right' ? `1px solid ${theme.appBorderColor}` : undefined,
-  '& > aside': {
-    overflow: 'hidden',
-  },
 }));
 
 const PanelSlot = styled.div({

--- a/code/core/src/manager/components/sidebar/Sidebar.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.tsx
@@ -128,6 +128,7 @@ export const Sidebar = React.memo(function Sidebar({
   const lastViewedProps = useLastViewed(selected);
   const { isMobile } = useLayout();
   const api = useStorybookApi();
+  const { viewMode } = api.getUrlState();
 
   const tagPresets = useMemo(
     () =>
@@ -145,6 +146,9 @@ export const Sidebar = React.memo(function Sidebar({
     headerRef
   );
 
+  const isPagesShown = viewMode !== undefined && viewMode !== 'story' && viewMode !== 'docs';
+  const skipLinkHref = isPagesShown ? '#main-content-wrapper' : '#storybook-preview-wrapper';
+
   return (
     <Container className="container sidebar-container" ref={headerRef} {...landmarkProps}>
       <h1 id="global-site-h1" className="sb-sr-only">
@@ -158,7 +162,7 @@ export const Sidebar = React.memo(function Sidebar({
               className="sidebar-header"
               menuHighlighted={menuHighlighted}
               menu={menu}
-              skipLinkHref="#storybook-preview-wrapper"
+              skipLinkHref={skipLinkHref}
               isLoading={isLoading}
               onMenuClick={onMenuClick}
             />


### PR DESCRIPTION
## What I did

Follow up on https://github.com/storybookjs/storybook/pull/33450 + improvements on the settings pages keyboard navigation

* Ensures the addon panel cannot be reached by keyboard when it's effectively collapsed
* Ensures the preview area is not rendered when a settings page is opened
  * right now, we keep it rendered but we don't render the addon panel, so upon closing a settings page, we have preserved a stateful story preview but discarded the state of the addon panel, which is inconsistent (should a play function re-run? what if some addons perform analytics on the story upon loading, but the story is different from its initial state?)
* Ensures landmark navigation accounts for previewe & panel being closed
* Makes settings pages a landmark region for more coherence
* Makes "Skip to content" go to the settings pages if they're open rather than the preview area (I didn't handle the links in the Sidebar tree because they cannot be reached without first navigating to a docs/story page)


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing


1. Go to a story and keep the panel open
  * Check that the preview area and addon panel are reachable when pressing F6 or Tab 
2. Now close the panel
  * Check that you cannot navigate to the addon panel with F6 or Tab
  * Check that the panel resize drag handle is rendered on the edge of the screen
3. Now go to a docs page
  * Check that no addon panel is rendered at all, including the resize handle
4. Now open the settings page
  * Check that the preview is not rendered and not kb-reachable under the settings page


## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resizable drag handle and dedicated main/panel layout containers for improved responsive and accessible layout

* **Tests**
  * Interactive stories added/updated to verify focus behavior, visibility, and collapsed panel states

* **Refactor**
  * Replaced legacy layout wrappers with streamlined container composition and simplified resizer wiring

* **Bug Fix**
  * Skip-link target now adapts when switching between pages and preview views
<!-- end of auto-generated comment: release notes by coderabbit.ai -->