### PR TITLE
fix(actions): fix state mutation and retain newest actions when limit is reached

### DIFF
--- a/code/core/src/actions/containers/ActionLogger/addAction.test.ts
+++ b/code/core/src/actions/containers/ActionLogger/addAction.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ActionDisplay } from '../../models';
+import { computeAddAction } from './addAction';
+
+function createAction(overrides: Partial<ActionDisplay> = {}): ActionDisplay {
+  return {
+    id: String(Math.random()),
+    count: 0,
+    data: { name: 'onClick', args: ['test'] },
+    options: { limit: 3, clearOnStoryChange: true },
+    ...overrides,
+  };
+}
+
+describe('computeAddAction', () => {
+  it('adds a new action with count 1', () => {
+    const action = createAction({ id: '1' });
+    const result = computeAddAction([], action);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(1);
+    expect(result[0].id).toBe('1');
+  });
+
+  it('increments count when consecutive actions have the same data', () => {
+    const action1 = createAction({ id: '1', data: { name: 'onClick', args: ['a'] } });
+    const action2 = createAction({ id: '2', data: { name: 'onClick', args: ['a'] } });
+
+    const state1 = computeAddAction([], action1);
+    const state2 = computeAddAction(state1, action2);
+
+    expect(state2).toHaveLength(1);
+    expect(state2[0].count).toBe(2);
+  });
+
+  it('does not mutate the input action objects', () => {
+    const action1 = createAction({ id: '1', data: { name: 'onClick', args: ['a'] } });
+    const state1 = computeAddAction([], action1);
+
+    expect(action1.count).toBe(0);
+
+    const action2 = createAction({ id: '2', data: { name: 'onClick', args: ['a'] } });
+    computeAddAction(state1, action2);
+
+    expect(action1.count).toBe(0);
+    expect(action2.count).toBe(0);
+    expect(state1[0].count).toBe(1);
+  });
+
+  it('does not mutate the previous state array', () => {
+    const action1 = createAction({ id: '1', data: { name: 'first', args: ['1'] } });
+    const state1 = computeAddAction([], action1);
+    const originalState1 = [...state1];
+
+    const action2 = createAction({ id: '2', data: { name: 'second', args: ['2'] } });
+    computeAddAction(state1, action2);
+
+    expect(state1).toEqual(originalState1);
+  });
+
+  it('retains newest actions when limit is reached, not oldest', () => {
+    const action1 = createAction({
+      id: '1',
+      data: { name: 'first', args: ['1'] },
+      options: { limit: 2, clearOnStoryChange: true },
+    });
+    const action2 = createAction({
+      id: '2',
+      data: { name: 'second', args: ['2'] },
+      options: { limit: 2, clearOnStoryChange: true },
+    });
+    const action3 = createAction({
+      id: '3',
+      data: { name: 'third', args: ['3'] },
+      options: { limit: 2, clearOnStoryChange: true },
+    });
+
+    let state = computeAddAction([], action1);
+    state = computeAddAction(state, action2);
+    state = computeAddAction(state, action3);
+
+    expect(state).toHaveLength(2);
+    expect(state[0].data.name).toBe('second');
+    expect(state[1].data.name).toBe('third');
+  });
+
+  it('respects limit even when incrementing count on the last action', () => {
+    const action1 = createAction({
+      id: '1',
+      data: { name: 'first', args: ['1'] },
+      options: { limit: 2, clearOnStoryChange: true },
+    });
+    const action2 = createAction({
+      id: '2',
+      data: { name: 'second', args: ['2'] },
+      options: { limit: 2, clearOnStoryChange: true },
+    });
+    const action3 = createAction({
+      id: '3',
+      data: { name: 'second', args: ['2'] },
+      options: { limit: 2, clearOnStoryChange: true },
+    });
+
+    let state = computeAddAction([], action1);
+    state = computeAddAction(state, action2);
+    state = computeAddAction(state, action3);
+
+    expect(state).toHaveLength(2);
+    expect(state[1].data.name).toBe('second');
+    expect(state[1].count).toBe(2);
+  });
+
+  it('adds distinct actions as separate entries', () => {
+    const action1 = createAction({ id: '1', data: { name: 'click', args: ['a'] } });
+    const action2 = createAction({ id: '2', data: { name: 'hover', args: ['b'] } });
+
+    let state = computeAddAction([], action1);
+    state = computeAddAction(state, action2);
+
+    expect(state).toHaveLength(2);
+    expect(state[0].data.name).toBe('click');
+    expect(state[1].data.name).toBe('hover');
+  });
+
+  it('falls back to default limit of 50 when limit is undefined', () => {
+    const actions: ActionDisplay[] = [];
+    let state = actions;
+
+    for (let i = 0; i < 55; i++) {
+      state = computeAddAction(
+        state,
+        createAction({
+          id: String(i),
+          data: { name: `action-${i}`, args: [i] },
+          options: { clearOnStoryChange: true },
+        }),
+      );
+    }
+
+    expect(state).toHaveLength(50);
+    expect(state[0].data.name).toBe('action-5');
+    expect(state[49].data.name).toBe('action-54');
+  });
+});

