### PR TITLE
Manifests: Fix Attached MDX causing wrong component entries

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -1956,6 +1956,31 @@ describe('StoryIndexGenerator', () => {
           }
         `);
       });
+
+      it('puts the Meta of stories file first in storiesImports even when it is not the last import', async () => {
+        const csfSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
+          './src/*.stories.(js|ts)',
+          options
+        );
+
+        const docsSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
+          './complex/MetaOfImportOrder.mdx',
+          options
+        );
+
+        const generator = new StoryIndexGenerator([csfSpecifier, docsSpecifier], options);
+        await generator.initialize();
+
+        const { storyIndex } = await generator.getIndexAndStats();
+        const docsEntry = storyIndex.entries['a--metaofimportorder'];
+
+        expect(docsEntry).toMatchObject({
+          type: 'docs',
+          title: 'A',
+          importPath: './complex/MetaOfImportOrder.mdx',
+          storiesImports: ['./src/A.stories.js', './src/B.stories.ts'],
+        });
+      });
     });
 
     describe('errors', () => {

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -553,6 +553,8 @@ export class StoryIndexGenerator {
       let csfEntry: StoryIndexEntryWithExtra | undefined;
       if (result.of) {
         const absoluteOf = makeAbsolute(result.of, normalizedPath, this.options.workingDir);
+        let metaDependency: StoriesCacheEntry | undefined;
+
         dependencies.forEach((dep) => {
           if (dep.entries.length > 0) {
             const first = dep.entries.find((e) => e.type !== 'docs') as StoryIndexEntryWithExtra;
@@ -563,11 +565,17 @@ export class StoryIndexGenerator {
               )
             ) {
               csfEntry = first;
+              metaDependency = dep;
             }
           }
-
-          sortedDependencies = [dep, ...dependencies.filter((d) => d !== dep)];
         });
+
+        if (metaDependency) {
+          sortedDependencies = [
+            metaDependency,
+            ...dependencies.filter((d) => d !== metaDependency),
+          ];
+        }
 
         invariant(
           csfEntry,

--- a/code/core/src/core-server/utils/__mockdata__/complex/MetaOfImportOrder.mdx
+++ b/code/core/src/core-server/utils/__mockdata__/complex/MetaOfImportOrder.mdx
@@ -1,0 +1,9 @@
+{/* References BStories first, but is attached to A */}
+import * as BStories from '../src/B.stories';
+import * as AStories from '../src/A.stories';
+
+<Meta of={AStories}/>
+
+# This file references two story files
+
+It is important that A.stories is the first listed in `storiesImports` even when it is not the last import.

--- a/code/core/src/core-server/utils/__mockdata__/complex/MetaOfImportOrder.mdx
+++ b/code/core/src/core-server/utils/__mockdata__/complex/MetaOfImportOrder.mdx
@@ -6,4 +6,4 @@ import * as AStories from '../src/A.stories';
 
 # This file references two story files
 
-It is important that A.stories is the first listed in `storiesImports` even when it is not the last import.
+It is important that A.stories is the first listed in `storiesImports` even when it is not the first import.

--- a/code/renderers/react/src/componentManifest/generator.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.test.ts
@@ -578,6 +578,101 @@ test('should create component manifest when only attached-mdx docs have manifest
   `);
 });
 
