### PR TITLE
Telemetry: Add project age

### DIFF
--- a/code/core/src/telemetry/anonymous-id.test.ts
+++ b/code/core/src/telemetry/anonymous-id.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { normalizeGitUrl, unhashedProjectId } from './anonymous-id';
+import { execSync } from 'child_process';
+
+import { getProjectSince, normalizeGitUrl, unhashedProjectId } from './anonymous-id';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
 
 describe('normalizeGitUrl', () => {
   it('trims off https://', () => {
@@ -103,5 +109,31 @@ describe('unhashedProjectId', () => {
     expect(
       unhashedProjectId('https://github.com/storybookjs/storybook.git\n', 'path\\to\\storybook')
     ).toBe('github.com/storybookjs/storybook.gitpath/to/storybook');
+  });
+});
+
+describe('getProjectSince', () => {
+  it('returns a Date from git log output', () => {
+    vi.mocked(execSync).mockReturnValue(Buffer.from('2024-06-15 18:23:01 +0000\n'));
+
+    expect(getProjectSince()).toEqual(new Date('2024-06-15 18:23:01 +0000'));
+    expect(vi.mocked(execSync)).toHaveBeenCalledWith('git log --reverse --format=%cd --date=iso', {
+      timeout: 1000,
+      stdio: 'pipe',
+    });
+  });
+
+  it('returns undefined if git log output is empty', () => {
+    vi.mocked(execSync).mockReturnValue(Buffer.from('   \n'));
+
+    expect(getProjectSince()).toBeUndefined();
+  });
+
+  it('returns undefined if git log fails', () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error('git not available');
+    });
+
+    expect(getProjectSince()).toBeUndefined();
   });
 });

--- a/code/core/src/telemetry/anonymous-id.test.ts
+++ b/code/core/src/telemetry/anonymous-id.test.ts
@@ -15,6 +15,7 @@ vi.mock(import('storybook/internal/common'), async (actualModule) => {
   return {
     ...actual,
     executeCommandSync: vi.fn(actual.executeCommandSync),
+    getProjectRoot: () => '/path/to/project/root',
   };
 });
 
