### PR TITLE
Core: Register CORS middleware before index.json route

### DIFF
--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -46,6 +46,17 @@ export async function storybookDevServer(options: Options) {
   const storyIndexGeneratorPromise =
     options.presets.apply<StoryIndexGenerator>('storyIndexGenerator');
 
+  app.use(compression({ level: 1 }));
+
+  if (typeof options.extendServer === 'function') {
+    options.extendServer(server);
+  }
+
+  // CORS middleware must be registered BEFORE route handlers to ensure all routes
+  // (including /index.json) receive proper CORS headers for Storybook Composition
+  app.use(getAccessControlMiddleware(core?.crossOriginIsolated ?? false));
+  app.use(getCachingMiddleware());
+
   registerIndexJsonRoute({
     app,
     storyIndexGeneratorPromise,
@@ -54,15 +65,6 @@ export async function storybookDevServer(options: Options) {
     workingDir,
     configDir,
   });
-
-  app.use(compression({ level: 1 }));
-
-  if (typeof options.extendServer === 'function') {
-    options.extendServer(server);
-  }
-
-  app.use(getAccessControlMiddleware(core?.crossOriginIsolated ?? false));
-  app.use(getCachingMiddleware());
 
   (await getMiddleware(options.configDir))(app);
 


### PR DESCRIPTION
## Description

Fixes #33724

The `/index.json` endpoint was missing CORS headers because the route handler was registered **before** the CORS middleware. This broke Storybook Composition when composing local Storybooks running on different ports.

## Root Cause

The middleware registration order in `dev-server.ts` was:
1. `registerIndexJsonRoute()` ❌ Route registered first
2. `app.use(compression(...))`
3. `app.use(getAccessControlMiddleware(...))` ❌ CORS middleware registered after

Since the `/index.json` route handler sends the response directly without calling `next()`, the CORS middleware never had a chance to add headers.

## Solution

Moved the middleware registration order so that CORS headers are applied to all routes:
1. `app.use(compression(...))`
2. `app.use(getAccessControlMiddleware(...))` ✅ CORS middleware first
3. `app.use(getCachingMiddleware())`
4. `registerIndexJsonRoute()` ✅ Route registered after

## Testing

- Local testing with Storybook Composition confirms CORS headers are now present on `/index.json`
- Verified `Access-Control-Allow-Origin: *` header is returned

## What this fixes

- Storybook Composition now works correctly across different ports
- No more CORS errors when fetching `/index.json` from a composed Storybook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-origin access to the index endpoint to ensure proper functionality for requests from different domains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->