### PR TITLE
fix(actions): prevent state mutation and keep newest actions on limit

### DIFF
--- a/code/core/src/actions/containers/ActionLogger/index.tsx
+++ b/code/core/src/actions/containers/ActionLogger/index.tsx
@@ -36,15 +36,18 @@ export default function ActionLogger({ active, api }: ActionLoggerProps) {
 
   const addAction = useCallback((action: ActionDisplay) => {
     setActions((prevActions) => {
-      const newActions = [...prevActions];
-      const previous = newActions.length && newActions[newActions.length - 1];
+      const previous = prevActions.length ? prevActions[prevActions.length - 1] : null;
+      let newActions;
+
       if (previous && safeDeepEqual(previous.data, action.data)) {
-        previous.count++;
+        newActions = [...prevActions];
+        newActions[newActions.length - 1] = { ...previous, count: previous.count + 1 };
       } else {
-        action.count = 1;
-        newActions.push(action);
+        newActions = [...prevActions, { ...action, count: 1 }];
       }
-      return newActions.slice(0, action.options.limit);
+
+      const limit = action.options?.limit;
+      return limit ? newActions.slice(-limit) : newActions;
     });
   }, []);
 


### PR DESCRIPTION
Fixes #34052. This PR prevents state mutations when updating `ActionLogger`'s actions in React and fixes the slice logic so that the newest actions are kept when reaching the limit (using `slice(-limit)` instead of `slice(0, limit)`). 

I have tested these changes to make sure they follow the immutability rules and ensure that `action.count` does not mutate the original objects.

(Auto-generated AI PR by Sigma)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed action logging to retain the most recent actions when limits are applied.
  * Improved state consistency during action tracking operations.

* **Refactor**
  * Streamlined action state update logic for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->