### PR TITLE
Core: Resolve builder preset path correctly in pnpm strict mode

### DIFF
--- a/code/core/src/core-server/load.ts
+++ b/code/core/src/core-server/load.ts
@@ -11,7 +11,7 @@ import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook
 
 import { global } from '@storybook/global';
 
-import { join, relative, resolve } from 'pathe';
+import { dirname, isAbsolute, join, relative, resolve } from 'pathe';
 
 import { resolvePackageDir } from '../shared/utils/module';
 
@@ -68,7 +68,13 @@ export async function loadStorybook(
   const builderName = typeof builder === 'string' ? builder : builder?.name;
 
   if (builderName) {
-    corePresets.push(join(resolvePackageDir(builderName), 'preset.js'));
+    /* builderName can be a bare package name (e.g. '@storybook/builder-vite') or an already-resolved
+       file URL / absolute path (e.g. 'file:///.../.../dist/index.js'). For bare package names, we
+       need to resolve the package directory first; for already-resolved paths, dirname works directly.
+    */
+    const isResolved = builderName.startsWith('file:') || isAbsolute(builderName);
+    const builderPresetDir = isResolved ? dirname(builderName) : resolvePackageDir(builderName);
+    corePresets.push(join(builderPresetDir, 'preset.js'));
   }
 
   // Load second pass: all presets are applied in order

--- a/code/core/src/core-server/load.ts
+++ b/code/core/src/core-server/load.ts
@@ -68,7 +68,7 @@ export async function loadStorybook(
   const builderName = typeof builder === 'string' ? builder : builder?.name;
 
   if (builderName) {
-    corePresets.push(join(dirname(builderName), 'preset.js'));
+    corePresets.push(join(resolvePackageDir(builderName), 'preset.js'));
   }
 
   // Load second pass: all presets are applied in order

--- a/code/core/src/core-server/load.ts
+++ b/code/core/src/core-server/load.ts
@@ -11,7 +11,7 @@ import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook
 
 import { global } from '@storybook/global';
 
-import { dirname, join, relative, resolve } from 'pathe';
+import { join, relative, resolve } from 'pathe';
 
 import { resolvePackageDir } from '../shared/utils/module';
 

--- a/code/core/src/shared/utils/module.ts
+++ b/code/core/src/shared/utils/module.ts
@@ -37,8 +37,8 @@ export const resolvePackageDir = (
       return dirname(fileURLToPath(importMetaResolve(join(pkg, 'package.json'))));
     } catch {
       // Fallback using require.resolve for strict pnpm environments where import.meta.resolve may fail
-      const require = createRequire(import.meta.url);
-      return dirname(require.resolve(join(pkg, 'package.json')));
+      const req = createRequire(parent ?? import.meta.url);
+      return dirname(req.resolve(join(pkg, 'package.json')));
     }
   }
 };

--- a/code/core/src/shared/utils/module.ts
+++ b/code/core/src/shared/utils/module.ts
@@ -32,8 +32,14 @@ export const resolvePackageDir = (
   try {
     return dirname(fileURLToPath(importMetaResolve(join(pkg, 'package.json'), parent)));
   } catch {
-    // Necessary fallback for Bun runtime
-    return dirname(fileURLToPath(importMetaResolve(join(pkg, 'package.json'))));
+    try {
+      // Necessary fallback for Bun runtime
+      return dirname(fileURLToPath(importMetaResolve(join(pkg, 'package.json'))));
+    } catch {
+      // Fallback using require.resolve for strict pnpm environments where import.meta.resolve may fail
+      const require = createRequire(import.meta.url);
+      return dirname(require.resolve(join(pkg, 'package.json')));
+    }
   }
 };
 


### PR DESCRIPTION
## What I did
Fixed builder preset path resolution in pnpm monorepos with strict module resolution (`shamefully-hoist=false`).

Supersedes #33750 (closed due to inactivity). This PR addresses the CI failures that were flagged by the reviewer on the original PR.

Closes #33748

## Problem
The current code uses `dirname(builderName)` to construct the path to the builder's preset file. When `builderName` is a bare package name like `@storybook/builder-vite`, `dirname()` performs string manipulation and returns `@storybook`, resulting in an invalid path `@storybook/preset.js` that causes `ERR_MODULE_NOT_FOUND` in pnpm's strict resolution mode.

## Why the original PR (#33750) had CI failures
The original one-line fix (`dirname(builderName)` → `resolvePackageDir(builderName)`) broke the `*--vitest` sandbox integration tests. The root cause: `builderName` is **not always a bare package name**. Framework presets resolve it via `import.meta.resolve()`, producing either:
- A **file URL**: `file:///path/to/node_modules/@storybook/builder-vite/dist/index.js`
- An **absolute path**: `/path/to/node_modules/@storybook/builder-vite/dist/index.js`

Passing a file URL or absolute path to `resolvePackageDir()` (which expects a bare package name) produced incorrect results, breaking preset loading in the CI sandbox tests.

The bare package name case only occurs when users specify the builder directly in their config (e.g. `core: { builder: '@storybook/builder-vite' }`), which is the scenario that fails under pnpm strict mode.

## Solution
**`code/core/src/core-server/load.ts`**: Detect whether `builderName` is already resolved (file URL or absolute path) vs a bare package name, and use the appropriate resolution strategy for each:
- **Already resolved** (file URL / absolute path): use `dirname()` as before
- **Bare package name**: use `resolvePackageDir()` to properly resolve the package directory

**`code/core/src/shared/utils/module.ts`**: Added a `require.resolve` fallback in `resolvePackageDir` for strict pnpm environments where both `import.meta.resolve` calls may fail. Uses `createRequire` (already imported) as a final fallback.

## Testing
- Verified the fix resolves the issue in a pnpm monorepo with `shamefully-hoist=false`
- Tested with `@storybook/builder-vite` and vitest browser mode
- Ran the full `core-server` test suite (255 tests pass, 0 regressions)
- Ran all preset-related tests that mock `resolvePackageDir` (30 tests pass)
- Reproduction: https://github.com/braedenfoster/storybook-pnpm-repro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust package resolution to correctly distinguish resolved paths from bare package names when loading presets.
  * Added an additional fallback for module resolution to improve reliability in strict package manager environments (e.g., pnpm), reducing resolution failures across runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->