### PR TITLE
Hotfix: Backport host/origin validation to requests and websocket connections

### DIFF
--- a/.github/workflows/publish.md
+++ b/.github/workflows/publish.md
@@ -4,11 +4,17 @@
 
 1. `git checkout v8`
 2. `git pull`
-3. `git checkout -b hotfix/v<next-patch-release-version>`
-4. Apply necessary hotfixes
-5. `cd scripts && yarn release:version --deferred --release-type patch --verbose && cd .. && git add . && git commit -m "Bump deferred version"`
-6. Add a new entry for the new version to the `CHANGELOG.md` file
-7. Trigger canary release via dispatching the workflow for `publish-canary`
-8. Test the canary release
+3. Define which next patch version this release will be (last released version + patch e.g. 8.1.2 -> 8.1.3)
+4. `git checkout -b hotfix/v<next-patch-release-version>`
+5. Apply necessary hotfixes, finish the work and make a PR. Save that PR number to use later.
+6. At the root of the repo, run a script to prepare for the new version
+   - `cd scripts && yarn release:version --deferred --release-type patch --verbose && cd .. && git add . && git commit -m "Bump deferred version"`
+7. Manually add a new entry for the new version to the `CHANGELOG.md` file including the description of the change
+8. Trigger canary release to test in real projects
+   1. Add the hotfix branch name as deployment branch here: https://github.com/storybookjs/storybook/settings/environments/1012979736/edit
+   2. Dispatch the `publish-canary` workflow and select the hotfix branch name and PR number: https://github.com/storybookjs/storybook/actions/workflows/publish.yml
+   3. Test the canary release (MealDrop has a [storybook/8.0.0](https://github.com/yannbf/mealdrop/tree/storybook/8.0.0) branch if you like to use for testing)
+   4. Remove the deployment branch name added in step 1
 9. Merge `hotfix/v<next-patch-release-version>` into `v8`
 10. Observe the `publish-normal` job
+11. Observe the generated release in GitHub releases page and make modifications to the release notes if necessary

--- a/.github/workflows/publish.md
+++ b/.github/workflows/publish.md
@@ -18,3 +18,51 @@
 9. Merge `hotfix/v<next-patch-release-version>` into `v8`
 10. Observe the `publish-normal` job
 11. Observe the generated release in GitHub releases page and make modifications to the release notes if necessary
+
+## Known CI issues
+
+Some CI failures are known and acceptable, so long as they do not impact the patch changes. Here's an overview of currently known and ignorable CI failures:
+
+### Test Runner Production: Running Test Runner
+
+103 failures:
+
+```
+Test suite failed to run
+
+    Failed to deserialize buffer as swc::config::Options
+    JSON: {"jsc":{"target":"es2023","transform":{"hidden":{"jest":true}}},"sourceMaps":"inline","module":{"type":"commonjs"},"filename":"/tmp/37b7a1ae084822841eff3e2d58b09cd9/addons-docs-docspage-error.test.js"}
+
+    Caused by:
+        unknown variant `es2023`, expected one of `es3`, `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020`, `es2021`, `es2022`, `esnext` at line 1 column 201
+```
+
+### Vitest integration: Running story tests in Vitest
+
+```
+⎯⎯⎯⎯⎯⎯⎯ Startup Error ⎯⎯⎯⎯⎯⎯⎯⎯
+Error [ERR_REQUIRE_ESM]: require() of ES Module /tmp/storybook/sandbox/experimental-nextjs-vite-default-ts/node_modules/vite/dist/node/index.js from /tmp/storybook/sandbox/experimental-nextjs-vite-default-ts/node_modules/vitest/dist/config.cjs not supported.
+Instead change the require of index.js in /tmp/storybook/sandbox/experimental-nextjs-vite-default-ts/node_modules/vitest/dist/config.cjs to a dynamic import() which is available in all CommonJS modules.
+    at _require.extensions.<computed> [as .js] (file:///tmp/storybook/sandbox/experimental-nextjs-vite-default-ts/node_modules/vite/dist/node/chunks/config.js:35920:9)
+    at Object.<anonymous> (/tmp/storybook/sandbox/experimental-nextjs-vite-default-ts/node_modules/vitest/dist/config.cjs:5:12)
+    at _require.extensions.<computed> [as .js] (file:///tmp/storybook/sandbox/experimental-nextjs-vite-default-ts/node_modules/vite/dist/node/chunks/config.js:35920:9) {
+  code: 'ERR_REQUIRE_ESM'
+}
+```
+
+```
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯
+
+FAIL   storybook (chromium)  template-stories/addons/docs/docspage/iframe.stories.ts > Basic
+
+Test timed out in 5000ms.
+If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
+ ❯ _test template-stories/addons/docs/docspage/iframe.stories.ts:16:7
+```
+
+### test-init-empty-npm-nextjs-ts: Storybook init from empty directory (NPM)
+
+```
+ERROR in main
+Module not found: TypeError: Cannot read properties of undefined (reading 'tap')
+```

--- a/.github/workflows/publish.md
+++ b/.github/workflows/publish.md
@@ -23,6 +23,12 @@
 
 Some CI failures are known and acceptable, so long as they do not impact the patch changes. Here's an overview of currently known and ignorable CI failures:
 
+- UI Review: bench/react-vite-default-ts-test-build
+- UI Review: bench/react-webpack-18-ts-test-build
+- UI Review: storybook-ui
+
+Additionally, certain jobs will fail with known and acceptable issues:
+
 ### Test Runner Production: Running Test Runner
 
 103 failures:

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ tsconfig.vitest-temp.json
 !/**/.yarn/versions
 !/**/.yarn/patches
 /**/.pnp.*
-!/node_modules
 
 # test-storybooks
 test-storybooks/ember-cli/ember-output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.6.18
+
+- Add request validation
+
 ## 8.6.17
 
 - Harden websocket connection

--- a/code/builders/builder-vite/src/vite-server.ts
+++ b/code/builders/builder-vite/src/vite-server.ts
@@ -12,10 +12,13 @@ export async function createViteServer(options: Options, devServer: Server) {
 
   const commonCfg = await commonConfig(options, 'development');
 
+  const { allowedHosts } = await presets.apply('core', {});
+
   const config: InlineConfig & { server: ServerOptions } = {
     ...commonCfg,
     // Set up dev server
     server: {
+      allowedHosts,
       middlewareMode: true,
       hmr: {
         port: options.port,
@@ -29,14 +32,12 @@ export async function createViteServer(options: Options, devServer: Server) {
     optimizeDeps: await getOptimizeDeps(commonCfg, options),
   };
 
-  const ipRegex = /^(?:\d{1,3}\.){3}\d{1,3}$|^(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}$/;
-
+  // '0.0.0.0' binds to all interfaces, which is useful for Docker and other containerized environments
   if (
-    !(config.server.allowedHosts as string[])?.length &&
-    options.host &&
-    !ipRegex.test(options.host)
+    options.host === '0.0.0.0' &&
+    (!allowedHosts || (Array.isArray(allowedHosts) && allowedHosts.length === 0))
   ) {
-    config.server.allowedHosts = [options.host.toLowerCase()];
+    config.server.allowedHosts = true;
   }
 
   const finalConfig = await presets.apply('viteFinal', config, options);

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -372,6 +372,7 @@
     "get-npm-tarball-url": "^2.0.3",
     "glob": "^10.0.0",
     "globby": "^14.0.1",
+    "host-validation-middleware": "^0.1.2",
     "jiti": "^1.21.6",
     "js-yaml": "^4.1.0",
     "lazy-universal-dotenv": "^4.0.0",

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -136,7 +136,20 @@ export async function buildDevStandalone(
     isCritical: true,
   });
 
-  const { renderer, builder, disableTelemetry } = await presets.apply('core', {});
+  const { allowedHosts, renderer, builder, disableTelemetry } = await presets.apply('core', {});
+
+  // '0.0.0.0' binds to all interfaces, which is useful for Docker and other containerized environments.
+  // By default we allow requests from all hosts in this case, but the user should be made aware of the risk.
+  if (
+    options.host === '0.0.0.0' &&
+    (!allowedHosts || (allowedHosts !== true && allowedHosts.length === 0))
+  ) {
+    logger.warn(dedent`
+      --host is set to 0.0.0.0 but no allowedHosts are defined. Allowing all hosts.
+      To restrict allowed hosts, set core.allowedHosts in your main Storybook config.
+      See: https://storybook.js.org/docs/api/main-config/main-config-core
+    `);
+  }
 
   if (!builder) {
     throw new MissingBuilderError();
@@ -251,6 +264,7 @@ export async function buildDevStandalone(
         name,
         address,
         networkAddress,
+        allowedHosts,
         managerTotalTime,
         previewTotalTime,
       });

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -17,7 +17,7 @@ import { oneWayHash, telemetry } from '@storybook/core/telemetry';
 import type { BuilderOptions, CLIOptions, LoadOptions, Options } from '@storybook/core/types';
 import { global } from '@storybook/global';
 
-import { deprecate } from '@storybook/core/node-logger';
+import { deprecate, logger } from '@storybook/core/node-logger';
 import { MissingBuilderError, NoStatsForViteDevError } from '@storybook/core/server-errors';
 
 import prompts from 'prompts';

--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -15,6 +15,7 @@ import { getManagerBuilder, getPreviewBuilder } from './utils/get-builders';
 import { getCachingMiddleware } from './utils/get-caching-middleware';
 import { getServerChannel } from './utils/get-server-channel';
 import { getAccessControlMiddleware } from './utils/getAccessControlMiddleware';
+import { getHostValidationMiddleware } from './utils/getHostValidationMiddleware';
 import { getStoryIndexGenerator } from './utils/getStoryIndexGenerator';
 import { getMiddleware } from './utils/middleware';
 import { openInBrowser } from './utils/open-in-browser';
@@ -28,9 +29,20 @@ export async function storybookDevServer(options: Options) {
 
   assert(core?.channelOptions?.wsToken, 'wsToken is required for securing the server channel');
 
+  const { port, host, initialPath } = options;
+  invariant(port, 'expected options to have a port');
+  const proto = options.https ? 'https' : 'http';
+  const { address, networkAddress } = getServerAddresses(port, host, proto, initialPath);
+
   const serverChannel = await options.presets.apply(
     'experimental_serverChannel',
-    getServerChannel(server, core.channelOptions.wsToken)
+    getServerChannel(server, {
+      token: core.channelOptions.wsToken,
+      host,
+      allowedHosts: core.allowedHosts,
+      localAddress: address,
+      networkAddress,
+    })
   );
 
   let indexError: Error | undefined;
@@ -47,15 +59,18 @@ export async function storybookDevServer(options: Options) {
     options.extendServer(server);
   }
 
+  app.use(
+    getHostValidationMiddleware({
+      host,
+      allowedHosts: core?.allowedHosts,
+      localAddress: address,
+      networkAddress,
+    })
+  );
   app.use(getAccessControlMiddleware(core?.crossOriginIsolated ?? false));
   app.use(getCachingMiddleware());
 
   getMiddleware(options.configDir)(app);
-
-  const { port, host, initialPath } = options;
-  invariant(port, 'expected options to have a port');
-  const proto = options.https ? 'https' : 'http';
-  const { address, networkAddress } = getServerAddresses(port, host, proto, initialPath);
 
   if (!core?.builder) {
     throw new MissingBuilderError();

--- a/code/core/src/core-server/utils/__tests__/getHostValidationMiddleware.test.ts
+++ b/code/core/src/core-server/utils/__tests__/getHostValidationMiddleware.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getHostValidationMiddleware, isValidHost } from '../getHostValidationMiddleware';
+
+function createMockRequest(headers: Record<string, string>) {
+  return { headers } as any;
+}
+
+function createMockResponse() {
+  const res: any = {
+    writeHead: vi.fn(),
+    end: vi.fn(),
+  };
+  return res;
+}
+
+describe('getHostValidationMiddleware', () => {
+  it('calls next() when allowedHosts is true (allow all)', () => {
+    const middleware = getHostValidationMiddleware({
+      host: 'localhost',
+      allowedHosts: true,
+    });
+    const req = createMockRequest({ host: 'malicious-site.com:6006' });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.writeHead).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when Host is invalid (strict allowedHosts)', () => {
+    const middleware = getHostValidationMiddleware({
+      host: 'localhost',
+      allowedHosts: [],
+      localAddress: 'http://localhost:6006',
+      networkAddress: 'http://192.168.1.100:6006',
+    });
+    const req = createMockRequest({ host: 'evil.com:6006' });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(res.writeHead).toHaveBeenCalledWith(403, { 'Content-Type': 'text/plain' });
+    expect(res.end).toHaveBeenCalledWith('Invalid host');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next() when Host is valid (matches localAddress)', () => {
+    const middleware = getHostValidationMiddleware({
+      host: 'localhost',
+      allowedHosts: [],
+      localAddress: 'http://localhost:6006',
+      networkAddress: 'http://192.168.1.100:6006',
+    });
+    const req = createMockRequest({ host: 'localhost:6006' });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.writeHead).not.toHaveBeenCalled();
+  });
+
+  it('calls next() when Host matches networkAddress', () => {
+    const middleware = getHostValidationMiddleware({
+      host: '0.0.0.0',
+      allowedHosts: [],
+      localAddress: 'http://localhost:6006',
+      networkAddress: 'http://192.168.1.100:6006',
+    });
+    const req = createMockRequest({ host: '192.168.1.100:6006' });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.writeHead).not.toHaveBeenCalled();
+  });
+
+  it('calls next() when allowedHosts is empty but Host matches localAddress', () => {
+    const middleware = getHostValidationMiddleware({
+      host: 'localhost',
+      allowedHosts: [],
+      localAddress: 'http://localhost:6006',
+      networkAddress: 'http://192.168.1.100:6006',
+    });
+    const req = createMockRequest({ host: 'localhost:6006' });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.writeHead).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when Host header is absent (allowedHosts not true)', () => {
+    const middleware = getHostValidationMiddleware({
+      host: 'localhost',
+      allowedHosts: [],
+      localAddress: 'http://localhost:6006',
+    });
+    const req = createMockRequest({});
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(res.writeHead).toHaveBeenCalledWith(403, { 'Content-Type': 'text/plain' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next() when Host matches allowedHosts hostname (custom domain)', () => {
+    const middleware = getHostValidationMiddleware({
+      allowedHosts: ['my-app.example.com'],
+    });
+    const req = createMockRequest({ host: 'my-app.example.com:6006' });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.writeHead).not.toHaveBeenCalled();
+  });
+});
+
+describe('isValidHost', () => {
+  const options = {
+    localAddress: 'http://localhost:6006',
+    networkAddress: 'http://192.168.1.100:6006',
+  } as any;
+
+  /** When allowedHosts is set to [], only local/network hosts are allowed (no default allow-all). */
+  const strictOptions = { ...options, allowedHosts: [] } as any;
+
+  it('returns true for exact local address match', () => {
+    expect(isValidHost('localhost:6006', options)).toBe(true);
+  });
+
+  it('returns true for network address match', () => {
+    expect(isValidHost('192.168.1.100:6006', options)).toBe(true);
+  });
+
+  it('returns true for localhost host', () => {
+    expect(isValidHost('localhost:6006', options)).toBe(true);
+  });
+
+  it('returns true for 127.0.0.1 host', () => {
+    expect(isValidHost('127.0.0.1:6006', options)).toBe(true);
+  });
+
+  it('when allowedHosts is undefined (default []), rejects unknown hosts', () => {
+    expect(isValidHost('malicious-site.com', options)).toBe(false);
+    expect(isValidHost('any-origin.example.com', options)).toBe(false);
+  });
+
+  it('when allowedHosts is true, allows any host', () => {
+    const allowAllOptions = { ...options, allowedHosts: true } as any;
+    expect(isValidHost('malicious-site.com', allowAllOptions)).toBe(true);
+    expect(isValidHost('any-origin.example.com', allowAllOptions)).toBe(true);
+  });
+
+  it('returns false for different host when allowedHosts is empty', () => {
+    expect(isValidHost('malicious-site.com', strictOptions)).toBe(false);
+  });
+
+  it('returns true for localhost with different port (host-validation-middleware allows localhost)', () => {
+    expect(isValidHost('localhost:8080', strictOptions)).toBe(true);
+  });
+
+  it('returns true for localhost with same host (host-validation-middleware allows localhost)', () => {
+    expect(isValidHost('localhost:6006', strictOptions)).toBe(true);
+  });
+
+  it('returns false for undefined host when not allow-all', () => {
+    expect(isValidHost(undefined, strictOptions)).toBe(false);
+  });
+
+  it('returns false for null host when not allow-all', () => {
+    expect(isValidHost(null as any, strictOptions)).toBe(false);
+  });
+
+  it('returns true when localAddress is missing but hostname is localhost (host-validation-middleware allows localhost)', () => {
+    const optionsWithoutLocal = {
+      networkAddress: 'http://192.168.1.100:6006',
+      allowedHosts: [],
+    } as any;
+    expect(isValidHost('localhost:6006', optionsWithoutLocal)).toBe(true);
+  });
+
+  it('handles https local/network addresses correctly', () => {
+    const httpsOptions = {
+      localAddress: 'https://localhost:6006',
+      networkAddress: 'https://192.168.1.100:6006',
+    } as any;
+    expect(isValidHost('localhost:6006', httpsOptions)).toBe(true);
+    expect(isValidHost('192.168.1.100:6006', httpsOptions)).toBe(true);
+    const strictHttpsOptions = { ...httpsOptions, allowedHosts: [] } as any;
+    expect(isValidHost('localhost:6006', strictHttpsOptions)).toBe(true);
+  });
+
+  it('handles network address without port', () => {
+    const optionsWithoutNetwork = {
+      localAddress: 'http://localhost:6006',
+    } as any;
+    expect(isValidHost('localhost:6006', optionsWithoutNetwork)).toBe(true);
+    const strictNoNetwork = { ...optionsWithoutNetwork, allowedHosts: [] } as any;
+    expect(isValidHost('192.168.1.100:6006', strictNoNetwork)).toBe(true);
+  });
+
+  it('returns true for different network IP (host-validation-middleware allows any IPv4)', () => {
+    expect(isValidHost('10.0.0.1:6006', strictOptions)).toBe(true);
+  });
+
+  it('returns true when request host is in allowedHosts', () => {
+    const optionsWithAllowed = {
+      ...options,
+      allowedHosts: ['my-app.example.com', 'other.example.com'],
+    } as any;
+    expect(isValidHost('my-app.example.com', optionsWithAllowed)).toBe(true);
+    expect(isValidHost('other.example.com', optionsWithAllowed)).toBe(true);
+  });
+
+  it('returns false when request host is not in allowedHosts and not local/network', () => {
+    const optionsWithAllowed = {
+      localAddress: 'http://localhost:6006',
+      networkAddress: 'http://192.168.1.100:6006',
+      allowedHosts: ['my-app.example.com'],
+    } as any;
+    expect(isValidHost('other-site.com', optionsWithAllowed)).toBe(false);
+  });
+
+  it('allowedHosts does not override default local/network checks', () => {
+    const optionsWithAllowed = {
+      ...options,
+      allowedHosts: ['my-app.example.com'],
+    } as any;
+    expect(isValidHost('localhost:6006', optionsWithAllowed)).toBe(true);
+    expect(isValidHost('192.168.1.100:6006', optionsWithAllowed)).toBe(true);
+  });
+
+  it('empty allowedHosts does not allow arbitrary hosts', () => {
+    const optionsWithEmptyAllowed = {
+      localAddress: 'http://localhost:6006',
+      allowedHosts: [],
+    } as any;
+    expect(isValidHost('localhost:6006', optionsWithEmptyAllowed)).toBe(true);
+    expect(isValidHost('arbitrary.com', optionsWithEmptyAllowed)).toBe(false);
+  });
+
+  it('when host is 0.0.0.0 and allowedHosts is empty, permits all hosts', () => {
+    const optionsZeroHost = {
+      host: '0.0.0.0',
+      allowedHosts: [],
+    } as any;
+    expect(isValidHost('malicious-site.com', optionsZeroHost)).toBe(true);
+    expect(isValidHost('any-origin.example.com', optionsZeroHost)).toBe(true);
+  });
+
+  it('when host is 0.0.0.0 but allowedHosts is not empty, does not permit arbitrary hosts', () => {
+    const optionsZeroHostWithAllowed = {
+      host: '0.0.0.0',
+      localAddress: 'http://localhost:6006',
+      allowedHosts: ['my-app.example.com'],
+    } as any;
+    expect(isValidHost('malicious-site.com', optionsZeroHostWithAllowed)).toBe(false);
+    expect(isValidHost('my-app.example.com', optionsZeroHostWithAllowed)).toBe(true);
+  });
+
+  it('when allowedHosts has hostnames, matches by hostname (host-validation-middleware ignores port in allowedHosts)', () => {
+    const optionsWithAllowed = {
+      localAddress: 'http://localhost:6006',
+      allowedHosts: ['my-app.example.com', 'other.example.com'],
+    } as any;
+    expect(isValidHost('my-app.example.com:8443', optionsWithAllowed)).toBe(true);
+    expect(isValidHost('other.example.com:8080', optionsWithAllowed)).toBe(true);
+    expect(isValidHost('other-site.com:8080', optionsWithAllowed)).toBe(false);
+  });
+});

--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Channel } from '@storybook/core/channels';
 
@@ -8,27 +8,41 @@ import { stringify } from 'telejson';
 
 import { ServerChannelTransport, getServerChannel } from '../get-server-channel';
 
+const mockToken = 'test-token-123';
+
+const options = {
+  localAddress: 'http://localhost:6006',
+  networkAddress: 'http://192.168.1.100:6006',
+  token: mockToken,
+} as any;
+
 describe('getServerChannel', () => {
   it('should return a channel', () => {
     const server = { on: vi.fn() } as any as Server;
-    const result = getServerChannel(server, 'test-token-123');
+    const result = getServerChannel(server, options);
     expect(result).toBeInstanceOf(Channel);
   });
 
   it('should attach to the http server', () => {
     const server = { on: vi.fn() } as any as Server;
-    getServerChannel(server, 'test-token-123');
+    getServerChannel(server, options);
     expect(server.on).toHaveBeenCalledWith('upgrade', expect.any(Function));
   });
 });
 
 describe('ServerChannelTransport', () => {
-  const mockToken = 'test-token-123';
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it('parses simple JSON', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter();
-    const transport = new ServerChannelTransport(server, mockToken);
+    const transport = new ServerChannelTransport(server, options);
     const handler = vi.fn();
     transport.setHandler(handler);
 
@@ -42,7 +56,7 @@ describe('ServerChannelTransport', () => {
   it('parses object JSON', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter();
-    const transport = new ServerChannelTransport(server, mockToken);
+    const transport = new ServerChannelTransport(server, options);
     const handler = vi.fn();
     transport.setHandler(handler);
 
@@ -56,7 +70,7 @@ describe('ServerChannelTransport', () => {
   it('supports telejson cyclical data', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter();
-    const transport = new ServerChannelTransport(server, mockToken);
+    const transport = new ServerChannelTransport(server, options);
     const handler = vi.fn();
     transport.setHandler(handler);
 
@@ -74,21 +88,30 @@ describe('ServerChannelTransport', () => {
       }
     `);
   });
-  it('skips telejson classes and functions in data', () => {
+
+  it('rejects connections without token', () => {
     const server = new EventEmitter() as any as Server;
-    const socket = new EventEmitter();
-    const transport = new ServerChannelTransport(server, mockToken);
-    const handler = vi.fn();
-    transport.setHandler(handler);
+    const socket = new EventEmitter() as any;
+    socket.write = vi.fn();
+    socket.destroy = vi.fn();
+    const destroySpy = vi.spyOn(socket, 'destroy');
+    const transport = new ServerChannelTransport(server, options);
 
-    // @ts-expect-error (an internal API)
-    transport.socket.emit('connection', socket);
+    // Simulate upgrade request without token
+    const request = {
+      url: '/storybook-server-channel',
+      headers: {
+        origin: 'http://localhost:6006',
+      },
+    } as any;
+    const head = Buffer.from('');
 
-    const input = { a() {}, b: class {} };
-    socket.emit('message', stringify(input));
+    server.listeners('upgrade')[0](request, socket, head);
 
-    expect(handler.mock.calls[0][0].a).toEqual(expect.any(String));
-    expect(handler.mock.calls[0][0].b).toEqual(expect.any(String));
+    expect(socket.write).toHaveBeenCalledWith(
+      'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
+    );
+    expect(destroySpy).toHaveBeenCalled();
   });
 
   it('rejects connections with invalid token', () => {
@@ -97,11 +120,14 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    new ServerChannelTransport(server, mockToken);
+    new ServerChannelTransport(server, options);
 
     // Simulate upgrade request with wrong token
     const request = {
       url: '/storybook-server-channel?token=wrong-token',
+      headers: {
+        origin: 'http://localhost:6006',
+      },
     } as any;
     const head = Buffer.from('');
 
@@ -120,15 +146,18 @@ describe('ServerChannelTransport', () => {
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
     const handleUpgradeSpy = vi.fn();
-    const transport = new ServerChannelTransport(server, mockToken);
+    const transport = new ServerChannelTransport(server, options);
 
     // Mock handleUpgrade to track if it's called
     // @ts-expect-error (accessing private property)
     transport.socket.handleUpgrade = handleUpgradeSpy;
 
-    // Simulate upgrade request with correct token
+    // Simulate upgrade request with correct token and valid origin
     const request = {
       url: `/storybook-server-channel?token=${mockToken}`,
+      headers: {
+        origin: 'http://localhost:6006',
+      },
     } as any;
     const head = Buffer.from('');
 
@@ -137,5 +166,141 @@ describe('ServerChannelTransport', () => {
     expect(socket.write).not.toHaveBeenCalled();
     expect(destroySpy).not.toHaveBeenCalled();
     expect(handleUpgradeSpy).toHaveBeenCalled();
+  });
+
+  it('rejects connections with invalid origin', () => {
+    const server = new EventEmitter() as any as Server;
+    const socket = new EventEmitter() as any;
+    socket.write = vi.fn();
+    socket.destroy = vi.fn();
+    const destroySpy = vi.spyOn(socket, 'destroy');
+    const transport = new ServerChannelTransport(server, options);
+
+    // Simulate upgrade request with invalid origin
+    const request = {
+      url: `/storybook-server-channel?token=${mockToken}`,
+      headers: {
+        origin: 'http://malicious-site.com',
+      },
+    } as any;
+    const head = Buffer.from('');
+
+    server.listeners('upgrade')[0](request, socket, head);
+
+    expect(socket.write).toHaveBeenCalledWith(
+      'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
+    );
+    expect(destroySpy).toHaveBeenCalled();
+  });
+
+  it('rejects connections without origin header', () => {
+    const server = new EventEmitter() as any as Server;
+    const socket = new EventEmitter() as any;
+    socket.write = vi.fn();
+    socket.destroy = vi.fn();
+    const destroySpy = vi.spyOn(socket, 'destroy');
+    const transport = new ServerChannelTransport(server, options);
+
+    // Simulate upgrade request without origin header
+    const request = {
+      url: `/storybook-server-channel?token=${mockToken}`,
+      headers: {},
+    } as any;
+    const head = Buffer.from('');
+
+    server.listeners('upgrade')[0](request, socket, head);
+
+    expect(socket.write).toHaveBeenCalledWith(
+      'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
+    );
+    expect(destroySpy).toHaveBeenCalled();
+  });
+
+  it('accepts connections with network address origin', () => {
+    const server = new EventEmitter() as any as Server;
+    const socket = new EventEmitter() as any;
+    socket.write = vi.fn();
+    socket.destroy = vi.fn();
+    const destroySpy = vi.spyOn(socket, 'destroy');
+    const handleUpgradeSpy = vi.fn();
+    const transport = new ServerChannelTransport(server, options);
+
+    // Mock handleUpgrade to track if it's called
+    // @ts-expect-error (accessing private property)
+    transport.socket.handleUpgrade = handleUpgradeSpy;
+
+    // Simulate upgrade request with network address origin
+    const request = {
+      url: `/storybook-server-channel?token=${mockToken}`,
+      headers: {
+        origin: 'http://192.168.1.100:6006',
+      },
+    } as any;
+    const head = Buffer.from('');
+
+    server.listeners('upgrade')[0](request, socket, head);
+
+    expect(socket.write).not.toHaveBeenCalled();
+    expect(destroySpy).not.toHaveBeenCalled();
+    expect(handleUpgradeSpy).toHaveBeenCalled();
+  });
+
+  it('accepts connections with 127.0.0.1 origin', () => {
+    const server = new EventEmitter() as any as Server;
+    const socket = new EventEmitter() as any;
+    socket.write = vi.fn();
+    socket.destroy = vi.fn();
+    const destroySpy = vi.spyOn(socket, 'destroy');
+    const handleUpgradeSpy = vi.fn();
+    const transport = new ServerChannelTransport(server, options);
+
+    // Mock handleUpgrade to track if it's called
+    // @ts-expect-error (accessing private property)
+    transport.socket.handleUpgrade = handleUpgradeSpy;
+
+    // Simulate upgrade request with 127.0.0.1 origin
+    const request = {
+      url: `/storybook-server-channel?token=${mockToken}`,
+      headers: {
+        origin: 'http://127.0.0.1:6006',
+      },
+    } as any;
+    const head = Buffer.from('');
+
+    server.listeners('upgrade')[0](request, socket, head);
+
+    expect(socket.write).not.toHaveBeenCalled();
+    expect(destroySpy).not.toHaveBeenCalled();
+    expect(handleUpgradeSpy).toHaveBeenCalled();
+  });
+
+  it('rejects connections to wrong path', () => {
+    const server = new EventEmitter() as any as Server;
+    const socket = new EventEmitter() as any;
+    socket.write = vi.fn();
+    socket.destroy = vi.fn();
+    const destroySpy = vi.spyOn(socket, 'destroy');
+    const handleUpgradeSpy = vi.fn();
+    const transport = new ServerChannelTransport(server, options);
+
+    // Mock handleUpgrade to track if it's called
+    // @ts-expect-error (accessing private property)
+    transport.socket.handleUpgrade = handleUpgradeSpy;
+
+    // Simulate upgrade request to wrong path
+    const request = {
+      url: `/wrong-path?token=${mockToken}`,
+      headers: {
+        origin: 'http://localhost:6006',
+      },
+    } as any;
+    const head = Buffer.from('');
+
+    server.listeners('upgrade')[0](request, socket, head);
+
+    // Should not call handleUpgrade for wrong path
+    expect(handleUpgradeSpy).not.toHaveBeenCalled();
+    // Socket should not be destroyed for wrong path (just ignored)
+    expect(destroySpy).not.toHaveBeenCalled();
   });
 });

--- a/code/core/src/core-server/utils/__tests__/validate-token.test.ts
+++ b/code/core/src/core-server/utils/__tests__/validate-token.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { isValidToken } from '../validate-token';
+
+describe('isValidToken', () => {
+  const validToken = 'test-token-123';
+
+  it('returns true for matching tokens', () => {
+    expect(isValidToken(validToken, validToken)).toBe(true);
+  });
+
+  it('returns false for non-matching tokens', () => {
+    expect(isValidToken('wrong-token', validToken)).toBe(false);
+  });
+
+  it('returns false for null token', () => {
+    expect(isValidToken(null, validToken)).toBe(false);
+  });
+
+  it('returns false for undefined token', () => {
+    expect(isValidToken(undefined as any, validToken)).toBe(false);
+  });
+
+  it('returns false for empty token', () => {
+    expect(isValidToken('', validToken)).toBe(false);
+  });
+
+  it('returns false when expected token is null', () => {
+    expect(isValidToken(validToken, null as any)).toBe(false);
+  });
+
+  it('returns false when expected token is undefined', () => {
+    expect(isValidToken(validToken, undefined as any)).toBe(false);
+  });
+
+  it('returns false for empty expected token', () => {
+    expect(isValidToken(validToken, '')).toBe(false);
+  });
+
+  it('returns false for tokens with different lengths', () => {
+    expect(isValidToken('short', 'much-longer-token')).toBe(false);
+  });
+
+  it('handles special characters in tokens', () => {
+    const specialToken = 'token-with-special-chars-!@#$%^&*()';
+    expect(isValidToken(specialToken, specialToken)).toBe(true);
+    expect(isValidToken(specialToken, 'different-token')).toBe(false);
+  });
+
+  it('handles unicode characters in tokens', () => {
+    const unicodeToken = 'token-with-unicode-🚀-测试';
+    expect(isValidToken(unicodeToken, unicodeToken)).toBe(true);
+    expect(isValidToken(unicodeToken, 'different-token')).toBe(false);
+  });
+});

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -6,10 +6,16 @@ import { Channel, HEARTBEAT_INTERVAL } from '@storybook/core/channels';
 import { isJSON, parse, stringify } from 'telejson';
 import WebSocket, { WebSocketServer } from 'ws';
 
+import { logger } from '../../node-logger';
 import { UniversalStore } from '../../shared/universal-store';
-import { isValidToken } from './validate-websocket-token';
+import { type HostValidationOptions, isValidHost } from './getHostValidationMiddleware';
+import { isValidToken } from './validate-token';
 
 type Server = NonNullable<NonNullable<ConstructorParameters<typeof WebSocketServer>[0]>['server']>;
+
+type ServerChannelTransportOptions = HostValidationOptions & {
+  token: string;
+};
 
 /**
  * This class represents a channel transport that allows for a one-to-many relationship between the
@@ -22,29 +28,36 @@ export class ServerChannelTransport {
 
   private handler?: ChannelHandler;
 
-  private token: string;
-
-  constructor(server: Server, token: string) {
-    this.token = token;
+  constructor(server: Server, options: ServerChannelTransportOptions) {
     this.socket = new WebSocketServer({ noServer: true });
 
     server.on('upgrade', (request: IncomingMessage, socket, head) => {
-      if (request.url) {
-        const url = new URL(request.url, 'http://localhost');
-        if (url.pathname === '/storybook-server-channel') {
-          const requestToken = url.searchParams.get('token');
-          if (!isValidToken(requestToken, this.token)) {
-            socket.write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
-            socket.destroy();
-            return;
-          }
-
-          this.socket.handleUpgrade(request, socket, head, (ws) => {
-            this.socket.emit('connection', ws, request);
-          });
+      try {
+        const url = request.url && new URL(request.url, options.localAddress);
+        if (!url || url.pathname !== '/storybook-server-channel') {
+          return;
         }
+
+        const originHost = request.headers.origin && new URL(request.headers.origin).host;
+        if (!isValidHost(originHost, options)) {
+          throw new Error('Invalid websocket origin');
+        }
+
+        const requestToken = url.searchParams.get('token');
+        if (!isValidToken(requestToken, options.token)) {
+          throw new Error('Invalid websocket token');
+        }
+
+        this.socket.handleUpgrade(request, socket, head, (ws) => {
+          this.socket.emit('connection', ws, request);
+        });
+      } catch (error) {
+        logger.warn(`Rejecting WebSocket connection: ${error}`);
+        socket.write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
+        socket.destroy();
       }
     });
+
     this.socket.on('connection', (wss) => {
       wss.on('message', (raw) => {
         const data = raw.toString();
@@ -87,8 +100,8 @@ export class ServerChannelTransport {
   }
 }
 
-export function getServerChannel(server: Server, token: string) {
-  const transports = [new ServerChannelTransport(server, token)];
+export function getServerChannel(server: Server, options: ServerChannelTransportOptions) {
+  const transports = [new ServerChannelTransport(server, options)];
 
   const channel = new Channel({ transports, async: true });
 

--- a/code/core/src/core-server/utils/getHostValidationMiddleware.ts
+++ b/code/core/src/core-server/utils/getHostValidationMiddleware.ts
@@ -1,0 +1,67 @@
+import type { IncomingMessage } from 'node:http';
+
+import { isHostAllowed } from 'host-validation-middleware';
+
+import type { Middleware } from '../../types';
+
+export type HostValidationOptions = {
+  host?: string;
+  allowedHosts?: string[] | true;
+  localAddress?: string;
+  networkAddress?: string;
+};
+
+export const DEFAULT_ALLOWED_HOSTS: NonNullable<HostValidationOptions['allowedHosts']> = [];
+
+/**
+ * Validates a host (Host header–shaped string, e.g. "localhost:6006") against known local/network
+ * addresses and allowed hosts. Callers must pass host-shaped input; normalize from an origin URL
+ * (e.g. new URL(origin).host) before invoking if needed.
+ *
+ * @param host - The host to validate (hostname or "hostname:port").
+ * @param options - The builder options.
+ * @returns `true` if the host is valid, `false` otherwise.
+ */
+export const isValidHost = (host: string | undefined, options: HostValidationOptions): boolean => {
+  const allowedHosts = options.allowedHosts ?? DEFAULT_ALLOWED_HOSTS;
+  if (allowedHosts === true) {
+    return true;
+  }
+  if (!host) {
+    return false;
+  }
+
+  try {
+    // Setting host to 0.0.0.0 binds to all hosts, which implies allowing all hosts.
+    // This is common in containerized environments like Docker.
+    if (options.host === '0.0.0.0' && allowedHosts.length === 0) {
+      return true;
+    }
+    return isHostAllowed(host, [
+      ...allowedHosts,
+      ...(options.localAddress ? [new URL(options.localAddress).host] : []),
+      ...(options.networkAddress ? [new URL(options.networkAddress).host] : []),
+    ]);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Validates the Host header against known local/network addresses and allowed hosts. Requests with
+ * no Host header (e.g. same-origin navigation, GET from address bar) are not allowed.
+ */
+export function getHostValidationMiddleware(
+  options: HostValidationOptions
+): Middleware<IncomingMessage> {
+  return (req, res, next) => {
+    const host = req.headers.host;
+    const allowedHosts = options.allowedHosts ?? DEFAULT_ALLOWED_HOSTS;
+    if (allowedHosts !== true && !isValidHost(host, options)) {
+      res.writeHead(403, { 'Content-Type': 'text/plain' });
+      res.end('Invalid host');
+      return;
+    }
+    next();
+  };
+}

--- a/code/core/src/core-server/utils/output-startup-information.ts
+++ b/code/core/src/core-server/utils/output-startup-information.ts
@@ -20,8 +20,16 @@ export function outputStartupInformation(options: {
   managerTotalTime?: [number, number];
   previewTotalTime?: [number, number];
 }) {
-  const { updateInfo, version, name, address, networkAddress, allowedHosts, managerTotalTime, previewTotalTime } =
-    options;
+  const {
+    updateInfo,
+    version,
+    name,
+    address,
+    networkAddress,
+    allowedHosts,
+    managerTotalTime,
+    previewTotalTime,
+  } = options;
 
   const updateMessage = createUpdateMessage(updateInfo, version);
 
@@ -55,7 +63,12 @@ export function outputStartupInformation(options: {
     ['On your network:', picocolors.cyan(networkAddress)]
   );
 
-  const otherAllowedHosts = allowedHosts === true ? 'all (insecure)' : allowedHosts?.length ? allowedHosts.join(', ') : undefined;
+  const otherAllowedHosts =
+    allowedHosts === true
+      ? 'all (insecure)'
+      : allowedHosts?.length
+        ? allowedHosts.join(', ')
+        : undefined;
   if (otherAllowedHosts) {
     serveMessage.push(['Other allowed hosts:', picocolors.cyan(otherAllowedHosts)]);
   }

--- a/code/core/src/core-server/utils/output-startup-information.ts
+++ b/code/core/src/core-server/utils/output-startup-information.ts
@@ -16,10 +16,11 @@ export function outputStartupInformation(options: {
   name: string;
   address: string;
   networkAddress: string;
+  allowedHosts?: string[] | true;
   managerTotalTime?: [number, number];
   previewTotalTime?: [number, number];
 }) {
-  const { updateInfo, version, name, address, networkAddress, managerTotalTime, previewTotalTime } =
+  const { updateInfo, version, name, address, networkAddress, allowedHosts, managerTotalTime, previewTotalTime } =
     options;
 
   const updateMessage = createUpdateMessage(updateInfo, version);
@@ -53,6 +54,11 @@ export function outputStartupInformation(options: {
     ['Local:', picocolors.cyan(address)],
     ['On your network:', picocolors.cyan(networkAddress)]
   );
+
+  const otherAllowedHosts = allowedHosts === true ? 'all (insecure)' : allowedHosts?.length ? allowedHosts.join(', ') : undefined;
+  if (otherAllowedHosts) {
+    serveMessage.push(['Other allowed hosts:', picocolors.cyan(otherAllowedHosts)]);
+  }
 
   const timeStatement = [
     managerTotalTime && `${picocolors.underline(prettyTime(managerTotalTime))} for manager`,

--- a/code/core/src/core-server/utils/server-init.ts
+++ b/code/core/src/core-server/utils/server-init.ts
@@ -10,7 +10,7 @@ export async function getServer(options: {
   sslCert?: string;
   sslKey?: string;
   sslCa?: string[];
-}) {
+}): Promise<http.Server | https.Server> {
   if (!options.https) {
     return http.createServer();
   }

--- a/code/core/src/core-server/utils/validate-token.ts
+++ b/code/core/src/core-server/utils/validate-token.ts
@@ -5,13 +5,13 @@ import { timingSafeEqual } from 'node:crypto';
  *
  * @returns `true` if tokens match, `false` otherwise
  */
-export function isValidToken(token: string | null, expectedToken: string): boolean {
-  if (!token || !expectedToken) {
+export function isValidToken(requestToken: string | null, expectedToken: string): boolean {
+  if (!requestToken || !expectedToken) {
     return false;
   }
 
-  const a = Buffer.from(token, 'utf8');
-  const b = Buffer.from(expectedToken, 'utf8');
+  const a = new Uint8Array(Buffer.from(requestToken, 'utf8'));
+  const b = new Uint8Array(Buffer.from(expectedToken, 'utf8'));
   try {
     return a.length === b.length && timingSafeEqual(a, b);
   } catch {

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -45,6 +45,11 @@ export interface CoreConfig {
    */
   enableCrashReports?: boolean;
   /**
+   * Enable hostname validation, currently only for WebSocket connections. Set to `[]` to disallow
+   * all hosts except known local/network address, or `true` to allow all hosts.
+   */
+  allowedHosts?: string[] | true;
+  /**
    * Enable CORS headings to run document in a "secure context" see:
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
    * This enables these headers in development-mode: Cross-Origin-Opener-Policy: same-origin
@@ -200,6 +205,8 @@ export interface BuilderOptions {
   versionCheck?: VersionCheck;
   disableWebpackDefaults?: boolean;
   serverChannelUrl?: string;
+  localAddress?: string;
+  networkAddress?: string;
 }
 
 export interface StorybookConfigOptions {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -8399,6 +8399,7 @@ __metadata:
     get-npm-tarball-url: "npm:^2.0.3"
     glob: "npm:^10.0.0"
     globby: "npm:^14.0.1"
+    host-validation-middleware: "npm:^0.1.2"
     jiti: "npm:^1.21.6"
     js-yaml: "npm:^4.1.0"
     jsdoc-type-pratt-parser: "npm:^4.0.0"
@@ -20165,6 +20166,13 @@ __metadata:
   dependencies:
     parse-passwd: "npm:^1.0.0"
   checksum: 10c0/3c099844f94b8b438f124bd5698bdcfef32b2d455115fb8050d7148e7f7b95fc89ba9922586c491f0e1cdebf437b1053c84ecddb8d596e109e9ac69c5b4a9e27
+  languageName: node
+  linkType: hard
+
+"host-validation-middleware@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "host-validation-middleware@npm:0.1.2"
+  checksum: 10c0/42a36849ed4898b7af574b4e5ea57070d8fcd7b98f6c7c027cd301612a83a48bf812066ef83fbc2ba9e7a50bc5986215ec802f06b64e14988f2117fbeb6bc24c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

This is a backport of #33835 for Storybook v8.6.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Run `npx ngrok http 6006`
- Verify that the ngrok URL serves an Invalid host error
- Update `.storybook/main.ts` to set `core.allowedHosts` to include the ngrok hostname (no protocol), then restart Storybook
- Verify that the ngrok URL serves Storybook properly, and it works

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34009-sha-c90626e7`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34009-sha-c90626e7 sandbox` or in an existing project with `npx storybook@0.0.0-pr-34009-sha-c90626e7 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34009-sha-c90626e7`](https://npmjs.com/package/storybook/v/0.0.0-pr-34009-sha-c90626e7) |
| **Triggered by** | @ghengeveld |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`origin-validation-v8`](https://github.com/storybookjs/storybook/tree/origin-validation-v8) |
| **Commit** | [`c90626e7`](https://github.com/storybookjs/storybook/commit/c90626e7679727d899c6311c83be6193def3360c) |
| **Datetime** | Wed Mar  4 15:04:14 UTC 2026 (`1772636654`) |
| **Workflow run** | [22675197081](https://github.com/storybookjs/storybook/actions/runs/22675197081) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34009`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host validation added for the dev server and WebSocket connections.
  * New allowedHosts option (string[] | true) plus localAddress/networkAddress to control permitted hosts.
  * Startup now displays allowed hosts and warns when binding to 0.0.0.0 for containerized setups.

* **Refactor**
  * Server channel and token handling moved to an options-based flow (public API updated).

* **Chores**
  * Added host-validation-middleware dependency.
  * .gitignore adjusted to ignore root node_modules.

* **Tests**
  * New comprehensive tests for host validation, token validation, and server channel behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->