### PR TITLE
fix(search): Preserve docs type for root-level docs entries

### DIFF
--- a/code/core/src/manager-api/lib/stories.ts
+++ b/code/core/src/manager-api/lib/stories.ts
@@ -267,7 +267,11 @@ export const transformStoryIndexToStoriesHash = (
         //   - Atoms / Button / LabelledButton
         //
         // In this example the entry for 'atoms-button' would *not* be a component.
-      } else if ((!acc[id] || acc[id].type === 'component') && idx === paths.length - 1) {
+      } else if (
+        (!acc[id] || acc[id].type === 'component') &&
+        idx === paths.length - 1 &&
+        !(item.type === 'docs' && paths.length === 1)
+      ) {
         acc[id] = merge<API_ComponentEntry>((acc[id] || {}) as API_ComponentEntry, {
           type: 'component',
           id,
@@ -297,11 +301,12 @@ export const transformStoryIndexToStoriesHash = (
     });
 
     // Finally add an entry for the docs/story/test itself
+    const isSingleSegmentDocs = item.type === 'docs' && paths.length === 1;
     acc[item.id] = {
       tags: [],
       ...item,
       depth: paths.length,
-      parent: 'parent' in item ? item.parent : paths[paths.length - 1],
+      parent: 'parent' in item ? item.parent : isSingleSegmentDocs ? undefined : paths[paths.length - 1],
       renderLabel,
       prepared: !!item.parameters,
     } as API_DocsEntry | API_StoryEntry;


### PR DESCRIPTION
## What I did

Fixed an issue where root-level docs entries (docs with single-segment titles like "Configure your project") were incorrectly typed as `component` in the search index, causing them to render the wrong icon type in search results.

## Root Cause

In `transformStoryIndexToStoriesHash`, when processing the last path segment, the code always created an `API_ComponentEntry` with `type: component`, regardless of the original item type. This caused root-level docs to be incorrectly marked as components.

## Fix

1. Skip creating a component entry for docs entries with single-segment titles by adding the condition to the if statement
2. Set `parent: undefined` for root-level docs entries so they are treated as orphans and appear at the root level

## Before
- Searching for "Configure your" matched a component-typed entry
- Search result showed component icon instead of document icon

## After
- Root-level docs entries preserve their `type: docs`
- Search results show the correct document icon
- Root-level docs appear at the correct hierarchy level

Fixes #34288

Co-Authored-By: CodeRabbit <bot@coderabbit.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of single-segment documentation items to ensure they are correctly organized and displayed within the story system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->