### PR TITLE
Next.js: Handle legacyBehavior prop in Link mock component 

### DIFF
--- a/code/frameworks/nextjs/src/export-mocks/link/index.tsx
+++ b/code/frameworks/nextjs/src/export-mocks/link/index.tsx
@@ -32,6 +32,27 @@ const MockLink = React.forwardRef<HTMLAnchorElement, any>(function MockLink(
     linkAction(hrefString, { replace, scroll, shallow, prefetch, locale });
   };
 
+  if (legacyBehavior) {
+    const child = React.Children.only(children) as React.ReactElement<any>;
+    const childProps: Record<string, any> = {
+      ref,
+      onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault();
+        if (child.props && typeof child.props.onClick === 'function') {
+          child.props.onClick(e);
+        }
+        linkAction(hrefString, { replace, scroll, shallow, prefetch, locale });
+      },
+      ...rest,
+    };
+
+    if (passHref || (child.type === 'a' && !('href' in (child.props || {})))) {
+      childProps.href = hrefString;
+    }
+
+    return React.cloneElement(child, childProps);
+  }
+
   return (
     <a ref={ref} href={hrefString} onClick={handleClick} {...rest}>
       {children}


### PR DESCRIPTION

Closes #33861 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed the Next.js `Link` mock component to properly handle the `legacyBehavior` prop. Previously, `MockLink` always rendered its own `<a>` tag, which caused nested `<a>` tags when users passed `legacyBehavior` with a child `<a>` element.

When `legacyBehavior` is `true`, the mock now uses `React.cloneElement` to inject props (`href`, `onClick`, `ref`) onto the child element instead of wrapping it in an `<a>`, matching the real Next.js Link behavior.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox with a Next.js template
2. Create a story using `<Link href="/about" legacyBehavior><a>About</a></Link>`
3. Verify it renders a single `<a>` tag (not nested `<a>` tags)
4. Verify the click action is still logged in the Actions panel
5. Also verify that non-legacy `<Link href="/about">About</Link>` still works as before
### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added legacyBehavior support to the Link component mock, enabling proper handling of child elements with ref, href, and onClick passthrough when legacy behavior is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->