### PR TITLE
CLI: Prompt for init crash reports

### DIFF
--- a/code/core/src/core-server/withTelemetry.test.ts
+++ b/code/core/src/core-server/withTelemetry.test.ts
@@ -457,7 +457,10 @@ describe('sendTelemetryError', () => {
     await sendTelemetryError(mockError, 'init', options, false);
 
     expect(prompt.confirm).not.toHaveBeenCalled();
-    expect(vi.mocked(cache.set).mock.calls).not.toContainEqual(['enableCrashReports', expect.anything()]);
+    expect(vi.mocked(cache.set).mock.calls).not.toContainEqual([
+      'enableCrashReports',
+      expect.anything(),
+    ]);
     expect(telemetry).toHaveBeenCalledWith(
       'error',
       expect.objectContaining({

--- a/code/core/src/core-server/withTelemetry.test.ts
+++ b/code/core/src/core-server/withTelemetry.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { cache, loadAllPresets } from 'storybook/internal/common';
+import { cache, isCI, loadAllPresets } from 'storybook/internal/common';
 import { prompt } from 'storybook/internal/node-logger';
 import { ErrorCollector, oneWayHash, telemetry } from 'storybook/internal/telemetry';
 
@@ -11,6 +11,18 @@ vi.mock('storybook/internal/telemetry', { spy: true });
 vi.mock('storybook/internal/node-logger', { spy: true });
 
 const cliOptions = {};
+const originalStdoutIsTTY = process.stdout.isTTY;
+
+const setStdoutIsTTY = (value: boolean | undefined) => {
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value,
+    configurable: true,
+  });
+};
+
+afterEach(() => {
+  setStdoutIsTTY(originalStdoutIsTTY);
+});
 
 describe('withTelemetry', () => {
   beforeEach(() => {
@@ -71,6 +83,52 @@ describe('withTelemetry', () => {
           isErrorInstance: true,
         }),
         expect.objectContaining({})
+      );
+    });
+
+    it('prompts for crash reports when init fails without preset options', async () => {
+      vi.mocked(isCI).mockReturnValue(false);
+      vi.mocked(cache.get).mockResolvedValueOnce(undefined);
+      vi.mocked(prompt.confirm).mockResolvedValueOnce(true);
+      setStdoutIsTTY(true);
+
+      await expect(async () =>
+        withTelemetry('init', { cliOptions, printError: vi.fn() }, run)
+      ).rejects.toThrow(error);
+
+      expect(prompt.confirm).toHaveBeenCalledTimes(1);
+      expect(cache.set).toHaveBeenCalledWith('enableCrashReports', true);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({
+          eventType: 'init',
+          error: expect.objectContaining({ message: 'An Error!', name: 'Error' }),
+          isErrorInstance: true,
+        }),
+        expect.objectContaining({ enableCrashReports: true })
+      );
+    });
+
+    it('does not send full error details when init prompt is rejected', async () => {
+      vi.mocked(isCI).mockReturnValue(false);
+      vi.mocked(cache.get).mockResolvedValueOnce(undefined);
+      vi.mocked(prompt.confirm).mockResolvedValueOnce(false);
+      setStdoutIsTTY(true);
+
+      await expect(async () =>
+        withTelemetry('init', { cliOptions, printError: vi.fn() }, run)
+      ).rejects.toThrow(error);
+
+      expect(prompt.confirm).toHaveBeenCalledTimes(1);
+      expect(cache.set).toHaveBeenCalledWith('enableCrashReports', false);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({
+          eventType: 'init',
+          error: undefined,
+          isErrorInstance: true,
+        }),
+        expect.objectContaining({ enableCrashReports: false })
       );
     });
 
@@ -412,11 +470,58 @@ describe('getErrorLevel', () => {
       },
       presetOptions: undefined,
       skipPrompt: false,
+      eventType: 'dev',
     };
 
     const errorLevel = await getErrorLevel(options);
 
     expect(errorLevel).toBe('error');
+  });
+
+  it('returns "full" for init when presetOptions are not provided and prompt is accepted', async () => {
+    const options: any = {
+      cliOptions: {
+        disableTelemetry: false,
+      },
+      presetOptions: undefined,
+      skipPrompt: false,
+      eventType: 'init',
+    };
+
+    vi.mocked(isCI).mockReturnValue(false);
+    vi.mocked(cache.get).mockResolvedValueOnce(undefined);
+    vi.mocked(prompt.confirm).mockResolvedValueOnce(true);
+    setStdoutIsTTY(true);
+
+    const errorLevel = await getErrorLevel(options);
+
+    expect(errorLevel).toBe('full');
+    expect(loadAllPresets).not.toHaveBeenCalled();
+    expect(prompt.confirm).toHaveBeenCalledTimes(1);
+    expect(cache.set).toHaveBeenCalledWith('enableCrashReports', true);
+  });
+
+  it('returns "error" for init when presetOptions are not provided and prompt is rejected', async () => {
+    const options: any = {
+      cliOptions: {
+        disableTelemetry: false,
+      },
+      presetOptions: undefined,
+      skipPrompt: false,
+      eventType: 'init',
+    };
+
+    vi.mocked(isCI).mockReturnValue(false);
+    vi.mocked(cache.get).mockResolvedValueOnce(undefined);
+    vi.mocked(prompt.confirm).mockResolvedValueOnce(false);
+    setStdoutIsTTY(true);
+
+    const errorLevel = await getErrorLevel(options);
+
+    expect(errorLevel).toBe('error');
+    expect(loadAllPresets).not.toHaveBeenCalled();
+    expect(prompt.confirm).toHaveBeenCalledTimes(1);
+    expect(cache.set).toHaveBeenCalledWith('enableCrashReports', false);
   });
 
   it('returns "full" when core.enableCrashReports is true', async () => {

--- a/code/core/src/core-server/withTelemetry.test.ts
+++ b/code/core/src/core-server/withTelemetry.test.ts
@@ -441,6 +441,64 @@ describe('sendTelemetryError', () => {
       })
     );
   });
