### PR TITLE
Builder-Vite: Use relative path for mocker entry in production builds

### DIFF
--- a/code/builders/builder-vite/src/plugins/vite-inject-mocker/plugin.test.ts
+++ b/code/builders/builder-vite/src/plugins/vite-inject-mocker/plugin.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Unit-tests for the vite-inject-mocker plugin, focused on the
+ * `transformIndexHtml` hook which must emit a **relative** `src`
+ * during production builds (so Storybook artifacts load when hosted
+ * at non-root paths, e.g. GitHub Pages) and an **absolute** `src`
+ * during development (so Vite's dev-server `resolveId` can match it).
+ *
+ * @see https://github.com/storybookjs/storybook/issues/32428
+ */
+
+// We need to mock the import.meta.resolve call and node:url before
+// importing the plugin, because the module resolves the mocker
+// runtime path at import time.
+vi.mock('node:url', () => ({
+  fileURLToPath: vi.fn(() => '/fake/mocker-runtime.js'),
+}));
+
+// Mock import.meta.resolve
+vi.stubGlobal('import', { meta: { resolve: () => 'file:///fake/mocker-runtime.js' } });
+
+// Dynamic import after mocks are set up
+const { viteInjectMockerRuntime } = await import('./plugin.js');
+
+function makeHtml(headAttrs = '') {
+  return `<!doctype html><html><head${headAttrs}><meta charset="utf-8" /></head><body></body></html>`;
+}
+
+describe('vite-inject-mocker plugin — transformIndexHtml', () => {
+  function createPlugin(command: 'build' | 'serve') {
+    const plugin = viteInjectMockerRuntime({ previewConfigPath: null }) as any;
+    // Simulate Vite calling configResolved
+    plugin.configResolved({ command } as any);
+    return plugin;
+  }
+
+  it('uses a relative path (./…) in build mode', () => {
+    const plugin = createPlugin('build');
+    const html = makeHtml();
+    const result = plugin.transformIndexHtml(html);
+
+    expect(result).toContain('src="./vite-inject-mocker-entry.js"');
+    expect(result).not.toContain('src="/vite-inject-mocker-entry.js"');
+  });
+
+  it('uses an absolute path (/…) in dev mode', () => {
+    const plugin = createPlugin('serve');
+    const html = makeHtml();
+    const result = plugin.transformIndexHtml(html);
+
+    expect(result).toContain('src="/vite-inject-mocker-entry.js"');
+    // Ensure it's not the relative form
+    expect(result).not.toContain('src="./vite-inject-mocker-entry.js"');
+  });
+
+  it('injects the script tag right after <head>', () => {
+    const plugin = createPlugin('build');
+    const html = makeHtml();
+    const result = plugin.transformIndexHtml(html);
+
+    const headIndex = result.indexOf('<head>');
+    const scriptIndex = result.indexOf('<script type="module"');
+    expect(scriptIndex).toBeGreaterThan(headIndex);
+    expect(scriptIndex).toBe(headIndex + '<head>'.length);
+  });
+
+  it('handles <head> tags with attributes', () => {
+    const plugin = createPlugin('build');
+    const html = makeHtml(' lang="en"');
+    const result = plugin.transformIndexHtml(html);
+
+    expect(result).toContain('src="./vite-inject-mocker-entry.js"');
+    expect(result).toContain('<head lang="en"><script type="module"');
+  });
+
+  it('returns undefined when <head> is missing', () => {
+    const plugin = createPlugin('build');
+    const result = plugin.transformIndexHtml('<html><body></body></html>');
+    expect(result).toBeUndefined();
+  });
+
+  it('preserves the rest of the HTML unchanged', () => {
+    const plugin = createPlugin('build');
+    const html = makeHtml();
+    const result = plugin.transformIndexHtml(html);
+
+    // Remove the injected script to verify the rest is intact
+    const cleaned = result.replace(
+      '<script type="module" src="./vite-inject-mocker-entry.js"></script>',
+      ''
+    );
+    expect(cleaned).toBe(html);
+  });
+});

--- a/code/builders/builder-vite/src/plugins/vite-inject-mocker/plugin.test.ts
+++ b/code/builders/builder-vite/src/plugins/vite-inject-mocker/plugin.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 /**
- * Unit-tests for the vite-inject-mocker plugin, focused on the
- * `transformIndexHtml` hook which must emit a **relative** `src`
- * during production builds (so Storybook artifacts load when hosted
- * at non-root paths, e.g. GitHub Pages) and an **absolute** `src`
- * during development (so Vite's dev-server `resolveId` can match it).
+ * Unit-tests for the vite-inject-mocker plugin, focused on the `transformIndexHtml` hook which must
+ * emit a **relative** `src` during production builds (so Storybook artifacts load when hosted at
+ * non-root paths, e.g. GitHub Pages) and an **absolute** `src` during development (so Vite's
+ * dev-server `resolveId` can match it).
  *
  * @see https://github.com/storybookjs/storybook/issues/32428
  */

--- a/code/builders/builder-vite/src/plugins/vite-inject-mocker/plugin.ts
+++ b/code/builders/builder-vite/src/plugins/vite-inject-mocker/plugin.ts
@@ -51,7 +51,12 @@ export const viteInjectMockerRuntime = (options: {
       const headTag = html.match(/<head[^>]*>/);
 
       if (headTag) {
-        const entryCode = `<script type="module" src="${ENTRY_PATH}"></script>`;
+        // Use a relative path for production builds so the script loads
+        // correctly when artifacts are hosted at non-root paths (e.g.,
+        // GitHub Pages subdirectories).  In dev mode, the absolute path
+        // is required so Vite's dev server can match it in resolveId.
+        const src = viteConfig.command === 'build' ? `.${ENTRY_PATH}` : ENTRY_PATH;
+        const entryCode = `<script type="module" src="${src}"></script>`;
         const headTagIndex = html.indexOf(headTag[0]);
         const newHtml =
           html.slice(0, headTagIndex + headTag[0].length) +


### PR DESCRIPTION
## Human View

### What I did

Fixed the `vite-inject-mocker` plugin to use a relative path (`./vite-inject-mocker-entry.js`) instead of an absolute path (`/vite-inject-mocker-entry.js`) when injecting the mocker runtime `<script>` tag during production builds.

### Why

When Storybook artifacts are hosted under a non-root base path (e.g. GitHub Pages at `https://user.github.io/my-repo/`), the browser resolves the absolute path against the host root, causing a 404:

```
# Absolute path (broken on non-root hosting):
GET https://user.github.io/vite-inject-mocker-entry.js  →  404

# Relative path (works everywhere):
GET https://user.github.io/my-repo/vite-inject-mocker-entry.js  →  200
```

This is consistent with other assets in `iframe.html` which already use relative paths (e.g. `./sb-common-assets/nunito-sans-regular.woff2`).

### How

The `transformIndexHtml` hook now checks `viteConfig.command`:
- **`build`** → uses `./vite-inject-mocker-entry.js` (relative, works at any base path)
- **`serve`** → keeps `/vite-inject-mocker-entry.js` (absolute, required for Vite dev-server `resolveId` matching)

The emitted chunk (`fileName: 'vite-inject-mocker-entry.js'`) is placed at the same directory level as `iframe.html`, so the relative path resolves correctly.

### Testing

Added 6 unit tests covering:
- Relative path in build mode
- Absolute path in dev mode
- Script injection position (right after `<head>`)
- `<head>` with attributes
- Missing `<head>` tag (graceful no-op)
- HTML preservation (no unintended mutations)

All 6 new tests pass. All pre-existing tests in `builder-vite` remain green.

### Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Unit tests added
- [x] Verified existing tests pass

Closes #32428

---

## AI View (DCCE Protocol v1.0)

### Metadata
- **Generator**: Claude (Anthropic) via Cursor IDE
- **Methodology**: AI-assisted development with human oversight and review

### AI Contribution Summary
- Solution design and implementation
- Test development (6 new test cases)

### Verification Steps Performed
1. Reproduced the reported issue
2. Analyzed source code to identify root cause
3. Implemented and tested the fix

### Human Review Guidance
- Core changes are in: `./vite-inject-mocker-entry.js`, `/vite-inject-mocker-entry.js`, `iframe.html`
- Review the breaking change implications

Made with M7 [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for the inject script behavior covering build and serve modes: placement immediately after <head>, handling of head attributes, no-op when no <head>, and preservation of the rest of the HTML.

* **Bug Fixes**
  * Fixed script path handling so production builds use relative paths and development uses absolute paths for correct loading across deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
