### PR TITLE
Docs: Add troubleshooting for react-docgen-typescript in monorepos

### DIFF
--- a/docs/_snippets/storybook-main-rdt-monorepo-include.md
+++ b/docs/_snippets/storybook-main-rdt-monorepo-include.md
@@ -1,0 +1,35 @@
+```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF 3"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+import type { StorybookConfig } from '@storybook/your-framework';
+
+const config: StorybookConfig = {
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      // Add your workspace package source files so they're included in the TS program
+      include: ['**/**.tsx', '../../packages/ui/src/**/*.tsx'],
+    },
+  },
+};
+
+export default config;
+```
+
+```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { defineMain } from '@storybook/your-framework/node';
+
+export default defineMain({
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      // Add your workspace package source files so they're included in the TS program
+      include: ['**/**.tsx', '../../packages/ui/src/**/*.tsx'],
+    },
+  },
+});
+```

--- a/docs/configure/integration/typescript.mdx
+++ b/docs/configure/integration/typescript.mdx
@@ -110,6 +110,22 @@ Out of the box, Storybook supports the `satisfies` operator for almost every fra
 
   {/* prettier-ignore-end */}
 
+  ### Inherited props are missing for components from workspace packages
+
+  If you're using `react-docgen-typescript` in a monorepo with npm/yarn/pnpm workspaces, you may find that components imported from a workspace package are missing inherited props (e.g., MUI's `ButtonProps`), while the same component imported locally works fine.
+
+  This happens because the underlying Vite plugin creates a TypeScript program from files matching its `include` glob (default: `**/**.tsx`), resolved from the Storybook project's directory. Workspace package files are outside that directory and aren't included in the program, so inherited types can't be resolved.
+
+  To fix this, add your workspace package source files to the `include` option:
+
+  {/* prettier-ignore-start */}
+
+  <CodeSnippets path="storybook-main-rdt-monorepo-include.md" />
+
+  {/* prettier-ignore-end */}
+
+  Adjust the path (`../../packages/ui/src/**/*.tsx`) to match your monorepo layout. Note that `tsconfigPath` only affects compiler options — it does not change which files are included in the TypeScript program.
+
   ### The types are not being generated for my component
 
   If you're working with a React project, type inference is automatically enabled for your components using the `react-docgen` library for improved build times and type safety. However, you may run into a situation where some options may not work as expected (e.g., [`Enums`](https://www.typescriptlang.org/docs/handbook/enums.html), React's [`forwardRef`](https://react.dev/reference/react/forwardRef)). This is primarily due to how the `react-docgen` package is implemented, making it difficult for Storybook to infer the component's metadata and generate types automatically. To solve this, you can update the `typescript` configuration option in your Storybook configuration file to use `react-docgen-typescript` instead. For example:


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry to the TypeScript configuration docs explaining why inherited props are missing when using `react-docgen-typescript` with workspace packages in a monorepo.

- Explains the root cause (Vite plugin's `include` glob only covers the Storybook project directory)
- Provides the fix (`include` option to add workspace source files)
- Notes that `tsconfigPath` doesn't help (it only affects compiler options, not the file list)

Addresses https://github.com/storybookjs/storybook/discussions/33837

## Test plan

- [ ] Verify the docs render correctly on the Storybook docs site
- [ ] Verify the code snippet tabs (CSF 3 / CSF Next) display properly