### PR TITLE
Docs: Add FAQ about sharing config in monorepos for CSF Next

### DIFF
--- a/docs/_snippets/csf-factories-automigrate-with-config-directory.md
+++ b/docs/_snippets/csf-factories-automigrate-with-config-directory.md
@@ -1,0 +1,14 @@
+```shell renderer="common" language="js" packageManager="npm"
+npx storybook automigrate csf-factories -c apps/admin/.storybook
+npx storybook automigrate csf-factories -c apps/website/.storybook
+```
+
+```shell renderer="common" language="js" packageManager="pnpm"
+pnpm dlx storybook automigrate csf-factories -c apps/admin/.storybook
+pnpm dlx storybook automigrate csf-factories -c apps/website/.storybook
+```
+
+```shell renderer="common" language="js" packageManager="yarn"
+yarn dlx storybook automigrate csf-factories -c apps/admin/.storybook
+yarn dlx storybook automigrate csf-factories -c apps/website/.storybook
+```

--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -290,6 +290,17 @@ You can automatically upgrade all of your project's stories from CSF 3 to CSF Ne
 
 <CodeSnippets path="csf-factories-automigrate.md" />
 
+<Callout variant="info" icon="💡">
+
+**Monorepos:** If your project has multiple Storybook configurations, run the command with the `-c` flag pointing to each config directory:
+
+```shell
+npx storybook automigrate csf-factories -c apps/admin/.storybook
+npx storybook automigrate csf-factories -c apps/website/.storybook
+```
+
+</Callout>
+
 It will run through each of the manual upgrade steps below on all of your story files.
 
 <details>

--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -290,16 +290,11 @@ You can automatically upgrade all of your project's stories from CSF 3 to CSF Ne
 
 <CodeSnippets path="csf-factories-automigrate.md" />
 
-<Callout variant="info" icon="💡">
+#### Monorepos
 
-**Monorepos:** If your project has multiple Storybook configurations, run the command with the `-c` flag pointing to each config directory:
+If your project has multiple Storybook configurations, run the command with the `-c` flag pointing to each config directory:
 
-```shell
-npx storybook automigrate csf-factories -c apps/admin/.storybook
-npx storybook automigrate csf-factories -c apps/website/.storybook
-```
-
-</Callout>
+<CodeSnippets path="csf-factories-automigrate-with-config-directory.md" />
 
 It will run through each of the manual upgrade steps below on all of your story files.
 


### PR DESCRIPTION
Closes #33616

## What I did

Added a note after the automigrate command explaining that in monorepos with multiple Storybook configs, you need to run the command with the `-c` flag pointing to each config directory.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

This is a documentation-only change. Manual testing:
1. View the rendered MDX in the docs site
2. Verify the callout appears directly after the automigrate command

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that doesn't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added monorepo guidance to CSF Next automigration docs, showing how to run the automigration with a config-directory flag for each config and including dedicated command snippets.
  * Included example command blocks demonstrating automigration across multiple Storybook configs using npm, pnpm, and yarn. Duplicate guidance appears in two relevant sections for discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->