### PR TITLE
fix(ui): improve keyboard accessibility for overflowing addon tabs  

### DIFF
--- a/code/core/src/components/components/Tabs/StatelessTabList.tsx
+++ b/code/core/src/components/components/Tabs/StatelessTabList.tsx
@@ -66,6 +66,7 @@ export interface StatelessTabListProps {
 export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const hasScrolledToSelected = useRef(false);
 
   const [showScrollButtons, setShowScrollButtons] = useState(false);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -126,6 +127,64 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
     };
   }, [throttledUpdateScrollState]);
 
+  const scrollTabIntoView = useCallback((tab: HTMLElement) => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) {
+      return;
+    }
+
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const tabRect = tab.getBoundingClientRect();
+
+    if (tabRect.left < containerRect.left) {
+      scrollContainer.scrollLeft -= containerRect.left - tabRect.left;
+    } else if (tabRect.right > containerRect.right) {
+      scrollContainer.scrollLeft += tabRect.right - containerRect.right;
+    }
+  }, []);
+
+  // Auto-scroll focused tab into view when navigating with arrow keys
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer || typeof window === 'undefined') {
+      return;
+    }
+
+    const handleFocusIn = (e: FocusEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.role === 'tab') {
+        scrollTabIntoView(target);
+        requestAnimationFrame(() => updateScrollState());
+      }
+    };
+
+    scrollContainer.addEventListener('focusin', handleFocusIn);
+    return () => scrollContainer.removeEventListener('focusin', handleFocusIn);
+  }, [scrollTabIntoView, updateScrollState]);
+
+  // Scroll the selected tab into view on initial render
+  useEffect(() => {
+    if (hasScrolledToSelected.current) {
+      return;
+    }
+
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer || typeof window === 'undefined') {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      const selectedTab = scrollContainer.querySelector('[data-selected]') as HTMLElement | null;
+      if (selectedTab) {
+        scrollTabIntoView(selectedTab);
+        updateScrollState();
+        hasScrolledToSelected.current = true;
+      }
+    }, 0);
+
+    return () => clearTimeout(timeoutId);
+  }, [scrollTabIntoView, updateScrollState]);
+
   const scroll = useCallback((direction: 'backward' | 'forward') => {
     const scrollContainer = scrollContainerRef.current;
     const container = containerRef.current;
@@ -160,7 +219,6 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
             ariaLabel="Scroll backward"
             disabled={!canScrollLeft}
             onClick={scrollBackward}
-            tabIndex={-1}
           >
             <ChevronSmallLeftIcon />
           </ScrollButton>
@@ -178,7 +236,6 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
             ariaLabel="Scroll forward"
             disabled={!canScrollRight}
             onClick={scrollForward}
-            tabIndex={-1}
           >
             <ChevronSmallRightIcon />
           </ScrollButton>

--- a/code/core/src/components/components/Tabs/StatelessTabList.tsx
+++ b/code/core/src/components/components/Tabs/StatelessTabList.tsx
@@ -150,7 +150,7 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
 
     const handleFocusIn = (e: FocusEvent) => {
       const target = e.target as HTMLElement;
-      if (target.role === 'tab') {
+      if (target.getAttribute('role') === 'tab') {
         scrollTabIntoView(target);
       }
     };
@@ -175,8 +175,8 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
       if (selectedTab) {
         scrollTabIntoView(selectedTab);
         updateScrollState();
-        hasScrolledToSelected.current = true;
       }
+      hasScrolledToSelected.current = true;
     }, 0);
 
     return () => clearTimeout(timeoutId);

--- a/code/core/src/components/components/Tabs/StatelessTabList.tsx
+++ b/code/core/src/components/components/Tabs/StatelessTabList.tsx
@@ -69,6 +69,7 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
   const hasScrolledToSelected = useRef(false);
 
   const [showScrollButtons, setShowScrollButtons] = useState(false);
+  const showScrollButtonsRef = useRef(false);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
 
@@ -82,9 +83,10 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
 
     const { scrollLeft, scrollWidth, clientWidth } = scrollContainer;
     const availableWidth =
-      container.clientWidth - (showScrollButtons ? SCROLL_BUTTON_WIDTH * 2 : 0);
+      container.clientWidth - (showScrollButtonsRef.current ? SCROLL_BUTTON_WIDTH * 2 : 0);
 
     const needsScrolling = scrollWidth > availableWidth;
+    showScrollButtonsRef.current = needsScrolling;
     setShowScrollButtons(needsScrolling);
 
     if (needsScrolling) {
@@ -94,11 +96,7 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
       setCanScrollLeft(false);
       setCanScrollRight(false);
     }
-  }, [showScrollButtons]);
-
-  const throttledUpdateScrollState = useCallback(() => {
-    updateScrollState();
-  }, [updateScrollState]);
+  }, []);
 
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current;
@@ -106,26 +104,26 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
       return;
     }
 
