### PR TITLE
Preact: Support inferring props from component types

### DIFF
--- a/code/renderers/preact/src/public-types.test.tsx
+++ b/code/renderers/preact/src/public-types.test.tsx
@@ -223,11 +223,7 @@ it('Infer mock function given to args in meta.', () => {
       expectTypeOf(args.onRender).toEqualTypeOf<() => void>();
     },
   };
-  type Expected = StoryAnnotations<
-    PreactRenderer,
-    Props & { onClick: Mock },
-    Partial<Props>
-  >;
+  type Expected = StoryAnnotations<PreactRenderer, Props & { onClick: Mock }, Partial<Props>>;
 
   expectTypeOf(Basic).toEqualTypeOf<Expected>();
 });

--- a/code/renderers/preact/src/public-types.test.tsx
+++ b/code/renderers/preact/src/public-types.test.tsx
@@ -8,7 +8,9 @@ import type { Args, StoryAnnotations, StrictArgs } from 'storybook/internal/type
 
 import { expectTypeOf } from 'expect-type';
 import { h } from 'preact';
-import type { FunctionComponent, VNode } from 'preact';
+import type { FunctionComponent } from 'preact';
+import { fn } from 'storybook/test';
+import type { Mock } from 'storybook/test';
 import type { SetOptional } from 'type-fest';
 
 import type { Decorator, Meta, StoryObj } from './public-types';
@@ -202,4 +204,30 @@ describe('Story args can be inferred', () => {
     type Expected = PreactStory<Props, SetOptional<Props, 'disabled'>>;
     expectTypeOf(Basic).toEqualTypeOf<Expected>();
   });
+});
+
+it('Infer mock function given to args in meta.', () => {
+  type Props = { label: string; onClick: () => void; onRender: () => void };
+  const TestButton: FunctionComponent<Props> = () => h('div', null);
+
+  const meta = {
+    component: TestButton,
+    args: { label: 'label', onClick: fn(), onRender: () => {} },
+  } satisfies Meta<typeof TestButton>;
+
+  type Story = StoryObj<typeof meta>;
+
+  const Basic: Story = {
+    play: async ({ args }) => {
+      expectTypeOf(args.onClick).toEqualTypeOf<Mock>();
+      expectTypeOf(args.onRender).toEqualTypeOf<() => void>();
+    },
+  };
+  type Expected = StoryAnnotations<
+    PreactRenderer,
+    Props & { onClick: Mock },
+    Partial<Props>
+  >;
+
+  expectTypeOf(Basic).toEqualTypeOf<Expected>();
 });

