### PR TITLE
fix: pin 6 unpinned action(s),extract 12 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/code-simplifier.lock.yml
+++ b/.github/workflows/code-simplifier.lock.yml
@@ -291,13 +291,14 @@ jobs:
         env:
           REPO_NAME: ${{ github.repository }}
           SERVER_URL: ${{ github.server_url }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git config --global am.keepcr true
           # Re-authenticate git with GitHub token
           SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-          git remote set-url origin "https://x-access-token:${{ github.token }}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
           echo "Git configured with standard GitHub Actions identity"
       - name: Checkout PR branch
         id: checkout-pr
@@ -715,13 +716,14 @@ jobs:
         env:
           REPO_NAME: ${{ github.repository }}
           SERVER_URL: ${{ github.server_url }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git config --global am.keepcr true
           # Re-authenticate git with GitHub token
           SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-          git remote set-url origin "https://x-access-token:${{ github.token }}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
           echo "Git configured with standard GitHub Actions identity"
       - name: Copy Copilot session state files to logs
         if: always()

--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
         # checks all markdown files from important folders including all subfolders
         with:
           # only show errors that occur instead of successful links + errors
@@ -25,4 +25,7 @@ jobs:
       - name: Send Discord Notification
         if: failure() # Only run this step if previous steps failed
         run: |
-          curl -H "Content-Type: application/json" -X POST -d '{"content":"The Markdown Links Check workflow has failed in the repository: [storybook]"}' ${{ secrets.DISCORD_MONITORING_URL }}
+          curl -H "Content-Type: application/json" -X POST -d '{"content":"The Markdown Links Check workflow has failed in the repository: [storybook]"}' ${DISCORD_MONITORING_URL}
+
+        env:
+          DISCORD_MONITORING_URL: ${{ secrets.DISCORD_MONITORING_URL }}

--- a/.github/workflows/duplicate-code-detector.lock.yml
+++ b/.github/workflows/duplicate-code-detector.lock.yml
@@ -284,13 +284,14 @@ jobs:
         env:
           REPO_NAME: ${{ github.repository }}
           SERVER_URL: ${{ github.server_url }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git config --global am.keepcr true
           # Re-authenticate git with GitHub token
           SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-          git remote set-url origin "https://x-access-token:${{ github.token }}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
           echo "Git configured with standard GitHub Actions identity"
       - name: Checkout PR branch
         id: checkout-pr
@@ -713,13 +714,14 @@ jobs:
         env:
           REPO_NAME: ${{ github.repository }}
           SERVER_URL: ${{ github.server_url }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git config --global am.keepcr true
           # Re-authenticate git with GitHub token
           SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-          git remote set-url origin "https://x-access-token:${{ github.token }}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
           echo "Git configured with standard GitHub Actions identity"
       - name: Copy Copilot session state files to logs
         if: always()

--- a/.github/workflows/generate-sandboxes.yml
+++ b/.github/workflows/generate-sandboxes.yml
@@ -81,7 +81,9 @@ jobs:
       - name: Publish
         # publish sandboxes even if the generation fails, as some sandboxes might have been generated successfully
         if: ${{ !cancelled() }}
-        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT }}@github.com/storybookjs/sandboxes.git --push --branch=next
+        run: yarn publish-sandboxes --remote=https://storybook-bot:${PAT_STORYBOOK_BOT}@github.com/storybookjs/sandboxes.git --push --branch=next
+        env:
+          PAT_STORYBOOK_BOT: ${{ secrets.PAT_STORYBOOK_BOT }}
 
       - name: Report failure to Discord
         if: failure()
@@ -150,7 +152,9 @@ jobs:
       - name: Publish
         # publish sandboxes even if the generation fails, as some sandboxes might have been generated successfully
         if: ${{ !cancelled() }}
-        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT }}@github.com/storybookjs/sandboxes.git --push --branch=main
+        run: yarn publish-sandboxes --remote=https://storybook-bot:${PAT_STORYBOOK_BOT}@github.com/storybookjs/sandboxes.git --push --branch=main
+        env:
+          PAT_STORYBOOK_BOT: ${{ secrets.PAT_STORYBOOK_BOT }}
 
       - name: Report failure to Discord
         if: failure()

--- a/.github/workflows/handle-release-branches.yml
+++ b/.github/workflows/handle-release-branches.yml
@@ -10,8 +10,10 @@ jobs:
     steps:
       - id: get-branch
         run: |
-          BRANCH=($(echo ${{ github.ref }} | sed -E 's/refs\/heads\///'))
+          BRANCH=($(echo ${GIT_REF} | sed -E 's/refs\/heads\///'))
           echo "branch=$BRANCH" >> $GITHUB_ENV
