### PR TITLE
Controls: Allow story argTypes to override control: false from meta

### DIFF
--- a/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { normalizeInputType, normalizeInputTypes } from './normalizeInputTypes';
 
 describe('normalizeInputType', () => {
-  it('does nothing to strict types', () => {
+  it('normalizes strict types and sets disable: false when type is present', () => {
     expect(
       normalizeInputType(
         {
@@ -18,9 +18,26 @@ describe('normalizeInputType', () => {
     ).toEqual({
       name: 'name',
       type: { name: 'string' },
-      control: { type: 'text' },
+      control: { type: 'text', disable: false },
       description: 'description',
       defaultValue: 'defaultValue',
+    });
+  });
+
+  it('preserves strict types with explicit disable', () => {
+    expect(
+      normalizeInputType(
+        {
+          name: 'name',
+          type: { name: 'string' },
+          control: { type: 'text', disable: true },
+        },
+        'arg'
+      )
+    ).toEqual({
+      name: 'name',
+      type: { name: 'string' },
+      control: { type: 'text', disable: true },
     });
   });
 
@@ -38,9 +55,37 @@ describe('normalizeInputType', () => {
     ).toEqual({
       name: 'arg',
       type: { name: 'string' },
-      control: { type: 'text' },
+      control: { type: 'text', disable: false },
       description: 'description',
       defaultValue: 'defaultValue',
+    });
+  });
+
+  it('sets disable: false when control type is specified to override inherited disable', () => {
+    expect(
+      normalizeInputType(
+        {
+          control: { type: 'select' },
+        },
+        'arg'
+      )
+    ).toEqual({
+      name: 'arg',
+      control: { type: 'select', disable: false },
+    });
+  });
+
+  it('preserves explicit disable: true in control object', () => {
+    expect(
+      normalizeInputType(
+        {
+          control: { type: 'select', disable: true },
+        },
+        'arg'
+      )
+    ).toEqual({
+      name: 'arg',
+      control: { type: 'select', disable: true },
     });
   });
 

--- a/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.ts
@@ -11,8 +11,19 @@ const normalizeType = (type: InputType['type']): StrictInputType['type'] => {
   return typeof type === 'string' ? { name: type } : type;
 };
 
-const normalizeControl = (control: InputType['control']): StrictInputType['control'] =>
-  typeof control === 'string' ? { type: control } : control;
+const normalizeControl = (control: InputType['control']): StrictInputType['control'] => {
+  if (typeof control === 'string') {
+    // When explicitly setting a control type, ensure disable is false to override
+    // any inherited disable: true from parent argTypes (fixes #27091)
+    return { type: control, disable: false };
+  }
+  // If control is an object with a type but no explicit disable, set disable: false
+  // to ensure it overrides any inherited disable: true
+  if (control && typeof control === 'object' && 'type' in control && !('disable' in control)) {
+    return { ...control, disable: false };
+  }
+  return control;
+};
 
 export const normalizeInputType = (inputType: InputType, key: string): StrictInputType => {
   const { type, control, ...rest } = inputType;


### PR DESCRIPTION
## Description

Fixes #27091

When meta defines `argTypes: { prop: { control: false } }`, story-level argTypes with `control: 'text'` or `control: { type: 'select' }` should be able to re-enable the control.

## Problem

The issue was that:
1. `control: false` was normalized to `{ disable: true }`
2. `control: 'text'` was normalized to `{ type: 'text' }`
3. When merged via `combineParameters`, both properties were kept, resulting in `{ disable: true, type: 'text' }`
4. The `disable: true` property meant the control stayed disabled

## Solution

When a control type is explicitly specified in `normalizeControl()`, the normalized control object now includes `disable: false` to override any inherited `disable: true` from parent argTypes.

## Changes

- Modified `normalizeControl()` in `normalizeInputTypes.ts` to set `disable: false` when a type is specified
- Added comprehensive tests for the new behavior

## Backward Compatibility

- `control: false` still disables controls ✅
- `control: { disable: true }` still works ✅  
- `control: { type: 'text', disable: true }` still keeps control disabled ✅
- But now `control: 'text'` properly overrides `control: false` ✅

## Example

```typescript
// meta.ts
export default {
  argTypes: {
    prop: { control: false }  // Disabled at meta level
  }
};

// Story.stories.ts - BEFORE: control stayed disabled, NOW: control works
export const WithControl = {
  argTypes: {
    prop: { control: 'text' }  // Now properly overrides to enable control
  }
};
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control normalization behavior to ensure that controls provided as strings or objects without an explicit disable flag now correctly default to being enabled with disable: false applied. This change properly overrides any inherited disabled state and ensures consistent and predictable behavior across all control specification formats used in the framework.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->