### PR TITLE
Core: Fix event source URL based on refId when multiple iframes share the same origin

### DIFF
--- a/code/core/src/channels/postmessage/getEventSourceUrl.ts
+++ b/code/core/src/channels/postmessage/getEventSourceUrl.ts
@@ -1,23 +1,43 @@
 import { logger } from 'storybook/internal/client-logger';
 
-export const getEventSourceUrl = (event: MessageEvent) => {
+/**
+ * When multiple iframes match the event origin (e.g. composed refs from the same origin),
+ * disambiguate by refId: the preview includes refId in the URL, so we pick the iframe whose src
+ * contains that refId. If there is only one candidate, return it.
+ */
+const pickFrameByRefId = (
+  candidates: HTMLIFrameElement[],
+  refId: string | undefined
+): HTMLIFrameElement | undefined => {
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+  if (candidates.length === 0 || !refId) {
+    return undefined;
+  }
+  return candidates.find((el) =>
+    (el.getAttribute('src') ?? '').includes(`refId=${encodeURIComponent(refId)}`)
+  );
+};
+
+export const getEventSourceUrl = (event: MessageEvent, refId?: string): string | null => {
   const frames: HTMLIFrameElement[] = Array.from(
     document.querySelectorAll('iframe[data-is-storybook]')
   );
   // try to find the originating iframe by matching it's contentWindow
   // This might not be cross-origin safe
-  const [frame, ...remainder] = frames.filter((element) => {
+  const candidates = frames.filter((element) => {
     try {
       return (
         element.contentWindow?.location.origin === (event.source as Window).location.origin &&
         element.contentWindow?.location.pathname === (event.source as Window).location.pathname
       );
-    } catch (err) {
+    } catch {
       // continue
     }
     try {
       return element.contentWindow === event.source;
-    } catch (err) {
+    } catch {
       // continue
     }
 
@@ -30,23 +50,23 @@ export const getEventSourceUrl = (event: MessageEvent) => {
       }
 
       ({ origin } = new URL(src, document.location.toString()));
-    } catch (err) {
+    } catch {
       return false;
     }
     return origin === event.origin;
   });
 
-  const src = frame?.getAttribute('src');
-  if (src && remainder.length === 0) {
+  const src = pickFrameByRefId(candidates, refId)?.getAttribute('src');
+
+  if (src) {
     const { protocol, host, pathname } = new URL(src, document.location.toString());
     return `${protocol}//${host}${pathname}`;
   }
 
-  if (remainder.length > 0) {
-    // If we found multiple matches, there's going to be trouble
+  if (candidates.length > 1) {
+    // Multiple matches and we couldn't disambiguate (e.g. no refId in message)
     logger.error('found multiple candidates for event source');
   }
 
-  // If we found no frames of matches
   return null;
 };

--- a/code/core/src/channels/postmessage/index.ts
+++ b/code/core/src/channels/postmessage/index.ts
@@ -212,7 +212,7 @@ export class PostMessageTransport implements ChannelTransport {
         }
 
         event.source =
-          this.config.page === 'preview' ? rawEvent.origin : getEventSourceUrl(rawEvent);
+          this.config.page === 'preview' ? rawEvent.origin : getEventSourceUrl(rawEvent, refId);
 
         if (!event.source) {
           pretty.error(


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/34094

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Updated channel event handling to consider `refId` when multiple iframes with the same origin exist.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Take a working Storybook and upgrade it
  - `npx storybook@0.0.0-pr-34105-sha-d0a83f8a upgrade`
- Build the Storybook to `storybook-static`
- Move the `storybook-static` folder into the `public` folder.
- Modify `.storybook/main.ts` with the below `refs` config.
- Start the (outer) Storybook and navigate to one of the stories on the Inner Storybook.
- Refresh the browser.
- Stories should load and work normally.

```ts
  refs: {
    'inner': {
      title: 'Inner Storybook',
      url: 'http://localhost:6006/storybook-static/',
    },
  }
```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34105-sha-d0a83f8a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34105-sha-d0a83f8a sandbox` or in an existing project with `npx storybook@0.0.0-pr-34105-sha-d0a83f8a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34105-sha-d0a83f8a`](https://npmjs.com/package/storybook/v/0.0.0-pr-34105-sha-d0a83f8a) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`fix-composition-on-common-base-url`](https://github.com/storybookjs/storybook/tree/fix-composition-on-common-base-url) |
| **Commit** | [`d0a83f8a`](https://github.com/storybookjs/storybook/commit/d0a83f8ac220043f7f8a83e14e0168248f59c8e2) |
| **Datetime** | Thu Mar 12 03:06:16 UTC 2026 (`1773284776`) |
| **Workflow run** | [22984743009](https://github.com/storybookjs/storybook/actions/runs/22984743009) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34105`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iframe source identification in multi-frame scenarios using reference identifiers for better disambiguation
  * Enhanced error handling when message source resolution encounters multiple candidate frames
  * Refined event source resolution logic for more accurate and reliable source determination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->