### PR TITLE
Added documentation for the table of contents

### DIFF
--- a/docs/api/doc-blocks/doc-block-tableofcontents.mdx
+++ b/docs/api/doc-blocks/doc-block-tableofcontents.mdx
@@ -1,0 +1,95 @@
+---
+title: 'TableOfContents'
+sidebar: 
+    order: 18
+    title: TableOfContents
+---
+
+The `TableOfContents` doc block displays an automatically generated list of links to other headings on the current page in the format of a table.
+
+<Callout variant="info">
+    To use the storybook "sidebar" table of contents layout, it should be configured with `parameters.doc.toc`
+</Callout>
+
+{/* prettier-ignore-start */}
+
+```md title="ButtonDocs.mdx"
+import { Meta, TableOfContents } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/TableOfContents">
+
+## Table of Contents
+
+<TableOfContents title="Example Toc" headingSelector="h2,h3"/>
+
+## Section 1
+
+## Section 2
+
+```
+
+{/* prettier-ignore-end */}
+
+### `TableOfContents`
+
+```js
+import { TableOfContents } from '@storybook/addon-docs/blocks';
+```
+
+TableOfContents accepts the following props:
+
+### `title`
+
+Type: `string | JSX.Element`
+
+Determine the title to be displayed above the table of contents. 
+
+
+### `disable`
+
+Type: `boolean`
+
+Enables or disables the rendering of the table.
+
+
+### `headingSelector`
+
+Type: `string`
+Default: `h3`
+
+CSS selector to determine which headings to include in the table of contents.
+
+### `contentsSelector`
+
+Type: `string`
+Default: `.sbdocs-content`
+
+CSS selector to determine the container that holds the content to be scanned for headings.
+
+### `ignoreSelector`
+
+Type: `string`
+Default: `.docs-story *, .skip-toc`
+
+CSS selector to determine which elements to ignore when scanning for headings.
+
+### `className`
+
+Type: `string`
+
+Apply custom CSS classes to the table of contents' wrapping element.
+
+### `unsafeTocbotOptions`
+
+Type: `object`
+
+Additional options to be passed directly to the underlying Tocbot. 
+Use as an escape hatch for features not yet supported by the TableOfContents component. 
+
+### `channel`
+
+Type: `Channel`
+
+Storybook's event channel to be used for navigation when clicking items in the table.
+
+

--- a/docs/api/doc-blocks/doc-block-tableofcontents.mdx
+++ b/docs/api/doc-blocks/doc-block-tableofcontents.mdx
@@ -49,7 +49,7 @@ Determine the title to be displayed above the table of contents.
 
 Type: `boolean`
 
-Enables or disables the rendering of the table.
+When set to `true` prevents the rendering of the table.
 
 
 ### `headingSelector`
@@ -90,6 +90,7 @@ Use as an escape hatch for features not yet supported by the TableOfContents com
 
 Type: `Channel`
 
-Storybook's event channel to be used for navigation when clicking items in the table.
+Storybook's event channel to be used for navigation when clicking items in the table. 
+This is automatically injected so does not need to be set up manually.
 
 

--- a/docs/api/doc-blocks/doc-block-tableofcontents.mdx
+++ b/docs/api/doc-blocks/doc-block-tableofcontents.mdx
@@ -13,7 +13,7 @@ The `TableOfContents` doc block displays an automatically generated list of link
 
 {/* prettier-ignore-start */}
 
-```md title="ButtonDocs.mdx"
+```md title="TableOfContentsDocs.mdx"
 import { Meta, TableOfContents } from '@storybook/addon-docs/blocks';
 
 <Meta title="Docs/TableOfContents"/>

--- a/docs/api/doc-blocks/doc-block-tableofcontents.mdx
+++ b/docs/api/doc-blocks/doc-block-tableofcontents.mdx
@@ -16,7 +16,7 @@ The `TableOfContents` doc block displays an automatically generated list of link
 ```md title="ButtonDocs.mdx"
 import { Meta, TableOfContents } from '@storybook/addon-docs/blocks';
 
-<Meta title="Docs/TableOfContents">
+<Meta title="Docs/TableOfContents"/>
 
 ## Table of Contents
 

--- a/docs/api/doc-blocks/doc-block-tableofcontents.mdx
+++ b/docs/api/doc-blocks/doc-block-tableofcontents.mdx
@@ -8,7 +8,7 @@ sidebar:
 The `TableOfContents` doc block displays an automatically generated list of links to other headings on the current page in the format of a table.
 
 <Callout variant="info">
-    To use the storybook "sidebar" table of contents layout, it should be configured with `parameters.doc.toc`
+    To use the storybook "sidebar" table of contents layout, it should be configured with `parameters.docs.toc`
 </Callout>
 
 {/* prettier-ignore-start */}

--- a/docs/writing-docs/doc-blocks.mdx
+++ b/docs/writing-docs/doc-blocks.mdx
@@ -240,6 +240,16 @@ The `Subtitle` block can serve as a secondary heading for your docs entry.
 
 ![Screenshot of Subtitle block](../_assets/api/doc-block-title-subtitle-description.png)
 
+### [TableOfContents](../api/doc-blocks/doc-block-tableofcontents.mdx)
+
+<Callout variant="info">
+
+  Accepts parameters in the namespace `parameters.docs.story`.
+
+</Callout>
+
+The `TableOfContents` block displays a list of the contents for the current docs page automatically formatted as a table. 
+
 ### [Title](../api/doc-blocks/doc-block-title.mdx)
 
 The `Title` block serves as the primary heading for your docs entry. It is typically used to provide the component or page name.

--- a/docs/writing-docs/doc-blocks.mdx
+++ b/docs/writing-docs/doc-blocks.mdx
@@ -244,7 +244,7 @@ The `Subtitle` block can serve as a secondary heading for your docs entry.
 
 <Callout variant="info">
 
-  Accepts parameters in the namespace `parameters.docs.story`.
+  Accepts parameters in the namespace `parameters.docs.toc`.
 
 </Callout>
 


### PR DESCRIPTION
Closes #33817

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## Description

Added the documentation for the table of contents. Attempted to match the formatting of other documentations. 

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Documentation only was added. No testing necessary aside from reading the docs.
-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the new TableOfContents doc block, including description and usage guidance.
  * Included an example snippet demonstrating rendering and integration.
  * Documented all public props with types and recommended defaults.
  * Updated the docs index to reference the new TableOfContents block and noted accepted namespace parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->