### PR TITLE
Revert "Toolbar: Remove extra toolbar divider when zoom controls not shown"

### DIFF
--- a/code/core/src/manager/components/preview/tools/menu.tsx
+++ b/code/core/src/manager/components/preview/tools/menu.tsx
@@ -11,7 +11,6 @@ import type { Combo } from 'storybook/manager-api';
 const menuMapper = ({ api, state }: Combo) => ({
   isVisible: api.getIsNavShown(),
   singleStory: state.singleStory,
-  viewMode: state.viewMode,
   toggle: () => api.toggleNav(),
 });
 
@@ -23,7 +22,7 @@ export const menuTool: Addon_BaseType = {
   match: ({ viewMode }) => ['story', 'docs'].includes(viewMode),
   render: () => (
     <Consumer filter={menuMapper}>
-      {({ isVisible, toggle, singleStory, viewMode }) =>
+      {({ isVisible, toggle, singleStory }) =>
         !singleStory &&
         !isVisible && (
           <>
@@ -36,7 +35,7 @@ export const menuTool: Addon_BaseType = {
             >
               <MenuIcon />
             </Button>
-            {viewMode === 'story' && <Separator />}
+            <Separator />
           </>
         )
       }


### PR DESCRIPTION
Reverts storybookjs/storybook#33731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified menu rendering logic by removing unnecessary view mode dependency, improving code maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->