### PR TITLE
UI: Hide addon panel Drag on pages without a panel

### DIFF
--- a/code/core/src/manager/components/layout/Layout.tsx
+++ b/code/core/src/manager/components/layout/Layout.tsx
@@ -201,7 +201,7 @@ export const Layout = ({ managerLayoutState, setManagerLayoutState, hasTab, ...s
           slotPages={slots.slotPages}
         />
 
-        {isDesktop && (
+        {isDesktop && showPanel && (
           <PanelContainer
             bottomPanelHeight={bottomPanelHeight}
             rightPanelWidth={rightPanelWidth}
@@ -209,7 +209,7 @@ export const Layout = ({ managerLayoutState, setManagerLayoutState, hasTab, ...s
             panelResizerRef={panelResizerRef}
             position={panelPosition}
           >
-            {showPanel && slots.slotPanel}
+            {slots.slotPanel}
           </PanelContainer>
         )}
         {isMobile && <Notifications />}


### PR DESCRIPTION
10.3 QA bugfix: Ensures the addon panel's resize drag is hidden on Docs or settings pages where there cannot be an addon panel.

The `showPanel` logic used to be true when the panel was 0px, making it unsuitable at the time to decide when to hide or show the Drag handle. Now, it only is true when the panel effectively must not be showable at all; so it's safe to use to also hide the Drag. 

#### Manual testing

1. Visit http://localhost:6006/?path=/settings/about
2. Tab all the way to the bottom of the page content
3. Keep tabbing and notice no resize handle shows up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized panel rendering logic in desktop layout for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->