### PR TITLE
CSF: Fix false positive detection of Zod v4 .meta() as CSF Factory

### DIFF
--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -858,7 +858,10 @@ export class CsfFile {
                     : callee.property.name;
                   const metaNode = node.arguments[0] as t.ObjectExpression;
                   self._parseMeta(metaNode, self._ast.program);
-                } else {
+                } else if (rootObject.name === 'preview') {
+                  // Only throw if the variable is named "preview" - this indicates
+                  // the user is trying to use CSF Factories but with a wrong import path.
+                  // Other .meta() calls (e.g., Zod v4's .meta()) are silently ignored.
                   throw new BadMetaError(
                     'meta() factory must be imported from .storybook/preview configuration',
                     configParent,


### PR DESCRIPTION
Closes #33654

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Fixed a bug where the CSF parser incorrectly identified Zod v4's `.meta()` method calls as Storybook's CSF Factories `meta()` function. This caused a `BadMetaError` when using Zod schemas with `.meta()` in story files:

```
BadMetaError: CSF: meta() factory must be imported from .storybook/preview configuration
```

**Root cause:** The parser was checking if *any* `.meta()` call on an imported variable came from a valid preview path, and throwing an error if not.

**Fix:** Changed the detection logic to only throw `BadMetaError` when the variable calling `.meta()` is specifically named `preview`. This is the canonical name used in CSF Factories (`preview.meta()`), so if someone has a variable with this name but imports it from the wrong path, they get a helpful error. For all other variable names (like `mySchema` from Zod), the `.meta()` call is silently ignored.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual testing required - the fix is fully covered by unit tests that simulate the exact Zod v4 usage patterns from the issue.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduce false positives by only flagging incorrect preview-style metadata imports and ignoring unrelated metadata calls from external libraries.

* **Tests**
  * Added tests ensuring external libraries' metadata chaining is ignored and that preview configuration path detection still validates correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->