### PR TITLE
CSF: Fix cross-file story imports in csf-factories codemod 

### DIFF
--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
@@ -79,38 +79,20 @@ export async function storyToCsfFactory(
 
   const sbConfigImportSpecifier = t.importDefaultSpecifier(t.identifier(sbConfigImportName));
 
-  programNode.body.forEach((node) => {
-    if (t.isImportDeclaration(node) && isValidPreviewPath(node.source.value)) {
-      const defaultImportSpecifier = node.specifiers.find((specifier) =>
-        t.isImportDefaultSpecifier(specifier)
-      );
-
-      if (!defaultImportSpecifier) {
-        node.specifiers.push(sbConfigImportSpecifier);
-      } else if (defaultImportSpecifier.local.name !== sbConfigImportName) {
-        sbConfigImportName = defaultImportSpecifier.local.name;
-      }
-
-      previewImport = node;
-    }
-  });
-
-  const hasMeta = !!csf._meta;
-
   /**
    * Collect imports from other .stories files.
    *
-   * When we see:
-   *   import * as BaseStories from './Button.stories';
-   *   import { Primary } from './Card.stories';
+   * When we see: import * as BaseStories from './Button.stories'; import { Primary } from
+   * './Card.stories';
    *
-   * We store the local names ("BaseStories", "Primary") so we can later
-   * transform references like `BaseStories.Primary.args` → `BaseStories.Primary.input.args`
+   * We store the local names ("BaseStories", "Primary") so we can later transform references like
+   * `BaseStories.Primary.args` → `BaseStories.Primary.input.args`
    *
-   * Why? Because those imported stories will ALSO be transformed to CSF4,
-   * so their properties will be under `.input` instead of directly on the object.
+   * Why? Because those imported stories will ALSO be transformed to CSF4, so their properties will
+   * be under `.input` instead of directly on the object.
    *
    * We track TWO types of imports:
+   *
    * - Namespace imports (import * as X): X.Story.args → X.Story.input.args
    * - Named imports (import { Story }): Story.args → Story.input.args
    */
@@ -144,7 +126,23 @@ export async function storyToCsfFactory(
         });
       }
     }
+
+    if (t.isImportDeclaration(node) && isValidPreviewPath(node.source.value)) {
+      const defaultImportSpecifier = node.specifiers.find((specifier) =>
+        t.isImportDefaultSpecifier(specifier)
+      );
+
+      if (!defaultImportSpecifier) {
+        node.specifiers.push(sbConfigImportSpecifier);
+      } else if (defaultImportSpecifier.local.name !== sbConfigImportName) {
+        sbConfigImportName = defaultImportSpecifier.local.name;
+      }
+
+      previewImport = node;
+    }
   });
+
+  const hasMeta = !!csf._meta;
 
   // Combined set for quick lookup
   const storyFileImports = new Set([...namespaceStoryImports, ...namedStoryImports]);
