### PR TITLE
Addon-Docs: Add expand/collapse toggle for compound component names in code preview

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Source.tsx
+++ b/code/addons/docs/src/blocks/blocks/Source.tsx
@@ -163,6 +163,7 @@ export const useSourceProps = (
     format,
     language,
     dark,
+    simplifiedCode: source?.simplifiedCode,
   };
 };
 

--- a/code/addons/docs/src/blocks/blocks/SourceContainer.tsx
+++ b/code/addons/docs/src/blocks/blocks/SourceContainer.tsx
@@ -15,6 +15,7 @@ export function argsHash(args: Args): ArgsHash {
 export interface SourceItem {
   code: string;
   format?: SyntaxHighlighterFormatTypes;
+  simplifiedCode?: string;
 }
 
 export type StorySources = Record<StoryId, Record<ArgsHash, SourceItem>>;
@@ -31,6 +32,7 @@ type SnippetRenderedEvent = {
   source: string;
   args?: Args;
   format?: SyntaxHighlighterFormatTypes;
+  simplifiedSource?: string;
 };
 
 export const UNKNOWN_ARGS_HASH = '--unknown--';
@@ -52,11 +54,13 @@ export const SourceContainer: FC<PropsWithChildren<{ channel: DocsContextProps['
         args = undefined,
         source,
         format,
+        simplifiedSource,
       } = typeof idOrEvent === 'string'
         ? {
             id: idOrEvent,
             source: inputSource,
             format: inputFormat,
+            simplifiedSource: undefined,
           }
         : idOrEvent;
 
@@ -75,7 +79,11 @@ export const SourceContainer: FC<PropsWithChildren<{ channel: DocsContextProps['
           ...current,
           [id]: {
             ...current[id],
-            [hash]: { code: source || '', format },
+            [hash]: {
+              code: source || '',
+              format,
+              simplifiedCode: simplifiedSource,
+            },
           },
         };
 

--- a/code/core/src/preview-api/modules/preview-web/emitTransformCode.ts
+++ b/code/core/src/preview-api/modules/preview-web/emitTransformCode.ts
@@ -12,16 +12,24 @@ type Transformer =
   | ((code: string, storyContext: ReducedStoryContext) => string | Promise<string>)
   | undefined;
 
-export async function emitTransformCode(source: string | undefined, context: ReducedStoryContext) {
+export async function emitTransformCode(
+  source: string | undefined,
+  context: ReducedStoryContext,
+  simplifiedSource?: string
+) {
   const transform = context.parameters?.docs?.source?.transform as Transformer;
   const { id, unmappedArgs } = context;
 
   const transformed = transform && source ? transform?.(source, context) : source;
   const result = transformed ? await transformed : undefined;
+  const transformedSimplified =
+    transform && simplifiedSource ? transform?.(simplifiedSource, context) : simplifiedSource;
+  const simplifiedResult = transformedSimplified ? await transformedSimplified : undefined;
 
   addons.getChannel().emit(SNIPPET_RENDERED, {
     id,
     source: result,
     args: unmappedArgs,
+    simplifiedSource: simplifiedResult,
   });
 }


### PR DESCRIPTION

Closes #33473 

## What I did
                                                          
Added an expand/collapse toggle button in the code preview that allows users to switch between simplified 
and full component names for compound components.                                                         
                                                                                                      
- **Collapsed (default):** Shows simplified names like `<CardHeader>`                                     
- **Expanded:** Shows full dot notation like `<Card.Header>`  

## Screenshots                                                                                            
                                                                                                            
### Code preview with toggle button (collapsed - default)                                                 
<img width="1010" height="551" alt="Screenshot 2026-01-31 at 12 46 02 PM" src="https://github.com/user-attachments/assets/e5944a5a-6111-4d86-83ae-fd033391f938" />                              
                                                                                                            
### Code preview expanded (showing full dot notation)                                                  
<img width="1025" height="620" alt="Screenshot 2026-01-31 at 12 46 47 PM" src="https://github.com/user-attachments/assets/3b606d82-c067-44c7-8335-0a852ae29f93" />
                                                                           
This addresses the issue where compound components like `<Card.Header>` were displayed as `<CardHeader>`  
in the Show Code preview, making copied code non-functional (`ReferenceError: CardHeader is not defined`).                                                                                    
                                                                                                      
**Changes:**                                                                                              
- `jsxDecorator.tsx`: Generate both full and simplified code versions                                     
- `emitTransformCode.ts`: Pass both code versions through the event system                                
- `SourceContainer.tsx`: Store both versions in context                                                   
- `Source.tsx`: Add toggle button UI to switch between views   

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`           
2. Add a compound component (e.g., Card with Card.Header, Card.Body subcomponents)                        
3. Create a story using the compound component with args                                                  
4. Open Storybook and navigate to the Docs page                                                           
5. Click "Show code" to expand the code preview                                                           
6. Verify "Expand code" button appears in the top right of the code block                                 
7. Click the toggle and verify code switches between `<CardHeader>` and `<Card.Header>`                   
8. Verify the toggle only appears when compound components are detected                                   
                                                                        

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a toggle to switch between simplified and full code views in source code blocks.
  * Automatic generation and display of simplified code versions for components, improving code readability and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->