### PR TITLE
Actions: Retain newest items when limit is reached

### DIFF
--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -36,15 +36,24 @@ export default function ActionLogger({ active, api }: ActionLoggerProps) {
 
   const addAction = useCallback((action: ActionDisplay) => {
     setActions((prevActions) => {
-      const newActions = [...prevActions];
-      const previous = newActions.length && newActions[newActions.length - 1];
-      if (previous && safeDeepEqual(previous.data, action.data)) {
-        previous.count++;
-      } else {
-        action.count = 1;
-        newActions.push(action);
+      const previous = prevActions.length > 0 ? prevActions[prevActions.length - 1] : null;
+      const limit = action.options.limit;
+
+      if (limit <= 0) {
+        return [];
       }
-      return newActions.slice(0, action.options.limit);
+
+      if (previous && safeDeepEqual(previous.data, action.data)) {
+        const updatedActions = [...prevActions];
+        updatedActions[updatedActions.length - 1] = {
+          ...previous,
+          count: previous.count + 1,
+        };
+        return updatedActions.slice(-limit);
+      }
+
+      const nextAction = { ...action, count: 1 };
+      return [...prevActions, nextAction].slice(-limit);
     });
   }, []);
 

--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -37,7 +37,8 @@ export default function ActionLogger({ active, api }: ActionLoggerProps) {
   const addAction = useCallback((action: ActionDisplay) => {
     setActions((prevActions) => {
       const previous = prevActions.length > 0 ? prevActions[prevActions.length - 1] : null;
-      const limit = action.options.limit;
+      const rawLimit = action.options.limit;
+      const limit = Number.isFinite(rawLimit) ? Math.max(0, Math.trunc(rawLimit)) : 0;
 
       if (limit <= 0) {
         return [];

--- a/code/core/template/stories/parameters-actions.stories.ts
+++ b/code/core/template/stories/parameters-actions.stories.ts
@@ -1,3 +1,5 @@
+import type { PlayFunctionContext } from 'storybook/internal/types';
+
 import { global as globalThis } from '@storybook/global';
 
 import { fn, userEvent, within } from 'storybook/test';
@@ -32,7 +34,7 @@ export const LimitRetainsNewest = {
       limit: 3,
     },
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement }: PlayFunctionContext<any>) => {
     const canvas = within(canvasElement);
     const button = await canvas.findByRole('button');
 

--- a/code/core/template/stories/parameters-actions.stories.ts
+++ b/code/core/template/stories/parameters-actions.stories.ts
@@ -1,5 +1,7 @@
 import { global as globalThis } from '@storybook/global';
 
+import { fn, userEvent, within } from 'storybook/test';
+
 import { withActions } from 'storybook/actions/decorator';
 
 export default {
@@ -19,4 +21,25 @@ export const Basic = {
     },
   },
   decorators: [withActions],
+};
+
+export const LimitRetainsNewest = {
+  args: {
+    onClick: fn(),
+  },
+  parameters: {
+    actions: {
+      limit: 3,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = await canvas.findByRole('button');
+
+    await userEvent.click(button);
+    await userEvent.click(button);
+    await userEvent.click(button);
+    await userEvent.click(button);
+    await userEvent.click(button);
+  },
 };

--- a/docs/essentials/actions.mdx
+++ b/docs/essentials/actions.mdx
@@ -96,6 +96,22 @@ Default: `1`
 
 Controls how many levels deep the action tree is initially expanded. Useful when action arguments contain nested objects and you want to see more detail by default.
 
+#### `limit`
+
+Type: `number`
+
+Default: `50`
+
+Controls how many actions are retained in the panel. When the limit is reached, Storybook keeps the **most recent** actions and discards older ones.
+
+#### `clearOnStoryChange`
+
+Type: `boolean`
+
+Default: `true`
+
+Clear the action panel when navigating between stories.
+
 ### Exports
 
 ```js


### PR DESCRIPTION
## What I changed

Addresses #34052 by fixing action log retention behavior and removing object mutation in `ActionLogger`.

### ✅ Fixes in `ActionLogger`
- Avoids mutating previous state entries (`previous.count++`)
- Avoids mutating incoming action objects (`action.count = 1`)
- Uses immutable updates for both merge and append paths
- Keeps **newest** entries when the panel reaches `actions.limit` via `slice(-limit)`
- Handles `limit <= 0` safely by returning an empty list

File:
- `code/core/src/actions/containers/ActionLogger/index.tsx`

### ✅ Story to showcase behavior when limit is reached
Added a story that sets `actions.limit = 3` and emits 5 clicks to demonstrate that only the latest 3 actions are retained.

File:
- `code/core/template/stories/parameters-actions.stories.ts`

### ✅ Documentation updates
Documented actions parameters:
- `limit` (default `50`) and that it keeps **most recent** actions when full
- `clearOnStoryChange` (default `true`)

File:
- `docs/essentials/actions.mdx`

## Why

The previous implementation made a shallow array copy, then mutated nested action objects, which breaks immutability expectations and can cause subtle state issues. It also trimmed with `slice(0, limit)`, which retains oldest entries and drops newest at capacity.

## Notes

- Installed workspace dependencies with `yarn install`.
- I couldn't run a small file-scoped lint task directly in this workspace setup; relying on CI to run full checks.

Fixes #34052


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Actions addon now enforces a configurable `limit` on retained actions (default: 50) and clears history when `limit` is non-positive.
  * Repeated identical actions are aggregated (counted) instead of listed repeatedly.
  * Added a Storybook story demonstrating the limit behavior.

* **Documentation**
  * Documented new `limit` and `clearOnStoryChange` Actions addon parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->