### PR TITLE
Angular: only load webpack dependencies on demand

### DIFF
--- a/code/frameworks/angular/src/server/framework-preset-angular-cli.ts
+++ b/code/frameworks/angular/src/server/framework-preset-angular-cli.ts
@@ -1,6 +1,5 @@
 import { logger } from 'storybook/internal/node-logger';
 import { AngularLegacyBuildOptionsError } from 'storybook/internal/server-errors';
-import { WebpackDefinePlugin, WebpackIgnorePlugin } from '@storybook/builder-webpack5';
 
 import type { BuilderContext } from '@angular-devkit/architect';
 import { targetFromTargetString } from '@angular-devkit/architect';
@@ -9,7 +8,6 @@ import { logging } from '@angular-devkit/core';
 import * as find from 'empathic/find';
 import type webpack from 'webpack';
 
-import { getWebpackConfig as getCustomWebpackConfig } from './angular-cli-webpack';
 import type { PresetOptions } from './preset-options';
 import { getProjectRoot, resolvePackageDir } from 'storybook/internal/common';
 import { relative } from 'pathe';
@@ -19,6 +17,9 @@ export async function webpackFinal(baseConfig: webpack.Configuration, options: P
     logger.info('Using base config because "@angular-devkit/build-angular" is not installed');
     return baseConfig;
   }
+
+  const { WebpackDefinePlugin, WebpackIgnorePlugin } = await import('@storybook/builder-webpack5');
+  const { getWebpackConfig: getCustomWebpackConfig } = await import('./angular-cli-webpack');
 
   checkForLegacyBuildOptions(options);
 


### PR DESCRIPTION
The dependencies `@angular-devkit/build-angular`, `@storybook/builder-webpack5` and `webpack` are only needed if you use webpack.

But if you use https://analogjs.org/docs/integrations/storybook to use angular + storybook via vite, then you only need `@angular/build` and `@storybook/builder-vite` instead.

The analogjs plugin still relies on `@storybook/angular`, but loading webpack dependencies on demand allows one to drop webpack dependencies.

/cc @brandonroberts 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved lazy loading to reduce initial setup time in the Angular framework preset, optimizing internal initialization and module loading behavior.
  * Small cleanup that reduces configuration-time overhead.
  * No changes to public APIs, exports, or runtime behavior—existing integrations and user-facing features remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->