### PR TITLE
Core: Fix iframe reference for composed Storybook on a subpath

### DIFF
--- a/code/core/src/manager/components/preview/FramesRenderer.tsx
+++ b/code/core/src/manager/components/preview/FramesRenderer.tsx
@@ -78,7 +78,7 @@ export const FramesRenderer: FC<FramesRendererProps> = ({
 
   refsToLoad.forEach((ref) => {
     const id = `storybook-ref-${ref.id}`;
-    if (!frames[id]?.startsWith(ref.url)) {
+    if (!frames[id]?.startsWith(`${ref.url.replace(/\/?$/, '/')}iframe.html`)) {
       frames[id] = api.getStoryHrefs(storyId, {
         queryParams: { ...queryParams, ...(version && { version }) },
         refId: ref.id,


### PR DESCRIPTION
Closes #34094

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

With Storybook composition, when one ref is at the root of an origin (e.g. https://example.com/) and another is in a subpath (e.g. https://example.com/sub/), composed iframe URLs were being reused (not updated), causing incorrect references when navigating to a composed story directly.

Because the root URL is a prefix of the subpath URL, a frame that already had the sub URL could be treated as "already set" for the root ref due to a naive `startsWith` check. The root ref’s iframe then kept the sub URL, so two iframes pointed at the same sub URL. The manager then saw multiple iframes with the same origin/path and couldn’t tell which one sent a message, leading to `found multiple candidates for event source` and `received setGlobals but was unable to determine the source of the event`.

To fix this, the `startsWith` check now includes `iframe.html` to avoid unexpected matches between different subpaths on the same domain.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34100-sha-210f2133`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34100-sha-210f2133 sandbox` or in an existing project with `npx storybook@0.0.0-pr-34100-sha-210f2133 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34100-sha-210f2133`](https://npmjs.com/package/storybook/v/0.0.0-pr-34100-sha-210f2133) |
| **Triggered by** | @ghengeveld |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`fix-composition-on-common-base-url`](https://github.com/storybookjs/storybook/tree/fix-composition-on-common-base-url) |
| **Commit** | [`210f2133`](https://github.com/storybookjs/storybook/commit/210f213313edc4bcba93b028f18c3dd7c2f941df) |
| **Datetime** | Wed Mar 11 10:35:08 UTC 2026 (`1773225308`) |
| **Workflow run** | [22948346645](https://github.com/storybookjs/storybook/actions/runs/22948346645) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34100`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined frame rendering logic to more accurately compare URLs when determining if frames need to be refreshed, ensuring proper handling of frame loading conditions based on updated URL matching criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->