### PR TITLE
Fix #33874: [Bug]: @storybook/builder-vite duplicates postcss plugins du

### DIFF
--- a/code/builders/builder-vite/src/build.ts
+++ b/code/builders/builder-vite/src/build.ts
@@ -46,8 +46,7 @@ export async function build(options: Options) {
   finalConfig.plugins?.push({
     name: 'storybook:enforce-output-dir',
     enforce: 'post',
-    config: (config) => ({
-      ...config,
+    config: () => ({
       build: {
         outDir: options.outputDir,
       },


### PR DESCRIPTION
Fixes #33874

## Summary
This PR fixes: [Bug]: @storybook/builder-vite duplicates postcss plugins during config resolution

## Changes
```
code/builders/builder-vite/src/build.ts | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Vite builder plugin configuration handling to modify how the output directory setting is applied during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->