### PR TITLE
Tests: Fix Layout story unduly failing

### DIFF
--- a/code/core/src/manager/components/layout/Layout.stories.tsx
+++ b/code/core/src/manager/components/layout/Layout.stories.tsx
@@ -167,15 +167,9 @@ export const DesktopCollapsedPanel: Story = {
     managerLayoutState: { ...defaultState, bottomPanelHeight: 0 },
   },
   play: async ({ canvas, step }) => {
-    await step('Verify panel is rendered but collapsed', async () => {
-      const panel = canvas.getByTestId('panel');
-      expect(panel.clientHeight).toBe(0);
-    });
-
-    await step('Verify panel cannot be focused', async () => {
-      const panel = canvas.getByTestId('panel');
-      panel.focus();
-      expect(panel).not.toHaveFocus();
+    await step('Verify panel is not rendered', async () => {
+      const panel = canvas.queryByTestId('panel');
+      expect(panel).not.toBeInTheDocument();
     });
   },
 };


### PR DESCRIPTION
## What I did

A [recent PR](https://github.com/storybookjs/storybook/pull/33588) introduced a change that breaks a layout story even though the PR CI is green.

This fixes the story to match with my expectation.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing
1. Visit http://localhost:6006/?path=/story/manager-layout--desktop-collapsed-panel
2. Notice play function passes

### Documentation
ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the collapsed panel component validation to verify complete removal from the DOM instead of checking for zero-height rendering and focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->