### PR TITLE
Builder-Vite: Add plugin to enforce Storybook's output directory in Vite build configuration

### DIFF
--- a/code/builders/builder-vite/src/build.ts
+++ b/code/builders/builder-vite/src/build.ts
@@ -41,13 +41,22 @@ export async function build(options: Options) {
   const finalConfig = (await presets.apply('viteFinal', config, options)) as InlineConfig;
 
   // Add a plugin to enforce Storybook's outDir after all other plugins.
-  // This prevents frameworks like TanStack Start/Nitro from redirecting
+  // This prevents frameworks like Nitro from redirecting
   // build output to their own directories (e.g., .output/public/).
   // The 'enforce: post' ensures this runs after all other config hooks.
   finalConfig.plugins?.push({
     name: 'storybook:enforce-output-dir',
     enforce: 'post',
-    config: () => ({
+    config: (config) => ({
+      ...config,
+      build: {
+        outDir: options.outputDir,
+      },
+    }),
+    // configEnvironment is a new method in Vite 6
+    // It is used to configure configs based on the environment
+    // E.g. Nitro uses this method to set the output directory to .output/public/
+    configEnvironment: () => ({
       build: {
         outDir: options.outputDir,
       },

--- a/code/builders/builder-vite/src/build.ts
+++ b/code/builders/builder-vite/src/build.ts
@@ -40,6 +40,20 @@ export async function build(options: Options) {
 
   const finalConfig = (await presets.apply('viteFinal', config, options)) as InlineConfig;
 
+  // Add a plugin to enforce Storybook's outDir after all other plugins.
+  // This prevents frameworks like TanStack Start/Nitro from redirecting
+  // build output to their own directories (e.g., .output/public/).
+  // The 'enforce: post' ensures this runs after all other config hooks.
+  finalConfig.plugins?.push({
+    name: 'storybook:enforce-output-dir',
+    enforce: 'post',
+    config: () => ({
+      build: {
+        outDir: options.outputDir,
+      },
+    }),
+  });
+
   if (options.features?.developmentModeForBuild) {
     finalConfig.plugins?.push({
       name: 'storybook:define-env',


### PR DESCRIPTION
Closes #33738

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixes an issue where Storybook build artifacts are incorrectly redirected to Nitro's output directory (.output/public/) instead of the expected Storybook output directory (storybook-static) when using TanStack Start projects.

- Adds a Vite plugin with enforce: 'post' to ensure Storybook's outDir takes precedence over framework plugins
- Prevents frameworks like Nitro from hijacking the build output location


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

[ ] Create a new TanStack Start project
[ ] Add Storybook using npx storybook@latest init
[ ] Run npx storybook build
[ ] Verify that storybook-static contains the sb-preview folder
[ ] Verify that .output/public/ does NOT contain Storybook's preview assets
[ ] Run Chromatic CLI to verify the build is valid

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the storybook build enforces the configured output directory so build artifacts are placed consistently and reliably across different build modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->