### PR TITLE
Toolbar: Remove extra toolbar divider when zoom controls not shown

### DIFF
--- a/code/core/src/manager/components/preview/tools/menu.tsx
+++ b/code/core/src/manager/components/preview/tools/menu.tsx
@@ -11,6 +11,7 @@ import type { Combo } from 'storybook/manager-api';
 const menuMapper = ({ api, state }: Combo) => ({
   isVisible: api.getIsNavShown(),
   singleStory: state.singleStory,
+  viewMode: state.viewMode,
   toggle: () => api.toggleNav(),
 });
 
@@ -22,7 +23,7 @@ export const menuTool: Addon_BaseType = {
   match: ({ viewMode }) => ['story', 'docs'].includes(viewMode),
   render: () => (
     <Consumer filter={menuMapper}>
-      {({ isVisible, toggle, singleStory }) =>
+      {({ isVisible, toggle, singleStory, viewMode }) =>
         !singleStory &&
         !isVisible && (
           <>
@@ -35,7 +36,9 @@ export const menuTool: Addon_BaseType = {
             >
               <MenuIcon />
             </Button>
-            <Separator />
+            {/* Only show separator in story mode where other tools (like remount) are visible.
+                In docs mode, most left-side tools are filtered out, leaving an orphaned separator (fixes #21429) */}
+            {viewMode === 'story' && <Separator />}
           </>
         )
       }

--- a/code/core/src/manager/components/preview/tools/menu.tsx
+++ b/code/core/src/manager/components/preview/tools/menu.tsx
@@ -36,8 +36,6 @@ export const menuTool: Addon_BaseType = {
             >
               <MenuIcon />
             </Button>
-            {/* Only show separator in story mode where other tools (like remount) are visible.
-                In docs mode, most left-side tools are filtered out, leaving an orphaned separator (fixes #21429) */}
             {viewMode === 'story' && <Separator />}
           </>
         )


### PR DESCRIPTION
## Description

Fixes #21429

In docs mode, an extra divider/separator was appearing in the toolbar even though no tools followed it.

## Problem

The `menuTool` component renders a `<Separator />` after the menu button. This separator is intended to visually separate the menu button from subsequent tools (like `remountTool`). 

However, in docs mode:
- `remountTool` has `match: ({ viewMode }) => viewMode === 'story'` 
- So it gets filtered out in docs mode
- But the `menuTool` still renders its separator
- Result: orphaned separator with nothing to separate

## Solution

Made the `<Separator />` conditional on `viewMode === 'story'`, since that's when the other left-side tools are actually visible.

## Before/After

**Before (docs mode):**
```
[Menu Button] | (empty space - other tools filtered out)
              ^
              orphaned separator
```

**After (docs mode):**
```
[Menu Button] (clean, no orphaned separator)
```

**Story mode (unchanged):**
```
[Menu Button] | [Remount Button] ...
              ^
              separator still appears correctly
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional rendering of menu separators to display correctly based on the current view mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->