### PR TITLE
CLI: Avoid hanging of postinstall during init

### DIFF
--- a/code/lib/create-storybook/src/commands/AddonConfigurationCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/AddonConfigurationCommand.test.ts
@@ -96,7 +96,7 @@ describe('AddonConfigurationCommand', () => {
       expect(addonVitestPostinstall).toHaveBeenCalledWith({
         packageManager: 'npm',
         configDir: '.storybook',
-        yes: false,
+        yes: true,
         skipInstall: true,
         skipDependencyManagement: true,
         logger,
@@ -122,7 +122,7 @@ describe('AddonConfigurationCommand', () => {
       expect(addonA11yPostinstall).toHaveBeenCalledWith({
         packageManager: 'npm',
         configDir: '.storybook',
-        yes: false,
+        yes: true,
         skipInstall: true,
         skipDependencyManagement: true,
         logger,
@@ -144,7 +144,7 @@ describe('AddonConfigurationCommand', () => {
       expect(postinstallAddon).toHaveBeenCalledWith('@storybook/addon-docs', {
         packageManager: 'npm',
         configDir: '.storybook',
-        yes: false,
+        yes: true,
         skipInstall: true,
         skipDependencyManagement: true,
         logger,
@@ -324,7 +324,7 @@ describe('executeAddonConfiguration', () => {
   it('should create command and execute with provided parameters', async () => {
     const result = await executeAddonConfiguration({
       packageManager: mockPackageManager,
-      options: { packageManager: PackageManagerName.NPM, yes: false, disableTelemetry: true },
+      options: { packageManager: PackageManagerName.NPM, disableTelemetry: true },
       addons: [],
       configDir: '.storybook',
     });
@@ -335,7 +335,7 @@ describe('executeAddonConfiguration', () => {
   it('should execute addon configuration through helper function', async () => {
     const result = await executeAddonConfiguration({
       packageManager: mockPackageManager,
-      options: { packageManager: PackageManagerName.NPM, yes: true, disableTelemetry: false },
+      options: { packageManager: PackageManagerName.NPM, disableTelemetry: false },
       addons: ['@storybook/addon-a11y'],
       configDir: '.storybook',
     });

--- a/code/lib/create-storybook/src/commands/AddonConfigurationCommand.ts
+++ b/code/lib/create-storybook/src/commands/AddonConfigurationCommand.ts
@@ -126,7 +126,7 @@ export class AddonConfigurationCommand {
         const options = {
           packageManager: this.packageManager.type,
           configDir,
-          yes: this.commandOptions.yes,
+          yes: true,
           skipInstall: true,
           skipDependencyManagement: true,
           logger,


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The post-install script for the accessibility add-on ran the Vitest auto migration, prompting whether the auto migration should run. Therefore, I have added the `--yes` flag to all post-install scripts to avoid prompts. 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Addon configuration prompts now auto-confirm during setup, streamlining addon installation and removing manual confirmation.

* **Tests**
  * Test expectations updated to reflect the auto-confirm behavior in addon post-install flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->