### PR TITLE
A11y: Fix keyboard accessibility for MDX heading anchors

### DIFF
--- a/code/addons/docs/src/_test_/Heading.test.tsx
+++ b/code/addons/docs/src/_test_/Heading.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Heading } from '../Heading';
+
+describe('Heading component', () => {
+  it('renders an accessible anchor for keyboard navigation', () => {
+    render(<Heading>My Heading</Heading>);
+    
+    const anchor = screen.getByRole('link', { name: /link to heading my heading/i });
+    
+    expect(anchor).toHaveAttribute('tabindex', '0');
+    expect(anchor).toHaveAttribute('aria-label', 'Link to heading My Heading');
+  });
+});

--- a/code/addons/docs/src/blocks/blocks/Heading.tsx
+++ b/code/addons/docs/src/blocks/blocks/Heading.tsx
@@ -21,9 +21,21 @@ export const Heading: FC<PropsWithChildren<HeadingProps>> = ({
   if (disableAnchor || typeof children !== 'string') {
     return <H2>{children}</H2>;
   }
+
   const tagID = slugs.slug(children.toLowerCase());
+
   return (
-    <HeaderMdx as="h2" id={tagID} {...props}>
+    <HeaderMdx as="h2" id={tagID} {...props} style={{ display: 'flex', alignItems: 'center' }}>
+      {/* Accessible anchor link */}
+      <a
+        href={`#${tagID}`}
+        className="anchor"
+        tabIndex={0}
+        aria-label={`Link to heading ${children}`}
+        style={{ marginRight: '0.5rem', textDecoration: 'none' }}
+      >
+        <span aria-hidden="true">#</span>
+      </a>
       {children}
     </HeaderMdx>
   );


### PR DESCRIPTION
## What

Fixes keyboard accessibility for anchor links generated in MDX headings.

## Why

Heading anchor links were not keyboard focusable, violating WCAG 2.1 keyboard accessibility guidelines.

## How

- Added keyboard focus support using `tabIndex`
- Added accessible labels for screen readers
- Marked decorative elements as `aria-hidden`

## Checklist

- [x] No breaking changes
- [x] No business logic affected
- [x] Accessibility improvement only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Heading components now include accessible anchor links with improved keyboard navigation support, enabling direct navigation to and linking of specific headings on the page.

* **Tests**
  * Added unit tests verifying keyboard accessibility and navigation functionality for heading anchor links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->