### PR TITLE
Docs: Add guide for excluding Storybook from TypeScript declaration builds

### DIFF
--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -546,4 +546,12 @@ Yes, the [doc blocks](../../writing-docs/doc-blocks.mdx) used to reference stori
 
 For more information on this experimental format's original proposal, refer to its [RFC on GitHub](https://github.com/storybookjs/storybook/discussions/30112). We welcome your comments!
 
+### Why do I get TypeScript errors when generating declaration files?
+
+Storybook's types sometimes reference internal modules, which can cause errors like `TS2742` or `TS4023` when generating `.d.ts` files.
+
+Additionally, if you use TypeScript's `isolatedDeclarations` option, it requires explicit type annotations for all exports. Since CSF factories are designed around type inference, explicit annotations aren't feasible.
+
+We recommend excluding stories from your declaration build. Stories are development-time assets—consumers of your package don't need their type definitions. Your IDE and type checking continue to work normally. See [Generating TypeScript declaration files](../../configure/integration/typescript.mdx#generating-typescript-declaration-files) for instructions.
+
 </If>

--- a/docs/configure/integration/typescript.mdx
+++ b/docs/configure/integration/typescript.mdx
@@ -87,6 +87,98 @@ Now, when you define a story or update an existing one, you'll automatically get
 
 {/* prettier-ignore-end */}
 
+## Generating TypeScript declaration files
+
+If you're building a library and have `"declaration": true` in your tsconfig, you may encounter errors like these when your stories are included in the build:
+
+```
+TS2742: The inferred type of 'Foo' cannot be named without a reference to
+'some-lib/node_modules/some-internal-module'. This is likely not portable.
+A type annotation is necessary.
+
+TS4023: Exported variable 'Foo' has or is using name 'Bar' from external module
+"some-lib/internal" but cannot be named.
+```
+
+This happens because Storybook's types sometimes reference internal modules that TypeScript cannot include in portable declaration files. We've fixed many of these issues over the years by re-exporting internal types, but new ones keep appearing as the API evolves—and we don't want to expose all our internal types.
+
+With CSF3, this can sometimes be worked around by explicitly importing the missing types. However, we recommend typing meta with `satisfies Meta<...>` for better type safety, and `satisfies` doesn't provide an explicit type annotation. With [CSF factories](../../api/csf/csf-next.mdx), explicit type annotations aren't feasible since the API is designed around type inference. If you use the [`isolatedDeclarations`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#isolated-declarations) option, the problem becomes unavoidable since it requires explicit annotations for all exports—which neither `satisfies` nor CSF factories provide.
+
+### Solution
+
+We recommend excluding story files from your declaration build. Stories are development-time assets—consumers of your package interact with your components, not your stories, so they don't need story type definitions. Your IDE and type checking continue to work normally.
+
+There are two ways to achieve this:
+
+### Option 1: Separate build config
+
+The simpler approach is to set `declaration: false` in your base config and create a separate `tsconfig.build.json` for generating declarations:
+
+```diff
+// tsconfig.json
+{
+  "compilerOptions": {
++   "declaration": false
+  }
+}
+```
+
+```json
+// tsconfig.build.json (new file)
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true
+  },
+  "exclude": ["**/*.stories.*", "**/*.story.*", ".storybook/**"]
+}
+```
+
+Then update your build script to use the build config:
+
+```bash
+tsc -p tsconfig.build.json
+```
+
+### Option 2: Project references
+
+Using [TypeScript project references](https://www.typescriptlang.org/docs/handbook/project-references.html) separates your app code from Storybook files. This is the approach used by `create-vite` and other modern tooling. The advantage over Option 1 is that your IDE will also show declaration build errors. The downside is that project references are more complex to set up.
+
+```json
+// tsconfig.json
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.storybook.json" }
+  ]
+}
+
+// tsconfig.build.json - your app code, generates declarations
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true
+    // ...other options
+  },
+  "include": ["src"],
+  "exclude": ["**/*.stories.*", "**/*.story.*"]
+}
+
+// tsconfig.storybook.json - stories and Storybook config
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": false
+  },
+  "include": ["src/**/*.stories.*", ".storybook/**"],
+  "references": [
+    { "path": "./tsconfig.build.json" }
+  ]
+}
+```
+
 ## Troubleshooting
 
 ### The `satisfies` operator is not working as expected


### PR DESCRIPTION
Closes #33770

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Add documentation explaining how to exclude story files when generating `.d.ts` declaration files. This is relevant for library authors who want to publish TypeScript declarations without including stories.

There are two separate issues addressed:
1. **Internal types leaking** - Storybook's types can reference internal modules, causing TS2742/TS4023 errors
2. **`isolatedDeclarations` incompatibility** - CSF factories (and `satisfies` in CSF3) don't provide explicit type annotations

**Changes:**
- Add new section "Generating TypeScript declaration files" to TypeScript configuration guide
  - Explains both issues (internal types + isolatedDeclarations)
  - Distinguishes between CSF3 and CSF factories
  - Two solutions: separate build config OR project references
- Add FAQ entry to CSF Next docs linking to the guide

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

This is a documentation-only change. To test:
1. Preview the docs locally
2. Verify the new section appears before "Troubleshooting" in `/docs/configure/integration/typescript.mdx`
3. Verify the FAQ entry appears in `/docs/api/csf/csf-next.mdx`
4. Verify the link from CSF Next FAQ to the TypeScript guide works correctly

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->