### PR TITLE
Refactor: extract createCorePreset factory and getFrameworkBuilderOpt…

### DIFF
--- a/code/core/src/common/utils/get-builder-options.test.ts
+++ b/code/core/src/common/utils/get-builder-options.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Options } from 'storybook/internal/types';
+
+import { createCorePreset, getFrameworkBuilderOptions } from './get-builder-options';
+
+function makeOptions(frameworkValue: unknown): Options {
+  return {
+    presets: { apply: vi.fn().mockResolvedValue(frameworkValue) },
+  } as unknown as Options;
+}
+
+describe('getFrameworkBuilderOptions', () => {
+  it('returns {} for a string framework or an object with no builder options', () => {
+    expect(getFrameworkBuilderOptions('@storybook/react-webpack5')).toEqual({});
+    expect(getFrameworkBuilderOptions({ name: '@storybook/react-webpack5' })).toEqual({});
+    expect(
+      getFrameworkBuilderOptions({ name: '@storybook/react-webpack5', options: { foo: 'bar' } })
+    ).toEqual({});
+  });
+
+  it('returns the builder options when present', () => {
+    const builderOptions = { fsCache: true };
+    expect(
+      getFrameworkBuilderOptions({
+        name: '@storybook/react-webpack5',
+        options: { builder: builderOptions },
+      })
+    ).toEqual(builderOptions);
+  });
+});
+
+describe('createCorePreset', () => {
+  it('produces the expected core config, merging incoming config and forwarding builder options', async () => {
+    const builderOptions = { fsCache: true };
+    const preset = createCorePreset({
+      builderName: '@storybook/builder-webpack5',
+      rendererName: '@storybook/react/preset',
+    });
+
+    const result = await preset(
+      { disableTelemetry: true },
+      makeOptions({ name: '@storybook/react-webpack5', options: { builder: builderOptions } })
+    );
+
+    expect(result).toMatchObject({
+      disableTelemetry: true,
+      builder: { name: '@storybook/builder-webpack5', options: builderOptions },
+      renderer: '@storybook/react/preset',
+    });
+  });
+
+  it('omits the renderer key when rendererName is not provided', async () => {
+    const preset = createCorePreset({ builderName: '@storybook/builder-webpack5' });
+    const result = await preset({}, makeOptions('@storybook/angular'));
+
+    expect(result).not.toHaveProperty('renderer');
+  });
+
+  it('calls beforeReturn with the resolved framework and options', async () => {
+    const hook = vi.fn();
+    const framework = { name: '@storybook/nextjs', options: { nextConfigPath: '/next.config.js' } };
+    const options = makeOptions(framework);
+
+    await createCorePreset({ builderName: '@storybook/builder-webpack5', beforeReturn: hook })(
+      {},
+      options
+    );
+
+    expect(hook).toHaveBeenCalledOnce();
+    expect(hook).toHaveBeenCalledWith(framework, options);
+  });
+});

--- a/code/core/src/common/utils/get-builder-options.test.ts
+++ b/code/core/src/common/utils/get-builder-options.test.ts
@@ -70,4 +70,25 @@ describe('createCorePreset', () => {
     expect(hook).toHaveBeenCalledOnce();
     expect(hook).toHaveBeenCalledWith(framework, options);
   });
+
+  it('awaits an async beforeReturn hook before returning', async () => {
+    let hookResolved = false;
+    const asyncHook = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            hookResolved = true;
+            resolve();
+          }, 0)
+        )
+    );
+
+    await createCorePreset({
+      builderName: '@storybook/builder-webpack5',
+      beforeReturn: asyncHook,
+    })({}, makeOptions({ name: '@storybook/nextjs', options: {} }));
+
+    expect(hookResolved).toBe(true);
+    expect(asyncHook).toHaveBeenCalledOnce();
+  });
 });

--- a/code/core/src/common/utils/get-builder-options.ts
+++ b/code/core/src/common/utils/get-builder-options.ts
@@ -1,4 +1,4 @@
-import type { Options } from 'storybook/internal/types';
+import type { Options, Preset, PresetPropertyFn } from 'storybook/internal/types';
 
 /**
  * Builder options can be specified in `core.builder.options` or `framework.options.builder`.
@@ -20,4 +20,45 @@ export async function getBuilderOptions<T extends Record<string, any>>(
   }
 
   return {};
+}
+
+/**
+ * Extracts builder options from a resolved framework preset value. A framework preset is either a
+ * plain string name or an object with an `options.builder` field.
+ */
+export function getFrameworkBuilderOptions(framework: Preset): Record<string, unknown> {
+  return typeof framework === 'string' ? {} : (framework?.options?.builder ?? {});
+}
+
+export interface CreateCorePresetOptions {
+  /** Resolved path or package name of the builder (e.g. result of `import.meta.resolve`). */
+  builderName: string;
+  /** Resolved path or package name of the renderer. Omit for frameworks with no renderer. */
+  rendererName?: string;
+  /** Optional async hook invoked after the framework is resolved but before the config is returned. */
+  beforeReturn?: (framework: Preset, options: Options) => Promise<void> | void;
+}
+
+/** Factory that creates a standard `core` preset handler for framework packages. */
+export function createCorePreset({
+  builderName,
+  rendererName,
+  beforeReturn,
+}: CreateCorePresetOptions): PresetPropertyFn<'core'> {
+  return async (config, options) => {
+    const framework = await options.presets.apply('framework');
+
+    if (beforeReturn) {
+      await beforeReturn(framework, options);
+    }
+
+    return {
+      ...config,
+      builder: {
+        name: builderName,
+        options: getFrameworkBuilderOptions(framework),
+      },
+      ...(rendererName !== undefined ? { renderer: rendererName } : {}),
+    };
+  };
 }

