### PR TITLE
Logger: Honor --loglevel for npmlog output

### DIFF
--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -2,7 +2,7 @@ import { getEnvConfig, optionalEnvToBoolean, parseList } from 'storybook/interna
 import { logTracker, logger } from 'storybook/internal/node-logger';
 import { addToGlobalContext } from 'storybook/internal/telemetry';
 
-import { program } from 'commander';
+import { Option, program } from 'commander';
 import leven from 'leven';
 import picocolors from 'picocolors';
 
@@ -45,7 +45,11 @@ const command = (name: string) =>
     )
     .option('--debug', 'Get more logs in debug mode', false)
     .option('--enable-crash-reports', 'Enable sending crash reports to telemetry data')
-    .option('--loglevel <trace | debug | info | warn | error | silent>', 'Define log level', 'info')
+    .addOption(
+      new Option('--loglevel <level>', 'Define log level')
+        .choices(['trace', 'debug', 'info', 'warn', 'error', 'silent'])
+        .default('info')
+    )
     .option(
       '--logfile [path]',
       'Write all debug logs to the specified file at the end of the run. Defaults to debug-storybook.log when [path] is not provided'
@@ -53,9 +57,8 @@ const command = (name: string) =>
     .hook('preAction', async (self) => {
       try {
         const options = self.opts();
-        if (options.loglevel) {
-          logger.setLogLevel(options.loglevel);
-        }
+        const loglevel = options.debug ? 'debug' : options.loglevel;
+        logger.setLogLevel(loglevel);
 
         if (options.logfile) {
           logTracker.enableLogWriting();

--- a/code/core/src/node-logger/index.test.ts
+++ b/code/core/src/node-logger/index.test.ts
@@ -48,6 +48,23 @@ describe('node-logger', () => {
     logger.warn(message);
     expect(loggerMock.warn).toHaveBeenCalledWith(message);
   });
+
+  it('should sync --loglevel with npmlog', () => {
+    logger.setLogLevel('debug');
+    expect(npmlog.level).toBe('verbose');
+    expect(loggerMock.setLogLevel).toHaveBeenCalledWith('debug');
+
+    logger.setLogLevel('trace');
+    expect(npmlog.level).toBe('silly');
+    expect(loggerMock.setLogLevel).toHaveBeenCalledWith('trace');
+  });
+
+  it('should keep setLevel and setLogLevel consistent', () => {
+    logger.setLevel('warn');
+    expect(npmlog.level).toBe('warn');
+    expect(loggerMock.setLogLevel).toHaveBeenCalledWith('warn');
+  });
+
   it('should have an error method', () => {
     const message = 'error message';
     logger.error(message);

--- a/code/core/src/node-logger/index.ts
+++ b/code/core/src/node-logger/index.ts
@@ -17,6 +17,22 @@ export type { LogLevel } from './logger/logger';
 // there are issues with the build: https://github.com/storybookjs/storybook/issues/14621
 npmLog.stream = process.stdout;
 
+const toNpmLogLevel = (level: newLogger.LogLevel): string => {
+  switch (level) {
+    case 'trace':
+      return 'silly';
+    case 'debug':
+      return 'verbose';
+    default:
+      return level;
+  }
+};
+
+const setLoggerLevel = (level: newLogger.LogLevel = 'info'): void => {
+  npmLog.level = toNpmLogLevel(level);
+  newLogger.setLogLevel(level);
+};
+
 function hex(hexColor: string) {
   // Ensure the hex color is 6 characters long and starts with '#'
   if (!/^#?[0-9A-Fa-f]{6}$/.test(hexColor)) {
@@ -57,10 +73,8 @@ export const logger = {
   warn: (message: string): void => newLogger.warn(message),
   trace: ({ message, time }: { message: string; time: [number, number] }): void =>
     newLogger.debug(`${message} (${colors.purple(prettyTime(time))})`),
-  setLevel: (level: newLogger.LogLevel = 'info'): void => {
-    npmLog.level = level;
-    newLogger.setLogLevel(level);
-  },
+  setLevel: setLoggerLevel,
+  setLogLevel: setLoggerLevel,
   error: (message: unknown): void => {
     let msg: string;
     if (message instanceof Error && message.stack) {


### PR DESCRIPTION
Fixes #22061.

- Ensure `logger.setLogLevel` updates both the new logger and the legacy `npmlog` instance (with sensible level mapping: trace->silly, debug->verbose).
- Make `--debug` actually take effect (forces loglevel=debug).
- Validate `--loglevel` values via commander choices.

Tests:
- yarn --cwd code vitest run --config core/vitest.config.ts core/src/node-logger/index.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log level option handling for more reliable CLI configuration.
  * Enhanced consistency in log level synchronization across logging systems.

* **Tests**
  * Added test coverage for log level synchronization and configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->