-    scrollContainer.addEventListener('scroll', throttledUpdateScrollState, { passive: true });
+    scrollContainer.addEventListener('scroll', updateScrollState, { passive: true });
 
     // SSR safety: ResizeObserver may not exist in all environments
     let resizeObserver: ResizeObserver | null = null;
     if (typeof ResizeObserver !== 'undefined') {
-      resizeObserver = new ResizeObserver(throttledUpdateScrollState);
+      resizeObserver = new ResizeObserver(updateScrollState);
       resizeObserver.observe(scrollContainer);
     }
 
     // Initial update - delay to ensure DOM is ready
-    const timeoutId = setTimeout(throttledUpdateScrollState, 0);
+    const timeoutId = setTimeout(updateScrollState, 0);
 
     return () => {
       clearTimeout(timeoutId);
-      scrollContainer.removeEventListener('scroll', throttledUpdateScrollState);
+      scrollContainer.removeEventListener('scroll', updateScrollState);
       if (resizeObserver) {
         resizeObserver.disconnect();
       }
     };
-  }, [throttledUpdateScrollState]);
+  }, [updateScrollState]);
 
   const scrollTabIntoView = useCallback((tab: HTMLElement) => {
     const scrollContainer = scrollContainerRef.current;
@@ -154,13 +152,12 @@ export const StatelessTabList: FC<StatelessTabListProps> = ({ children, ...rest 
       const target = e.target as HTMLElement;
       if (target.role === 'tab') {
         scrollTabIntoView(target);
-        requestAnimationFrame(() => updateScrollState());
       }
     };
 
     scrollContainer.addEventListener('focusin', handleFocusIn);
     return () => scrollContainer.removeEventListener('focusin', handleFocusIn);
-  }, [scrollTabIntoView, updateScrollState]);
+  }, [scrollTabIntoView]);
 
   // Scroll the selected tab into view on initial render
   useEffect(() => {

--- a/code/core/src/components/components/Tabs/TabList.stories.tsx
+++ b/code/core/src/components/components/Tabs/TabList.stories.tsx
@@ -1,6 +1,6 @@
 import { Bar } from 'storybook/internal/components';
 
-import { expect } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 
 import preview from '../../../../../.storybook/preview';
 import { TabList } from './TabList';
@@ -145,5 +145,72 @@ export const PreservesAriaLabels = meta.story({
   play: ({ canvas }) => {
     const tabOne = canvas.getAllByRole('tab')[0];
     expect(tabOne).toHaveAttribute('aria-label', 'Tab one');
+  },
+});
+
+export const ScrollButtonsAreKeyboardAccessible = meta.story({
+  name: 'Scroll Buttons Are Keyboard Accessible',
+  parameters: {
+    data: {
+      tabs: MANY_TABS,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Scroll buttons should be present and focusable (no tabIndex={-1})
+    const scrollForwardButton = canvas.getByRole('button', { name: 'Scroll forward' });
+    expect(scrollForwardButton).not.toHaveAttribute('tabindex', '-1');
+    expect(scrollForwardButton).toBeEnabled();
+
+    const scrollBackwardButton = canvas.getByRole('button', { name: 'Scroll backward' });
+    expect(scrollBackwardButton).toBeDisabled();
+  },
+});
+
+export const ArrowKeyScrollsOverflowingTabs = meta.story({
+  name: 'Arrow Keys Scroll Overflowing Tabs Into View',
+  parameters: {
+    data: {
+      tabs: MANY_TABS,
+    },
+  },
+  decorators: [
+    (Story, { args }) => {
+      return (
+        <Bar
+          border
+          scrollable={false}
+          innerStyle={{ width: 400, padding: 0 }}
+          backgroundColor={'rgba(0,0,0,.05)'}
+        >
+          <Story args={{ ...args }} />
+        </Bar>
+      );
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tabs = canvas.getAllByRole('tab');
+
+    // Focus the first tab
+    await userEvent.click(tabs[0]);
+    expect(tabs[0]).toHaveFocus();
+
+    // Arrow right through several tabs — each should auto-scroll into view
+    for (let i = 1; i < Math.min(tabs.length, 8); i++) {
+      await userEvent.keyboard('{ArrowRight}');
+    }
+
+    // After arrowing right, a later tab should have focus and be visible
+    const focusedTab = canvasElement.querySelector('[role="tab"]:focus') as HTMLElement;
+    expect(focusedTab).toBeTruthy();
+
+    // Verify the focused tab is within the visible scroll area
+    const scrollContainer = canvasElement.querySelector('[style*="overflow"]') ?? canvasElement;
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const tabRect = focusedTab.getBoundingClientRect();
+    expect(tabRect.right).toBeLessThanOrEqual(containerRect.right + 1);
+    expect(tabRect.left).toBeGreaterThanOrEqual(containerRect.left - 1);
   },
 });

--- a/code/core/src/components/components/Tabs/TabList.stories.tsx
+++ b/code/core/src/components/components/Tabs/TabList.stories.tsx
@@ -207,7 +207,19 @@ export const ArrowKeyScrollsOverflowingTabs = meta.story({
     expect(focusedTab).toBeTruthy();
 
     // Verify the focused tab is within the visible scroll area
-    const scrollContainer = canvasElement.querySelector('[style*="overflow"]') ?? canvasElement;
+    // Walk up from the tablist to find the actual scrollable container (styled-components
+    // apply overflow via class, not inline style, so [style*="overflow"] won't match).
+    const tablist = canvasElement.querySelector('[role="tablist"]');
+    let scrollContainer: Element = canvasElement;
+    let node = tablist?.parentElement;
+    while (node) {
+      const overflow = getComputedStyle(node).overflowX;
+      if (overflow === 'auto' || overflow === 'scroll') {
+        scrollContainer = node;
+        break;
+      }
+      node = node.parentElement;
+    }
     const containerRect = scrollContainer.getBoundingClientRect();
     const tabRect = focusedTab.getBoundingClientRect();
     expect(tabRect.right).toBeLessThanOrEqual(containerRect.right + 1);


### PR DESCRIPTION
Closes #23257 

## What I did

Improved keyboard accessibility for the addon panel's overflowing tab list.

The original issue described a dropdown ("Addons ▼") that was keyboard-inaccessible. This dropdown has been replaced with scroll buttons (`<` `>`) in Storybook 10. However, the new scroll-based overflow had accessibility gaps:

1. Arrow-key navigation to off-screen tabs didn't auto-scroll the container
2. Scroll buttons had `tabIndex={-1}`, making them unreachable by keyboard
3. If the selected tab was off-screen on initial render, it wasn't scrolled into view

### Changes
- Added `scrollTabIntoView` helper that adjusts only `ScrollContainer.scrollLeft` (avoids `scrollIntoView()` which can cause ancestor containers to jump)
- Added `focusin` listener to auto-scroll when a tab receives focus via arrow keys
- Added initial-render scroll to the selected (`[data-selected]`) tab
- Removed `tabIndex={-1}` from scroll buttons so keyboard users can reach them
- Stabilized `updateScrollState` identity using a ref to prevent unnecessary effect re-registration

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `cd code && yarn storybook:ui`
2. Open Storybook in your browser
3. Shrink the addon panel so tabs overflow (scroll buttons appear)
4. Use arrow keys to navigate tabs — verify off-screen tabs scroll into view
5. Tab to the scroll buttons (`<` `>`) — verify they are focusable and work with Enter/Space
6. Select a tab that would be off-screen, then reload — verify it scrolls into view

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent repeated auto-scrolling of the initially selected tab on load.
  * Ensure focused tabs (arrow-key navigation) are scrolled into view when focused.
  * Improve scroll-state calculations so navigation buttons show/hide correctly and update reliably.
  * Scroll arrow buttons are now keyboard-focusable and participate in keyboard navigation.

* **Tests**
  * Added interactive Storybook stories validating keyboard-driven tab scrolling and scroll-button accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->