### PR TITLE
Docs: Add guide for excluding Storybook from TypeScript declaration builds

### DIFF
--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -546,4 +546,10 @@ Yes, the [doc blocks](../../writing-docs/doc-blocks.mdx) used to reference stori
 
 For more information on this experimental format's original proposal, refer to its [RFC on GitHub](https://github.com/storybookjs/storybook/discussions/30112). We welcome your comments!
 
+### Why do I get TypeScript errors when generating declaration files?
+
+CSF factories (`preview.meta()`, `meta.story()`) use complex type inference that can cause `TS2742` errors when generating `.d.ts` files. This is expected—story files don't need declaration files since they're development-time assets, not part of your package's public API.
+
+The solution is to exclude stories from your declaration build using a separate `tsconfig.build.json`. See [Generating TypeScript declaration files](../../configure/integration/typescript.mdx#generating-typescript-declaration-files) for detailed instructions.
+
 </If>

--- a/docs/configure/integration/typescript.mdx
+++ b/docs/configure/integration/typescript.mdx
@@ -87,6 +87,74 @@ Now, when you define a story or update an existing one, you'll automatically get
 
 {/* prettier-ignore-end */}
 
+## Generating TypeScript declaration files
+
+If you're building a library and want to generate TypeScript declaration files (`.d.ts`), you should exclude your story files from the declaration build. Story files are development-time assets—they help document and test components, but consumers of your package don't need their type definitions.
+
+This is especially important when using [CSF factories](../../api/csf/csf-next.mdx) (`preview.meta()`, `meta.story()`) or TypeScript's [`isolatedDeclarations`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#isolated-declarations) option. These patterns use complex type inference that can cause errors like:
+
+```
+TS2742: The inferred type of 'meta' cannot be named without a reference to
+'@storybook/react/node_modules/@storybook/types'. This is likely not portable.
+```
+
+### Solution: Separate tsconfig for builds
+
+Create a `tsconfig.build.json` that extends your base config but excludes stories:
+
+```json
+// tsconfig.build.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true
+  },
+  "exclude": ["**/*.stories.*", "**/*.story.*", ".storybook/**"]
+}
+```
+
+Then update your build script to use this config:
+
+```bash
+tsc -p tsconfig.build.json
+```
+
+Your IDE and type checking continue to work normally—only the declaration output excludes stories.
+
+### Alternative: Project references
+
+Using [TypeScript project references](https://www.typescriptlang.org/docs/handbook/project-references.html) separates your app code from Storybook files. This approach has an advantage: your IDE will show type errors from all configs, not just the base one. The downside is that project references are more complex to set up and maintain.
+
+```json
+// tsconfig.json
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.storybook.json" }
+  ]
+}
+
+// tsconfig.app.json - your app code, generates declarations
+{
+  "compilerOptions": {
+    "declaration": true
+    // ...other options
+  },
+  "include": ["src"],
+  "exclude": ["**/*.stories.*", "**/*.story.*"]
+}
+
+// tsconfig.storybook.json - stories and Storybook config
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "declaration": false
+  },
+  "include": ["src/**/*.stories.*", ".storybook/**"]
+}
+```
+
 ## Troubleshooting
 
 ### The `satisfies` operator is not working as expected


### PR DESCRIPTION
Closes #33770

## What I did

Add documentation explaining how to exclude story files when generating `.d.ts` declaration files. This is relevant for library authors who want to publish TypeScript declarations without including stories.

## Changes

**`docs/configure/integration/typescript.mdx`**
- Add new section "Generating TypeScript declaration files" with two solutions:
  - Simple `tsconfig.build.json` approach
  - Project references approach for better IDE support

**`docs/api/csf/csf-next.mdx`**
- Add FAQ entry "Why do I get TypeScript errors when generating declaration files?" linking to the TypeScript guide

## How to test

Preview the docs and verify:
1. The new section appears before "Troubleshooting" in the TypeScript guide
2. The FAQ entry appears in the CSF Next page
3. The link from CSF Next FAQ to the TypeScript guide works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ addressing TypeScript errors when generating declaration files with CSF Next factories.
  * Added comprehensive guidance on excluding story files from declaration builds using two recommended approaches.
  * Included configuration examples and best practices for TypeScript setup integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->