### PR TITLE
Addon-Vitest: Append Storybook project to existing test.projects array without double nesting

### DIFF
--- a/code/addons/vitest/src/updateVitestFile.test.ts
+++ b/code/addons/vitest/src/updateVitestFile.test.ts
@@ -854,6 +854,95 @@ describe('updateConfigFile', () => {
     `);
   });
 
+  it('appends storybook project to existing test.projects array (no double nesting)', async () => {
+    const source = babel.babelParse(
+      await loadTemplate('vitest.config.3.2.template.ts', {
+        CONFIG_DIR: '.storybook',
+        BROWSER_CONFIG: "{ provider: 'playwright' }",
+        SETUP_FILE: '../.storybook/vitest.setup.ts',
+      })
+    );
+    const target = babel.babelParse(`
+      import { mergeConfig, defineConfig } from 'vitest/config'
+      import viteConfig from './vite.config'
+
+      export default mergeConfig(
+        viteConfig,
+        defineConfig({
+          test: {
+            expect: { requireAssertions: true },
+            projects: [
+              {
+                extends: "./vite.config.ts",
+                test: { name: "client" },
+              },
+              {
+                extends: "./vite.config.ts",
+                test: { name: "server" },
+              },
+            ],
+          },
+        })
+      )
+    `);
+
+    const before = babel.generate(target).code;
+    const updated = updateConfigFile(source, target);
+    expect(updated).toBe(true);
+
+    const after = babel.generate(target).code;
+
+    // check if the code was updated at all
+    expect(after).not.toBe(before);
+
+    // check if the code was updated correctly (storybook project appended to existing projects, no double nesting)
+    expect(getDiff(before, after)).toMatchInlineSnapshot(`
+      "  import { mergeConfig, defineConfig } from 'vitest/config';
+        import viteConfig from './vite.config';
+        
+      + import path from 'node:path';
+      + import { fileURLToPath } from 'node:url';
+      + import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+      + const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+      + 
+      + // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
+      + 
+        export default mergeConfig(viteConfig, defineConfig({
+          test: {
+            expect: {
+              requireAssertions: true
+      ...
+              test: {
+                name: "server"
+              }
+        
+      +     }, {
+      +       extends: true,
+      +       plugins: [
+      +       // The plugin will run tests for the stories defined in your Storybook config
+      +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
+      +       storybookTest({
+      +         configDir: path.join(dirname, '.storybook')
+      +       })],
+      +       test: {
+      +         name: 'storybook',
+      +         browser: {
+      +           enabled: true,
+      +           headless: true,
+      +           provider: 'playwright',
+      +           instances: [{
+      +             browser: 'chromium'
+      +           }]
+      +         },
+      +         setupFiles: ['../.storybook/vitest.setup.ts']
+      +       }
+      + 
+            }]
+          }
+        }));"
+    `);
+  });
+
   it('extracts coverage config and keeps it at top level when using workspace', async () => {
     const source = babel.babelParse(
       await loadTemplate('vitest.config.template.ts', {

--- a/code/addons/vitest/src/updateVitestFile.ts
+++ b/code/addons/vitest/src/updateVitestFile.ts
@@ -232,8 +232,64 @@ export const updateConfigFile = (source: BabelFile['ast'], target: BabelFile['as
                 p.type === 'ObjectProperty' && p.key.type === 'Identifier' && p.key.name === 'test'
             ) as t.ObjectProperty | undefined;
 
-            if (templateTestProp && templateTestProp.value.type === 'ObjectExpression') {
-              // Find the workspace/projects array in the template
+            const hasProjectsProp = (
+              p: t.ObjectMethod | t.ObjectProperty | t.SpreadElement
+            ): p is t.ObjectProperty =>
+              p.type === 'ObjectProperty' &&
+              p.key.type === 'Identifier' &&
+              p.key.name === 'projects' &&
+              p.value.type === 'ArrayExpression';
+
+            // Check if the existing config already uses a projects array (multi-project setup).
+            // If so, we must append the storybook project to that array instead of wrapping
+            // the entire test config as a single project (which would cause double nesting).
+            const existingProjectsProp = existingTestProp.value.properties.find(hasProjectsProp);
+
+            if (existingProjectsProp) {
+              // Existing config already has test.projects: append storybook project(s) to it
+              if (templateTestProp && templateTestProp.value.type === 'ObjectExpression') {
+                const templateProjectsProp =
+                  templateTestProp.value.properties.find(hasProjectsProp);
+                if (templateProjectsProp && templateProjectsProp.value.type === 'ArrayExpression') {
+                  const templateElements = (templateProjectsProp.value as t.ArrayExpression)
+                    .elements;
+                  (existingProjectsProp.value as t.ArrayExpression).elements.push(
+                    ...templateElements
+                  );
+                }
+                // Merge other test-level options from template (e.g. coverage) into existing test
+                for (const templateProp of templateTestProp.value.properties) {
+                  if (
+                    templateProp.type === 'ObjectProperty' &&
+                    templateProp.key.type === 'Identifier' &&
+                    (templateProp.key as t.Identifier).name !== 'projects'
+                  ) {
+                    const existingProp = existingTestProp.value.properties.find(
+                      (p) =>
+                        p.type === 'ObjectProperty' &&
+                        p.key.type === 'Identifier' &&
+                        (p.key as t.Identifier).name === (templateProp.key as t.Identifier).name
+                    );
+                    if (!existingProp && templateProp.type === 'ObjectProperty') {
+                      existingTestProp.value.properties.push(templateProp);
+                    }
+                  }
+                }
+              }
+              // Merge only non-test properties from template to avoid re-adding storybook project
+              const otherTemplateProps = properties.filter(
+                (p) =>
+                  !(
+                    p.type === 'ObjectProperty' &&
+                    p.key.type === 'Identifier' &&
+                    p.key.name === 'test'
+                  )
+              );
+              if (otherTemplateProps.length > 0) {
+                mergeProperties(otherTemplateProps, targetConfigObject.properties);
+              }
+            } else if (templateTestProp && templateTestProp.value.type === 'ObjectExpression') {
+              // Existing test has no projects array: wrap entire test config as one project
               const workspaceOrProjectsProp = templateTestProp.value.properties.find(
                 (p) =>
                   p.type === 'ObjectProperty' &&


### PR DESCRIPTION
Closes #33706

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When running the postinstall script for `@storybook/addon-vitest`, the migration logic could incorrectly wrap an existing Vitest config that already used a `projects` array inside a new project object. That produced an invalid double-nested structure (`test.projects[0].test.projects`) and broke Vitest.

**Result:** A config like:

```ts
test: {
  expect: { requireAssertions: true },
  projects: [
    { extends: "./vite.config.ts", test: { name: "client" } },
    { extends: "./vite.config.ts", test: { name: "server" } },
  ],
},
```

is now updated to add the storybook project as a third item in `projects`, instead of wrapping client/server in an extra project and breaking the structure.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. In a project that already has `vitest.config.ts` with `test.projects` (e.g. client + server), add/init `@storybook/addon-vitest`.
2. Confirm `vitest.config.ts` is updated so the storybook project is a new entry in the existing `projects` array, not a wrapper around the previous config.
3. Run `npx vitest --project=storybook` and ensure tests run.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33708-sha-df1d2018`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33708-sha-df1d2018 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33708-sha-df1d2018 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33708-sha-df1d2018`](https://npmjs.com/package/storybook/v/0.0.0-pr-33708-sha-df1d2018) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/addon-vitest-prevent-double-nesting`](https://github.com/storybookjs/storybook/tree/valentin/addon-vitest-prevent-double-nesting) |
| **Commit** | [`df1d2018`](https://github.com/storybookjs/storybook/commit/df1d2018d5dafa18c10418747667deec77e94d01) |
| **Datetime** | Thu Jan 29 10:44:53 UTC 2026 (`1769683493`) |
| **Workflow run** | [21475119273](https://github.com/storybookjs/storybook/actions/runs/21475119273) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33708`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vitest configuration merging to prevent double nesting when appending Storybook projects to existing multi-project arrays.
  * Enhanced multi-project configuration handling to properly preserve existing test settings while adding new projects.

* **Tests**
  * Added test coverage for Storybook project configuration appending to existing multi-project arrays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->