### PR TITLE
Addon Vitest: Support simple vite.config without defineConfig helper

### DIFF
--- a/code/core/src/cli/AddonVitestService.test.ts
+++ b/code/core/src/cli/AddonVitestService.test.ts
@@ -601,5 +601,48 @@ describe('AddonVitestService', () => {
       expect(result.reasons).toBeDefined();
       expect(result.reasons!.length).toBe(2);
     });
+
+    it('should validate mergeConfig with plain object literal', async () => {
+      vi.mocked(find.any)
+        .mockReturnValueOnce(undefined) // workspace
+        .mockReturnValueOnce('vitest.config.ts'); // config
+      vi.mocked(fs.readFile).mockResolvedValue(
+        'export default mergeConfig(viteConfig, { test: { name: "node" } })'
+      );
+      const result = await service.validateConfigFiles('.storybook');
+      expect(result.compatible).toBe(true);
+    });
+
+    it('should validate mergeConfig with defineConfig call', async () => {
+      vi.mocked(find.any)
+        .mockReturnValueOnce(undefined) // workspace
+        .mockReturnValueOnce('vitest.config.ts'); // config
+      vi.mocked(fs.readFile).mockResolvedValue(
+        'export default mergeConfig(viteConfig, defineConfig({ test: { name: "node" } }))'
+      );
+      const result = await service.validateConfigFiles('.storybook');
+      expect(result.compatible).toBe(true);
+    });
+
+    it('should validate mergeConfig with multiple plain objects', async () => {
+      vi.mocked(find.any)
+        .mockReturnValueOnce(undefined) // workspace
+        .mockReturnValueOnce('vitest.config.ts'); // config
+      vi.mocked(fs.readFile).mockResolvedValue(
+        'export default mergeConfig({ test: {} }, { plugins: [] })'
+      );
+      const result = await service.validateConfigFiles('.storybook');
+      expect(result.compatible).toBe(true);
+    });
+
+    it('should reject mergeConfig with invalid object (non-object argument)', async () => {
+      vi.mocked(find.any)
+        .mockReturnValueOnce(undefined) // workspace
+        .mockReturnValueOnce('vitest.config.ts'); // config
+      vi.mocked(fs.readFile).mockResolvedValue('export default mergeConfig(viteConfig, "string")');
+      const result = await service.validateConfigFiles('.storybook');
+      expect(result.compatible).toBe(false);
+      expect(result.reasons!.some((r) => r.includes('invalid Vitest config'))).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/33409

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes a bug in the Vitest addon configuration validation where mergeConfig calls using plain object literals were incorrectly flagged as incompatible.

**Before (broken):**

```tsx
// This was incorrectly flagged as incompatible
export default mergeConfig(viteConfig, {
  test: { name: 'node', environment: 'happy-dom' }
})
```

**Before (worked):**

```tsx
// This worked correctly
export default mergeConfig(viteConfig, defineConfig({
  test: { name: 'node', environment: 'happy-dom' }
}))
```

Both configurations are semantically equivalent and should be supported.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. **Create a test project** with a `vitest.config.ts` using `mergeConfig` with a plain object literal:

```ts
import { mergeConfig, coverageConfigDefaults } from 'vitest/config'
import viteConfig from './vite.config'

export default mergeConfig(
  viteConfig,
  {
    test: {
      name: 'node',
      environment: 'happy-dom',
    },
  }
)
```

2. **Run Storybook init** with the Vitest addon:
```bash
npx storybook@next init
# or add the addon to existing Storybook
npx storybook@next add @storybook/addon-test
```

3. **Verify** that:
   - The config file is correctly detected as compatible (no "unsupported format" error)
   - The Storybook project is properly added to the Vitest configuration
   - Running `npx vitest --project=storybook` works correctly

4. **Test with `defineConfig` variant** (should continue to work):
```ts
export default mergeConfig(
  viteConfig,
  defineConfig({
    test: { name: 'node', environment: 'happy-dom' }
  })
)
```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33694-sha-d9eaac60`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33694-sha-d9eaac60 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33694-sha-d9eaac60 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33694-sha-d9eaac60`](https://npmjs.com/package/storybook/v/0.0.0-pr-33694-sha-d9eaac60) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/addon-vitest-support-simple-workspace-config`](https://github.com/storybookjs/storybook/tree/valentin/addon-vitest-support-simple-workspace-config) |
| **Commit** | [`d9eaac60`](https://github.com/storybookjs/storybook/commit/d9eaac606468607769050f30f50ddbe855e97457) |
| **Datetime** | Wed Jan 28 14:55:14 UTC 2026 (`1769612114`) |
| **Workflow run** | [21443036614](https://github.com/storybookjs/storybook/actions/runs/21443036614) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33694`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for configuration validation scenarios.

* **Refactor**
  * Improved configuration validation logic to handle additional configuration patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->