### PR TITLE
Vue3: Add test for generic components with CSF factories

### DIFF
--- a/code/renderers/vue3/src/__tests__/GenericComponent.vue
+++ b/code/renderers/vue3/src/__tests__/GenericComponent.vue
@@ -1,0 +1,33 @@
+<template>
+  <ul class="generic-list">
+    <li
+      v-for="(item, index) in items"
+      :key="index"
+      :class="{ selected: selectedItem === item }"
+      @click="selectItem(item)"
+    >
+      {{ getLabel(item) }}
+    </li>
+  </ul>
+</template>
+
+<script lang="ts" setup generic="T">
+import { ref } from 'vue';
+
+const props = defineProps<{
+  items: T[];
+  getLabel: (item: T) => string;
+  defaultSelected?: T;
+}>();
+
+const emit = defineEmits<{
+  (e: 'select', item: T): void;
+}>();
+
+const selectedItem = ref<T | undefined>(props.defaultSelected);
+
+const selectItem = (item: T) => {
+  selectedItem.value = item;
+  emit('select', item);
+};
+</script>

--- a/code/renderers/vue3/src/csf-factories.test.ts
+++ b/code/renderers/vue3/src/csf-factories.test.ts
@@ -1,7 +1,7 @@
 // this file tests Typescript types that's why there are no assertions
 import { describe, expect, expectTypeOf, it, test } from 'vitest';
 
-import type { Canvas, ComponentAnnotations, StoryAnnotations } from 'storybook/internal/types';
+import type { Canvas } from 'storybook/internal/types';
 
 import { h } from 'vue';
 
@@ -9,6 +9,7 @@ import BaseLayout from './__tests__/BaseLayout.vue';
 import Button from './__tests__/Button.vue';
 import Decorator2TsVue from './__tests__/Decorator2.vue';
 import DecoratorTsVue from './__tests__/Decorator.vue';
+import GenericComponent from './__tests__/GenericComponent.vue';
 import { __definePreview } from './preview';
 import type { ComponentPropsAndSlots, Decorator, Meta, StoryObj } from './public-types';
 
@@ -195,5 +196,36 @@ it('allow types to be inferred from render as well', () => {
 
   const Story = meta.story({
     args: { disabled: true },
+  });
+});
+
+describe('Generic components (issue #24238)', () => {
+  // Generic Vue components with TypeScript generics work with CSF factories
+  // by passing the type parameter directly: GenericComponent<ConcreteType>
+  // See: https://github.com/storybookjs/storybook/issues/24238
+
+  it('✅ Generic components work by passing type parameter directly', () => {
+    const meta = preview.meta({
+      component: GenericComponent<{ id: number; name: string }>,
+    });
+
+    const Story = meta.story({
+      args: {
+        items: [
+          {
+            id: 1,
+            name: 'John Doe',
+          },
+        ],
+        getLabel: (item) => {
+          // item is correctly typed as { id: number; name: string }
+          expectTypeOf(item).toMatchObjectType<{ id: number; name: string }>();
+          return item.name;
+        },
+      },
+    });
+
+    // Verify the story has the correct args
+    expect(Story.input.args?.items).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Related to #24238

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds a unit test demonstrating that generic Vue components (using `<script lang="ts" setup generic="T">`) work correctly with CSF Next.

**The key finding:** With CSF Next, you can pass the type parameter directly:

```typescript
const meta = preview.meta({
  component: GenericComponent<{ id: number; name: string }>,
});

const Story = meta.story({
  args: {
    items: [{ id: 1, name: 'John Doe' }],
    getLabel: (item) => item.name, // item is correctly typed!
  },
});
```

This addresses the long-standing issue #24238 where generic Vue components had type inference issues with traditional CSF3 (the generic type `T` would default to `unknown`).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual testing required - this PR adds a type-level unit test that verifies TypeScript inference works correctly with generic Vue components.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->