### PR TITLE
fix(actions): correct options.limit application in ActionLogger

### DIFF
--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -44,7 +44,7 @@ export default function ActionLogger({ active, api }: ActionLoggerProps) {
         action.count = 1;
         newActions.push(action);
       }
-      return newActions.slice(0, action.options.limit);
+      return action.options.limit ? newActions.slice(-action.options.limit) : newActions;
     });
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes a logic bug in the `ActionLogger` container where `options.limit` was not correctly applied when trimming the actions log.

### The Bug

Actions are appended to the **end** of the array via `newActions.push(action)`. The original code used:

```ts
return newActions.slice(0, action.options.limit);
```

`slice(0, limit)` keeps the **first** `limit` items (the **oldest** actions). Once the limit was reached, **new actions were silently dropped** rather than the oldest ones being evicted. This meant the actions panel would stop updating once it hit the limit.

### The Fix

```ts
return action.options.limit ? newActions.slice(-action.options.limit) : newActions;
```

`slice(-limit)` keeps the **last** `limit` items (the **most recent** actions), so the panel always shows the latest actions and correctly evicts the oldest ones. The falsy guard prevents `slice(-0)` (which returns an empty array) when `limit` is `0` or `undefined`.

Closes #34052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected action logging behavior: when reaching the action limit, the most recent actions are now retained instead of the earliest ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->