### PR TITLE
Core: Handle BROWSER=none correctly and improve error messages

### DIFF
--- a/code/core/src/core-server/utils/open-browser/open-in-browser.ts
+++ b/code/core/src/core-server/utils/open-browser/open-in-browser.ts
@@ -6,28 +6,41 @@ import { dedent } from 'ts-dedent';
 import { openBrowser } from './opener';
 
 export async function openInBrowser(address: string) {
-  let errorOccured = false;
+  let errorOccurred = false;
+  let openBrowserResult: boolean | undefined;
 
   try {
-    await openBrowser(address);
+    openBrowserResult = await openBrowser(address);
   } catch (error) {
-    errorOccured = true;
+    errorOccurred = true;
+  }
+
+  // If openBrowser returned false, it means BROWSER=none was set intentionally
+  // In this case, don't try to open a browser at all (fixes #24191)
+  if (openBrowserResult === false) {
+    return;
   }
 
   try {
-    if (errorOccured) {
+    if (errorOccurred) {
       await open(address);
-      errorOccured = false;
+      errorOccurred = false;
     }
   } catch (error) {
-    errorOccured = true;
+    errorOccurred = true;
   }
 
-  if (errorOccured) {
+  if (errorOccurred) {
+    const browserEnv = process.env.BROWSER;
+    const browserHint = browserEnv
+      ? `\n\nNote: BROWSER environment variable is set to "${browserEnv}". ` +
+        `To disable browser opening, use BROWSER=none or the --ci flag.`
+      : '';
+
     logger.error(dedent`
         Could not open ${address} inside a browser. If you're running this command inside a
         docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
-        browser by default.
+        browser by default.${browserHint}
       `);
   }
 }


### PR DESCRIPTION
## Description

Fixes #24191

When the `BROWSER` environment variable is set to `none`, Storybook should not attempt to open a browser. This fix ensures the behavior is correct and improves error messages.

## Changes

1. **Properly handle openBrowser() return value**: When `openBrowser()` returns `false` (indicating `BROWSER=none` was set intentionally), we now skip the fallback `open()` call entirely.

2. **Improved error messages**: When browser opening fails, the error message now includes the current `BROWSER` environment variable value if set, helping users diagnose issues like typos or invalid values.

## Before this fix

Even when `openBrowser()` returned `false` for `BROWSER=none`, the code might still attempt the fallback browser opening with the `open` package.

## After this fix

```bash
# This now works correctly - no browser opens, no error
BROWSER=none npx storybook dev

# Invalid values now show helpful error messages
BROWSER=invalid npx storybook dev
# Error: Could not open http://localhost:6006 inside a browser...
# Note: BROWSER environment variable is set to "invalid". 
# To disable browser opening, use BROWSER=none or the --ci flag.
```

## Testing

- Tested with `BROWSER=none` - no browser opens, no error
- Tested with invalid BROWSER values - error message includes the value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and messaging when browser fails to open.
  * Added support for `BROWSER=none` and `--ci` environment flags to prevent automatic browser opening.
  * Enhanced error messages with helpful guidance on controlling browser behavior.
  * Refined browser opening logic for more reliable execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->