+
+  it('does not prompt for non-blocking init errors without cached consent', async () => {
+    const options: any = {
+      cliOptions: {},
+      skipPrompt: false,
+    };
+    const mockError = new Error('Init non-blocking error');
+
+    vi.mocked(isCI).mockReturnValue(false);
+    vi.mocked(cache.get).mockResolvedValueOnce(undefined);
+    vi.mocked(prompt.confirm).mockResolvedValueOnce(true);
+    setStdoutIsTTY(true);
+
+    await sendTelemetryError(mockError, 'init', options, false);
+
+    expect(prompt.confirm).not.toHaveBeenCalled();
+    expect(vi.mocked(cache.set).mock.calls).not.toContainEqual(['enableCrashReports', expect.anything()]);
+    expect(telemetry).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({
+        eventType: 'init',
+        blocking: false,
+        error: undefined,
+        isErrorInstance: true,
+      }),
+      expect.objectContaining({
+        enableCrashReports: false,
+        immediate: true,
+      })
+    );
+  });
+
+  it('uses cached crash report consent for non-blocking init errors', async () => {
+    const options: any = {
+      cliOptions: {},
+      skipPrompt: false,
+    };
+    const mockError = new Error('Init non-blocking error');
+
+    vi.mocked(cache.get).mockResolvedValueOnce(true);
+
+    await sendTelemetryError(mockError, 'init', options, false);
+
+    expect(prompt.confirm).not.toHaveBeenCalled();
+    expect(telemetry).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({
+        eventType: 'init',
+        blocking: false,
+        error: expect.objectContaining({ message: 'Init non-blocking error', name: 'Error' }),
+        isErrorInstance: true,
+      }),
+      expect.objectContaining({
+        enableCrashReports: true,
+        immediate: true,
+      })
+    );
+  });
 });
 
 describe('getErrorLevel', () => {

--- a/code/core/src/core-server/withTelemetry.ts
+++ b/code/core/src/core-server/withTelemetry.ts
@@ -16,6 +16,7 @@ type TelemetryOptions = {
   presetOptions?: Parameters<typeof loadAllPresets>[0];
   printError?: (err: any) => void;
   skipPrompt?: boolean;
+  eventType?: EventType;
 };
 
 const promptCrashReports = async () => {
@@ -40,29 +41,30 @@ export async function getErrorLevel({
   cliOptions,
   presetOptions,
   skipPrompt,
+  eventType,
 }: TelemetryOptions): Promise<ErrorLevel> {
   if (cliOptions.disableTelemetry) {
     return 'none';
   }
 
-  // If we are running init or similar, we just have to go with true here
-  if (!presetOptions) {
+  if (!presetOptions && eventType !== 'init') {
     return 'error';
   }
 
-  // should we load the preset?
-  const presets = await loadAllPresets(presetOptions);
+  if (presetOptions) {
+    const presets = await loadAllPresets(presetOptions);
 
-  // If the user has chosen to enable/disable crash reports in main.js
-  // or disabled telemetry, we can return that
-  const core = await presets.apply('core');
+    // If the user has chosen to enable/disable crash reports in main.js
+    // or disabled telemetry, we can return that
+    const core = await presets.apply('core');
 
-  if (core?.enableCrashReports !== undefined) {
-    return core.enableCrashReports ? 'full' : 'error';
-  }
+    if (core?.enableCrashReports !== undefined) {
+      return core.enableCrashReports ? 'full' : 'error';
+    }
 
-  if (core?.disableTelemetry) {
-    return 'none';
+    if (core?.disableTelemetry) {
+      return 'none';
+    }
   }
 
   // Deal with typo, remove in future version (7.1?)
@@ -96,7 +98,7 @@ export async function sendTelemetryError(
   try {
     let errorLevel = 'error';
     try {
-      errorLevel = await getErrorLevel(options);
+      errorLevel = await getErrorLevel({ ...options, eventType });
     } catch (err) {
       // If this throws, eg. due to main.js breaking, we fall back to 'error'
     }

--- a/code/core/src/core-server/withTelemetry.ts
+++ b/code/core/src/core-server/withTelemetry.ts
@@ -98,7 +98,11 @@ export async function sendTelemetryError(
   try {
     let errorLevel = 'error';
     try {
-      errorLevel = await getErrorLevel({ ...options, eventType });
+      errorLevel = await getErrorLevel({
+        ...options,
+        eventType,
+        skipPrompt: options.skipPrompt || (eventType === 'init' && !blocking),
+      });
     } catch (err) {
       // If this throws, eg. due to main.js breaking, we fall back to 'error'
     }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Prompt for crash report consent when `storybook init` fails, so init errors can include full stack traces after the user opts in. This reuses the existing consent/cache flow and adds coverage for both accept and reject paths.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

##### Crash report prompting

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. From the repo root, compile `create-storybook` with `yarn nx compile create-storybook`.
2. In a separate terminal, start the local telemetry collector with `cd scripts && yarn jiti ./event-log-collector.ts`.
3. Create a fresh temp project and trigger an init failure:
   `tmp="$(mktemp -d)" && cd "$tmp" && printf '{ "name": "sb-init-repro", "private": true }\n' > package.json && HOME="$tmp/.home" env -u STORYBOOK_DISABLE_TELEMETRY STORYBOOK_TELEMETRY_URL="http://127.0.0.1:6007/event-log" STORYBOOK_TELEMETRY_DEBUG=1 node PATH_TO_STORYBOOK_REPO/storybook/code/lib/create-storybook/dist/bin/index.js --no-dev`
4. Confirm init fails with project detection and now shows the crash report consent prompt.
5. Accept the prompt once, then inspect events with `curl -s http://127.0.0.1:6007/event-log | python -m json.tool` and verify the `error` event includes `payload.error`.
6. Repeat with a fresh temp directory/Home and reject the prompt; verify the `error` event is still sent but `payload.error` is omitted.

##### _Not_ prompting in non-blocking error cases

1. Build the local `create-storybook` CLI from the Storybook repo:

```bash
cd /Users/jeppe/dev/work/storybook/storybook
yarn nx compile create-storybook
```

2. Start the local telemetry event collector in a separate terminal:

```bash
cd /Users/jeppe/dev/work/storybook/storybook/scripts
yarn jiti ./event-log-collector.ts
```

3. Create a fresh Vite React TypeScript app:

```bash
npm create vite@latest sb-nonblocking-repro -- --template react-ts
cd sb-nonblocking-repro
npm install
```

4. Replace `vite.config.ts` with this file:

```ts
import { defineConfig } from 'vite';
import react from '@vitejs/plugin-react';

export default defineConfig(() => ({
  plugins: [react()],
}));
```

5. Run `storybook init` with the locally built CLI and point telemetry at the event collector:

```bash
env -u STORYBOOK_DISABLE_TELEMETRY \
STORYBOOK_TELEMETRY_URL="http://127.0.0.1:6007/event-log" \
STORYBOOK_TELEMETRY_DEBUG=1 \
node PATH_TO_YOUR_STORYBOOK_REPO/storybook/code/lib/create-storybook/dist/bin/index.js \
  --features test \
  --yes \
  --no-dev
```

**Expected result**

- `storybook init` continues far enough to hit addon-vitest setup
- addon-vitest setup fails **non-fatally**
- **no crash-report consent prompt appears**

**Inspect the captured telemetry**

```bash
curl -s http://127.0.0.1:6007/event-log | python -m json.tool
```

Look for an `error` event with:

- `"eventType": "init"`
- `"blocking": false`
- no `payload.error` field unless crash-report consent was already cached beforehand

If needed, I can also write the matching **blocking init error** verification steps in the same format.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded telemetry tests: improved TTY handling, covered init failure paths, prompt/consent flows, cached-consent and non-blocking init scenarios; added assertions for consent persistence and telemetry payloads.

* **Bug Fixes**
  * Init events now respect cached crash-report consent, include full error details only when consented, and suppress prompts for non-blocking init events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->