### PR TITLE
refactor(frameworks): deduplicate defineMain via createDefineMain factory

### DIFF
--- a/code/core/src/common/index.ts
+++ b/code/core/src/common/index.ts
@@ -52,3 +52,5 @@ export * from './utils/command';
 export { versions };
 
 export { createFileSystemCache, FileSystemCache } from './utils/file-cache';
+
+export * from './utils/define-main';

--- a/code/core/src/common/utils/define-main.ts
+++ b/code/core/src/common/utils/define-main.ts
@@ -1,0 +1,11 @@
+/**
+ * Creates a typed `defineMain` function for a specific framework's StorybookConfig.
+ *
+ * Each framework package exports its own `defineMain` via this factory so the
+ * identity-function implementation lives in one place.
+ */
+export function createDefineMain<TConfig>() {
+  return function defineMain(config: TConfig): TConfig {
+    return config
+  }
+}

--- a/code/frameworks/angular/src/node/index.ts
+++ b/code/frameworks/angular/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/ember/src/node/index.ts
+++ b/code/frameworks/ember/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/html-vite/src/node/index.ts
+++ b/code/frameworks/html-vite/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/nextjs-vite/src/node/index.ts
+++ b/code/frameworks/nextjs-vite/src/node/index.ts
@@ -1,5 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
+
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/nextjs/src/node/index.ts
+++ b/code/frameworks/nextjs/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/preact-vite/src/node/index.ts
+++ b/code/frameworks/preact-vite/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/react-native-web-vite/src/node/index.ts
+++ b/code/frameworks/react-native-web-vite/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/react-vite/src/node/index.ts
+++ b/code/frameworks/react-vite/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/react-webpack5/src/node/index.ts
+++ b/code/frameworks/react-webpack5/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/server-webpack5/src/node/index.ts
+++ b/code/frameworks/server-webpack5/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/svelte-vite/src/node/index.ts
+++ b/code/frameworks/svelte-vite/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/sveltekit/src/node/index.ts
+++ b/code/frameworks/sveltekit/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/vue3-vite/src/node/index.ts
+++ b/code/frameworks/vue3-vite/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }

--- a/code/frameworks/web-components-vite/src/node/index.ts
+++ b/code/frameworks/web-components-vite/src/node/index.ts
@@ -1,7 +1,7 @@
-import type { StorybookConfig } from '../types';
+import { createDefineMain } from 'storybook/internal/common'
 
-export function defineMain(config: StorybookConfig) {
-  return config;
-}
+import type { StorybookConfig } from '../types'
 
-export type { StorybookConfig };
+export const defineMain = createDefineMain<StorybookConfig>()
+
+export type { StorybookConfig }


### PR DESCRIPTION
## Summary

Closes #34238

`defineMain` — a trivial identity function used for type-safe `main.ts` config — was copy-pasted identically across all 14 framework packages. This created an ongoing maintenance burden: any change to the function must be replicated 14 times, and the `nextjs-vite` package had already drifted (missing the trailing `export type { StorybookConfig }` line).

## Changes

**New:** `code/core/src/common/utils/define-main.ts`

Exported from `storybook/internal/common`.

**Updated:** All 14 `code/frameworks/*/src/node/index.ts` files now use:


**Also fixed:** `nextjs-vite` was missing `export type { StorybookConfig }`. This PR adds it back, making it consistent with all other frameworks.

## Why this approach

The issue mentions a generic factory (`createDefineMain<T>()`) as the recommended solution. It avoids any change to the public API — users still call `defineMain(config)` exactly as before. The factory just moves the implementation to one file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated configuration setup across all supported frameworks through a unified factory utility. This improves consistency and code maintainability without changing how developers interact with Storybook's configuration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->