### PR TITLE
React: Fix manifest stories empty when meta has no explicit title

### DIFF
--- a/code/renderers/react/src/componentManifest/generator.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.test.ts
@@ -575,6 +575,89 @@ test('should create component manifest when only attached-mdx docs have manifest
   `);
 });
 
+test('stories are populated when meta has no explicit title', async () => {
+  vol.fromJSON(
+    {
+      ['./package.json']: JSON.stringify({ name: 'some-package' }),
+      ['./src/stories/Card.stories.ts']: dedent`
+        import type { Meta, StoryObj } from '@storybook/react';
+        import { Card } from './Card';
+
+        const meta: Meta<typeof Card> = {
+          component: Card,
+        };
+        export default meta;
+        type Story = StoryObj<typeof meta>;
+
+        export const Default: Story = { args: { label: 'Click me' } };
+        export const Large: Story = { args: { label: 'Big button', size: 'large' } };
+      `,
+      ['./src/stories/Card.tsx']: dedent`
+        import React from 'react';
+        export interface CardProps {
+          label: string;
+          size?: 'small' | 'large';
+        }
+
+        /** A simple card component */
+        export const Card = ({ label, size }: CardProps) => {
+          return <div className={size}>{label}</div>;
+        };
+      `,
+    },
+    '/app'
+  );
+
+  const manifestEntries = [
+    {
+      type: 'story',
+      subtype: 'story',
+      id: 'card--default',
+      name: 'Default',
+      title: 'Card',
+      importPath: './src/stories/Card.stories.ts',
+      componentPath: './src/stories/Card.tsx',
+      tags: [Tag.DEV, Tag.TEST, Tag.MANIFEST],
+      exportName: 'Default',
+    },
+    {
+      type: 'story',
+      subtype: 'story',
+      id: 'card--large',
+      name: 'Large',
+      title: 'Card',
+      importPath: './src/stories/Card.stories.ts',
+      componentPath: './src/stories/Card.tsx',
+      tags: [Tag.DEV, Tag.TEST, Tag.MANIFEST],
+      exportName: 'Large',
+    },
+  ];
+
+  const result = await manifests(undefined, { manifestEntries } as any);
+  const component = result?.components?.components?.['card'];
+
+  // When no explicit title is in the meta, stories should still be populated
+  // because the generator should use the index entry's title as fallback
+  expect(component?.stories).toMatchInlineSnapshot(`
+    [
+      {
+        "description": undefined,
+        "id": "card--default",
+        "name": "Default",
+        "snippet": "const Default = () => <Card label="Click me" />;",
+        "summary": undefined,
+      },
+      {
+        "description": undefined,
+        "id": "card--large",
+        "name": "Large",
+        "snippet": "const Large = () => <Card label="Big button" size="large" />;",
+        "summary": undefined,
+      },
+    ]
+  `);
+});
+
 test('should extract story description and summary from JSDoc comments', async () => {
   const code = withCSF3(dedent`
     /**

--- a/code/renderers/react/src/componentManifest/generator.ts
+++ b/code/renderers/react/src/componentManifest/generator.ts
@@ -130,7 +130,7 @@ export const manifests: PresetPropertyFn<
             (entry as DocsIndexEntry).storiesImports[0];
       const absoluteImportPath = path.join(process.cwd(), storyFilePath);
       const storyFile = cachedReadFileSync(absoluteImportPath, 'utf-8') as string;
-      const csf = loadCsf(storyFile, { makeTitle: (title) => title ?? 'No title' }).parse();
+      const csf = loadCsf(storyFile, { makeTitle: () => entry.title }).parse();
 
       const componentName = csf._meta?.component;
       const id = entry.id.split('--')[0];


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed component manifest generating empty `stories: []` when story files don't have an explicit `title` in their meta object (the common case — Storybook auto-generates titles from file paths).

The manifest generator re-parses story files with `loadCsf()` and needs a `makeTitle` callback to compute the title. Previously, the fallback was `'No title'`, causing the CSF parser to generate wrong story IDs (e.g. `no-title--logged-in` instead of `header--logged-in`). Since `extractStories` filters by matching against the index entry IDs, none matched — resulting in empty `stories: []`.

The fix: always use `entry.title` from the story index, which was already correctly computed by the `StoryIndexGenerator` (via `userOrAutoTitleFromSpecifier`). There's no need to inspect the user's title from the file since the index already has the canonical answer.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Create a React Vite project with stories that have **no explicit `title`** in their meta (the common/default case)
2. Enable `features: { experimentalComponentsManifest: true }` in `.storybook/main.ts`
3. Run `storybook build` or `storybook dev`
4. Check `/manifests/components.json` — stories should now be populated for all components, not just those with explicit titles

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Component manifest generation now reliably falls back to the entry title when story/metadata lacks an explicit title, ensuring stable, predictable story names.

* **Tests**
  * Added tests confirming stories are populated using the entry title as a fallback when metadata has no explicit title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->