### PR TITLE
Codemod: Fix csf-2-to-3 failing due to quoted filenames

### DIFF
--- a/code/lib/codemod/src/index.test.ts
+++ b/code/lib/codemod/src/index.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, readFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { runCodemod } from './index';
+
+const logger = {
+  step: vi.fn(),
+  log: vi.fn(),
+};
+
+const csf2Source = `import { Meta, Story } from '@storybook/react-vite'
+
+import { Chart, ChartProps } from './chart'
+
+export default {
+  component: Chart,
+  title: 'Chart',
+} as Meta
+
+const Template: Story<ChartProps> = (args) => <Chart {...args} />
+
+export const SimpleBar = Template.bind({})
+SimpleBar.args = { name: 'test' }
+`;
+
+describe('runCodemod', () => {
+  const tempDir = join(tmpdir(), 'storybook-codemod-test');
+
+  beforeEach(() => {
+    mkdirSync(tempDir, { recursive: true });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * https://github.com/storybookjs/storybook/issues/33639
+   *
+   * Reproduces the bug where csf-2-to-3 silently fails because filenames
+   * are incorrectly quoted when passed to spawnSync.
+   *
+   * Test file from: https://github.com/seb-oss/green/blob/b634df24d2dae157300f73b711e569d1755eb138/libs/react-charts/src/lib/chart.stories.tsx
+   */
+  it('should transform CSF2 Template.bind({}) files with csf-2-to-3', async () => {
+    const storyFile = join(tempDir, 'chart.stories.tsx');
+    writeFileSync(storyFile, csf2Source);
+
+    await runCodemod('csf-2-to-3', {
+      glob: storyFile,
+      logger,
+    });
+
+    const result = readFileSync(storyFile, 'utf-8');
+
+    // csf-2-to-3 should transform Template.bind({}) to CSF3 object
+    expect(result).not.toContain('Template.bind({})');
+    expect(result).toContain('export const SimpleBar = {');
+  });
+
+  it('should handle filenames with spaces', async () => {
+    const storyFile = join(tempDir, 'my component.stories.tsx');
+    writeFileSync(storyFile, csf2Source);
+
+    await runCodemod('csf-2-to-3', {
+      glob: storyFile,
+      logger,
+    });
+
+    const result = readFileSync(storyFile, 'utf-8');
+
+    expect(result).not.toContain('Template.bind({})');
+    expect(result).toContain('export const SimpleBar = {');
+  });
+
+  it('should handle glob patterns', async () => {
+    const storyFile1 = join(tempDir, 'chart.stories.tsx');
+    const storyFile2 = join(tempDir, 'button.stories.tsx');
+    writeFileSync(storyFile1, csf2Source);
+    writeFileSync(storyFile2, csf2Source);
+
+    await runCodemod('csf-2-to-3', {
+      glob: join(tempDir, '*.stories.tsx'),
+      logger,
+    });
+
+    const result1 = readFileSync(storyFile1, 'utf-8');
+    const result2 = readFileSync(storyFile2, 'utf-8');
+
+    expect(result1).not.toContain('Template.bind({})');
+    expect(result2).not.toContain('Template.bind({})');
+  });
+
+  it('should handle recursive glob patterns', async () => {
+    const nestedDir = join(tempDir, 'components', 'charts');
+    mkdirSync(nestedDir, { recursive: true });
+
+    const storyFile1 = join(tempDir, 'root.stories.tsx');
+    const storyFile2 = join(nestedDir, 'nested.stories.tsx');
+    writeFileSync(storyFile1, csf2Source);
+    writeFileSync(storyFile2, csf2Source);
+
+    await runCodemod('csf-2-to-3', {
+      glob: join(tempDir, '**/*.stories.tsx'),
+      logger,
+    });
+
+    const result1 = readFileSync(storyFile1, 'utf-8');
+    const result2 = readFileSync(storyFile2, 'utf-8');
+
+    expect(result1).not.toContain('Template.bind({})');
+    expect(result2).not.toContain('Template.bind({})');
+  });
+});

--- a/code/lib/codemod/src/index.test.ts
+++ b/code/lib/codemod/src/index.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { writeFileSync, readFileSync, mkdirSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runCodemod } from './index';
 
@@ -40,10 +41,11 @@ describe('runCodemod', () => {
   /**
    * https://github.com/storybookjs/storybook/issues/33639
    *
-   * Reproduces the bug where csf-2-to-3 silently fails because filenames
-   * are incorrectly quoted when passed to spawnSync.
+   * Reproduces the bug where csf-2-to-3 silently fails because filenames are incorrectly quoted
+   * when passed to spawnSync.
    *
-   * Test file from: https://github.com/seb-oss/green/blob/b634df24d2dae157300f73b711e569d1755eb138/libs/react-charts/src/lib/chart.stories.tsx
+   * Test file from:
+   * https://github.com/seb-oss/green/blob/b634df24d2dae157300f73b711e569d1755eb138/libs/react-charts/src/lib/chart.stories.tsx
    */
   it('should transform CSF2 Template.bind({}) files with csf-2-to-3', async () => {
     const storyFile = join(tempDir, 'chart.stories.tsx');

--- a/code/lib/codemod/src/index.ts
+++ b/code/lib/codemod/src/index.ts
@@ -86,7 +86,7 @@ export async function runCodemod(
         '-t',
         `${TRANSFORM_DIR}/${codemod}.js`,
         ...parserArgs,
-        ...files.map((file) => `"${file}"`),
+        ...files,
       ],
       {
         stdio: 'inherit',


### PR DESCRIPTION
Closes #33639

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed the `csf-2-to-3` codemod silently failing with "file does not exist" errors.

### The Bug

When running `npx storybook migrate csf-2-to-3 --glob "**/*.stories.tsx"`, files were not being transformed and jscodeshift reported files as not existing.

### Root Cause

The bug was introduced by an incomplete refactor. Here's the history:

| Date | PR | Author | Change | Result |
|------|--------|--------|--------|--------|
| Jul 2023 | [#23498](https://github.com/storybookjs/storybook/pull/23498) | Norbert | Created file with `shell: true`, no quotes | ❌ Broke on filenames with `()` |
| Mar 2024 | [#26430](https://github.com/storybookjs/storybook/pull/26430) | Yuki | Added quotes to fix shell escaping | ✅ Fixed |
| Nov 2025 | [#32984](https://github.com/storybookjs/storybook/pull/32984) | Valentin | Removed `shell: true` for security, but left quotes | ❌ Broke everything |

**Why quotes were needed with `shell: true`:**

```bash
# Without quotes, parentheses cause shell syntax errors:
$ bash -c 'echo foo(bar).tsx'
bash: syntax error near unexpected token `('

# With quotes, shell treats it as literal:
$ bash -c 'echo "foo(bar).tsx"'
foo(bar).tsx
```

**Why quotes break without `shell: true`:**

When using `spawnSync` with an array of arguments (no shell), Node.js passes each element directly to the child process. The quotes become **literal characters** in the filename:

```typescript
// With shell: true - quotes are interpreted by shell
spawnSync('node', ['jscodeshift', '"file.tsx"'], { shell: true })
// → jscodeshift receives: file.tsx ✅

// Without shell - quotes are literal
spawnSync('node', ['jscodeshift', '"file.tsx"'])
// → jscodeshift receives: "file.tsx" (with quotes!) ❌
// → Error: file "file.tsx" does not exist
```

### The Fix

Simply remove the quotes since `spawnSync` with an array handles argument escaping automatically:

```typescript
// Before (broken):
...files.map((file) => `"${file}"`),

// After (fixed):
...files,
```

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Tested in the [green repo](https://github.com/seb-oss/green) (from the original issue):

```bash
# All these patterns now work:
npx storybook migrate csf-2-to-3 --glob "libs/react-charts/src/lib/chart.stories.tsx"  # Direct path
npx storybook migrate csf-2-to-3 --glob "libs/react-charts/src/lib/*.stories.tsx"      # Wildcard
npx storybook migrate csf-2-to-3 --glob "libs/**/*.stories.tsx"                        # Recursive
npx storybook migrate csf-2-to-3 --glob "/absolute/path/to/file.stories.tsx"           # Absolute
npx storybook migrate csf-2-to-3 --glob "libs/my components/src/file.stories.tsx"      # Spaces in path
```

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that doesn't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for the CSF2→CSF3 codemod, covering template-to-export conversions, filenames with spaces, and various glob matching scenarios.
* **Bug Fixes**
  * Improved how file paths are passed to the codemod tool to ensure correct processing across different patterns and nested files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->