### PR TITLE
UI: Ensure Controls panel can scroll horizontally for now

### DIFF
--- a/code/core/src/components/components/addon-panel/addon-panel.tsx
+++ b/code/core/src/components/components/addon-panel/addon-panel.tsx
@@ -25,7 +25,11 @@ const useUpdate = (update: boolean, value: any) => {
 export interface AddonPanelProps {
   active: boolean;
   children: ReactElement;
+  /** Whether the panel has a vertical scrollbar, `true` by default. */
   hasScrollbar?: boolean;
+  /** Whether the panel has an horizontal scrollbar, `false` by default */
+  hasHorizontalScrollbar?: boolean;
+
 }
 
 const Div = styled.div(({ theme }) => ({
@@ -33,12 +37,12 @@ const Div = styled.div(({ theme }) => ({
   height: '100%',
 }));
 
-export const AddonPanel = ({ active, children, hasScrollbar = true }: AddonPanelProps) => {
+export const AddonPanel = ({ active, children, hasScrollbar = true, hasHorizontalScrollbar = false }: AddonPanelProps) => {
   return (
     // the hidden attribute is an valid html element that's both accessible and works to visually hide content
     <Div hidden={!active}>
-      {hasScrollbar ? (
-        <ScrollArea vertical>{useUpdate(active, children)}</ScrollArea>
+      {hasScrollbar || hasHorizontalScrollbar ? (
+        <ScrollArea vertical={hasScrollbar} horizontal={hasHorizontalScrollbar}>{useUpdate(active, children)}</ScrollArea>
       ) : (
         useUpdate(active, children)
       )}

--- a/code/core/src/components/components/addon-panel/addon-panel.tsx
+++ b/code/core/src/components/components/addon-panel/addon-panel.tsx
@@ -29,7 +29,6 @@ export interface AddonPanelProps {
   hasScrollbar?: boolean;
   /** Whether the panel has an horizontal scrollbar, `false` by default */
   hasHorizontalScrollbar?: boolean;
-
 }
 
 const Div = styled.div(({ theme }) => ({
@@ -37,12 +36,19 @@ const Div = styled.div(({ theme }) => ({
   height: '100%',
 }));
 
-export const AddonPanel = ({ active, children, hasScrollbar = true, hasHorizontalScrollbar = false }: AddonPanelProps) => {
+export const AddonPanel = ({
+  active,
+  children,
+  hasScrollbar = true,
+  hasHorizontalScrollbar = false,
+}: AddonPanelProps) => {
   return (
     // the hidden attribute is an valid html element that's both accessible and works to visually hide content
     <Div hidden={!active}>
       {hasScrollbar || hasHorizontalScrollbar ? (
-        <ScrollArea vertical={hasScrollbar} horizontal={hasHorizontalScrollbar}>{useUpdate(active, children)}</ScrollArea>
+        <ScrollArea vertical={hasScrollbar} horizontal={hasHorizontalScrollbar}>
+          {useUpdate(active, children)}
+        </ScrollArea>
       ) : (
         useUpdate(active, children)
       )}

--- a/code/core/src/controls/manager.tsx
+++ b/code/core/src/controls/manager.tsx
@@ -123,7 +123,7 @@ export default addons.register(ADDON_ID, (api) => {
           return null;
         }
         return (
-          <AddonPanel active={active}>
+          <AddonPanel active={active} hasHorizontalScrollbar hasScrollbar>
             <ControlsPanel saveStory={saveStory} createStory={createStory} />
           </AddonPanel>
         );


### PR DESCRIPTION
Closes #33856

## What I did

There were a few stale PRs not doing exactly what we needed, and we kinda need to own the decision to introduce a WCAG Reflow violation until we have time to design a narrower controls table for vertical addon panels with @MichaelArestad.

This PR allows AddonPanel to enable bidirectional scrolling, in a non-breaking way with existing code. Then, the Controls panel uses that new prop to fix the reported issue.

## Checklist for Contributors

#### Manual testing

1. Go to a story with lots of controls, e.g. http://localhost:6006/?path=/story/core-controls-conditional--toggle-control&args=colorMode:!false;text:therearefrogseverywhere;dynamicText:evenwhereyoudontexpectthem
2. Make the addon panel vertical and narrow
3. Notice the horizontal scrollbar on hover/focus within the panel


### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Addon panels now support optional horizontal scrolling in addition to vertical scrolling. Users can enable independent horizontal scroll for wide content; the horizontal option is off by default to preserve existing behavior. Panels continue to respect the existing vertical-scroll setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->