### PR TITLE
A11y: Add ScrollArea prop focusable for when it has static children

### DIFF
--- a/code/core/src/components/components/ScrollArea/ScrollArea.stories.tsx
+++ b/code/core/src/components/components/ScrollArea/ScrollArea.stories.tsx
@@ -123,3 +123,37 @@ export const CustomSize = () => (
     ))}
   </ScrollArea>
 );
+
+export const FocusableVertical = () => (
+  <ScrollArea vertical focusable>
+    {list((i) => (
+      <Fragment key={i}>
+        <Block>{i}</Block>
+        <br />
+      </Fragment>
+    ))}
+  </ScrollArea>
+);
+
+export const FocusableHorizontal = () => (
+  <ScrollArea horizontal focusable>
+    <div style={{ padding: 5 }}>
+      {list((i) => (
+        <Block key={i}>{i}</Block>
+      ))}
+    </div>
+  </ScrollArea>
+);
+
+export const FocusableBoth = () => (
+  <ScrollArea horizontal vertical focusable>
+    {list((i) => (
+      <Fragment key={i}>
+        {list((ii) => (
+          <Block key={ii}>{ii * i}</Block>
+        ))}
+        <br />
+      </Fragment>
+    ))}
+  </ScrollArea>
+);

--- a/code/core/src/components/components/ScrollArea/ScrollArea.tsx
+++ b/code/core/src/components/components/ScrollArea/ScrollArea.tsx
@@ -11,6 +11,11 @@ export interface ScrollAreaProps {
   offset?: number;
   scrollbarSize?: number;
   scrollPadding?: number | string;
+  /**
+   * Set this to define a tabIndex on the scrollable content; only needed when content has no
+   * interactive elements.
+   */
+  focusable?: boolean;
 }
 
 const ScrollAreaRoot = styled(ScrollAreaPrimitive.Root)<{ scrollbarsize: number; offset: number }>(
@@ -89,11 +94,12 @@ export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
       scrollbarSize = 6,
       scrollPadding = 0,
       className,
+      focusable = false,
     },
     ref
   ) => (
     <ScrollAreaRoot scrollbarsize={scrollbarSize} offset={offset} className={className}>
-      <ScrollAreaViewport ref={ref} style={{ scrollPadding }}>
+      <ScrollAreaViewport ref={ref} style={{ scrollPadding }} tabIndex={focusable ? 0 : undefined}>
         {children}
       </ScrollAreaViewport>
       {horizontal && (

--- a/code/core/src/components/components/ScrollArea/ScrollArea.tsx
+++ b/code/core/src/components/components/ScrollArea/ScrollArea.tsx
@@ -28,10 +28,18 @@ const ScrollAreaRoot = styled(ScrollAreaPrimitive.Root)<{ scrollbarsize: number;
   })
 );
 
-const ScrollAreaViewport = styled(ScrollAreaPrimitive.Viewport)({
-  width: '100%',
-  height: '100%',
-});
+const ScrollAreaViewport = styled(ScrollAreaPrimitive.Viewport)<{ focusable: boolean }>(
+  ({ focusable, theme }) => ({
+    width: '100%',
+    height: '100%',
+    '&:focus': focusable
+      ? {
+          outline: `2px solid ${theme.color.secondary}`,
+          outlineOffset: -2,
+        }
+      : {},
+  })
+);
 
 const ScrollAreaScrollbar = styled(ScrollAreaPrimitive.Scrollbar)<{
   offset: number;
@@ -99,7 +107,12 @@ export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
     ref
   ) => (
     <ScrollAreaRoot scrollbarsize={scrollbarSize} offset={offset} className={className}>
-      <ScrollAreaViewport ref={ref} style={{ scrollPadding }} tabIndex={focusable ? 0 : undefined}>
+      <ScrollAreaViewport
+        ref={ref}
+        style={{ scrollPadding }}
+        tabIndex={focusable ? 0 : undefined}
+        focusable={focusable}
+      >
         {children}
       </ScrollAreaViewport>
       {horizontal && (

--- a/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
@@ -91,7 +91,7 @@ const Wrapper = styled.div<WrapperProps>(
 );
 
 const UnstyledScroller = ({ children, className }: ScrollAreaProps) => (
-  <ScrollArea horizontal vertical className={className}>
+  <ScrollArea horizontal vertical focusable className={className}>
     {children}
   </ScrollArea>
 );


### PR DESCRIPTION
Fixes https://www.chromatic.com/test?appId=635781f3500dd2c49e189caf&id=699774e0d5f9296fd0ff61a1&panel=accessibility-panel

## What I did

Fixed an a11y violation whereby scrollable areas cannot be reached via keyboard (https://dequeuniversity.com/rules/axe/4.10/scrollable-region-focusable?application=axeAPI / SC 2.1.1).

Added a prop for ScrollArea letting us mark it as focusable when we know our own scrollable content is entirely static (e.g. code snippets in syntax highlighter).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!NOTE]
> **YOU MUST TEST WITH FIREFOX, NOT CHROME.** Chrome makes scroll areas focusable by default.


1. Visit http://localhost:6006/?path=/story/components-scrollarea--both
2. Notice you cannot really interact with the content
3. Visit http://localhost:6006/?path=/story/components-scrollarea--focusable-both
4. Now you can tab into the scroll area and use arrow keys to navigate


### Documentation
ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ScrollArea now supports keyboard-focusable scrollable content, allowing users to tab into scroll regions and navigate with the keyboard for improved accessibility.
  * Added interactive examples showcasing focusable ScrollArea variants: vertical, horizontal, and both (bidirectional), so users can preview and test keyboard focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->