+test('should prefer story entries over attached-mdx docs entries for the same component id', async () => {
+  vol.fromJSON(
+    {
+      ['./package.json']: JSON.stringify({ name: 'some-package' }),
+      ['./src/Primary/Primary.stories.tsx']: dedent`
+        import type { Meta } from '@storybook/react';
+        import { Primary } from './Primary';
+
+        const meta = {
+          title: 'Example/Primary',
+          component: Primary,
+        } satisfies Meta<typeof Primary>;
+        export default meta;
+
+        export const Default = () => <Primary title="Primary title" />;
+      `,
+      ['./src/Primary/Primary.tsx']: dedent`
+        import React from 'react';
+
+        export interface PrimaryProps {
+          title: string;
+        }
+
+        /** Primary component description */
+        export const Primary = ({ title }: PrimaryProps) => <div>{title}</div>;
+      `,
+      ['./src/OtherFile/OtherFile.stories.tsx']: dedent`
+        import type { Meta } from '@storybook/react';
+        import { OtherFile } from './OtherFile';
+
+        const meta = {
+          title: 'Example/Other File',
+          component: OtherFile,
+        } satisfies Meta<typeof OtherFile>;
+        export default meta;
+
+        export const Default = () => <OtherFile label="Other file label" />;
+      `,
+      ['./src/OtherFile/OtherFile.tsx']: dedent`
+        import React from 'react';
+
+        export interface OtherFileProps {
+          label: string;
+        }
+
+        /** Other file component description */
+        export const OtherFile = ({ label }: OtherFileProps) => (
+          <button type="button">{label}</button>
+        );
+      `,
+    },
+    '/app'
+  );
+
+  const manifestEntries = [
+    {
+      type: 'docs',
+      id: 'example-primary--docs',
+      name: 'Docs',
+      title: 'Example/Primary',
+      importPath: './src/Primary/Primary.mdx',
+      tags: [Tag.DEV, Tag.TEST, Tag.MANIFEST, Tag.ATTACHED_MDX],
+      storiesImports: [
+        './src/OtherFile/OtherFile.stories.tsx',
+        './src/Primary/Primary.stories.tsx',
+      ],
+    },
+    {
+      type: 'story',
+      subtype: 'story',
+      id: 'example-primary--default',
+      name: 'Default',
+      title: 'Example/Primary',
+      importPath: './src/Primary/Primary.stories.tsx',
+      componentPath: './src/Primary/Primary.tsx',
+      tags: [Tag.DEV, Tag.TEST, Tag.MANIFEST],
+      exportName: 'Default',
+    },
+  ];
+
+  const result = await manifests(undefined, { manifestEntries } as any);
+
+  const component = result?.components?.components?.['example-primary'];
+
+  expect(component?.name).toBe('Primary');
+  expect(component?.path).toBe('./src/Primary/Primary.stories.tsx');
+  expect(component?.stories).toMatchObject([
+    {
+      id: 'example-primary--default',
+      name: 'Default',
+    },
+  ]);
+  expect(component?.stories[0]?.snippet).toContain('<Primary');
+});
+
 test('stories are populated when meta has no explicit title', async () => {
   vol.fromJSON(
     {

--- a/code/renderers/react/src/componentManifest/generator.ts
+++ b/code/renderers/react/src/componentManifest/generator.ts
@@ -9,7 +9,6 @@ import {
   type StorybookConfigRaw,
 } from 'storybook/internal/types';
 
-import { uniqBy } from 'es-toolkit/array';
 import path from 'pathe';
 
 import { getCodeSnippet } from './generateCodeSnippet';
@@ -22,6 +21,41 @@ import { cachedFindUp, cachedReadFileSync, invalidateCache, invariant } from './
 interface ReactComponentManifest extends ComponentManifest {
   reactDocgen?: DocObj;
   reactDocgenTypescript?: ComponentDocWithExportName;
+}
+
+function selectComponentEntries(manifestEntries: IndexEntry[]) {
+  const entriesByComponentId = new Map<string, IndexEntry>();
+
+  manifestEntries
+    .filter(
+      (entry) =>
+        (entry.type === 'story' && entry.subtype === 'story') ||
+        // Attached docs entries are the only docs entries that can contribute to a
+        // component manifest, because they point back to a story file through storiesImports.
+        (entry.type === 'docs' &&
+          entry.tags?.includes(Tag.ATTACHED_MDX) &&
+          entry.storiesImports.length > 0)
+    )
+    .forEach((entry) => {
+      const componentId = entry.id.split('--')[0];
+      const existingEntry = entriesByComponentId.get(componentId);
+
+      if (!existingEntry) {
+        // Keep the first eligible entry as a fallback so docs-only manifest coverage
+        // continues to work when no story entry for that component carries the manifest tag.
+        entriesByComponentId.set(componentId, entry);
+        return;
+      }
+
+      if (existingEntry.type === 'docs' && entry.type === 'story') {
+        // When both entries exist for the same component id, the story entry is authoritative.
+        // Attached docs may list unrelated stories first in storiesImports, so using the story
+        // entry avoids resolving the manifest from the wrong file.
+        entriesByComponentId.set(componentId, entry);
+      }
+    });
+
+  return [...entriesByComponentId.values()];
 }
 
 function findMatchingComponent(
@@ -114,18 +148,7 @@ export const manifests: PresetPropertyFn<
 
   const startTime = performance.now();
 
-  const entriesByUniqueComponent = uniqBy(
-    manifestEntries.filter(
-      (entry) =>
-        (entry.type === 'story' && entry.subtype === 'story') ||
-        // addon-docs will add docs entries to these manifest entries afterwards
-        // Docs entries have importPath pointing to MDX file, but storiesImports[0] points to the story file
-        (entry.type === 'docs' &&
-          entry.tags?.includes(Tag.ATTACHED_MDX) &&
-          entry.storiesImports.length > 0)
-    ),
-    (entry) => entry.id.split('--')[0]
-  );
+  const entriesByUniqueComponent = selectComponentEntries(manifestEntries);
 
   const components = entriesByUniqueComponent
     .map((entry): ReactComponentManifest | undefined => {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes an issue where attached MDX files would sometimes cause the manifest generator to point component entries to the wrong stories file.

It also fixes a bug in `StoryIndexGenerator`, where it wouldn't correctly sort `storiesImports` and put the "primary" story (as defined via `<Meta of={PrimaryStoryFile} />`) first in the array, even though it should.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

See unit tests

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34101-sha-6ae40b39`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34101-sha-6ae40b39 sandbox` or in an existing project with `npx storybook@0.0.0-pr-34101-sha-6ae40b39 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34101-sha-6ae40b39`](https://npmjs.com/package/storybook/v/0.0.0-pr-34101-sha-6ae40b39) |
| **Triggered by** | @JReinhold |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`jeppe/fix-manifest-attached-mdx`](https://github.com/storybookjs/storybook/tree/jeppe/fix-manifest-attached-mdx) |
| **Commit** | [`6ae40b39`](https://github.com/storybookjs/storybook/commit/6ae40b393d6a41a6da91fb443ba35eaec514c51f) |
| **Datetime** | Wed Mar 11 12:41:35 UTC 2026 (`1773232895`) |
| **Workflow run** | [22953067254](https://github.com/storybookjs/storybook/actions/runs/22953067254) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34101`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently prioritize Meta (CSF) story sources when multiple story files are referenced.
  * Ensure story entries take precedence over attached docs for the same component so the canonical story is used.

* **Tests**
  * Added test coverage verifying Meta import/order prioritization.
  * Added test coverage validating story-over-docs precedence in component manifest generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->