--- a/code/renderers/preact/src/public-types.test.tsx
+++ b/code/renderers/preact/src/public-types.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment happy-dom
+/** @jsxImportSource preact */
+// this file tests TypeScript types — that's why there are no runtime assertions
+import { describe, it } from 'vitest';
+
+import { satisfies } from 'storybook/internal/common';
+import type { Args, StoryAnnotations, StrictArgs } from 'storybook/internal/types';
+
+import { expectTypeOf } from 'expect-type';
+import { h } from 'preact';
+import type { FunctionComponent, VNode } from 'preact';
+import type { SetOptional } from 'type-fest';
+
+import type { Decorator, Meta, StoryObj } from './public-types';
+import type { PreactRenderer } from './types';
+
+type PreactStory<TArgs, TRequiredArgs> = StoryAnnotations<PreactRenderer, TArgs, TRequiredArgs>;
+
+type ButtonProps = { label: string; disabled: boolean };
+const Button: FunctionComponent<ButtonProps> = () => h('div', null);
+
+describe('Meta correctly extracts props from component types', () => {
+  it('✅ Meta<typeof Component> extracts component props', () => {
+    const meta = satisfies<Meta<typeof Button>>()({
+      component: Button,
+      args: { label: 'good', disabled: false },
+    });
+
+    expectTypeOf(meta.args).toMatchTypeOf<Partial<ButtonProps>>();
+  });
+
+  it('✅ Meta<Props> still works when passing props directly', () => {
+    const meta = satisfies<Meta<ButtonProps>>()({
+      component: Button,
+      args: { label: 'good', disabled: false },
+    });
+
+    expectTypeOf(meta.args).toMatchTypeOf<Partial<ButtonProps>>();
+  });
+
+  it('✅ Meta can be used without generic', () => {
+    expectTypeOf({ component: Button }).toMatchTypeOf<Meta>();
+  });
+});
+
+describe('Args can be provided in multiple ways', () => {
+  it('✅ All required args may be provided in meta', () => {
+    const meta = satisfies<Meta<typeof Button>>()({
+      component: Button,
+      args: { label: 'good', disabled: false },
+    });
+
+    type Story = StoryObj<typeof meta>;
+    const Basic: Story = {};
+
+    expectTypeOf(Basic).toEqualTypeOf<
+      PreactStory<ButtonProps, SetOptional<ButtonProps, 'label' | 'disabled'>>
+    >();
+  });
+
+  it('✅ Required args may be provided partial in meta and the story', () => {
+    const meta = satisfies<Meta<typeof Button>>()({
+      component: Button,
+      args: { label: 'good' },
+    });
+    const Basic: StoryObj<typeof meta> = {
+      args: { disabled: false },
+    };
+
+    type Expected = PreactStory<ButtonProps, SetOptional<ButtonProps, 'label'>>;
+    expectTypeOf(Basic).toEqualTypeOf<Expected>();
+  });
+
+  it('❌ The combined shape of meta args and story args must match the required args.', () => {
+    {
+      const meta = satisfies<Meta<typeof Button>>()({ component: Button });
+      const Basic: StoryObj<typeof meta> = {
+        // @ts-expect-error disabled not provided ❌
+        args: { label: 'good' },
+      };
+
+      type Expected = PreactStory<ButtonProps, ButtonProps>;
+      expectTypeOf(Basic).toEqualTypeOf<Expected>();
+    }
+    {
+      const meta = satisfies<Meta<typeof Button>>()({
+        component: Button,
+        args: { label: 'good' },
+      });
+      // @ts-expect-error disabled not provided ❌
+      const Basic: StoryObj<typeof meta> = {};
+
+      type Expected = PreactStory<ButtonProps, SetOptional<ButtonProps, 'label'>>;
+      expectTypeOf(Basic).toEqualTypeOf<Expected>();
+    }
+    {
+      const meta = satisfies<Meta<ButtonProps>>()({ component: Button });
+      const Basic: StoryObj<typeof meta> = {
+        // @ts-expect-error disabled not provided ❌
+        args: { label: 'good' },
+      };
+
+      type Expected = PreactStory<ButtonProps, ButtonProps>;
+      expectTypeOf(Basic).toEqualTypeOf<Expected>();
+    }
+  });
+
+  it('Component can be used as generic parameter for StoryObj', () => {
+    type Expected = PreactStory<ButtonProps, Partial<ButtonProps>>;
+    expectTypeOf<StoryObj<typeof Button>>().toEqualTypeOf<Expected>();
+  });
+});
+
+it('StoryObj<typeof meta> is allowed when meta is upcasted to Meta<Props>', () => {
+  expectTypeOf<StoryObj<Meta<ButtonProps>>>().toEqualTypeOf<
+    PreactStory<ButtonProps, Partial<ButtonProps>>
+  >();
+});
+
+it('StoryObj<typeof meta> is allowed when meta is upcasted to Meta<typeof Cmp>', () => {
+  expectTypeOf<StoryObj<Meta<typeof Button>>>().toEqualTypeOf<
+    PreactStory<ButtonProps, Partial<ButtonProps>>
+  >();
+});
+
+it('StoryObj<typeof meta> is allowed when all arguments are optional', () => {
+  expectTypeOf<StoryObj<Meta<{ label?: string }>>>().toEqualTypeOf<
+    PreactStory<{ label?: string }, { label?: string }>
+  >();
+});
+
+it('Props can be defined as interfaces, issue #21768', () => {
+  interface Props {
+    label: string;
+  }
+
+  const Component: FunctionComponent<Props> = ({ label }) => h('span', null, label);
+
+  const withDecorator: Decorator = (Story) => h(Story, null);
+
+  const meta = {
+    component: Component,
+    args: {
+      label: 'label',
+    },
+    decorators: [withDecorator],
+  } satisfies Meta<Props>;
+
+  const Basic: StoryObj<typeof meta> = {};
+
+  type Expected = PreactStory<Props, SetOptional<Props, 'label'>>;
+  expectTypeOf(Basic).toEqualTypeOf<Expected>();
+});
+
+it('Components without Props can be used, issue #21768', () => {
+  const Component: FunctionComponent = () => h('div', null);
+  const withDecorator: Decorator = (Story) => h(Story, null);
+
+  const meta = {
+    component: Component,
+    decorators: [withDecorator],
+  } satisfies Meta<typeof Component>;
+
+  const Basic: StoryObj<typeof meta> = {};
+
+  type Expected = PreactStory<{}, {}>;
+  expectTypeOf(Basic).toEqualTypeOf<Expected>();
+});
+
+describe('Story args can be inferred', () => {
+  it('Correct args are inferred when type is widened for render function', () => {
+    type ThemeData = 'light' | 'dark';
+    type Props = ButtonProps & { theme: ThemeData };
+
+    const meta = satisfies<Meta<Props>>()({
+      component: Button,
+      args: { disabled: false },
+      render: (args) => {
+        return h('div', null, args.label);
+      },
+    });
+
+    const Basic: StoryObj<typeof meta> = { args: { theme: 'light', label: 'good' } };
+
+    type Expected = PreactStory<Props, SetOptional<Props, 'disabled'>>;
+    expectTypeOf(Basic).toMatchTypeOf<Expected>();
+  });
+
+  const withDecorator: Decorator<{ decoratorArg: number }> = (Story, { args }) => h(Story, null);
+
+  it('Correct args are inferred when type is widened for decorators', () => {
+    type Props = ButtonProps & { decoratorArg: number };
+
+    const meta = satisfies<Meta<Props>>()({
+      component: Button,
+      args: { disabled: false },
+      decorators: [withDecorator],
+    });
+
+    const Basic: StoryObj<typeof meta> = { args: { decoratorArg: 0, label: 'good' } };
+
+    type Expected = PreactStory<Props, SetOptional<Props, 'disabled'>>;
+    expectTypeOf(Basic).toEqualTypeOf<Expected>();
+  });
+});

