### PR TITLE
CSFFactories: Add non-interactive mode and --glob flag

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/index.ts
@@ -122,6 +122,7 @@ export const automigrate = async ({
   isLatest,
   storiesPaths,
   hasCsfFactoryPreview,
+  glob,
 }: AutofixOptions): Promise<{
   fixResults: Record<string, FixStatus>;
   preCheckFailure?: PreCheckFailure;
@@ -147,6 +148,7 @@ export const automigrate = async ({
       storybookVersion,
       storiesPaths,
       yes,
+      glob,
     });
 
     return null;

--- a/code/lib/cli-storybook/src/automigrate/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/index.ts
@@ -146,6 +146,7 @@ export const automigrate = async ({
       result: null,
       storybookVersion,
       storiesPaths,
+      yes,
     });
 
     return null;
@@ -380,6 +381,7 @@ export async function runFixes({
               skipInstall,
               storybookVersion,
               storiesPaths,
+              yes,
             });
             logger.log(`✅ ran ${picocolors.cyan(f.id)} migration`);
 

--- a/code/lib/cli-storybook/src/automigrate/multi-project.ts
+++ b/code/lib/cli-storybook/src/automigrate/multi-project.ts
@@ -264,7 +264,7 @@ export async function runAutomigrationsForProjects(
   selectedAutomigrations: AutomigrationCheckResult[],
   options: MultiProjectRunAutomigrationOptions
 ): Promise<Record<ConfigDir, AutomigrationResult>> {
-  const { dryRun, skipInstall, automigrations } = options;
+  const { dryRun, skipInstall, automigrations, yes } = options;
   const projectResults: Record<ConfigDir, AutomigrationResult> = {};
 
   const applicableAutomigrations = selectedAutomigrations.filter((am) =>
@@ -378,6 +378,7 @@ export async function runAutomigrationsForProjects(
             skipInstall,
             storybookVersion: project.storybookVersion,
             storiesPaths: project.storiesPaths,
+            yes,
           };
 
           await fix.run(runOptions);

--- a/code/lib/cli-storybook/src/automigrate/types.ts
+++ b/code/lib/cli-storybook/src/automigrate/types.ts
@@ -26,6 +26,8 @@ export interface RunOptions<ResultType> {
   storiesPaths: string[];
   /** Skip prompts and use defaults (from --yes flag) */
   yes?: boolean;
+  /** Glob pattern for story files (for csf-factories codemod) */
+  glob?: string;
 }
 
 /**
@@ -99,6 +101,8 @@ export interface AutofixOptionsFromCLI {
   skipInstall?: boolean;
   hideMigrationSummary?: boolean;
   skipDoctor?: boolean;
+  /** Glob pattern for story files (for csf-factories codemod) */
+  glob?: string;
 }
 
 export enum FixStatus {

--- a/code/lib/cli-storybook/src/automigrate/types.ts
+++ b/code/lib/cli-storybook/src/automigrate/types.ts
@@ -24,6 +24,8 @@ export interface RunOptions<ResultType> {
   skipInstall?: boolean;
   storybookVersion: string;
   storiesPaths: string[];
+  /** Skip prompts and use defaults (from --yes flag) */
+  yes?: boolean;
 }
 
 /**

--- a/code/lib/cli-storybook/src/bin/run.ts
+++ b/code/lib/cli-storybook/src/bin/run.ts
@@ -278,6 +278,7 @@ command('automigrate [fixId]')
     'The renderer package for the framework Storybook is using.'
   )
   .option('--skip-doctor', 'Skip doctor check')
+  .option('--glob <pattern>', 'Glob pattern for story files (for csf-factories codemod)')
   .action(async (fixId, options) => {
     withTelemetry('automigrate', { cliOptions: options }, async () => {
       logger.intro(fixId ? `Running ${fixId} automigration` : 'Running automigrations');

--- a/code/lib/cli-storybook/src/codemod/csf-factories.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.ts
@@ -20,17 +20,18 @@ async function runStoriesCodemod(options: {
   useSubPathImports: boolean;
   previewConfigPath: string;
   yes: boolean | undefined;
+  glob: string | undefined;
 }) {
-  const { dryRun, packageManager, yes, ...codemodOptions } = options;
+  const { dryRun, packageManager, yes, glob, ...codemodOptions } = options;
   try {
     const inSandbox = optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX);
     const isNonInteractive = yes || inSandbox;
-    let globString = '**/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}';
+    let globString = glob ?? '**/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}';
 
-    if (inSandbox) {
-      // Sandbox always uses limited glob for faster testing
+    if (!glob && inSandbox) {
+      // Sandbox uses limited glob for faster testing (unless glob explicitly provided)
       globString = '{stories,src}/**/{Button,Header,Page,button,header,page}.stories.*';
-    } else if (!isNonInteractive) {
+    } else if (!glob && !isNonInteractive) {
       logger.log('Please enter the glob for your stories to migrate');
       globString = await prompt.text({
         message: 'glob',
@@ -67,8 +68,9 @@ export const csfFactories: CommandFix = {
     packageManager,
     configDir,
     yes,
+    glob,
   }) {
-    let useSubPathImports = true;
+    let useSubPathImports = false;
     const isNonInteractive = yes || optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX);
 
     if (!isNonInteractive) {
@@ -113,6 +115,7 @@ export const csfFactories: CommandFix = {
       useSubPathImports,
       previewConfigPath: previewConfigPath!,
       yes,
+      glob,
     });
 
     logger.step('Applying codemod on your main config...');

--- a/code/lib/cli-storybook/src/codemod/csf-factories.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.ts
@@ -24,14 +24,13 @@ async function runStoriesCodemod(options: {
 }) {
   const { dryRun, packageManager, yes, glob, ...codemodOptions } = options;
   try {
-    const inSandbox = optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX);
-    const isNonInteractive = yes || inSandbox;
+    const inSandbox = optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX) ?? false;
     let globString = glob ?? '**/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}';
 
     if (!glob && inSandbox) {
       // Sandbox uses limited glob for faster testing (unless glob explicitly provided)
       globString = '{stories,src}/**/{Button,Header,Page,button,header,page}.stories.*';
-    } else if (!glob && !isNonInteractive) {
+    } else if (!glob && !yes) {
       logger.log('Please enter the glob for your stories to migrate');
       globString = await prompt.text({
         message: 'glob',
@@ -70,10 +69,11 @@ export const csfFactories: CommandFix = {
     yes,
     glob,
   }) {
-    let useSubPathImports = false;
-    const isNonInteractive = yes || optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX);
+    const inSandbox = optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX) ?? false;
+    // Defaults to false for users and true in sandbox
+    let useSubPathImports = inSandbox;
 
-    if (!isNonInteractive) {
+    if (!yes && !inSandbox) {
       // prompt whether the user wants to use imports map
       logger.logBox(dedent`
         The CSF Factories format can benefit from using absolute imports of your ${picocolors.cyan(previewConfigPath)} file. We can configure that for you, using subpath imports (a node standard), by adjusting the imports property of your package.json.

--- a/code/lib/cli-storybook/src/codemod/csf-factories.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.ts
@@ -23,17 +23,18 @@ async function runStoriesCodemod(options: {
 }) {
   const { dryRun, packageManager, yes, ...codemodOptions } = options;
   try {
-    const isNonInteractive = yes || optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX);
+    const inSandbox = optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX);
+    const isNonInteractive = yes || inSandbox;
     let globString = '**/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}';
 
-    if (isNonInteractive && optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX)) {
-      // Use sandbox-specific glob only in sandbox mode
+    if (inSandbox) {
+      // Sandbox always uses limited glob for faster testing
       globString = '{stories,src}/**/{Button,Header,Page,button,header,page}.stories.*';
     } else if (!isNonInteractive) {
       logger.log('Please enter the glob for your stories to migrate');
       globString = await prompt.text({
         message: 'glob',
-        initialValue: '**/*.{stories,story}.{js,jsx,ts,tsx,mjs,mjsx,mts,mtsx}',
+        initialValue: globString,
       });
     }
 


### PR DESCRIPTION
Closes #33639

## What I did

Added support for running the `csf-factories` automigration non-interactively using the `--yes` flag, and added a `--glob` option for specifying custom glob patterns.

### Changes:

1. **`--yes` flag support**: When passed, the codemod skips all prompts and uses defaults
2. **`--glob <pattern>` flag**: Allows specifying a custom glob pattern for story files
3. **`useSubPathImports` defaults to `false`**: Safer default since subpath imports don't work in all setups

### Behavior:

| Mode | Glob | useSubPathImports |
|------|------|-------------------|
| Interactive (default) | Prompted | Prompted |
| `--glob` only | Custom pattern | Prompted |
| `--yes` | Default: `**/*.{stories,story}.*` | `false` |
| `--yes --glob "src/**"` | Custom pattern | `false` |
| Sandbox (`IN_STORYBOOK_SANDBOX`) | Limited sandbox glob | `false` |

**Usage:**
```bash
# Non-interactive with defaults
npx storybook automigrate csf-factories --yes

# Non-interactive with custom glob
npx storybook automigrate csf-factories --yes --glob "src/**/*.stories.tsx"

# Interactive with custom glob (prompts for useSubPathImports only)
npx storybook automigrate csf-factories --glob "src/**/*.stories.tsx"
```

## Manual Testing Results

All tests performed on `react-vite-default-ts` sandbox.

### Test 1: `--yes` without `--glob`
```bash
node cli-storybook/dist/bin/index.js automigrate csf-factories --yes
```
**Result:** ✅ PASS
- No prompts shown
- Used default glob `**/*.{stories,story}.*`
- Transformed 83 files across the project
- Used relative imports (useSubPathImports=false)

### Test 2: `--yes --glob` with pattern
```bash
node cli-storybook/dist/bin/index.js automigrate csf-factories --yes --glob "src/stories/*.stories.ts"
```
**Result:** ✅ PASS
- No prompts shown
- Only matched files in `src/stories/` directory
- Transformed 2 files (Button, Header), skipped 1 (Page already CSF4)
- Used relative imports

### Test 3: `--glob` with single file
```bash
node cli-storybook/dist/bin/index.js automigrate csf-factories --yes --glob "src/stories/Button.stories.ts"
```
**Result:** ✅ PASS
- Only Button.stories.ts was transformed
- Other story files untouched

### Test 4: Sandbox mode (`IN_STORYBOOK_SANDBOX=true`)
```bash
IN_STORYBOOK_SANDBOX=true node cli-storybook/dist/bin/index.js automigrate csf-factories
```
**Result:** ✅ PASS
- No prompts shown (sandbox is always non-interactive)
- Used limited sandbox glob `{stories,src}/**/{Button,Header,Page,...}.stories.*`
- Only transformed Button, Header (2 files), skipped Page (already CSF4)

### Test 5: Transformation correctness
**Result:** ✅ PASS
- CSF3 stories correctly transformed to CSF4 factory pattern
- `export default meta` → `preview.meta({...})`
- `export const Story: Story = {...}` → `export const Story = meta.story({...})`
- Relative imports used: `import preview from "../../.storybook/preview"`

### Test 6: Interactive mode (without `--yes`) - backwards compatibility
```bash
node cli-storybook/dist/bin/index.js automigrate csf-factories
```
**Result:** ✅ PASS
- Shows prompt for `useSubPathImports` selection (Relative vs Subpath imports)
- Shows prompt for glob pattern
- Old interactive behavior preserved

### Test 7: `--glob` without `--yes` (partial interactive)
```bash
node cli-storybook/dist/bin/index.js automigrate csf-factories --glob "src/stories/Button.stories.ts"
```
**Result:** ✅ PASS
- Shows prompt for `useSubPathImports` selection
- Skips glob prompt (uses provided `--glob` value)
- Allows customizing glob while still being prompted for import style

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

See "Manual Testing Results" section above - 7 test scenarios verified.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added `--glob` flag to automigrate command, enabling custom glob patterns for more granular story file selection
- Introduced non-interactive mode allowing automigrations to execute without prompts or interactive user confirmations
- Improved csf-factories codemod to support both automated execution modes and custom file pattern targeting for greater flexibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->