### PR TITLE
UI: Ensure consistent heading anchor margin across themes

### DIFF
--- a/code/addons/docs/src/blocks/blocks/mdx.tsx
+++ b/code/addons/docs/src/blocks/blocks/mdx.tsx
@@ -144,6 +144,8 @@ const OcticonHeaders = SUPPORTED_MDX_HEADERS.reduce(
   (acc, headerType) => ({
     ...acc,
     [headerType]: styled(headerType)({
+      paddingLeft: 24,
+      marginLeft: -24,
       '& svg': {
         position: 'relative',
         top: '-0.1em',


### PR DESCRIPTION
## Summary

- Fixes the anchor link icon on docs headings being clipped/cut off in the light theme
- Adds `paddingLeft: 24` and `marginLeft: -24` to `OcticonHeaders` to create consistent space for the floated `OcticonAnchor` icon across both light and dark themes
- The heading text alignment remains unchanged since the padding and negative margin cancel out

## Details

The `OcticonAnchor` component uses `float: left` with `marginLeft: -24px` to position the link icon to the left of heading text. However, the `OcticonHeaders` styled components had no left padding to accommodate this, causing the icon to be clipped at the container edge in certain theme configurations.

Closes #31505

## Test plan

- [ ] Verify anchor link icons are fully visible on docs headings in light theme
- [ ] Verify anchor link icons remain correctly positioned in dark theme
- [ ] Verify heading text alignment is unchanged (padding and negative margin cancel out)

Co-authored-by: Egger <egger@horny-toad.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted header spacing with left padding and margin adjustments to improve visual alignment in documentation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->