### PR TITLE
SvelteKit: Fix template stories using runes mode

### DIFF
--- a/code/frameworks/sveltekit/template/stories_svelte-kit-skeleton-ts/modules/Navigation.svelte
+++ b/code/frameworks/sveltekit/template/stories_svelte-kit-skeleton-ts/modules/Navigation.svelte
@@ -1,37 +1,44 @@
 <script>
-	import { goto, invalidate, invalidateAll, afterNavigate, replaceState, pushState } from '$app/navigation';
+  import {
+    goto,
+    invalidate,
+    invalidateAll,
+    afterNavigate,
+    replaceState,
+    pushState,
+  } from '$app/navigation';
 
-	export let afterNavigateFn;
+  const { afterNavigateFn } = $props();
 
-	afterNavigate(afterNavigateFn);
+  afterNavigate(afterNavigateFn);
 </script>
 
 <button
-	on:click={() => {
-		goto('/storybook-goto');
-	}}>goto</button
+  on:click={() => {
+    goto('/storybook-goto');
+  }}>goto</button
 >
 
 <button
-	on:click={() => {
-		invalidate('/storybook-invalidate');
-	}}>invalidate</button
+  on:click={() => {
+    invalidate('/storybook-invalidate');
+  }}>invalidate</button
 >
 
 <button
-	on:click={() => {
-		invalidateAll();
-	}}>invalidateAll</button
+  on:click={() => {
+    invalidateAll();
+  }}>invalidateAll</button
 >
 
 <button
-	on:click={() => {
-		pushState('/storybook-push-state', {});
-	}}>pushState</button
+  on:click={() => {
+    pushState('/storybook-push-state', {});
+  }}>pushState</button
 >
 
 <button
-	on:click={() => {
-		replaceState('/storybook-replace-state', {});
-	}}>replaceState</button
+  on:click={() => {
+    replaceState('/storybook-replace-state', {});
+  }}>replaceState</button
 >


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Recent release of `sv` enforced rune mode for all new SvelteKit apps. We had one component used in template stories that was not using runes, causing CI to fail building.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

-

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Navigation component's internal prop handling mechanism for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->