### PR TITLE
Core: Fix iframe URL issues and Addons display for /index.html

### DIFF
--- a/code/core/src/manager-api/modules/refs.ts
+++ b/code/core/src/manager-api/modules/refs.ts
@@ -18,6 +18,7 @@ import {
   transformStoryIndexToStoriesHash,
 } from '../lib/stories';
 import type { ModuleFn } from '../lib/types';
+import { normalizeToDirectory } from './url';
 
 const { location, fetch } = global;
 
@@ -81,10 +82,9 @@ export const getSourceType = (source: string, refId?: string) => {
   const { origin: localOrigin, pathname: localPathname } = location;
   const { origin: sourceOrigin, pathname: sourcePathname } = new URL(source);
 
-  const localFull = `${localOrigin + localPathname}`.replace('/iframe.html', '').replace(/\/$/, '');
-  const sourceFull = `${sourceOrigin + sourcePathname}`
-    .replace('/iframe.html', '')
-    .replace(/\/$/, '');
+  // Use directory path for comparison
+  const localFull = `${localOrigin}${normalizeToDirectory(localPathname)}`.replace(/\/$/, '');
+  const sourceFull = `${sourceOrigin}${normalizeToDirectory(sourcePathname)}`.replace(/\/$/, '');
 
   if (localFull === sourceFull) {
     return ['local', sourceFull];

--- a/code/core/src/manager-api/modules/url.ts
+++ b/code/core/src/manager-api/modules/url.ts
@@ -52,6 +52,16 @@ const mergeSerializedParams = (params: string, extraParams: string) => {
     .join(';');
 };
 
+// Normalize pathname to directory path
+// e.g. '/index.html' -> '/', '/storybook/' -> '/storybook/'
+export const normalizeToDirectory = (pathname: string): string => {
+  if (pathname.endsWith('/')) {
+    return pathname;
+  }
+  const lastSlash = pathname.lastIndexOf('/');
+  return lastSlash >= 0 ? pathname.slice(0, lastSlash + 1) : '/';
+};
+
 // Initialize the state based on the URL.
 // NOTE:
 //   Although we don't change the URL when you change the state, we do support setting initial state
@@ -247,10 +257,11 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
         throw new Error(`Invalid refId: ${refId}`);
       }
 
-      const originAddress = global.window.location.origin + location.pathname;
+      const basePath = normalizeToDirectory(location.pathname || '/');
+      const originAddress = global.window.location.origin + basePath;
       const networkAddress = global.STORYBOOK_NETWORK_ADDRESS ?? originAddress;
       const managerBase =
-        base === 'origin' ? originAddress : base === 'network' ? networkAddress : location.pathname;
+        base === 'origin' ? originAddress : base === 'network' ? networkAddress : basePath;
       const previewBase = refId
         ? refs[refId].url + '/iframe.html'
         : global.PREVIEW_URL || `${managerBase}iframe.html`;


### PR DESCRIPTION
Closes #33548

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

* url.ts: Added `normalizeToDirectory` to extract directory paths from a pathname. Converts file paths like `/index.html` to `/` while keeping directory paths unchanged. Fixes iframe URL concatenation errors.
* refs.ts: Uses the normalized directory path to determine `sourceType`, preventing local sources from being misclassified as external.

Another error in the latest code

Phenomenon: When accessing `/index.html`, the iframe keeps loading indefinitely.

Cause:
`getStoryHrefs` directly concatenates `${location.pathname}iframe.html`. When `pathname` is `/index.html`, the generated iframe URL becomes `/index.htmliframe.html`, causing a 404 error.

Addons not displaying

Phenomenon: Accessing `/index.html` loads the page normally, but the top toolbar and Addons panel are missing.

Cause:
When accessing `/index.html`, `getSourceType` misclassifies it as `external` (because it compares the full pathname), causing the `navigate` redirect to be skipped. The URL remains at `?path=/`, so Addons do not display due to a viewMode mismatch.
## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run:
    

```bash
yarn task --task compile
```

2. In the sandbox, build and run the sandbox static service:
    

```bash
yarn build-storybook
python3 -m http.server 8000 --directory storybook-static
```

3. Access [http://localhost:8000/index.html](http://localhost:8000/index.html) to confirm that the automatic redirect works and Addons are displayed correctly.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced path normalization and improved consistency in source type detection logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->