### PR TITLE
Codemod: Fix glob pattern handling on Windows

### DIFF
--- a/code/lib/codemod/src/index.ts
+++ b/code/lib/codemod/src/index.ts
@@ -3,11 +3,10 @@ import { readdirSync } from 'node:fs';
 import { rename as renameAsync } from 'node:fs/promises';
 import { extname, join } from 'node:path';
 
-import { normalize } from 'pathe';
-
 import { resolvePackageDir } from 'storybook/internal/common';
 
 import { sync as spawnSync } from 'cross-spawn';
+import { normalize } from 'pathe';
 import { glob as tinyglobby } from 'tinyglobby';
 
 import { jscodeshiftToPrettierParser } from './lib/utils';

--- a/code/lib/codemod/src/index.ts
+++ b/code/lib/codemod/src/index.ts
@@ -3,6 +3,8 @@ import { readdirSync } from 'node:fs';
 import { rename as renameAsync } from 'node:fs/promises';
 import { extname, join } from 'node:path';
 
+import { normalize } from 'pathe';
+
 import { resolvePackageDir } from 'storybook/internal/common';
 
 import { sync as spawnSync } from 'cross-spawn';
@@ -60,7 +62,8 @@ export async function runCodemod(
     }
   }
 
-  const files = await tinyglobby([glob, '!**/node_modules', '!**/dist']);
+  // Normalize the glob pattern to use forward slashes (required for glob patterns on Windows)
+  const files = await tinyglobby([normalize(glob), '!**/node_modules', '!**/dist']);
   const extensions = new Set(files.map((file) => extname(file).slice(1)));
   const commaSeparatedExtensions = Array.from(extensions).join(',');
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed a Windows-specific bug where `runCodemod` in `@storybook/codemod` failed to find files because `tinyglobby` requires forward slashes in glob patterns, but `path.join()` on Windows produces backslash-separated paths.

### The Bug

When running codemods on Windows, files were silently not being transformed because:

1. User or code provides a path like `C:\Users\...\file.stories.tsx` (or uses `path.join()` to construct it)
2. `tinyglobby` requires forward slashes for glob patterns
3. The backslash path doesn't match any files
4. Codemod reports "0 files" and does nothing

### Root Cause

The `cli-storybook` version of `runCodemod` already handles this correctly using the `slash` package:

```typescript
// code/lib/cli-storybook/src/automigrate/codemod.ts
const files = await globby(slash(globPattern), { ... });
```

But the `@storybook/codemod` version was missing this normalization:

```typescript
// code/lib/codemod/src/index.ts (before fix)
const files = await tinyglobby([glob, '!**/node_modules', '!**/dist']);
```

### The Fix

Use `pathe.normalize()` (already used throughout the codebase) to normalize paths before passing to `tinyglobby`:

```typescript
// code/lib/codemod/src/index.ts (after fix)
import { normalize } from 'pathe';
// ...
const files = await tinyglobby([normalize(glob), '!**/node_modules', '!**/dist']);
```

### How this was discovered

This pre-existing bug was exposed by the unit tests added in #33646. The tests use `path.join(tmpdir(), ...)` which produces backslash paths on Windows, causing the tests to fail on Windows CI (ci:daily). The bug itself has existed longer - it would have affected any Windows user calling the codemod with a backslash path.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

This was caught by the existing unit tests in `src/index.test.ts` which were failing on Windows CI (ci:daily). The fix makes those tests pass. This affects real Windows users, not just tests - anyone using `npx storybook migrate` on Windows with backslash paths would be affected.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed glob pattern path handling on Windows to ensure consistent use of forward-slash notation, improving cross-platform compatibility.
  * Improved reliability of file matching and downstream processing on Windows systems, reducing cases of missed or incorrectly processed files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->