### PR TITLE
feat(cli): restore --watch flag for build-storybook command

### DIFF
--- a/code/builders/builder-vite/src/build.ts
+++ b/code/builders/builder-vite/src/build.ts
@@ -94,7 +94,7 @@ export async function build(options: Options) {
   if (options.watch) {
     finalConfig.build = {
       ...finalConfig.build,
-      watch: {},
+      watch: finalConfig.build?.watch ?? {},
     };
   }
 

--- a/code/builders/builder-vite/src/build.ts
+++ b/code/builders/builder-vite/src/build.ts
@@ -91,6 +91,13 @@ export async function build(options: Options) {
 
   finalConfig.customLogger ??= await createViteLogger();
 
+  if (options.watch) {
+    finalConfig.build = {
+      ...finalConfig.build,
+      watch: {},
+    };
+  }
+
   await viteBuild(finalConfig);
 
   const statsPlugin = findPlugin(

--- a/code/builders/builder-webpack5/src/index.ts
+++ b/code/builders/builder-webpack5/src/index.ts
@@ -268,36 +268,82 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
   }
 
   const webpackCompilation = new Promise<Stats>((succeed, fail) => {
-    compiler.run((error, stats) => {
-      if (error) {
-        compiler.close(() => fail(new WebpackInvocationError({ error })));
-        return;
-      }
-
-      if (!stats) {
-        throw new WebpackMissingStatsError();
-      }
-
-      const { warnings, errors } = getWebpackStats({ config, stats });
-
-      if (warnings.length > 0) {
-        warnings?.forEach((e) => logger.warn(e.message));
-      }
-
-      if (errors.length > 0) {
-        errors.forEach((e) => logger.error(e.message));
-        compiler.close(() => fail(new WebpackCompilationError({ errors })));
-        return;
-      }
-
-      compiler.close((closeErr) => {
-        if (closeErr) {
-          return fail(new WebpackInvocationError({ error: closeErr }));
+    if (options.watch) {
+      let isFirstBuild = true;
+      logger.info('Watching for changes...');
+      compiler.watch(config.watchOptions || {}, (error, stats) => {
+        if (error) {
+          logger.error(error.message);
+          if (isFirstBuild) {
+            isFirstBuild = false;
+            fail(new WebpackInvocationError({ error }));
+          }
+          return;
         }
 
-        return succeed(stats as Stats);
+        if (!stats) {
+          if (isFirstBuild) {
+            isFirstBuild = false;
+            fail(new WebpackMissingStatsError());
+          }
+          return;
+        }
+
+        const { warnings, errors } = getWebpackStats({ config, stats });
+
+        if (warnings.length > 0) {
+          warnings?.forEach((e) => logger.warn(e.message));
+        }
+
+        if (errors.length > 0) {
+          errors.forEach((e) => logger.error(e.message));
+          if (isFirstBuild) {
+            isFirstBuild = false;
+            fail(new WebpackCompilationError({ errors }));
+          }
+          return;
+        }
+
+        if (isFirstBuild) {
+          isFirstBuild = false;
+          succeed(stats);
+        } else {
+          logger.info(`Rebuild completed in ${printDuration(startTime)}`);
+        }
+        logger.info('Watching for changes...');
       });
-    });
+    } else {
+      compiler.run((error, stats) => {
+        if (error) {
+          compiler.close(() => fail(new WebpackInvocationError({ error })));
+          return;
+        }
+
+        if (!stats) {
+          throw new WebpackMissingStatsError();
+        }
+
+        const { warnings, errors } = getWebpackStats({ config, stats });
+
+        if (warnings.length > 0) {
+          warnings?.forEach((e) => logger.warn(e.message));
+        }
+
+        if (errors.length > 0) {
+          errors.forEach((e) => logger.error(e.message));
+          compiler.close(() => fail(new WebpackCompilationError({ errors })));
+          return;
+        }
+
+        compiler.close((closeErr) => {
+          if (closeErr) {
+            return fail(new WebpackInvocationError({ error: closeErr }));
+          }
+
+          return succeed(stats as Stats);
+        });
+      });
+    }
   });
 
   const previewResolvedDir = join(corePath, 'dist/preview');

--- a/code/builders/builder-webpack5/src/index.ts
+++ b/code/builders/builder-webpack5/src/index.ts
@@ -270,8 +270,11 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
   const webpackCompilation = new Promise<Stats>((succeed, fail) => {
     if (options.watch) {
       let isFirstBuild = true;
+      let rebuildStartTime = startTime;
       logger.info('Watching for changes...');
       compiler.watch(config.watchOptions || {}, (error, stats) => {
+        const currentRebuildStart = rebuildStartTime;
+        rebuildStartTime = process.hrtime();
         if (error) {
           logger.error(error.message);
           if (isFirstBuild) {
@@ -308,7 +311,7 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
           isFirstBuild = false;
           succeed(stats);
         } else {
-          logger.info(`Rebuild completed in ${printDuration(startTime)}`);
+          logger.info(`Rebuild completed in ${printDuration(currentRebuildStart)}`);
         }
         logger.info('Watching for changes...');
       });
@@ -320,7 +323,13 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
         }
 
         if (!stats) {
-          throw new WebpackMissingStatsError();
+          compiler.close((closeErr) => {
+            if (closeErr) {
+              return fail(new WebpackInvocationError({ error: closeErr }));
+            }
+            return fail(new WebpackMissingStatsError());
+          });
+          return;
         }
 
         const { warnings, errors } = getWebpackStats({ config, stats });

--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -146,6 +146,7 @@ command('dev')
 command('build')
   .option('-o, --output-dir <dir-name>', 'Directory where to store built files')
   .option('-c, --config-dir <dir-name>', 'Directory where to load Storybook configurations from')
+  .option('-w, --watch', 'Watch for changes and rebuild automatically')
   .option('--quiet', 'Suppress verbose build output')
   .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
   .option(
@@ -188,7 +189,9 @@ command('build')
       process.exit(1);
     });
 
-    logger.outro('Storybook build completed successfully');
+    if (!options.watch) {
+      logger.outro('Storybook build completed successfully');
+    }
   });
 
 command('index')

--- a/code/core/src/core-server/build-static.ts
+++ b/code/core/src/core-server/build-static.ts
@@ -172,7 +172,9 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     logConfig('Preview webpack config', await previewBuilder.getConfig(fullOptions));
   }
 
-  if (options.ignorePreview) {
+  if (options.watch) {
+    logger.info('Building preview in watch mode..');
+  } else if (options.ignorePreview) {
     logger.info(`Not building preview`);
   } else {
     logger.info('Building preview..');

--- a/code/core/src/core-server/build-static.ts
+++ b/code/core/src/core-server/build-static.ts
@@ -172,10 +172,10 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     logConfig('Preview webpack config', await previewBuilder.getConfig(fullOptions));
   }
 
-  if (options.watch) {
-    logger.info('Building preview in watch mode..');
-  } else if (options.ignorePreview) {
+  if (options.ignorePreview) {
     logger.info(`Not building preview`);
+  } else if (options.watch) {
+    logger.info('Building preview in watch mode..');
   } else {
     logger.info('Building preview..');
   }

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -205,6 +205,7 @@ export interface CLIOptions extends CLIBaseOptions {
   statsJson?: string | boolean;
   outputDir?: string;
   previewOnly?: boolean;
+  watch?: boolean;
 }
 
 export interface BuilderOptions {


### PR DESCRIPTION
## Summary

Restores the `--watch` flag for `build-storybook` that was removed in #16165.

## Problem

The `--watch` option was originally added in #2762 but regressed during build pipeline refactors. Rather than fix it, #16165 removed the flag entirely. Users have been requesting this feature back (28+ reactions on #15946).

## Solution

This PR re-adds the `-w, --watch` flag and properly wires it through to both builders:

### Webpack5 Builder
- Uses `compiler.watch()` instead of `compiler.run()` when `options.watch` is true
- Handles rebuild logging and error recovery without crashing the watcher
- Resolves after first successful build so the rest of the pipeline can complete

### Vite Builder  
- Sets `build.watch: {}` on the vite config when `options.watch` is true
- Leverages Vite's native rollup-watch/chokidar integration

### Files Changed
- `code/core/src/bin/core.ts` — Added `-w, --watch` option to build command
- `code/core/src/types/modules/core-common.ts` — Added `watch?: boolean` to CLIOptions
- `code/core/src/core-server/build-static.ts` — Watch mode logging
- `code/builders/builder-webpack5/src/index.ts` — Webpack watch implementation
- `code/builders/builder-vite/src/build.ts` — Vite watch implementation

## Usage

```bash
build-storybook --watch
build-storybook -w
```

Closes #15946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global build "watch" mode (-w, --watch) that automatically rebuilds on changes, logs build progress (including watch-specific messages like "Watching for changes..." and "Building preview in watch mode.."), suppresses the one-time completion message during active watching, and improves per-build logging for warnings and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->