### PR TITLE
Dependencies: Update `vite-plugin-storybook-nextjs` to ^3.2.4

### DIFF
--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -87,7 +87,7 @@
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
     "styled-jsx": "5.1.6",
-    "vite-plugin-storybook-nextjs": "^3.1.9"
+    "vite-plugin-storybook-nextjs": "^3.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8397,7 +8397,7 @@ __metadata:
     semver: "npm:^7.7.3"
     styled-jsx: "npm:5.1.6"
     typescript: "npm:^5.9.3"
-    vite-plugin-storybook-nextjs: "npm:^3.1.9"
+    vite-plugin-storybook-nextjs: "npm:^3.2.4"
   peerDependencies:
     next: ^14.1.0 || ^15.0.0 || ^16.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -30857,9 +30857,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-storybook-nextjs@npm:^3.1.9":
-  version: 3.1.9
-  resolution: "vite-plugin-storybook-nextjs@npm:3.1.9"
+"vite-plugin-storybook-nextjs@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "vite-plugin-storybook-nextjs@npm:3.2.4"
   dependencies:
     "@next/env": "npm:16.0.0"
     image-size: "npm:^2.0.0"
@@ -30869,9 +30869,9 @@ __metadata:
     vite-tsconfig-paths: "npm:^5.1.4"
   peerDependencies:
     next: ^14.1.0 || ^15.0.0 || ^16.0.0
-    storybook: ^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0
-    vite: ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10c0/2d854d47debd556154bd575f1e0d962561a73a88e2cdeb0b1719e3510a6b77475a75667213568466866c08e6c21c3c4a50e982814823f24de00e3759c30872d5
+    storybook: ^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 10c0/74c4969ec5f19e3045d301cfc72c2702134c19223851a81f955ae2f26252305a6f5ebe101d21e91bd2d88fd76d2ed10b7ae22a5c63b47f085328b87864a63664
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump vite-plugin-storybook-nextjs from ^3.1.9 to ^3.2.4 to pick up
important fixes including next/image resolution for package imports
(v3.2.2) and Vite 8 support (v3.2.0).

## What I did

Updated `vite-plugin-storybook-nextjs` dependency in `@storybook/nextjs-vite` from `^3.1.9` to `^3.2.4`.

The previous semver range resolved to `3.1.12` at most, missing important fixes in the `3.2.x` line:

- **v3.2.2** — Fix next-image resolution for package image imports
- **v3.2.0** — Vite 8 support

Without this bump, Storybook Vitest browser tests fail for stories using `next/image`:

> Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. Check the render method of `NextImage`.

Since `vite-plugin-storybook-nextjs` is released independently, it may be worth adding automated update tooling or tightening release coordination to reduce the chance of similar regressions in the future.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a Next.js project using `@storybook/nextjs-vite` with `@storybook/addon-vitest`
2. Add a story that uses `next/image` with a static image import
3. Run Vitest browser tests — should pass without `Element type is invalid` error

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)