### PR TITLE
UI: Prevent Copy button overlapping code at high zoom levels

### DIFF
--- a/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.stories.tsx
+++ b/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.stories.tsx
@@ -224,6 +224,20 @@ export const BorderedCopyable = {
   },
 };
 
+export const BorderedCopyableSmallViewport = {
+  args: {
+    ...BorderedCopyable.args,
+  },
+  parameters: {
+    chromatic: { viewports: [320] },
+  },
+  render: (args: ComponentProps<typeof SyntaxHighlighter>) => (
+    <div style={{ width: 320 }}>
+      <SyntaxHighlighter {...args} />
+    </div>
+  ),
+};
+
 export const Padded = {
   args: {
     padded: true,

--- a/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
@@ -63,6 +63,7 @@ export interface WrapperProps {
   bordered?: boolean;
   padded?: boolean;
   showLineNumbers?: boolean;
+  copyable?: boolean;
 }
 
 const Wrapper = styled.div<WrapperProps>(
@@ -86,6 +87,12 @@ const Wrapper = styled.div<WrapperProps>(
           '.react-syntax-highlighter-line-number::before': {
             content: 'attr(data-line-number)',
           },
+        }
+      : {},
+  ({ copyable }) =>
+    copyable
+      ? {
+          paddingBottom: 28,
         }
       : {}
 );
@@ -227,6 +234,7 @@ export const SyntaxHighlighter = ({
       bordered={bordered}
       padded={padded}
       showLineNumbers={showLineNumbers}
+      copyable={copyable}
       className={className}
     >
       <Scroller>


### PR DESCRIPTION
  ## Description                                                                                                                                                                            
  Fix the Copy button overlapping the code block content at 400% browser zoom (WCAG 2.1 Reflow test).                                                                                       
                                                                                                                                                                                            
  ## Related Issue                                          
  Fixes #23641

  ## Changes Made
  - Added `paddingBottom: 28` to the `Wrapper` component when `copyable` is true, ensuring the Copy button always has dedicated space below the code content
  - Added `BorderedCopyableSmallViewport` story for Chromatic visual regression testing at 320px viewport

  ## Checklist
  - [x] Tests pass (4468 passed)
  - [x] Linter passes (0 errors)
  - [x] Viewport story added for Chromatic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional copy-to-clipboard feature for syntax highlighter. When enabled, users can copy highlighted code with instant visual confirmation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->