### PR TITLE
React Native Web: Fix vite8 support by bumping vite-plugin-rnw

### DIFF
--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -54,8 +54,8 @@
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
-    "vite-plugin-rnw": "^0.0.10",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-plugin-rnw": "^0.0.11",
+    "vite-tsconfig-paths": "^6.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.19.1",

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -125,15 +125,6 @@ export const addWorkaroundResolutions = async ({
     };
   }
 
-  if (key === 'react-native-web-vite/expo-ts') {
-    additionalResolutions = {
-      ...additionalResolutions,
-      // The expo sandbox started to break in beta 5, yet to investigate the root cause
-      // in the meantime, we downgrade to the version where things worked.
-      vite: '8.0.0-beta.4',
-    };
-  }
-
   packageJson.resolutions = {
     ...packageJson.resolutions,
     '@testing-library/dom': '^9.3.4',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,16 +2111,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bunchtogether/vite-plugin-flow@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@bunchtogether/vite-plugin-flow@npm:1.0.2"
-  dependencies:
-    flow-remove-types: "npm:^2.158.0"
-    rollup-pluginutils: "npm:^2.8.2"
-  checksum: 10c0/84faf014977196470bbeae686b4e167de2805777389f8a0da88647484df7cf39db3da91907d75ea810ea77175c0cdd40a9a3ad92b7c7c44681b0cd1f4156c7b8
-  languageName: node
-  linkType: hard
-
 "@chromatic-com/storybook@npm:^5.0.0":
   version: 5.0.0
   resolution: "@chromatic-com/storybook@npm:5.0.0"
@@ -7462,17 +7452,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-beta.46":
-  version: 1.0.0-beta.46
-  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.46"
-  checksum: 10c0/45664c89b2e24262b103457ca14e1aa0b7f658f5ace4eb4f10f327d88810cad908ec3150d8fc646fe285b96eb66b25defce97aa6eb0a45fe23a8a2dbcda0040c
-  languageName: node
-  linkType: hard
-
-"@rolldown/pluginutils@npm:1.0.0-beta.47":
-  version: 1.0.0-beta.47
-  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.47"
-  checksum: 10c0/eb0cfa7334d66f090c47eaac612174936b05f26e789352428cb6e03575b590f355de30d26b42576ea4e613d8887b587119d19b2e4b3a8909ceb232ca1cf746c8
+"@rolldown/pluginutils@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.3"
+  checksum: 10c0/3928b6282a30f307d1b075d2f217180ae173ea9e00638ce46ab65f089bd5f7a0b2c488ae1ce530f509387793c656a2910337c4cd68fa9d37d7e439365989e699
   languageName: node
   linkType: hard
 
@@ -7480,6 +7463,13 @@ __metadata:
   version: 1.0.0-rc.9
   resolution: "@rolldown/pluginutils@npm:1.0.0-rc.9"
   checksum: 10c0/fca488fb96b134ccf95b42632b6112b4abb8b3a9688f166fbd627410def2538ee201953717d234ddecbff62dfe4edc4e72c657b01a9d0750134608d767eea5fd
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0-rc.9":
+  version: 1.0.0-rc.10
+  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.10"
+  checksum: 10c0/7478f982d2705fef5f844e714aa264571d30368ef90883642fdc9eb869613c0c3060e8a8f69255e37a6fb600cbe4be35ce273d1f808fa6fe2a4b4e72116caf29
   languageName: node
   linkType: hard
 
@@ -8617,8 +8607,8 @@ __metadata:
     "@storybook/react-vite": "workspace:*"
     "@types/node": "npm:^22.19.1"
     typescript: "npm:^5.9.3"
-    vite-plugin-rnw: "npm:^0.0.10"
-    vite-tsconfig-paths: "npm:^5.1.4"
+    vite-plugin-rnw: "npm:^0.0.11"
+    vite-tsconfig-paths: "npm:^6.1.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -10845,19 +10835,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:^5.1.0":
-  version: 5.1.1
-  resolution: "@vitejs/plugin-react@npm:5.1.1"
+"@vitejs/plugin-react@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@vitejs/plugin-react@npm:5.2.0"
   dependencies:
-    "@babel/core": "npm:^7.28.5"
+    "@babel/core": "npm:^7.29.0"
     "@babel/plugin-transform-react-jsx-self": "npm:^7.27.1"
     "@babel/plugin-transform-react-jsx-source": "npm:^7.27.1"
-    "@rolldown/pluginutils": "npm:1.0.0-beta.47"
+    "@rolldown/pluginutils": "npm:1.0.0-rc.3"
     "@types/babel__core": "npm:^7.20.5"
     react-refresh: "npm:^0.18.0"
   peerDependencies:
-    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10c0/e590efaea1eabfbb1beb6e8c9fac0742fd299808e3368e63b2825ce24740adb8a28fcb2668b14b7ca1bdb42890cfefe94d02dd358dcbbf8a27ddf377b9a82abf
+    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/bac0a409e71eee954a05bc41580411c369bd5f9ef0586a1f9743fba76ad6603c437d93d407d230780015361f93d1592c55e53314813cded6369c36d3c1e8edbf
   languageName: node
   linkType: hard
 
@@ -16938,13 +16928,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "estree-walker@npm:0.6.1"
-  checksum: 10c0/6dabc855faa04a1ffb17b6a9121b6008ba75ab5a163ad9dc3d7fca05cfda374c5f5e91418d783496620ca75e99a73c40874d8b75f23b4117508cc8bde78e7b41
-  languageName: node
-  linkType: hard
-
 "estree-walker@npm:^2.0.2":
   version: 2.0.2
   resolution: "estree-walker@npm:2.0.2"
@@ -17698,17 +17681,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-remove-types@npm:^2.158.0":
-  version: 2.291.0
-  resolution: "flow-remove-types@npm:2.291.0"
+"flow-remove-types@npm:^2.305.0":
+  version: 2.306.0
+  resolution: "flow-remove-types@npm:2.306.0"
   dependencies:
-    hermes-parser: "npm:0.32.0"
+    hermes-parser: "npm:0.34.0"
     pirates: "npm:^3.0.2"
     vlq: "npm:^0.2.1"
   bin:
     flow-node: flow-node
     flow-remove-types: flow-remove-types
-  checksum: 10c0/b074977261f44955103552f854418979926a92b09b740cb613852c9044b21056a1f70ac8b783ca3d74321d23907cc30c31332a5faca28e2340b8b83622b58f2a
+  checksum: 10c0/2b965f5aa70e7d0b4d6ae6ef115f655fdb8ddd6e21563a2efda5644dc9b64dec1490f45b6658f2cf0ad11299bc199aeb78d589428e46ae0b5dba84a8dc09f92a
   languageName: node
   linkType: hard
 
@@ -18939,19 +18922,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-estree@npm:0.32.0":
-  version: 0.32.0
-  resolution: "hermes-estree@npm:0.32.0"
-  checksum: 10c0/3b67d1fe44336240ef7f9c40ecbf363279ba263d51efe120570c3862cc109e652fc09aebddfe6b73d0f0246610bee130e4064c359f1f4cbf002bdb1d99717ef2
+"hermes-estree@npm:0.34.0":
+  version: 0.34.0
+  resolution: "hermes-estree@npm:0.34.0"
+  checksum: 10c0/bd4ad520838c69aa79887230a2030fe1e07d0826389112e2c23a8b18494f9f2fa6b1639f413ad978f3468daea66903869188481f9500aaa1fb79ed6266afb744
   languageName: node
   linkType: hard
 
-"hermes-parser@npm:0.32.0":
-  version: 0.32.0
-  resolution: "hermes-parser@npm:0.32.0"
+"hermes-parser@npm:0.34.0":
+  version: 0.34.0
+  resolution: "hermes-parser@npm:0.34.0"
   dependencies:
-    hermes-estree: "npm:0.32.0"
-  checksum: 10c0/5902d2c5d347c0629fba07a47eaad5569590ac69bc8bfb2e454e08d2dfbe1ebd989d88518dca2cba64061689b5eac5960ae6bd15a4a66600bbf377498a3234b7
+    hermes-estree: "npm:0.34.0"
+  checksum: 10c0/e20657a21ebc3187f53780f5f2c5dd7434f4371979d05b016ff06306b6db63f9d2575ee60c63e9e7d831dd0f592542193a50a6e8397678d4a312fc5373bbe382
   languageName: node
   linkType: hard
 
@@ -27123,15 +27106,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-pluginutils@npm:^2.8.2":
-  version: 2.8.2
-  resolution: "rollup-pluginutils@npm:2.8.2"
-  dependencies:
-    estree-walker: "npm:^0.6.1"
-  checksum: 10c0/20947bec5a5dd68b5c5c8423911e6e7c0ad834c451f1a929b1f4e2bc08836ad3f1a722ef2bfcbeca921870a0a283f13f064a317dc7a6768496e98c9a641ba290
-  languageName: node
-  linkType: hard
-
 "rollup@npm:4.34.8":
   version: 4.34.8
   resolution: "rollup@npm:4.34.8"
@@ -30874,20 +30848,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-rnw@npm:^0.0.10":
-  version: 0.0.10
-  resolution: "vite-plugin-rnw@npm:0.0.10"
+"vite-plugin-rnw@npm:^0.0.11":
+  version: 0.0.11
+  resolution: "vite-plugin-rnw@npm:0.0.11"
   dependencies:
-    "@bunchtogether/vite-plugin-flow": "npm:^1.0.2"
-    "@rolldown/pluginutils": "npm:1.0.0-beta.46"
-    "@vitejs/plugin-react": "npm:^5.1.0"
-    magic-string: "npm:^0.30.11"
+    "@rolldown/pluginutils": "npm:^1.0.0-rc.9"
+    "@vitejs/plugin-react": "npm:^5.2.0"
+    flow-remove-types: "npm:^2.305.0"
+    magic-string: "npm:^0.30.21"
     vite-plugin-commonjs: "npm:^0.10.4"
   peerDependencies:
     react-native-web: "*"
     typescript: ^5
-    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10c0/a8d97b0475f7de5977f959d029a9a51fd534c6785a800c5aa733abbac8a635e7cbab831a4221b6e5bbc00d03d81c4046199ed3ff33cbe0f7eead6d93c205bed4
+    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/28553936d25c1f47a1ea24d8b8dd9574d3f2d3a4cf7d65cfc58670dd7e7e6e075e6248762793fadb73ae754e2ad3fb80fd28e10be56c48a507d5ae7bd34b64e4
   languageName: node
   linkType: hard
 
@@ -30922,6 +30896,19 @@ __metadata:
     vite:
       optional: true
   checksum: 10c0/6228f23155ea25d92b1e1702284cf8dc52ad3c683c5ca691edd5a4c82d2913e7326d00708cef1cbfde9bb226261df0e0a12e03ef1d43b6a92d8f02b483ef37e3
+  languageName: node
+  linkType: hard
+
+"vite-tsconfig-paths@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "vite-tsconfig-paths@npm:6.1.1"
+  dependencies:
+    debug: "npm:^4.1.1"
+    globrex: "npm:^0.1.2"
+    tsconfck: "npm:^3.0.3"
+  peerDependencies:
+    vite: "*"
+  checksum: 10c0/5e61080991418fefa08c5b98995cdcada4931ae01ac97ef9e2ee941051f61b76890a6e7ba48bed3b2a229ec06fef33a06621bba4ce457b3f4233ad31dc0c1d1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

bumped vite-plugin-rnw for vite8 support
also removed the extra vite override

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing




1. Run  sandbox for template `yarn task --task sandbox --start-from auto --template react-native-web-vite/expo-ts`
2. Open Storybook in your browser
3. Access example stories

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34231-sha-98e5e0d4`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34231-sha-98e5e0d4 sandbox` or in an existing project with `npx storybook@0.0.0-pr-34231-sha-98e5e0d4 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34231-sha-98e5e0d4`](https://npmjs.com/package/storybook/v/0.0.0-pr-34231-sha-98e5e0d4) |
| **Triggered by** | @shilman |
| **Repository** | [dannyhw/storybook](https://github.com/dannyhw/storybook) |
| **Branch** | [`dannyhw/fix/rnw-vite8-support`](https://github.com/dannyhw/storybook/tree/dannyhw/fix/rnw-vite8-support) |
| **Commit** | [`98e5e0d4`](https://github.com/dannyhw/storybook/commit/98e5e0d42eb1f64d51864dfa2287c8a28b874998) |
| **Datetime** | Fri Mar 20 06:15:29 UTC 2026 (`1773987329`) |
| **Workflow run** | [23331457716](https://github.com/storybookjs/storybook/actions/runs/23331457716) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34231`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
