### PR TITLE
Storybook React Native Web: Issue with Testing addon

### DIFF
--- a/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
@@ -67,6 +67,24 @@ describe('Yarn 2 Proxy', () => {
         })
       );
     });
+
+    it('should use `yarn dlx` when useRemotePkg is true', async () => {
+      const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({
+        stdout: '',
+      } as any);
+
+      await yarn2Proxy.runPackageCommand({
+        args: ['storybook@latest', 'automigrate'],
+        useRemotePkg: true,
+      });
+
+      expect(executeCommandSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          command: 'yarn',
+          args: ['dlx', 'storybook@latest', 'automigrate'],
+        })
+      );
+    });
   });
 
   describe('addDependencies', () => {

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.ts
@@ -100,11 +100,15 @@ export class Yarn2Proxy extends JsPackageManager {
 
   public runPackageCommand({
     args,
+    useRemotePkg = false,
     ...options
-  }: Omit<ExecuteCommandOptions, 'command'> & { args: string[] }): ResultPromise {
+  }: Omit<ExecuteCommandOptions, 'command'> & {
+    args: string[];
+    useRemotePkg?: boolean;
+  }): ResultPromise {
     return executeCommand({
       command: 'yarn',
-      args: ['exec', ...args],
+      args: [useRemotePkg ? 'dlx' : 'exec', ...args],
       ...options,
     });
   }


### PR DESCRIPTION
Fixes #33844

## Summary
This PR fixes: [Bug]: Storybook React Native Web - Issue with Testing addons installation

## Changes
```
.../src/common/js-package-manager/Yarn2Proxy.test.ts   | 18 ++++++++++++++++++
 code/core/src/common/js-package-manager/Yarn2Proxy.ts  |  8 ++++++--
 2 files changed, 24 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an optional flag to enable remote package execution through yarn's dlx subcommand, while maintaining backward compatibility with the default execution method.

* **Tests**
  * Added test coverage validating remote package execution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->