### PR TITLE
Actions: Fix HandlerFunction type to support async callback props

### DIFF
--- a/code/core/src/actions/models/HandlerFunction.test-d.ts
+++ b/code/core/src/actions/models/HandlerFunction.test-d.ts
@@ -1,0 +1,8 @@
+import { expectTypeOf } from 'expect-type';
+import type { HandlerFunction } from './HandlerFunction';
+
+// Should be assignable to async callback props (the fixed case)
+expectTypeOf<HandlerFunction>().toMatchTypeOf<() => Promise<void>>();
+
+// Should remain assignable to plain void callbacks
+expectTypeOf<HandlerFunction>().toMatchTypeOf<() => void>();

--- a/code/core/src/actions/models/HandlerFunction.test-d.ts
+++ b/code/core/src/actions/models/HandlerFunction.test-d.ts
@@ -1,8 +1,8 @@
-import { expectTypeOf } from 'expect-type';
+import { expectTypeOf } from 'vitest';
 import type { HandlerFunction } from './HandlerFunction';
 
 // Should be assignable to async callback props (the fixed case)
-expectTypeOf<HandlerFunction>().toMatchTypeOf<() => Promise<void>>();
+expectTypeOf<HandlerFunction>().toExtend<() => Promise<void>>();
 
 // Should remain assignable to plain void callbacks
-expectTypeOf<HandlerFunction>().toMatchTypeOf<() => void>();
+expectTypeOf<HandlerFunction>().toExtend<() => void>();

--- a/code/core/src/actions/models/HandlerFunction.test-d.ts
+++ b/code/core/src/actions/models/HandlerFunction.test-d.ts
@@ -1,4 +1,5 @@
 import { expectTypeOf } from 'vitest';
+
 import type { HandlerFunction } from './HandlerFunction';
 
 // Should be assignable to async callback props (the fixed case)

--- a/code/core/src/actions/models/HandlerFunction.ts
+++ b/code/core/src/actions/models/HandlerFunction.ts
@@ -1,1 +1,1 @@
-export type HandlerFunction = (...args: any[]) => void | Promise<void>;
+export type HandlerFunction = (...args: any[]) => any;

--- a/code/core/src/actions/models/HandlerFunction.ts
+++ b/code/core/src/actions/models/HandlerFunction.ts
@@ -1,1 +1,1 @@
-export type HandlerFunction = (...args: any[]) => any;
+export type HandlerFunction = (...args: any[]) => void | Promise<void>;

--- a/code/core/src/actions/models/HandlerFunction.ts
+++ b/code/core/src/actions/models/HandlerFunction.ts
@@ -1,1 +1,1 @@
-export type HandlerFunction = (...args: any[]) => void;
+export type HandlerFunction = (...args: any[]) => any;


### PR DESCRIPTION
Closes #23731

## What I did

Changed the return type of `HandlerFunction` from `void` to `any` so that action handlers can be assigned to async callback props (e.g. `onSubmit: () => Promise<void>`) without causing type errors.

The issue is that `(...args: any[]) => void` is not assignable to `(...args: any[]) => Promise<void>`, but `(...args: any[]) => any` is, since `any` is compatible with all return types.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

This is a type-only change. Verified that the existing `HandlerFunction` usages in the codebase (e.g. `action()` return type, `ActionsMap`, test stories) remain compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Handler functions may now return Promise<void> as well as void, enabling async handlers and broader compatibility in composed flows.

* **Tests**
  * Added type-level tests asserting both async and sync handler signatures to improve type safety and guard against regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->