### PR TITLE
Build: Fix failure discord message CI workflow helper

### DIFF
--- a/scripts/bench/bench-packages.ts
+++ b/scripts/bench/bench-packages.ts
@@ -410,7 +410,7 @@ const run = async () => {
     .option(
       '-p, --pull-request <number>',
       'The PR number to add compare results to. Only used together with --baseBranch',
-      function parseInt(value) {
+      function parsePrNumber(value) {
         if (value === '0' || value === '') {
           return null;
         }

--- a/scripts/bench/bench-packages.ts
+++ b/scripts/bench/bench-packages.ts
@@ -411,6 +411,9 @@ const run = async () => {
       '-p, --pull-request <number>',
       'The PR number to add compare results to. Only used together with --baseBranch',
       function parseInt(value) {
+        if (value === '0' || value === '') {
+          return null;
+        }
         const parsedValue = Number.parseInt(value);
         if (Number.isNaN(parsedValue)) {
           throw new InvalidArgumentError('Must be a number');

--- a/scripts/ci/utils/helpers.ts
+++ b/scripts/ci/utils/helpers.ts
@@ -224,7 +224,7 @@ export const workflow = {
         'discord/status': {
           only_for_branches: ['main', 'next', 'next-release', 'latest-release'].join(','),
           fail_only: true,
-          failure_message: `yarn get-report-message ${workflow} ${template}`,
+          failure_message: `$(yarn get-report-message ${workflow} ${template})`,
         },
       },
     ];


### PR DESCRIPTION
## What I did

I learned the discord reporting isn't behaving correctly, it needs to look like this:
https://github.com/storybookjs/storybook/blob/9a9f5382b1acee5a29690a67509c56459032a353/.circleci/config.yml#L26C34-L26C36

Also the package-branchmarking is failing with a parse error like so:
https://app.circleci.com/pipelines/github/storybookjs/storybook/113473/workflows/763903e1-fa93-4389-9dde-75c5b16dd746/jobs/1034344

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CI failure notifications now run and capture the report command output so status messages show the actual result instead of a literal command.
  * Benchmark CLI: the pull-request option treats "0" or an empty value as unset, causing PR-related upload/compare steps to be skipped for those inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->