--- a/code/frameworks/angular/src/preset.ts
+++ b/code/frameworks/angular/src/preset.ts
@@ -1,3 +1,4 @@
+import { createCorePreset } from 'storybook/internal/common';
 import type { PresetProperty } from 'storybook/internal/types';
 
 import type { StandaloneOptions } from './builders/utils/standalone-options';
@@ -33,17 +34,9 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   return annotations;
 };
 
-export const core: PresetProperty<'core'> = async (config, options) => {
-  const framework = await options.presets.apply('framework');
-
-  return {
-    ...config,
-    builder: {
-      name: import.meta.resolve('@storybook/builder-webpack5'),
-      options: typeof framework === 'string' ? {} : framework.options.builder || {},
-    },
-  };
-};
+export const core = createCorePreset({
+  builderName: import.meta.resolve('@storybook/builder-webpack5'),
+});
 
 export const typescript: PresetProperty<'typescript'> = async (config) => {
   return {

--- a/code/frameworks/ember/src/preset.ts
+++ b/code/frameworks/ember/src/preset.ts
@@ -1,4 +1,8 @@
-import { getProjectRoot, resolvePathInStorybookCache } from 'storybook/internal/common';
+import {
+  createCorePreset,
+  getProjectRoot,
+  resolvePathInStorybookCache,
+} from 'storybook/internal/common';
 import type { PresetProperty } from 'storybook/internal/types';
 
 import { getVirtualModules } from '@storybook/builder-webpack5';
@@ -40,14 +44,6 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (baseConfig, 
   };
 };
 
-export const core: PresetProperty<'core'> = async (config, options) => {
-  const framework = await options.presets.apply('framework');
-
-  return {
-    ...config,
-    builder: {
-      name: import.meta.resolve('@storybook/builder-webpack5'),
-      options: typeof framework === 'string' ? {} : framework.options.builder || {},
-    },
-  };
-};
+export const core = createCorePreset({
+  builderName: import.meta.resolve('@storybook/builder-webpack5'),
+});

--- a/code/frameworks/nextjs-vite/src/preset.ts
+++ b/code/frameworks/nextjs-vite/src/preset.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { createCorePreset } from 'storybook/internal/common';
 import type { PresetProperty } from 'storybook/internal/types';
 
 import type { StorybookConfigVite } from '@storybook/builder-vite';
@@ -19,20 +20,10 @@ const require = createRequire(import.meta.url);
 // the ESM output of this package is broken, so I had to force it to use the CJS version it's shipping.
 const vitePluginStorybookNextjs = require('vite-plugin-storybook-nextjs');
 
-export const core: PresetProperty<'core'> = async (config, options) => {
-  const framework = await options.presets.apply('framework');
-
-  return {
-    ...config,
-    builder: {
-      name: fileURLToPath(import.meta.resolve('@storybook/builder-vite')),
-      options: {
-        ...(typeof framework === 'string' ? {} : framework.options.builder || {}),
-      },
-    },
-    renderer: fileURLToPath(import.meta.resolve('@storybook/react/preset')),
-  };
-};
+export const core = createCorePreset({
+  builderName: fileURLToPath(import.meta.resolve('@storybook/builder-vite')),
+  rendererName: fileURLToPath(import.meta.resolve('@storybook/react/preset')),
+});
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry = []) => {
   const annotations = [

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { getProjectRoot } from 'storybook/internal/common';
+import { createCorePreset, getProjectRoot } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 import type { PresetProperty } from 'storybook/internal/types';
 
@@ -21,32 +21,23 @@ export const addons: PresetProperty<'addons'> = [
   fileURLToPath(import.meta.resolve('@storybook/preset-react-webpack')),
 ];
 
-export const core: PresetProperty<'core'> = async (config, options) => {
-  const framework = await options.presets.apply<StorybookConfig['framework']>('framework');
-
+export const core = createCorePreset({
+  builderName: fileURLToPath(import.meta.resolve('@storybook/builder-webpack5')),
+  rendererName: fileURLToPath(import.meta.resolve('@storybook/react/preset')),
   // Load the Next.js configuration before we need it in webpackFinal (below).
   // This gives Next.js an opportunity to override some of webpack's internals
   // (see next/dist/server/config-utils.js) before @storybook/builder-webpack5
   // starts to use it. Without this, webpack's file system cache (fsCache: true)
   // does not work.
-  await configureConfig({
-    // Pass in a dummy webpack config object for now, since we don't want to
-    // modify the real one yet. We pass in the real one in webpackFinal.
-    baseConfig: {},
-    nextConfigPath: typeof framework === 'string' ? undefined : framework.options.nextConfigPath,
-  });
-
-  return {
-    ...config,
-    builder: {
-      name: fileURLToPath(import.meta.resolve('@storybook/builder-webpack5')),
-      options: {
-        ...(typeof framework === 'string' ? {} : framework.options.builder || {}),
-      },
-    },
-    renderer: fileURLToPath(import.meta.resolve('@storybook/react/preset')),
-  };
-};
+  beforeReturn: async (framework) => {
+    await configureConfig({
+      // Pass in a dummy webpack config object for now, since we don't want to
+      // modify the real one yet. We pass in the real one in webpackFinal.
+      baseConfig: {},
+      nextConfigPath: typeof framework === 'string' ? undefined : framework.options?.nextConfigPath,
+    });
+  },
+});
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry = []) => {
   const annotations = [...entry, fileURLToPath(import.meta.resolve('@storybook/nextjs/preview'))];

--- a/code/frameworks/react-webpack5/src/preset.ts
+++ b/code/frameworks/react-webpack5/src/preset.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 
+import { createCorePreset } from 'storybook/internal/common';
 import type { PresetProperty } from 'storybook/internal/types';
 
 import { WebpackDefinePlugin } from '@storybook/builder-webpack5';
@@ -10,18 +11,10 @@ export const addons: PresetProperty<'addons'> = [
   fileURLToPath(import.meta.resolve('@storybook/preset-react-webpack')),
 ];
 
-export const core: PresetProperty<'core'> = async (config, options) => {
-  const framework = await options.presets.apply('framework');
-
-  return {
-    ...config,
-    builder: {
-      name: fileURLToPath(import.meta.resolve('@storybook/builder-webpack5')),
-      options: typeof framework === 'string' ? {} : framework.options.builder || {},
-    },
-    renderer: fileURLToPath(import.meta.resolve('@storybook/react/preset')),
-  };
-};
+export const core = createCorePreset({
+  builderName: fileURLToPath(import.meta.resolve('@storybook/builder-webpack5')),
+  rendererName: fileURLToPath(import.meta.resolve('@storybook/react/preset')),
+});
 
 export const webpack: StorybookConfig['webpack'] = async (config, options) => {
   config.resolve = config.resolve || {};

--- a/code/frameworks/server-webpack5/src/preset.ts
+++ b/code/frameworks/server-webpack5/src/preset.ts
@@ -1,18 +1,11 @@
+import { createCorePreset } from 'storybook/internal/common';
 import type { PresetProperty } from 'storybook/internal/types';
 
 export const addons: PresetProperty<'addons'> = [
   import.meta.resolve('@storybook/preset-server-webpack'),
 ];
 
-export const core: PresetProperty<'core'> = async (config, options) => {
-  const framework = await options.presets.apply('framework');
-
-  return {
-    ...config,
-    builder: {
-      name: import.meta.resolve('@storybook/builder-webpack5'),
-      options: typeof framework === 'string' ? {} : framework.options.builder || {},
-    },
-    renderer: import.meta.resolve('@storybook/server/preset'),
-  };
-};
+export const core = createCorePreset({
+  builderName: import.meta.resolve('@storybook/builder-webpack5'),
+  rendererName: import.meta.resolve('@storybook/server/preset'),
+});


### PR DESCRIPTION
Closes #34258

## What I did

Extracts the structural duplication in framework `core` preset handlers into two shared helpers in `storybook/internal/common`

### Problem

Six framework packages (`react-webpack5`, `server-webpack5`, `angular`, `ember`, `nextjs-vite`, `nextjs`) each contained an identical `core` preset handler structure: 
resolve the framework, forward its builder options, declare a builder and optional renderer.
Any change to this pattern required editing six files independently.

The inline expression `typeof framework === 'string' ? {} : framework.options.builder || {}` was also duplicated verbatim across all six.

### Solution

Two helpers are added to `code/core/src/common/utils/get-builder-options.ts`:

1. **`getFrameworkBuilderOptions(framework: Preset)`**: pure synchronous function that
   resolves builder options from a framework preset value. Addresses the inline ternary
   duplication directly.

2. **`createCorePreset({ builderName, rendererName?, beforeReturn? })`**: factory function
   that encapsulates the entire `core` preset handler. All six framework packages are updated
   to use it. The optional `beforeReturn` async hook accommodates the Next.js preset, which
   must call `configureConfig(...)` before returning.

Both are automatically re-exported via the existing `storybook/internal/common` barrel.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Pure refactor, no runtime behaviour changes. No Manual testing needed.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated core preset configuration into a shared utility used by multiple framework integrations, standardizing builder/renderer wiring and lifecycle hook behavior.

* **Tests**
  * Added tests validating builder option extraction, renderer inclusion/omission, and preset hook execution semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->