### PR TITLE
CLI: Handle npm alias versions in Vite autoblock check

### DIFF
--- a/code/lib/cli-storybook/src/autoblock/utils.test.ts
+++ b/code/lib/cli-storybook/src/autoblock/utils.test.ts
@@ -46,6 +46,34 @@ describe('findOutdatedPackage', () => {
     expect(result).toBe(false);
   });
 
+  it('uses alias target version when package is not installed', async () => {
+    vi.mocked(packageManager.getModulePackageJSON).mockResolvedValue(null);
+    vi.mocked(packageManager.getDependencyVersion).mockReturnValue('npm:vite5@^5.4.16');
+
+    const result = await findOutdatedPackage(
+      {
+        vite: '5.0.0',
+      },
+      { packageManager }
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('does not report outdated when installed version equals minimum', async () => {
+    vi.mocked(packageManager.getModulePackageJSON).mockResolvedValue({ version: '5.0.0' } as any);
+    vi.mocked(packageManager.getDependencyVersion).mockReturnValue('^5.0.0');
+
+    const result = await findOutdatedPackage(
+      {
+        vite: '5.0.0',
+      },
+      { packageManager }
+    );
+
+    expect(result).toBe(false);
+  });
+
   it('still reports outdated package when npm alias target version is below minimum', async () => {
     vi.mocked(packageManager.getModulePackageJSON).mockResolvedValue({ version: '0.1.12' } as any);
     vi.mocked(packageManager.getDependencyVersion).mockReturnValue('npm:vite5@^4.9.9');

--- a/code/lib/cli-storybook/src/autoblock/utils.test.ts
+++ b/code/lib/cli-storybook/src/autoblock/utils.test.ts
@@ -1,0 +1,66 @@
+import type { JsPackageManager } from 'storybook/internal/common';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { findOutdatedPackage } from './utils';
+
+describe('findOutdatedPackage', () => {
+  const packageManager = {
+    getModulePackageJSON: vi.fn(),
+    getDependencyVersion: vi.fn(),
+  } as unknown as JsPackageManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns outdated package when installed version is below minimum', async () => {
+    vi.mocked(packageManager.getModulePackageJSON).mockResolvedValue({ version: '4.9.9' } as any);
+    vi.mocked(packageManager.getDependencyVersion).mockReturnValue('^4.9.9');
+
+    const result = await findOutdatedPackage(
+      {
+        vite: '5.0.0',
+      },
+      { packageManager }
+    );
+
+    expect(result).toEqual({
+      packageName: 'vite',
+      installedVersion: '4.9.9',
+      minimumVersion: '5.0.0',
+    });
+  });
+
+  it('uses npm alias target version when alias package version is lower', async () => {
+    vi.mocked(packageManager.getModulePackageJSON).mockResolvedValue({ version: '0.1.12' } as any);
+    vi.mocked(packageManager.getDependencyVersion).mockReturnValue('npm:vite5@^5.4.16');
+
+    const result = await findOutdatedPackage(
+      {
+        vite: '5.0.0',
+      },
+      { packageManager }
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('still reports outdated package when npm alias target version is below minimum', async () => {
+    vi.mocked(packageManager.getModulePackageJSON).mockResolvedValue({ version: '0.1.12' } as any);
+    vi.mocked(packageManager.getDependencyVersion).mockReturnValue('npm:vite5@^4.9.9');
+
+    const result = await findOutdatedPackage(
+      {
+        vite: '5.0.0',
+      },
+      { packageManager }
+    );
+
+    expect(result).toEqual({
+      packageName: 'vite',
+      installedVersion: '4.9.9',
+      minimumVersion: '5.0.0',
+    });
+  });
+});

--- a/code/lib/cli-storybook/src/autoblock/utils.test.ts
+++ b/code/lib/cli-storybook/src/autoblock/utils.test.ts
@@ -2,7 +2,7 @@ import type { JsPackageManager } from 'storybook/internal/common';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { findOutdatedPackage } from './utils';
+import { findOutdatedPackage } from './utils.ts';
 
 describe('findOutdatedPackage', () => {
   const packageManager = {

--- a/code/lib/cli-storybook/src/autoblock/utils.ts
+++ b/code/lib/cli-storybook/src/autoblock/utils.ts
@@ -2,7 +2,6 @@ import type { JsPackageManager } from 'storybook/internal/common';
 import { getVitePlusVersions } from 'storybook/internal/common';
 import { CLI_COLORS } from 'storybook/internal/node-logger';
 
-import picocolors from 'picocolors';
 import { coerce, gt, lt } from 'semver';
 
 import { shortenPath } from '../util.ts';

--- a/code/lib/cli-storybook/src/autoblock/utils.ts
+++ b/code/lib/cli-storybook/src/autoblock/utils.ts
@@ -3,7 +3,7 @@ import { getVitePlusVersions } from 'storybook/internal/common';
 import { CLI_COLORS } from 'storybook/internal/node-logger';
 
 import picocolors from 'picocolors';
-import { lt } from 'semver';
+import { coerce, gt, lt } from 'semver';
 
 import { shortenPath } from '../util.ts';
 import type { AutoblockerResult } from './types.ts';
@@ -15,6 +15,54 @@ type Result<M extends Record<string, string>> = {
 };
 
 const typedKeys = <TKey extends string>(obj: Record<TKey, any>) => Object.keys(obj) as TKey[];
+
+const normalizeSemver = (version: string | null | undefined): string | null =>
+  version ? (coerce(version, { includePrerelease: true })?.version ?? null) : null;
+
+const extractNpmAliasVersion = (specifier: string | null): string | null => {
+  if (!specifier?.startsWith('npm:')) {
+    return null;
+  }
+
+  const atIndex = specifier.lastIndexOf('@');
+  if (atIndex <= 'npm:'.length) {
+    return null;
+  }
+
+  return normalizeSemver(specifier.slice(atIndex + 1));
+};
+
+const getComparableInstalledVersion = async (
+  packageName: string,
+  packageManager: JsPackageManager
+): Promise<string | null> => {
+  // When vite-plus is used, packages like vite are overridden and their
+  // package.json reports the vite-plus wrapper version (e.g. 0.1.16) instead
+  // of the actual vendored version. Check vite-plus first.
+  const vitePlusVersions = await getVitePlusVersions();
+  let installedVersion = vitePlusVersions?.[packageName] ?? null;
+
+  if (!installedVersion) {
+    installedVersion = (await packageManager.getModulePackageJSON(packageName))?.version ?? null;
+  }
+
+  const aliasVersion = extractNpmAliasVersion(packageManager.getDependencyVersion(packageName));
+
+  if (!installedVersion) {
+    return aliasVersion;
+  }
+
+  if (!aliasVersion) {
+    return installedVersion;
+  }
+
+  const normalizedInstalledVersion = normalizeSemver(installedVersion);
+  if (!normalizedInstalledVersion) {
+    return installedVersion;
+  }
+
+  return gt(aliasVersion, normalizedInstalledVersion) ? aliasVersion : normalizedInstalledVersion;
+};
 
 /**
  * Finds the outdated package in the list of packages.
@@ -30,24 +78,11 @@ export async function findOutdatedPackage<M extends Record<string, string>>(
   }
 ): Promise<false | Result<M>> {
   const list = await Promise.all(
-    typedKeys(minimalVersionsMap).map(async (packageName) => {
-      // When vite-plus is used, packages like vite are overridden and their
-      // package.json reports the vite-plus wrapper version (e.g. 0.1.16) instead
-      // of the actual vendored version. Check vite-plus first.
-      const vitePlusVersions = await getVitePlusVersions();
-      let installedVersion = vitePlusVersions?.[packageName] ?? null;
-
-      if (!installedVersion) {
-        const packageJson = await options.packageManager.getModulePackageJSON(packageName);
-        installedVersion = packageJson?.version ?? null;
-      }
-
-      return {
-        packageName,
-        installedVersion,
-        minimumVersion: minimalVersionsMap[packageName],
-      };
-    })
+    typedKeys(minimalVersionsMap).map(async (packageName) => ({
+      packageName,
+      installedVersion: await getComparableInstalledVersion(packageName, options.packageManager),
+      minimumVersion: minimalVersionsMap[packageName],
+    }))
   );
 
   return list.reduce<false | Result<M>>(


### PR DESCRIPTION
## Summary
Fixes a false blocker in `storybook upgrade` when `vite` is installed via npm alias (for example `vite: "npm:vite5@^5.4.16"`).

## Problem
The dependency version check used the installed alias package version (e.g. `0.1.12`) instead of the alias target version, causing a false failure against the Vite >= 5.0.0 requirement.

## Changes
- Added npm alias-aware version extraction in autoblock dependency checks.
- If a dependency spec is an npm alias, compare against the alias target semver.
- Keep existing behavior for non-alias dependencies.
- Added regression tests for:
  - normal outdated detection
  - alias target above minimum (should pass)
  - alias target below minimum (should fail)

## Files
- `code/lib/cli-storybook/src/autoblock/utils.ts`
- `code/lib/cli-storybook/src/autoblock/utils.test.ts`

Closes #34234


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package version detection to normalize versions and correctly handle `npm:` alias specifiers.
  * Enhanced comparison logic to more reliably identify outdated packages across varied dependency formats.

* **Tests**
  * Added comprehensive tests covering version normalization, alias targets, missing installs, and boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->