### PR TITLE
fix(docs): improve ArgsTable borders in forced-colors mode

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -159,6 +159,21 @@ export const TableWrapper = styled.table<{
               borderBottomRightRadius: theme.appBorderRadius,
             },
           }),
+
+      '@media (forced-colors: active)': {
+        filter: 'none',
+
+        '> tr > *': {
+          borderColor: 'CanvasText',
+        },
+
+        ...(inAddonPanel
+          ? null
+          : {
+              outline: '1px solid CanvasText',
+              outlineOffset: -1,
+            }),
+      },
     },
     // End awesome table styling
   },

--- a/code/addons/docs/src/blocks/components/ArgsTable/Skeleton.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/Skeleton.tsx
@@ -7,11 +7,18 @@ const TableWrapper = styled.div(({ theme }) => ({
   width: '100%',
   borderSpacing: 0,
   color: theme.color.defaultText,
+  '@media (forced-colors: active)': {
+    outline: '1px solid CanvasText',
+    outlineOffset: -1,
+  },
 }));
 
 const Row = styled.div(({ theme }) => ({
   display: 'flex',
   borderBottom: `1px solid ${theme.appBorderColor}`,
+  '@media (forced-colors: active)': {
+    borderBottomColor: 'CanvasText',
+  },
 
   '&:last-child': {
     borderBottom: 0,

--- a/code/core/assets/server/base-preview-head.html
+++ b/code/core/assets/server/base-preview-head.html
@@ -452,6 +452,18 @@
     padding: 2px 5px;
   }
 
+  @media (forced-colors: active) {
+    .sb-argstableBlock-body {
+      box-shadow: none;
+      outline: 1px solid CanvasText;
+      outline-offset: -1px;
+    }
+
+    .sb-argstableBlock-body tr:not(:first-child) {
+      border-top-color: CanvasText;
+    }
+  }
+
   .sb-sr-only,
   .sb-hidden-until-focus:not(:focus) {
     position: absolute;


### PR DESCRIPTION
## Summary
- improve ArgsTable border visibility in forced-colors mode
- align the loading skeleton with the same high-contrast treatment
- update the static preview loader so pre-hydration docs UI stays consistent

## Testing
- git diff --check
- prettier --check on the 3 touched files
- yarn build addon-docs storybook

## Notes
- Fixes #24147.
- No new automated test was added because this is a narrow CSS accessibility fix that is better verified in browser/visual high-contrast mode.
- A narrow ESLint attempt was blocked in this fresh clone because the repo-local eslint-plugin-storybook expects built internal Storybook artifacts before it can be resolved.