### PR TITLE
Test: Update event creation logic in user-event package

### DIFF
--- a/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch
+++ b/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch
@@ -1,3 +1,25 @@
+diff --git a/dist/cjs/event/createEvent.js b/dist/cjs/event/createEvent.js
+index b63c0093f492f5072ce2eabb74ca290144353548..5e68db5bb9f62aa43f1c849b185912b0b34021c8 100644
+--- a/dist/cjs/event/createEvent.js
++++ b/dist/cjs/event/createEvent.js
+@@ -38,7 +38,16 @@ function createEvent(type, target, init) {
+     const window = getWindow.getWindow(target);
+     const { EventType, defaultInit } = eventMap.eventMap[type];
+     const event = new (getEventConstructors(window))[EventType](type, defaultInit);
+-    eventInitializer[EventType].forEach((f)=>f(event, init !== null && init !== undefined ? init : {}));
++    var eventInit = {};
++    for (var key in init) {
++        if (Object.prototype.hasOwnProperty.call(init, key)) {
++            eventInit[key] = init[key];
++        }
++    }
++    eventInit.view = window;
++    eventInitializer[EventType].forEach(function(f) {
++        f(event, eventInit);
++    });
+     return event;
+ }
+ /* istanbul ignore next */ function getEventConstructors(window) {
 diff --git a/dist/cjs/utils/dataTransfer/Clipboard.js b/dist/cjs/utils/dataTransfer/Clipboard.js
 index 434be791b156984a8b76287bc0cc6c8955df4203..e28a15e85e2dccff058a18b4b80b099b7016d688 100644
 --- a/dist/cjs/utils/dataTransfer/Clipboard.js
@@ -23,6 +45,28 @@ index 434be791b156984a8b76287bc0cc6c8955df4203..e28a15e85e2dccff058a18b4b80b099b
  }
  
  exports.attachClipboardStubToView = attachClipboardStubToView;
+diff --git a/dist/esm/event/createEvent.js b/dist/esm/event/createEvent.js
+index 1c741ba446f40917727236e9e4ad29a20357d03a..9a4b63935923a9a271bfc9fd161fe7c477303256 100644
+--- a/dist/esm/event/createEvent.js
++++ b/dist/esm/event/createEvent.js
+@@ -36,7 +36,16 @@ function createEvent(type, target, init) {
+     const window = getWindow(target);
+     const { EventType, defaultInit } = eventMap[type];
+     const event = new (getEventConstructors(window))[EventType](type, defaultInit);
+-    eventInitializer[EventType].forEach((f)=>f(event, init !== null && init !== undefined ? init : {}));
++    var eventInit = {};
++    for (var key in init) {
++        if (Object.prototype.hasOwnProperty.call(init, key)) {
++            eventInit[key] = init[key];
++        }
++    }
++    eventInit.view = window;
++    eventInitializer[EventType].forEach(function(f) {
++        f(event, eventInit);
++    });
+     return event;
+ }
+ /* istanbul ignore next */ function getEventConstructors(window) {
 diff --git a/dist/esm/utils/dataTransfer/Clipboard.js b/dist/esm/utils/dataTransfer/Clipboard.js
 index 2ed2676b52adaee045d2594b051c08a4b133e7df..337e644ed268ad4ad0ce9a601d6d0aec73264d5e 100644
 --- a/dist/esm/utils/dataTransfer/Clipboard.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -8951,10 +8951,10 @@ __metadata:
 
 "@testing-library/user-event@patch:@testing-library/user-event@npm%3A14.6.1#~/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch":
   version: 14.6.1
-  resolution: "@testing-library/user-event@patch:@testing-library/user-event@npm%3A14.6.1#~/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch::version=14.6.1&hash=228211"
+  resolution: "@testing-library/user-event@patch:@testing-library/user-event@npm%3A14.6.1#~/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch::version=14.6.1&hash=4faa83"
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
-  checksum: 10c0/837761d0a6f87268e0e4c69c1afaf14ddadea51aab44e82d22a12e1ae7c970f9af900b7d7379ed672132b76694c32f8cbd786020300261e805b499898b8f20f4
+  checksum: 10c0/b3d9c3351e7a3bb9169bd5262aaad7911647cf38d4f24d217561481a028fe3a5d0fbd9e6320017a264c4ef2bd52947079e3c665bd6a768ff85780da1012e3672
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/33145

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I applied a patch to `@testing-library/user-event` to ensure that events emitted in tests contain the `view` property, as [specified in the specification](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/view).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

- Open the repro https://github.com/peterkogo/storybook-event-view
- Install the canary and run Storybook
- Notice that the `"Cannot read properties of null (reading 'document')"` error is not present anymore.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33787-sha-735201a3`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33787-sha-735201a3 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33787-sha-735201a3 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33787-sha-735201a3`](https://npmjs.com/package/storybook/v/0.0.0-pr-33787-sha-735201a3) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-event-view-undefined`](https://github.com/storybookjs/storybook/tree/valentin/fix-event-view-undefined) |
| **Commit** | [`735201a3`](https://github.com/storybookjs/storybook/commit/735201a3a1e2591195ead3d98a3da86176d36218) |
| **Datetime** | Fri Feb  6 18:28:53 UTC 2026 (`1770402533`) |
| **Workflow run** | [21761451970](https://github.com/storybookjs/storybook/actions/runs/21761451970) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33787`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
