### PR TITLE
Addon-Vitest: Fix cancel run tracking

### DIFF
--- a/code/addons/vitest/src/node/test-manager.test.ts
+++ b/code/addons/vitest/src/node/test-manager.test.ts
@@ -22,7 +22,7 @@ const vitest = vi.hoisted(() => ({
   init: vi.fn(),
   close: vi.fn(),
   onCancel: vi.fn(),
-  runTestSpecifications: vi.fn(),
+  runTestSpecifications: vi.fn().mockResolvedValue(undefined),
   cancelCurrentRun: vi.fn(),
   globTestSpecifications: vi.fn(),
   getModuleProjects: vi.fn(() => []),
@@ -53,7 +53,9 @@ vi.mock('vitest/node', async (importOriginal) => ({
 const createVitest = mockCreateVitest;
 
 beforeEach(() => {
+  vi.clearAllMocks();
   createVitest.mockResolvedValue(vitest);
+  vitest.runTestSpecifications.mockResolvedValue(undefined);
 });
 
 const mockIndex = {
@@ -420,5 +422,73 @@ describe('TestManager', () => {
     });
 
     expect(createVitest).not.toHaveBeenCalled();
+  });
+
+  it('should wait for the current run to finish before resolving cancel', async () => {
+    vitest.globTestSpecifications.mockImplementation(() => tests);
+    const runningTestRun = Promise.withResolvers<void>();
+    vitest.runTestSpecifications.mockReturnValueOnce(runningTestRun.promise);
+
+    const testManager = await TestManager.start(options);
+    const triggerRunPromise = testManager.handleTriggerRunEvent({
+      type: 'TRIGGER_RUN',
+      payload: {
+        triggeredBy: 'global',
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(vitest.runTestSpecifications).toHaveBeenCalledWith(tests, true);
+    });
+
+    let didCancelResolve = false;
+    const cancelPromise = testManager.handleCancelEvent().then(() => {
+      didCancelResolve = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(vitest.cancelCurrentRun).toHaveBeenCalledWith('keyboard-input');
+    });
+
+    await Promise.resolve();
+    expect(didCancelResolve).toBe(false);
+
+    runningTestRun.resolve();
+
+    await triggerRunPromise;
+    await cancelPromise;
+
+    expect(didCancelResolve).toBe(true);
+  });
+
+  it('should reset the focused test pattern when Vitest cancels a run', async () => {
+    vitest.globTestSpecifications.mockImplementation(() => tests);
+    const runningTestRun = Promise.withResolvers<void>();
+    vitest.runTestSpecifications.mockReturnValueOnce(runningTestRun.promise);
+
+    const testManager = await TestManager.start(options);
+    const triggerRunPromise = testManager.handleTriggerRunEvent({
+      type: 'TRIGGER_RUN',
+      payload: {
+        storyIds: ['story--one'],
+        triggeredBy: 'global',
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(setTestNamePattern).toHaveBeenCalledWith(new RegExp(`^One$`));
+    });
+
+    const onCancel = vitest.onCancel.mock.calls[0]?.[0];
+
+    expect(onCancel).toBeTypeOf('function');
+
+    setTestNamePattern.mockClear();
+    onCancel();
+
+    expect(setTestNamePattern).toHaveBeenCalledWith('');
+
+    runningTestRun.resolve();
+    await triggerRunPromise;
   });
 });

--- a/code/addons/vitest/src/node/vitest-manager.ts
+++ b/code/addons/vitest/src/node/vitest-manager.ts
@@ -54,6 +54,18 @@ export class VitestManager {
 
   constructor(private testManager: TestManager) {}
 
+  private trackRunningPromise<T>(run: () => Promise<T>) {
+    const runningPromise = run().finally(() => {
+      if (this.runningPromise === runningPromise) {
+        this.runningPromise = null;
+      }
+    });
+
+    this.runningPromise = runningPromise;
+
+    return runningPromise;
+  }
+
   async startVitest({ coverage }: { coverage: boolean }) {
     const { createVitest } = await import('vitest/node');
 
@@ -153,7 +165,7 @@ export class VitestManager {
 
     if (this.vitest) {
       this.vitest.onCancel(() => {
-        // TODO: handle cancellation
+        this.resetGlobalTestNamePattern();
       });
     }
 
@@ -408,7 +420,9 @@ export class VitestManager {
       },
     }));
 
-    await this.vitest!.runTestSpecifications(filteredTestSpecifications, true);
+    await this.trackRunningPromise(() =>
+      this.vitest!.runTestSpecifications(filteredTestSpecifications, true)
+    );
     this.resetGlobalTestNamePattern();
   }
 
@@ -519,7 +533,9 @@ export class VitestManager {
         }));
         await this.vitest!.cancelCurrentRun('keyboard-input');
         await this.runningPromise;
-        await this.vitest!.runTestSpecifications(filteredTestSpecifications, false);
+        await this.trackRunningPromise(() =>
+          this.vitest!.runTestSpecifications(filteredTestSpecifications, false)
+        );
       },
     });
   }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Track active Vitest runs so cancel and restart flows wait for the current run to finish before starting the next one. This also resets the focused test name pattern when Vitest emits a cancellation event, and adds unit coverage for both behaviors.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

No manual testing was run. Verified locally with `node .yarn/releases/yarn-4.10.3.cjs --cwd code vitest run addons/vitest/src/node/test-manager.test.ts`.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
