### PR TITLE
Fix #33854: [Bug]: eslint 10 support

### DIFF
--- a/code/lib/eslint-plugin/src/rules/meta-satisfies-type.ts
+++ b/code/lib/eslint-plugin/src/rules/meta-satisfies-type.ts
@@ -33,7 +33,7 @@ export default createStorybookRule({
 
   create(context) {
     // variables should be defined here
-    const sourceCode = context.getSourceCode();
+    const sourceCode = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/code/lib/eslint-plugin/src/rules/no-title-property-in-meta.ts
+++ b/code/lib/eslint-plugin/src/rules/no-title-property-in-meta.ts
@@ -51,7 +51,7 @@ export default createStorybookRule({
               {
                 messageId: 'removeTitleInMeta',
                 fix(fixer) {
-                  const fullText = context.getSourceCode().text;
+                  const fullText = context.sourceCode.text;
                   const propertyTextWithExtraCharacter = fullText.slice(
                     titleNode.range[0],
                     titleNode.range[1] + 1

--- a/code/lib/eslint-plugin/src/rules/prefer-pascal-case.ts
+++ b/code/lib/eslint-plugin/src/rules/prefer-pascal-case.ts
@@ -91,7 +91,7 @@ export default createStorybookRule({
             {
               messageId: 'convertToPascalCase',
               *fix(fixer) {
-                const fullText = context.getSourceCode().text;
+                const fullText = context.sourceCode.text;
                 const fullName = fullText.slice(id.range[0], id.range[1]);
                 const suffix = fullName.substring(name.length);
                 const pascal = toPascalCase(name);

--- a/code/lib/eslint-plugin/src/rules/use-storybook-testing-library.ts
+++ b/code/lib/eslint-plugin/src/rules/use-storybook-testing-library.ts
@@ -68,7 +68,7 @@ export default createStorybookRule({
       //
       // import foo, { bar } from 'baz';
       //        ^        ^ end
-      const fullText = context.getSourceCode().text;
+      const fullText = context.sourceCode.text;
       const importEnd = node.range[1];
       const closingBrace = fullText.indexOf('}', end - 1);
       if (closingBrace > -1 && closingBrace <= importEnd) {


### PR DESCRIPTION
Fixes #33854

## Summary
This PR fixes: [Bug]: eslint 10 support

## Changes
```
code/lib/eslint-plugin/src/rules/meta-satisfies-type.ts           | 2 +-
 code/lib/eslint-plugin/src/rules/no-title-property-in-meta.ts     | 2 +-
 code/lib/eslint-plugin/src/rules/prefer-pascal-case.ts            | 2 +-
 code/lib/eslint-plugin/src/rules/use-storybook-testing-library.ts | 2 +-
 4 files changed, 4 insertions(+), 4 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code patterns for improved consistency and maintainability. No behavioral changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->