### PR TITLE
actions: keep newest entries when limit is reached

### DIFF
--- a/code/core/src/actions/containers/ActionLogger/index.test.ts
+++ b/code/core/src/actions/containers/ActionLogger/index.test.ts
@@ -11,6 +11,15 @@ const makeAction = (id: string, args: any[], limit = 50): ActionDisplay => ({
 });
 
 describe('applyActionToList', () => {
+  it('returns an empty list when limit is zero', () => {
+    const first = makeAction('1', [1], 0);
+    const second = makeAction('2', [2], 0);
+
+    const next = applyActionToList(applyActionToList([], first), second);
+
+    expect(next).toEqual([]);
+  });
+
   it('keeps the most recent actions when the limit is reached', () => {
     const limit = 2;
     const first = makeAction('1', [1], limit);

--- a/code/core/src/actions/containers/ActionLogger/index.test.ts
+++ b/code/core/src/actions/containers/ActionLogger/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ActionDisplay } from '../../models';
+import { applyActionToList } from './index';
+
+const makeAction = (id: string, args: any[], limit = 50): ActionDisplay => ({
+  id,
+  count: 0,
+  data: { name: 'onClick', args },
+  options: { limit },
+});
+
+describe('applyActionToList', () => {
+  it('keeps the most recent actions when the limit is reached', () => {
+    const limit = 2;
+    const first = makeAction('1', [1], limit);
+    const second = makeAction('2', [2], limit);
+    const third = makeAction('3', [3], limit);
+
+    const next = applyActionToList(applyActionToList(applyActionToList([], first), second), third);
+
+    expect(next).toHaveLength(2);
+    expect(next.map((entry) => entry.id)).toEqual(['2', '3']);
+  });
+
+  it('increments count immutably when the latest action data matches', () => {
+    const previous = { ...makeAction('1', ['same']), count: 1 };
+    const incoming = makeAction('2', ['same']);
+
+    const next = applyActionToList([previous], incoming);
+
+    expect(next).toHaveLength(1);
+    expect(next[0]).not.toBe(previous);
+    expect(next[0]).toMatchObject({ id: '1', count: 2 });
+    expect(previous.count).toBe(1);
+  });
+});

--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -29,6 +29,9 @@ export const applyActionToList = (
   action: ActionDisplay
 ): ActionDisplay[] => {
   const limit = action.options.limit ?? Number.POSITIVE_INFINITY;
+  if (limit <= 0) {
+    return [];
+  }
   const previous = prevActions.length ? prevActions[prevActions.length - 1] : null;
 
   if (previous && safeDeepEqual(previous.data, action.data)) {

--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -24,6 +24,23 @@ const safeDeepEqual = (a: any, b: any): boolean => {
   }
 };
 
+export const applyActionToList = (
+  prevActions: ActionDisplay[],
+  action: ActionDisplay
+): ActionDisplay[] => {
+  const limit = action.options.limit ?? Number.POSITIVE_INFINITY;
+  const previous = prevActions.length ? prevActions[prevActions.length - 1] : null;
+
+  if (previous && safeDeepEqual(previous.data, action.data)) {
+    const updated = [...prevActions];
+    updated[updated.length - 1] = { ...previous, count: previous.count + 1 };
+    return updated.slice(-limit);
+  }
+
+  const newAction = { ...action, count: 1 };
+  return [...prevActions, newAction].slice(-limit);
+};
+
 export default function ActionLogger({ active, api }: ActionLoggerProps) {
   const [actions, setActions] = useState<ActionDisplay[]>([]);
   const parameter = useParameter<ActionsParameters['actions']>(PARAM_KEY);
@@ -35,17 +52,7 @@ export default function ActionLogger({ active, api }: ActionLoggerProps) {
   }, [api]);
 
   const addAction = useCallback((action: ActionDisplay) => {
-    setActions((prevActions) => {
-      const newActions = [...prevActions];
-      const previous = newActions.length && newActions[newActions.length - 1];
-      if (previous && safeDeepEqual(previous.data, action.data)) {
-        previous.count++;
-      } else {
-        action.count = 1;
-        newActions.push(action);
-      }
-      return newActions.slice(0, action.options.limit);
-    });
+    setActions((prevActions) => applyActionToList(prevActions, action));
   }, []);
 
   const handleStoryChange = useCallback(() => {

--- a/code/core/template/stories/basics.stories.ts
+++ b/code/core/template/stories/basics.stories.ts
@@ -2,6 +2,9 @@ import { global as globalThis } from '@storybook/global';
 
 import { action } from 'storybook/actions';
 
+const optionLimitAction = action('onClick', { limit: 3 });
+let optionLimitSequence = 0;
+
 export default {
   component: globalThis.__TEMPLATE_COMPONENTS__.Button,
   args: {
@@ -87,6 +90,12 @@ export const OptionPersist = {
 };
 export const OptionDepth = {
   args: { onClick: action('onClick', { depth: 2 }) },
+};
+export const OptionLimit = {
+  args: {
+    onClick: () => optionLimitAction({ seq: optionLimitSequence++ }),
+    label: 'Click me repeatedly (limit: 3)',
+  },
 };
 
 export const Disabled = {

--- a/docs/essentials/actions.mdx
+++ b/docs/essentials/actions.mdx
@@ -104,11 +104,11 @@ import { action } from 'storybook/actions';
 
 #### `action`
 
-Type: `(name?: string, options?: { limit?: number }) => void`
+Type: `(name?: string, options?: ActionOptions) => void`
 
 Allows you to create an action that appears in the actions panel of the Storybook UI when clicked. The action function takes an optional name parameter, which is used to identify the action in the UI.
 
-You can optionally pass an options object to control how events are stored in the panel.
+You can optionally pass an options object to control how events are stored in the panel. Supported fields include `limit`, `depth`, and `clearOnStoryChange` (plus serializer-related options from `telejson`).
 
 ##### `options.limit`
 

--- a/docs/essentials/actions.mdx
+++ b/docs/essentials/actions.mdx
@@ -104,9 +104,19 @@ import { action } from 'storybook/actions';
 
 #### `action`
 
-Type: `(name?: string) => void`
+Type: `(name?: string, options?: { limit?: number }) => void`
 
 Allows you to create an action that appears in the actions panel of the Storybook UI when clicked. The action function takes an optional name parameter, which is used to identify the action in the UI.
+
+You can optionally pass an options object to control how events are stored in the panel.
+
+##### `options.limit`
+
+Type: `number`
+
+Default: `50`
+
+Maximum number of entries retained in the Actions panel for this action. Once the limit is reached, Storybook keeps the **most recent** entries and drops older ones.
 
 {/* prettier-ignore-start */}
 


### PR DESCRIPTION
## Summary
Fixes Actions panel retention logic when `options.limit` is reached so Storybook keeps the newest entries instead of the oldest.

## Changes
- Updated `code/core/src/actions/containers/ActionLogger/index.tsx`:
  - switched retention from `slice(0, limit)` to latest-window behavior (`slice(-limit)`)
  - removed mutable state updates in `setActions` updater (immutable updates for `count` and new entries)
- Added regression tests in `code/core/src/actions/containers/ActionLogger/index.test.ts`:
  - keeps newest entries at capacity
  - increments count immutably for repeated payloads
- Added a story scenario in `code/core/template/stories/basics.stories.ts`:
  - `OptionLimit` to showcase panel behavior with a small limit
- Updated docs in `docs/essentials/actions.mdx`:
  - documents `action(..., { limit })`
  - clarifies that oldest entries are dropped and newest are retained once limit is reached

## Notes
I couldn’t run local vitest in this environment because dependency installation timed out; CI should validate the full suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action logging supports a configurable limit option to retain only the most recent entries (default: 50).
  * Added a demo story showing limited action logging with an incrementing sequence.

* **Documentation**
  * Updated docs to describe the new action options, including limit, defaults, and retention behavior.

* **Tests**
  * Added tests covering limit behavior and immutable updates to logged actions.

* **Refactor**
  * Improved internal handling to produce immutable action list updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->