### PR TITLE
Viewport: Skip viewport validation before parameters load

### DIFF
--- a/code/core/src/viewport/useViewport.ts
+++ b/code/core/src/viewport/useViewport.ts
@@ -194,6 +194,11 @@ export const useViewport = () => {
   }, [storyGlobals, update]);
 
   useEffect(() => {
+    // Skip if parameter not loaded to avoid race condition with default MINIMAL_VIEWPORTS
+    if (!parameter) {
+      return;
+    }
+
     // Reset the viewport to the story global value if the URL state defines an invalid option
     if (option) {
       if (Object.hasOwn(options, option)) {
@@ -203,7 +208,7 @@ export const useViewport = () => {
         update(normalizeGlobal(storyGlobals?.[PARAM_KEY], false));
       }
     }
-  }, [storyGlobals, options, option, update]);
+  }, [parameter, storyGlobals, options, option, update]);
 
   useEffect(() => {
     api.setAddonShortcut(ADDON_ID, {


### PR DESCRIPTION
Closes #33777

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->
Skip viewport validation when `parameter` is not yet available to prevent premature resets

### Why
`initialGlobals.viewport.value` is validated before `INITIAL_VIEWPORTS` is loaded, causing valid viewports to be treated as invalid and reset.
## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing
Add the configuration to `preview.ts`:

```ts
import { INITIAL_VIEWPORTS } from "storybook/viewport";

const preview: Preview = {
  parameters: {
    viewport: {
      options: INITIAL_VIEWPORTS,
    },
  },
  initialGlobals: {
    viewport: {
      value: "iphone14",
      isRotated: true,
    },
  },
};
```
<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->
### PS
If `initialGlobals.viewport.value` is not present in `parameters.viewport.options`, it is silently reset without warning or error.
### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where viewport configuration could be applied before required parameters finished loading, ensuring stable initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->