### PR TITLE
Vite: Use vite hook filter for performance improvements

### DIFF
--- a/code/addons/docs/src/mdx-plugin.ts
+++ b/code/addons/docs/src/mdx-plugin.ts
@@ -26,31 +26,36 @@ export async function mdxPlugin(options: Options): Promise<Plugin> {
   return {
     name: 'storybook:mdx-plugin',
     enforce: 'pre',
-    async transform(src, id) {
-      if (!filter(id)) {
-        return undefined;
-      }
+    transform: {
+      filter: {
+        id: include,
+      },
+      async handler(src, id) {
+        if (!filter(id)) {
+          return undefined;
+        }
 
-      const mdxLoaderOptions: CompileOptions = await presets.apply('mdxLoaderOptions', {
-        ...mdxPluginOptions,
-        mdxCompileOptions: {
-          providerImportSource: import.meta.resolve('@storybook/addon-docs/mdx-react-shim'),
-          ...mdxPluginOptions?.mdxCompileOptions,
-          rehypePlugins: [
-            ...(mdxPluginOptions?.mdxCompileOptions?.rehypePlugins ?? []),
-            rehypeSlug,
-            rehypeExternalLinks,
-          ],
-        },
-      });
+        const mdxLoaderOptions: CompileOptions = await presets.apply('mdxLoaderOptions', {
+          ...mdxPluginOptions,
+          mdxCompileOptions: {
+            providerImportSource: import.meta.resolve('@storybook/addon-docs/mdx-react-shim'),
+            ...mdxPluginOptions?.mdxCompileOptions,
+            rehypePlugins: [
+              ...(mdxPluginOptions?.mdxCompileOptions?.rehypePlugins ?? []),
+              rehypeSlug,
+              rehypeExternalLinks,
+            ],
+          },
+        });
 
-      const code = String(await compile(src, mdxLoaderOptions));
+        const code = String(await compile(src, mdxLoaderOptions));
 
-      return {
-        code,
-        // TODO: support source maps
-        map: null,
-      };
+        return {
+          code,
+          // TODO: support source maps
+          map: null,
+        };
+      },
     },
   };
 }

--- a/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
@@ -17,12 +17,19 @@ import {
   getResolvedVirtualModuleId,
 } from '../virtual-file-names';
 
+const escapeRegExp = (str: string) => str.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+
 export function codeGeneratorPlugin(options: Options): Plugin {
   const iframePath = fileURLToPath(importMetaResolve('@storybook/builder-vite/input/iframe.html'));
   let iframeId: string;
   let projectRoot: string;
   const storyIndexGeneratorPromise: Promise<StoryIndexGenerator> =
     options.presets.apply<StoryIndexGenerator>('storyIndexGenerator');
+
+  const resolveIdFilter = [
+    ...SB_VIRTUAL_FILE_IDS.map((id) => new RegExp(escapeRegExp(id))),
+    new RegExp(escapeRegExp(iframePath)),
+  ];
 
   return {
     name: 'storybook:code-generator-plugin',
@@ -56,37 +63,43 @@ export function codeGeneratorPlugin(options: Options): Plugin {
       projectRoot = config.root;
       iframeId = `${config.root}/iframe.html`;
     },
-    resolveId(source) {
-      if (SB_VIRTUAL_FILE_IDS.includes(source)) {
-        return getResolvedVirtualModuleId(source);
-      }
-      if (source === iframePath) {
-        return iframeId;
-      }
+    resolveId: {
+      filter: { id: resolveIdFilter },
+      handler(source) {
+        if (SB_VIRTUAL_FILE_IDS.includes(source)) {
+          return getResolvedVirtualModuleId(source);
+        }
+        if (source === iframePath) {
+          return iframeId;
+        }
 
-      return undefined;
+        return undefined;
+      },
     },
-    async load(id) {
-      switch (id) {
-        case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_STORIES_FILE): {
-          const storyIndexGenerator = await storyIndexGeneratorPromise;
-          const index = await storyIndexGenerator?.getIndex();
-          return generateImportFnScriptCode(index);
-        }
+    load: {
+      filter: { id: /\0virtual:\/@storybook\/builder-vite\// },
+      async handler(id) {
+        switch (id) {
+          case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_STORIES_FILE): {
+            const storyIndexGenerator = await storyIndexGeneratorPromise;
+            const index = await storyIndexGenerator?.getIndex();
+            return generateImportFnScriptCode(index);
+          }
 
-        case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_ADDON_SETUP_FILE): {
-          return generateAddonSetupCode();
+          case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_ADDON_SETUP_FILE): {
+            return generateAddonSetupCode();
+          }
+          case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_APP_FILE): {
+            return generateModernIframeScriptCode(options, projectRoot);
+          }
+          case iframeId: {
+            return readFileSync(
+              fileURLToPath(importMetaResolve('@storybook/builder-vite/input/iframe.html')),
+              'utf-8'
+            );
+          }
         }
-        case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_APP_FILE): {
-          return generateModernIframeScriptCode(options, projectRoot);
-        }
-        case iframeId: {
-          return readFileSync(
-            fileURLToPath(importMetaResolve('@storybook/builder-vite/input/iframe.html')),
-            'utf-8'
-          );
-        }
-      }
+      },
     },
     async transformIndexHtml(html, ctx) {
       if (ctx.path !== '/iframe.html') {

--- a/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
@@ -76,30 +76,27 @@ export function codeGeneratorPlugin(options: Options): Plugin {
         return undefined;
       },
     },
-    load: {
-      filter: { id: /\0virtual:\/@storybook\/builder-vite\// },
-      async handler(id) {
-        switch (id) {
-          case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_STORIES_FILE): {
-            const storyIndexGenerator = await storyIndexGeneratorPromise;
-            const index = await storyIndexGenerator?.getIndex();
-            return generateImportFnScriptCode(index);
-          }
-
-          case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_ADDON_SETUP_FILE): {
-            return generateAddonSetupCode();
-          }
-          case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_APP_FILE): {
-            return generateModernIframeScriptCode(options, projectRoot);
-          }
-          case iframeId: {
-            return readFileSync(
-              fileURLToPath(importMetaResolve('@storybook/builder-vite/input/iframe.html')),
-              'utf-8'
-            );
-          }
+    async load(id) {
+      switch (id) {
+        case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_STORIES_FILE): {
+          const storyIndexGenerator = await storyIndexGeneratorPromise;
+          const index = await storyIndexGenerator?.getIndex();
+          return generateImportFnScriptCode(index);
         }
-      },
+
+        case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_ADDON_SETUP_FILE): {
+          return generateAddonSetupCode();
+        }
+        case getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_APP_FILE): {
+          return generateModernIframeScriptCode(options, projectRoot);
+        }
+        case iframeId: {
+          return readFileSync(
+            fileURLToPath(importMetaResolve('@storybook/builder-vite/input/iframe.html')),
+            'utf-8'
+          );
+        }
+      }
     },
     async transformIndexHtml(html, ctx) {
       if (ctx.path !== '/iframe.html') {

--- a/code/builders/builder-vite/src/plugins/external-globals-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/external-globals-plugin.ts
@@ -42,6 +42,9 @@ export async function externalGlobalsPlugin(externals: Record<string, string>): 
   await init;
   const { mergeAlias } = await import('vite');
 
+  const globalsList = Object.keys(externals);
+  const globalsCodeFilter = new RegExp(globalsList.map(escapeKeys).join('|'));
+
   return {
     name: 'storybook:external-globals-plugin',
     enforce: 'post',
@@ -75,28 +78,29 @@ export async function externalGlobalsPlugin(externals: Record<string, string>): 
       };
     },
     // Replace imports with variables destructured from global scope
-    async transform(code: string, id: string) {
-      const globalsList = Object.keys(externals);
-
-      if (globalsList.every((glob) => !code.includes(glob))) {
-        return undefined;
-      }
-
-      const [imports] = parse(code);
-      const src = new MagicString(code);
-      imports.forEach(({ n: path, ss: startPosition, se: endPosition }) => {
-        const packageName = path;
-        if (packageName && globalsList.includes(packageName)) {
-          const importStatement = src.slice(startPosition, endPosition);
-          const transformedImport = rewriteImport(importStatement, externals, packageName);
-          src.update(startPosition, endPosition, transformedImport);
+    transform: {
+      filter: { code: globalsCodeFilter },
+      async handler(code: string, id: string) {
+        if (globalsList.every((glob) => !code.includes(glob))) {
+          return undefined;
         }
-      });
 
-      return {
-        code: src.toString(),
-        map: null,
-      };
+        const [imports] = parse(code);
+        const src = new MagicString(code);
+        imports.forEach(({ n: path, ss: startPosition, se: endPosition }) => {
+          const packageName = path;
+          if (packageName && globalsList.includes(packageName)) {
+            const importStatement = src.slice(startPosition, endPosition);
+            const transformedImport = rewriteImport(importStatement, externals, packageName);
+            src.update(startPosition, endPosition, transformedImport);
+          }
+        });
+
+        return {
+          code: src.toString(),
+          map: null,
+        };
+      },
     },
   } satisfies Plugin;
 }

--- a/code/builders/builder-vite/src/plugins/inject-export-order-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/inject-export-order-plugin.ts
@@ -11,29 +11,32 @@ export async function injectExportOrderPlugin() {
     name: 'storybook:inject-export-order-plugin',
     // This should only run after the typescript has been transpiled
     enforce: 'post',
-    async transform(code: string, id: string) {
-      if (!filter(id)) {
-        return undefined;
-      }
+    transform: {
+      filter: { id: include },
+      async handler(code: string, id: string) {
+        if (!filter(id)) {
+          return undefined;
+        }
 
-      // TODO: Maybe convert `injectExportOrderPlugin` to function that returns object,
-      //  and run `await init;` once and then call `parse()` without `await`,
-      //  instead of calling `await parse()` every time.
-      const [, exports] = await parse(code);
+        // TODO: Maybe convert `injectExportOrderPlugin` to function that returns object,
+        //  and run `await init;` once and then call `parse()` without `await`,
+        //  instead of calling `await parse()` every time.
+        const [, exports] = await parse(code);
 
-      const exportNames = exports.map((e) => code.substring(e.s, e.e));
+        const exportNames = exports.map((e) => code.substring(e.s, e.e));
 
-      if (exportNames.includes('__namedExportsOrder')) {
-        // user has defined named exports already
-        return undefined;
-      }
-      const s = new MagicString(code);
-      const orderedExports = exportNames.filter((e) => e !== 'default');
-      s.append(`;export const __namedExportsOrder = ${JSON.stringify(orderedExports)};`);
-      return {
-        code: s.toString(),
-        map: s.generateMap({ hires: true, source: id }),
-      };
+        if (exportNames.includes('__namedExportsOrder')) {
+          // user has defined named exports already
+          return undefined;
+        }
+        const s = new MagicString(code);
+        const orderedExports = exportNames.filter((e) => e !== 'default');
+        s.append(`;export const __namedExportsOrder = ${JSON.stringify(orderedExports)};`);
+        return {
+          code: s.toString(),
+          map: s.generateMap({ hires: true, source: id }),
+        };
+      },
     },
   };
 }

--- a/code/builders/builder-vite/src/plugins/strip-story-hmr-boundaries.ts
+++ b/code/builders/builder-vite/src/plugins/strip-story-hmr-boundaries.ts
@@ -9,22 +9,26 @@ import type { Plugin } from 'vite';
 export async function stripStoryHMRBoundary(): Promise<Plugin> {
   const { createFilter } = await import('vite');
 
-  const filter = createFilter(/\.stories\.(tsx?|jsx?|svelte|vue)$/);
+  const include = /\.stories\.(tsx?|jsx?|svelte|vue)$/;
+  const filter = createFilter(include);
   return {
     name: 'storybook:strip-hmr-boundary-plugin',
     enforce: 'post',
-    async transform(src, id) {
-      if (!filter(id)) {
-        return undefined;
-      }
+    transform: {
+      filter: { id: include },
+      async handler(src, id) {
+        if (!filter(id)) {
+          return undefined;
+        }
 
-      const s = new MagicString(src);
-      s.replace(/import\.meta\.hot\.accept\w*/, '(function hmrBoundaryNoop(){})');
+        const s = new MagicString(src);
+        s.replace(/import\.meta\.hot\.accept\w*/, '(function hmrBoundaryNoop(){})');
 
-      return {
-        code: s.toString(),
-        map: s.generateMap({ hires: true, source: id }),
-      };
+        return {
+          code: s.toString(),
+          map: s.generateMap({ hires: true, source: id }),
+        };
+      },
     },
   };
 }

--- a/code/builders/builder-vite/src/plugins/vite-inject-mocker/plugin.ts
+++ b/code/builders/builder-vite/src/plugins/vite-inject-mocker/plugin.ts
@@ -41,11 +41,14 @@ export const viteInjectMockerRuntime = (options: {
         });
       }
     },
