### PR TITLE
Docs: fix typo in writing stories guide

### DIFF
--- a/docs/writing-stories/index.mdx
+++ b/docs/writing-stories/index.mdx
@@ -149,7 +149,7 @@ Note that features which require `args`, like [Controls](../essentials/controls.
  
 By default, stories will render the component defined in the `defineMeta` call (for Svelte CSF) or in the default export (for CSF), with the `args` passed to it.
 
-If you need to customize the rendering of your story, you can provide a snippet (for Svelte CSF) or a `render` fuction (for CSF) that accepts `args` and renders whatever you need.
+If you need to customize the rendering of your story, you can provide a snippet (for Svelte CSF) or a `render` function (for CSF) that accepts `args` and renders whatever you need.
 
 For example, if you want to render a `Button` inside an `Alert`:
 


### PR DESCRIPTION
Closes #

## What I did

- fixed a typo in the writing stories guide by changing "fuction" to "function"
- related issue: N/A (trivial docs fix)
- guideline alignment: follows [CONTRIBUTING.md](https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md) as a single-file documentation-only change

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Not run; documentation-only wording change.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that do not fit in the above categories.

   </details>

### Canary release

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typographical error in the writing stories guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->