### PR TITLE
Core: Zoom tool refinements - Hide reset button when value is initial

### DIFF
--- a/code/core/src/components/components/Button/Button.tsx
+++ b/code/core/src/components/components/Button/Button.tsx
@@ -60,6 +60,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variant = 'outline',
       padding = 'medium',
       disabled = false,
+      hidden = false,
       readOnly = false,
       active,
       onClick,
@@ -138,7 +139,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             variant={variant}
             size={size}
             padding={padding}
-            disabled={disabled || readOnly}
+            disabled={disabled || hidden || readOnly}
+            hidden={hidden}
             readOnly={readOnly}
             active={active}
             animating={isAnimating}
@@ -166,6 +168,7 @@ const StyledButton = styled('button', {
   variant?: 'outline' | 'solid' | 'ghost';
   active?: boolean;
   disabled?: boolean;
+  hidden?: boolean;
   readOnly?: boolean;
   animating?: boolean;
   animation?: 'none' | 'rotate360' | 'glow' | 'jiggle';
@@ -175,6 +178,7 @@ const StyledButton = styled('button', {
     variant,
     size,
     disabled,
+    hidden,
     readOnly,
     active,
     animating,
@@ -217,6 +221,7 @@ const StyledButton = styled('button', {
     whiteSpace: 'nowrap',
     userSelect: 'none',
     opacity: disabled && !readOnly ? 0.5 : 1,
+    visibility: hidden ? 'hidden' : 'visible',
     margin: 0,
     fontSize: `${theme.typography.size.s1}px`,
     fontWeight: theme.typography.weight.bold,

--- a/code/core/src/components/components/Button/Button.tsx
+++ b/code/core/src/components/components/Button/Button.tsx
@@ -60,7 +60,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variant = 'outline',
       padding = 'medium',
       disabled = false,
-      hidden = false,
       readOnly = false,
       active,
       onClick,
@@ -139,8 +138,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             variant={variant}
             size={size}
             padding={padding}
-            disabled={disabled || hidden || readOnly}
-            hidden={hidden}
+            disabled={disabled || readOnly}
             readOnly={readOnly}
             active={active}
             animating={isAnimating}
@@ -168,7 +166,6 @@ const StyledButton = styled('button', {
   variant?: 'outline' | 'solid' | 'ghost';
   active?: boolean;
   disabled?: boolean;
-  hidden?: boolean;
   readOnly?: boolean;
   animating?: boolean;
   animation?: 'none' | 'rotate360' | 'glow' | 'jiggle';
@@ -178,7 +175,6 @@ const StyledButton = styled('button', {
     variant,
     size,
     disabled,
-    hidden,
     readOnly,
     active,
     animating,
@@ -221,7 +217,6 @@ const StyledButton = styled('button', {
     whiteSpace: 'nowrap',
     userSelect: 'none',
     opacity: disabled && !readOnly ? 0.5 : 1,
-    visibility: hidden ? 'hidden' : 'visible',
     margin: 0,
     fontSize: `${theme.typography.size.s1}px`,
     fontWeight: theme.typography.weight.bold,

--- a/code/core/src/manager/components/preview/tools/zoom.tsx
+++ b/code/core/src/manager/components/preview/tools/zoom.tsx
@@ -81,15 +81,16 @@ export const Zoom = memo<{
                   </ActionList.Button>
                 }
                 after={
-                  <ActionList.Button
-                    size="small"
-                    padding="small"
-                    style={{ visibility: value !== INITIAL_ZOOM_LEVEL ? 'visible' : 'hidden' }}
-                    onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
-                    ariaLabel="Reset zoom"
-                  >
-                    <UndoIcon />
-                  </ActionList.Button>
+                  value !== INITIAL_ZOOM_LEVEL && (
+                    <ActionList.Button
+                      size="small"
+                      padding="small"
+                      onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
+                      ariaLabel="Reset zoom"
+                    >
+                      <UndoIcon />
+                    </ActionList.Button>
+                  )
                 }
                 value={`${Math.round(value * 100)}%`}
                 minValue={1}

--- a/code/core/src/manager/components/preview/tools/zoom.tsx
+++ b/code/core/src/manager/components/preview/tools/zoom.tsx
@@ -81,15 +81,15 @@ export const Zoom = memo<{
                   </ActionList.Button>
                 }
                 after={
-                  <ActionList.Button
-                    size="small"
-                    padding="small"
-                    disabled={value === INITIAL_ZOOM_LEVEL}
-                    onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
-                    ariaLabel="Reset zoom"
-                  >
-                    <UndoIcon />
-                  </ActionList.Button>
+                      <ActionList.Button
+                        size="small"
+                        padding="small"
+                        style={{visibility: value !== INITIAL_ZOOM_LEVEL ? 'visible' : 'hidden'}}
+                        onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
+                        ariaLabel="Reset zoom"
+                      >
+                        <UndoIcon />
+                      </ActionList.Button>
                 }
                 value={`${Math.round(value * 100)}%`}
                 minValue={1}

--- a/code/core/src/manager/components/preview/tools/zoom.tsx
+++ b/code/core/src/manager/components/preview/tools/zoom.tsx
@@ -81,15 +81,15 @@ export const Zoom = memo<{
                   </ActionList.Button>
                 }
                 after={
-                      <ActionList.Button
-                        size="small"
-                        padding="small"
-                        style={{visibility: value !== INITIAL_ZOOM_LEVEL ? 'visible' : 'hidden'}}
-                        onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
-                        ariaLabel="Reset zoom"
-                      >
-                        <UndoIcon />
-                      </ActionList.Button>
+                  <ActionList.Button
+                    size="small"
+                    padding="small"
+                    style={{ visibility: value !== INITIAL_ZOOM_LEVEL ? 'visible' : 'hidden' }}
+                    onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
+                    ariaLabel="Reset zoom"
+                  >
+                    <UndoIcon />
+                  </ActionList.Button>
                 }
                 value={`${Math.round(value * 100)}%`}
                 minValue={1}

--- a/code/core/src/manager/components/preview/tools/zoom.tsx
+++ b/code/core/src/manager/components/preview/tools/zoom.tsx
@@ -19,6 +19,12 @@ const ZoomButton = styled(Button)({
   minWidth: 48,
 });
 
+const ZoomResetButton = styled(ActionList.Button)<{ $isInitialValue: boolean }>(
+  ({ $isInitialValue }) => ({
+    visibility: $isInitialValue ? 'hidden' : undefined,
+  })
+);
+
 const Context = createContext({ value: INITIAL_ZOOM_LEVEL, set: (v: number) => {} });
 
 const ZoomInput = styled(NumericInput)({
@@ -81,16 +87,16 @@ export const Zoom = memo<{
                   </ActionList.Button>
                 }
                 after={
-                  value !== INITIAL_ZOOM_LEVEL && (
-                    <ActionList.Button
-                      size="small"
-                      padding="small"
-                      onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
-                      ariaLabel="Reset zoom"
-                    >
-                      <UndoIcon />
-                    </ActionList.Button>
-                  )
+                  <ZoomResetButton
+                    size="small"
+                    padding="small"
+                    $isInitialValue={value === INITIAL_ZOOM_LEVEL}
+                    onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
+                    ariaLabel="Reset zoom"
+                    aria-hidden={value === INITIAL_ZOOM_LEVEL}
+                  >
+                    <UndoIcon />
+                  </ZoomResetButton>
                 }
                 value={`${Math.round(value * 100)}%`}
                 minValue={1}

--- a/code/core/src/manager/components/preview/tools/zoom.tsx
+++ b/code/core/src/manager/components/preview/tools/zoom.tsx
@@ -90,10 +90,10 @@ export const Zoom = memo<{
                   <ZoomResetButton
                     size="small"
                     padding="small"
-                    hidden={value === INITIAL_ZOOM_LEVEL}
                     $isInitialValue={value === INITIAL_ZOOM_LEVEL}
                     onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
                     ariaLabel="Reset zoom"
+                    aria-hidden={value === INITIAL_ZOOM_LEVEL}
                   >
                     <UndoIcon />
                   </ZoomResetButton>

--- a/code/core/src/manager/components/preview/tools/zoom.tsx
+++ b/code/core/src/manager/components/preview/tools/zoom.tsx
@@ -81,15 +81,16 @@ export const Zoom = memo<{
                   </ActionList.Button>
                 }
                 after={
-                  <ActionList.Button
-                    size="small"
-                    padding="small"
-                    hidden={value === INITIAL_ZOOM_LEVEL}
-                    onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
-                    ariaLabel="Reset zoom"
-                  >
-                    <UndoIcon />
-                  </ActionList.Button>
+                  value !== INITIAL_ZOOM_LEVEL && (
+                    <ActionList.Button
+                      size="small"
+                      padding="small"
+                      onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
+                      ariaLabel="Reset zoom"
+                    >
+                      <UndoIcon />
+                    </ActionList.Button>
+                  )
                 }
                 value={`${Math.round(value * 100)}%`}
                 minValue={1}

--- a/code/core/src/manager/components/preview/tools/zoom.tsx
+++ b/code/core/src/manager/components/preview/tools/zoom.tsx
@@ -81,16 +81,15 @@ export const Zoom = memo<{
                   </ActionList.Button>
                 }
                 after={
-                  value !== INITIAL_ZOOM_LEVEL && (
-                    <ActionList.Button
-                      size="small"
-                      padding="small"
-                      onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
-                      ariaLabel="Reset zoom"
-                    >
-                      <UndoIcon />
-                    </ActionList.Button>
-                  )
+                  <ActionList.Button
+                    size="small"
+                    padding="small"
+                    hidden={value === INITIAL_ZOOM_LEVEL}
+                    onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
+                    ariaLabel="Reset zoom"
+                  >
+                    <UndoIcon />
+                  </ActionList.Button>
                 }
                 value={`${Math.round(value * 100)}%`}
                 minValue={1}

--- a/code/core/src/manager/components/preview/tools/zoom.tsx
+++ b/code/core/src/manager/components/preview/tools/zoom.tsx
@@ -90,10 +90,10 @@ export const Zoom = memo<{
                   <ZoomResetButton
                     size="small"
                     padding="small"
+                    hidden={value === INITIAL_ZOOM_LEVEL}
                     $isInitialValue={value === INITIAL_ZOOM_LEVEL}
                     onClick={() => zoomTo(INITIAL_ZOOM_LEVEL)}
                     ariaLabel="Reset zoom"
-                    aria-hidden={value === INITIAL_ZOOM_LEVEL}
                   >
                     <UndoIcon />
                   </ZoomResetButton>


### PR DESCRIPTION
#33614 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->
The reset button is no longer displayed when Zoom is in its initial state.
I used `visibility: hidden` to ensure the menu width remains consistent even when the button is hidden.
Since the styling isn't complex and many parts already use inline styles, I added them inline to make it easier to see which styles apply under which conditions.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

![reset button](https://github.com/user-attachments/assets/9c617a1b-224e-429c-b714-7e52014ec158)

I confirmed that the button disappears when the initial value is set.
I also confirmed that the menu width does not change based on the button's visibility, as intended.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an improved zoom reset control that appears only when zoom is not at its default level.

* **Refactor**
  * Zoom reset behavior updated: the control is now hidden at the default zoom level instead of being disabled, creating a cleaner interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->