### PR TITLE
Bug: Skip re-processing already transformed config files for CSF factories

### DIFF
--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
   vi.mocked(formatFileContent).mockImplementation(async (_path, content) => content);
 });
 expect.addSnapshotSerializer({
-  serialize: (val: unknown) => (typeof val === 'string' ? val : val.toString()),
+  serialize: (val: any) => (typeof val === 'string' ? val : val.toString()),
   test: () => true,
 });
 

--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
   vi.mocked(formatFileContent).mockImplementation(async (_path, content) => content);
 });
 expect.addSnapshotSerializer({
-  serialize: (val: any) => (typeof val === 'string' ? val : val.toString()),
+  serialize: (val: unknown) => (typeof val === 'string' ? val : val.toString()),
   test: () => true,
 });
 
@@ -174,6 +174,31 @@ describe('main/preview codemod: general parsing functionality', () => {
     `;
     const transformed = await transform(original);
     expect(transformed).toEqual(original);
+  });
+
+  it('should add missing import when already transformed but import is absent', async () => {
+    await expect(
+      transform(dedent`
+        export default defineMain({});
+      `)
+    ).resolves.toMatchInlineSnapshot(`
+      import { defineMain } from "@storybook/react-vite/node";
+      export default defineMain({});
+    `);
+  });
+
+  it('should add missing specifier when already transformed but defineMain is not in existing import', async () => {
+    await expect(
+      transform(dedent`
+        import { someHelper } from '@storybook/react-vite/node';
+
+        export default defineMain({});
+      `)
+    ).resolves.toMatchInlineSnapshot(`
+      import { someHelper, defineMain } from '@storybook/react-vite/node';
+
+      export default defineMain({});
+    `);
   });
 
   it('should remove legacy main config type imports if unused', async () => {

--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
@@ -39,7 +39,6 @@ export async function configToCsfFactory(
 
     // Unwrap TS syntax (e.g. `as`, `satisfies`) around the default export expression
     const declaration =
-      // eslint-disable-next-line no-underscore-dangle
       typeof (config as any)._unwrap === 'function'
         ? (config as any)._unwrap(node.declaration)
         : node.declaration;
@@ -50,7 +49,23 @@ export async function configToCsfFactory(
       declaration.callee.name === methodName
     );
   });
-  if (isAlreadyTransformed && !hasNamedExports) {
+
+  // Check whether the required framework import (e.g. defineMain from '@storybook/react-vite/node') is already present
+  const expectedImportSource = frameworkPackage + (configType === 'main' ? '/node' : '');
+  const hasCorrectImport = programNode.body.some(
+    (node) =>
+      t.isImportDeclaration(node) &&
+      node.importKind !== 'type' &&
+      node.source.value === expectedImportSource &&
+      node.specifiers.some(
+        (spec) =>
+          t.isImportSpecifier(spec) &&
+          t.isIdentifier(spec.imported) &&
+          spec.imported.name === methodName
+      )
+  );
+
+  if (isAlreadyTransformed && !hasNamedExports && hasCorrectImport) {
     return info.source;
   }
 
@@ -73,19 +88,21 @@ export async function configToCsfFactory(
     );
   }
 
-  /**
-   * Scenario 1: Mixed exports
-   *
-   * ```
-   * export const tags = [];
-   * export default {
-   *   parameters: {},
-   * };
-   * ```
-   *
-   * Transform into: `export default defineMain({ tags: [], parameters: {} })`
-   */
-  if (config._exportsObject && hasNamedExports) {
+  if (isAlreadyTransformed && !hasNamedExports) {
+    // already transformed with no named exports — skip transformation but still run import fixup below
+  } else if (config._exportsObject && hasNamedExports) {
+    /**
+     * Scenario 1: Mixed exports
+     *
+     * ```
+     * export const tags = [];
+     * export default {
+     *   parameters: {},
+     * };
+     * ```
+     *
+     * Transform into: `export default defineMain({ tags: [], parameters: {} })`
+     */
     // when merging named exports with default exports, add the named exports first in the list
     config._exportsObject.properties = [...defineConfigProps, ...config._exportsObject.properties];
     programNode.body = removeExportDeclarations(programNode, exportDecls);

--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
@@ -33,6 +33,19 @@ export async function configToCsfFactory(
   const defineConfigProps = getConfigProperties(exportDecls, { configType });
   const hasNamedExports = defineConfigProps.length > 0;
 
+  // Early return if the code is already transformed (default export is already defineMain/definePreview)
+  const isAlreadyTransformed = programNode.body.some(
+    (node) =>
+      t.isExportDefaultDeclaration(node) &&
+      t.isCallExpression(node.declaration) &&
+      t.isIdentifier(node.declaration.callee) &&
+      node.declaration.callee.name === methodName
+  );
+
+  if (isAlreadyTransformed && !hasNamedExports) {
+    return info.source;
+  }
+
   function findDeclarationNodeIndex(declarationName: string): number {
     return programNode.body.findIndex(
       (n) =>

--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
@@ -34,14 +34,22 @@ export async function configToCsfFactory(
   const hasNamedExports = defineConfigProps.length > 0;
 
   // Early return if the code is already transformed (default export is already defineMain/definePreview)
-  const isAlreadyTransformed = programNode.body.some(
-    (node) =>
-      t.isExportDefaultDeclaration(node) &&
-      t.isCallExpression(node.declaration) &&
-      t.isIdentifier(node.declaration.callee) &&
-      node.declaration.callee.name === methodName
-  );
+  const isAlreadyTransformed = programNode.body.some((node) => {
+    if (!t.isExportDefaultDeclaration(node)) return false;
 
+    // Unwrap TS syntax (e.g. `as`, `satisfies`) around the default export expression
+    const declaration =
+      // eslint-disable-next-line no-underscore-dangle
+      typeof (config as any)._unwrap === 'function'
+        ? (config as any)._unwrap(node.declaration)
+        : node.declaration;
+
+    return (
+      t.isCallExpression(declaration) &&
+      t.isIdentifier(declaration.callee) &&
+      declaration.callee.name === methodName
+    );
+  });
   if (isAlreadyTransformed && !hasNamedExports) {
     return info.source;
   }

--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.ts
@@ -50,7 +50,7 @@ export async function configToCsfFactory(
       declaration.callee.name === methodName
     );
   });
-  if (isAlreadyTransformed && !hasNamedExports) {
+  if ((configType === 'main' && isAlreadyTransformed) || (configType === 'preview' && isAlreadyTransformed && !hasNamedExports)) {
     return info.source;
   }
 


### PR DESCRIPTION
…orues

Fix in next release

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`configTOCsfFactories` had no early return for already transformed code

THe failing test was for

```ts
import { defineMain } from '@storybook/react-vite/node';

export default defineMain({});
````

the test title state that there's nothing to change but the issue is that `dedent` applies \n to the code, then `transform` applies `recast` uppon the code which apply platform line break. on windows it would be `\r\n` . Then the test would break
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- check that csf factories still works 

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection of already-transformed default exports so configs are preserved and redundant wrapping/merging is skipped when appropriate.
  * Ensures required framework imports are present (inserting or updating imports as needed) even when skipping other transformations, avoiding incomplete or broken configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->