### PR TITLE
CI: Relax Danger label rules on release PRs

### DIFF
--- a/scripts/dangerfile.js
+++ b/scripts/dangerfile.js
@@ -42,6 +42,8 @@ const { labels } = danger.github.issue;
 const prLogConfig = pkg['pr-log'];
 
 const branchVersion = Versions.MINOR;
+const targetBranch = danger.github.pr.base.ref;
+const isReleasePr = ['latest-release', 'next-release'].includes(targetBranch);
 
 /** @param {string[]} labels */
 const checkRequiredLabels = (labels) => {
@@ -66,18 +68,29 @@ const checkRequiredLabels = (labels) => {
     );
   }
 
-  const foundRequiredLabels = intersection(requiredLabels, labels);
-  if (foundRequiredLabels.length === 0) {
-    fail(`PR is not labeled with one of: ${JSON.stringify(requiredLabels)}`);
-  } else if (foundRequiredLabels.length > 1) {
-    fail(`Please choose only one of these labels: ${JSON.stringify(foundRequiredLabels)}`);
-  }
+  if (isReleasePr) {
+    // Release PRs only need `ci:daily`.
+    if (!labels.includes('ci:daily')) {
+      fail(
+        'Release PRs targeting latest-release or next-release must include the "ci:daily" label.'
+      );
+    }
+    return;
+  } else {
+    // All other PRs to `next` to a qualifying change type and one of several applicable CI labels.
+    const foundRequiredLabels = intersection(requiredLabels, labels);
+    if (foundRequiredLabels.length === 0) {
+      fail(`PR is not labeled with one of: ${JSON.stringify(requiredLabels)}`);
+    } else if (foundRequiredLabels.length > 1) {
+      fail(`Please choose only one of these labels: ${JSON.stringify(foundRequiredLabels)}`);
+    }
 
-  const foundCILabels = intersection(ciLabels, labels);
-  if (foundCILabels.length === 0) {
-    fail(`PR is not labeled with one of: ${JSON.stringify(ciLabels)}`);
-  } else if (foundCILabels.length > 1) {
-    fail(`Please choose only one of these labels: ${JSON.stringify(foundCILabels)}`);
+    const foundCILabels = intersection(ciLabels, labels);
+    if (foundCILabels.length === 0) {
+      fail(`PR is not labeled with one of: ${JSON.stringify(ciLabels)}`);
+    } else if (foundCILabels.length > 1) {
+      fail(`Please choose only one of these labels: ${JSON.stringify(foundCILabels)}`);
+    }
   }
 };
 


### PR DESCRIPTION
## What I did

A recent change to Danger Script (ensuring contributors only create PRs against `next`) causes the label check to occur in release PRs.

This here PR ensures the release PRs only get asked to have `ci:daily`.

