### PR TITLE
Docgen: Update extraction of React docgen

### DIFF
--- a/code/core/src/core-server/utils/get-dummy-args-from-argtypes.test.ts
+++ b/code/core/src/core-server/utils/get-dummy-args-from-argtypes.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { SBType } from '../../types';
 import {
   generateDummyArgsFromArgTypes,
   generateDummyValueFromSBType,
@@ -99,11 +100,17 @@ describe('new-story-docgen', () => {
 
     it('generates array values', () => {
       expect(
-        generateDummyValueFromSBType({ name: 'array', value: { name: 'other', value: 'X' } })
+        generateDummyValueFromSBType({
+          name: 'array',
+          value: [{ name: 'other', value: 'X' }] as unknown as SBType,
+        })
       ).toEqual([]);
-      expect(generateDummyValueFromSBType({ name: 'array', value: { name: 'number' } })).toEqual([
-        0,
-      ]);
+      expect(
+        generateDummyValueFromSBType({
+          name: 'array',
+          value: [{ name: 'number' }] as unknown as SBType,
+        })
+      ).toEqual([0]);
     });
 
     it('generates tuple values', () => {

--- a/code/core/src/core-server/utils/get-dummy-args-from-argtypes.ts
+++ b/code/core/src/core-server/utils/get-dummy-args-from-argtypes.ts
@@ -227,11 +227,13 @@ export function generateDummyValueFromSBType(
     }
 
     case 'array': {
+      const v = sbType.value as unknown as SBType[];
+
       // If we don't know what the element is, be conservative and return empty.
-      if (sbType.value?.length < 1 || sbType.value[0]?.name === 'other') {
+      if (v?.length < 1 || v[0]?.name === 'other') {
         return [];
       }
-      return [generateDummyValueFromSBType(sbType.value[0], propName, options)];
+      return [generateDummyValueFromSBType(v[0], propName, options)];
     }
 
     case 'tuple':

--- a/code/core/src/core-server/utils/get-dummy-args-from-argtypes.ts
+++ b/code/core/src/core-server/utils/get-dummy-args-from-argtypes.ts
@@ -228,10 +228,10 @@ export function generateDummyValueFromSBType(
 
     case 'array': {
       // If we don't know what the element is, be conservative and return empty.
-      if (sbType.value.name === 'other') {
+      if (sbType.value?.length < 1 || sbType.value[0]?.name === 'other') {
         return [];
       }
-      return [generateDummyValueFromSBType(sbType.value, propName, options)];
+      return [generateDummyValueFromSBType(sbType.value[0], propName, options)];
     }
 
     case 'tuple':

--- a/code/core/src/csf/SBType.ts
+++ b/code/core/src/csf/SBType.ts
@@ -9,7 +9,7 @@ export type SBScalarType = SBBaseType & {
 
 export type SBArrayType = SBBaseType & {
   name: 'array';
-  value: SBType[];
+  value: SBType;
 };
 export type SBNodeType = SBBaseType & {
   // Framework-specific “renderable node” (e.g. ReactNode, Vue VNode).

--- a/code/core/src/csf/SBType.ts
+++ b/code/core/src/csf/SBType.ts
@@ -9,7 +9,7 @@ export type SBScalarType = SBBaseType & {
 
 export type SBArrayType = SBBaseType & {
   name: 'array';
-  value: SBType;
+  value: SBType[];
 };
 export type SBNodeType = SBBaseType & {
   // Framework-specific “renderable node” (e.g. ReactNode, Vue VNode).

--- a/code/renderers/react/src/componentManifest/reactDocgen/extractReactDocgenInfo.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/extractReactDocgenInfo.ts
@@ -74,5 +74,5 @@ export const extractArgTypesFromDocgen = ({
     return null;
   }
 
-  return extractArgTypes({ __docgenInfo: docgen.reactDocgen }) ?? {};
+  return extractArgTypes({ __docgenInfo: docgen.reactDocgen.data }) ?? {};
 };


### PR DESCRIPTION
## What I did

Noticed a bug in the gathering of `react-docgen`-data, we passed the containing-object data, instead of the data.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33598-sha-c91e37ca`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33598-sha-c91e37ca sandbox` or in an existing project with `npx storybook@0.0.0-pr-33598-sha-c91e37ca upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33598-sha-c91e37ca`](https://npmjs.com/package/storybook/v/0.0.0-pr-33598-sha-c91e37ca) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/fix-js-docgen-data`](https://github.com/storybookjs/storybook/tree/norbert/fix-js-docgen-data) |
| **Commit** | [`c91e37ca`](https://github.com/storybookjs/storybook/commit/c91e37ca5a30fe1dbfc6fbe2a4d90463907df679) |
| **Datetime** | Tue Jan 20 15:00:09 UTC 2026 (`1768921209`) |
| **Workflow run** | [21176214594](https://github.com/storybookjs/storybook/actions/runs/21176214594) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33598`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected component documentation extraction so documentation data is sourced and interpreted reliably.
  * Improved generation of array-type argument values with safer handling for empty or unspecified element types, reducing incorrect or unexpected argument outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->