-    resolveId(source) {
-      if (source === ENTRY_PATH) {
-        return mockerRuntimePath;
-      }
-      return undefined;
+    resolveId: {
+      filter: { id: /vite-inject-mocker-entry\.js/ },
+      handler(source) {
+        if (source === ENTRY_PATH) {
+          return mockerRuntimePath;
+        }
+        return undefined;
+      },
     },
     transformIndexHtml(html: string) {
       const headTag = html.match(/<head[^>]*>/);

--- a/code/builders/builder-vite/src/plugins/vite-mock/plugin.ts
+++ b/code/builders/builder-vite/src/plugins/vite-mock/plugin.ts
@@ -162,16 +162,19 @@ export function viteMockPlugin(options: MockPluginOptions): Plugin[] {
     },
     {
       name: 'storybook:mock-loader-preview',
-      transform(code, id) {
-        if (id === normalizedPreviewConfigPath) {
-          try {
-            return rewriteSbMockImportCalls(code);
-          } catch (e) {
-            logger.debug(`Could not transform sb.mock(import(...)) calls in ${id}: ${e}`);
-            return null;
+      transform: {
+        filter: { id: normalizedPreviewConfigPath },
+        handler(code, id) {
+          if (id === normalizedPreviewConfigPath) {
+            try {
+              return rewriteSbMockImportCalls(code);
+            } catch (e) {
+              logger.debug(`Could not transform sb.mock(import(...)) calls in ${id}: ${e}`);
+              return null;
+            }
           }
-        }
-        return null;
+          return null;
+        },
       },
     },
   ];

--- a/code/frameworks/react-vite/src/plugins/react-docgen.ts
+++ b/code/frameworks/react-vite/src/plugins/react-docgen.ts
@@ -61,39 +61,42 @@ export async function reactDocgen({
   return {
     name: 'storybook:react-docgen-plugin',
     enforce: 'pre',
-    async transform(src: string, id: string) {
-      if (!filter(relative(cwd, id))) {
-        return;
-      }
-
-      try {
-        const docgenResults = parse(src, {
-          resolver: defaultResolver,
-          handlers,
-          importer: getReactDocgenImporter(matchPath),
-          filename: id,
-        }) as DocObj[];
-        const s = new MagicString(src);
-
-        docgenResults.forEach((info) => {
-          const { actualName, definedInFile, ...docgenInfo } = info;
-          if (actualName && definedInFile == id) {
-            const docNode = JSON.stringify(docgenInfo);
-            s.append(`;${actualName}.__docgenInfo=${docNode}`);
-          }
-        });
-
-        return {
-          code: s.toString(),
-          map: s.generateMap({ hires: true, source: id }),
-        };
-      } catch (e: any) {
-        // Ignore the error when react-docgen cannot find a react component
-        if (e.code === ERROR_CODES.MISSING_DEFINITION) {
+    transform: {
+      filter: { id: { include, exclude } },
+      async handler(src: string, id: string) {
+        if (!filter(relative(cwd, id))) {
           return;
         }
-        throw e;
-      }
+
+        try {
+          const docgenResults = parse(src, {
+            resolver: defaultResolver,
+            handlers,
+            importer: getReactDocgenImporter(matchPath),
+            filename: id,
+          }) as DocObj[];
+          const s = new MagicString(src);
+
+          docgenResults.forEach((info) => {
+            const { actualName, definedInFile, ...docgenInfo } = info;
+            if (actualName && definedInFile == id) {
+              const docNode = JSON.stringify(docgenInfo);
+              s.append(`;${actualName}.__docgenInfo=${docNode}`);
+            }
+          });
+
+          return {
+            code: s.toString(),
+            map: s.generateMap({ hires: true, source: id }),
+          };
+        } catch (e: any) {
+          // Ignore the error when react-docgen cannot find a react component
+          if (e.code === ERROR_CODES.MISSING_DEFINITION) {
+            return;
+          }
+          throw e;
+        }
+      },
     },
   };
 }

--- a/code/frameworks/react-vite/src/plugins/react-docgen.ts
+++ b/code/frameworks/react-vite/src/plugins/react-docgen.ts
@@ -61,42 +61,39 @@ export async function reactDocgen({
   return {
     name: 'storybook:react-docgen-plugin',
     enforce: 'pre',
-    transform: {
-      filter: { id: { include, exclude } },
-      async handler(src: string, id: string) {
-        if (!filter(relative(cwd, id))) {
+    async transform(src: string, id: string) {
+      if (!filter(relative(cwd, id))) {
+        return;
+      }
+
+      try {
+        const docgenResults = parse(src, {
+          resolver: defaultResolver,
+          handlers,
+          importer: getReactDocgenImporter(matchPath),
+          filename: id,
+        }) as DocObj[];
+        const s = new MagicString(src);
+
+        docgenResults.forEach((info) => {
+          const { actualName, definedInFile, ...docgenInfo } = info;
+          if (actualName && definedInFile == id) {
+            const docNode = JSON.stringify(docgenInfo);
+            s.append(`;${actualName}.__docgenInfo=${docNode}`);
+          }
+        });
+
+        return {
+          code: s.toString(),
+          map: s.generateMap({ hires: true, source: id }),
+        };
+      } catch (e: any) {
+        // Ignore the error when react-docgen cannot find a react component
+        if (e.code === ERROR_CODES.MISSING_DEFINITION) {
           return;
         }
-
-        try {
-          const docgenResults = parse(src, {
-            resolver: defaultResolver,
-            handlers,
-            importer: getReactDocgenImporter(matchPath),
-            filename: id,
-          }) as DocObj[];
-          const s = new MagicString(src);
-
-          docgenResults.forEach((info) => {
-            const { actualName, definedInFile, ...docgenInfo } = info;
-            if (actualName && definedInFile == id) {
-              const docNode = JSON.stringify(docgenInfo);
-              s.append(`;${actualName}.__docgenInfo=${docNode}`);
-            }
-          });
-
-          return {
-            code: s.toString(),
-            map: s.generateMap({ hires: true, source: id }),
-          };
-        } catch (e: any) {
-          // Ignore the error when react-docgen cannot find a react component
-          if (e.code === ERROR_CODES.MISSING_DEFINITION) {
-            return;
-          }
-          throw e;
-        }
-      },
+        throw e;
+      }
     },
   };
 }

--- a/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
+++ b/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
@@ -116,31 +116,34 @@ export async function svelteDocgen(): Promise<PluginOption> {
 
   return {
     name: 'storybook:svelte-docgen-plugin',
-    async transform(src: string, id: string) {
-      if (id.startsWith('\0') || !filter(id)) {
-        return undefined;
-      }
+    transform: {
+      filter: { id: { include, exclude } },
+      async handler(src: string, id: string) {
+        if (id.startsWith('\0') || !filter(id)) {
+          return undefined;
+        }
 
-      const resource = relative(cwd, id);
+        const resource = relative(cwd, id);
 
-      // Get props information
-      const docgen = generateDocgen(resource, sourceFileCache);
-      const data = transformToSvelteDocParserDataItems(docgen);
+        // Get props information
+        const docgen = generateDocgen(resource, sourceFileCache);
+        const data = transformToSvelteDocParserDataItems(docgen);
 
-      const componentDoc: SvelteComponentDoc & { keywords?: string[] } = {
-        data: data,
-        name: basename(resource),
-      };
+        const componentDoc: SvelteComponentDoc & { keywords?: string[] } = {
+          data: data,
+          name: basename(resource),
+        };
 
-      const s = new MagicString(src);
-      const outputAst = this.parse(src);
-      const componentName = getComponentName(outputAst as unknown as AST.Program);
-      s.append(`\n;${componentName}.__docgen = ${JSON.stringify(componentDoc)}`);
+        const s = new MagicString(src);
+        const outputAst = this.parse(src);
+        const componentName = getComponentName(outputAst as unknown as AST.Program);
+        s.append(`\n;${componentName}.__docgen = ${JSON.stringify(componentDoc)}`);
 
-      return {
-        code: s.toString(),
-        map: s.generateMap({ hires: true, source: id }),
-      };
+        return {
+          code: s.toString(),
+          map: s.generateMap({ hires: true, source: id }),
+        };
+      },
     },
   };
 }

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -34,118 +34,124 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
 
   return {
     name: 'storybook:vue-component-meta-plugin',
-    async transform(src, id) {
-      if (!filter(id)) {
-        return undefined;
-      }
-
-      try {
-        const exportNames = checker.getExportNames(id);
-        let componentsMeta = exportNames.map((name) => checker.getComponentMeta(id, name));
-        componentsMeta = await applyTempFixForEventDescriptions(id, componentsMeta);
-
-        const metaSources: MetaSource[] = [];
-
-        componentsMeta.forEach((meta, index) => {
-          // filter out empty meta
-          const isEmpty =
-            !meta.props.length && !meta.events.length && !meta.slots.length && !meta.exposed.length;
-
-          if (isEmpty || meta.type === TypeMeta.Unknown) {
-            return;
-          }
-
-          const exportName = exportNames[index];
-
-          // we remove nested object schemas here since they are not used inside Storybook (we don't generate controls for object properties)
-          // and they can cause "out of memory" issues for large/complex schemas (e.g. HTMLElement)
-          // it also reduced the bundle size when running "storybook build" when such schemas are used
-          (['props', 'events', 'slots', 'exposed'] as const).forEach((key) => {
-            meta[key].forEach((value) => {
-              if (Array.isArray(value.schema)) {
-                value.schema.forEach((eventSchema) => removeNestedSchemas(eventSchema));
-              } else {
-                removeNestedSchemas(value.schema);
-              }
-            });
-          });
-
-          const exposed =
-            // the meta also includes duplicated entries in the "exposed" array with "on"
-            // prefix (e.g. onClick instead of click), so we need to filter them out here
-            meta.exposed
-              .filter((expose) => {
-                let nameWithoutOnPrefix = expose.name;
-
-                if (nameWithoutOnPrefix.startsWith('on')) {
-                  nameWithoutOnPrefix = lowercaseFirstLetter(expose.name.replace('on', ''));
-                }
-
-                const hasEvent = meta.events.find((event) => event.name === nameWithoutOnPrefix);
-                return !hasEvent;
-              })
-              // remove unwanted duplicated "$slots" expose
-              .filter((expose) => {
-                if (expose.name === '$slots') {
-                  const slotNames = meta.slots.map((slot) => slot.name);
-                  return !slotNames.every((slotName) => expose.type.includes(slotName));
-                }
-                return true;
-              });
-
-          metaSources.push({
-            exportName,
-            displayName: exportName === 'default' ? getFilenameWithoutExtension(id) : exportName,
-            ...meta,
-            exposed,
-            sourceFiles: id,
-          });
-        });
-
-        // if there is no component meta, return undefined
-
-        // if there is no component meta, return undefined
-        if (metaSources.length === 0) {
+    transform: {
+      filter: { id: { include, exclude } },
+      async handler(src, id) {
+        if (!filter(id)) {
           return undefined;
         }
 
-        const s = new MagicString(src);
+        try {
+          const exportNames = checker.getExportNames(id);
+          let componentsMeta = exportNames.map((name) => checker.getComponentMeta(id, name));
+          componentsMeta = await applyTempFixForEventDescriptions(id, componentsMeta);
 
-        metaSources.forEach((meta) => {
-          const isDefaultExport = meta.exportName === 'default';
-          const name = isDefaultExport ? '_sfc_main' : meta.exportName;
+          const metaSources: MetaSource[] = [];
 
-          // we can only add the "__docgenInfo" to variables that are actually defined in the current file
-          // so e.g. re-exports like "export { default as MyComponent } from './MyComponent.vue'" must be ignored
-          // to prevent runtime errors
-          if (
-            new RegExp(`export {.*${name}.*}`).test(src) ||
-            new RegExp(`export \\* from ['"]\\S*${name}['"]`).test(src) ||
-            // when using re-exports, some exports might be resolved via checker.getExportNames
-            // but are not directly exported inside the current file so we need to ignore them too
-            !src.includes(name)
-          ) {
-            return;
+          componentsMeta.forEach((meta, index) => {
+            // filter out empty meta
+            const isEmpty =
+              !meta.props.length &&
+              !meta.events.length &&
+              !meta.slots.length &&
+              !meta.exposed.length;
+
+            if (isEmpty || meta.type === TypeMeta.Unknown) {
+              return;
+            }
+
+            const exportName = exportNames[index];
+
+            // we remove nested object schemas here since they are not used inside Storybook (we don't generate controls for object properties)
+            // and they can cause "out of memory" issues for large/complex schemas (e.g. HTMLElement)
+            // it also reduced the bundle size when running "storybook build" when such schemas are used
+            (['props', 'events', 'slots', 'exposed'] as const).forEach((key) => {
+              meta[key].forEach((value) => {
+                if (Array.isArray(value.schema)) {
+                  value.schema.forEach((eventSchema) => removeNestedSchemas(eventSchema));
+                } else {
+                  removeNestedSchemas(value.schema);
+                }
+              });
+            });
+
+            const exposed =
+              // the meta also includes duplicated entries in the "exposed" array with "on"
+              // prefix (e.g. onClick instead of click), so we need to filter them out here
+              meta.exposed
+                .filter((expose) => {
+                  let nameWithoutOnPrefix = expose.name;
+
+                  if (nameWithoutOnPrefix.startsWith('on')) {
+                    nameWithoutOnPrefix = lowercaseFirstLetter(expose.name.replace('on', ''));
+                  }
+
+                  const hasEvent = meta.events.find((event) => event.name === nameWithoutOnPrefix);
+                  return !hasEvent;
+                })
+                // remove unwanted duplicated "$slots" expose
+                .filter((expose) => {
+                  if (expose.name === '$slots') {
+                    const slotNames = meta.slots.map((slot) => slot.name);
+                    return !slotNames.every((slotName) => expose.type.includes(slotName));
+                  }
+                  return true;
+                });
+
+            metaSources.push({
+              exportName,
+              displayName: exportName === 'default' ? getFilenameWithoutExtension(id) : exportName,
+              ...meta,
+              exposed,
+              sourceFiles: id,
+            });
+          });
+
+          // if there is no component meta, return undefined
+
+          // if there is no component meta, return undefined
+          if (metaSources.length === 0) {
+            return undefined;
           }
 
-          if (!id.endsWith('.vue') && isDefaultExport) {
-            // we can not add the __docgenInfo if the component is default exported directly
-            // so we need to safe it to a variable instead and export default it instead
-            s.replace('export default ', 'const _sfc_main = ');
-            s.append('\nexport default _sfc_main;');
-          }
-          s.append(`\n;${name}.__docgenInfo = Object.assign({
-            displayName: ${name}.name ?? ${name}.__name
-          }, ${JSON.stringify(meta)})`);
-        });
+          const s = new MagicString(src);
 
-        return {
-          code: s.toString(),
-          map: s.generateMap({ hires: true, source: id }),
-        };
-      } catch (e) {
-        return undefined;
-      }
+          metaSources.forEach((meta) => {
+            const isDefaultExport = meta.exportName === 'default';
+            const name = isDefaultExport ? '_sfc_main' : meta.exportName;
+
+            // we can only add the "__docgenInfo" to variables that are actually defined in the current file
+            // so e.g. re-exports like "export { default as MyComponent } from './MyComponent.vue'" must be ignored
+            // to prevent runtime errors
+            if (
+              new RegExp(`export {.*${name}.*}`).test(src) ||
+              new RegExp(`export \\* from ['"]\\S*${name}['"]`).test(src) ||
+              // when using re-exports, some exports might be resolved via checker.getExportNames
+              // but are not directly exported inside the current file so we need to ignore them too
+              !src.includes(name)
+            ) {
+              return;
+            }
+
+            if (!id.endsWith('.vue') && isDefaultExport) {
+              // we can not add the __docgenInfo if the component is default exported directly
+              // so we need to safe it to a variable instead and export default it instead
+              s.replace('export default ', 'const _sfc_main = ');
+              s.append('\nexport default _sfc_main;');
+            }
+            s.append(`\n;${name}.__docgenInfo = Object.assign({
+              displayName: ${name}.name ?? ${name}.__name
+            }, ${JSON.stringify(meta)})`);
+          });
+
+          return {
+            code: s.toString(),
+            map: s.generateMap({ hires: true, source: id }),
+          };
+        } catch (e) {
+          return undefined;
+        }
+      },
     },
     // handle hot updates to update the component meta on file changes
     async handleHotUpdate({ file, read, server, modules, timestamp }) {

--- a/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
@@ -10,22 +10,25 @@ export async function vueDocgen(): Promise<Plugin> {
 
   return {
     name: 'storybook:vue-docgen-plugin',
-    async transform(src, id) {
-      if (!filter(id)) {
-        return undefined;
-      }
+    transform: {
+      filter: { id: include },
+      async handler(src, id) {
+        if (!filter(id)) {
+          return undefined;
+        }
 
-      const metaData = await parse(id);
+        const metaData = await parse(id);
 
-      const s = new MagicString(src);
-      s.append(`;_sfc_main.__docgenInfo = Object.assign({
-        displayName: _sfc_main.name ?? _sfc_main.__name
-      }, ${JSON.stringify(metaData)});`);
+        const s = new MagicString(src);
+        s.append(`;_sfc_main.__docgenInfo = Object.assign({
+          displayName: _sfc_main.name ?? _sfc_main.__name
+        }, ${JSON.stringify(metaData)});`);
 
-      return {
-        code: s.toString(),
-        map: s.generateMap({ hires: true, source: id }),
-      };
+        return {
+          code: s.toString(),
+          map: s.generateMap({ hires: true, source: id }),
+        };
+      },
     },
   };
 }


### PR DESCRIPTION
Closes #33899

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR moves Vite plugins to use `HookObject`s instead of functions.

For example `transform(code, id)` would move to 
```ts
{ 
  transform: {
    filter: { id, code },
    handler(code, id) {}
  }
}
```

This allows to reduce the overhead between JS/Rust runtimes for vite 8 with rolldown. Implementation within handlers doesn't change, `filter()` are left within to keep plugins backward compatible with vite < 6.3

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal plugin transformation APIs for consistency across multiple build and framework plugins, maintaining existing functionality with no impact on end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->