### PR TITLE
Vite: Add mock entries to optimizeDeps.entries

### DIFF
--- a/code/builders/builder-vite/src/plugins/storybook-optimize-deps-plugin.test.ts
+++ b/code/builders/builder-vite/src/plugins/storybook-optimize-deps-plugin.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { escapeGlobPath } from './storybook-optimize-deps-plugin';
+import { escapeGlobPath, getMockRedirectIncludeEntries } from './storybook-optimize-deps-plugin';
 
 describe('escapeGlobPath', () => {
   it('should not modify a plain path without special characters', () => {
@@ -40,5 +40,37 @@ describe('escapeGlobPath', () => {
     expect(escapeGlobPath('./src/my-component/Button.stories.tsx')).toBe(
       './src/my-component/Button.stories.tsx'
     );
+  });
+});
+
+describe('getMockRedirectIncludeEntries', () => {
+  it('should include only manual mock redirect paths', () => {
+    expect(
+      getMockRedirectIncludeEntries([
+        { redirectPath: '/project/src/lib/__mocks__/db.ts' },
+        { redirectPath: null },
+      ])
+    ).toEqual(['/project/src/lib/__mocks__/db.ts']);
+  });
+
+  it('should escape special glob characters in redirect paths', () => {
+    expect(
+      getMockRedirectIncludeEntries([
+        { redirectPath: '/project/src/(group)/__mocks__/db.ts' },
+        { redirectPath: '/project/src/[id]/__mocks__/db.ts' },
+      ])
+    ).toEqual([
+      '/project/src/\\(group\\)/__mocks__/db.ts',
+      '/project/src/\\[id\\]/__mocks__/db.ts',
+    ]);
+  });
+
+  it('should dedupe redirect paths', () => {
+    expect(
+      getMockRedirectIncludeEntries([
+        { redirectPath: '/project/src/lib/__mocks__/db.ts' },
+        { redirectPath: '/project/src/lib/__mocks__/db.ts' },
+      ])
+    ).toEqual(['/project/src/lib/__mocks__/db.ts']);
   });
 });

--- a/code/builders/builder-vite/src/plugins/storybook-optimize-deps-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/storybook-optimize-deps-plugin.ts
@@ -1,5 +1,6 @@
 import { loadPreviewOrConfigFile } from 'storybook/internal/common';
 import type { StoryIndexGenerator } from 'storybook/internal/core-server';
+import { babelParser, extractMockCalls, findMockRedirect } from 'storybook/internal/mocking-utils';
 import type { Options, PreviewAnnotation, StoryIndex } from 'storybook/internal/types';
 
 import { resolve } from 'pathe';
@@ -16,6 +17,20 @@ import { getUniqueImportPaths } from '../utils/unique-import-paths';
  */
 export function escapeGlobPath(filePath: string): string {
   return filePath.replace(/[()[\]{}!*?|+@]/g, '\\$&');
+}
+
+/** Converts extracted sb.mock calls into optimizeDeps include entries for manual **mocks** files. */
+export function getMockRedirectIncludeEntries(
+  mockCalls: Array<{ redirectPath: string | null }>
+): string[] {
+  return Array.from(
+    new Set(
+      mockCalls
+        .map((mockCall) => mockCall.redirectPath)
+        .filter((redirectPath): redirectPath is string => redirectPath !== null)
+        .map(escapeGlobPath)
+    )
+  );
 }
 
 /** A Vite plugin that configures dependency optimization for Storybook's dev server. */
@@ -41,6 +56,22 @@ export function storybookOptimizeDepsPlugin(options: Options): Plugin {
       // Include the user's preview file and all addon/framework/renderer preview annotations
       // as optimizer entries so Vite can discover all transitive CJS dependencies automatically.
       const previewOrConfigFile = loadPreviewOrConfigFile({ configDir: options.configDir });
+
+      const mockRedirectIncludeEntries = previewOrConfigFile
+        ? getMockRedirectIncludeEntries(
+            extractMockCalls(
+              {
+                previewConfigPath: previewOrConfigFile,
+                coreOptions: { disableTelemetry: true },
+                configDir: options.configDir,
+              },
+              babelParser,
+              projectRoot,
+              findMockRedirect
+            )
+          )
+        : [];
+
       const previewAnnotationEntries = [...previewAnnotations, previewOrConfigFile]
         .filter((path): path is PreviewAnnotation => path !== undefined)
         .map((path) => processPreviewAnnotation(path, projectRoot));
@@ -56,6 +87,7 @@ export function storybookOptimizeDepsPlugin(options: Options): Plugin {
             ...(typeof config.optimizeDeps?.entries === 'string'
               ? [config.optimizeDeps.entries]
               : (config.optimizeDeps?.entries ?? [])),
+            ...mockRedirectIncludeEntries,
             ...getUniqueImportPaths(index).map(escapeGlobPath),
             ...previewAnnotationEntries.map(escapeGlobPath),
           ],


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Added support in the Vite optimize-deps plugin to include manual `sb.mock(...)` redirect targets (files in `__mocks__`) in `optimizeDeps.include`, so dependencies imported by those mock files are pre-bundled correctly.

Specifically:
- Reused existing mock extraction/resolution utilities (`extractMockCalls`, `findMockRedirect`) in the optimize-deps plugin.
- Added a helper that derives include entries from `redirectPath` only, escapes glob-sensitive characters, and deduplicates entries.
- Merged derived mock entries into `optimizeDeps.include` while preserving existing include ordering.
- Added focused unit tests for include derivation behavior.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

No additional manual testing was performed. This change is covered by focused unit tests and validation commands (`nx compile`, `nx check`, targeted `vitest`, and lint).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34167-sha-d83eb160`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34167-sha-d83eb160 sandbox` or in an existing project with `npx storybook@0.0.0-pr-34167-sha-d83eb160 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34167-sha-d83eb160`](https://npmjs.com/package/storybook/v/0.0.0-pr-34167-sha-d83eb160) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/support-optimize-deps-for-mocks`](https://github.com/storybookjs/storybook/tree/valentin/support-optimize-deps-for-mocks) |
| **Commit** | [`d83eb160`](https://github.com/storybookjs/storybook/commit/d83eb16009843ab7230420bcedecf7a984dd1f09) |
| **Datetime** | Mon Mar 16 22:08:39 UTC 2026 (`1773698919`) |
| **Workflow run** | [23168229627](https://github.com/storybookjs/storybook/actions/runs/23168229627) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34167`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced mock redirect processing in Storybook's Vite dependency optimization for improved build handling.

* **Tests**
  * Added comprehensive test suite for mock redirect functionality, validating deduplication, escaping, and null-path filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->