@@ -127,22 +128,35 @@ describe('unhashedProjectId', () => {
 });
 
 describe('getProjectSince', () => {
-  it('returns the Storybook creation date from git log output', () => {
-    expect(getProjectSince()).toEqual(new Date('2015-12-11T10:54:01.000Z'));
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
   });
 
-  it('returns undefined if git log output is empty', () => {
+  it('returns the Storybook creation date from git log output', () => {
+    vi.mocked(executeCommandSync).mockReturnValue(
+      '2025-12-11 16:24:01 +0530\n' + '2014-12-11 19:09:10 +0530'
+    );
+
+    expect(getProjectSince()).toEqual(new Date('2025-12-11T10:54:01.000Z'));
+  });
+
+  it('returns undefined if git log output is empty', async () => {
     vi.mocked(executeCommandSync).mockReturnValue('');
 
-    expect(getProjectSince()).toBeUndefined();
+    const { getProjectSince: getProjSince } = await import('./anonymous-id');
+
+    expect(getProjSince()).toBeUndefined();
   });
 
-  it('returns undefined if git log fails', () => {
+  it('returns undefined if git log fails', async () => {
     vi.mocked(executeCommandSync).mockImplementation(() => {
       throw new Error('git not available');
     });
 
-    expect(getProjectSince()).toBeUndefined();
+    const { getProjectSince: getProjSince } = await import('./anonymous-id');
+
+    expect(getProjSince()).toBeUndefined();
   });
 });
 
@@ -150,9 +164,12 @@ describe('getAnonymousProjectId', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+
+    vi.spyOn(process, 'cwd').mockReturnValue('/path/to/project/root');
   });
 
   it('returns hashed project id for Storybook repo when git command succeeds', async () => {
+    vi.mocked(executeCommandSync).mockReturnValue('git@github.com:storybookjs/storybook.git');
     const result = getAnonymousProjectId();
 
     expect(result).toMatch('061e4ee22a1f7c079849d97234b3be94d016fb1f24ba11878c41f8b48c0213bf');

--- a/code/core/src/telemetry/anonymous-id.test.ts
+++ b/code/core/src/telemetry/anonymous-id.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { executeCommandSync } from 'storybook/internal/common';
 
-import { getProjectSince, normalizeGitUrl, unhashedProjectId } from './anonymous-id';
+import {
+  getAnonymousProjectId,
+  getProjectSince,
+  normalizeGitUrl,
+  unhashedProjectId,
+} from './anonymous-id';
 
 vi.mock(import('storybook/internal/common'), async (actualModule) => {
   const actual = await actualModule();
@@ -11,6 +16,10 @@ vi.mock(import('storybook/internal/common'), async (actualModule) => {
     ...actual,
     executeCommandSync: vi.fn(actual.executeCommandSync),
   };
+});
+
+beforeEach(() => {
+  vi.mocked(executeCommandSync).mockReset();
 });
 
 describe('normalizeGitUrl', () => {
@@ -134,5 +143,30 @@ describe('getProjectSince', () => {
     });
 
     expect(getProjectSince()).toBeUndefined();
+  });
+});
+
+describe('getAnonymousProjectId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns hashed project id for Storybook repo when git command succeeds', async () => {
+    const result = getAnonymousProjectId();
+
+    expect(result).toMatch('061e4ee22a1f7c079849d97234b3be94d016fb1f24ba11878c41f8b48c0213bf');
+  });
+
+  it('returns undefined when git command fails', async () => {
+    const { getAnonymousProjectId: getAnonId } = await import('./anonymous-id');
+
+    vi.mocked(executeCommandSync).mockImplementation(() => {
+      throw new Error('git not available');
+    });
+
+    const result = getAnonId();
+
+    expect(result).toBeUndefined();
   });
 });

--- a/code/core/src/telemetry/anonymous-id.test.ts
+++ b/code/core/src/telemetry/anonymous-id.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { execSync } from 'child_process';
+import { executeCommandSync } from 'storybook/internal/common';
 
 import { getProjectSince, normalizeGitUrl, unhashedProjectId } from './anonymous-id';
 
-vi.mock('child_process', () => ({
-  execSync: vi.fn(),
-}));
+vi.mock(import('storybook/internal/common'), async (actualModule) => {
+  const actual = await actualModule();
+
+  return {
+    ...actual,
+    executeCommandSync: vi.fn(actual.executeCommandSync),
+  };
+});
 
 describe('normalizeGitUrl', () => {
   it('trims off https://', () => {
@@ -113,24 +118,18 @@ describe('unhashedProjectId', () => {
 });
 
 describe('getProjectSince', () => {
-  it('returns a Date from git log output', () => {
-    vi.mocked(execSync).mockReturnValue(Buffer.from('2024-06-15 18:23:01 +0000\n'));
-
-    expect(getProjectSince()).toEqual(new Date('2024-06-15 18:23:01 +0000'));
-    expect(vi.mocked(execSync)).toHaveBeenCalledWith('git log --reverse --format=%cd --date=iso', {
-      timeout: 1000,
-      stdio: 'pipe',
-    });
+  it('returns the Storybook creation date from git log output', () => {
+    expect(getProjectSince()).toEqual(new Date('2015-12-11T10:54:01.000Z'));
   });
 
   it('returns undefined if git log output is empty', () => {
-    vi.mocked(execSync).mockReturnValue(Buffer.from('   \n'));
+    vi.mocked(executeCommandSync).mockReturnValue('');
 
     expect(getProjectSince()).toBeUndefined();
   });
 
   it('returns undefined if git log fails', () => {
-    vi.mocked(execSync).mockImplementation(() => {
+    vi.mocked(executeCommandSync).mockImplementation(() => {
       throw new Error('git not available');
     });
 

--- a/code/core/src/telemetry/anonymous-id.ts
+++ b/code/core/src/telemetry/anonymous-id.ts
@@ -1,8 +1,7 @@
 import { relative } from 'node:path';
 
-import { getProjectRoot } from 'storybook/internal/common';
+import { executeCommandSync, getProjectRoot } from 'storybook/internal/common';
 
-import { execSync } from 'child_process';
 // eslint-disable-next-line depend/ban-dependencies
 import slash from 'slash';
 
@@ -41,12 +40,13 @@ export const getAnonymousProjectId = () => {
   try {
     const projectRootPath = relative(getProjectRoot(), process.cwd());
 
-    const originBuffer = execSync(`git config --local --get remote.origin.url`, {
+    const result = executeCommandSync({
+      command: 'git',
+      args: ['config', '--get', 'remote.origin.url'],
       timeout: 1000,
-      stdio: `pipe`,
     });
 
-    anonymousProjectId = oneWayHash(unhashedProjectId(String(originBuffer), projectRootPath));
+    anonymousProjectId = oneWayHash(unhashedProjectId(result, projectRootPath));
   } catch (_) {
     //
   }
@@ -56,12 +56,15 @@ export const getAnonymousProjectId = () => {
 
 export const getProjectSince = () => {
   try {
-    const dateBuffer = execSync(`git log --reverse --format=%cd --date=iso`, {
+    const dateBuffer = executeCommandSync({
+      command: 'git',
+      args: ['log', '--reverse', '--format=%cd', '--date=iso'],
       timeout: 1000,
-      stdio: `pipe`,
     });
 
-    const date = new Date(String(dateBuffer).trim());
+    const firstLine = String(dateBuffer).trim().split('\n')[0];
+
+    const date = new Date(firstLine);
 
     if (Number.isNaN(date.getTime())) {
       return undefined;

--- a/code/core/src/telemetry/anonymous-id.ts
+++ b/code/core/src/telemetry/anonymous-id.ts
@@ -32,6 +32,8 @@ export function unhashedProjectId(remoteUrl: string, projectRootPath: string) {
 }
 
 let anonymousProjectId: string;
+let getProjectSinceResult: Date | undefined;
+
 export const getAnonymousProjectId = () => {
   if (anonymousProjectId) {
     return anonymousProjectId;
@@ -56,6 +58,10 @@ export const getAnonymousProjectId = () => {
 
 export const getProjectSince = () => {
   try {
+    if (getProjectSinceResult) {
+      return getProjectSinceResult;
+    }
+
     const dateBuffer = executeCommandSync({
       command: 'git',
       args: ['log', '--reverse', '--format=%cd', '--date=iso'],
@@ -70,6 +76,7 @@ export const getProjectSince = () => {
       return undefined;
     }
 
+    getProjectSinceResult = date;
     return date;
   } catch (_) {
     //

--- a/code/core/src/telemetry/anonymous-id.ts
+++ b/code/core/src/telemetry/anonymous-id.ts
@@ -53,3 +53,24 @@ export const getAnonymousProjectId = () => {
 
   return anonymousProjectId;
 };
+
+export const getProjectSince = () => {
+  try {
+    const dateBuffer = execSync(`git log --reverse --format=%cd --date=iso`, {
+      timeout: 1000,
+      stdio: `pipe`,
+    });
+
+    const date = new Date(String(dateBuffer).trim());
+
+    if (Number.isNaN(date.getTime())) {
+      return undefined;
+    }
+
+    return date;
+  } catch (_) {
+    //
+  }
+
+  return undefined;
+};

--- a/code/core/src/telemetry/telemetry.ts
+++ b/code/core/src/telemetry/telemetry.ts
@@ -10,7 +10,7 @@ import { nanoid } from 'nanoid';
 
 import { version } from '../../package.json';
 import { resolvePackageDir } from '../shared/utils/module';
-import { getAnonymousProjectId } from './anonymous-id';
+import { getAnonymousProjectId, getProjectSince } from './anonymous-id';
 import { detectAgent } from './detect-agent';
 import { set as saveToCache } from './event-cache';
 import { fetch } from './fetch';
@@ -107,6 +107,7 @@ export async function sendTelemetry(
     : {
         ...globalContext,
         anonymousId: getAnonymousProjectId(),
+        projectSince: getProjectSince()?.getTime(),
       };
 
   let request: any;

--- a/docs/configure/telemetry.mdx
+++ b/docs/configure/telemetry.mdx
@@ -68,7 +68,7 @@ Will generate the following output:
     "nodeVersion": "24.11.0",
     "storybookVersion": "10.3.0-alpha.9",
     "cliVersion": "10.3.0-alpha.9",
-    "projectSince": "1717334400000"
+    "projectSince": 1717334400000
   },
   "payload": {
     "versionStatus": "cached",

--- a/docs/configure/telemetry.mdx
+++ b/docs/configure/telemetry.mdx
@@ -62,6 +62,14 @@ Will generate the following output:
 {
   "anonymousId": "8bcfdfd5f9616a1923dd92adf89714331b2d18693c722e05152a47f8093392bb",
   "eventType": "dev",
+  "context": {
+    "isTTY": true,
+    "platform": "macOS",
+    "nodeVersion": "24.11.0",
+    "storybookVersion": "10.3.0-alpha.9",
+    "cliVersion": "10.3.0-alpha.9",
+    "projectSince": "1717334400000"
+  },
   "payload": {
     "versionStatus": "cached",
     "storyIndex": {


### PR DESCRIPTION
Closes N/A

## What I did

Collect the project age so we can understand whether Storybook is being installed into new projects

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run `create-storybook` in a project with `STORYBOOK_TELEMETRY_DEBUG=1` and verify the output

### Documentation

Updated `telemetry.mdx` to include new data being collected

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry now captures the project's creation date and includes it as a projectSince value in the public telemetry context payload.

* **Tests**
  * Expanded test coverage for project creation date detection across successful, empty, and error scenarios; added deterministic mocks for command execution and setup.

* **Documentation**
  * Updated telemetry docs and example event payloads to show the new projectSince field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->