### PR TITLE
fix(react): preserve key prop in Canvas DocBlock generated source

### DIFF
--- a/code/renderers/react/src/docs/jsxDecorator.test.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.test.tsx
@@ -71,6 +71,42 @@ describe('renderJsx', () => {
       </div>
     `);
   });
+  it('key prop on children is preserved in generated source', () => {
+    const Item: FC<PropsWithChildren<{ title: string }>> = ({ title, children }) => (
+      <div title={title}>{children}</div>
+    );
+    const Wrapper: FC<PropsWithChildren> = ({ children }) => <div>{children}</div>;
+    expect(
+      renderJsx(
+        <Wrapper>
+          {[
+            <Item key="item1" title="First">
+              content
+            </Item>,
+            <Item key="item2" title="Second">
+              content
+            </Item>,
+          ]}
+        </Wrapper>,
+        {}
+      )
+    ).toMatchInlineSnapshot(`
+      <Wrapper>
+        <Item
+          key="item1"
+          title="First"
+        >
+          content
+        </Item>
+        <Item
+          key="item2"
+          title="Second"
+        >
+          content
+        </Item>
+      </Wrapper>
+    `);
+  });
   it('large objects', () => {
     const obj = Array.from({ length: 20 }).reduce((acc, _, i) => {
       // @ts-expect-error (Converted from ts-ignore)

--- a/code/renderers/react/src/docs/jsxDecorator.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.tsx
@@ -58,6 +58,14 @@ function simplifyNodeForStringify(node: ReactNode): ReactNode {
       acc[cur] = simplifyNodeForStringify(node.props[cur]);
       return acc;
     }, {});
+    // React stores `key` on the element itself, not in `props`. The library
+    // react-element-to-jsx-string reads element.key, but it calls
+    // React.Children.toArray internally which prefixes user-specified keys
+    // with ".$", causing them to be treated as auto-generated and omitted.
+    // By copying key into props here we ensure it survives that transformation.
+    if (node.key !== null) {
+      props.key = node.key;
+    }
     return {
       ...node,
       props,


### PR DESCRIPTION
## What I did

Fixes #24581

When a story passes React elements with `key` props as children (e.g. via args), the `key` prop was missing from the generated source code shown in the Canvas DocBlock.

**Root cause:** React stores `key` on the element object itself (not in `props`). The `react-element-to-jsx-string` library reads `element.key` to include it in output, but it calls `React.Children.toArray` internally which prefixes all keys with `".$"`. The library's check for auto-generated keys (`key.search(/^\./)` returning `0` which is falsy in JS) then incorrectly treats user-specified keys as auto-generated and omits them.

**Fix:** In `simplifyNodeForStringify`, copy `node.key` into `props` before passing the element to the library. This ensures the original key value is present in `element.props` and survives `React.Children.toArray`'s transformation.

## How to test

Before this fix, given a story like:

```tsx
export const ExpandByDefault = {
  component: Accordion,
  args: {
    children: [
      <AccordionItem key='accordion1' title='Accordion 1'>content</AccordionItem>,
      <AccordionItem key='accordion2' title='Accordion 2'>content</AccordionItem>,
    ],
  },
}
```

The Canvas source would show `<AccordionItem title="Accordion 1">` — missing `key`.

After this fix, it correctly shows `<AccordionItem key="accordion1" title="Accordion 1">`.

A unit test is included in `jsxDecorator.test.tsx` that covers this case.

## Checklist for contributors

- [ ] I've verified the fix works locally by running a proof-of-concept Node.js script
- [x] I've added a unit test to `jsxDecorator.test.tsx`
- [x] I've linked the issue this fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSX rendering to properly preserve and display `key` attributes on React elements, ensuring component keys are correctly reflected in generated JSX output.

* **Tests**
  * Added test coverage verifying that `key` attributes are maintained alongside other props in JSX string generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->