### PR TITLE
Docs: Add `allowedHosts` core config option 

### DIFF
--- a/docs/_snippets/main-config-core-allowed-hosts.md
+++ b/docs/_snippets/main-config-core-allowed-hosts.md
@@ -1,0 +1,25 @@
+```js filename=".storybook/main.js" renderer="common" language="js"
+export default {
+  // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  core: {
+    allowedHosts: ['storybook.example.local'],
+  },
+};
+```
+
+```ts filename=".storybook/main.ts" renderer="common" language="ts"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+import type { StorybookConfig } from '@storybook/your-framework';
+
+const config: StorybookConfig = {
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  core: {
+    allowedHosts: ['storybook.example.local'],
+  },
+};
+
+export default config;
+```

--- a/docs/_snippets/main-config-core-allowed-hosts.md
+++ b/docs/_snippets/main-config-core-allowed-hosts.md
@@ -1,4 +1,4 @@
-```js filename=".storybook/main.js" renderer="common" language="js"
+```js filename=".storybook/main.js" renderer="common" language="js" tabTitle="CSF 3"
 export default {
   // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
   framework: '@storybook/your-framework',
@@ -9,7 +9,7 @@ export default {
 };
 ```
 
-```ts filename=".storybook/main.ts" renderer="common" language="ts"
+```ts filename=".storybook/main.ts" renderer="common" language="ts" tabTitle="CSF 3"
 // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
 import type { StorybookConfig } from '@storybook/your-framework';
 
@@ -22,4 +22,96 @@ const config: StorybookConfig = {
 };
 
 export default config;
+```
+
+```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { defineMain } from '@storybook/your-framework/node';
+
+export default defineMain({
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  framework: '@storybook/your-framework',
+  core: {
+    allowedHosts: ['storybook.example.local'],
+  },
+});
+```
+
+<!-- JS snippets still needed while providing both CSF 3 & Next -->
+
+```js filename=".storybook/main.js" renderer="react" language="js" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { defineMain } from '@storybook/your-framework/node';
+
+export default defineMain({
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  core: {
+    allowedHosts: ['storybook.example.local'],
+  },
+});
+```
+
+```ts filename=".storybook/main.ts" renderer="vue" language="ts" tabTitle="CSF Next 🧪"
+import { defineMain } from '@storybook/vue3-vite/node';
+
+export default defineMain({
+  framework: '@storybook/vue3-vite',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  core: {
+    allowedHosts: ['storybook.example.local'],
+  },
+});
+```
+
+<!-- JS snippets still needed while providing both CSF 3 & Next -->
+
+```js filename=".storybook/main.js" renderer="vue" language="js" tabTitle="CSF Next 🧪"
+import { defineMain } from '@storybook/vue3-vite/node';
+
+export default defineMain({
+  framework: '@storybook/vue3-vite',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  core: {
+    allowedHosts: ['storybook.example.local'],
+  },
+});
+```
+
+```ts filename=".storybook/main.ts" renderer="angular" language="ts" tabTitle="CSF Next 🧪"
+import { defineMain } from '@storybook/angular/node';
+
+export default defineMain({
+  framework: '@storybook/angular',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  core: {
+    allowedHosts: ['storybook.example.local'],
+  },
+});
+```
+
+```ts filename=".storybook/main.ts" renderer="web-components" language="ts" tabTitle="CSF Next 🧪"
+import { defineMain } from '@storybook/web-components-vite/node';
+
+export default defineMain({
+  framework: '@storybook/web-components-vite',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  core: {
+    allowedHosts: ['storybook.example.local'],
+  },
+});
+```
+
+<!-- JS snippets still needed while providing both CSF 3 & Next -->
+
+```js filename=".storybook/main.js" renderer="web-components" language="js" tabTitle="CSF Next 🧪"
+import { defineMain } from '@storybook/web-components-vite/node';
+
+export default defineMain({
+  framework: '@storybook/web-components-vite',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  core: {
+    allowedHosts: ['storybook.example.local'],
+  },
+});
 ```

--- a/docs/api/main-config/main-config-core.mdx
+++ b/docs/api/main-config/main-config-core.mdx
@@ -32,7 +32,7 @@ Type: `string[] | true`
 
 Default: `[]`
 
-Configures the allowed hosts for the Storybook dev server, used for Origin and Host header validation. Storybook's localhost and local network (or `--host`) addresses are always allowed. Use this when accessing your local Storybook instance through a reverse proxy (e.g. your webapp dev server). Set to `true` to disable hostname validation (insecure).
+Configures the allowed hosts for the Storybook dev server, used for Origin and Host header validation. Storybook's localhost and local network (or [`--host`](../cli-options.mdx#dev)) addresses are always allowed. Use this when accessing your local Storybook instance through a reverse proxy (e.g. your webapp dev server). Set to `true` to disable hostname validation (insecure).
 
 {/* prettier-ignore-start */}
 

--- a/docs/api/main-config/main-config-core.mdx
+++ b/docs/api/main-config/main-config-core.mdx
@@ -11,6 +11,7 @@ Type:
 
 ```ts
 {
+  allowedHosts?: string[] | true;
   builder?: string | { name: string; options?: BuilderOptions };
   channelOptions?: ChannelOptions;
   crossOriginIsolated?: boolean;
@@ -24,6 +25,20 @@ Type:
 ```
 
 Configures Storybook's internal features.
+
+## `allowedHosts`
+
+Type: `string[] | true`
+
+Default: `[]`
+
+Configures the allowed hosts for the Storybook dev server, used for Origin and Host header validation. Storybook's localhost and local network (or `--host`) addresses are always allowed. Use this when accessing your local Storybook instance through a reverse proxy (e.g. your webapp dev server). Set to `true` to disable hostname validation (insecure).
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="main-config-core-allowed-hosts.md" />
+
+{/* prettier-ignore-end */}
 
 ## `builder`
 


### PR DESCRIPTION
## What I did

Added configuration snippet and documentation for `allowedHosts` in Storybook core settings. See https://github.com/storybookjs/storybook/pull/33835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive documentation and configuration examples for the allowed hosts feature, enabling developers to configure which hosts can access the development server. Includes examples spanning React, Vue, Angular, and web-components frameworks, with both standard and typed configuration methods, plus various modern CSF setup patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->