### PR TITLE
Fix state mutation and wrong slice direction in Actions addon

### DIFF
--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -36,15 +36,18 @@ export default function ActionLogger({ active, api }: ActionLoggerProps) {
 
   const addAction = useCallback((action: ActionDisplay) => {
     setActions((prevActions) => {
-      const newActions = [...prevActions];
-      const previous = newActions.length && newActions[newActions.length - 1];
+      const previous = prevActions.length ? prevActions[prevActions.length - 1] : null;
+      const limit = action.options.limit ?? 50;
+
+      let newActions: ActionDisplay[];
       if (previous && safeDeepEqual(previous.data, action.data)) {
-        previous.count++;
+        const updated = [...prevActions];
+        updated[updated.length - 1] = { ...previous, count: previous.count + 1 };
+        newActions = updated;
       } else {
-        action.count = 1;
-        newActions.push(action);
+        newActions = [...prevActions, { ...action, count: 1 }];
       }
-      return newActions.slice(0, action.options.limit);
+      return newActions.slice(-limit);
     });
   }, []);
 


### PR DESCRIPTION
Fixes #34052. The addAction callback was directly mutating objects in state (previous.count++, action.count = 1), which violates React immutability principle and can cause subtle state update bugs. Also, slice(0, limit) was keeping the oldest actions instead of the newest.

This PR fixes both issues:
- Creates new objects instead of mutating existing ones when incrementing count or adding new actions
- Uses slice(-limit) to retain the most recent actions instead of the oldest
- Provides safe fallback for undefined limit value