### PR TITLE
Addon-Vitest: Skip postinstall setup when configured

### DIFF
--- a/code/addons/vitest/src/postinstall.test.ts
+++ b/code/addons/vitest/src/postinstall.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import { isConfigAlreadySetup } from './postinstall';
 
-const setupPath = '/project/.storybook/vitest.setup.ts';
-
 describe('postinstall helpers', () => {
   it('detects a fully configured Vitest config with addon plugin', () => {
     const config = `
@@ -25,7 +23,7 @@ describe('postinstall helpers', () => {
       });
     `;
 
-    expect(isConfigAlreadySetup('/project/vitest.config.ts', config, setupPath)).toBe(true);
+    expect(isConfigAlreadySetup('/project/vitest.config.ts', config)).toBe(true);
   });
 
   it('returns false when storybookTest plugin is not used', () => {
@@ -46,6 +44,6 @@ describe('postinstall helpers', () => {
       });
     `;
 
-    expect(isConfigAlreadySetup('/project/vitest.config.ts', config, setupPath)).toBe(false);
+    expect(isConfigAlreadySetup('/project/vitest.config.ts', config)).toBe(false);
   });
 });

--- a/code/addons/vitest/src/postinstall.test.ts
+++ b/code/addons/vitest/src/postinstall.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { isConfigAlreadySetup } from './postinstall';
+
+const setupPath = '/project/.storybook/vitest.setup.ts';
+
+describe('postinstall helpers', () => {
+  it('detects a fully configured Vitest config with addon plugin', () => {
+    const config = `
+      import { defineConfig } from 'vitest/config';
+      import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+
+      export default defineConfig({
+        test: {
+          projects: [
+            {
+              extends: true,
+              plugins: [storybookTest({ configDir: '.storybook' })],
+              test: {
+                setupFiles: ['./.storybook/vitest.setup.ts'],
+              },
+            },
+          ],
+        },
+      });
+    `;
+
+    expect(isConfigAlreadySetup('/project/vitest.config.ts', config, setupPath)).toBe(true);
+  });
+
+  it('returns false when storybookTest plugin is not used', () => {
+    const config = `
+      import { defineConfig } from 'vitest/config';
+
+      export default defineConfig({
+        test: {
+          projects: [
+            {
+              extends: true,
+              test: {
+                setupFiles: ['./.storybook/vitest.setup.ts'],
+              },
+            },
+          ],
+        },
+      });
+    `;
+
+    expect(isConfigAlreadySetup('/project/vitest.config.ts', config, setupPath)).toBe(false);
+  });
+});

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import { writeFile } from 'node:fs/promises';
 
-import { babelParse, generate } from 'storybook/internal/babel';
+import { babelParse, generate, traverse } from 'storybook/internal/babel';
 import { AddonVitestService } from 'storybook/internal/cli';
 import {
   JsPackageManagerFactory,
@@ -15,7 +15,6 @@ import type { StorybookError } from 'storybook/internal/server-errors';
 import {
   AddonVitestPostinstallConfigUpdateError,
   AddonVitestPostinstallError,
-  AddonVitestPostinstallExistingSetupFileError,
   AddonVitestPostinstallFailedAddonA11yError,
   AddonVitestPostinstallPrerequisiteCheckError,
   AddonVitestPostinstallWorkspaceUpdateError,
@@ -33,6 +32,7 @@ import { loadTemplate, updateConfigFile, updateWorkspaceFile } from './updateVit
 
 const ADDON_NAME = '@storybook/addon-vitest' as const;
 const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.cts', '.mts', '.cjs', '.mjs'];
+const STORYBOOK_TEST_PLUGIN_SOURCE = `${ADDON_NAME}/vitest-plugin`;
 
 const addonA11yName = '@storybook/addon-a11y';
 
@@ -174,17 +174,13 @@ export default async function postInstall(options: PostinstallOptions) {
     allDeps.typescript || findFile('tsconfig', [...EXTENSIONS, '.json']) ? 'ts' : 'js';
 
   const vitestSetupFile = resolve(options.configDir, `vitest.setup.${fileExtension}`);
+  const existingSetupFile =
+    EXTENSIONS.map((ext) => resolve(options.configDir, `vitest.setup${ext}`)).find(existsSync) ||
+    null;
 
-  if (existsSync(vitestSetupFile)) {
-    const errorMessage = dedent`
-    Found an existing Vitest setup file:
-    ${vitestSetupFile}
-    Please refer to the documentation to complete the setup manually:
-    https://storybook.js.org/docs/next/${DOCUMENTATION_LINK}#manual-setup-advanced
-  `;
-    logger.line();
-    logger.error(`${errorMessage}\n`);
-    errors.push(new AddonVitestPostinstallExistingSetupFileError({ filePath: vitestSetupFile }));
+  if (existingSetupFile) {
+    logger.step(`Found existing Vitest setup file, reusing:`);
+    logger.log(`${existingSetupFile}\n`);
   } else {
     logger.step(`Creating a Vitest setup file for Storybook:`);
     logger.log(`${vitestSetupFile}\n`);
@@ -243,16 +239,25 @@ export default async function postInstall(options: PostinstallOptions) {
   // If there's an existing workspace file, we update that file to include the Storybook Addon Vitest plugin.
   // We assume the existing workspaces include the Vite(st) config, so we won't add it.
   if (vitestWorkspaceFile) {
+    const workspaceFileContent = await fs.readFile(vitestWorkspaceFile, 'utf8');
+    const alreadyConfigured = isConfigAlreadySetup(vitestWorkspaceFile, workspaceFileContent);
+
+    if (alreadyConfigured) {
+      logger.step(
+        CLI_COLORS.success('Vitest for Storybook is already properly configured. Skipping setup.')
+      );
+      return;
+    }
+
     const workspaceTemplate = await loadTemplate('vitest.workspace.template.ts', {
       EXTENDS_WORKSPACE: viteConfigFile
         ? relative(dirname(vitestWorkspaceFile), viteConfigFile)
         : '',
       CONFIG_DIR: options.configDir,
-      SETUP_FILE: relative(dirname(vitestWorkspaceFile), vitestSetupFile),
+      SETUP_FILE: relative(dirname(vitestWorkspaceFile), existingSetupFile ?? vitestSetupFile),
     }).then((t) => t.replace(`\n  'ROOT_CONFIG',`, '').replace(/\s+extends: '',/, ''));
-    const workspaceFile = await fs.readFile(vitestWorkspaceFile, 'utf8');
     const source = babelParse(workspaceTemplate);
-    const target = babelParse(workspaceFile);
+    const target = babelParse(workspaceFileContent);
 
     const updated = updateWorkspaceFile(source, target);
     if (updated) {
@@ -290,10 +295,12 @@ export default async function postInstall(options: PostinstallOptions) {
 
     const templateName = getTemplateName();
 
-    if (templateName) {
+    const alreadyConfigured = isConfigAlreadySetup(rootConfig, configFile);
+
+    if (templateName && !alreadyConfigured) {
       const configTemplate = await loadTemplate(templateName, {
         CONFIG_DIR: options.configDir,
-        SETUP_FILE: relative(dirname(rootConfig), vitestSetupFile),
+        SETUP_FILE: relative(dirname(rootConfig), existingSetupFile ?? vitestSetupFile),
       });
 
       const source = babelParse(configTemplate);
@@ -301,7 +308,11 @@ export default async function postInstall(options: PostinstallOptions) {
       updated = updateConfigFile(source, target);
     }
 
-    if (target && updated) {
+    if (alreadyConfigured) {
+      logger.step(
+        CLI_COLORS.success('Vitest for Storybook is already properly configured. Skipping setup.')
+      );
+    } else if (target && updated) {
       logger.step(`Updating your ${vitestConfigFile ? 'Vitest' : 'Vite'} config file:`);
       logger.log(`  ${rootConfig}`);
 
@@ -411,4 +422,53 @@ export default async function postInstall(options: PostinstallOptions) {
     );
     throw new AddonVitestPostinstallError({ errors });
   }
+}
+
+function isStorybookTestPluginSource(value: string) {
+  return value === STORYBOOK_TEST_PLUGIN_SOURCE;
+}
+
+export function isConfigAlreadySetup(_configPath: string, configContent: string) {
+  let ast: ReturnType<typeof babelParse>;
+  try {
+    ast = babelParse(configContent);
+  } catch (e) {
+    return false;
+  }
+
+  const pluginIdentifiers = new Set<string>();
+
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const source = path.node.source.value;
+      if (typeof source === 'string' && isStorybookTestPluginSource(source)) {
+        path.node.specifiers.forEach((specifier) => {
+          if ('local' in specifier && specifier.local?.name) {
+            pluginIdentifiers.add(specifier.local.name);
+          }
+        });
+      }
+    },
+  });
+
+  let pluginReferenced = false;
+
+  traverse(ast, {
+    CallExpression(path) {
+      if (pluginReferenced) {
+        path.stop();
+        return;
+      }
+      const callee = path.node.callee;
+      if (
+        callee.type === 'Identifier' &&
+        (pluginIdentifiers.has(callee.name) || callee.name === 'storybookTest')
+      ) {
+        pluginReferenced = true;
+        path.stop();
+      }
+    },
+  });
+
+  return pluginReferenced;
 }

--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -482,22 +482,6 @@ export class AddonVitestPostinstallFailedAddonA11yError extends StorybookError {
   }
 }
 
-export class AddonVitestPostinstallExistingSetupFileError extends StorybookError {
-  constructor(public data: { filePath: string }) {
-    super({
-      name: 'AddonVitestPostinstallExistingSetupFileError',
-      category: Category.CLI_INIT,
-      isHandledError: true,
-      code: 7,
-      documentation: `https://storybook.js.org/docs/writing-tests/integrations/vitest-addon#manual-setup-advanced`,
-      message: dedent`
-        Found an existing Vitest setup file: ${data.filePath}
-        Please refer to the documentation to complete the setup manually.
-      `,
-    });
-  }
-}
-
 export class AddonVitestPostinstallWorkspaceUpdateError extends StorybookError {
   constructor(public data: { filePath: string }) {
     super({


### PR DESCRIPTION
Closes #33695

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR refactors the `@storybook/addon-vitest` postinstall script to be more idempotent and user-friendly. Instead of failing when it encounters existing configurations or setup files, the script now intelligently detects existing setups and avoids redundant modifications.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33712-sha-bdf0cf9e`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33712-sha-bdf0cf9e sandbox` or in an existing project with `npx storybook@0.0.0-pr-33712-sha-bdf0cf9e upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33712-sha-bdf0cf9e`](https://npmjs.com/package/storybook/v/0.0.0-pr-33712-sha-bdf0cf9e) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/addon-vitest-skip-existing-configs`](https://github.com/storybookjs/storybook/tree/valentin/addon-vitest-skip-existing-configs) |
| **Commit** | [`bdf0cf9e`](https://github.com/storybookjs/storybook/commit/bdf0cf9ef7e99f4230898948966a16ac2ad39494) |
| **Datetime** | Fri Jan 30 07:06:56 UTC 2026 (`1769756816`) |
| **Workflow run** | [21507518897](https://github.com/storybookjs/storybook/actions/runs/21507518897) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33712`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Postinstall now detects existing Vitest+Storybook setup and reuses existing setup files or skips redundant config updates instead of failing.

* **Tests**
  * Added unit tests covering detection of Vitest/Storybook configuration.

* **Chores**
  * Removed an internal exported error type related to the postinstall flow (internal cleanup).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->