### PR TITLE
Addon-Docs: Re-export ArgsTable from blocks for compatibility

### DIFF
--- a/code/addons/docs/src/__tests__/blocks.test.ts
+++ b/code/addons/docs/src/__tests__/blocks.test.ts
@@ -1,0 +1,11 @@
+import * as blocks from '../blocks';
+
+describe('blocks module compatibility exports', () => {
+  test('exports ArgsTable', () => {
+    expect(blocks.ArgsTable).toBeDefined();
+  });
+
+  test('ArgsTable equals PureArgsTable', () => {
+    expect(blocks.ArgsTable).toBe(blocks.PureArgsTable);
+  });
+});

--- a/code/addons/docs/src/blocks.ts
+++ b/code/addons/docs/src/blocks.ts
@@ -1,6 +1,8 @@
 // FIXME: sort this out, maybe with package.json exports map
 // https://medium.com/swlh/npm-new-package-json-exports-field-1a7d1f489ccf
 export { ArgsTable as PureArgsTable } from './blocks/components/ArgsTable/ArgsTable';
+// Compatibility re-export: ensure named `ArgsTable` is available to consumers
+export { ArgsTable } from './blocks/components/ArgsTable/ArgsTable';
 export { TableOfContents } from './blocks/components';
 
 export type { SortType } from './blocks/components';


### PR DESCRIPTION
PR: re-export `ArgsTable` from `@storybook/addon-docs/blocks`

Summary
-------
This small change re-exports the `ArgsTable` implementation from `code/addons/docs/src/blocks.ts` so that consumers importing `ArgsTable` from `@storybook/addon-docs/blocks` continue to work with bundlers that may rename internal exports (for example Vite optimizeDeps producing `PureArgsTable`).

Rationale
---------
- Some bundlers / pre-bundlers can alter compiled modules and effectively remove/change named exports consumers expect, resulting in runtime errors like:
  ``Error: The requested module '.../blocks.js' does not provide an export named 'ArgsTable'``
- Storybook currently exports an equivalent implementation under a different name (`PureArgsTable`). Re-exporting `ArgsTable` from the same source restores compatibility with MDX files and third-party docs that import `ArgsTable` directly.

Change
------
- Re-export `ArgsTable` from `code/addons/docs/src/blocks.ts` so the module exports the named symbol expected by consumers.

Tests
-----
- Added unit test at `code/addons/docs/src/__tests__/blocks.test.ts` that asserts `ArgsTable` is exported and is the same as `PureArgsTable`.

Changelog
---------
- Fix: re-export `ArgsTable` from `@storybook/addon-docs/blocks` to restore compatibility with imports that expect the named export.

Please review; happy to adjust if you'd prefer a different approach (e.g., changing package exports map or build pipeline).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ArgsTable` as a direct public export alongside the existing alias for improved API accessibility.

* **Tests**
  * Added compatibility validation tests for the blocks module exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->