### PR TITLE
Docs: Add FAQ about generic Vue components in CSF Next

### DIFF
--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -542,6 +542,35 @@ While using CSF Next, you can still use the older formats, as long as they are n
 
 Yes, the [doc blocks](../../writing-docs/doc-blocks.mdx) used to reference stories in MDX files support the CSF Next format with no changes needed.
 
+<If renderer="vue">
+
+### How do I use generic Vue components?
+
+Generic Vue components (using `<script lang="ts" setup generic="T">`) work seamlessly with CSF Next. Simply pass the type parameter directly to the component:
+
+```ts title="GenericList.stories.ts"
+import preview from '#.storybook/preview';
+
+import GenericList from './GenericList.vue';
+
+const meta = preview.meta({
+  // 👇 Pass the type parameter directly
+  component: GenericList<{ id: number; name: string }>,
+});
+
+export const Example = meta.story({
+  args: {
+    items: [{ id: 1, name: 'John Doe' }],
+    // 👇 item is correctly typed as { id: number; name: string }
+    getLabel: (item) => item.name,
+  },
+});
+```
+
+This solves a [long-standing type inference issue](https://github.com/storybookjs/storybook/issues/24238) where the generic type `T` would default to `unknown` in prior CSF versions.
+
+</If>
+
 ### How can I know more about this format and provide feedback?
 
 For more information on this experimental format's original proposal, refer to its [RFC on GitHub](https://github.com/storybookjs/storybook/discussions/30112). We welcome your comments!

--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -542,35 +542,6 @@ While using CSF Next, you can still use the older formats, as long as they are n
 
 Yes, the [doc blocks](../../writing-docs/doc-blocks.mdx) used to reference stories in MDX files support the CSF Next format with no changes needed.
 
-<If renderer="vue">
-
-### How do I use generic Vue components?
-
-Generic Vue components (using `<script lang="ts" setup generic="T">`) work seamlessly with CSF Next. Simply pass the type parameter directly to the component:
-
-```ts title="GenericList.stories.ts"
-import preview from '#.storybook/preview';
-
-import GenericList from './GenericList.vue';
-
-const meta = preview.meta({
-  // 👇 Pass the type parameter directly
-  component: GenericList<{ id: number; name: string }>,
-});
-
-export const Example = meta.story({
-  args: {
-    items: [{ id: 1, name: 'John Doe' }],
-    // 👇 item is correctly typed as { id: number; name: string }
-    getLabel: (item) => item.name,
-  },
-});
-```
-
-This solves a [long-standing type inference issue](https://github.com/storybookjs/storybook/issues/24238) where the generic type `T` would default to `unknown` in prior CSF versions.
-
-</If>
-
 ### How can I know more about this format and provide feedback?
 
 For more information on this experimental format's original proposal, refer to its [RFC on GitHub](https://github.com/storybookjs/storybook/discussions/30112). We welcome your comments!

--- a/docs/writing-stories/typescript.mdx
+++ b/docs/writing-stories/typescript.mdx
@@ -69,32 +69,57 @@ Sometimes stories need to define args that aren’t included in the component's 
 {/* prettier-ignore-end */}
 
 <IfRenderer renderer="vue">
-  ## Vue specific tips
 
-  Vue has excellent support for TypeScript, and we have done our utmost to take advantage of that in the stories files. For example, consider the following strongly typed Vue 3 single file component (SFC):
+## Vue specific tips
 
-  ```html
-  <script setup lang="ts">
-    defineProps<{ count: number; disabled: boolean }>();
+Vue has excellent support for TypeScript, and we have done our utmost to take advantage of that in the stories files. For example, consider the following strongly typed Vue 3 single file component (SFC):
 
-    const emit = defineEmits<{
-      (e: 'increaseBy', amount: number): void;
-      (e: 'decreaseBy', amount: number): void;
-    }>();
-  </script>
+```html
+<script setup lang="ts">
+  defineProps<{ count: number; disabled: boolean }>();
 
-  <template>
-    <div class="card">
-      {{ count }}
-      <button @click="emit('increaseBy', 1)" :disabled="disabled">Increase by 1</button>
-      <button @click="$emit('decreaseBy', 1)" :disabled="disabled">Decrease by 1</button>
-    </div>
-  </template>
-  ```
+  const emit = defineEmits<{
+    (e: 'increaseBy', amount: number): void;
+    (e: 'decreaseBy', amount: number): void;
+  }>();
+</script>
 
-  You can type check SFC files with vue-tsc and get editor support in VSCode by installing the official [Vue](https://marketplace.visualstudio.com/items?itemName=Vue.volar) extension.
+<template>
+  <div class="card">
+    {{ count }}
+    <button @click="emit('increaseBy', 1)" :disabled="disabled">Increase by 1</button>
+    <button @click="$emit('decreaseBy', 1)" :disabled="disabled">Decrease by 1</button>
+  </div>
+</template>
+```
 
-  This setup will add type support for `*.vue` imports to your `*.stories.ts` files, providing the same type safety and autocomplete features.
+You can type check SFC files with `vue-tsc` and get editor support in VSCode by installing the official [Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar).
+
+This setup will add type support for `*.vue` imports to your `*.stories.ts` files, providing the same type safety and autocomplete features.
+
+[CSF Next](../api/csf/csf-next.mdx) adds support for [Generic Vue components](https://vuejs.org/api/sfc-script-setup.html#generics) (using `<script lang="ts" setup generic="T">`). Simply pass the type parameter directly to the component:
+
+```ts title="GenericList.stories.ts"
+import preview from '../.storybook/preview';
+
+import GenericList from './GenericList.vue';
+
+const meta = preview.meta({
+  // 👇 Pass the type parameter directly
+  component: GenericList<{ id: number; name: string }>,
+});
+
+export const Example = meta.story({
+  args: {
+    items: [{ id: 1, name: 'John Doe' }],
+    // 👇 item is correctly typed as { id: number; name: string }
+    getLabel: (item) => item.name,
+  },
+});
+```
+
+Prior CSF versions suffer from a [long-standing type inference issue](https://github.com/storybookjs/storybook/issues/24238) where the generic type `T` would default to `unknown`.
+
 </IfRenderer>
 
 <IfRenderer renderer="svelte">


### PR DESCRIPTION
Related to #24238

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added a FAQ entry to the CSF Next documentation explaining how generic Vue components work with CSF Next.

Generic Vue components (using `<script lang="ts" setup generic="T">`) had type inference issues with traditional CSF3 (the generic type `T` would default to `unknown`). With CSF Next, users can simply pass the type parameter directly:

```typescript
const meta = preview.meta({
  component: GenericList<{ id: number; name: string }>,
});
```

This documents the solution to issue #24238.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Documentation-only change, no manual testing required.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced Vue TypeScript tips with clearer, structured examples.
  * Added guidance on type checking, editor support, and Vue tooling.
  * Introduced examples for using generics in Vue components.
  * Reorganized documentation with explicit separation of script and template blocks for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->