--- a/code/renderers/preact/src/public-types.ts
+++ b/code/renderers/preact/src/public-types.ts
@@ -1,6 +1,8 @@
 import type {
   AnnotatedStoryFn,
   Args,
+  ArgsFromMeta,
+  ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
   StoryContext as GenericStoryContext,
@@ -9,6 +11,9 @@ import type {
   StoryAnnotations,
   StrictArgs,
 } from 'storybook/internal/types';
+
+import type { ComponentProps, ComponentType } from 'preact';
+import type { SetOptional, Simplify } from 'type-fest';
 
 import type { PreactRenderer } from './types';
 
@@ -20,21 +25,40 @@ export type { PreactRenderer };
  *
  * @see [Default export](https://storybook.js.org/docs/api/csf#default-export)
  */
-export type Meta<TArgs = Args> = ComponentAnnotations<PreactRenderer, TArgs>;
+export type Meta<TCmpOrArgs = Args> = [TCmpOrArgs] extends [ComponentType<any>]
+  ? ComponentAnnotations<PreactRenderer, ComponentProps<TCmpOrArgs>>
+  : ComponentAnnotations<PreactRenderer, TCmpOrArgs>;
 
 /**
  * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/api/csf#named-story-exports)
  */
-export type StoryFn<TArgs = Args> = AnnotatedStoryFn<PreactRenderer, TArgs>;
+export type StoryFn<TCmpOrArgs = Args> = [TCmpOrArgs] extends [ComponentType<any>]
+  ? AnnotatedStoryFn<PreactRenderer, ComponentProps<TCmpOrArgs>>
+  : AnnotatedStoryFn<PreactRenderer, TCmpOrArgs>;
 
 /**
  * Story object that represents a CSFv3 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/api/csf#named-story-exports)
  */
-export type StoryObj<TArgs = Args> = StoryAnnotations<PreactRenderer, TArgs>;
+export type StoryObj<TMetaOrCmpOrArgs = Args> = [TMetaOrCmpOrArgs] extends [
+  {
+    render?: ArgsStoryFn<PreactRenderer, any>;
+    component?: infer Component;
+    args?: infer DefaultArgs;
+  },
+]
+  ? Simplify<
+      (Component extends ComponentType<any> ? ComponentProps<Component> : unknown) &
+        ArgsFromMeta<PreactRenderer, TMetaOrCmpOrArgs>
+    > extends infer TArgs
+    ? StoryAnnotations<PreactRenderer, TArgs, SetOptional<TArgs, keyof TArgs & keyof DefaultArgs>>
+    : never
+  : TMetaOrCmpOrArgs extends ComponentType<any>
+    ? StoryAnnotations<PreactRenderer, ComponentProps<TMetaOrCmpOrArgs>>
+    : StoryAnnotations<PreactRenderer, TMetaOrCmpOrArgs>;
 
 export type Decorator<TArgs = StrictArgs> = DecoratorFunction<PreactRenderer, TArgs>;
 export type Loader<TArgs = StrictArgs> = LoaderFunction<PreactRenderer, TArgs>;

--- a/code/renderers/preact/src/public-types.ts
+++ b/code/renderers/preact/src/public-types.ts
@@ -54,11 +54,24 @@ export type StoryObj<TMetaOrCmpOrArgs = Args> = [TMetaOrCmpOrArgs] extends [
       (Component extends ComponentType<any> ? ComponentProps<Component> : unknown) &
         ArgsFromMeta<PreactRenderer, TMetaOrCmpOrArgs>
     > extends infer TArgs
-    ? StoryAnnotations<PreactRenderer, TArgs, SetOptional<TArgs, keyof TArgs & keyof DefaultArgs>>
+    ? StoryAnnotations<
+        PreactRenderer,
+        AddMocks<TArgs, DefaultArgs>,
+        SetOptional<TArgs, keyof TArgs & keyof DefaultArgs>
+      >
     : never
   : TMetaOrCmpOrArgs extends ComponentType<any>
     ? StoryAnnotations<PreactRenderer, ComponentProps<TMetaOrCmpOrArgs>>
     : StoryAnnotations<PreactRenderer, TMetaOrCmpOrArgs>;
+
+// This performs a downcast to function types that are mocks, when a mock fn is given to meta args.
+export type AddMocks<TArgs, DefaultArgs> = Simplify<{
+  [T in keyof TArgs]: T extends keyof DefaultArgs
+    ? DefaultArgs[T] extends (...args: any) => any & { mock: {} } // allow any function with a mock object
+      ? DefaultArgs[T]
+      : TArgs[T]
+    : TArgs[T];
+}>;
 
 export type Decorator<TArgs = StrictArgs> = DecoratorFunction<PreactRenderer, TArgs>;
 export type Loader<TArgs = StrictArgs> = LoaderFunction<PreactRenderer, TArgs>;

--- a/code/renderers/preact/src/types.ts
+++ b/code/renderers/preact/src/types.ts
@@ -12,6 +12,6 @@ export interface ShowErrorArgs {
 }
 
 export interface PreactRenderer extends WebRenderer {
-  component: AnyComponent<any, any>;
+  component: AnyComponent<this['T'], any>;
   storyResult: StoryFnPreactReturnType;
 }


### PR DESCRIPTION
Relates to https://github.com/storybookjs/storybook/discussions/33749

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`Meta<typeof Button>` in `@storybook/preact` doesn't extract props correctly, forcing users to pass props types directly (`Meta<ButtonProps>`) as a workaround. The root cause: `PreactRenderer.component` was typed as `AnyComponent<any, any>` (discarding prop info), and `Meta`/`StoryFn`/`StoryObj` lacked the conditional `ComponentProps` extraction logic that the React renderer has.

### Changes

- **`types.ts`** — `component: AnyComponent<any, any>` → `AnyComponent<this['T'], any>` to bind props via the `T` slot.
- **`public-types.ts`** — `Meta`, `StoryFn`, and `StoryObj` now use conditional types to detect `ComponentType` and extract `ComponentProps`, with full `ArgsFromMeta` inference and `SetOptional` support for `StoryObj<typeof meta>` — mirroring the React renderer.
- **`public-types.test.tsx`** (new) — Type-level test suite covering props extraction, partial/missing args errors, meta inference, interfaces, no-props components, render/decorator arg widening.

### Result

```tsx
// ✅ This now works — no workaround needed
const meta = { component: Button } satisfies Meta<typeof Button>;
type Story = StoryObj<typeof meta>; // correctly infers ButtonProps
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

Testing should be surfaced by the types in the repository

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced type inference for component props and story arguments.
  * Added `StoryContext` and `Preview` types for better TypeScript support.
  * Improved handling of mocked function properties in stories.

* **Tests**
  * Added comprehensive type validation tests for component typing with Storybook integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->