### PR TITLE
Build: Retry-mechanism for dts bundle-generation

### DIFF
--- a/scripts/build/utils/generate-types.ts
+++ b/scripts/build/utils/generate-types.ts
@@ -8,6 +8,9 @@ import type { BuildEntries } from './entry-utils';
 
 const DIR_CODE = join(import.meta.dirname, '..', '..', '..', 'code');
 
+const MAX_DTS_ATTEMPTS = 2;
+const RETRY_DELAY_MS = 500;
+
 export async function generateTypesFiles(cwd: string, data: BuildEntries) {
   const DIR_CWD = cwd;
   const DIR_REL = relative(DIR_CODE, DIR_CWD);
@@ -27,64 +30,78 @@ export async function generateTypesFiles(cwd: string, data: BuildEntries) {
   await Promise.all(
     dtsEntries.map(async (entryPoint) => {
       return limited(async () => {
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const dtsProcess = spawn(
-          `"${join(ROOT_DIRECTORY, 'node_modules', '.bin', 'jiti')}"`,
-          [`"${join(import.meta.dirname, 'dts-process.ts')}"`, `"${entryPoint}"`],
-          {
-            shell: true,
-            cwd: DIR_CWD,
-            stdio: ['ignore', 'inherit', 'pipe'],
-          }
-        );
-        processes.push(dtsProcess);
-
-        // Filter stderr to exclude messages containing "are imported from external module", which is an ignorable warning from rollup
-        dtsProcess.stderr?.on('data', (data) => {
-          const message = data.toString();
-          if (!message.includes('are imported from external module')) {
-            process.stderr.write(data);
-          }
-        });
-
-        await Promise.race([
-          new Promise((resolve) => {
-            dtsProcess.on('exit', () => {
-              resolve(void 0);
-            });
-            dtsProcess.on('error', () => {
-              resolve(void 0);
-            });
-            dtsProcess.on('close', () => {
-              resolve(void 0);
-            });
-          }),
-          new Promise((resolve) => {
-            timer = setTimeout(() => {
-              console.log('⌛ Timed out generating d.ts files for', entryPoint);
-
-              dtsProcess.kill(408); // timed out
-              resolve(void 0);
-            }, 120000);
-          }),
-        ]);
-
-        if (timer) {
-          clearTimeout(timer);
-        }
-
-        if (dtsProcess.exitCode !== 0) {
-          console.error(
-            '\n❌ Generating types for',
-            picocolors.cyan(relative(cwd, entryPoint)),
-            ' failed'
+        for (let attempt = 1; attempt <= MAX_DTS_ATTEMPTS; attempt++) {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          const dtsProcess = spawn(
+            `"${join(ROOT_DIRECTORY, 'node_modules', '.bin', 'jiti')}"`,
+            [`"${join(import.meta.dirname, 'dts-process.ts')}"`, `"${entryPoint}"`],
+            {
+              shell: true,
+              cwd: DIR_CWD,
+              stdio: ['ignore', 'inherit', 'pipe'],
+            }
           );
-          // If any fail, kill all the other processes and exit (bail)
-          processes.forEach((p) => p.kill());
-          processes = [];
-          process.exit(dtsProcess.exitCode || 1);
-        } else if (!process.env.CI) {
-          console.log('✅ Generated types for', picocolors.cyan(join(DIR_REL, entryPoint)));
+          processes.push(dtsProcess);
+
+          // Filter stderr to exclude messages containing "are imported from external module", which is an ignorable warning from rollup
+          dtsProcess.stderr?.on('data', (data) => {
+            const message = data.toString();
+            if (!message.includes('are imported from external module')) {
+              process.stderr.write(data);
+            }
+          });
+
+          await Promise.race([
+            new Promise((resolve) => {
+              dtsProcess.on('exit', () => {
+                resolve(void 0);
+              });
+              dtsProcess.on('error', () => {
+                resolve(void 0);
+              });
+              dtsProcess.on('close', () => {
+                resolve(void 0);
+              });
+            }),
+            new Promise((resolve) => {
+              timer = setTimeout(() => {
+                console.log('⌛ Timed out generating d.ts files for', entryPoint);
+
+                dtsProcess.kill(408); // timed out
+                resolve(void 0);
+              }, 120000);
+            }),
+          ]);
+
+          if (timer) {
+            clearTimeout(timer);
+          }
+
+          if (dtsProcess.exitCode !== 0) {
+            if (attempt < MAX_DTS_ATTEMPTS) {
+              // Race: parallel DTS can read a .d.ts another process is still writing → invalid. Retry + delay usually fixes (flake in core:compile:production since #33759).
+              console.warn(
+                `⚠️ DTS failed for ${picocolors.cyan(relative(cwd, entryPoint))}, retrying (${attempt}/${MAX_DTS_ATTEMPTS})...`
+              );
+              processes = processes.filter((p) => p !== dtsProcess);
+              await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+              continue;
+            }
+            console.error(
+              '\n❌ Generating types for',
+              picocolors.cyan(relative(cwd, entryPoint)),
+              ' failed'
+            );
+            // If any fail after all retries, kill all the other processes and exit (bail)
+            processes.forEach((p) => p.kill());
+            processes = [];
+            process.exit(dtsProcess.exitCode || 1);
+          }
+
+          if (!process.env.CI) {
+            console.log('✅ Generated types for', picocolors.cyan(join(DIR_REL, entryPoint)));
+          }
+          break;
         }
       });
     })


### PR DESCRIPTION
## What I did

We run dts bundling on 5 entrypoints at a time.
This is usually fine, however occasionally we run into the problem where `entrypoint A` uses `entrypoint B`.
This is fine, of course, but then if `entrypoint B` is at that time getting generated, the file might be partially written.
When `entrypoint A` then tries to load the `b.d.ts` file it will error and yield a "not a valid module".

I've tried a few things to solve this, but ultimately landed on a retry mechanism, because everything else i tried to make the system more predictable had severe performance implications.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I manually ran the compile step a few times, and I noticed no changes, no regressions.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented automatic retry mechanism for type declaration file generation during the build process. Failed generation processes are now automatically retried up to two times with a 500-millisecond delay between attempts before the build fails, improving overall reliability when facing transient errors. Enhanced logging for retry events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->