### PR TITLE
UI: Hide manifest tag for now

### DIFF
--- a/code/core/src/manager/components/sidebar/TagsFilterPanel.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilterPanel.tsx
@@ -59,6 +59,7 @@ interface TagsFilterPanelProps {
   excludedFilters: string[];
 }
 
+/* Those tags are hidden in the UI. There's a more general built-in list defined in `shared/constants/tags`. */
 const BUILT_IN_TAGS = new Set([
   'dev',
   'test',
@@ -67,6 +68,7 @@ const BUILT_IN_TAGS = new Set([
   'unattached-mdx',
   'play-fn',
   'test-fn',
+  'manifest',
 ]);
 
 // This equality check works on the basis that there are no duplicates in the arrays.


### PR DESCRIPTION
## What I did

**10.3 QA:** Hid the manifest tag from the TagsFilterPanel UI as it is not yet documented for every user and therefore not yet meaningful to them.

## Checklist for Contributors

#### Manual testing

Check that the manifest tag is gone from the TagsFilterPanel UI.

<img width="511" height="733" alt="image" src="https://github.com/user-attachments/assets/7a92a4c0-89e6-45eb-8de3-c5d6e8a4eaed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The 'manifest' tag is now classified as a built-in tag, ensuring consistent display and behavior in the tag filter panel alongside other standard tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->