### PR TITLE
Cleanup: Remove root prettierRC and update snapshots

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,0 @@
-{
-  "printWidth": 100,
-  "tabWidth": 2,
-  "bracketSpacing": true,
-  "trailingComma": "es5",
-  "singleQuote": true,
-  "arrowParens": "always"
-}

--- a/code/core/src/core-server/utils/get-new-story-file.test.ts
+++ b/code/core/src/core-server/utils/get-new-story-file.test.ts
@@ -50,9 +50,9 @@ describe('get-new-story-file', () => {
 
     expect(exportedStoryName).toBe('Default');
     expect(storyFileContent).toMatchInlineSnapshot(`
-      "import type { Meta, StoryObj } from '@storybook/nextjs';
+      "import type { Meta, StoryObj } from "@storybook/nextjs";
 
-      import { Page } from './Page';
+      import { Page } from "./Page";
 
       const meta = {
         component: Page,
@@ -89,9 +89,9 @@ describe('get-new-story-file', () => {
 
     expect(exportedStoryName).toBe('Default');
     expect(storyFileContent).toMatchInlineSnapshot(`
-      "import type { Meta, StoryObj } from '@storybook/react-vite';
+      "import type { Meta, StoryObj } from "@storybook/react-vite";
 
-      import { Page } from './Page';
+      import { Page } from "./Page";
 
       const meta = {
         component: Page,
@@ -128,7 +128,7 @@ describe('get-new-story-file', () => {
 
     expect(exportedStoryName).toBe('Default');
     expect(storyFileContent).toMatchInlineSnapshot(`
-      "import Page from './Page';
+      "import Page from "./Page";
 
       const meta = {
         component: Page,
@@ -166,7 +166,7 @@ describe('get-new-story-file', () => {
       } as unknown as Options
     );
 
-    expect(storyFileContent).toContain("import { fn } from 'storybook/test';");
+    expect(storyFileContent).toContain('import { fn } from "storybook/test";');
     expect(storyFileContent).toContain('fn()');
     expect(storyFileContent).not.toContain(STORYBOOK_FN_PLACEHOLDER);
   });
@@ -258,10 +258,10 @@ describe('get-new-story-file', () => {
 
     expect(exportedStoryName).toBe('Default');
     expect(storyFileContent).toMatchInlineSnapshot(`
-      "import { fn } from 'storybook/test';
-      import preview from '#.storybook/preview';
+      "import { fn } from "storybook/test";
+      import preview from "#.storybook/preview";
 
-      import { Page } from './Page';
+      import { Page } from "./Page";
 
       const meta = preview.meta({
         component: Page,
@@ -269,7 +269,7 @@ describe('get-new-story-file', () => {
 
       export const Default = meta.story({
         args: {
-          label: 'label',
+          label: "label",
           answer: 0,
           onClick: fn(),
         },

--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.test.ts
@@ -38,8 +38,8 @@ describe('stories codemod', () => {
             export const A = {};
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        const meta = preview.meta({ title: 'Component' });
+        import preview from "#.storybook/preview";
+        const meta = preview.meta({ title: "Component" });
         export const A = meta.story();
       `);
     });
@@ -62,9 +62,9 @@ describe('stories codemod', () => {
          * @license MIT
          * Copyright 2024
          */
-        import preview from '#.storybook/preview';
+        import preview from "#.storybook/preview";
 
-        const meta = preview.meta({ title: 'Component' });
+        const meta = preview.meta({ title: "Component" });
         export const A = meta.story();
       `);
     });
@@ -76,10 +76,10 @@ describe('stories codemod', () => {
             export const A = {};
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
+        import preview from "#.storybook/preview";
 
         const meta = preview.meta({
-          title: 'Component',
+          title: "Component",
         });
 
         export const A = meta.story();
@@ -94,8 +94,8 @@ describe('stories codemod', () => {
             export const A = {};
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        const componentMeta = preview.meta({ title: 'Component' });
+        import preview from "#.storybook/preview";
+        const componentMeta = preview.meta({ title: "Component" });
         export const A = componentMeta.story();
       `);
     });
@@ -111,8 +111,8 @@ describe('stories codemod', () => {
             };
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        const componentMeta = preview.meta({ title: 'Component' });
+        import preview from "#.storybook/preview";
+        const componentMeta = preview.meta({ title: "Component" });
         export const A = componentMeta.story({
           args: { primary: true },
           render: (args) => <Component {...args} />,
@@ -132,8 +132,8 @@ describe('stories codemod', () => {
             };
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview, { decorators } from '#.storybook/preview';
-        const componentMeta = preview.meta({ title: 'Component' });
+        import preview, { decorators } from "#.storybook/preview";
+        const componentMeta = preview.meta({ title: "Component" });
         export const A = componentMeta.story({
           args: { primary: true },
           render: (args) => <Component {...args} />,
@@ -153,8 +153,8 @@ describe('stories codemod', () => {
             };
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import previewConfig from '#.storybook/preview';
-        const componentMeta = previewConfig.meta({ title: 'Component' });
+        import previewConfig from "#.storybook/preview";
+        const componentMeta = previewConfig.meta({ title: "Component" });
         export const A = componentMeta.story({
           args: { primary: true },
           render: (args) => <Component {...args} />,
@@ -174,8 +174,8 @@ describe('stories codemod', () => {
             };
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import storybookPreview from '#.storybook/preview';
-        const componentMeta = storybookPreview.meta({ title: 'Component' });
+        import storybookPreview from "#.storybook/preview";
+        const componentMeta = storybookPreview.meta({ title: "Component" });
         const preview = {};
         export const A = componentMeta.story({
           args: { primary: true },
@@ -209,10 +209,10 @@ describe('stories codemod', () => {
             };
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
+        import preview from "#.storybook/preview";
 
         const meta = preview.meta({
-          title: 'Component',
+          title: "Component",
         });
 
         const someData = {};
@@ -266,8 +266,8 @@ describe('stories codemod', () => {
             };
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        const myMeta = preview.meta({ title: 'Component', args: {} });
+        import preview from "#.storybook/preview";
+        const myMeta = preview.meta({ title: "Component", args: {} });
 
         const metaProperties = {
           ...myMeta.input,
@@ -320,12 +320,12 @@ describe('stories codemod', () => {
             };
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import * as BaseStories from './Button.stories';
-        import { Primary as ImportedPrimary } from './Card.stories';
+        import preview from "#.storybook/preview";
+        import * as BaseStories from "./Button.stories";
+        import { Primary as ImportedPrimary } from "./Card.stories";
 
         const meta = preview.meta({
-          title: 'Component',
+          title: "Component",
         });
 
         export const A = meta.story({
@@ -336,7 +336,7 @@ describe('stories codemod', () => {
           ...BaseStories.Secondary.input,
           args: {
             ...BaseStories.Secondary.input.args,
-            label: 'Custom',
+            label: "Custom",
           },
         });
 
@@ -362,7 +362,7 @@ describe('stories codemod', () => {
             export const D = A.extends({});
           `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Component' };
+        export default { title: "Component" };
         export const A = {};
         export const B = {
           play: async () => {
@@ -438,7 +438,7 @@ describe('stories codemod', () => {
             )
           )
         ).resolves.toMatchInlineSnapshot(`
-          import preview, { extra } from '#.storybook/preview';
+          import preview, { extra } from "#.storybook/preview";
           const meta = preview.meta({});
           export const A = meta.story();
         `);
@@ -459,7 +459,7 @@ describe('stories codemod', () => {
             )
           )
         ).resolves.toMatchInlineSnapshot(`
-          import preview, { extra } from '../../preview';
+          import preview, { extra } from "../../preview";
           const meta = preview.meta({});
           export const A = meta.story();
         `);
@@ -476,8 +476,8 @@ describe('stories codemod', () => {
             export const CSF1Story = () => <div>Hello</div>;
           `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        const meta = preview.meta({ title: 'Component' });
+        import preview from "#.storybook/preview";
+        const meta = preview.meta({ title: "Component" });
         export const CSF1Story = meta.story(() => <div>Hello</div>);
       `);
     });
@@ -496,10 +496,10 @@ describe('stories codemod', () => {
       `;
     it('meta satisfies syntax', async () => {
       await expect(transform(inlineMetaSatisfies)).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import { ComponentProps } from './Component';
+        import preview from "#.storybook/preview";
+        import { ComponentProps } from "./Component";
 
-        const meta = preview.meta({ title: 'Component', component: Component });
+        const meta = preview.meta({ title: "Component", component: Component });
 
         export const A = meta.story({
           args: { primary: true },
@@ -519,10 +519,10 @@ describe('stories codemod', () => {
       `;
     it('meta as syntax', async () => {
       await expect(transform(inlineMetaAs)).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import { ComponentProps } from './Component';
+        import preview from "#.storybook/preview";
+        import { ComponentProps } from "./Component";
 
-        const meta = preview.meta({ title: 'Component', component: Component });
+        const meta = preview.meta({ title: "Component", component: Component });
 
         export const A = meta.story({
           args: { primary: true },
@@ -542,10 +542,10 @@ describe('stories codemod', () => {
       `;
     it('meta satisfies syntax', async () => {
       await expect(transform(metaSatisfies)).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import { ComponentProps } from './Component';
+        import preview from "#.storybook/preview";
+        import { ComponentProps } from "./Component";
 
-        const meta = preview.meta({ title: 'Component', component: Component });
+        const meta = preview.meta({ title: "Component", component: Component });
 
         export const A = meta.story({
           args: { primary: true },
@@ -566,10 +566,10 @@ describe('stories codemod', () => {
       `;
     it('meta type syntax', async () => {
       await expect(transform(metaTypeDef)).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import { ComponentProps } from './Component';
+        import preview from "#.storybook/preview";
+        import { ComponentProps } from "./Component";
 
-        const meta = preview.meta({ title: 'Component', component: Component });
+        const meta = preview.meta({ title: "Component", component: Component });
 
         export const A = meta.story({
           args: { primary: true },
@@ -590,10 +590,10 @@ describe('stories codemod', () => {
       `;
     it('meta as syntax', async () => {
       await expect(transform(metaAs)).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import { ComponentProps } from './Component';
+        import preview from "#.storybook/preview";
+        import { ComponentProps } from "./Component";
 
-        const meta = preview.meta({ title: 'Component', component: Component });
+        const meta = preview.meta({ title: "Component", component: Component });
 
         export const A = meta.story({
           args: { primary: true },
@@ -614,10 +614,10 @@ describe('stories codemod', () => {
       `;
     it('story satisfies syntax', async () => {
       await expect(transform(storySatisfies)).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import { ComponentProps } from './Component';
+        import preview from "#.storybook/preview";
+        import { ComponentProps } from "./Component";
 
-        const meta = preview.meta({ title: 'Component', component: Component });
+        const meta = preview.meta({ title: "Component", component: Component });
 
         export const A = meta.story({
           args: { primary: true },
@@ -638,10 +638,10 @@ describe('stories codemod', () => {
       `;
     it('story as syntax', async () => {
       await expect(transform(storyAs)).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import { ComponentProps } from './Component';
+        import preview from "#.storybook/preview";
+        import { ComponentProps } from "./Component";
 
-        const meta = preview.meta({ title: 'Component', component: Component });
+        const meta = preview.meta({ title: "Component", component: Component });
 
         export const A = meta.story({
           args: { primary: true },
@@ -676,8 +676,8 @@ describe('stories codemod', () => {
         export const A: Story = {};`
         )
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import { ComponentProps } from './Component';
+        import preview from "#.storybook/preview";
+        import { ComponentProps } from "./Component";
 
         const meta = preview.meta({});
 
@@ -708,7 +708,7 @@ describe('stories codemod', () => {
       expect(result).not.toContain('UnusedAndShouldBeRemoved');
 
       expect(result).toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
+        import preview from "#.storybook/preview";
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         type Data = Record<string, any>;
@@ -717,7 +717,7 @@ describe('stories codemod', () => {
         }
 
         const meta = preview.meta({
-          title: 'Table',
+          title: "Table",
         });
 
         export const A = meta.story({
@@ -746,15 +746,15 @@ describe('stories codemod', () => {
           export const A = {};
         `)
       ).resolves.toMatchInlineSnapshot(`
-        import preview from '#.storybook/preview';
-        import { Meta } from '@storybook/react';
-        import { Button } from './Button';
+        import preview from "#.storybook/preview";
+        import { Meta } from "@storybook/react";
+        import { Button } from "./Button";
 
         type ThisShouldNotBeRemoved = Meta<typeof Button>;
         const something: ThisShouldNotBeRemoved = {};
 
         const meta = preview.meta({
-          title: 'Button',
+          title: "Button",
         });
 
         export const A = meta.story();

--- a/code/lib/codemod/src/transforms/__tests__/__snapshots__/upgrade-deprecated-types.test.ts.snap
+++ b/code/lib/codemod/src/transforms/__tests__/__snapshots__/upgrade-deprecated-types.test.ts.snap
@@ -15,11 +15,13 @@ import {
   StoryFn as Story_,
   Meta as ComponentMeta_,
   StoryObj as ComponentStoryObj_,
-} from '@storybook/react';
-import { Cat } from './Cat';
+} from "@storybook/react";
+import { Cat } from "./Cat";
 
-const meta = { title: 'Cat', component: Cat } satisfies ComponentMeta_<typeof Cat>;
-const meta2: ComponentMeta_<typeof Cat> = { title: 'Cat', component: Cat };
+const meta = { title: "Cat", component: Cat } satisfies ComponentMeta_<
+  typeof Cat
+>;
+const meta2: ComponentMeta_<typeof Cat> = { title: "Cat", component: Cat };
 export default meta;
 
 export const A: Story__<typeof Cat> = (args) => <Cat {...args} />;
@@ -27,18 +29,18 @@ export const B: any = (args) => <Button {...args} />;
 export const C: StoryFn_<typeof Cat> = (args) => <Cat {...args} />;
 export const D: ComponentStoryObj_<typeof Cat> = {
   args: {
-    name: 'Fluffy',
+    name: "Fluffy",
   },
 };
 export const E: Story_<CatProps> = (args) => <Cat {...args} />;
 `;
 
 exports[`upgrade-deprecated-types > typescript > upgrade namespaces 1`] = `
-import * as SB from '@storybook/react';
-import { Cat, CatProps } from './Cat';
+import * as SB from "@storybook/react";
+import { Cat, CatProps } from "./Cat";
 
-const meta = { title: 'Cat', component: Cat } satisfies SB.Meta<typeof Cat>;
-const meta2: SB.Meta<typeof Cat> = { title: 'Cat', component: Cat };
+const meta = { title: "Cat", component: Cat } satisfies SB.Meta<typeof Cat>;
+const meta2: SB.Meta<typeof Cat> = { title: "Cat", component: Cat };
 export default meta;
 
 export const A: SB.StoryFn<typeof Cat> = (args) => <Cat {...args} />;
@@ -46,18 +48,18 @@ export const B: any = (args) => <Button {...args} />;
 export const C: SB.StoryFn<typeof Cat> = (args) => <Cat {...args} />;
 export const D: SB.StoryObj<typeof Cat> = {
   args: {
-    name: 'Fluffy',
+    name: "Fluffy",
   },
 };
 export const E: SB.StoryFn<CatProps> = (args) => <Cat {...args} />;
 `;
 
 exports[`upgrade-deprecated-types > typescript > upgrade regular imports 1`] = `
-import { StoryFn, Meta, StoryObj } from '@storybook/react';
-import { Cat, CatProps } from './Cat';
+import { StoryFn, Meta, StoryObj } from "@storybook/react";
+import { Cat, CatProps } from "./Cat";
 
-const meta = { title: 'Cat', component: Cat } satisfies Meta<typeof Cat>;
-const meta2: Meta<CatProps> = { title: 'Cat', component: Cat };
+const meta = { title: "Cat", component: Cat } satisfies Meta<typeof Cat>;
+const meta2: Meta<CatProps> = { title: "Cat", component: Cat };
 export default meta;
 
 export const A: StoryFn<typeof Cat> = (args) => <Cat {...args} />;
@@ -65,7 +67,7 @@ export const B: any = (args) => <Button {...args} />;
 export const C: StoryFn<typeof Cat> = (args) => <Cat {...args} />;
 export const D: StoryObj<typeof Cat> = {
   args: {
-    name: 'Fluffy',
+    name: "Fluffy",
   },
 };
 export const E: StoryFn<CatProps> = (args) => <Cat {...args} />;

--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -30,7 +30,7 @@ describe('csf-2-to-3', () => {
           export const B = (args) => <Button {...args} />;
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Cat' };
+        export default { title: "Cat" };
         export const A = () => <Cat />;
         export const B = {
           render: (args) => <Button {...args} />,
@@ -49,11 +49,11 @@ describe('csf-2-to-3', () => {
           A.play = () => {};
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Cat' };
+        export default { title: "Cat" };
 
         export const A = {
           render: () => <Cat />,
-          name: 'foo',
+          name: "foo",
           parameters: { bar: 2 },
           play: () => {},
         };
@@ -72,7 +72,7 @@ describe('csf-2-to-3', () => {
           const C = (args) => <Cherry {...args} />;
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'components/Fruit', includeStories: ['A'] };
+        export default { title: "components/Fruit", includeStories: ["A"] };
 
         export const A = {
           render: (args) => <Apple {...args} />,
@@ -106,7 +106,7 @@ describe('csf-2-to-3', () => {
           export const B = (args) => <Banana {...args} />;
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Cat', component: Cat };
+        export default { title: "Cat", component: Cat };
         export const A = {};
         export const B = {
           render: (args) => <Banana {...args} />,
@@ -124,7 +124,7 @@ describe('csf-2-to-3', () => {
           };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Cat', component: Cat };
+        export default { title: "Cat", component: Cat };
 
         export const A = {
           render: (args) => <Cat {...args} />,
@@ -141,7 +141,7 @@ describe('csf-2-to-3', () => {
           A.args = { isPrimary: false };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Cat' };
+        export default { title: "Cat" };
         const Template = (args) => <Cat {...args} />;
 
         export const A = {
@@ -171,7 +171,7 @@ describe('csf-2-to-3', () => {
           D.args = { bla: false };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Cat' };
+        export default { title: "Cat" };
         const Template = (args) => <Cat {...args} />;
 
         export const A = {
@@ -212,7 +212,7 @@ describe('csf-2-to-3', () => {
           B.args = { isPrimary: true };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Cat', component: Cat };
+        export default { title: "Cat", component: Cat };
 
         export const A = {
           args: { isPrimary: false },
@@ -238,7 +238,7 @@ describe('csf-2-to-3', () => {
           C.parameters = { foo: 2 };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Cat', component: Cat };
+        export default { title: "Cat", component: Cat };
 
         export const A = {};
         export const B = () => <Cat name="frisky" />;
@@ -260,7 +260,7 @@ describe('csf-2-to-3', () => {
           };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        export default { title: 'Cat' };
+        export default { title: "Cat" };
 
         export const A = {
           render: (args) => <Cat {...args} />,
@@ -315,21 +315,21 @@ describe('csf-2-to-3', () => {
           };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        import { Meta, StoryObj as CSF3, StoryFn as CSF2 } from '@storybook/react';
-        import { CatProps } from './Cat';
+        import { Meta, StoryObj as CSF3, StoryFn as CSF2 } from "@storybook/react";
+        import { CatProps } from "./Cat";
 
-        const meta = { title: 'Cat', component: Cat } satisfies Meta<CatProps>;
+        const meta = { title: "Cat", component: Cat } satisfies Meta<CatProps>;
         export default meta;
 
         export const A: CSF2<CatProps> = () => <Cat />;
 
         export const B: CSF3<CatProps> = {
-          args: { name: 'already csf3' },
+          args: { name: "already csf3" },
         };
 
         export const C: CSF3<CatProps> = {
           args: {
-            name: 'Fluffy',
+            name: "Fluffy",
           },
         };
       `);
@@ -374,17 +374,17 @@ describe('csf-2-to-3', () => {
           };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        import { StoryObj, StoryFn } from '@storybook/react';
+        import { StoryObj, StoryFn } from "@storybook/react";
 
         // some extra whitespace to test
 
         export default {
-          title: 'Cat',
+          title: "Cat",
           component: Cat,
         } as Meta<CatProps>;
 
         export const A: StoryObj<CatProps> = {
-          args: { name: 'Fluffy' },
+          args: { name: "Fluffy" },
         };
 
         export const B: any = {
@@ -395,23 +395,23 @@ describe('csf-2-to-3', () => {
 
         export const D: StoryObj<CatProps> = {
           args: {
-            name: 'Fluffy',
+            name: "Fluffy",
           },
         };
 
         export const E: StoryObj<Cat> = {
-          args: { name: 'Fluffy' },
+          args: { name: "Fluffy" },
         };
 
         export const F: StoryObj = {
           args: {
-            name: 'Fluffy',
+            name: "Fluffy",
           },
         };
 
         export const G: StoryObj<typeof Cat> = {
           args: {
-            name: 'Fluffy',
+            name: "Fluffy",
           },
         };
       `);
@@ -431,7 +431,7 @@ describe('csf-2-to-3', () => {
           export const Default = Template.bind({})
         `)
       ).resolves.toMatchInlineSnapshot(`
-        import { StoryFn, Meta } from '@storybook/react';
+        import { StoryFn, Meta } from "@storybook/react";
 
         export default {
           component: Cat,


### PR DESCRIPTION
https://github.com/storybookjs/storybook/pull/34183
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Follow-up PR friol https://github.com/storybookjs/storybook/pull/34183 . This is actually one of the reverted commits. 

This PR removes prettierRC in our root monorepo as it was modifying codegens snapshots in tests. We can remove prettierRC because codegen formatting relies on users prettier config. The reason we didn't move prettier to OXC is because we don't expect' everyone to move to oxfmt right now, this might be something to handle once oxfmt reaches 1,0

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- no need, just check the formatted files

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration and test snapshots to enforce consistent double-quote string literals across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->