### PR TITLE
fix(actions): fix state mutation and slice direction in ActionLogger

### DIFF
--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -36,15 +36,17 @@ export default function ActionLogger({ active, api }: ActionLoggerProps) {
 
   const addAction = useCallback((action: ActionDisplay) => {
     setActions((prevActions) => {
+      const limit = Math.max(0, Number(action.options?.limit) || 0);
       const previous = prevActions.length ? prevActions[prevActions.length - 1] : null;
 
       if (previous && safeDeepEqual(previous.data, action.data)) {
         const updated = [...prevActions];
         updated[updated.length - 1] = { ...previous, count: previous.count + 1 };
-        return updated.slice(-action.options.limit);
+        return limit > 0 ? updated.slice(-limit) : updated;
       } else {
         const newAction = { ...action, count: 1 };
-        return [...prevActions, newAction].slice(-action.options.limit);
+        const newActions = [...prevActions, newAction];
+        return limit > 0 ? newActions.slice(-limit) : newActions;
       }
     });
   }, []);

--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -36,15 +36,16 @@ export default function ActionLogger({ active, api }: ActionLoggerProps) {
 
   const addAction = useCallback((action: ActionDisplay) => {
     setActions((prevActions) => {
-      const newActions = [...prevActions];
-      const previous = newActions.length && newActions[newActions.length - 1];
+      const previous = prevActions.length ? prevActions[prevActions.length - 1] : null;
+
       if (previous && safeDeepEqual(previous.data, action.data)) {
-        previous.count++;
+        const updated = [...prevActions];
+        updated[updated.length - 1] = { ...previous, count: previous.count + 1 };
+        return updated.slice(-action.options.limit);
       } else {
-        action.count = 1;
-        newActions.push(action);
+        const newAction = { ...action, count: 1 };
+        return [...prevActions, newAction].slice(-action.options.limit);
       }
-      return newActions.slice(0, action.options.limit);
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- Fixed state mutation in `addAction` callback — `previous.count++` and `action.count = 1` were mutating objects in place, violating React's immutability principle and potentially causing reconciliation bugs
- Changed `slice(0, limit)` to `slice(-limit)` so the most recent actions are retained instead of the oldest ones

## What Changed
**File:** `code/core/src/actions/containers/ActionLogger/index.tsx`

- When merging duplicate actions, create a new object with incremented count instead of mutating `previous.count++`
- When adding new actions, create a copy with `count: 1` instead of mutating `action.count = 1`
- Use `slice(-limit)` to keep newest entries when at capacity

## Test plan
- [ ] Verify actions panel shows the most recent actions when limit is reached
- [ ] Verify duplicate action count increments correctly
- [ ] Verify no state-related React warnings in console

Fixes #34052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked action logging to use immutable updates, reducing side effects and rare count/increment inconsistencies.
  * Maintains existing behavior and action-limit trimming while improving stability and predictability of action counts shown in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->