### PR TITLE
Controls: Fix Object contrast issue and tidy up code

### DIFF
--- a/code/addons/docs/src/blocks/controls/Object.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, FC, FocusEvent, SyntheticEvent } from 'react';
+import type { FC, FocusEvent, SyntheticEvent } from 'react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Button, Form, ToggleButton } from 'storybook/internal/components';
@@ -6,15 +6,13 @@ import { Button, Form, ToggleButton } from 'storybook/internal/components';
 import { AddIcon, SubtractIcon } from '@storybook/icons';
 
 import { cloneDeep } from 'es-toolkit/object';
-import { type Theme, styled, useTheme } from 'storybook/theming';
+import { styled, useTheme } from 'storybook/theming';
 
 import { getControlId, getControlSetterButtonId } from './helpers';
 import { JsonTree } from './react-editable-json-tree';
 import type { ControlProps, ObjectConfig, ObjectValue } from './types';
 
 const { window: globalWindow } = globalThis;
-
-type JsonTreeProps = ComponentProps<typeof JsonTree>;
 
 const Wrapper = styled.div(({ theme }) => ({
   position: 'relative',
@@ -39,7 +37,13 @@ const Wrapper = styled.div(({ theme }) => ({
     alignItems: 'center',
   },
   '.rejt-name': {
+    color: theme.color.secondary,
     lineHeight: '22px',
+  },
+  '.rejt-not-collapsed-list': {
+    listStyle: 'none',
+    margin: '0 0 0 1rem',
+    padding: 0,
   },
   '.rejt-not-collapsed-delimiter': {
     lineHeight: '22px',
@@ -56,6 +60,9 @@ const Wrapper = styled.div(({ theme }) => ({
   '.rejt-value-node:hover > .rejt-value': {
     background: theme.base === 'light' ? theme.color.lighter : 'hsl(0 0 100 / 0.02)',
     borderColor: theme.appBorderColor,
+  },
+  '.rejt-collapsed-value': {
+    color: theme.color.defaultText,
   },
 }));
 
@@ -155,23 +162,6 @@ const selectValue = (event: SyntheticEvent<HTMLInputElement>) => {
 
 export type ObjectProps = ControlProps<ObjectValue> & ObjectConfig;
 
-const getCustomStyleFunction: (theme: Theme) => JsonTreeProps['getStyle'] = (theme) => () => ({
-  name: {
-    color: theme.color.secondary,
-  },
-  collapsed: {
-    color: theme.color.dark,
-  },
-  ul: {
-    listStyle: 'none',
-    margin: '0 0 0 1rem',
-    padding: 0,
-  },
-  li: {
-    outline: 0,
-  },
-});
-
 export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange, argType }) => {
   const theme = useTheme();
   const data = useMemo(() => value && cloneDeep(value), [value]);
@@ -266,7 +256,6 @@ export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange, argType 
           data={data}
           rootName={name}
           onFullyUpdate={onChange}
-          getStyle={getCustomStyleFunction(theme)}
           cancelButtonElement={<ButtonInline type="button">Cancel</ButtonInline>}
           addButtonElement={
             <ButtonInline type="submit" primary>

--- a/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodeAccordion.tsx
+++ b/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodeAccordion.tsx
@@ -99,7 +99,7 @@ export function JsonNodeAccordion({
         {name} :
       </Trigger>
       <Region
-        role="region"
+        role="group"
         id={ids.region}
         aria-labelledby={ids.trigger}
         className="rejt-accordion-region"

--- a/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodes.tsx
+++ b/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodes.tsx
@@ -325,8 +325,7 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
 
   renderCollapsed() {
     const { name, data, keyPath, deep } = this.state;
-    const { handleRemove, readOnly, getStyle, dataType, minusMenuElement } = this.props;
-    const { minus, collapsed } = getStyle(name, data, keyPath, deep, dataType);
+    const { handleRemove, readOnly, dataType, minusMenuElement } = this.props;
 
     const isReadOnly = readOnly(name, data, keyPath, deep, dataType);
 
@@ -335,13 +334,12 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
       cloneElement(minusMenuElement, {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
-        style: minus,
         'aria-label': `remove the array '${String(name)}'`,
       });
 
     return (
       <>
-        <span style={collapsed}>
+        <span className="rejt-collapsed-value">
           [...] {data.length} {data.length === 1 ? 'item' : 'items'}
         </span>
         {!isReadOnly && removeItemButton}
@@ -356,7 +354,6 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
       handleRemove,
       onDeltaUpdate,
       readOnly,
-      getStyle,
       dataType,
       addButtonElement,
       cancelButtonElement,
@@ -370,7 +367,6 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
       logger,
       onSubmitValueParser,
     } = this.props;
-    const { minus, plus, delimiter, ul, addForm } = getStyle(name, data, keyPath, deep, dataType);
 
     const isReadOnly = readOnly(name, data, keyPath, deep, dataType);
 
@@ -379,7 +375,6 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
       cloneElement(plusMenuElement, {
         onClick: this.handleAddMode,
         className: 'rejt-plus-menu',
-        style: plus,
         'aria-label': `add a new item to the '${String(name)}' array`,
       });
     const removeItemButton =
@@ -387,7 +382,6 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
       cloneElement(minusMenuElement, {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
-        style: minus,
         'aria-label': `remove the array '${String(name)}'`,
       });
 
@@ -396,11 +390,9 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
     const endObject = ']';
     return (
       <>
-        <span className="rejt-not-collapsed-delimiter" style={delimiter}>
-          {startObject}
-        </span>
+        <span className="rejt-not-collapsed-delimiter">{startObject}</span>
         {!addFormVisible && addItemButton}
-        <ul className="rejt-not-collapsed-list" style={ul}>
+        <ul className="rejt-not-collapsed-list">
           {data.map((item, index) => (
             <JsonNode
               key={index}
@@ -414,7 +406,6 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
               onUpdate={this.onChildUpdate}
               onDeltaUpdate={onDeltaUpdate}
               readOnly={readOnly}
-              getStyle={getStyle}
               addButtonElement={addButtonElement}
               cancelButtonElement={cancelButtonElement}
               inputElementGenerator={inputElementGenerator}
@@ -430,7 +421,7 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
           ))}
         </ul>
         {!isReadOnly && addFormVisible && (
-          <div className="rejt-add-form" style={addForm}>
+          <div className="rejt-add-form">
             <JsonAddValue
               handleAdd={this.handleAddValueAdd}
               handleCancel={this.handleAddValueCancel}
@@ -444,9 +435,7 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
             />
           </div>
         )}
-        <span className="rejt-not-collapsed-delimiter" style={delimiter}>
-          {endObject}
-        </span>
+        <span className="rejt-not-collapsed-delimiter">{endObject}</span>
         {!isReadOnly && removeItemButton}
       </>
     );
@@ -481,7 +470,6 @@ interface JsonArrayProps {
   onDeltaUpdate: (...args: any) => any;
   readOnly: (...args: any) => any;
   dataType?: string;
-  getStyle: (...args: any) => any;
   addButtonElement?: ReactElement;
   cancelButtonElement?: ReactElement;
   inputElementGenerator: (...args: any) => any;
@@ -619,13 +607,11 @@ export class JsonFunctionValue extends Component<JsonFunctionValueProps, JsonFun
       originalValue,
       readOnly,
       dataType,
-      getStyle,
       textareaElementGenerator,
       minusMenuElement,
       keyPath: comeFromKeyPath = [],
     } = this.props;
 
-    const style = getStyle(name, originalValue, keyPath, deep, dataType);
     let result = null;
     let minusElement = null;
     const resultOnlyResult = readOnly(name, originalValue, keyPath, deep, dataType);
@@ -646,19 +632,11 @@ export class JsonFunctionValue extends Component<JsonFunctionValueProps, JsonFun
         onKeyDown: this.onKeydown,
       });
 
-      result = (
-        <span className="rejt-edit-form" style={style.editForm}>
-          {textareaElementLayout}
-        </span>
-      );
+      result = <span className="rejt-edit-form">{textareaElementLayout}</span>;
       minusElement = null;
     } else {
       result = (
-        <span
-          className="rejt-value"
-          style={style.value}
-          onClick={resultOnlyResult ? undefined : this.handleEditMode}
-        >
+        <span className="rejt-value" onClick={resultOnlyResult ? undefined : this.handleEditMode}>
           {value}
         </span>
       );
@@ -670,7 +648,6 @@ export class JsonFunctionValue extends Component<JsonFunctionValueProps, JsonFun
         cloneElement(minusMenuElement, {
           onClick: handleRemove,
           className: 'rejt-minus-menu',
-          style: style.minus,
           'aria-label': `remove the function '${String(name)}'${
             String(parentPropertyName) ? ` from '${String(parentPropertyName)}'` : ''
           }`,
@@ -679,10 +656,8 @@ export class JsonFunctionValue extends Component<JsonFunctionValueProps, JsonFun
     }
 
     return (
-      <li className="rejt-value-node" style={style.li}>
-        <span className="rejt-name" style={style.name}>
-          {name} :{' '}
-        </span>
+      <li className="rejt-value-node">
+        <span className="rejt-name">{name} : </span>
         {result}
         {minusElement}
       </li>
@@ -700,7 +675,6 @@ interface JsonFunctionValueProps {
   handleUpdateValue?: (...args: any) => any;
   readOnly: (...args: any) => any;
   dataType?: string;
-  getStyle: (...args: any) => any;
   cancelButtonElement?: ReactElement;
   textareaElementGenerator: (...args: any) => any;
   minusMenuElement?: ReactElement;
@@ -748,7 +722,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
       onUpdate,
       onDeltaUpdate,
       readOnly,
-      getStyle,
       addButtonElement,
       cancelButtonElement,
       inputElementGenerator,
@@ -778,7 +751,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             onDeltaUpdate={onDeltaUpdate}
             readOnly={readOnlyTrue}
             dataType={dataType}
-            getStyle={getStyle}
             addButtonElement={addButtonElement}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
@@ -805,7 +777,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             onDeltaUpdate={onDeltaUpdate}
             readOnly={readOnly}
             dataType={dataType}
-            getStyle={getStyle}
             addButtonElement={addButtonElement}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
@@ -832,7 +803,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             onDeltaUpdate={onDeltaUpdate}
             readOnly={readOnly}
             dataType={dataType}
-            getStyle={getStyle}
             addButtonElement={addButtonElement}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
@@ -858,7 +828,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             handleUpdateValue={handleUpdateValue}
             readOnly={readOnly}
             dataType={dataType}
-            getStyle={getStyle}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
             minusMenuElement={minusMenuElement}
@@ -878,7 +847,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             handleUpdateValue={handleUpdateValue}
             readOnly={readOnly}
             dataType={dataType}
-            getStyle={getStyle}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
             minusMenuElement={minusMenuElement}
@@ -898,7 +866,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             handleUpdateValue={handleUpdateValue}
             readOnly={readOnly}
             dataType={dataType}
-            getStyle={getStyle}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
             minusMenuElement={minusMenuElement}
@@ -918,7 +885,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             handleUpdateValue={handleUpdateValue}
             readOnly={readOnlyTrue}
             dataType={dataType}
-            getStyle={getStyle}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
             minusMenuElement={minusMenuElement}
@@ -938,7 +904,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             handleUpdateValue={handleUpdateValue}
             readOnly={readOnly}
             dataType={dataType}
-            getStyle={getStyle}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
             minusMenuElement={minusMenuElement}
@@ -958,7 +923,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             handleUpdateValue={handleUpdateValue}
             readOnly={readOnly}
             dataType={dataType}
-            getStyle={getStyle}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
             minusMenuElement={minusMenuElement}
@@ -978,7 +942,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             handleUpdateValue={handleUpdateValue}
             readOnly={readOnly}
             dataType={dataType}
-            getStyle={getStyle}
             cancelButtonElement={cancelButtonElement}
             textareaElementGenerator={textareaElementGenerator}
             minusMenuElement={minusMenuElement}
@@ -998,7 +961,6 @@ export class JsonNode extends Component<JsonNodeProps, JsonNodeState> {
             handleUpdateValue={handleUpdateValue}
             readOnly={readOnlyTrue}
             dataType={dataType}
-            getStyle={getStyle}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementGenerator}
             minusMenuElement={minusMenuElement}
@@ -1023,7 +985,6 @@ interface JsonNodeProps {
   onUpdate: (...args: any) => any;
   onDeltaUpdate: (...args: any) => any;
   readOnly: (...args: any) => any;
-  getStyle: (...args: any) => any;
   addButtonElement?: ReactElement;
   cancelButtonElement?: ReactElement;
   inputElementGenerator: (...args: any) => any;
@@ -1210,9 +1171,8 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
 
   renderCollapsed() {
     const { name, keyPath, deep, data } = this.state;
-    const { handleRemove, readOnly, dataType, getStyle, minusMenuElement } = this.props;
+    const { handleRemove, readOnly, dataType, minusMenuElement } = this.props;
 
-    const { minus, collapsed } = getStyle(name, data, keyPath, deep, dataType);
     const keyList = Object.getOwnPropertyNames(data);
 
     const isReadOnly = readOnly(name, data, keyPath, deep, dataType);
@@ -1222,13 +1182,12 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
       cloneElement(minusMenuElement, {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
-        style: minus,
         'aria-label': `remove the object '${String(name)}'`,
       });
 
     return (
       <>
-        <span style={collapsed}>
+        <span className="rejt-collapsed-value">
           {'{...}'} {keyList.length} {keyList.length === 1 ? 'key' : 'keys'}
         </span>
         {!isReadOnly && removeItemButton}
@@ -1243,7 +1202,6 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
       handleRemove,
       onDeltaUpdate,
       readOnly,
-      getStyle,
       dataType,
       addButtonElement,
       cancelButtonElement,
@@ -1258,7 +1216,6 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
       onSubmitValueParser,
     } = this.props;
 
-    const { minus, plus, addForm, ul, delimiter } = getStyle(name, data, keyPath, deep, dataType);
     const keyList = Object.getOwnPropertyNames(data);
 
     const isReadOnly = readOnly(name, data, keyPath, deep, dataType);
@@ -1268,7 +1225,6 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
       cloneElement(plusMenuElement, {
         onClick: this.handleAddMode,
         className: 'rejt-plus-menu',
-        style: plus,
         'aria-label': `add a new property to the object '${String(name)}'`,
       });
     const removeItemButton =
@@ -1276,7 +1232,6 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
       cloneElement(minusMenuElement, {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
-        style: minus,
         'aria-label': `remove the object '${String(name)}'`,
       });
 
@@ -1293,7 +1248,6 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
         onUpdate={this.onChildUpdate}
         onDeltaUpdate={onDeltaUpdate}
         readOnly={readOnly}
-        getStyle={getStyle}
         addButtonElement={addButtonElement}
         cancelButtonElement={cancelButtonElement}
         inputElementGenerator={inputElementGenerator}
@@ -1313,15 +1267,11 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
 
     return (
       <>
-        <span className="rejt-not-collapsed-delimiter" style={delimiter}>
-          {startObject}
-        </span>
+        <span className="rejt-not-collapsed-delimiter">{startObject}</span>
         {!isReadOnly && addItemButton}
-        <ul className="rejt-not-collapsed-list" style={ul}>
-          {list}
-        </ul>
+        <ul className="rejt-not-collapsed-list">{list}</ul>
         {!isReadOnly && addFormVisible && (
-          <div className="rejt-add-form" style={addForm}>
+          <div className="rejt-add-form">
             <JsonAddValue
               handleAdd={this.handleAddValueAdd}
               handleCancel={this.handleAddValueCancel}
@@ -1334,9 +1284,7 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
             />
           </div>
         )}
-        <span className="rejt-not-collapsed-delimiter" style={delimiter}>
-          {endObject}
-        </span>
+        <span className="rejt-not-collapsed-delimiter">{endObject}</span>
         {!isReadOnly && removeItemButton}
       </>
     );
@@ -1371,7 +1319,6 @@ interface JsonObjectProps {
   onDeltaUpdate: (...args: any) => any;
   readOnly: (...args: any) => any;
   dataType?: string;
-  getStyle: (...args: any) => any;
   addButtonElement?: ReactElement;
   cancelButtonElement?: ReactElement;
   inputElementGenerator: (...args: any) => any;
@@ -1509,13 +1456,11 @@ export class JsonValue extends Component<JsonValueProps, JsonValueState> {
       originalValue,
       readOnly,
       dataType,
-      getStyle,
       inputElementGenerator,
       minusMenuElement,
       keyPath: comeFromKeyPath,
     } = this.props;
 
-    const style = getStyle(name, originalValue, keyPath, deep, dataType);
     const isReadOnly = readOnly(name, originalValue, keyPath, deep, dataType);
     const isEditing = editEnabled && !isReadOnly;
     const inputElement = inputElementGenerator(
@@ -1540,28 +1485,21 @@ export class JsonValue extends Component<JsonValueProps, JsonValueState> {
       cloneElement(minusMenuElement, {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
-        style: style.minus,
         'aria-label': `remove the property '${String(name)}' with value '${String(originalValue)}'${
           String(parentPropertyName) ? ` from '${String(parentPropertyName)}'` : ''
         }`,
       });
 
     return (
-      <li className="rejt-value-node" style={style.li}>
-        <span className="rejt-name" style={style.name}>
+      <li className="rejt-value-node">
+        <span className="rejt-name">
           {name}
           {' : '}
         </span>
         {isEditing ? (
-          <span className="rejt-edit-form" style={style.editForm}>
-            {inputElementLayout}
-          </span>
+          <span className="rejt-edit-form">{inputElementLayout}</span>
         ) : (
-          <span
-            className="rejt-value"
-            style={style.value}
-            onClick={isReadOnly ? undefined : this.handleEditMode}
-          >
+          <span className="rejt-value" onClick={isReadOnly ? undefined : this.handleEditMode}>
             {String(value)}
           </span>
         )}
@@ -1581,7 +1519,6 @@ interface JsonValueProps {
   handleUpdateValue?: (...args: any) => any;
   readOnly: (...args: any) => any;
   dataType?: string;
-  getStyle: (...args: any) => any;
   cancelButtonElement?: ReactElement;
   inputElementGenerator: (...args: any) => any;
   minusMenuElement?: ReactElement;

--- a/code/addons/docs/src/blocks/controls/react-editable-json-tree/index.tsx
+++ b/code/addons/docs/src/blocks/controls/react-editable-json-tree/index.tsx
@@ -50,7 +50,6 @@ export class JsonTree extends Component<JsonTreeProps, JsonTreeState> {
       isCollapsed,
       onDeltaUpdate,
       readOnly,
-      getStyle,
       addButtonElement,
       cancelButtonElement,
       inputElement,
@@ -94,7 +93,6 @@ export class JsonTree extends Component<JsonTreeProps, JsonTreeState> {
             onUpdate={this.onUpdate}
             onDeltaUpdate={onDeltaUpdate ?? (() => {})}
             readOnly={readOnlyFunction as (...args: any) => any}
-            getStyle={getStyle ?? (() => ({}))}
             addButtonElement={addButtonElement}
             cancelButtonElement={cancelButtonElement}
             inputElementGenerator={inputElementFunction as (...args: any) => any}
@@ -123,7 +121,6 @@ interface JsonTreeProps {
   onFullyUpdate?: (...args: any) => any;
   onDeltaUpdate?: (...args: any) => any;
   readOnly?: boolean | ((...args: any) => any);
-  getStyle?: (...args: any) => any;
   addButtonElement?: ReactElement;
   cancelButtonElement?: ReactElement;
   inputElement?: ReactElement | ((...args: any) => ReactElement);
@@ -142,17 +139,6 @@ interface JsonTreeProps {
 JsonTree.defaultProps = {
   rootName: 'root',
   isCollapsed: (keyPath, deep) => deep !== -1,
-  getStyle: (keyName, data, keyPath, deep, dataType) => {
-    switch (dataType) {
-      case 'Object':
-      case 'Error':
-        return object;
-      case 'Array':
-        return array;
-      default:
-        return value;
-    }
-  },
   readOnly: () => false,
   onFullyUpdate: () => {},
   onDeltaUpdate: () => {},


### PR DESCRIPTION

## What I did

Caught an a11y issue in a contributor's UI Tests that had nothing to do with them, so opening a PR to fix it.

I've used the opportunity to remove a redundant styling API for Object control internals.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories

#### Manual testing


1. Visit http://localhost:6006/?path=/story/addons-docs-blocks-controls-object--object&globals=sb_theme:side-by-side
2. Notice absence of contrast a11y violations


### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved semantic accessibility in the tree control by adjusting ARIA roles for better screen-reader behavior.

* **Refactor**
  * Styling simplified: styling is now driven by built-in CSS classes instead of a customizable per-node style function, streamlining visual consistency and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->