### PR TITLE
Docs: Mention React version requirement for addons

### DIFF
--- a/docs/addons/writing-addons.mdx
+++ b/docs/addons/writing-addons.mdx
@@ -30,6 +30,10 @@ The addon built in this guide is a UI-based addon, specifically a [toolbar](./ad
 
 {/* prettier-ignore-end */}
 
+<Callout variant="info">
+  Addons with a UI must use the same React version as Storybook does. If your component library uses a different React version, you must use addons that are built and published as standalone packages. We'll cover how to do this with the [Addon Kit](https://github.com/storybookjs/addon-kit).
+</Callout>
+
 ## Setup
 
 To create your first addon, you're going to use the [Addon Kit](https://github.com/storybookjs/addon-kit), a ready-to-use template featuring all the required building blocks, dependencies and configurations to help you get started building your addon. In the Addon Kit repository, click the **Use this template** button to create a new repository based on the Addon Kit's code.

--- a/docs/addons/writing-addons.mdx
+++ b/docs/addons/writing-addons.mdx
@@ -31,7 +31,7 @@ The addon built in this guide is a UI-based addon, specifically a [toolbar](./ad
 {/* prettier-ignore-end */}
 
 <Callout variant="info">
-  Addons with a UI must use the same React version as Storybook does. If your component library uses a different React version, you must use addons that are built and published as standalone packages. We'll cover how to do this with the [Addon Kit](https://github.com/storybookjs/addon-kit).
+Addons with a UI must use the same React version as Storybook. If your component library uses a different React version, you must use addons that are built and published as standalone packages. We'll cover how to do this with the [Addon Kit](https://github.com/storybookjs/addon-kit).
 </Callout>
 
 ## Setup


### PR DESCRIPTION
## What I did

Clarified that addons must align their React version w/ Storybook, and must be externally packaged if users use a different React version in their preview code. I did this in a way that doesn't explicitly mention versions to avoid the callout expiring upon future releases.

This should address user feedback received via Chromatic about running custom addons in React 19 codebases.

## Checklist for Contributors

### Testing

N/A

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying that UI addons must use the same React version as Storybook, with recommendations for using standalone addons when versions differ.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->