### PR TITLE
Core: Revert Pull Request #33420 from Maelryn/fix/copy-button-overlap

### DIFF
--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -38,7 +38,6 @@ const ChildrenContainer = styled.div<PreviewProps & { layout: Layout }>(
     flexWrap: 'wrap',
     overflow: 'auto',
     flexDirection: isColumn ? 'column' : 'row',
-    width: 'fit-content',
 
     '& .innerZoomElementWrapper > *': isColumn
       ? {
@@ -173,18 +172,9 @@ const PositionedToolbar = styled(Toolbar)({
   height: 40,
 });
 
-const Relative = styled.div(({ theme }) => ({
+const Relative = styled.div({
   overflow: 'hidden',
   position: 'relative',
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: theme.layoutMargin,
-}));
-
-const RelativeActionBar = styled(ActionBar)({
-  position: 'relative',
-  marginLeft: 'auto',
-  alignSelf: 'flex-end',
 });
 
 /**
@@ -288,7 +278,7 @@ export const Preview: FC<PreviewProps> = ({
               )}
             </Zoom.Element>
           </ChildrenContainer>
-          <RelativeActionBar actionItems={actionItems} />
+          <ActionBar actionItems={actionItems} />
         </Relative>
       </ZoomContext.Provider>
       {withSource && expanded && source}

--- a/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
@@ -69,9 +69,6 @@ const Wrapper = styled.div<WrapperProps>(
   ({ theme }) => ({
     position: 'relative',
     overflow: 'hidden',
-    display: 'flex',
-    flexWrap: 'wrap',
-    gap: theme.layoutMargin,
     color: theme.color.defaultText,
   }),
   ({ theme, bordered }) =>
@@ -101,16 +98,6 @@ const UnstyledScroller = ({ children, className }: ScrollAreaProps) => (
 const Scroller = styled(UnstyledScroller)(
   {
     position: 'relative',
-    width: 'fit-content',
-    maxWidth: '100%',
-    '> div': {
-      width: 'fit-content',
-      maxWidth: '100%',
-      '> div > pre': {
-        width: 'fit-content',
-        maxWidth: '100%',
-      },
-    },
   },
   ({ theme }) => themedSyntax(theme)
 );
@@ -133,15 +120,10 @@ See https://github.com/storybookjs/storybook/issues/18090
 const Code = styled.div(({ theme }) => ({
   flex: 1,
   paddingLeft: 2, // TODO: To match theming/global.ts for now
+  paddingRight: theme.layoutMargin,
   opacity: 1,
   fontFamily: theme.typography.fonts.mono,
 }));
-
-const RelativeActionBar = styled(ActionBar)({
-  position: 'relative',
-  marginLeft: 'auto',
-  alignSelf: 'flex-end',
-});
 
 const processLineNumber = (row: any) => {
   const children = [...row.children];
@@ -265,7 +247,7 @@ export const SyntaxHighlighter = ({
       </Scroller>
 
       {copyable ? (
-        <RelativeActionBar actionItems={[{ title: copied ? 'Copied' : 'Copy', onClick }]} />
+        <ActionBar actionItems={[{ title: copied ? 'Copied' : 'Copy', onClick }]} />
       ) : null}
     </Wrapper>
   );


### PR DESCRIPTION
This reverts commit ecc7fa889a1fedb789175e63bb3466b706571f02, reversing changes made to 518c70cab9787fe117e8a9d95a438a92f4b5072d.

The PR's latest commits introduced UI layout regressions I failed to catch. Let's revert it and I'll write another PR without the regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified layout styling in preview and code syntax highlighter components by removing flex constraints and width limitations for more flexible rendering.
  * Standardized action bar component implementation across components.

* **Style**
  * Adjusted horizontal padding in code syntax highlighting for improved visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->