### PR TITLE
Core: Avoid hanging when inferring args for recursive calls on DOM elemens

### DIFF
--- a/code/core/src/preview-api/modules/store/inferArgTypes.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.ts
@@ -6,7 +6,12 @@ import { dedent } from 'ts-dedent';
 
 import { combineParameters } from './parameters';
 
-const inferType = (value: any, name: string, visited: Set<any>): SBType => {
+const inferType = (
+  value: any,
+  name: string,
+  visited: Set<any>,
+  cache: Map<any, SBType>
+): SBType => {
   const type = typeof value;
   switch (type) {
     case 'boolean':
@@ -19,6 +24,12 @@ const inferType = (value: any, name: string, visited: Set<any>): SBType => {
       break;
   }
   if (value) {
+    // Check cache first for previously computed results
+    if (cache.has(value)) {
+      return cache.get(value)!;
+    }
+
+    // Check for cycles (currently being processed in this path)
     if (visited.has(value)) {
       logger.warn(dedent`
         We've detected a cycle in arg '${name}'. Args should be JSON-serializable.
@@ -29,25 +40,36 @@ const inferType = (value: any, name: string, visited: Set<any>): SBType => {
       `);
       return { name: 'other', value: 'cyclic object' };
     }
+
     visited.add(value);
+
+    let result: SBType;
+
     if (Array.isArray(value)) {
       const childType: SBType =
         value.length > 0
-          ? inferType(value[0], name, new Set(visited))
+          ? inferType(value[0], name, visited, cache)
           : { name: 'other', value: 'unknown' };
-      return { name: 'array', value: childType };
+      result = { name: 'array', value: childType };
+    } else {
+      const fieldTypes = mapValues(value, (field) => inferType(field, name, visited, cache));
+      result = { name: 'object', value: fieldTypes };
     }
-    const fieldTypes = mapValues(value, (field) => inferType(field, name, new Set(visited)));
-    return { name: 'object', value: fieldTypes };
+
+    visited.delete(value); // Remove from current path after processing
+    cache.set(value, result); // Cache the result for future lookups
+
+    return result;
   }
   return { name: 'object', value: {} };
 };
 
 export const inferArgTypes: ArgTypesEnhancer<Renderer> = (context) => {
   const { id, argTypes: userArgTypes = {}, initialArgs = {} } = context;
+  const cache = new Map<any, SBType>();
   const argTypes = mapValues(initialArgs, (arg, key) => ({
     name: key,
-    type: inferType(arg, `${id}.${key}`, new Set()),
+    type: inferType(arg, `${id}.${key}`, new Set(), cache),
   }));
   const userArgTypesNames = mapValues(userArgTypes, (argType, key) => ({
     name: key,


### PR DESCRIPTION
Closes #33821
Closes #17098 
Closes #19575 
Closes #28750
Closes #17482 
Closes #16855

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### The problem (thanks @sonsu-lee for the investigations!):

> `inferType()` in `inferArgTypes.ts` recursively traversed **all properties** of any object to infer arg types for the Controls panel. When args contained refs (`createRef()`) whose `.current` pointed to DOM elements after rendering, this caused exponential traversal through the DOM tree and React Fiber internals, freezing the browser tab.
> 
> The existing `visited` Set uses `new Set(visited)` at each branch for sibling path independence, so the same object reached via different paths is not detected as a cycle — leading to exponential traversal on wide objects like DOM elements (200+ properties each).

### Fix

Unlike in the [original PR](https://github.com/storybookjs/storybook/pull/33834), which attempts to solve the issue by being very conservative about which data types to support, I have used a `Map` to cache the inferred results and share the same `visited` set across all branches, reducing theamount of warning messages in scenarios, where e.g. plain class instances may be allowed as args.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-33922-sha-8e1bafbc`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-33922-sha-8e1bafbc sandbox` or in an existing project with `npx storybook@0.0.0-pr-33922-sha-8e1bafbc upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-33922-sha-8e1bafbc`](https://npmjs.com/package/storybook/v/0.0.0-pr-33922-sha-8e1bafbc) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-performance-in-infer-arg-types`](https://github.com/storybookjs/storybook/tree/valentin/fix-performance-in-infer-arg-types) |
| **Commit** | [`8e1bafbc`](https://github.com/storybookjs/storybook/commit/8e1bafbc9921290e5601ab1b8b9ba0505aeb392d) |
| **Datetime** | Wed Feb 25 09:40:40 UTC 2026 (`1772012440`) |
| **Workflow run** | [22391094558](https://github.com/storybookjs/storybook/actions/runs/22391094558) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=33922`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and detection of circular references in component argument types.

* **Performance**
  * Argument type inference performance enhanced through caching mechanism to reduce redundant computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->