### PR TITLE
Addon-Vitest: Support vite/vitest config with deferred export

### DIFF
--- a/code/addons/vitest/src/updateVitestFile.test.ts
+++ b/code/addons/vitest/src/updateVitestFile.test.ts
@@ -301,13 +301,8 @@ describe('updateConfigFile', () => {
     );
     const target = babel.babelParse(`
       import { defineConfig } from 'vite'
-      import { devtools } from '@tanstack/devtools-vite'
-      import { tanstackStart } from '@tanstack/react-start/plugin/vite'
       import viteReact from '@vitejs/plugin-react'
-      import viteTsConfigPaths from 'vite-tsconfig-paths'
       import { fileURLToPath, URL } from 'url'
-
-      import tailwindcss from '@tailwindcss/vite'
 
       const config = defineConfig({
         resolve: {
@@ -331,55 +326,54 @@ describe('updateConfigFile', () => {
     const after = babel.generate(target).code;
 
     expect(getDiff(before, after)).toMatchInlineSnapshot(`
-      "  ...
-        import viteTsConfigPaths from 'vite-tsconfig-paths';
-        import { fileURLToPath, URL } from 'url';
-        import tailwindcss from '@tailwindcss/vite';
-        
-      + import path from 'node:path';
-      + import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
-      + const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
-      + 
-      + // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
-      + 
-        const config = defineConfig({
-          resolve: {
-            preserveSymlinks: true,
-            alias: {
-              '@': fileURLToPath(new URL('./src', import.meta.url))
-            }
-          },
-        
-      -   plugins: [viteReact()]
-      - 
-      +   plugins: [viteReact()],
-      +   test: {
-      +     projects: [{
-      +       extends: true,
-      +       plugins: [
-      +       // The plugin will run tests for the stories defined in your Storybook config
-      +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-      +       storybookTest({
-      +         configDir: path.join(dirname, '.storybook')
-      +       })],
-      +       test: {
-      +         name: 'storybook',
-      +         browser: {
-      +           enabled: true,
-      +           headless: true,
-      +           provider: 'playwright',
-      +           instances: [{
-      +             browser: 'chromium'
-      +           }]
-      +         },
-      +         setupFiles: ['../.storybook/vitest.setup.ts']
-      +       }
-      +     }]
-      +   }
-      + 
-        });
-        export default config;"
-    `);
+  "  import { defineConfig } from 'vite';
+    import viteReact from '@vitejs/plugin-react';
+    import { fileURLToPath, URL } from 'url';
+    
+  + import path from 'node:path';
+  + import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+  + const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+  + 
+  + // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
+  + 
+    const config = defineConfig({
+      resolve: {
+        preserveSymlinks: true,
+        alias: {
+          '@': fileURLToPath(new URL('./src', import.meta.url))
+        }
+      },
+    
+  -   plugins: [viteReact()]
+  - 
+  +   plugins: [viteReact()],
+  +   test: {
+  +     projects: [{
+  +       extends: true,
+  +       plugins: [
+  +       // The plugin will run tests for the stories defined in your Storybook config
+  +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
+  +       storybookTest({
+  +         configDir: path.join(dirname, '.storybook')
+  +       })],
+  +       test: {
+  +         name: 'storybook',
+  +         browser: {
+  +           enabled: true,
+  +           headless: true,
+  +           provider: 'playwright',
+  +           instances: [{
+  +             browser: 'chromium'
+  +           }]
+  +         },
+  +         setupFiles: ['../.storybook/vitest.setup.ts']
+  +       }
+  +     }]
+  +   }
+  + 
+    });
+    export default config;"
+`);
   });
 
   it('edits projects property of test config', async () => {

--- a/code/addons/vitest/src/updateVitestFile.ts
+++ b/code/addons/vitest/src/updateVitestFile.ts
@@ -55,6 +55,60 @@ const mergeProperties = (
 };
 
 /**
+ * Resolves the target's default export to the actual config object expression we can merge into.
+ * Handles: export default defineConfig({}), export default {}, and export default config (where
+ * config is a variable holding defineConfig({}) or {}).
+ */
+const getTargetConfigObject = (
+  target: BabelFile['ast'],
+  exportDefault: t.ExportDefaultDeclaration
+): t.ObjectExpression | null => {
+  const decl = exportDefault.declaration;
+  if (decl.type === 'ObjectExpression') {
+    return decl;
+  }
+  if (
+    decl.type === 'CallExpression' &&
+    decl.callee.type === 'Identifier' &&
+    decl.callee.name === 'defineConfig' &&
+    decl.arguments[0]?.type === 'ObjectExpression'
+  ) {
+    return decl.arguments[0] as t.ObjectExpression;
+  }
+  if (decl.type === 'Identifier') {
+    const varName = decl.name;
+    const varDecl = target.program.body.find(
+      (n): n is t.VariableDeclaration =>
+        n.type === 'VariableDeclaration' &&
+        n.declarations.some((d) => d.id.type === 'Identifier' && d.id.name === varName)
+    );
+    if (!varDecl) {
+      return null;
+    }
+    const declarator = varDecl.declarations.find(
+      (d) => d.id.type === 'Identifier' && d.id.name === varName
+    );
+    if (!declarator?.init) {
+      return null;
+    }
+    const init = declarator.init;
+    if (
+      init.type === 'CallExpression' &&
+      init.callee.type === 'Identifier' &&
+      init.callee.name === 'defineConfig' &&
+      init.arguments[0]?.type === 'ObjectExpression'
+    ) {
+      return init.arguments[0] as t.ObjectExpression;
+    }
+    if (init.type === 'ObjectExpression') {
+      return init;
+    }
+    return null;
+  }
+  return null;
+};
+
+/**
  * Merges a source Vitest configuration AST into a target configuration AST.
  *
  * This function intelligently combines configuration elements from a source file (typically a
@@ -98,27 +152,42 @@ export const updateConfigFile = (source: BabelFile['ast'], target: BabelFile['as
   }
 
   // Check if this is a function notation that we don't support
+  const rejectFunctionNotation = (decl: t.ExportDefaultDeclaration['declaration']) => {
+    if (
+      decl.type === 'CallExpression' &&
+      decl.callee.type === 'Identifier' &&
+      decl.callee.name === 'defineConfig' &&
+      decl.arguments.length > 0 &&
+      decl.arguments[0].type === 'ArrowFunctionExpression'
+    ) {
+      return true;
+    }
+    return false;
+  };
   if (
     targetExportDefault.declaration.type === 'CallExpression' &&
-    targetExportDefault.declaration.callee.type === 'Identifier' &&
-    targetExportDefault.declaration.callee.name === 'defineConfig' &&
-    targetExportDefault.declaration.arguments.length > 0 &&
-    targetExportDefault.declaration.arguments[0].type === 'ArrowFunctionExpression'
+    rejectFunctionNotation(targetExportDefault.declaration)
   ) {
-    // This is function notation that we don't support
     return false;
   }
+  if (targetExportDefault.declaration.type === 'Identifier') {
+    const varName = targetExportDefault.declaration.name;
+    const varDecl = target.program.body.find(
+      (n): n is t.VariableDeclaration =>
+        n.type === 'VariableDeclaration' &&
+        n.declarations.some((d) => d.id.type === 'Identifier' && d.id.name === varName)
+    );
+    const declarator = varDecl?.declarations.find(
+      (d) => d.id.type === 'Identifier' && d.id.name === varName
+    );
+    if (declarator?.init?.type === 'CallExpression' && rejectFunctionNotation(declarator.init)) {
+      return false;
+    }
+  }
 
-  // Check if we can handle mergeConfig patterns
+  // Check if we can handle mergeConfig patterns (including export default config where config = defineConfig({}))
   let canHandleConfig = false;
-  if (targetExportDefault.declaration.type === 'ObjectExpression') {
-    canHandleConfig = true;
-  } else if (
-    targetExportDefault.declaration.type === 'CallExpression' &&
-    targetExportDefault.declaration.callee.type === 'Identifier' &&
-    targetExportDefault.declaration.callee.name === 'defineConfig' &&
-    targetExportDefault.declaration.arguments[0]?.type === 'ObjectExpression'
-  ) {
+  if (getTargetConfigObject(target, targetExportDefault) !== null) {
     canHandleConfig = true;
   } else if (
     targetExportDefault.declaration.type === 'CallExpression' &&
@@ -173,16 +242,9 @@ export const updateConfigFile = (source: BabelFile['ast'], target: BabelFile['as
         sourceNode.declaration.arguments[0].type === 'ObjectExpression'
       ) {
         const { properties } = sourceNode.declaration.arguments[0];
-        if (exportDefault.declaration.type === 'ObjectExpression') {
-          mergeProperties(properties, exportDefault.declaration.properties);
-          updated = true;
-        } else if (
-          exportDefault.declaration.type === 'CallExpression' &&
-          exportDefault.declaration.callee.type === 'Identifier' &&
-          exportDefault.declaration.callee.name === 'defineConfig' &&
-          exportDefault.declaration.arguments[0]?.type === 'ObjectExpression'
-        ) {
-          mergeProperties(properties, exportDefault.declaration.arguments[0].properties);
+        const targetConfigObject = getTargetConfigObject(target, exportDefault);
+        if (targetConfigObject !== null) {
+          mergeProperties(properties, targetConfigObject.properties);
           updated = true;
         } else if (
           exportDefault.declaration.type === 'CallExpression' &&


### PR DESCRIPTION
Closes #33753

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Vitest addon’s config updater (`updateVitestFile`) previously only supported config files that export the config **inline**, e.g. `export default defineConfig({ ... })`. It did not support the pattern where the config is assigned to a variable and exported on a separate line:

```ts
const config = defineConfig({
  resolve: { ... },
  plugins: [viteReact()],
})
export default config
```

This pattern is common in setups like **TanStack Start** and other projects that build the config in multiple steps. For those, the addon’s postinstall never merged in the Vitest/Storybook test configuration.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create or use a project whose Vite/Vitest config uses the variable + `export default config` pattern (e.g. a TanStack Start app, or a minimal `vite.config.ts` with `const config = defineConfig({...}); export default config`).
2. Add the Vitest addon (e.g. via Storybook init or manually) so that the postinstall/update step runs on the config file.
3. Confirm the config file is updated: new imports (e.g. `path`, `storybookTest`), the `dirname` helper if needed, and the `test` block (with `projects` and the Storybook test config) are merged into the same object that is exported (the one assigned to `config`).
4. Run Vitest/Storybook tests to ensure the addon works with the updated config.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Vitest configuration update support to handle configurations exported via `defineConfig` patterns and indirect variable references.
  * Improved merging logic for complex test and workspace configurations.
  * Better compatibility with diverse Vitest configuration export styles.

* **Tests**
  * Added test coverage for configuration updates with `defineConfig` patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->