### PR TITLE
Addon-Vitest: Improve config file detection in monorepos

### DIFF
--- a/code/addons/vitest/src/node/vitest-manager.ts
+++ b/code/addons/vitest/src/node/vitest-manager.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 import type {
   CoverageOptions,
@@ -13,7 +13,7 @@ import { Tag } from 'storybook/internal/core-server';
 import type { StoryId, StoryIndex, StoryIndexEntry } from 'storybook/internal/types';
 
 import * as find from 'empathic/find';
-import path, { dirname, join, normalize } from 'pathe';
+import path, { dirname, join, normalize, resolve } from 'pathe';
 // eslint-disable-next-line depend/ban-dependencies
 import slash from 'slash';
 
@@ -75,19 +75,40 @@ export class VitestManager {
         : { enabled: false }
     ) as CoverageOptions;
 
-    const vitestWorkspaceConfig = find.any(
-      [
-        ...VITEST_WORKSPACE_FILE_EXTENSION.map((ext) => `vitest.workspace.${ext}`),
-        ...VITEST_CONFIG_FILE_EXTENSIONS.map((ext) => `vitest.config.${ext}`),
-      ],
-      { last: getProjectRoot() }
-    );
+    // In monorepos, the Storybook configDir (e.g. packages/web-app/.storybook) identifies
+    // the sub-package. We start the Vitest config search from its parent (the package root)
+    // and traverse upward to the project root, so configs in both sub-packages and the
+    // monorepo root are found. Without this, find.any defaults to process.cwd() which may
+    // be the monorepo root and would miss sub-package configs entirely.
+    const configDir = this.testManager.storybookOptions.configDir;
+    const packageRoot = configDir ? dirname(resolve(configDir)) : undefined;
+
+    const configFiles = [
+      ...VITEST_WORKSPACE_FILE_EXTENSION.map((ext) => `vitest.workspace.${ext}`),
+      ...VITEST_CONFIG_FILE_EXTENSIONS.flatMap((ext) => [
+        `vitest.config.${ext}`,
+        `vite.config.${ext}`,
+      ]),
+    ];
+
+    let vitestWorkspaceConfig: string | undefined;
+
+    for (const file of configFiles) {
+      const maybe = find.any([file], { cwd: packageRoot, last: getProjectRoot() });
+      if (maybe && existsSync(maybe)) {
+        const content = readFileSync(maybe, 'utf8');
+        if (content.includes('storybookTest')) {
+          vitestWorkspaceConfig = maybe;
+          break;
+        }
+      }
+    }
 
     const projectName = 'storybook:' + process.env.STORYBOOK_CONFIG_DIR;
 
     try {
       this.vitest = await createVitest('test', {
-        root: vitestWorkspaceConfig ? dirname(vitestWorkspaceConfig) : process.cwd(),
+        root: vitestWorkspaceConfig ? dirname(vitestWorkspaceConfig) : packageRoot || process.cwd(),
         watch: true,
         passWithNoTests: false,
         project: [projectName],


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/33805

## What I did

Fixed Vitest config file detection in `@storybook/addon-vitest` so it works correctly in monorepo sub-packages.

### Problem

When using `@storybook/addon-vitest` inside a monorepo sub-package (e.g. `./packages/web-app`), the Vitest backend fails to start with the error: **"No projects found for [project-name]"**.

This happens because the addon's `VitestManager.startVitest()` searches for Vitest config files using `find.any()` starting from `process.cwd()` up to `getProjectRoot()`. In a monorepo, both can resolve to the monorepo root (where `.git` lives), so a `vitest.config.ts` located in the sub-package directory is never discovered. This scenario happens if `storybook` is called from the root with `--config-dir` pointing to a sub-directory.

### Fix

Three changes in `code/addons/vitest/src/node/vitest-manager.ts`:

1. **Start config search from the package root instead of `process.cwd()`** — The Storybook `configDir` (e.g. `packages/web-app/.storybook`) already identifies the sub-package. We derive the package root as `dirname(resolve(configDir))` and pass it as the `cwd` to `find.any()`, which then traverses upward to `getProjectRoot()`. This ensures configs in both sub-packages and the monorepo root are found.

2. **Validate found configs contain `storybookTest`** — When multiple config files exist in the search path, the code now reads each candidate and checks if it contains the `storybookTest` plugin reference. This prevents picking up unrelated Vite/Vitest configs that don't include the Storybook test plugin. The search also now includes `vite.config.*` files in addition to `vitest.config.*` and `vitest.workspace.*`.

3. **Improved `root` fallback** — When no matching config is found, the Vitest `root` falls back to `packageRoot` (the sub-package directory) instead of `process.cwd()` (the monorepo root).

### Behavior in different scenarios

| Scenario | Before | After |
|---|---|---|
| Monorepo, config in sub-package | Fails: "No projects found" | Finds config in sub-package |
| Monorepo, config at root | Works | Works (search traverses up) |
| Single-package repo | Works | Works (packageRoot = project root) |

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Reproduction: https://github.com/valentinpalkovic/valentinpalkovic-turbo-repo-reproduction-no-projects-found

1. Run `pnpm i`
2. Run `pnpm storybook`
3. Open Storybook and run the tests. They work as expected (canary used)
4. Change the storybook version in all package.json's to the latest release
5. Start Storybook and run tests. Observe test failure due to "No projects found" error

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33814-sha-b09081a7`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33814-sha-b09081a7 sandbox` or in an existing project with `npx storybook@0.0.0-pr-33814-sha-b09081a7 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33814-sha-b09081a7`](https://npmjs.com/package/storybook/v/0.0.0-pr-33814-sha-b09081a7) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/improve-config-file-detection`](https://github.com/storybookjs/storybook/tree/valentin/improve-config-file-detection) |
| **Commit** | [`b09081a7`](https://github.com/storybookjs/storybook/commit/b09081a7c8c82a54d27d962f72b71cfbd0a9cb0f) |
| **Datetime** | Thu Feb 12 09:03:58 UTC 2026 (`1770887038`) |
| **Workflow run** | [21940111984](https://github.com/storybookjs/storybook/actions/runs/21940111984) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33814`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
