### PR TITLE
Docs: Add small viewport stories for Preview and Source blocks

### DIFF
--- a/code/addons/docs/src/blocks/components/Preview.stories.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.stories.tsx
@@ -340,3 +340,29 @@ export const WithAdditionalActions = () => (
     </Button>
   </Preview>
 );
+
+export const SingleSmallViewport = () => (
+  <div style={{ width: 320 }}>
+    <Preview inline>
+      <Button ariaLabel={false} variant="outline">
+        Button 1
+      </Button>
+    </Preview>
+  </div>
+);
+SingleSmallViewport.parameters = {
+  chromatic: { viewports: [320] },
+};
+
+export const CodeExpandedSmallViewport = () => (
+  <div style={{ width: 320 }}>
+    <Preview inline isExpanded withSource={sourceStories.JSX.args}>
+      <Button ariaLabel={false} variant="outline">
+        Button 1
+      </Button>
+    </Preview>
+  </div>
+);
+CodeExpandedSmallViewport.parameters = {
+  chromatic: { viewports: [320] },
+};

--- a/code/addons/docs/src/blocks/components/Source.stories.tsx
+++ b/code/addons/docs/src/blocks/components/Source.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Source, SourceError } from './Source';
@@ -74,4 +76,18 @@ export const SourceUnavailable: Story = {
     error: SourceError.SOURCE_UNAVAILABLE,
     format: false,
   },
+};
+
+export const JSXSmallViewport: Story = {
+  args: {
+    ...JSX.args,
+  },
+  parameters: {
+    chromatic: { viewports: [320] },
+  },
+  render: (args) => (
+    <div style={{ width: 320 }}>
+      <Source {...args} />
+    </div>
+  ),
 };


### PR DESCRIPTION
Adds small viewport (320px) stories for Preview and Source doc block components, to improve Chromatic visual regression testing at narrow widths.

This was suggested by @Sidnioulz in https://github.com/storybookjs/storybook/pull/33961#issuecomment-2693289498.

Changes made:
- "Preview.stories.tsx":  Added "SingleSmallViewport" and "CodeExpandedSmallViewport" stories
- "Source.stories.tsx": Added "JSXSmallViewport" story

All stories wrap the component in a 320px container and set "chromatic: {viewports: [320]}" for visual snapshot testing.

 Checklist                                                                                                                                                                              
  - [x] Stories added
  - [x] Linter passes (0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new small viewport test stories for component preview and source documentation, ensuring proper rendering at 320px width for mobile-sized screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->