### PR TITLE
Manager: Update logic to use base path instead of full pathname

### DIFF
--- a/code/core/src/manager-api/modules/refs.ts
+++ b/code/core/src/manager-api/modules/refs.ts
@@ -81,10 +81,8 @@ export const getSourceType = (source: string, refId?: string) => {
   const { origin: localOrigin, pathname: localPathname } = location;
   const { origin: sourceOrigin, pathname: sourcePathname } = new URL(source);
 
-  const localFull = `${localOrigin + localPathname}`.replace('/iframe.html', '').replace(/\/$/, '');
-  const sourceFull = `${sourceOrigin + sourcePathname}`
-    .replace('/iframe.html', '')
-    .replace(/\/$/, '');
+  const localFull = `${localOrigin + localPathname}`.replace(/\/[^\/]*$/, '');
+  const sourceFull = `${sourceOrigin + sourcePathname}`.replace(/\/[^\/]*$/, '');
 
   if (localFull === sourceFull) {
     return ['local', sourceFull];


### PR DESCRIPTION
Closes #33548

## What I did

Updated url.ts and ref.ts to use base path instead of full pathname. This solved a logic error when finding relative files that had assumed the pathname didn't end with `/`

PR based on https://github.com/storybookjs/storybook/pull/33624
I've added @ia319 as co-author to the commit.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Basic test:
1. Run a sandbox for template: `yarn start`
2. Open Storybook in your browser
3. Change URL to: http://localhost:6006/index.html
4. Expect same result as when initially opening storybook.

Advanced with refs:
1. Create two different sandboxes:
  1. Run a sandbox for template: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
  2. 1. Run a sandbox for template: `yarn task --task sandbox --start-from auto --template lit-vite/default-ts`
2. navigate to ../storybook-sandboxes/react-vite-default-ts and run `npm run build-storybook`
3. run `npx http-server . --cors --port 8080`
4. in a separate terminal, navigate to ../storybook-sandboxes/lit-vite-default-ts
5. modify .storybook/main.ts, add to the config:

```
  "refs": {
    "react": {
      "title": "React Components",
      "url": "http://localhost:8080/storybook-static/"
    }
  },
```
 
7. run `npm run build-storybook`
8. run `npx http-server . --cors --port 8081`
9. open browser to http://localhost:8081/storybook-static/
10. confirm page loads with composed storybook
11. select globe icon next to 'React Components' (extra actions button) and select view external storybook (page should load as expected with index.html in path)
12. open browser to http://localhost:8081/storybook-static/index.html
13. confirm page loads with composed storybook
14. select globe icon next to 'React Components' (extra actions button) and select view external storybook (page should load as expected with index.html in path)


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL comparison logic to more consistently match reference URLs across different path structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->