### PR TITLE
Actions: Add expandLevel parameter to configure tree depth

### DIFF
--- a/code/core/src/actions/components/ActionLogger/index.tsx
+++ b/code/core/src/actions/components/ActionLogger/index.tsx
@@ -30,6 +30,7 @@ interface InspectorProps {
   showNonenumerable: boolean;
   name: any;
   data: any;
+  expandLevel?: number;
 }
 
 const ThemedInspector = withTheme(({ theme, ...props }: InspectorProps) => (
@@ -38,10 +39,11 @@ const ThemedInspector = withTheme(({ theme, ...props }: InspectorProps) => (
 
 interface ActionLoggerProps {
   actions: ActionDisplay[];
+  expandLevel?: number;
   onClear: () => void;
 }
 
-export const ActionLogger = ({ actions, onClear }: ActionLoggerProps) => {
+export const ActionLogger = ({ actions, expandLevel, onClear }: ActionLoggerProps) => {
   const wrapperRef = useRef<ElementRef<typeof Wrapper>>(null);
   const wrapper = wrapperRef.current;
   const wasAtBottom = wrapper && wrapper.scrollHeight - wrapper.scrollTop === wrapper.clientHeight;
@@ -67,6 +69,7 @@ export const ActionLogger = ({ actions, onClear }: ActionLoggerProps) => {
                 showNonenumerable={false}
                 name={action.data.name}
                 data={action.data.args ?? action.data}
+                expandLevel={expandLevel}
               />
             </InspectorContainer>
           </Action>

--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { STORY_CHANGED } from 'storybook/internal/core-events';
 
 import { dequal as deepEqual } from 'dequal';
 import type { API } from 'storybook/manager-api';
+import { useParameter } from 'storybook/manager-api';
 
 import { ActionLogger as ActionLoggerComponent } from '../../components/ActionLogger';
 import { CLEAR_ID, EVENT_ID, PARAM_KEY } from '../../constants';
@@ -15,11 +16,6 @@ interface ActionLoggerProps {
   api: API;
 }
 
-interface ActionLoggerState {
-  actions: ActionDisplay[];
-  expandLevel: number;
-}
-
 const safeDeepEqual = (a: any, b: any): boolean => {
   try {
     return deepEqual(a, b);
@@ -28,78 +24,54 @@ const safeDeepEqual = (a: any, b: any): boolean => {
   }
 };
 
-export default class ActionLogger extends Component<ActionLoggerProps, ActionLoggerState> {
-  private mounted: boolean;
+export default function ActionLogger({ active, api }: ActionLoggerProps) {
+  const [actions, setActions] = useState<ActionDisplay[]>([]);
+  const parameter = useParameter<ActionsParameters['actions']>(PARAM_KEY);
+  const expandLevel = parameter?.expandLevel ?? 1;
 
-  constructor(props: ActionLoggerProps) {
-    super(props);
+  const clearActions = useCallback(() => {
+    api.emit(CLEAR_ID);
+    setActions([]);
+  }, [api]);
 
-    this.mounted = false;
-
-    this.state = { actions: [], expandLevel: 1 };
-  }
-
-  override componentDidMount() {
-    this.mounted = true;
-    const { api } = this.props;
-
-    api.on(EVENT_ID, this.addAction);
-    api.on(STORY_CHANGED, this.handleStoryChange);
-
-    const expandLevel =
-      api.getCurrentParameter<ActionsParameters['actions']>(PARAM_KEY)?.expandLevel ?? 1;
-    this.setState({ expandLevel });
-  }
-
-  override componentWillUnmount() {
-    this.mounted = false;
-    const { api } = this.props;
-
-    api.off(STORY_CHANGED, this.handleStoryChange);
-    api.off(EVENT_ID, this.addAction);
-  }
-
-  handleStoryChange = () => {
-    const { api } = this.props;
-    const { actions } = this.state;
-    if (actions.length > 0 && actions[0].options.clearOnStoryChange) {
-      this.clearActions();
-    }
-    const expandLevel =
-      api.getCurrentParameter<ActionsParameters['actions']>(PARAM_KEY)?.expandLevel ?? 1;
-    this.setState({ expandLevel });
-  };
-
-  addAction = (action: ActionDisplay) => {
-    this.setState((prevState: ActionLoggerState) => {
-      const actions = [...prevState.actions];
-      const previous = actions.length && actions[actions.length - 1];
+  const addAction = useCallback((action: ActionDisplay) => {
+    setActions((prevActions) => {
+      const newActions = [...prevActions];
+      const previous = newActions.length && newActions[newActions.length - 1];
       if (previous && safeDeepEqual(previous.data, action.data)) {
         previous.count++;
       } else {
         action.count = 1;
-        actions.push(action);
+        newActions.push(action);
       }
-      return { actions: actions.slice(0, action.options.limit) };
+      return newActions.slice(0, action.options.limit);
     });
-  };
+  }, []);
 
-  clearActions = () => {
-    const { api } = this.props;
+  const handleStoryChange = useCallback(() => {
+    if (actions.length > 0 && actions[0].options.clearOnStoryChange) {
+      clearActions();
+    }
+  }, [actions, clearActions]);
 
-    // clear number of actions
-    api.emit(CLEAR_ID);
-    this.setState({ actions: [] });
-  };
+  useEffect(() => {
+    api.on(EVENT_ID, addAction);
+    api.on(STORY_CHANGED, handleStoryChange);
 
-  override render() {
-    const { actions = [], expandLevel } = this.state;
-    const { active } = this.props;
-    const props = {
+    return () => {
+      api.off(EVENT_ID, addAction);
+      api.off(STORY_CHANGED, handleStoryChange);
+    };
+  }, [api, addAction, handleStoryChange]);
+
+  const props = useMemo(
+    () => ({
       actions,
       expandLevel,
-      onClear: this.clearActions,
-    };
-    return active ? <ActionLoggerComponent {...props} /> : null;
-  }
+      onClear: clearActions,
+    }),
+    [actions, expandLevel, clearActions]
+  );
+
+  return active ? <ActionLoggerComponent {...props} /> : null;
 }

--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -6,8 +6,9 @@ import { dequal as deepEqual } from 'dequal';
 import type { API } from 'storybook/manager-api';
 
 import { ActionLogger as ActionLoggerComponent } from '../../components/ActionLogger';
-import { CLEAR_ID, EVENT_ID } from '../../constants';
+import { CLEAR_ID, EVENT_ID, PARAM_KEY } from '../../constants';
 import type { ActionDisplay } from '../../models';
+import type { ActionsParameters } from '../../types';
 
 interface ActionLoggerProps {
   active: boolean;
@@ -16,6 +17,7 @@ interface ActionLoggerProps {
 
 interface ActionLoggerState {
   actions: ActionDisplay[];
+  expandLevel: number;
 }
 
 const safeDeepEqual = (a: any, b: any): boolean => {
@@ -34,7 +36,7 @@ export default class ActionLogger extends Component<ActionLoggerProps, ActionLog
 
     this.mounted = false;
 
-    this.state = { actions: [] };
+    this.state = { actions: [], expandLevel: 1 };
   }
 
   override componentDidMount() {
@@ -43,6 +45,10 @@ export default class ActionLogger extends Component<ActionLoggerProps, ActionLog
 
     api.on(EVENT_ID, this.addAction);
     api.on(STORY_CHANGED, this.handleStoryChange);
+
+    const expandLevel =
+      api.getCurrentParameter<ActionsParameters['actions']>(PARAM_KEY)?.expandLevel ?? 1;
+    this.setState({ expandLevel });
   }
 
   override componentWillUnmount() {
@@ -54,10 +60,14 @@ export default class ActionLogger extends Component<ActionLoggerProps, ActionLog
   }
 
   handleStoryChange = () => {
+    const { api } = this.props;
     const { actions } = this.state;
     if (actions.length > 0 && actions[0].options.clearOnStoryChange) {
       this.clearActions();
     }
+    const expandLevel =
+      api.getCurrentParameter<ActionsParameters['actions']>(PARAM_KEY)?.expandLevel ?? 1;
+    this.setState({ expandLevel });
   };
 
   addAction = (action: ActionDisplay) => {
@@ -83,10 +93,11 @@ export default class ActionLogger extends Component<ActionLoggerProps, ActionLog
   };
 
   override render() {
-    const { actions = [] } = this.state;
+    const { actions = [], expandLevel } = this.state;
     const { active } = this.props;
     const props = {
       actions,
+      expandLevel,
       onClear: this.clearActions,
     };
     return active ? <ActionLoggerComponent {...props} /> : null;

--- a/code/core/src/actions/types.ts
+++ b/code/core/src/actions/types.ts
@@ -38,6 +38,13 @@ export interface ActionsParameters {
      * @example `handles: ['mouseover', 'click .btn']`
      */
     handles?: string[];
+
+    /**
+     * An integer specifying to which level the tree should be initially expanded.
+     *
+     * @default 1
+     */
+    expandLevel?: number;
   };
 }
 

--- a/docs/essentials/actions.mdx
+++ b/docs/essentials/actions.mdx
@@ -88,6 +88,14 @@ Disable the action panel.
 
 This parameter is most useful to allow overriding at more specific levels. For example, if this parameter is set to `true` at the project level, it could then be re-enabled by setting it to `false` at the meta (component) or story level.
 
+#### `expandLevel`
+
+Type: `number`
+
+Default: `1`
+
+Controls how many levels deep the action tree is initially expanded. Useful when action arguments contain nested objects and you want to see more detail by default.
+
 ### Exports
 
 ```js


### PR DESCRIPTION
## What this PR does

Adds an `expandLevel` parameter to the actions addon configuration, allowing users to control how deep the action object tree is initially expanded in the panel.

The addon uses [react-inspector](https://www.npmjs.com/package/react-inspector)'s `Inspector` component which already supports an `expandLevel` prop — this PR exposes it as a configurable story parameter.

## How to use

```ts
// .storybook/preview.ts  (global)
const preview = {
  parameters: {
    actions: { expandLevel: 2 },
  },
};
```

```ts
// Individual story
const meta = {
  parameters: {
    actions: { expandLevel: 3 },
  },
};
```

The default value is `1` (same as before — no visible change for existing users).

## Closes

Closes #22390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable initial expansion level for the action inspector (controls how many tree levels are expanded on load; default: 1).

* **Refactor**
  * Action logger rewritten to a modern implementation for more reliable, responsive action capture and display.

* **Documentation**
  * Updated docs describing the new expansion-level parameter and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->