@@ -237,9 +235,7 @@ export async function storyToCsfFactory(
     /**
      * Handle SAME-FILE story references.
      *
-     * Examples:
-     *   Primary.args → Primary.input.args
-     *   meta.args → meta.input.args
+     * Examples: Primary.args → Primary.input.args meta.args → meta.input.args
      */
     Identifier(nodePath) {
       const identifierName = nodePath.node.name;
@@ -301,17 +297,14 @@ export async function storyToCsfFactory(
     /**
      * Handle CROSS-FILE story references.
      *
-     * When we import stories from another file:
-     *   import * as BaseStories from './Button.stories';
+     * When we import stories from another file: import * as BaseStories from './Button.stories';
      *
-     * And use them like:
-     *   BaseStories.Primary.args
+     * And use them like: BaseStories.Primary.args
      *
-     * We need to transform to:
-     *   BaseStories.Primary.input.args
+     * We need to transform to: BaseStories.Primary.input.args
      *
-     * Why? Because the imported file will ALSO be transformed to CSF4,
-     * where story properties are accessed via `.input`.
+     * Why? Because the imported file will ALSO be transformed to CSF4, where story properties are
+     * accessed via `.input`.
      */
     MemberExpression(nodePath) {
       const node = nodePath.node;

--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
@@ -97,6 +97,58 @@ export async function storyToCsfFactory(
 
   const hasMeta = !!csf._meta;
 
+  /**
+   * Collect imports from other .stories files.
+   *
+   * When we see:
+   *   import * as BaseStories from './Button.stories';
+   *   import { Primary } from './Card.stories';
+   *
+   * We store the local names ("BaseStories", "Primary") so we can later
+   * transform references like `BaseStories.Primary.args` → `BaseStories.Primary.input.args`
+   *
+   * Why? Because those imported stories will ALSO be transformed to CSF4,
+   * so their properties will be under `.input` instead of directly on the object.
+   *
+   * We track TWO types of imports:
+   * - Namespace imports (import * as X): X.Story.args → X.Story.input.args
+   * - Named imports (import { Story }): Story.args → Story.input.args
+   */
+  const namespaceStoryImports = new Set<string>(); // import * as X
+  const namedStoryImports = new Set<string>(); // import { X } or import X
+
+  programNode.body.forEach((node) => {
+    if (t.isImportDeclaration(node)) {
+      const importPath = node.source.value;
+
+      // Check if this import is from a .stories file
+      // Matches: ./Button.stories, ../components/Card.stories.tsx, etc.
+      const isStoryFileImport = /\.stories(\.(ts|tsx|js|jsx|mjs|mts))?$/.test(importPath);
+
+      if (isStoryFileImport) {
+        // Collect all imported names from this story file
+        node.specifiers.forEach((specifier) => {
+          if (t.isImportNamespaceSpecifier(specifier)) {
+            // import * as BaseStories from './Button.stories'
+            // BaseStories.Primary is a story, so we need: BaseStories.Primary.input
+            namespaceStoryImports.add(specifier.local.name);
+          } else if (t.isImportSpecifier(specifier)) {
+            // import { Primary } from './Button.stories'
+            // Primary itself is a story, so we need: Primary.input
+            namedStoryImports.add(specifier.local.name);
+          } else if (t.isImportDefaultSpecifier(specifier)) {
+            // import ButtonStories from './Button.stories'
+            // This typically imports the meta, not stories, so we treat it like namespace
+            namespaceStoryImports.add(specifier.local.name);
+          }
+        });
+      }
+    }
+  });
+
+  // Combined set for quick lookup
+  const storyFileImports = new Set([...namespaceStoryImports, ...namedStoryImports]);
+
   // @TODO: Support unconventional formats:
   // `export function Story() { };` and `export { Story };
   // These are not part of csf._storyExports but rather csf._storyStatements and are tricky to support.
@@ -180,7 +232,15 @@ export async function storyToCsfFactory(
   // For each story, replace any reference of story reuse e.g.
   // Story.args -> Story.input.args
   // meta.args -> meta.input.args
+  // BaseStories.Primary.args -> BaseStories.Primary.input.args (cross-file)
   traverse(csf._ast, {
+    /**
+     * Handle SAME-FILE story references.
+     *
+     * Examples:
+     *   Primary.args → Primary.input.args
+     *   meta.args → meta.input.args
+     */
     Identifier(nodePath) {
       const identifierName = nodePath.node.name;
       const binding = nodePath.scope.getBinding(identifierName);
@@ -227,14 +287,147 @@ export async function storyToCsfFactory(
             t.memberExpression(t.identifier(identifierName), t.identifier('input'))
           );
         } catch (err: any) {
-          // This is a tough one to support, we just skip for now.
-          // Relates to `Stories.Story.args` where Stories is coming from another file. We can't know whether it should be transformed or not.
+          // This error occurs for cross-file references like `Stories.Story.args`
+          // which are handled by the MemberExpression visitor below.
           if (err.message.includes(`instead got "MemberExpression"`)) {
             return;
           } else {
             throw err;
           }
         }
+      }
+    },
+
+    /**
+     * Handle CROSS-FILE story references.
+     *
+     * When we import stories from another file:
+     *   import * as BaseStories from './Button.stories';
+     *
+     * And use them like:
+     *   BaseStories.Primary.args
+     *
+     * We need to transform to:
+     *   BaseStories.Primary.input.args
+     *
+     * Why? Because the imported file will ALSO be transformed to CSF4,
+     * where story properties are accessed via `.input`.
+     */
+    MemberExpression(nodePath) {
+      const node = nodePath.node;
+
+      // We're looking for patterns like: BaseStories.Primary.args
+      // Which is: MemberExpression { object: MemberExpression { object: Identifier, property }, property }
+      //
+      // We want to find the inner MemberExpression (BaseStories.Primary)
+      // and check if its object (BaseStories) is from a story file import.
+
+      // Check if this is a nested member expression (e.g., BaseStories.Primary.args)
+      // We want to transform BaseStories.Primary → BaseStories.Primary.input
+      // So we look for MemberExpression where object is also a MemberExpression
+
+      const innerObject = node.object;
+
+      // Check if the object is a MemberExpression like BaseStories.Primary
+      if (t.isMemberExpression(innerObject)) {
+        const importName = innerObject.object; // BaseStories
+        const storyName = innerObject.property; // Primary
+        const accessedProperty = node.property; // args
+
+        // Verify: importName is an Identifier that's in our storyFileImports set
+        if (
+          t.isIdentifier(importName) &&
+          storyFileImports.has(importName.name) &&
+          t.isIdentifier(storyName)
+        ) {
+          // Skip if already transformed: BaseStories.Primary.input.args
+          // This check prevents infinite loops when the traverser revisits modified nodes
+          if (t.isIdentifier(storyName, { name: 'input' })) {
+            return;
+          }
+
+          // Only process if the accessed property is an Identifier
+          if (!t.isIdentifier(accessedProperty)) {
+            return;
+          }
+
+          // Skip if the current property being accessed is 'input'
+          // This means we're looking at something like: BaseStories.Primary.input
+          // which was already transformed in a previous iteration
+          if (accessedProperty.name === 'input') {
+            return;
+          }
+
+          // Skip if accessing a property in the disallow list
+          if (reuseDisallowList.includes(accessedProperty.name)) {
+            return;
+          }
+
+          // Transform: BaseStories.Primary.args → BaseStories.Primary.input.args
+          // We do this by replacing the inner object (BaseStories.Primary)
+          // with (BaseStories.Primary.input)
+          nodePath.node.object = t.memberExpression(innerObject, t.identifier('input'));
+
+          // Skip traversing into the newly created node to prevent infinite loops
+          nodePath.skip();
+        }
+      }
+
+      // Handle NAMED IMPORTS: import { Primary } from './Button.stories'
+      // Usage: Primary.args → Primary.input.args
+      //
+      // Pattern: MemberExpression { object: Identifier("Primary"), property: Identifier("args") }
+      // Where "Primary" is in our namedStoryImports set (NOT namespace imports)
+      if (t.isIdentifier(innerObject) && namedStoryImports.has(innerObject.name)) {
+        const accessedProperty = node.property;
+
+        // Only process if the property is an Identifier
+        if (!t.isIdentifier(accessedProperty)) {
+          return;
+        }
+
+        // Skip if this is already accessing .input
+        if (accessedProperty.name === 'input') {
+          return;
+        }
+
+        // Skip if accessing a property in the disallow list
+        if (reuseDisallowList.includes(accessedProperty.name)) {
+          return;
+        }
+
+        // Transform: Primary.args → Primary.input.args
+        nodePath.replaceWith(
+          t.memberExpression(
+            t.memberExpression(innerObject, t.identifier('input')),
+            accessedProperty
+          )
+        );
+        nodePath.skip();
+        return;
+      }
+
+      // Handle NAMESPACE IMPORTS spread: import * as BaseStories from './Button.stories'
+      // Usage: ...BaseStories.Secondary → ...BaseStories.Secondary.input
+      //
+      // Pattern: SpreadElement containing MemberExpression { object: Identifier("BaseStories"), property: Identifier("Secondary") }
+      if (t.isIdentifier(innerObject) && namespaceStoryImports.has(innerObject.name)) {
+        const storyName = node.property;
+
+        // Skip if this is already .input
+        if (t.isIdentifier(storyName, { name: 'input' })) {
+          return;
+        }
+
+        // Check if parent is a SpreadElement (...BaseStories.Secondary)
+        const parent = nodePath.parent;
+        if (t.isSpreadElement(parent)) {
+          // Transform: ...BaseStories.Secondary → ...BaseStories.Secondary.input
+          nodePath.replaceWith(t.memberExpression(node, t.identifier('input')));
+          nodePath.skip();
+        }
+        // Note: For non-spread namespace access like BaseStories.Primary.args,
+        // it's handled by the nested MemberExpression case above
       }
     },
   });


### PR DESCRIPTION
Closes #33710 

## What I did

The CSF factories codemod was not correctly transforming cross-file story imports. When stories were imported from another file, and their properties were accessed or spread, the codemod failed to add `.input` to the references, resulting in broken code at runtime.                                          
                                                                                                        
### Before (broken)                                                                                       
```typescript                                                                                             
import * as BaseStories from './Button.stories';                                                          
                                                                                                        
export const MyStory = {                                                                                  
...BaseStories.Primary,           //  Should be .input 
args: BaseStories.Primary.args,   //  Should be .input.args                                           
};                                                                                                        
```  
### After (fixed)                                                                                             
```typescript                                                                                                        
import * as BaseStories from './Button.stories';                                                          
                                                                                                        
export const MyStory = meta.story({                                                                       
...BaseStories.Primary.input,           //  Correct                                                   
args: BaseStories.Primary.input.args,   // Correct                                                   
});                                                                                                       
```                                                                                                        
How it works                                                                                              
                                                                                                        
1. Track story file imports by type - Separately track namespace imports (import * as X) vs named imports (import { X }) since they require different transformations.                                              
2. Handle namespace imports (3-level pattern: Base.Story.args):                                           
   - Detect when the object is from a .stories file namespace import                                       
   - Insert .input between the story name and the accessed property                                        
3. Handle named imports (2-level pattern: Story.args):                                                    
   - Detect when the identifier is a named import from a .stories file                                     
   - Insert .input after the story name                                                                    
4. Handle spread patterns:                                                                                
   - ...BaseStories.Secondary → ...BaseStories.Secondary.input         

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a story file that imports stories from another file                                             
2. Use spread operators or property access on the imported stories                                        
3. Run npx storybook automigrate csf-factories                                                            
4. Verify the output correctly includes .input for cross-file references  

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded migration to handle story references imported from other files, converting them to the new CSF4 input-based form across modules.

* **Tests**
  * Added cross-file migration tests covering multiple import scenarios (includes duplicated coverage instances).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->