### PR TITLE
Docs: clarify story discovery vs generated story globs

### DIFF
--- a/docs/writing-stories/index.mdx
+++ b/docs/writing-stories/index.mdx
@@ -30,6 +30,26 @@ components/
 │  ├─ Button.stories.js | ts | jsx | tsx | svelte
 ```
 
+<Callout variant="info">
+  You can place stories anywhere, as long as your [`.storybook/main.js|.ts` stories globs](../configure/index.mdx#configure-story-rendering) include those paths.
+</Callout>
+
+When you run `npm create storybook@latest`, the generated `stories` configuration uses a single root (`../src` when that directory exists, otherwise `../stories`). If your stories live in additional folders, add matching globs in your Storybook config:
+
+```ts title=".storybook/main.ts"
+import type { StorybookConfig } from '@storybook/your-framework';
+
+const config: StorybookConfig = {
+  stories: [
+    '../src/**/*.mdx',
+    '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../packages/**/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+  ],
+};
+
+export default config;
+```
+
 ## Component Story Format
 
 <If renderer="svelte">


### PR DESCRIPTION
## Summary
This updates the "Where to put stories" section to clarify that:

- colocating stories next to components is recommended,
- but Storybook only loads stories that match `.storybook/main` `stories` globs,
- and the config generated by `npm create storybook@latest` uses a single root by default (`../src` if present, otherwise `../stories`).

The page now includes an explicit config example showing how to add additional glob paths when stories live outside the default root.

Fixes #31926

## Validation
- Reviewed generated default behavior in `code/lib/create-storybook/src/generators/configure.ts`.
- Manual docs diff review (`docs/writing-stories/index.mdx`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that stories can be placed in various project locations by configuring Storybook glob patterns.
  * Added configuration examples showing how to extend Storybook to recognize story files across multiple paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->