### PR TITLE
Docs: Adjust Next.js snippets to include draftmode

### DIFF
--- a/docs/_snippets/nextjs-headers-mock.md
+++ b/docs/_snippets/nextjs-headers-mock.md
@@ -1,8 +1,8 @@
 ```js filename="MyForm.stories.js" renderer="react" language="js" tabTitle="CSF 3"
-import { expect } from 'storybook/test';
+import { expect, fn } from 'storybook/test';
 
 // Replace your-framework with nextjs or nextjs-vite
-import { cookies, headers } from '@storybook/your-framework/headers';
+import { cookies, headers, draftMode } from '@storybook/your-framework/headers';
 
 import MyForm from './my-form';
 
@@ -12,16 +12,22 @@ export default {
 
 export const LoggedInEurope = {
   async beforeEach() {
-    // 👇 Set mock cookies and headers ahead of rendering
+    // 👇 Set mock cookies, headers and draft mode ahead of rendering
     cookies().set('username', 'Sol');
     headers().set('timezone', 'Central European Summer Time');
+    draftMode.mockReturnValue({
+      isEnabled: true,
+      enable: fn(),
+      disable: fn(),
+    });
   },
   async play() {
     // 👇 Assert that your component called the mocks
     await expect(cookies().get).toHaveBeenCalledOnce();
     await expect(cookies().get).toHaveBeenCalledWith('username');
     await expect(headers().get).toHaveBeenCalledOnce();
-    await expect(cookies().get).toHaveBeenCalledWith('timezone');
+    await expect(headers().get).toHaveBeenCalledWith('timezone');
+    await expect(draftMode).toHaveBeenCalled();
   },
 };
 ```
@@ -30,10 +36,10 @@ export const LoggedInEurope = {
 // Replace your-framework with nextjs or nextjs-vite
 import type { Meta, StoryObj } from '@storybook/your-framework';
 
-import { expect } from 'storybook/test';
+import { expect, fn } from 'storybook/test';
 
 // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
-import { cookies, headers } from '@storybook/your-framework/headers.mock';
+import { cookies, headers, draftMode } from '@storybook/your-framework/headers.mock';
 
 import MyForm from './my-form';
 
@@ -46,28 +52,34 @@ type Story = StoryObj<typeof meta>;
 
 export const LoggedInEurope: Story = {
   async beforeEach() {
-    // 👇 Set mock cookies and headers ahead of rendering
+    // 👇 Set mock cookies, headers and draft mode ahead of rendering
     cookies().set('username', 'Sol');
     headers().set('timezone', 'Central European Summer Time');
+    draftMode.mockReturnValue({
+      isEnabled: true,
+      enable: fn(),
+      disable: fn(),
+    });
   },
   async play() {
     // 👇 Assert that your component called the mocks
     await expect(cookies().get).toHaveBeenCalledOnce();
     await expect(cookies().get).toHaveBeenCalledWith('username');
     await expect(headers().get).toHaveBeenCalledOnce();
-    await expect(cookies().get).toHaveBeenCalledWith('timezone');
+    await expect(headers().get).toHaveBeenCalledWith('timezone');
+    await expect(draftMode).toHaveBeenCalled();
   },
 };
 ```
 
 ```ts filename="MyForm.stories.ts" renderer="react" language="ts" tabTitle="CSF Next 🧪"
-import { expect } from 'storybook/test';
+import { expect, fn } from 'storybook/test';
 
 /*
  * Replace your-framework with nextjs or nextjs-vite
  * 👇 Must include the `.mock` portion of filename to have mocks typed correctly
  */
-import { cookies, headers } from '@storybook/your-framework/headers.mock';
+import { cookies, headers, draftMode } from '@storybook/your-framework/headers.mock';
 
 import preview from '../.storybook/preview';
 
@@ -79,16 +91,22 @@ const meta = preview.meta({
 
 export const LoggedInEurope = meta.story({
   async beforeEach() {
-    // 👇 Set mock cookies and headers ahead of rendering
+    // 👇 Set mock cookies, headers and draft mode ahead of rendering
     cookies().set('username', 'Sol');
     headers().set('timezone', 'Central European Summer Time');
+    draftMode.mockReturnValue({
+      isEnabled: true,
+      enable: fn(),
+      disable: fn(),
+    });
   },
   async play() {
     // 👇 Assert that your component called the mocks
     await expect(cookies().get).toHaveBeenCalledOnce();
     await expect(cookies().get).toHaveBeenCalledWith('username');
     await expect(headers().get).toHaveBeenCalledOnce();
-    await expect(cookies().get).toHaveBeenCalledWith('timezone');
+    await expect(headers().get).toHaveBeenCalledWith('timezone');
+    await expect(draftMode).toHaveBeenCalled();
   },
 });
 ```
@@ -96,10 +114,10 @@ export const LoggedInEurope = meta.story({
 <!-- JS snippets still needed while providing both CSF 3 & Next -->
 
 ```js filename="MyForm.stories.js" renderer="react" language="js" tabTitle="CSF Next 🧪"
-import { expect } from 'storybook/test';
+import { expect, fn } from 'storybook/test';
 
 // Replace your-framework with nextjs or nextjs-vite
-import { cookies, headers } from '@storybook/your-framework/headers';
+import { cookies, headers, draftMode } from '@storybook/your-framework/headers';
 
 import preview from '../.storybook/preview';
 
@@ -111,16 +129,22 @@ const meta = preview.meta({
 
 export const LoggedInEurope = meta.story({
   async beforeEach() {
-    // 👇 Set mock cookies and headers ahead of rendering
+    // 👇 Set mock cookies, headers and draft mode ahead of rendering
     cookies().set('username', 'Sol');
     headers().set('timezone', 'Central European Summer Time');
+    draftMode.mockReturnValue({
+      isEnabled: true,
+      enable: fn(),
+      disable: fn(),
+    });
   },
   async play() {
     // 👇 Assert that your component called the mocks
     await expect(cookies().get).toHaveBeenCalledOnce();
     await expect(cookies().get).toHaveBeenCalledWith('username');
     await expect(headers().get).toHaveBeenCalledOnce();
-    await expect(cookies().get).toHaveBeenCalledWith('timezone');
+    await expect(headers().get).toHaveBeenCalledWith('timezone');
+    await expect(draftMode).toHaveBeenCalled();
   },
 });
 ```


### PR DESCRIPTION
## What I changed
- Added `draftMode` usage to `docs/_snippets/nextjs-headers-mock.md` for all snippet variants (CSF 3/Next, JS/TS).
- Demonstrated how to mock draft mode state via `draftMode.mockReturnValue(...)`.
- Fixed an incorrect assertion in the same snippet (`cookies().get('timezone')` -> `headers().get('timezone')`).

## Why
Closes #28851

## Verification
- `yarn prettier --check docs/_snippets/nextjs-headers-mock.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Next.js headers mocking documentation to include draft mode support alongside existing cookies and headers functionality.

* **Tests**
  * Enhanced mock setup to verify draft mode handling with proper initialization and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->