### PR TITLE
Next.js-Vite: Fix failing postcss mutation

### DIFF
--- a/code/builders/builder-vite/src/vite-config.ts
+++ b/code/builders/builder-vite/src/vite-config.ts
@@ -60,6 +60,12 @@ export async function commonConfig(
   const sbConfig: InlineConfig = {
     configFile: false,
     plugins: await pluginConfig(options),
+    root: projectRoot,
+    // Allow storybook deployed as subfolder. See https://github.com/storybookjs/builder-vite/issues/238
+    base: './',
+    ...(options.cacheKey
+      ? { cacheDir: resolvePathInStorybookCache('sb-vite', options.cacheKey) }
+      : {}),
     // Pass build.target option from user's vite config
     build: {
       target: buildProperty?.target,
@@ -72,28 +78,11 @@ export async function commonConfig(
 }
 
 export async function pluginConfig(options: Options) {
-  const projectRoot = resolve(options.configDir, '..');
-
   const plugins = [
     // Shared core plugins (resolve conditions, envPrefix, fs.allow, externals, env vars, etc.)
     ...(await corePlugins([], options)),
     await storybookExternalGlobalsPlugin(options),
     await csfPlugin(options),
-    // Builder-specific: root, base, and cacheDir
-    {
-      name: 'storybook:builder-vite-config',
-      enforce: 'pre' as const,
-      config() {
-        return {
-          root: projectRoot,
-          // Allow storybook deployed as subfolder. See https://github.com/storybookjs/builder-vite/issues/238
-          base: './',
-          ...(options.cacheKey
-            ? { cacheDir: resolvePathInStorybookCache('sb-vite', options.cacheKey) }
-            : {}),
-        };
-      },
-    },
     // Entry plugin: virtual modules for stories, addon setup, and main app entry
     ...(await storybookEntryPlugin(options)),
     // Builder-specific: webpack-compatible stats for turbosnap/chromatic


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed an issue where some vite config options, such as `root`, were not defined inline, but provided via plugins, which led to a late resolution, and other plugins, like the nextjs-vite ones, were not able to read `config.root` in time.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal build configuration management for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->