+        env:
+          GIT_REF: ${{ github.ref }}
     outputs:
       branch: ${{ env.branch }}
       is-latest-branch: ${{ env.branch == 'main' }}
@@ -26,7 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: curl -X POST "https://api.netlify.com/build_hooks/${{ secrets.FRONTPAGE_HOOK }}"
+      - run: curl -X POST "https://api.netlify.com/build_hooks/${FRONTPAGE_HOOK}"
+        env:
+          FRONTPAGE_HOOK: ${{ secrets.FRONTPAGE_HOOK }}
 
   get-next-release-branch:
     needs: branch-checks
@@ -39,7 +43,7 @@ jobs:
           path: next
 
       - id: next-version
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # release
         with:
           path: ${{ github.workspace }}/next/code/package.json
           prop_path: version
@@ -97,5 +101,8 @@ jobs:
         run: |
           curl -X POST https://api.github.com/repos/storybookjs/frontpage/dispatches \
           -H 'Accept: application/vnd.github.v3+json' \
-          -u ${{ secrets.FRONTPAGE_ACCESS_TOKEN }} \
+          -u ${FRONTPAGE_ACCESS_TOKEN} \
           --data '{"event_type": "request-create-frontpage-branch", "client_payload": { "branch": "${{ needs.create-next-release-branch.outputs.branch || needs.branch-checks.outputs.branch }}" }}'
+
+        env:
+          FRONTPAGE_ACCESS_TOKEN: ${{ secrets.FRONTPAGE_ACCESS_TOKEN }}

--- a/.github/workflows/nx.yml
+++ b/.github/workflows/nx.yml
@@ -51,7 +51,7 @@ jobs:
             fi
           fi
 
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/next" ]]; then
+          if [[ "${{ github.event_name }}" == "push" && "${GIT_REF}" == "refs/heads/next" ]]; then
             tags="merged"
           fi
 
@@ -60,6 +60,8 @@ jobs:
           fi
 
           echo "tag=$tags" >> "$GITHUB_OUTPUT"
+        env:
+          GIT_REF: ${{ github.ref }}
       - name: Select distribution config
         id: dist
         run: |
@@ -91,7 +93,7 @@ jobs:
           node-version: 22
           cache: 'yarn'
       - run: yarn install --immutable
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - id: nx
         name: 'Run nx'
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,9 @@ jobs:
 
       - name: Get target branch
         id: target
-        run: echo "target=${{ github.ref_name == 'next-release' && 'next' || 'main' }}" >> $GITHUB_OUTPUT
+        run: echo "target=${REF_NAME}" >> $GITHUB_OUTPUT
+        env:
+          REF_NAME: ${{ github.ref_name == 'next-release' && 'next' || 'main' }}
 
       - name: Get changelog for ${{ steps.version.outputs.current-version }}
         if: steps.publish-needed.outputs.published == 'false'
@@ -203,7 +205,7 @@ jobs:
 
       - name: Create Sentry release
         if: steps.publish-needed.outputs.published == 'false'
-        uses: getsentry/action-release@v3
+        uses: getsentry/action-release@dab6548b3c03c4717878099e43782cf5be654289 # v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
-      - uses: balazsorban44/nissuer@1.10.0
+      - uses: balazsorban44/nissuer@92ef22afd6a75e5e588f5d689a1fd3433f596f82 # 1.10.0
         with:
           label-comments: |
             {

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -60,7 +60,7 @@ jobs:
     if: github.repository_owner == 'storybookjs' && needs.get-parameters.outputs.workflow != ''
     steps:
       - name: Trigger Normal tests
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@c0b95d02a088b47c1f2f4db04fd8af8bd19eee54 # v1
         with:
           url: 'https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline'
           method: 'POST'


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/code-simplifier.lock.yml` | Extracted 2 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/cron-weekly.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/cron-weekly.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/duplicate-code-detector.lock.yml` | Extracted 2 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/generate-sandboxes.yml` | Extracted 2 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/handle-release-branches.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/handle-release-branches.yml` | Extracted 3 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/nx.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/nx.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/publish.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/publish.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/triage.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/trigger-circle-ci-workflow.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-012 | high | `.github/workflows/handle-release-branches.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-007 | medium | `.github/workflows/danger-js.yml` | Unpinned Third-Party Action Using Mutable Tag |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration and deployment security by pinning external GitHub Actions to specific commit versions and moving sensitive credentials to workflow environment variables for safer credential handling across automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->