### PR TITLE
Composition: Handle 401 responses with loginUrl from Chromatic

### DIFF
--- a/code/core/src/common/utils/get-storybook-refs.test.ts
+++ b/code/core/src/common/utils/get-storybook-refs.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { checkRef } from './get-storybook-refs';
+
+describe('checkRef', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns true when fetch returns 200', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as Response);
+    expect(await checkRef('https://chromatic.com')).toBe(true);
+  });
+
+  it('returns false when fetch returns 401', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({ ok: false, status: 401 } as Response);
+    expect(await checkRef('https://chromatic.com')).toBe(false);
+  });
+
+  it('returns false when fetch returns 200 with loginUrl', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ loginUrl: 'https://chromatic.com/login' }),
+    } as Response);
+    expect(await checkRef('https://chromatic.com')).toBe(false);
+  });
+
+  it('returns false when fetch fails', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+    expect(await checkRef('https://chromatic.com')).toBe(false);
+  });
+});

--- a/code/core/src/common/utils/get-storybook-refs.ts
+++ b/code/core/src/common/utils/get-storybook-refs.ts
@@ -58,7 +58,7 @@ export const getAutoRefs = async (options: Options): Promise<Record<string, Ref>
   );
 };
 
-const checkRef = (url: string) =>
+export const checkRef = (url: string) =>
   fetch(`${url}/iframe.html`).then(
     async ({ ok, status }) => {
       if (ok) {

--- a/code/core/src/manager-api/modules/refs.ts
+++ b/code/core/src/manager-api/modules/refs.ts
@@ -118,6 +118,17 @@ async function handleRequest(
       throw new Error('Unexpected boolean response');
     }
     if (!response.ok) {
+      // Check for 401 responses that may contain loginUrl
+      if (response.status === 401) {
+        try {
+          const json = await response.json();
+          if (json.loginUrl) {
+            return { loginUrl: json.loginUrl };
+          }
+        } catch {
+          // Fall through to error handling if JSON parsing fails
+        }
+      }
       throw new Error(`Unexpected response not OK: ${response.statusText}`);
     }
 

--- a/code/core/src/manager-api/tests/refs.test.ts
+++ b/code/core/src/manager-api/tests/refs.test.ts
@@ -73,6 +73,7 @@ function createMockStore(initialState: Partial<State> = {}) {
 
 interface ResponseResult {
   ok?: boolean;
+  status?: number;
   err?: Error;
   response?: () => never | object | Promise<object>;
 }
@@ -86,13 +87,14 @@ type ResponseKeys =
   | 'metadata';
 
 function respond(result: ResponseResult): Promise<Response> {
-  const { err, ok, response } = result;
+  const { err, ok, status, response } = result;
   if (err) {
     return Promise.reject(err);
   }
 
   return Promise.resolve({
     ok: ok ?? !!response,
+    status: status ?? (ok ? 200 : 500),
     json: response,
   } as Response);
 }
@@ -765,6 +767,52 @@ describe('Refs API', () => {
           ],
         ]
       `);
+
+      expect(store.setState.mock.calls[0][0]).toMatchInlineSnapshot(`
+        {
+          "refs": {
+            "fake": {
+              "filteredIndex": undefined,
+              "id": "fake",
+              "index": undefined,
+              "internal_index": undefined,
+              "loginUrl": "https://example.com/login",
+              "title": "Fake",
+              "type": "auto-inject",
+              "url": "https://example.com",
+            },
+          },
+        }
+      `);
+    });
+
+    it('checks refs (auth with 401)', async () => {
+      // given
+      const { api } = initRefs({ provider, store } as any, { runCheck: false });
+
+      setupResponses({
+        indexPrivate: {
+          ok: false,
+          status: 401,
+          response: async () => ({ loginUrl: 'https://example.com/login' }),
+        },
+        storiesPrivate: {
+          ok: false,
+          status: 401,
+          response: async () => ({ loginUrl: 'https://example.com/login' }),
+        },
+        metadata: {
+          ok: false,
+          status: 401,
+          response: async () => ({ loginUrl: 'https://example.com/login' }),
+        },
+      });
+
+      await api.checkRef({
+        id: 'fake',
+        url: 'https://example.com',
+        title: 'Fake',
+      });
 
       expect(store.setState.mock.calls[0][0]).toMatchInlineSnapshot(`
         {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Chromatic is changing their endpoints to return HTTP 401 instead of 200 when authentication is required for private Storybooks. Previously, they returned `200 OK` with `{ loginUrl: "..." }` in the response body. After this change, they will return `401 Unauthorized` with the same `{ loginUrl: "..." }` body.

This PR updates the refs/composition feature to handle both scenarios:
- **Runtime** (`refs.ts`): Extract `loginUrl` from 401 response bodies in `handleRequest()`
- **Build-time** (`get-storybook-refs.ts`): Already returns `false` for 401 (no change needed), exported `checkRef` for testing
- **Tests**: Added unit tests for both code paths

### Note for Chromatic

Chromatic can only roll out this change (returning 401 instead of 200) after deprecating Storybook < 10.2. Until then, the following endpoints must continue returning `200 OK` with `{ loginUrl: "..." }` for backwards compatibility:

- `GET /index.json`
- `GET /stories.json`
- `GET /metadata.json`

Note: `/iframe.html` does not need to be in this list - both 200 with `loginUrl` and 401 result in the same behavior: the build-time check marks the ref as `type: 'unknown'`, which triggers the runtime fetch with credentials.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Manual testing was performed with the following steps:

1. Added a private Chromatic ref to `code/.storybook/main.ts`:
   ```ts
   refs: {
     private: {
       title: 'Private (auth test)',
       url: 'https://62e7a15f87b0f4a7bed2cf04-ejukkgyspq.chromatic.com',
     },
   },
   ```

2. Ran `yarn nx run-many -t compile` and `yarn storybook:ui`

3. Created a Playwright test that intercepts requests and returns 401 with `loginUrl`:
   ```ts
   await page.route('**/62e7a15f87b0f4a7bed2cf04-ejukkgyspq.chromatic.com/**', (route) => {
     return route.fulfill({
       status: 401,
       contentType: 'application/json',
       body: JSON.stringify({ loginUrl: 'https://www.chromatic.com/start' }),
     });
   });
   ```

4. Verified that clicking the "Private (auth test)" ref in the sidebar shows "Sign in to browse this Storybook" with a login button

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->