### PR TITLE
Core: Prevent story-local viewport from persisting in URL

### DIFF
--- a/code/core/src/manager-api/modules/globals.ts
+++ b/code/core/src/manager-api/modules/globals.ts
@@ -130,7 +130,7 @@ export const init: ModuleFn<SubAPI, SubState> = ({ store, fullAPI, provider }) =
     SET_GLOBALS,
     function handleSetGlobals(this: any, { globals, globalTypes }: SetGlobalsPayload) {
       const { ref } = getEventMetadata(this, fullAPI)!;
-      const currentGlobals = store.getState()?.globals;
+      const currentUserGlobals = store.getState()?.userGlobals;
 
       if (!ref) {
         store.setState({ globals, userGlobals: globals, globalTypes });
@@ -138,14 +138,12 @@ export const init: ModuleFn<SubAPI, SubState> = ({ store, fullAPI, provider }) =
         logger.warn('received globals from a non-local ref. This is not currently supported.');
       }
 
-      // If we have stored globals different to what the preview just inited with,
-      // we should update it to those values
       if (
-        currentGlobals &&
-        Object.keys(currentGlobals).length !== 0 &&
-        !deepEqual(globals, currentGlobals)
+        currentUserGlobals &&
+        Object.keys(currentUserGlobals).length !== 0 &&
+        !deepEqual(globals, currentUserGlobals)
       ) {
-        api.updateGlobals(currentGlobals);
+        api.updateGlobals(currentUserGlobals);
       }
     }
   );

--- a/code/core/src/manager-api/tests/globals.test.ts
+++ b/code/core/src/manager-api/tests/globals.test.ts
@@ -71,7 +71,7 @@ describe('globals API', () => {
     });
   });
 
-  it('emits UPDATE_GLOBALS if retains a globals value different to what receives on SET_GLOBALS', () => {
+  it('emits UPDATE_GLOBALS if retains a user globals value different to what receives on SET_GLOBALS', () => {
     const channel = new EventEmitter();
     const listener = vi.fn();
     channel.on(UPDATE_GLOBALS, listener);
@@ -83,6 +83,7 @@ describe('globals API', () => {
     } as unknown as ModuleArgs);
     store.setState({
       ...state,
+      userGlobals: { a: 'c' },
       globals: { a: 'c' },
     });
 
@@ -101,6 +102,31 @@ describe('globals API', () => {
       globals: { a: 'c' },
       options: { target: 'storybook-preview-iframe' },
     });
+  });
+
+  it('does not push story globals to preview when SET_GLOBALS fires with empty globals', () => {
+    const channel = new EventEmitter();
+    const listener = vi.fn();
+    channel.on(UPDATE_GLOBALS, listener);
+
+    const store = createMockStore();
+    const { state } = initModule({
+      store,
+      provider: { channel },
+    } as unknown as ModuleArgs);
+    store.setState({
+      ...state,
+      userGlobals: {},
+      storyGlobals: { viewport: 'mobile1' },
+      globals: { viewport: 'mobile1' },
+    });
+
+    channel.emit(SET_GLOBALS, {
+      globals: {},
+      globalTypes: {},
+    } satisfies SetGlobalsPayload);
+
+    expect(listener).not.toHaveBeenCalled();
   });
 
   it('ignores SET_STORIES from other refs', () => {


### PR DESCRIPTION
Closes #34133

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When a story has a defined `viewport` global (in code), that value should not be synced with the URL, because otherwise the value will stick around in the URL and apply to stories which otherwise do not have a viewport specified. To fix this issue, I've updated the globals state handler to only sync `userGlobals` (rather than `globals`) back to the globals state when `SET_GLOBALS` is emitted.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Have a Storybook with some stories defined with a `viewport` global, and some without.
2. Navigate back and forth between some stories with and some stories without a specified viewport. Confirm the URL does not include any viewport global at any point.
3. Navigate to a normal story (no viewport) and change the viewport via the toolbar. Confirm the URL reflects this change.
4. Navigate to a story with viewport. Confirm that viewport is applied, but the previously selected viewport is still present in the URL.
5. Navigate to a normal story again. Confirm the previously selected viewport is applied once again.
6. Reset the viewport tool. Confirm the global is removed from the URL.
7. Navigate back and forth between some stories with and some stories without a specified viewport. Confirm the URL does not include any viewport global at any point.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34153-sha-e6470d88`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34153-sha-e6470d88 sandbox` or in an existing project with `npx storybook@0.0.0-pr-34153-sha-e6470d88 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34153-sha-e6470d88`](https://npmjs.com/package/storybook/v/0.0.0-pr-34153-sha-e6470d88) |
| **Triggered by** | @ghengeveld |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`fix-persistent-story-viewport`](https://github.com/storybookjs/storybook/tree/fix-persistent-story-viewport) |
| **Commit** | [`e6470d88`](https://github.com/storybookjs/storybook/commit/e6470d88b36c115706fcc81bc77bab505f73ffdf) |
| **Datetime** | Mon Mar 16 09:42:53 UTC 2026 (`1773654173`) |
| **Workflow run** | [23137334965](https://github.com/storybookjs/storybook/actions/runs/23137334965) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34153`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed global settings handling to properly distinguish between user-defined and system globals, preventing unnecessary updates when globals are empty or unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->