### PR TITLE
UI: Make addon panel content scrollable

### DIFF
--- a/code/core/src/components/components/addon-panel/addon-panel.tsx
+++ b/code/core/src/components/components/addon-panel/addon-panel.tsx
@@ -38,9 +38,7 @@ export const AddonPanel = ({ active, children, hasScrollbar = true }: AddonPanel
     // the hidden attribute is an valid html element that's both accessible and works to visually hide content
     <Div hidden={!active}>
       {hasScrollbar ? (
-        <ScrollArea vertical horizontal>
-          {useUpdate(active, children)}
-        </ScrollArea>
+        <ScrollArea vertical>{useUpdate(active, children)}</ScrollArea>
       ) : (
         useUpdate(active, children)
       )}

--- a/code/core/src/components/components/addon-panel/addon-panel.tsx
+++ b/code/core/src/components/components/addon-panel/addon-panel.tsx
@@ -38,7 +38,9 @@ export const AddonPanel = ({ active, children, hasScrollbar = true }: AddonPanel
     // the hidden attribute is an valid html element that's both accessible and works to visually hide content
     <Div hidden={!active}>
       {hasScrollbar ? (
-        <ScrollArea vertical>{useUpdate(active, children)}</ScrollArea>
+        <ScrollArea vertical horizontal>
+          {useUpdate(active, children)}
+        </ScrollArea>
       ) : (
         useUpdate(active, children)
       )}

--- a/code/core/src/controls/components/ControlsPanel.tsx
+++ b/code/core/src/controls/components/ControlsPanel.tsx
@@ -35,6 +35,7 @@ const AddonWrapper = styled.div<{ showSaveFromUI: boolean }>(({ showSaveFromUI, 
   maxHeight: '100vh',
   paddingBottom: showSaveFromUI ? 41 : 0,
   backgroundColor: theme.background.content,
+  overflow: 'auto',
 
   table: {
     backgroundColor: theme.background.app,


### PR DESCRIPTION
Closes #33856

## What I did

Wrapped the addon panel content in a ScrollArea component to enable both vertical and horizontal scrolling when the panel is positioned on the right.

File modified: ./code/core/src/components/components/addon-panel/addon-panel.tsx

Change introduced:
```
<ScrollArea vertical horizontal>
  {useUpdate(active, children)}
</ScrollArea>
```

## Checklist for Contributors

### Testing
#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

> No automated tests were added, as this is a UI behavior fix. Verified manually.

#### Manual testing
- Start Storybook.
- Open the Addon panel.
- Move the panel to the right side.
- Go to the "Controls" tab.
- Confirm that overflowing content is scrollable vertically and horizontally.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)
- [x] No documentation update required (internal UI fix)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced the Controls Panel to enable automatic scrolling when content exceeds available space, ensuring improved usability and seamless access to all controls without compromising the interface layout or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->