### PR TITLE
UI: Fix code/copy buttons overlap with content

### DIFF
--- a/code/addons/docs/src/blocks/components/Preview.stories.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.stories.tsx
@@ -60,7 +60,7 @@ export const ActionBarWrapping = {
     </Preview>
   ),
   globals: {
-    viewport: 'mobile1',
+    viewport: { value: 'mobile1' },
   },
 };
 

--- a/code/addons/docs/src/blocks/components/Preview.stories.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.stories.tsx
@@ -51,6 +51,19 @@ export const CodeError = () => (
   </Preview>
 );
 
+export const ActionBarWrapping = {
+  render: () => (
+    <Preview inline isExpanded withSource={sourceStories.JSX.args}>
+      <Button ariaLabel={false} variant="outline">
+        Button with long text
+      </Button>
+    </Preview>
+  ),
+  globals: {
+    viewport: 'mobile1',
+  },
+};
+
 export const Single = () => (
   <Preview inline>
     <Button ariaLabel={false} variant="outline">

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -1,9 +1,12 @@
-import type { ClipboardEvent, FC, PropsWithChildren, ReactElement, ReactNode } from 'react';
+import type { FC, PropsWithChildren, ReactElement, ReactNode } from 'react';
 import React, { Children, useCallback, useContext, useState } from 'react';
 
-import { ActionBar, Zoom } from 'storybook/internal/components';
+import { Bar, Button, ToggleButton, Zoom } from 'storybook/internal/components';
 import type { ActionItem } from 'storybook/internal/components';
 
+import { CopyIcon, MarkupIcon } from '@storybook/icons';
+
+import { useId } from '@react-aria/utils';
 import { darken } from 'polished';
 import { styled } from 'storybook/theming';
 
@@ -35,10 +38,6 @@ const ChildrenContainer = styled.div<PreviewProps & { layout: Layout }>(
   ({ isColumn, columns, layout }) => ({
     display: isColumn || !columns ? 'block' : 'flex',
     position: 'relative',
-    flex: 1,
-    flexShrink: 0,
-    flexBasis: 'fit-content',
-    maxWidth: '100%',
     flexWrap: 'wrap',
     overflow: 'auto',
     flexDirection: isColumn ? 'column' : 'row',
@@ -79,6 +78,10 @@ const ChildrenContainer = styled.div<PreviewProps & { layout: Layout }>(
       : {}
 );
 
+const ActionBar = styled(Bar)({
+  marginTop: -40,
+});
+
 const StyledSource = styled(Source)(({ theme }) => ({
   margin: 0,
   borderTopLeftRadius: 0,
@@ -102,9 +105,9 @@ const PreviewContainer = styled.div<PreviewProps>(
     overflow: 'hidden',
     margin: '25px 0 40px',
     ...getBlockBackgroundStyle(theme),
-    borderBottomLeftRadius: (withSource && isExpanded && 0) as any,
-    borderBottomRightRadius: (withSource && isExpanded && 0) as any,
-    borderBottomWidth: (isExpanded && 0) as any,
+    borderBottomLeftRadius: withSource && isExpanded ? 0 : undefined,
+    borderBottomRightRadius: withSource && isExpanded ? 0 : undefined,
+    borderBottomWidth: isExpanded ? 0 : undefined,
 
     'h3 + &': {
       marginTop: '16px',
@@ -112,51 +115,6 @@ const PreviewContainer = styled.div<PreviewProps>(
   }),
   ({ withToolbar }) => withToolbar && { paddingTop: 40 }
 );
-
-interface SourceItem {
-  source?: ReactElement | null;
-  actionItem: ActionItem;
-}
-
-const getSource = (
-  withSource: SourceProps | undefined,
-  expanded: boolean,
-  setExpanded: Function
-): SourceItem => {
-  switch (true) {
-    case !!(withSource && withSource.error): {
-      return {
-        source: null,
-        actionItem: {
-          title: 'No code available',
-          className: 'docblock-code-toggle docblock-code-toggle--disabled',
-          disabled: true,
-          onClick: () => setExpanded(false),
-        },
-      };
-    }
-    case expanded: {
-      return {
-        source: <StyledSource {...withSource} dark />,
-        actionItem: {
-          title: 'Hide code',
-          className: 'docblock-code-toggle docblock-code-toggle--expanded',
-          onClick: () => setExpanded(false),
-        },
-      };
-    }
-    default: {
-      return {
-        source: <StyledSource {...withSource} dark />,
-        actionItem: {
-          title: 'Show code',
-          className: 'docblock-code-toggle',
-          onClick: () => setExpanded(true),
-        },
-      };
-    }
-  }
-};
 
 function getChildProps(children: ReactNode) {
   if (Children.count(children) === 1) {
@@ -176,11 +134,7 @@ const PositionedToolbar = styled(Toolbar)({
   height: 40,
 });
 
-const ActionBarContainer = styled.div({
-  overflow: 'hidden',
-  display: 'flex',
-  flexWrap: 'wrap',
-});
+const COPIED_LABEL_ANIMATION_DURATION = 2000;
 
 /**
  * A preview component for showing one or more component `Story` items. The preview also shows the
@@ -201,74 +155,53 @@ export const Preview: FC<PreviewProps> = ({
   ...props
 }) => {
   const [expanded, setExpanded] = useState(isExpanded);
-  const { source, actionItem } = getSource(withSource, expanded, setExpanded);
+  const [copied, setCopied] = useState(false);
   const [scale, setScale] = useState(1);
-  const previewClasses = [className].concat(['sbdocs', 'sbdocs-preview', 'sb-unstyled']);
-
-  const defaultActionItems = withSource ? [actionItem] : [];
-  const [additionalActionItems, setAdditionalActionItems] = useState(
+  const [additionalActionItems] = useState<ActionItem[]>(
     additionalActions ? [...additionalActions] : []
   );
-  const actionItems = [...defaultActionItems, ...additionalActionItems];
-
-  const { window: globalWindow } = globalThis;
+  const sourceId = useId();
+  const previewClasses = [className].concat(['sbdocs', 'sbdocs-preview', 'sb-unstyled']);
 
   const context = useContext(DocsContext);
 
   const copyToClipboard = useCallback(async (text: string) => {
     const { createCopyToClipboardFunction } = await import('storybook/internal/components');
-    createCopyToClipboardFunction();
+    await createCopyToClipboardFunction()(text);
   }, []);
 
-  const onCopyCapture = (e: ClipboardEvent<HTMLInputElement>) => {
-    // When the selection range is neither empty nor collapsed, we can assume
-    // user's intention is to copy the selected text, instead of the story's
-    // code snippet.
-    const selection: Selection | null = globalWindow.getSelection();
-    if (selection && selection.type === 'Range') {
+  const handleCopyCode = useCallback(() => {
+    if (copied) {
       return;
     }
-
-    e.preventDefault();
-    if (additionalActionItems.filter((item) => item.title === 'Copied').length === 0) {
-      copyToClipboard(source?.props.code ?? '').then(() => {
-        setAdditionalActionItems([
-          ...additionalActionItems,
-          {
-            title: 'Copied',
-            onClick: () => {},
-          },
-        ]);
-        globalWindow.setTimeout(
-          () =>
-            setAdditionalActionItems(
-              additionalActionItems.filter((item) => item.title !== 'Copied')
-            ),
-          1500
-        );
-      });
-    }
-  };
+    copyToClipboard(withSource?.code ?? '').then(() => {
+      setCopied(true);
+      globalThis.window.setTimeout(() => setCopied(false), COPIED_LABEL_ANIMATION_DURATION);
+    });
+  }, [copied, copyToClipboard, withSource?.code]);
 
   const childProps = getChildProps(children);
 
+  const hasSourceError = !!(withSource && withSource.error);
+  const hasValidSource = !!(withSource && !withSource.error);
+
   return (
-    <PreviewContainer
-      {...{ withSource, withToolbar }}
-      {...props}
-      className={previewClasses.join(' ')}
-    >
-      {withToolbar && (
-        <PositionedToolbar
-          isLoading={isLoading}
-          border
-          zoom={(z: number) => setScale(scale * z)}
-          resetZoom={() => setScale(1)}
-          storyId={!isLoading && childProps ? getStoryId(childProps, context) : undefined}
-        />
-      )}
-      <ZoomContext.Provider value={{ scale }}>
-        <ActionBarContainer className="docs-story" onCopyCapture={withSource && onCopyCapture}>
+    <>
+      <PreviewContainer
+        {...{ withSource, withToolbar }}
+        {...props}
+        className={previewClasses.join(' ')}
+      >
+        {withToolbar && (
+          <PositionedToolbar
+            isLoading={isLoading}
+            border
+            zoom={(z: number) => setScale(scale * z)}
+            resetZoom={() => setScale(1)}
+            storyId={!isLoading && childProps ? getStoryId(childProps, context) : undefined}
+          />
+        )}
+        <ZoomContext.Provider value={{ scale }}>
           <ChildrenContainer
             isColumn={isColumn || !Array.isArray(children)}
             columns={columns}
@@ -283,11 +216,55 @@ export const Preview: FC<PreviewProps> = ({
               )}
             </Zoom.Element>
           </ChildrenContainer>
-          <ActionBar actionItems={actionItems} flexLayout />
-        </ActionBarContainer>
-      </ZoomContext.Provider>
-      {withSource && expanded && source}
-    </PreviewContainer>
+        </ZoomContext.Provider>
+        {hasValidSource && expanded && (
+          <div id={sourceId}>
+            <StyledSource {...withSource} dark copyable={false} />
+          </div>
+        )}
+      </PreviewContainer>
+      {(withSource || additionalActionItems.length > 0) && (
+        <ActionBar className="sbdocs sbdocs-preview-actions">
+          {hasSourceError && (
+            <Button
+              disabled
+              variant="ghost"
+              className="docblock-code-toggle docblock-code-toggle--disabled"
+            >
+              <MarkupIcon /> No code available
+            </Button>
+          )}
+          {hasValidSource && (
+            <>
+              <ToggleButton
+                pressed={expanded}
+                aria-expanded={expanded}
+                aria-controls={sourceId}
+                onClick={() => setExpanded(!expanded)}
+                variant="ghost"
+                className={`docblock-code-toggle${expanded ? ' docblock-code-toggle--expanded' : ''}`}
+              >
+                <MarkupIcon /> {expanded ? 'Hide code' : 'Show code'}
+              </ToggleButton>
+              <Button variant="ghost" onClick={handleCopyCode}>
+                <CopyIcon /> {copied ? 'Copied!' : 'Copy code'}
+              </Button>
+            </>
+          )}
+          {additionalActionItems.map(({ title, className, onClick, disabled }, index: number) => (
+            <Button
+              key={index}
+              className={className}
+              onClick={onClick}
+              disabled={!!disabled}
+              variant="ghost"
+            >
+              {title}
+            </Button>
+          ))}
+        </ActionBar>
+      )}
+    </>
   );
 };
 

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -1,6 +1,7 @@
 import type { FC, PropsWithChildren, ReactElement, ReactNode } from 'react';
-import React, { Children, useCallback, useContext, useState } from 'react';
+import React, { Children, useCallback, useContext, useMemo, useState } from 'react';
 
+import { logger } from 'storybook/internal/client-logger';
 import { Bar, Button, ToggleButton, Zoom } from 'storybook/internal/components';
 import type { ActionItem } from 'storybook/internal/components';
 
@@ -155,10 +156,11 @@ export const Preview: FC<PreviewProps> = ({
   ...props
 }) => {
   const [expanded, setExpanded] = useState(isExpanded);
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
   const [scale, setScale] = useState(1);
-  const [additionalActionItems] = useState<ActionItem[]>(
-    additionalActions ? [...additionalActions] : []
+  const additionalActionItems = useMemo(
+    () => (additionalActions ? [...additionalActions] : []),
+    [additionalActions]
   );
   const sourceId = useId();
   const previewClasses = [className].concat(['sbdocs', 'sbdocs-preview', 'sb-unstyled']);
@@ -170,15 +172,17 @@ export const Preview: FC<PreviewProps> = ({
     await createCopyToClipboardFunction()(text);
   }, []);
 
-  const handleCopyCode = useCallback(() => {
-    if (copied) {
-      return;
+  const handleCopyCode = useCallback(async () => {
+    try {
+      await copyToClipboard(withSource?.code ?? '');
+      setCopied('Copied!');
+    } catch (err) {
+      logger.error(err);
+      setCopied('Copy error!');
     }
-    copyToClipboard(withSource?.code ?? '').then(() => {
-      setCopied(true);
-      globalThis.window.setTimeout(() => setCopied(false), COPIED_LABEL_ANIMATION_DURATION);
-    });
-  }, [copied, copyToClipboard, withSource?.code]);
+
+    globalThis.window.setTimeout(() => setCopied(null), COPIED_LABEL_ANIMATION_DURATION);
+  }, [copyToClipboard, withSource?.code]);
 
   const childProps = getChildProps(children);
 
@@ -227,6 +231,7 @@ export const Preview: FC<PreviewProps> = ({
         <ActionBar className="sbdocs sbdocs-preview-actions" innerStyle={{ paddingInline: 0 }}>
           {hasSourceError && (
             <Button
+              ariaLabel={false}
               disabled
               variant="ghost"
               className="docblock-code-toggle docblock-code-toggle--disabled"
@@ -237,6 +242,7 @@ export const Preview: FC<PreviewProps> = ({
           {hasValidSource && (
             <>
               <ToggleButton
+                ariaLabel={false}
                 pressed={expanded}
                 aria-expanded={expanded}
                 aria-controls={sourceId}
@@ -246,8 +252,8 @@ export const Preview: FC<PreviewProps> = ({
               >
                 <MarkupIcon /> {expanded ? 'Hide code' : 'Show code'}
               </ToggleButton>
-              <Button variant="ghost" onClick={handleCopyCode}>
-                <CopyIcon /> {copied ? 'Copied!' : 'Copy code'}
+              <Button ariaLabel={false} variant="ghost" onClick={handleCopyCode}>
+                <CopyIcon /> {copied ?? 'Copy code'}
               </Button>
             </>
           )}

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -208,6 +208,7 @@ export const Preview: FC<PreviewProps> = ({
             columns={columns}
             layout={layout}
             inline={inline}
+            className="docs-story"
           >
             <Zoom.Element centered={layout === 'centered'} scale={inline ? scale : 1}>
               {Array.isArray(children) ? (

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -35,6 +35,10 @@ const ChildrenContainer = styled.div<PreviewProps & { layout: Layout }>(
   ({ isColumn, columns, layout }) => ({
     display: isColumn || !columns ? 'block' : 'flex',
     position: 'relative',
+    flex: 1,
+    flexShrink: 0,
+    flexBasis: 'fit-content',
+    maxWidth: '100%',
     flexWrap: 'wrap',
     overflow: 'auto',
     flexDirection: isColumn ? 'column' : 'row',
@@ -172,9 +176,10 @@ const PositionedToolbar = styled(Toolbar)({
   height: 40,
 });
 
-const Relative = styled.div({
+const ActionBarContainer = styled.div({
   overflow: 'hidden',
-  position: 'relative',
+  display: 'flex',
+  flexWrap: 'wrap',
 });
 
 /**
@@ -263,7 +268,7 @@ export const Preview: FC<PreviewProps> = ({
         />
       )}
       <ZoomContext.Provider value={{ scale }}>
-        <Relative className="docs-story" onCopyCapture={withSource && onCopyCapture}>
+        <ActionBarContainer className="docs-story" onCopyCapture={withSource && onCopyCapture}>
           <ChildrenContainer
             isColumn={isColumn || !Array.isArray(children)}
             columns={columns}
@@ -278,8 +283,8 @@ export const Preview: FC<PreviewProps> = ({
               )}
             </Zoom.Element>
           </ChildrenContainer>
-          <ActionBar actionItems={actionItems} />
-        </Relative>
+          <ActionBar actionItems={actionItems} flexLayout />
+        </ActionBarContainer>
       </ZoomContext.Provider>
       {withSource && expanded && source}
     </PreviewContainer>

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -81,6 +81,7 @@ const ChildrenContainer = styled.div<PreviewProps & { layout: Layout }>(
 
 const ActionBar = styled(Bar)({
   marginTop: -40,
+  marginBottom: 40,
 });
 
 const StyledSource = styled(Source)(({ theme }) => ({

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -224,7 +224,7 @@ export const Preview: FC<PreviewProps> = ({
         )}
       </PreviewContainer>
       {(withSource || additionalActionItems.length > 0) && (
-        <ActionBar className="sbdocs sbdocs-preview-actions">
+        <ActionBar className="sbdocs sbdocs-preview-actions" innerStyle={{ paddingInline: 0 }}>
           {hasSourceError && (
             <Button
               disabled

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -101,15 +101,11 @@ const StyledSource = styled(Source)(({ theme }) => ({
 }));
 
 const PreviewContainer = styled.div<PreviewProps>(
-  ({ theme, withSource, isExpanded }) => ({
+  ({ theme }) => ({
     position: 'relative',
     overflow: 'hidden',
     margin: '25px 0 40px',
     ...getBlockBackgroundStyle(theme),
-    borderBottomLeftRadius: withSource && isExpanded ? 0 : undefined,
-    borderBottomRightRadius: withSource && isExpanded ? 0 : undefined,
-    borderBottomWidth: isExpanded ? 0 : undefined,
-
     'h3 + &': {
       marginTop: '16px',
     },

--- a/code/addons/docs/src/blocks/components/Source.tsx
+++ b/code/addons/docs/src/blocks/components/Source.tsx
@@ -44,8 +44,8 @@ export interface SourceCodeProps {
   /** The formatter the syntax highlighter uses for your story’s code. */
   format?: ComponentProps<typeof SyntaxHighlighter>['format'];
   /** Display the source snippet in a dark mode. */
-  dark?: boolean;
-}
+  dark?: boolean;  /** Whether to show the copy button. Defaults to true. */
+  copyable?: boolean;}
 
 export interface SourceProps extends SourceCodeProps {
   isLoading?: boolean;
@@ -91,6 +91,7 @@ const Source: FunctionComponent<SourceProps> = ({
   code,
   dark,
   format = true,
+  copyable = true,
   ...rest
 }) => {
   const { typography } = useTheme();
@@ -104,7 +105,7 @@ const Source: FunctionComponent<SourceProps> = ({
   const syntaxHighlighter = (
     <StyledSyntaxHighlighter
       bordered
-      copyable
+      copyable={copyable}
       format={format}
       language={language ?? 'jsx'}
       className="docblock-source sb-unstyled"

--- a/code/addons/docs/src/blocks/components/Source.tsx
+++ b/code/addons/docs/src/blocks/components/Source.tsx
@@ -44,8 +44,10 @@ export interface SourceCodeProps {
   /** The formatter the syntax highlighter uses for your story’s code. */
   format?: ComponentProps<typeof SyntaxHighlighter>['format'];
   /** Display the source snippet in a dark mode. */
-  dark?: boolean;  /** Whether to show the copy button. Defaults to true. */
-  copyable?: boolean;}
+  dark?: boolean;
+  /** Whether to show the copy button. Defaults to true. */
+  copyable?: boolean;
+}
 
 export interface SourceProps extends SourceCodeProps {
   isLoading?: boolean;

--- a/code/addons/docs/src/blocks/examples/ButtonSomeAutodocs.stories.tsx
+++ b/code/addons/docs/src/blocks/examples/ButtonSomeAutodocs.stories.tsx
@@ -28,6 +28,11 @@ export const Secondary: Story = {
   args: {
     label: 'Button',
   },
+  globals: {
+    backgrounds: {
+      grid: true,
+    },
+  },
 };
 
 export const ForcedBgLight: Story = {

--- a/code/core/src/backgrounds/decorator.ts
+++ b/code/core/src/backgrounds/decorator.ts
@@ -34,8 +34,14 @@ export const withBackgroundAndGrid: DecoratorFunction = (StoryFn, context) => {
   const showGrid = typeof data === 'string' ? false : data.grid || false;
   const shownBackground = !!item && !disable;
 
-  const backgroundSelector = viewMode === 'docs' ? `#anchor--${id} .docs-story` : '.sb-show-main';
-  const gridSelector = viewMode === 'docs' ? `#anchor--${id} .docs-story` : '.sb-show-main';
+  const backgroundSelector =
+    viewMode === 'docs'
+      ? `#anchor--${id} .docs-story, #anchor--primary--${id} .docs-story`
+      : '.sb-show-main';
+  const gridSelector =
+    viewMode === 'docs'
+      ? `#anchor--${id} .docs-story, #anchor--primary--${id} .docs-story`
+      : '.sb-show-main';
 
   const isLayoutPadded = parameters.layout === undefined || parameters.layout === 'padded';
   const defaultOffset = viewMode === 'docs' ? 20 : isLayoutPadded ? 16 : 0;

--- a/code/core/src/components/components/ActionBar/ActionBar.stories.tsx
+++ b/code/core/src/components/components/ActionBar/ActionBar.stories.tsx
@@ -27,6 +27,9 @@ export default {
       </div>
     ),
   ],
+  args: {
+    sb11FlexLayout: true,
+  },
 };
 
 export const SingleItem = () => <ActionBar actionItems={[{ title: 'Clear', onClick: action1 }]} />;

--- a/code/core/src/components/components/ActionBar/ActionBar.stories.tsx
+++ b/code/core/src/components/components/ActionBar/ActionBar.stories.tsx
@@ -27,9 +27,6 @@ export default {
       </div>
     ),
   ],
-  args: {
-    sb11FlexLayout: true,
-  },
 };
 
 export const SingleItem = () => <ActionBar actionItems={[{ title: 'Clear', onClick: action1 }]} />;

--- a/code/core/src/components/components/ActionBar/ActionBar.tsx
+++ b/code/core/src/components/components/ActionBar/ActionBar.tsx
@@ -3,15 +3,25 @@ import React from 'react';
 
 import { styled } from 'storybook/theming';
 
-const Container = styled.div(({ theme }) => ({
-  position: 'absolute',
-  bottom: 0,
-  right: 0,
-  maxWidth: '100%',
-  display: 'flex',
-  background: theme.background.content,
-  zIndex: 1,
-}));
+const Container = styled.div<{ $flexLayout?: boolean }>(({ theme, $flexLayout = false }) => [
+  {
+    background: theme.background.content,
+  },
+  $flexLayout
+    ? {
+        display: 'inline-flex',
+        marginInlineStart: 'auto',
+        alignSelf: 'flex-end',
+      }
+    : {
+        position: 'absolute',
+        bottom: 0,
+        right: 0,
+        maxWidth: '100%',
+        display: 'flex',
+        zIndex: 1,
+      },
+]);
 
 export const ActionButton = styled.button<{ disabled: boolean }>(
   ({ theme }) => ({
@@ -67,15 +77,23 @@ export interface ActionItem {
 }
 
 export interface ActionBarProps {
+  /** Items to render in this ActionBar. */
   actionItems: ActionItem[];
+  /**
+   * When true, ActionBar aligns to the flex end and inline end of a wrapping row flex container.
+   * When false, ActionBar is positioned absolutely at the bottom right of its relative parent.
+   */
+  flexLayout?: boolean;
 }
 
-export const ActionBar = ({ actionItems, ...props }: ActionBarProps) => (
-  <Container {...props}>
-    {actionItems.map(({ title, className, onClick, disabled }, index: number) => (
-      <ActionButton key={index} className={className} onClick={onClick} disabled={!!disabled}>
-        {title}
-      </ActionButton>
-    ))}
-  </Container>
-);
+export const ActionBar = ({ actionItems, flexLayout = false, ...props }: ActionBarProps) => {
+  return (
+    <Container {...props} $flexLayout={flexLayout}>
+      {actionItems.map(({ title, className, onClick, disabled }, index: number) => (
+        <ActionButton key={index} className={className} onClick={onClick} disabled={!!disabled}>
+          {title}
+        </ActionButton>
+      ))}
+    </Container>
+  );
+};

--- a/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
@@ -68,6 +68,8 @@ export interface WrapperProps {
 const Wrapper = styled.div<WrapperProps>(
   ({ theme }) => ({
     position: 'relative',
+    display: 'flex',
+    flexWrap: 'wrap',
     overflow: 'hidden',
     color: theme.color.defaultText,
   }),
@@ -97,7 +99,10 @@ const UnstyledScroller = ({ children, className }: ScrollAreaProps) => (
 );
 const Scroller = styled(UnstyledScroller)(
   {
-    position: 'relative',
+    flex: 1,
+    flexShrink: 0,
+    flexBasis: 'fit-content',
+    maxWidth: '100%',
   },
   ({ theme }) => themedSyntax(theme)
 );
@@ -247,7 +252,7 @@ export const SyntaxHighlighter = ({
       </Scroller>
 
       {copyable ? (
-        <ActionBar actionItems={[{ title: copied ? 'Copied' : 'Copy', onClick }]} />
+        <ActionBar actionItems={[{ title: copied ? 'Copied' : 'Copy', onClick }]} flexLayout />
       ) : null}
     </Wrapper>
   );

--- a/docs/_snippets/storybook-addon-use-global.md
+++ b/docs/_snippets/storybook-addon-use-global.md
@@ -21,7 +21,7 @@ export const withGlobals = (StoryFn: StoryFunction<Renderer>, context: StoryCont
   const isInDocs = context.viewMode === 'docs';
 
   const outlineStyles = useMemo(() => {
-    const selector = isInDocs ? `#anchor--${context.id} .docs-story` : '.sb-show-main';
+    const selector = isInDocs ? `#anchor--${context.id} .docs-story, #anchor--primary--${context.id} .docs-story` : '.sb-show-main';
 
     return outlineCSS(selector);
   }, [context.id]);


### PR DESCRIPTION
Closes #23642

This is the proper fix for the PR I had to revert earlier today (https://github.com/storybookjs/storybook/pull/33877).

## What I did

Implemented the [following design changes](https://www.figma.com/design/7M5y4W56hqBJBrowKqgZSN/Move-the-%22Code%22-button-2026?node-id=0-1&p=f&t=AujbCtkFOGvZGZcz-0):
* Reworked the styling and position of Preview actions
* Moved the code copy button up into Preview actions
* Fixed up other use cases of SyntaxHighlighter to have a flex-wrap layout where the copy button is guaranteed not to overlap with content

## Checklist for Contributors

### Testing

A story was added to showcase the wrapping in preview.

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Open Storybook, go to preview stories
2. Play around with container width

### Documentation
ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New mobile preview example showcasing long-button wrapping
  * Added opt-in copyable control for source blocks
  * Action bar flexible layout mode for alternative positioning

* **Bug Fixes**
  * Copy-to-clipboard shows "Copied!" confirmation
  * Disabled copy UI when no code is available

* **Improvements**
  * Simplified source rendering and expanded/error handling
  * Improved accessibility attributes and toolbar behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->