### PR TITLE
UI: Fix modal text selection

### DIFF
--- a/code/addons/vitest/src/components/GlobalErrorModal.stories.tsx
+++ b/code/addons/vitest/src/components/GlobalErrorModal.stories.tsx
@@ -81,7 +81,7 @@ export const FatalError: Story = {
     const canvas = within(canvasElement.parentElement!);
     const button = canvas.getByText('Open modal');
     await userEvent.click(button);
-    await expect(canvas.findByText('Storybook Tests error details')).resolves.toBeInTheDocument();
+    await expect(canvas.findByText('Storybook Test Error Details')).resolves.toBeInTheDocument();
   },
 };
 

--- a/code/addons/vitest/src/components/GlobalErrorModal.tsx
+++ b/code/addons/vitest/src/components/GlobalErrorModal.tsx
@@ -31,6 +31,7 @@ const ModalTitle = styled(Modal.Title)(({ theme: { typography } }) => ({
 const ModalStackTrace = styled.pre(({ theme }) => ({
   whiteSpace: 'pre-wrap',
   wordWrap: 'break-word',
+  userSelect: 'text',
   overflow: 'auto',
   maxHeight: '60vh',
   margin: 0,
@@ -147,9 +148,9 @@ export function GlobalErrorModal({ onRerun, storeState }: GlobalErrorModalProps)
   ) : null;
 
   return (
-    <Modal ariaLabel="Storybook Tests error details" onOpenChange={setModalOpen} open={isModalOpen}>
+    <Modal ariaLabel="Storybook Test Error Details" onOpenChange={setModalOpen} open={isModalOpen}>
       <ModalBar>
-        <ModalTitle>Storybook Tests error details</ModalTitle>
+        <ModalTitle>Storybook Test Error Details</ModalTitle>
         <ModalActionBar>
           <Button onClick={onRerun} variant="ghost" ariaLabel={false}>
             <SyncIcon />

--- a/code/core/src/components/components/Modal/Modal.tsx
+++ b/code/core/src/components/components/Modal/Modal.tsx
@@ -216,19 +216,22 @@ function BaseModal({
         />
         <div role="dialog" aria-label={ariaLabel} ref={overlayRef} {...finalModalProps}>
           <ModalContext.Provider value={{ close }}>
-            {/* We need to set the FocusScope ourselves somehow, Overlay won't set it. */}
-            <Components.Container
-              data-deprecated={deprecated}
-              $variant={variant}
-              $status={status}
-              $transitionDuration={transitionDuration}
-              className={className}
-              width={width}
-              height={height}
-              {...props}
-            >
-              {children}
-            </Components.Container>
+            {/* This div exists to help the FocusScope, see https://github.com/adobe/react-spectrum/issues/1604. */}
+            <div tabIndex={-1}>
+              {/* We need to set the FocusScope ourselves somehow, Overlay won't set it. */}
+              <Components.Container
+                data-deprecated={deprecated}
+                $variant={variant}
+                $status={status}
+                $transitionDuration={transitionDuration}
+                className={className}
+                width={width}
+                height={height}
+                {...props}
+              >
+                {children}
+              </Components.Container>
+            </div>
           </ModalContext.Provider>
         </div>
       </FocusScope>


### PR DESCRIPTION
## What I did

Text selection was kinda buggy in our Modal. Turns out this is a known issue with how React Aria enforces focus traps. They provide a workaround (`div tabIndex={-1}` around the Modal content), so this PR applies it.

The PR also makes minor changes to the GlobalErrorModal for more coherent title capitalisation (@MichaelArestad feel free to give instructions on that).

## Checklist for Contributors

### Testing

#### Manual testing

1. Go to http://localhost:6006/?path=/story/addons-vitest-globalerrormodal--fatal-error
2. Select text in the modal

### Documentation
ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error message text from "Storybook Tests" to "Storybook Test" for consistency.

* **Improvements**
  * Users can now select and copy text from error stack traces in the modal.
  * Enhanced focus management in modal interactions for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->