### PR TITLE
Core: Prevent browser freeze when args contain non-serializable values

### DIFF
--- a/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
@@ -215,7 +215,7 @@ describe('inferArgTypes', () => {
     } as any);
     const elapsed = performance.now() - start;
 
-    expect(elapsed).toBeLessThan(100);
+    expect(elapsed).toBeLessThan(500);
     expect(result.el.type).toEqual({ name: 'other', value: 'FakeElement' });
   });
 
@@ -238,7 +238,7 @@ describe('inferArgTypes', () => {
     } as any);
     const elapsed = performance.now() - start;
 
-    expect(elapsed).toBeLessThan(100);
+    expect(elapsed).toBeLessThan(500);
     expect(result.formRef.type).toEqual({
       name: 'object',
       value: { current: { name: 'other', value: 'FakeHTMLFormElement' } },

--- a/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
@@ -143,4 +143,122 @@ describe('inferArgTypes', () => {
       },
     });
   });
+
+  it('handles Date, RegExp, and Error without warnings', () => {
+    vi.mocked(logger.warn).mockClear();
+    expect(
+      inferArgTypes({
+        initialArgs: {
+          a: new Date('2024-01-01'),
+          b: /test/gi,
+          c: new Error('test'),
+        },
+      } as any)
+    ).toEqual({
+      a: { name: 'a', type: { name: 'other', value: 'Date' } },
+      b: { name: 'b', type: { name: 'other', value: 'RegExp' } },
+      c: { name: 'c', type: { name: 'other', value: 'Error' } },
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns for Map and Set instances', () => {
+    vi.mocked(logger.warn).mockClear();
+    expect(
+      inferArgTypes({
+        initialArgs: {
+          a: new Map([['key', 'value']]),
+          b: new Set([1, 2, 3]),
+        },
+      } as any)
+    ).toEqual({
+      a: { name: 'a', type: { name: 'other', value: 'Map' } },
+      b: { name: 'b', type: { name: 'other', value: 'Set' } },
+    });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('non-serializable value'));
+  });
+
+  it('warns and skips non-plain objects (class instances)', () => {
+    class MyClass {
+      value = 42;
+    }
+    vi.mocked(logger.warn).mockClear();
+    expect(
+      inferArgTypes({
+        initialArgs: {
+          a: new MyClass(),
+        },
+      } as any)
+    ).toEqual({
+      a: { name: 'a', type: { name: 'other', value: 'MyClass' } },
+    });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('non-serializable value'));
+  });
+
+  it('does not hang on DOM-like structures with many properties', () => {
+    class FakeElement {
+      nodeType = 1;
+      nodeName = 'DIV';
+      [key: string]: any;
+      constructor() {
+        for (let i = 0; i < 200; i++) {
+          this[`attr${i}`] = `value${i}`;
+        }
+        this.__reactFiber = { child: this };
+      }
+    }
+    const domLike = new FakeElement();
+
+    const start = performance.now();
+    const result = inferArgTypes({
+      initialArgs: { el: domLike },
+    } as any);
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(100);
+    expect(result.el.type).toEqual({ name: 'other', value: 'FakeElement' });
+  });
+
+  it('does not hang on mutable refs pointing to complex objects', () => {
+    class FakeHTMLFormElement {
+      parentNode: any;
+      __reactFiber: any;
+      constructor() {
+        this.parentNode = { childNodes: [this] };
+        this.__reactFiber = { stateNode: this, return: {}, child: {} };
+      }
+    }
+    const fakeDOM = new FakeHTMLFormElement();
+    const ref = { current: fakeDOM };
+
+    vi.mocked(logger.warn).mockClear();
+    const start = performance.now();
+    const result = inferArgTypes({
+      initialArgs: { formRef: ref },
+    } as any);
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(100);
+    expect(result.formRef.type).toEqual({
+      name: 'object',
+      value: { current: { name: 'other', value: 'FakeHTMLFormElement' } },
+    });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('non-serializable value'));
+  });
+
+  it('handles null and undefined args gracefully', () => {
+    vi.mocked(logger.warn).mockClear();
+    expect(
+      inferArgTypes({
+        initialArgs: {
+          nullArg: null,
+          undefinedArg: undefined,
+        },
+      } as any)
+    ).toEqual({
+      nullArg: { name: 'nullArg', type: { name: 'object', value: {} } },
+      undefinedArg: { name: 'undefinedArg', type: { name: 'object', value: {} } },
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## What I did

`inferType()` in `inferArgTypes.ts` recursively traversed **all properties** of any object to infer arg types for the Controls panel. When args contained refs (`createRef()`) whose `.current` pointed to DOM elements after rendering, this caused exponential traversal through the DOM tree and React Fiber internals, freezing the browser tab.

The existing `visited` Set uses `new Set(visited)` at each branch for sibling path independence, so the same object reached via different paths is not detected as a cycle — leading to exponential traversal on wide objects like DOM elements (200+ properties each).

Added an `isPlainObject` guard so that non-plain objects (DOM elements, class instances, `Map`, `Set`, etc.) are returned as opaque types instead of being recursed into. `Date`, `RegExp`, and `Error` are handled explicitly before this guard to avoid false warnings, since telejson already serializes them safely.

Closes #33821, closes #17098, closes #19575, closes #28750, closes #17482, closes #16855

Possibly related: #29381

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests

#### Manual testing

1. Create a story with non-serializable args (e.g. `createRef()`, a fetcher object containing React components)
2. Run Storybook and switch between stories
3. Verify the browser tab does not freeze
4. Verify a console warning appears for non-serializable args

Reproduction repo: https://github.com/sonsu-lee/storybook-args-serialize-bug

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safe stringify utility and interactive demo stories to showcase argument-type behaviors.

* **Bug Fixes**
  * Enhanced type inference for built-ins and non-plain objects; improved warnings for non-serializable values and safer traversal of complex structures.
  * Safer object preview rendering to avoid errors with circular or non-serializable data.

* **Tests**
  * Added comprehensive unit tests covering edge cases, cycles, refs, and complex nested inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->