--- a/code/core/src/actions/containers/ActionLogger/addAction.ts
+++ b/code/core/src/actions/containers/ActionLogger/addAction.ts
@@ -1,0 +1,30 @@
+import { dequal as deepEqual } from 'dequal';
+
+import type { ActionDisplay } from '../../models';
+
+const safeDeepEqual = (a: any, b: any): boolean => {
+  try {
+    return deepEqual(a, b);
+  } catch (e) {
+    return false;
+  }
+};
+
+const DEFAULT_LIMIT = 50;
+
+export function computeAddAction(
+  prevActions: ActionDisplay[],
+  action: ActionDisplay
+): ActionDisplay[] {
+  const limit = action.options.limit ?? DEFAULT_LIMIT;
+  const previous = prevActions.length ? prevActions[prevActions.length - 1] : null;
+
+  if (previous && safeDeepEqual(previous.data, action.data)) {
+    const updated = [...prevActions];
+    updated[updated.length - 1] = { ...previous, count: previous.count + 1 };
+    return updated.slice(-limit);
+  }
+
+  const newAction = { ...action, count: 1 };
+  return [...prevActions, newAction].slice(-limit);
+}

--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { STORY_CHANGED } from 'storybook/internal/core-events';
 
-import { dequal as deepEqual } from 'dequal';
 import type { API } from 'storybook/manager-api';
 import { useParameter } from 'storybook/manager-api';
 
@@ -10,19 +9,12 @@ import { ActionLogger as ActionLoggerComponent } from '../../components/ActionLo
 import { CLEAR_ID, EVENT_ID, PARAM_KEY } from '../../constants';
 import type { ActionDisplay } from '../../models';
 import type { ActionsParameters } from '../../types';
+import { computeAddAction } from './addAction';
 
 interface ActionLoggerProps {
   active: boolean;
   api: API;
 }
-
-const safeDeepEqual = (a: any, b: any): boolean => {
-  try {
-    return deepEqual(a, b);
-  } catch (e) {
-    return false;
-  }
-};
 
 export default function ActionLogger({ active, api }: ActionLoggerProps) {
   const [actions, setActions] = useState<ActionDisplay[]>([]);
@@ -35,17 +27,7 @@ export default function ActionLogger({ active, api }: ActionLoggerProps) {
   }, [api]);
 
   const addAction = useCallback((action: ActionDisplay) => {
-    setActions((prevActions) => {
-      const newActions = [...prevActions];
-      const previous = newActions.length && newActions[newActions.length - 1];
-      if (previous && safeDeepEqual(previous.data, action.data)) {
-        previous.count++;
-      } else {
-        action.count = 1;
-        newActions.push(action);
-      }
-      return newActions.slice(0, action.options.limit);
-    });
+    setActions((prevActions) => computeAddAction(prevActions, action));
   }, []);
 
   const handleStoryChange = useCallback(() => {

--- a/docs/essentials/actions.mdx
+++ b/docs/essentials/actions.mdx
@@ -88,6 +88,14 @@ Disable the action panel.
 
 This parameter is most useful to allow overriding at more specific levels. For example, if this parameter is set to `true` at the project level, it could then be re-enabled by setting it to `false` at the meta (component) or story level.
 
+#### `limit`
+
+Type: `number`
+
+Default: `50`
+
+The maximum number of actions to display in the actions panel. When the limit is reached, the oldest actions are removed to make room for the newest ones.
+
 #### `expandLevel`
 
 Type: `number`


### PR DESCRIPTION
## Summary

Fixes #34052

The `addAction` callback in the Actions addon had two bugs:

### 1. State mutation
`previous.count++` and `action.count = 1` mutated objects directly inside a React state updater, violating immutability and potentially causing reconciliation issues.

### 2. Wrong slice direction
`slice(0, limit)` kept the **oldest** actions and discarded the **newest** when the limit was reached. Changed to `slice(-limit)` so the most recent actions are retained.

## Changes

- **`code/core/src/actions/containers/ActionLogger/addAction.ts`** -- Extracted the state update logic into a pure `computeAddAction` function that creates new objects instead of mutating, and uses `slice(-limit)` to keep newest entries.
- **`code/core/src/actions/containers/ActionLogger/index.tsx`** -- Simplified the component to use the extracted function.
- **`code/core/src/actions/containers/ActionLogger/addAction.test.ts`** -- 7 unit tests covering: adding actions, count incrementing, immutability of inputs, immutability of previous state, limit retaining newest, limit with count increment, and distinct action entries.
- **`docs/essentials/actions.mdx`** -- Documented the `limit` parameter (type, default value, behavior when reached).

## Checklist from #34052

- [x] Ensuring that we retain **new** messages, not old ones
- [x] Checking documentation to ensure the limit parameter is documented, and that what happens when the limit is reached is also documented
- [ ] Adding stories that showcase the behaviour of addon panel when the limit is reached (the Actions addon has no existing stories; unit tests for the extracted logic cover limit behavior instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `limit` parameter (default 50) to control the maximum number of displayed actions; oldest actions are discarded when the limit is reached.
  * Actions with identical data now group into a single entry with an incrementing count.

* **Tests**
  * Added comprehensive tests covering add/group/limit behaviors and immutability.

* **Documentation**
  * Updated docs describing the new `limit` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->