### PR TITLE
CI: Gate nx workflow to main repo to prevent fork runs

### DIFF
--- a/.github/workflows/nx.yml
+++ b/.github/workflows/nx.yml
@@ -21,13 +21,14 @@ env:
 jobs:
   nx:
     if: >
-      (github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        (contains(github.event.pull_request.labels.*.name, 'ci:normal') ||
-         contains(github.event.pull_request.labels.*.name, 'ci:merged') ||
-         contains(github.event.pull_request.labels.*.name, 'ci:daily'))
-      ) || (github.event_name == 'push' && github.ref == 'refs/heads/next') ||
-      (github.event_name == 'schedule')
+      github.repository == 'storybookjs/storybook' &&
+        ((github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          (contains(github.event.pull_request.labels.*.name, 'ci:normal') ||
+           contains(github.event.pull_request.labels.*.name, 'ci:merged') ||
+           contains(github.event.pull_request.labels.*.name, 'ci:daily'))
+        ) || (github.event_name == 'push' && github.ref == 'refs/heads/next') ||
+        (github.event_name == 'schedule'))
 
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Added `github.repository == 'storybookjs/storybook'` as a top-level guard to the `nx` workflow job condition. The `schedule` and `push` events were not gated to the main repository, so forks with this workflow would trigger unnecessary CI runs consuming Nx Cloud resources. Other scheduled workflows already had similar guards.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual testing necessary — this is a CI workflow condition change. Verification will happen automatically when the workflow triggers on the next push to `next` or scheduled cron run.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to incorporate repository-level validation and access controls. The workflow now includes repository name verification as part of its overall job execution conditions while preserving all existing conditional logic for pull request processing, branch-specific deployments, and regularly scheduled task automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->