### PR TITLE
Scripts: Add Storybook setup eval harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ yarn storybook:vitest
 | Run unit tests                  | `yarn test`                                                                    |
 | Run Storybook Vitest tests      | `yarn storybook:vitest`                                                        |
 | Run Storybook setup evals       | `yarn eval:storybook-setup run --benchmark mealdrop --agent codex-cli --tier sonnet` |
+| Run all setup eval benchmarks   | `yarn eval:storybook-setup run --agent codex-cli --tier sonnet`                |
 | Generate a sandbox              | `yarn task sandbox --template react-vite/default-ts --start-from auto`         |
 | Run sandbox E2E tests           | `yarn task e2e-tests-dev --template react-vite/default-ts --start-from auto`   |
 | Run sandbox test-runner tests   | `yarn task test-runner-dev --template react-vite/default-ts --start-from auto` |
@@ -235,6 +236,7 @@ For Storybook setup prompt work:
 
 - Use `yarn eval:storybook-setup list` to inspect the benchmark set, variants, and model options
 - Use `yarn eval:storybook-setup run --benchmark <id> --agent <claude-code|codex-cli> --prepare-only` to validate clone, cleanup, install, and `storybook init`
+- Omit `--benchmark` to run the full configured benchmark set sequentially
 - Full eval artifacts are written outside the repo by default to `../storybook-setup-evals/`
 
 ## Quality and Logging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ yarn storybook:vitest
 | Build the internal Storybook UI | `cd code && yarn storybook:ui:build`                                           |
 | Run unit tests                  | `yarn test`                                                                    |
 | Run Storybook Vitest tests      | `yarn storybook:vitest`                                                        |
+| Run Storybook setup evals       | `yarn eval:storybook-setup run --benchmark mealdrop --agent codex-cli --tier sonnet` |
 | Generate a sandbox              | `yarn task sandbox --template react-vite/default-ts --start-from auto`         |
 | Run sandbox E2E tests           | `yarn task e2e-tests-dev --template react-vite/default-ts --start-from auto`   |
 | Run sandbox test-runner tests   | `yarn task test-runner-dev --template react-vite/default-ts --start-from auto` |
@@ -229,6 +230,12 @@ When writing tests:
 - Test real behavior, not just syntax patterns
 - Use coverage when useful: `yarn vitest run --coverage <test-file>`
 - Mock external dependencies like file system access and loggers
+
+For Storybook setup prompt work:
+
+- Use `yarn eval:storybook-setup list` to inspect the benchmark set, variants, and model options
+- Use `yarn eval:storybook-setup run --benchmark <id> --agent <claude-code|codex-cli> --prepare-only` to validate clone, cleanup, install, and `storybook init`
+- Full eval artifacts are written outside the repo by default to `../storybook-setup-evals/`
 
 ## Quality and Logging
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "ci-tests": "cd code; yarn ci-tests",
+    "eval:storybook-setup": "yarn --cwd scripts eval:storybook-setup",
     "fmt:check": "oxfmt --check .",
     "fmt:write": "oxfmt .",
     "get-report-message": "cd scripts; yarn get-report-message",

--- a/scripts/evals/storybook-setup/README.md
+++ b/scripts/evals/storybook-setup/README.md
@@ -1,0 +1,160 @@
+# Storybook Setup Eval Harness
+
+This harness evaluates post-`storybook init` setup prompts against real React/Vite repositories.
+
+It is intentionally closer to the `storybookjs/mcp` eval suite than to a one-off benchmark script:
+
+- real benchmark definitions
+- prompt variants
+- normalized agent/model adapters
+- one trial directory per run
+- structured JSON artifacts for later comparison
+
+The main difference is that this harness starts from a freshly cloned real repository, removes any existing Storybook state, runs `npx storybook@latest init --yes`, checkpoints that exact baseline, and only then runs the setup prompt through an agent.
+
+## Why this shape
+
+The current design follows a few principles that are now standard in stronger agent-eval systems:
+
+- Keep tasks representative and end-to-end rather than synthetic.
+- Use deterministic execution-based checks wherever possible.
+- Preserve the exact starting state so you can compare a real baseline against the agent run.
+- Treat public benchmark contamination as a risk, so prefer fresh real repos over static gold-patch tasks.
+
+This is aligned with:
+
+- Terminal-Bench’s task + execution harness model: [docs](https://www.tbench.ai/docs)
+- OpenAI’s analysis of benchmark contamination and narrow/wide tests in SWE-bench Verified: [article](https://openai.com/index/why-we-no-longer-evaluate-swe-bench-verified/)
+- Anthropic’s guidance on representative, high-signal technical evaluations: [article](https://www.anthropic.com/engineering/AI-resistant-technical-evaluations)
+- SWE-Skills-Bench’s fixed-commit, acceptance-criteria, deterministic-verification setup: [paper](https://arxiv.org/abs/2603.15401)
+
+## Benchmarks
+
+The default benchmark set currently contains:
+
+- `mealdrop`
+- `edgy`
+- `wikitok`
+- `baklava`
+- `echarts-react`
+- `evergreen-ci`
+
+Each benchmark stores:
+
+- repository URL
+- optional branch override
+- optional nested `projectDir`
+- a short description
+- tags for filtering and later analysis
+
+## Agents and tiers
+
+The harness currently supports:
+
+- `claude-code`
+- `codex-cli`
+
+And normalizes them into three tiers:
+
+- `opus`
+- `sonnet`
+- `haiku`
+
+Those tiers map to provider-specific models:
+
+- Claude: `claude-opus-4.6`, `claude-sonnet-4.6`, `claude-haiku-4.5`
+- Codex: `gpt-5.4`, `gpt-5-codex`, `gpt-5-codex-mini`
+
+You can also override the exact model slug with `--model`.
+
+## Trial lifecycle
+
+Each `run` trial does this:
+
+1. Clone the benchmark repo into a dedicated trial directory.
+2. Remove existing Storybook files, sample stories, Storybook deps, and Storybook scripts.
+3. Install repository dependencies with the repo’s package manager.
+4. Run `npx storybook@latest init --yes` in the benchmark’s target directory.
+5. Run one more package-manager install so the post-init dependency graph is actually materialized.
+6. Commit that post-init state as the local baseline checkpoint.
+7. Generate the prompt with benchmark context and candidate component suggestions.
+8. Execute the setup prompt through Claude Code or Codex.
+9. Grade the final repo with:
+   - `storybook build`
+   - ghost-stories before/after metrics in isolated grading copies
+   - diff-based Storybook file summaries
+   - setup-pattern detection
+
+The default artifact root is `../storybook-setup-evals/`.
+
+## Commands
+
+List the configured benchmarks, variants, and model options:
+
+```bash
+yarn --cwd scripts eval:storybook-setup list
+```
+
+Prepare a benchmark but stop before the agent run:
+
+```bash
+yarn --cwd scripts eval:storybook-setup run \
+  --benchmark mealdrop \
+  --agent codex-cli \
+  --prepare-only
+```
+
+Run a full Codex trial:
+
+```bash
+yarn --cwd scripts eval:storybook-setup run \
+  --benchmark edgy \
+  --agent codex-cli \
+  --tier sonnet \
+  --variant baseline
+```
+
+Run a full Claude trial:
+
+```bash
+yarn --cwd scripts eval:storybook-setup run \
+  --benchmark baklava \
+  --agent claude-code \
+  --tier opus \
+  --variant strict-self-heal
+```
+
+## Output format
+
+Each trial writes a structured `result.json` artifact with:
+
+- benchmark metadata
+- prompt variant metadata
+- agent/model/tier metadata
+- environment details
+- cleanup/install/init/post-init-install records
+- baseline commit hash
+- candidate component list
+- agent execution summary
+- changed-file summary
+- Storybook-file diff summary
+- detected setup patterns
+- Storybook build result
+- ghost-stories before/after result
+- artifact paths
+
+High-value fields for prompt experiments include:
+
+- `execution.validationCommands`
+- `changes.storybookFiles`
+- `changes.setupPatterns`
+- `grading.ghostStories.before.summary.successRateWithoutEmptyRender`
+- `grading.ghostStories.after.summary.successRateWithoutEmptyRender`
+- `execution.costUsd`
+- `execution.turns`
+
+## Notes
+
+- The ghost-stories grading step is intentionally best-effort. It runs in isolated grading copies and may skip when the benchmark environment cannot support the required Vitest/browser setup.
+- `storybook build` is treated as the hard pass/fail setup check because it validates the actual Storybook config left by the agent.
+- The prompt variants are deliberately file-based so future experiments can add or remove hints without changing the runner.

--- a/scripts/evals/storybook-setup/README.md
+++ b/scripts/evals/storybook-setup/README.md
@@ -72,6 +72,7 @@ You can also override the exact model slug with `--model`.
 Each `run` trial does this:
 
 1. Clone the benchmark repo into a dedicated trial directory.
+   The harness now refreshes a cached source clone under `.cache/repos/` first, then copies that clean source into the trial.
 2. Remove existing Storybook files, sample stories, Storybook deps, and Storybook scripts.
 3. Install repository dependencies with the repo’s package manager.
 4. Run `npx storybook@latest init --yes` in the benchmark’s target directory.
@@ -95,6 +96,14 @@ List the configured benchmarks, variants, and model options:
 yarn --cwd scripts eval:storybook-setup list
 ```
 
+Run all configured benchmarks with one command:
+
+```bash
+yarn --cwd scripts eval:storybook-setup run \
+  --agent codex-cli \
+  --tier sonnet
+```
+
 Prepare a benchmark but stop before the agent run:
 
 ```bash
@@ -102,6 +111,15 @@ yarn --cwd scripts eval:storybook-setup run \
   --benchmark mealdrop \
   --agent codex-cli \
   --prepare-only
+```
+
+Run a benchmark multiple times:
+
+```bash
+yarn --cwd scripts eval:storybook-setup run \
+  --benchmark mealdrop \
+  --agent claude-code \
+  --iterations 3
 ```
 
 Run a full Codex trial:
@@ -122,6 +140,15 @@ yarn --cwd scripts eval:storybook-setup run \
   --agent claude-code \
   --tier opus \
   --variant strict-self-heal
+```
+
+Append a local prompt file after the selected prompt variant:
+
+```bash
+yarn --cwd scripts eval:storybook-setup run \
+  --benchmark edgy \
+  --agent codex-cli \
+  --prompt-file /absolute/path/to/extra-prompt.md
 ```
 
 ## Output format
@@ -158,3 +185,4 @@ High-value fields for prompt experiments include:
 - The ghost-stories grading step is intentionally best-effort. It runs in isolated grading copies and may skip when the benchmark environment cannot support the required Vitest/browser setup.
 - `storybook build` is treated as the hard pass/fail setup check because it validates the actual Storybook config left by the agent.
 - The prompt variants are deliberately file-based so future experiments can add or remove hints without changing the runner.
+- Package-manager commands are run with a sanitized public-registry environment so the Storybook monorepo's local registry config does not leak into benchmark repos.

--- a/scripts/evals/storybook-setup/agents.ts
+++ b/scripts/evals/storybook-setup/agents.ts
@@ -175,6 +175,8 @@ async function executeCodexCli({
     MODEL_CONFIGS[model].cliModel,
     '-c',
     'suppress_unstable_features_warning=true',
+    '-c',
+    `model_reasoning_effort="${MODEL_CONFIGS[model].reasoningEffort}"`,
     '-',
   ];
 

--- a/scripts/evals/storybook-setup/agents.ts
+++ b/scripts/evals/storybook-setup/agents.ts
@@ -1,0 +1,269 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { x } from 'tinyexec';
+
+import type { AgentExecutionSummary, AgentName, SupportedModel } from './types';
+import { MODEL_CONFIGS } from './models';
+
+type ExecuteAgentOptions = {
+  agent: AgentName;
+  model: SupportedModel;
+  prompt: string;
+  repoRoot: string;
+  logsDir: string;
+};
+
+const VALIDATION_COMMAND_PATTERN =
+  /\bstorybook\b|\bbuild-storybook\b|\bvitest\b|\btest-storybook\b|\bdoctor\b/;
+
+function isValidationCommand(command: string) {
+  return VALIDATION_COMMAND_PATTERN.test(command);
+}
+
+function parseJsonLines<T>(value: string): T[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as T];
+      } catch {
+        return [];
+      }
+    });
+}
+
+async function executeClaudeCode({
+  model,
+  prompt,
+  repoRoot,
+  logsDir,
+}: ExecuteAgentOptions): Promise<AgentExecutionSummary> {
+  const transcriptPath = path.join(logsDir, 'claude-stream.jsonl');
+  const stderrPath = path.join(logsDir, 'claude-stderr.log');
+  const command = [
+    'claude',
+    '-p',
+    '--verbose',
+    '--output-format',
+    'stream-json',
+    '--permission-mode',
+    'bypassPermissions',
+    '--model',
+    MODEL_CONFIGS[model].cliModel,
+    '--add-dir',
+    repoRoot,
+  ];
+
+  const startedAt = Date.now();
+  const result = x(command[0], command.slice(1), {
+    nodeOptions: {
+      cwd: repoRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    },
+  });
+  result.process?.stdin?.write(prompt);
+  result.process?.stdin?.end();
+  const completed = await result;
+  const durationMs = Date.now() - startedAt;
+
+  await writeFile(transcriptPath, completed.stdout);
+  await writeFile(stderrPath, completed.stderr);
+
+  const events = parseJsonLines<Record<string, unknown>>(completed.stdout);
+  let apiDurationMs: number | undefined;
+  let turns: number | undefined;
+  let costUsd: number | undefined;
+  let finalMessage: string | undefined;
+  let promptTokens: number | undefined;
+  let outputTokens: number | undefined;
+  const toolCalls: Array<{ name: string; input?: Record<string, unknown> }> = [];
+  const commandExecutions: Array<{ command: string; exitCode?: number }> = [];
+
+  for (const event of events) {
+    if (event.type === 'assistant' && typeof event.message === 'object' && event.message) {
+      const message = event.message as {
+        content?: Array<Record<string, unknown>>;
+        usage?: { input_tokens?: number; output_tokens?: number };
+      };
+      promptTokens ??= message.usage?.input_tokens;
+      outputTokens = (outputTokens ?? 0) + (message.usage?.output_tokens ?? 0);
+
+      for (const item of message.content ?? []) {
+        if (item.type === 'text' && typeof item.text === 'string') {
+          finalMessage = item.text;
+        }
+        if (item.type === 'tool_use' && typeof item.name === 'string') {
+          const input =
+            typeof item.input === 'object' && item.input ? (item.input as Record<string, unknown>) : undefined;
+          toolCalls.push({ name: item.name, input });
+          if (item.name === 'Bash' && typeof input?.command === 'string') {
+            commandExecutions.push({
+              command: input.command,
+            });
+          }
+        }
+      }
+    }
+
+    if (event.type === 'result') {
+      const typedEvent = event as {
+        duration_api_ms?: number;
+        num_turns?: number;
+        total_cost_usd?: number;
+        result?: string;
+        usage?: {
+          input_tokens?: number;
+          output_tokens?: number;
+          cache_creation_input_tokens?: number;
+          cache_read_input_tokens?: number;
+        };
+      };
+      apiDurationMs = typedEvent.duration_api_ms;
+      turns = typedEvent.num_turns;
+      costUsd = typedEvent.total_cost_usd;
+      finalMessage = typeof typedEvent.result === 'string' ? typedEvent.result : finalMessage;
+      promptTokens =
+        typedEvent.usage?.input_tokens ??
+        typedEvent.usage?.cache_creation_input_tokens ??
+        typedEvent.usage?.cache_read_input_tokens ??
+        promptTokens;
+      outputTokens = typedEvent.usage?.output_tokens ?? outputTokens;
+    }
+  }
+
+  return {
+    durationMs,
+    apiDurationMs,
+    turns,
+    costUsd,
+    promptTokens,
+    outputTokens,
+    totalTokens:
+      promptTokens !== undefined && outputTokens !== undefined ? promptTokens + outputTokens : undefined,
+    finalMessage,
+    commandExecutions,
+    toolCalls,
+    validationCommands: commandExecutions
+      .map((entry) => entry.command)
+      .filter((commandText) => isValidationCommand(commandText)),
+    transcriptPath,
+    stderrPath,
+  };
+}
+
+async function executeCodexCli({
+  model,
+  prompt,
+  repoRoot,
+  logsDir,
+}: ExecuteAgentOptions): Promise<AgentExecutionSummary> {
+  const transcriptPath = path.join(logsDir, 'codex-stream.jsonl');
+  const stderrPath = path.join(logsDir, 'codex-stderr.log');
+  const command = [
+    'codex',
+    'exec',
+    '--json',
+    '--ephemeral',
+    '--skip-git-repo-check',
+    '--dangerously-bypass-approvals-and-sandbox',
+    '-C',
+    repoRoot,
+    '-m',
+    MODEL_CONFIGS[model].cliModel,
+    '-c',
+    'suppress_unstable_features_warning=true',
+    '-',
+  ];
+
+  const startedAt = Date.now();
+  const result = x(command[0], command.slice(1), {
+    nodeOptions: {
+      cwd: repoRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    },
+  });
+  result.process?.stdin?.write(prompt);
+  result.process?.stdin?.end();
+  const completed = await result;
+  const durationMs = Date.now() - startedAt;
+
+  await writeFile(transcriptPath, completed.stdout);
+  await writeFile(stderrPath, completed.stderr);
+
+  const events = parseJsonLines<Record<string, unknown>>(completed.stdout);
+  let finalMessage: string | undefined;
+  let turns: number | undefined;
+  let promptTokens: number | undefined;
+  let outputTokens: number | undefined;
+  const toolCalls: Array<{ name: string; input?: Record<string, unknown> }> = [];
+  const commandExecutions: Array<{ command: string; exitCode?: number }> = [];
+
+  for (const event of events) {
+    if (event.type === 'item.completed' && typeof event.item === 'object' && event.item) {
+      const item = event.item as {
+        type?: string;
+        text?: string;
+        command?: string;
+        exit_code?: number;
+      };
+
+      if (item.type === 'agent_message' && typeof item.text === 'string') {
+        finalMessage = item.text;
+      }
+
+      if (item.type === 'command_execution' && typeof item.command === 'string') {
+        commandExecutions.push({
+          command: item.command,
+          exitCode: item.exit_code,
+        });
+        toolCalls.push({
+          name: 'command_execution',
+          input: {
+            command: item.command,
+            exitCode: item.exit_code,
+          },
+        });
+      }
+    }
+
+    if (event.type === 'turn.completed' && typeof event.usage === 'object' && event.usage) {
+      const usage = event.usage as {
+        input_tokens?: number;
+        output_tokens?: number;
+        cached_input_tokens?: number;
+      };
+      turns = (turns ?? 0) + 1;
+      promptTokens =
+        (promptTokens ?? 0) + (usage.input_tokens ?? 0) + (usage.cached_input_tokens ?? 0);
+      outputTokens = (outputTokens ?? 0) + (usage.output_tokens ?? 0);
+    }
+  }
+
+  return {
+    durationMs,
+    turns,
+    promptTokens,
+    outputTokens,
+    totalTokens:
+      promptTokens !== undefined && outputTokens !== undefined ? promptTokens + outputTokens : undefined,
+    finalMessage,
+    commandExecutions,
+    toolCalls,
+    validationCommands: commandExecutions
+      .map((entry) => entry.command)
+      .filter((commandText) => isValidationCommand(commandText)),
+    transcriptPath,
+    stderrPath,
+  };
+}
+
+export async function executeAgent(options: ExecuteAgentOptions) {
+  if (options.agent === 'claude-code') {
+    return executeClaudeCode(options);
+  }
+
+  return executeCodexCli(options);
+}

--- a/scripts/evals/storybook-setup/benchmarks.ts
+++ b/scripts/evals/storybook-setup/benchmarks.ts
@@ -1,0 +1,62 @@
+import type { BenchmarkProject } from './types';
+
+export const BENCHMARKS: BenchmarkProject[] = [
+  {
+    id: 'mealdrop',
+    name: 'MealDrop',
+    repo: 'https://github.com/yannbf/mealdrop',
+    branch: 'without-storybook',
+    description:
+      'React app with styled-components, Redux, and react-router-dom. Useful for provider and global-style setup.',
+    tags: ['react', 'vite', 'styled-components', 'redux', 'router'],
+  },
+  {
+    id: 'edgy',
+    name: 'Edgy',
+    repo: 'https://github.com/catherineisonline/edgy',
+    description:
+      'React app with Tailwind CSS, Headless UI, and react-router-dom. Useful for CSS pipeline and router decorators.',
+    tags: ['react', 'vite', 'tailwind', 'headlessui', 'router'],
+  },
+  {
+    id: 'wikitok',
+    name: 'Wikitok',
+    repo: 'https://github.com/IsaacGemal/wikitok',
+    projectDir: 'frontend',
+    description: 'Nested frontend app with Tailwind CSS. Useful for monorepo-ish project-dir handling.',
+    tags: ['react', 'vite', 'tailwind', 'nested-project'],
+  },
+  {
+    id: 'baklava',
+    name: 'baklava',
+    repo: 'https://github.com/fortanix/baklava',
+    branch: 'master',
+    description: 'Component library with Zustand state. Useful for library-style story authoring.',
+    tags: ['react', 'component-library', 'zustand'],
+  },
+  {
+    id: 'echarts-react',
+    name: 'echarts',
+    repo: 'https://github.com/tmkx/echarts-react',
+    description: 'React wrapper around ECharts. Useful for third-party rendering dependencies.',
+    tags: ['react', 'library', 'echarts'],
+  },
+  {
+    id: 'evergreen-ci',
+    name: 'Evergreen CI',
+    repo: 'https://github.com/evergreen-ci/ui',
+    projectDir: 'packages/lib',
+    description:
+      'Large workspace package with GraphQL and application providers. Useful for nested-package and provider-heavy setup.',
+    tags: ['react', 'workspace', 'graphql', 'nested-project'],
+  },
+];
+
+export function getBenchmarkById(id: string) {
+  const benchmark = BENCHMARKS.find((entry) => entry.id === id);
+  if (!benchmark) {
+    throw new Error(`Unknown benchmark "${id}".`);
+  }
+
+  return benchmark;
+}

--- a/scripts/evals/storybook-setup/candidate-components.test.ts
+++ b/scripts/evals/storybook-setup/candidate-components.test.ts
@@ -1,0 +1,49 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { selectCandidateComponents } from './candidate-components';
+
+const TEST_ROOT = join(process.cwd(), '.tmp-storybook-setup-eval-candidates');
+
+afterEach(async () => {
+  await import('node:fs/promises').then((fs) => fs.rm(TEST_ROOT, { recursive: true, force: true }));
+});
+
+describe('selectCandidateComponents', () => {
+  it('returns simple exported JSX files before more complex ones', async () => {
+    await mkdir(join(TEST_ROOT, 'src'), { recursive: true });
+    await mkdir(join(TEST_ROOT, 'src', 'stories'), { recursive: true });
+    await writeFile(
+      join(TEST_ROOT, 'src', 'Simple.tsx'),
+      `export function Simple() { return <div>simple</div>; }\n`
+    );
+    await writeFile(
+      join(TEST_ROOT, 'src', 'Complex.tsx'),
+      `import { memo } from 'react';
+import { useStore } from './store';
+
+export const Complex = memo(function Complex() {
+  const value = useStore();
+  return (
+    <section>
+      <div>{value}</div>
+      <div>extra</div>
+      <div>content</div>
+    </section>
+  );
+});
+`
+    );
+    await writeFile(
+      join(TEST_ROOT, 'src', 'stories', 'Button.tsx'),
+      `export function Button() { return <button>storybook sample</button>; }\n`
+    );
+
+    const candidates = await selectCandidateComponents(TEST_ROOT, 2);
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]?.path.endsWith('Simple.tsx')).toBe(true);
+    expect(candidates[1]?.path.endsWith('Complex.tsx')).toBe(true);
+  });
+});

--- a/scripts/evals/storybook-setup/candidate-components.ts
+++ b/scripts/evals/storybook-setup/candidate-components.ts
@@ -1,0 +1,72 @@
+import { readFile } from 'node:fs/promises';
+
+// eslint-disable-next-line depend/ban-dependencies
+import { glob } from 'glob';
+
+import type { CandidateComponent } from './types';
+
+const DEFAULT_GLOB = '**/*.{tsx,jsx}';
+const DEFAULT_SAMPLE_COUNT = 6;
+
+const IGNORE_PATTERNS = [
+  '**/node_modules/**',
+  '**/.git/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/coverage/**',
+  '**/storybook-static/**',
+  '**/*.test.*',
+  '**/*.spec.*',
+  '**/*.stories.*',
+  '**/*.story.*',
+  '**/*.config.*',
+  '**/*.d.*',
+  '**/__mocks__/**',
+  '**/stories/{Button,Header,Page}.*',
+  '**/stories/{button,header,page}.*',
+  '**/src/stories/{Button,Header,Page}.*',
+  '**/src/stories/{button,header,page}.*',
+];
+
+function looksLikeReactComponent(source: string) {
+  const hasExport = /\bexport\s+(default|const|function|class|\{)/.test(source);
+  const hasJsx = /<[A-Za-z][^>]*>/.test(source) || /return\s*\(\s*</.test(source);
+  return hasExport && hasJsx;
+}
+
+function getComplexity(source: string) {
+  const lines = source.split('\n');
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0).length;
+  const importCount = lines.filter((line) => line.trim().startsWith('import ')).length;
+  const rawComplexity = nonEmptyLines + importCount * 0.5;
+  const normalized = rawComplexity / (32 / 0.3);
+  return Number(Math.min(normalized, 1).toFixed(2));
+}
+
+export async function selectCandidateComponents(
+  cwd: string,
+  sampleCount = DEFAULT_SAMPLE_COUNT
+): Promise<CandidateComponent[]> {
+  const files = await glob(DEFAULT_GLOB, {
+    cwd,
+    absolute: true,
+    ignore: IGNORE_PATTERNS,
+  });
+
+  const candidates: CandidateComponent[] = [];
+  for (const filePath of files) {
+    try {
+      const source = await readFile(filePath, 'utf8');
+      if (!looksLikeReactComponent(source)) {
+        continue;
+      }
+
+      candidates.push({
+        path: filePath,
+        complexity: getComplexity(source),
+      });
+    } catch {}
+  }
+
+  return candidates.sort((left, right) => left.complexity - right.complexity).slice(0, sampleCount);
+}

--- a/scripts/evals/storybook-setup/cli.ts
+++ b/scripts/evals/storybook-setup/cli.ts
@@ -1,11 +1,53 @@
 import { Command } from 'commander';
 
-import { BENCHMARKS } from './benchmarks';
+import { BENCHMARKS, getBenchmarkById } from './benchmarks';
 import { ALL_MODELS, ALL_TIERS } from './models';
 import { getDefaultWorkspaceRoot, runEval } from './run';
 import { PROMPT_VARIANTS } from './variants';
 
 const program = new Command();
+
+function formatDuration(durationMs?: number) {
+  if (durationMs == null) {
+    return '-';
+  }
+
+  if (durationMs < 1_000) {
+    return `${durationMs}ms`;
+  }
+
+  if (durationMs < 60_000) {
+    return `${Math.round(durationMs / 1_000)}s`;
+  }
+
+  const minutes = Math.floor(durationMs / 60_000);
+  const seconds = Math.round((durationMs % 60_000) / 1_000);
+  return `${minutes}m${seconds}s`;
+}
+
+function formatCost(costUsd?: number) {
+  if (costUsd == null) {
+    return '-';
+  }
+
+  return `$${costUsd.toFixed(2)}`;
+}
+
+function printSummary(results: Awaited<ReturnType<typeof runEval>>[]) {
+  if (results.length === 0) {
+    return;
+  }
+
+  console.log('\nSummary:');
+  for (const result of results) {
+    const buildStatus = result.grading.storybookBuild.status.toUpperCase();
+    console.log(
+      `- ${result.benchmark.id}: build=${buildStatus} cost=${formatCost(
+        result.execution?.costUsd
+      )} duration=${formatDuration(result.execution?.durationMs)}`
+    );
+  }
+}
 
 program.name('storybook-setup-eval');
 program.description('Eval harness for post-init Storybook setup prompts against real React/Vite repositories.');
@@ -37,29 +79,64 @@ program
 
 program
   .command('run')
-  .requiredOption('--benchmark <id>', 'Benchmark id to run')
   .requiredOption('--agent <agent>', 'Agent to use: claude-code or codex-cli')
+  .option('--benchmark <id>', 'Benchmark id to run. Omit to run all configured benchmarks.')
   .option('--variant <id>', 'Prompt variant id', 'baseline')
   .option('--tier <tier>', 'Tier to use when model is omitted', 'sonnet')
   .option('--model <model>', 'Explicit model override')
+  .option('--prompt-file <path>', 'Append a custom prompt file after the selected variant prompt')
+  .option('--iterations <count>', 'Run each selected benchmark this many times', '1')
   .option(
     '--workspace-root <path>',
     `Workspace for trial clones and artifacts. Defaults to ${getDefaultWorkspaceRoot()}`
   )
   .option('--prepare-only', 'Clone, clean, install, init, and checkpoint without running an agent')
-  .description('Run a single benchmark trial.')
+  .description('Run one benchmark or all configured benchmarks.')
   .action(async (options) => {
-    const result = await runEval({
-      benchmarkId: options.benchmark,
-      agent: options.agent,
-      model: options.model,
-      tier: options.tier,
-      variantId: options.variant,
-      workspaceRoot: options.workspaceRoot,
-      prepareOnly: options.prepareOnly,
-    });
+    const iterations = Number.parseInt(options.iterations, 10);
+    if (!Number.isFinite(iterations) || iterations < 1) {
+      throw new Error(`Invalid iterations value "${options.iterations}".`);
+    }
 
-    console.log(JSON.stringify(result, null, 2));
+    const selectedBenchmarks = options.benchmark
+      ? [getBenchmarkById(options.benchmark)]
+      : BENCHMARKS;
+    const totalRuns = selectedBenchmarks.length * iterations;
+    const results: Awaited<ReturnType<typeof runEval>>[] = [];
+
+    for (const benchmark of selectedBenchmarks) {
+      for (let iteration = 1; iteration <= iterations; iteration += 1) {
+        const label =
+          iterations > 1
+            ? `${benchmark.id} (${iteration}/${iterations})`
+            : benchmark.id;
+        console.log(`\nRunning ${label}...`);
+
+        const result = await runEval({
+          benchmarkId: benchmark.id,
+          agent: options.agent,
+          model: options.model,
+          tier: options.tier,
+          variantId: options.variant,
+          workspaceRoot: options.workspaceRoot,
+          prepareOnly: options.prepareOnly,
+          promptFile: options.promptFile,
+        });
+
+        results.push(result);
+        if (totalRuns === 1) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(
+            `Finished ${label}. Artifact: ${result.artifacts.resultPath}`
+          );
+        }
+      }
+    }
+
+    if (results.length > 1) {
+      printSummary(results);
+    }
   });
 
 program.parseAsync(process.argv).catch((error) => {

--- a/scripts/evals/storybook-setup/cli.ts
+++ b/scripts/evals/storybook-setup/cli.ts
@@ -1,0 +1,68 @@
+import { Command } from 'commander';
+
+import { BENCHMARKS } from './benchmarks';
+import { ALL_MODELS, ALL_TIERS } from './models';
+import { getDefaultWorkspaceRoot, runEval } from './run';
+import { PROMPT_VARIANTS } from './variants';
+
+const program = new Command();
+
+program.name('storybook-setup-eval');
+program.description('Eval harness for post-init Storybook setup prompts against real React/Vite repositories.');
+
+program
+  .command('list')
+  .description('List configured benchmarks, variants, and model tiers.')
+  .action(() => {
+    console.log('Benchmarks:');
+    for (const benchmark of BENCHMARKS) {
+      console.log(`- ${benchmark.id}: ${benchmark.name} (${benchmark.tags.join(', ')})`);
+    }
+
+    console.log('\nPrompt variants:');
+    for (const variant of PROMPT_VARIANTS) {
+      console.log(`- ${variant.id}: ${variant.description}`);
+    }
+
+    console.log('\nModel tiers:');
+    for (const tier of ALL_TIERS) {
+      console.log(`- ${tier}`);
+    }
+
+    console.log('\nExplicit models:');
+    for (const model of ALL_MODELS) {
+      console.log(`- ${model.id} (${model.agent}, ${model.tier})`);
+    }
+  });
+
+program
+  .command('run')
+  .requiredOption('--benchmark <id>', 'Benchmark id to run')
+  .requiredOption('--agent <agent>', 'Agent to use: claude-code or codex-cli')
+  .option('--variant <id>', 'Prompt variant id', 'baseline')
+  .option('--tier <tier>', 'Tier to use when model is omitted', 'sonnet')
+  .option('--model <model>', 'Explicit model override')
+  .option(
+    '--workspace-root <path>',
+    `Workspace for trial clones and artifacts. Defaults to ${getDefaultWorkspaceRoot()}`
+  )
+  .option('--prepare-only', 'Clone, clean, install, init, and checkpoint without running an agent')
+  .description('Run a single benchmark trial.')
+  .action(async (options) => {
+    const result = await runEval({
+      benchmarkId: options.benchmark,
+      agent: options.agent,
+      model: options.model,
+      tier: options.tier,
+      variantId: options.variant,
+      workspaceRoot: options.workspaceRoot,
+      prepareOnly: options.prepareOnly,
+    });
+
+    console.log(JSON.stringify(result, null, 2));
+  });
+
+program.parseAsync(process.argv).catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/evals/storybook-setup/environment.test.ts
+++ b/scripts/evals/storybook-setup/environment.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPublicPackageManagerEnv } from './environment';
+
+describe('getPublicPackageManagerEnv', () => {
+  it('forces the public npm registry and removes other npm_config values', () => {
+    process.env.npm_config_registry = 'http://localhost:6002';
+    process.env.npm_config_userconfig = '/tmp/local-npmrc';
+    process.env.npm_config_cache = '/tmp/cache';
+
+    const env = getPublicPackageManagerEnv({
+      CI: '1',
+    });
+
+    expect(env.npm_config_registry).toBe('https://registry.npmjs.org/');
+    expect(env.npm_config_userconfig).toBeUndefined();
+    expect(env.npm_config_cache).toBeUndefined();
+    expect(env.CI).toBe('1');
+    expect(env.YARN_ENABLE_IMMUTABLE_INSTALLS).toBe('false');
+  });
+});

--- a/scripts/evals/storybook-setup/environment.ts
+++ b/scripts/evals/storybook-setup/environment.ts
@@ -1,0 +1,19 @@
+export function getPublicPackageManagerEnv(
+  overrides: Record<string, string | undefined> = {}
+): Record<string, string | undefined> {
+  const env = { ...process.env } as Record<string, string | undefined>;
+
+  env.npm_config_registry = 'https://registry.npmjs.org/';
+  env.YARN_ENABLE_IMMUTABLE_INSTALLS = overrides.YARN_ENABLE_IMMUTABLE_INSTALLS ?? 'false';
+
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('npm_config_') && key !== 'npm_config_registry') {
+      delete env[key];
+    }
+  }
+
+  return {
+    ...env,
+    ...overrides,
+  };
+}

--- a/scripts/evals/storybook-setup/ghost-stories.ts
+++ b/scripts/evals/storybook-setup/ghost-stories.ts
@@ -1,0 +1,221 @@
+import { mkdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { x } from 'tinyexec';
+
+import { selectCandidateComponents } from './candidate-components';
+import type { GhostStoriesSummary } from './types';
+
+type VitestAssertion = {
+  status?: string;
+  fullName?: string;
+  failureMessages?: string[];
+  meta?: {
+    storyId?: string;
+    reports?: Array<{
+      type?: string;
+      result?: {
+        emptyRender?: boolean;
+      };
+    }>;
+  };
+};
+
+type VitestSuite = {
+  assertionResults?: VitestAssertion[];
+};
+
+type VitestJsonReport = {
+  numTotalTests?: number;
+  numPassedTests?: number;
+  testResults?: VitestSuite[];
+};
+
+export type GhostStoriesExecutionResult =
+  | {
+      ok: true;
+      summary: GhostStoriesSummary;
+    }
+  | {
+      ok: false;
+      summary: GhostStoriesSummary;
+    };
+
+function categorizeError(errorMessage: string) {
+  const normalized = errorMessage.toLowerCase();
+  if (normalized.includes('cannot find module') || normalized.includes('failed to resolve import')) {
+    return 'module-resolution';
+  }
+
+  if (normalized.includes('context') || normalized.includes('provider')) {
+    return 'missing-provider';
+  }
+
+  if (normalized.includes('css') || normalized.includes('tailwind') || normalized.includes('styled')) {
+    return 'styling';
+  }
+
+  if (normalized.includes('network') || normalized.includes('fetch')) {
+    return 'data-fetching';
+  }
+
+  return 'other';
+}
+
+function parseVitestReport(report: VitestJsonReport, candidateCount: number): GhostStoriesSummary {
+  const testResults = report.testResults ?? [];
+  const categorizedErrors = new Map<
+    string,
+    {
+      count: number;
+      uniqueErrors: Set<string>;
+      matchedDependencies: Set<string>;
+    }
+  >();
+  const uniqueErrorMessages = new Set<string>();
+  let passedButEmptyRender = 0;
+
+  for (const suite of testResults) {
+    for (const assertion of suite.assertionResults ?? []) {
+      const hasEmptyRender = assertion.meta?.reports?.some(
+        (entry) => entry.type === 'render-analysis' && entry.result?.emptyRender === true
+      );
+      if (assertion.status === 'passed' && hasEmptyRender) {
+        passedButEmptyRender += 1;
+      }
+
+      if (assertion.status !== 'failed') {
+        continue;
+      }
+
+      const error = assertion.failureMessages?.[0]?.split('\n')[0];
+      if (!error) {
+        continue;
+      }
+
+      const category = categorizeError(error);
+      const current = categorizedErrors.get(category) ?? {
+        count: 0,
+        uniqueErrors: new Set<string>(),
+        matchedDependencies: new Set<string>(),
+      };
+      current.count += 1;
+      current.uniqueErrors.add(error);
+      uniqueErrorMessages.add(error);
+      categorizedErrors.set(category, current);
+    }
+  }
+
+  const total = report.numTotalTests ?? 0;
+  const passed = report.numPassedTests ?? 0;
+
+  return {
+    candidateCount,
+    total,
+    passed,
+    passedButEmptyRender,
+    successRate: total > 0 ? Number((passed / total).toFixed(2)) : 0,
+    successRateWithoutEmptyRender:
+      total > 0 ? Number(((passed - passedButEmptyRender) / total).toFixed(2)) : 0,
+    uniqueErrorCount: uniqueErrorMessages.size,
+    categorizedErrors: Object.fromEntries(
+      Array.from(categorizedErrors.entries()).map(([category, data]) => [
+        category,
+        {
+          count: data.count,
+          uniqueCount: data.uniqueErrors.size,
+          matchedDependencies: Array.from(data.matchedDependencies).sort(),
+        },
+      ])
+    ),
+  };
+}
+
+export async function runGhostStoriesEval(projectRoot: string): Promise<GhostStoriesExecutionResult> {
+  const candidates = await selectCandidateComponents(projectRoot, 20);
+  const baseSummary: GhostStoriesSummary = {
+    candidateCount: candidates.length,
+    analyzedCount: candidates.length,
+    avgComplexity:
+      candidates.length > 0
+        ? Number(
+            (
+              candidates.reduce((sum, candidate) => sum + candidate.complexity, 0) / candidates.length
+            ).toFixed(2)
+          )
+        : 0,
+  };
+
+  if (candidates.length === 0) {
+    return {
+      ok: false,
+      summary: {
+        ...baseSummary,
+        runError: 'No candidate components found for ghost-stories.',
+      },
+    };
+  }
+
+  const cacheDir = join(projectRoot, '.storybook-setup-eval');
+  const outputFile = join(cacheDir, `ghost-stories-${Date.now()}.json`);
+  await mkdir(cacheDir, { recursive: true });
+
+  const vitestResult = await x(
+    'npx',
+    [
+      '--no-install',
+      'vitest',
+      'run',
+      '--reporter=json',
+      '--testTimeout=1000',
+      `--outputFile=${outputFile}`,
+      ...candidates.map((candidate) => candidate.path),
+    ],
+    {
+      nodeOptions: {
+        cwd: projectRoot,
+        env: {
+          ...process.env,
+          STORYBOOK_COMPONENT_PATHS: candidates.map((candidate) => candidate.path).join(';'),
+        },
+      },
+    }
+  );
+
+  if (vitestResult.exitCode !== 0) {
+    const output = `${vitestResult.stdout}\n${vitestResult.stderr}`.toLowerCase();
+    const runError =
+      output.includes('no tests found')
+        ? 'No tests found'
+        : output.includes('playwright')
+          ? 'Playwright is not installed'
+          : 'Vitest ghost-stories run failed';
+
+    return {
+      ok: false,
+      summary: {
+        ...baseSummary,
+        runError,
+      },
+    };
+  }
+
+  try {
+    const report = JSON.parse(await readFile(outputFile, 'utf8')) as VitestJsonReport;
+    return {
+      ok: true,
+      summary: {
+        ...baseSummary,
+        ...parseVitestReport(report, candidates.length),
+      },
+    };
+  } catch {
+    return {
+      ok: false,
+      summary: {
+        ...baseSummary,
+        runError: 'Failed to read or parse Vitest JSON report',
+      },
+    };
+  }
+}

--- a/scripts/evals/storybook-setup/ghost-stories.ts
+++ b/scripts/evals/storybook-setup/ghost-stories.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { x } from 'tinyexec';
 
 import { selectCandidateComponents } from './candidate-components';
+import { getPublicPackageManagerEnv } from './environment';
 import type { GhostStoriesSummary } from './types';
 
 type VitestAssertion = {
@@ -174,10 +175,9 @@ export async function runGhostStoriesEval(projectRoot: string): Promise<GhostSto
     {
       nodeOptions: {
         cwd: projectRoot,
-        env: {
-          ...process.env,
+        env: getPublicPackageManagerEnv({
           STORYBOOK_COMPONENT_PATHS: candidates.map((candidate) => candidate.path).join(';'),
-        },
+        }),
       },
     }
   );

--- a/scripts/evals/storybook-setup/models.ts
+++ b/scripts/evals/storybook-setup/models.ts
@@ -1,0 +1,96 @@
+import type { AgentName, ModelConfig, ModelTier, SupportedModel } from './types';
+
+export const MODEL_CONFIGS: Record<SupportedModel, ModelConfig> = {
+  'claude-opus-4.6': {
+    id: 'claude-opus-4.6',
+    agent: 'claude-code',
+    cliModel: 'opus',
+    tier: 'opus',
+    label: 'Claude Opus 4.6',
+  },
+  'claude-sonnet-4.6': {
+    id: 'claude-sonnet-4.6',
+    agent: 'claude-code',
+    cliModel: 'sonnet',
+    tier: 'sonnet',
+    label: 'Claude Sonnet 4.6',
+  },
+  'claude-haiku-4.5': {
+    id: 'claude-haiku-4.5',
+    agent: 'claude-code',
+    cliModel: 'haiku',
+    tier: 'haiku',
+    label: 'Claude Haiku 4.5',
+  },
+  'gpt-5.4': {
+    id: 'gpt-5.4',
+    agent: 'codex-cli',
+    cliModel: 'gpt-5.4',
+    tier: 'opus',
+    label: 'GPT-5.4',
+    notes: 'Default highest-capability Codex tier.',
+  },
+  'gpt-5-codex': {
+    id: 'gpt-5-codex',
+    agent: 'codex-cli',
+    cliModel: 'gpt-5-codex',
+    tier: 'sonnet',
+    label: 'GPT-5 Codex',
+    notes: 'Balanced Codex coding model.',
+  },
+  'gpt-5-codex-mini': {
+    id: 'gpt-5-codex-mini',
+    agent: 'codex-cli',
+    cliModel: 'gpt-5-codex-mini',
+    tier: 'haiku',
+    label: 'GPT-5 Codex Mini',
+    notes: 'Fastest low-cost Codex tier.',
+  },
+  'gpt-5.4-mini': {
+    id: 'gpt-5.4-mini',
+    agent: 'codex-cli',
+    cliModel: 'gpt-5.4-mini',
+    tier: 'sonnet',
+    label: 'GPT-5.4 Mini',
+    notes: 'Supported as an explicit override; not the default tier mapping.',
+  },
+  'gpt-5.2-codex': {
+    id: 'gpt-5.2-codex',
+    agent: 'codex-cli',
+    cliModel: 'gpt-5.2-codex',
+    tier: 'sonnet',
+    label: 'GPT-5.2 Codex',
+    notes: 'Legacy Codex model retained for comparison runs.',
+  },
+};
+
+export const DEFAULT_MODEL_BY_TIER: Record<AgentName, Record<ModelTier, SupportedModel>> = {
+  'claude-code': {
+    opus: 'claude-opus-4.6',
+    sonnet: 'claude-sonnet-4.6',
+    haiku: 'claude-haiku-4.5',
+  },
+  'codex-cli': {
+    opus: 'gpt-5.4',
+    sonnet: 'gpt-5-codex',
+    haiku: 'gpt-5-codex-mini',
+  },
+};
+
+export const ALL_MODELS = Object.values(MODEL_CONFIGS);
+
+export const ALL_TIERS: ModelTier[] = ['opus', 'sonnet', 'haiku'];
+
+export function resolveModel(agent: AgentName, tier?: ModelTier, explicitModel?: SupportedModel) {
+  if (explicitModel) {
+    const config = MODEL_CONFIGS[explicitModel];
+    if (config.agent !== agent) {
+      throw new Error(`Model "${explicitModel}" is not supported by ${agent}.`);
+    }
+
+    return config;
+  }
+
+  const resolvedTier = tier ?? 'sonnet';
+  return MODEL_CONFIGS[DEFAULT_MODEL_BY_TIER[agent][resolvedTier]];
+}

--- a/scripts/evals/storybook-setup/models.ts
+++ b/scripts/evals/storybook-setup/models.ts
@@ -7,6 +7,7 @@ export const MODEL_CONFIGS: Record<SupportedModel, ModelConfig> = {
     cliModel: 'opus',
     tier: 'opus',
     label: 'Claude Opus 4.6',
+    reasoningEffort: 'high',
   },
   'claude-sonnet-4.6': {
     id: 'claude-sonnet-4.6',
@@ -14,6 +15,7 @@ export const MODEL_CONFIGS: Record<SupportedModel, ModelConfig> = {
     cliModel: 'sonnet',
     tier: 'sonnet',
     label: 'Claude Sonnet 4.6',
+    reasoningEffort: 'medium',
   },
   'claude-haiku-4.5': {
     id: 'claude-haiku-4.5',
@@ -21,6 +23,7 @@ export const MODEL_CONFIGS: Record<SupportedModel, ModelConfig> = {
     cliModel: 'haiku',
     tier: 'haiku',
     label: 'Claude Haiku 4.5',
+    reasoningEffort: 'medium',
   },
   'gpt-5.4': {
     id: 'gpt-5.4',
@@ -28,6 +31,7 @@ export const MODEL_CONFIGS: Record<SupportedModel, ModelConfig> = {
     cliModel: 'gpt-5.4',
     tier: 'opus',
     label: 'GPT-5.4',
+    reasoningEffort: 'high',
     notes: 'Default highest-capability Codex tier.',
   },
   'gpt-5-codex': {
@@ -36,6 +40,7 @@ export const MODEL_CONFIGS: Record<SupportedModel, ModelConfig> = {
     cliModel: 'gpt-5-codex',
     tier: 'sonnet',
     label: 'GPT-5 Codex',
+    reasoningEffort: 'medium',
     notes: 'Balanced Codex coding model.',
   },
   'gpt-5-codex-mini': {
@@ -44,6 +49,7 @@ export const MODEL_CONFIGS: Record<SupportedModel, ModelConfig> = {
     cliModel: 'gpt-5-codex-mini',
     tier: 'haiku',
     label: 'GPT-5 Codex Mini',
+    reasoningEffort: 'medium',
     notes: 'Fastest low-cost Codex tier.',
   },
   'gpt-5.4-mini': {
@@ -52,6 +58,7 @@ export const MODEL_CONFIGS: Record<SupportedModel, ModelConfig> = {
     cliModel: 'gpt-5.4-mini',
     tier: 'sonnet',
     label: 'GPT-5.4 Mini',
+    reasoningEffort: 'medium',
     notes: 'Supported as an explicit override; not the default tier mapping.',
   },
   'gpt-5.2-codex': {
@@ -60,6 +67,7 @@ export const MODEL_CONFIGS: Record<SupportedModel, ModelConfig> = {
     cliModel: 'gpt-5.2-codex',
     tier: 'sonnet',
     label: 'GPT-5.2 Codex',
+    reasoningEffort: 'high',
     notes: 'Legacy Codex model retained for comparison runs.',
   },
 };

--- a/scripts/evals/storybook-setup/prompts/base.md
+++ b/scripts/evals/storybook-setup/prompts/base.md
@@ -1,0 +1,26 @@
+You are finishing Storybook setup for an existing React + Vite codebase.
+
+Starting state:
+
+- Storybook was already installed with `npx storybook@latest init --yes`.
+- Do not rerun `storybook init`.
+- The goal is not to create a demo app. The goal is to make Storybook work for the actual project code.
+
+Objectives:
+
+1. Make Storybook render the project's real components with the providers, globals, aliases, styles, mocks, and environment they need.
+2. Replace or remove init placeholder stories/components when they stop being useful.
+3. Add or update a small representative set of stories for existing components from the project.
+4. Prefer reusable setup in `.storybook` over per-story hacks.
+
+Constraints:
+
+- Keep changes focused on Storybook setup and the minimum related support files.
+- Avoid changing product source unless it is genuinely required to make components testable or renderable.
+- Reuse existing app providers and styling entry points when possible.
+
+Verification:
+
+- Run your own non-interactive verification commands.
+- Fix the highest-signal Storybook problem first.
+- Iterate until the setup is stable enough that another user can keep writing stories without additional setup work.

--- a/scripts/evals/storybook-setup/prompts/doctor-hints.md
+++ b/scripts/evals/storybook-setup/prompts/doctor-hints.md
@@ -1,0 +1,4 @@
+Diagnostic preference:
+
+- Before large config changes, prefer a fast diagnostic command if it can reduce ambiguity.
+- Use Storybook-specific diagnostics when available, then fold that output into the next fix.

--- a/scripts/evals/storybook-setup/prompts/strict-self-heal.md
+++ b/scripts/evals/storybook-setup/prompts/strict-self-heal.md
@@ -1,0 +1,8 @@
+Self-heal loop:
+
+1. Inspect the first render/build failure.
+2. Make the smallest high-signal fix.
+3. Re-run a relevant Storybook validation command.
+4. Repeat until the remaining failures are clearly outside setup scope.
+
+Do not stop after the first partial improvement.

--- a/scripts/evals/storybook-setup/run.ts
+++ b/scripts/evals/storybook-setup/run.ts
@@ -12,6 +12,7 @@ import { ROOT_DIRECTORY } from '../../utils/constants';
 import { getBenchmarkById } from './benchmarks';
 import { selectCandidateComponents } from './candidate-components';
 import { executeAgent } from './agents';
+import { getPublicPackageManagerEnv } from './environment';
 import { runGhostStoriesEval } from './ghost-stories';
 import { resolveModel } from './models';
 import { detectSetupPatterns } from './setup-patterns';
@@ -36,6 +37,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROMPTS_DIRECTORY = join(__dirname, 'prompts');
 
 const DEFAULT_WORKSPACE_ROOT = resolve(ROOT_DIRECTORY, '../storybook-setup-evals');
+const CACHE_DIRECTORY_NAME = '.cache';
+const REPO_CACHE_DIRECTORY_NAME = 'repos';
 const STORYBOOK_STARTER_FILES = new Set([
   'Button.tsx',
   'Button.stories.ts',
@@ -86,13 +89,17 @@ function getWorkspaceRoot(workspaceRoot?: string) {
   return resolve(workspaceRoot ?? DEFAULT_WORKSPACE_ROOT);
 }
 
+function getRepoCacheRoot(workspaceRoot: string) {
+  return join(workspaceRoot, CACHE_DIRECTORY_NAME, REPO_CACHE_DIRECTORY_NAME);
+}
+
 async function runCommand(
   name: string,
   logsDir: string,
   command: string,
   args: string[],
   cwd: string,
-  env?: Record<string, string>
+  env?: Record<string, string | undefined>
 ): Promise<CommandRecord> {
   const logPath = join(logsDir, `${name}.log`);
   const startedAt = Date.now();
@@ -134,6 +141,26 @@ async function detectCliVersion(binary: string) {
   }
 }
 
+async function getDefaultBranch(repoRoot: string) {
+  const headRef = await x('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+    nodeOptions: { cwd: repoRoot },
+  });
+
+  if (headRef.exitCode === 0) {
+    return headRef.stdout.trim().replace('refs/remotes/origin/', '');
+  }
+
+  const fallback = await x('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    nodeOptions: { cwd: repoRoot },
+  });
+
+  if (fallback.exitCode !== 0) {
+    throw new Error(`Failed to detect default branch for ${repoRoot}.`);
+  }
+
+  return fallback.stdout.trim();
+}
+
 function detectPackageManager(repoRoot: string): PackageManager {
   if (existsSync(join(repoRoot, 'pnpm-lock.yaml'))) {
     return 'pnpm';
@@ -155,6 +182,60 @@ function getInstallCommand(packageManager: PackageManager): [string, string[]] {
     default:
       return ['npm', ['install']];
   }
+}
+
+async function ensureCachedBenchmarkClone(
+  benchmark: BenchmarkProject,
+  workspaceRoot: string,
+  logsDir: string
+) {
+  const cacheRoot = getRepoCacheRoot(workspaceRoot);
+  const cacheDir = join(cacheRoot, benchmark.id);
+
+  await ensureDir(cacheRoot);
+
+  if (!existsSync(cacheDir)) {
+    const cloneArgs = ['clone', '--depth', '1'];
+    if (benchmark.branch) {
+      cloneArgs.push('--branch', benchmark.branch);
+    }
+    cloneArgs.push(benchmark.repo, cacheDir);
+    await runCommand('cache-clone', logsDir, 'git', cloneArgs, cacheRoot);
+    return cacheDir;
+  }
+
+  const targetBranch = benchmark.branch ?? (await getDefaultBranch(cacheDir));
+  await runCommand('cache-fetch', logsDir, 'git', ['fetch', 'origin'], cacheDir);
+  await runCommand('cache-checkout', logsDir, 'git', ['checkout', targetBranch], cacheDir);
+  await runCommand(
+    'cache-reset',
+    logsDir,
+    'git',
+    ['reset', '--hard', `origin/${targetBranch}`],
+    cacheDir
+  );
+  await runCommand('cache-clean', logsDir, 'git', ['clean', '-fdx', '-e', 'node_modules'], cacheDir);
+
+  return cacheDir;
+}
+
+async function copyCachedBenchmarkToTrial(
+  cacheDir: string,
+  trialRepoDir: string
+) {
+  await cp(cacheDir, trialRepoDir, {
+    recursive: true,
+    filter: (source) => {
+      const relativePath = relative(cacheDir, source);
+      return (
+        relativePath.length === 0 ||
+        (!relativePath.startsWith('.git') &&
+          !relativePath.includes('/.git') &&
+          !relativePath.startsWith('node_modules') &&
+          !relativePath.includes('/node_modules/'))
+      );
+    },
+  });
 }
 
 async function findPackageJsonFiles(repoRoot: string) {
@@ -346,13 +427,18 @@ async function buildPrompt(
   benchmark: BenchmarkProject,
   projectRoot: string,
   targetDirLabel: string,
-  candidateComponents: Array<{ path: string; complexity: number }>
+  candidateComponents: Array<{ path: string; complexity: number }>,
+  promptFile?: string
 ) {
   const promptParts: string[] = [];
 
   for (const promptFile of variant.promptFiles) {
     const promptPath = join(PROMPTS_DIRECTORY, promptFile);
     promptParts.push(await readFile(promptPath, 'utf8'));
+  }
+
+  if (promptFile) {
+    promptParts.push(await readFile(resolve(promptFile), 'utf8'));
   }
 
   const candidateList =
@@ -384,21 +470,6 @@ ${candidateList}
   return `${promptParts.join('\n\n')}\n`;
 }
 
-async function cloneBenchmark(
-  benchmark: BenchmarkProject,
-  trialPaths: TrialPaths,
-  logsDir: string
-): Promise<string> {
-  const args = ['clone', '--depth', '1'];
-  if (benchmark.branch) {
-    args.push('--branch', benchmark.branch);
-  }
-  args.push(benchmark.repo, trialPaths.repoDir);
-
-  await runCommand('clone', logsDir, 'git', args, dirname(trialPaths.repoDir));
-  return trialPaths.repoDir;
-}
-
 async function captureGitCommit(repoRoot: string) {
   const commit = await x('git', ['rev-parse', 'HEAD'], {
     nodeOptions: { cwd: repoRoot },
@@ -427,6 +498,18 @@ async function createBaselineCommit(repoRoot: string, logsDir: string) {
   return captureGitCommit(repoRoot);
 }
 
+async function initializeTrialGitRepo(repoRoot: string, logsDir: string) {
+  await runCommand('git-init', logsDir, 'git', ['init'], repoRoot);
+  await runCommand('git-set-user-name', logsDir, 'git', ['config', 'user.name', 'storybook-eval'], repoRoot);
+  await runCommand(
+    'git-set-user-email',
+    logsDir,
+    'git',
+    ['config', 'user.email', 'storybook-eval@example.com'],
+    repoRoot
+  );
+}
+
 async function prepareProject(
   benchmark: BenchmarkProject,
   trialPaths: TrialPaths
@@ -437,7 +520,11 @@ async function prepareProject(
   await ensureDir(trialPaths.artifactsDir);
   await ensureDir(trialPaths.tempDir);
 
-  const repoRoot = await cloneBenchmark(benchmark, trialPaths, trialPaths.logsDir);
+  const workspaceRoot = dirname(dirname(trialPaths.trialDir));
+  const cachedRepoRoot = await ensureCachedBenchmarkClone(benchmark, workspaceRoot, trialPaths.logsDir);
+  await copyCachedBenchmarkToTrial(cachedRepoRoot, trialPaths.repoDir);
+
+  const repoRoot = trialPaths.repoDir;
   const packageManager = detectPackageManager(repoRoot);
   const projectRoot = resolve(repoRoot, benchmark.projectDir ?? '.');
   const targetDirLabel = relative(repoRoot, projectRoot) || '.';
@@ -445,10 +532,9 @@ async function prepareProject(
   const cleanup = await cleanupStorybookFiles(repoRoot);
 
   const [installCommandName, installArgs] = getInstallCommand(packageManager);
-  const installEnv = {
+  const installEnv = getPublicPackageManagerEnv({
     CI: '1',
-    YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
-  };
+  });
   const install = await runCommand(
     'install',
     trialPaths.logsDir,
@@ -464,7 +550,10 @@ async function prepareProject(
     'npx',
     ['storybook@latest', 'init', '--yes'],
     projectRoot,
-    { CI: '1' }
+    getPublicPackageManagerEnv({
+      CI: '1',
+      STORYBOOK_DISABLE_TELEMETRY: '1',
+    })
   );
 
   const postInitInstall = await runCommand(
@@ -476,6 +565,7 @@ async function prepareProject(
     installEnv
   );
 
+  await initializeTrialGitRepo(repoRoot, trialPaths.logsDir);
   const candidateComponents = await selectCandidateComponents(projectRoot);
   const baselineCommit = await createBaselineCommit(repoRoot, trialPaths.logsDir);
 
@@ -539,7 +629,10 @@ async function ensureAddonVitest(projectRoot: string, logsDir: string, label: st
     'npx',
     ['storybook@latest', 'add', '@storybook/addon-vitest', '--yes'],
     projectRoot,
-    { CI: '1' }
+    getPublicPackageManagerEnv({
+      CI: '1',
+      STORYBOOK_DISABLE_TELEMETRY: '1',
+    })
   );
 }
 
@@ -610,7 +703,10 @@ async function runStorybookBuild(
       commandName,
       commandArgs,
       projectRoot,
-      { CI: '1' }
+      getPublicPackageManagerEnv({
+        CI: '1',
+        STORYBOOK_DISABLE_TELEMETRY: '1',
+      })
     );
     return {
       status: 'passed',
@@ -674,7 +770,8 @@ export async function runEval(options: RunOptions) {
     benchmark,
     preparedProject.projectRoot,
     preparedProject.targetDirLabel,
-    preparedProject.candidateComponents
+    preparedProject.candidateComponents,
+    options.promptFile
   );
   await writeFile(trialPaths.promptPath, prompt);
 

--- a/scripts/evals/storybook-setup/run.ts
+++ b/scripts/evals/storybook-setup/run.ts
@@ -1,0 +1,919 @@
+import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import process from 'node:process';
+
+// eslint-disable-next-line depend/ban-dependencies
+import { glob } from 'glob';
+import { x } from 'tinyexec';
+
+import { ROOT_DIRECTORY } from '../../utils/constants';
+import { getBenchmarkById } from './benchmarks';
+import { selectCandidateComponents } from './candidate-components';
+import { executeAgent } from './agents';
+import { resolveModel } from './models';
+import { detectSetupPatterns } from './setup-patterns';
+import type {
+  AgentName,
+  BenchmarkProject,
+  ChangedFileSummary,
+  CleanupSummary,
+  CommandRecord,
+  EvalResult,
+  GhostStoriesResult,
+  PackageManager,
+  PackageJsonCleanup,
+  PreparedProject,
+  PromptVariant,
+  RunOptions,
+  StepResult,
+} from './types';
+import { getVariantById } from './variants';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROMPTS_DIRECTORY = join(__dirname, 'prompts');
+
+const DEFAULT_WORKSPACE_ROOT = resolve(ROOT_DIRECTORY, '../storybook-setup-evals');
+const STORYBOOK_STARTER_FILES = new Set([
+  'Button.tsx',
+  'Button.stories.ts',
+  'Button.stories.tsx',
+  'button.tsx',
+  'button.stories.ts',
+  'button.stories.tsx',
+  'Header.tsx',
+  'Header.stories.ts',
+  'Header.stories.tsx',
+  'header.tsx',
+  'header.stories.ts',
+  'header.stories.tsx',
+  'Page.tsx',
+  'Page.stories.ts',
+  'Page.stories.tsx',
+  'page.tsx',
+  'page.stories.ts',
+  'page.stories.tsx',
+]);
+
+type TrialPaths = {
+  trialDir: string;
+  repoDir: string;
+  logsDir: string;
+  artifactsDir: string;
+  promptPath: string;
+  resultPath: string;
+  tempDir: string;
+};
+
+function createTrialId(
+  benchmarkId: string,
+  variantId: string,
+  agent: AgentName,
+  model: string,
+  timestamp = new Date()
+) {
+  const iso = timestamp.toISOString().slice(0, 19).replace(/[:]/g, '-');
+  return `${iso}-${benchmarkId}-${variantId}-${agent}-${model.replace(/[^\w.-]/g, '-')}`;
+}
+
+async function ensureDir(pathName: string) {
+  await mkdir(pathName, { recursive: true });
+}
+
+function getWorkspaceRoot(workspaceRoot?: string) {
+  return resolve(workspaceRoot ?? DEFAULT_WORKSPACE_ROOT);
+}
+
+async function runCommand(
+  name: string,
+  logsDir: string,
+  command: string,
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>
+): Promise<CommandRecord> {
+  const logPath = join(logsDir, `${name}.log`);
+  const startedAt = Date.now();
+  const result = await x(command, args, {
+    nodeOptions: {
+      cwd,
+      env: env ? { ...process.env, ...env } : process.env,
+    },
+  });
+  const durationMs = Date.now() - startedAt;
+
+  await writeFile(logPath, `${result.stdout}${result.stderr}`);
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${name} failed with exit code ${result.exitCode}. See ${logPath} for details.`
+    );
+  }
+
+  return {
+    name,
+    command: [command, ...args].join(' '),
+    cwd,
+    durationMs,
+    exitCode: result.exitCode,
+    logPath,
+  };
+}
+
+async function detectCliVersion(binary: string) {
+  try {
+    const result = await x(binary, ['--version']);
+    if (result.exitCode !== 0) {
+      return undefined;
+    }
+    return result.stdout.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function detectPackageManager(repoRoot: string): PackageManager {
+  if (existsSync(join(repoRoot, 'pnpm-lock.yaml'))) {
+    return 'pnpm';
+  }
+
+  if (existsSync(join(repoRoot, 'yarn.lock')) || existsSync(join(repoRoot, '.yarnrc.yml'))) {
+    return 'yarn';
+  }
+
+  return 'npm';
+}
+
+function getInstallCommand(packageManager: PackageManager): [string, string[]] {
+  switch (packageManager) {
+    case 'pnpm':
+      return ['pnpm', ['install']];
+    case 'yarn':
+      return ['yarn', ['install']];
+    default:
+      return ['npm', ['install']];
+  }
+}
+
+async function findPackageJsonFiles(repoRoot: string) {
+  return glob('**/package.json', {
+    cwd: repoRoot,
+    absolute: true,
+    ignore: ['**/node_modules/**', '**/dist/**', '**/.git/**'],
+  });
+}
+
+function isStorybookDependency(name: string) {
+  return name === 'storybook' || name.startsWith('@storybook/') || name === 'eslint-plugin-storybook';
+}
+
+async function removeStorybookFromPackageJson(filePath: string): Promise<PackageJsonCleanup | undefined> {
+  const packageJson = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
+  const removedDependencies: string[] = [];
+  const removedScripts: string[] = [];
+
+  for (const sectionName of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    const section = packageJson[sectionName];
+    if (!section || typeof section !== 'object') {
+      continue;
+    }
+
+    for (const dependencyName of Object.keys(section)) {
+      if (!isStorybookDependency(dependencyName)) {
+        continue;
+      }
+
+      delete (section as Record<string, unknown>)[dependencyName];
+      removedDependencies.push(`${sectionName}:${dependencyName}`);
+    }
+  }
+
+  if (packageJson.scripts && typeof packageJson.scripts === 'object') {
+    for (const scriptName of Object.keys(packageJson.scripts as Record<string, unknown>)) {
+      if (!scriptName.includes('storybook')) {
+        continue;
+      }
+
+      delete (packageJson.scripts as Record<string, unknown>)[scriptName];
+      removedScripts.push(scriptName);
+    }
+  }
+
+  if (removedDependencies.length === 0 && removedScripts.length === 0) {
+    return undefined;
+  }
+
+  await writeFile(filePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+  return {
+    path: filePath,
+    removedDependencies,
+    removedScripts,
+  };
+}
+
+async function maybeRemoveStarterStoriesDirectory(directoryPath: string) {
+  if (!existsSync(directoryPath)) {
+    return false;
+  }
+
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  if (entries.length === 0) {
+    await rm(directoryPath, { recursive: true, force: true });
+    return true;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory() && entry.name !== 'assets') {
+      return false;
+    }
+
+    if (entry.isDirectory()) {
+      continue;
+    }
+
+    if (!STORYBOOK_STARTER_FILES.has(entry.name)) {
+      return false;
+    }
+  }
+
+  await rm(directoryPath, { recursive: true, force: true });
+  return true;
+}
+
+async function cleanupStorybookFiles(repoRoot: string): Promise<CleanupSummary> {
+  const removedFiles: string[] = [];
+  const removedDirectories: string[] = [];
+  const updatedPackageJsons: PackageJsonCleanup[] = [];
+
+  for (const filePath of await glob('**/*.{stories,story}.{js,jsx,ts,tsx,mdx}', {
+    cwd: repoRoot,
+    absolute: true,
+    ignore: ['**/node_modules/**', '**/dist/**', '**/.git/**'],
+  })) {
+    await rm(filePath, { force: true });
+    removedFiles.push(filePath);
+  }
+
+  for (const directoryPath of await glob('**/.storybook', {
+    cwd: repoRoot,
+    absolute: true,
+    ignore: ['**/node_modules/**', '**/.git/**'],
+  })) {
+    await rm(directoryPath, { recursive: true, force: true });
+    removedDirectories.push(directoryPath);
+  }
+
+  for (const directoryPath of await glob('**/storybook-static', {
+    cwd: repoRoot,
+    absolute: true,
+    ignore: ['**/node_modules/**', '**/.git/**'],
+  })) {
+    await rm(directoryPath, { recursive: true, force: true });
+    removedDirectories.push(directoryPath);
+  }
+
+  for (const starterDirectory of [
+    join(repoRoot, 'stories'),
+    join(repoRoot, 'src', 'stories'),
+    join(repoRoot, 'packages', 'lib', 'stories'),
+  ]) {
+    if (await maybeRemoveStarterStoriesDirectory(starterDirectory)) {
+      removedDirectories.push(starterDirectory);
+    }
+  }
+
+  for (const packageJsonPath of await findPackageJsonFiles(repoRoot)) {
+    const cleanup = await removeStorybookFromPackageJson(packageJsonPath);
+    if (cleanup) {
+      updatedPackageJsons.push(cleanup);
+    }
+  }
+
+  return {
+    removedFiles: removedFiles.sort(),
+    removedDirectories: removedDirectories.sort(),
+    updatedPackageJsons: updatedPackageJsons.sort((left, right) => left.path.localeCompare(right.path)),
+  };
+}
+
+async function getChangedFiles(repoRoot: string, baselineCommit: string): Promise<ChangedFileSummary[]> {
+  const statusResult = await x('git', ['diff', '--name-status', baselineCommit], {
+    nodeOptions: { cwd: repoRoot },
+  });
+  const summaries: ChangedFileSummary[] = [];
+
+  for (const line of statusResult.stdout.split('\n').filter(Boolean)) {
+    const [rawStatus, ...fileParts] = line.split('\t');
+    const filePath = fileParts.at(-1);
+    if (!rawStatus || !filePath) {
+      continue;
+    }
+
+    const numstat = await x('git', ['diff', '--numstat', baselineCommit, '--', filePath], {
+      nodeOptions: { cwd: repoRoot },
+    });
+    const [added, removed] = (numstat.stdout.split('\t') || []) as [string?, string?];
+
+    summaries.push({
+      path: filePath,
+      status: rawStatus[0] as ChangedFileSummary['status'],
+      addedLines: Number(added) || 0,
+      removedLines: Number(removed) || 0,
+    });
+  }
+
+  return summaries.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function filterStorybookFiles(files: ChangedFileSummary[]) {
+  return files.filter((entry) => {
+    return (
+      entry.path.includes('.storybook/') ||
+      entry.path.includes('storybook/') ||
+      entry.path.includes('preview.') ||
+      entry.path.includes('manager.') ||
+      entry.path.includes('.stories.') ||
+      entry.path.includes('.story.')
+    );
+  });
+}
+
+async function buildPrompt(
+  variant: PromptVariant,
+  benchmark: BenchmarkProject,
+  projectRoot: string,
+  targetDirLabel: string,
+  candidateComponents: Array<{ path: string; complexity: number }>
+) {
+  const promptParts: string[] = [];
+
+  for (const promptFile of variant.promptFiles) {
+    const promptPath = join(PROMPTS_DIRECTORY, promptFile);
+    promptParts.push(await readFile(promptPath, 'utf8'));
+  }
+
+  const candidateList =
+    candidateComponents.length === 0
+      ? '- No obvious candidate components were detected automatically. Inspect the project and choose representative components yourself.'
+      : candidateComponents
+          .map((candidate, index) => {
+            const relativePath = relative(projectRoot, candidate.path);
+            return `${index + 1}. ${relativePath} (complexity ${candidate.complexity})`;
+          })
+          .join('\n');
+
+  promptParts.push(`
+<benchmark_context>
+- Benchmark project: ${benchmark.name}
+- Repository: ${benchmark.repo}
+- Repository branch: ${benchmark.branch ?? 'default'}
+- Target project directory: ${targetDirLabel}
+- Repository tags: ${benchmark.tags.join(', ')}
+- A clean \`npx storybook@latest init --yes\` has already been run. Do not rerun \`storybook init\`.
+- Keep the work focused on making Storybook usable for the real application code, not the demo files generated by init.
+</benchmark_context>
+
+<candidate_components>
+${candidateList}
+</candidate_components>
+`.trim());
+
+  return `${promptParts.join('\n\n')}\n`;
+}
+
+async function cloneBenchmark(
+  benchmark: BenchmarkProject,
+  trialPaths: TrialPaths,
+  logsDir: string
+): Promise<string> {
+  const args = ['clone', '--depth', '1'];
+  if (benchmark.branch) {
+    args.push('--branch', benchmark.branch);
+  }
+  args.push(benchmark.repo, trialPaths.repoDir);
+
+  await runCommand('clone', logsDir, 'git', args, dirname(trialPaths.repoDir));
+  return trialPaths.repoDir;
+}
+
+async function captureGitCommit(repoRoot: string) {
+  const commit = await x('git', ['rev-parse', 'HEAD'], {
+    nodeOptions: { cwd: repoRoot },
+  });
+  return commit.stdout.trim();
+}
+
+async function createBaselineCommit(repoRoot: string, logsDir: string) {
+  await runCommand('git-add-baseline', logsDir, 'git', ['add', '-A'], repoRoot);
+  await runCommand(
+    'git-commit-baseline',
+    logsDir,
+    'git',
+    [
+      '-c',
+      'user.name=storybook-eval',
+      '-c',
+      'user.email=storybook-eval@example.com',
+      'commit',
+      '--no-gpg-sign',
+      '-m',
+      'eval baseline after storybook init',
+    ],
+    repoRoot
+  );
+  return captureGitCommit(repoRoot);
+}
+
+async function prepareProject(
+  benchmark: BenchmarkProject,
+  trialPaths: TrialPaths
+): Promise<PreparedProject> {
+  await ensureDir(trialPaths.trialDir);
+  await ensureDir(dirname(trialPaths.repoDir));
+  await ensureDir(trialPaths.logsDir);
+  await ensureDir(trialPaths.artifactsDir);
+  await ensureDir(trialPaths.tempDir);
+
+  const repoRoot = await cloneBenchmark(benchmark, trialPaths, trialPaths.logsDir);
+  const packageManager = detectPackageManager(repoRoot);
+  const projectRoot = resolve(repoRoot, benchmark.projectDir ?? '.');
+  const targetDirLabel = relative(repoRoot, projectRoot) || '.';
+
+  const cleanup = await cleanupStorybookFiles(repoRoot);
+
+  const [installCommandName, installArgs] = getInstallCommand(packageManager);
+  const installEnv = {
+    CI: '1',
+    YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
+  };
+  const install = await runCommand(
+    'install',
+    trialPaths.logsDir,
+    installCommandName,
+    installArgs,
+    repoRoot,
+    installEnv
+  );
+
+  const init = await runCommand(
+    'storybook-init',
+    trialPaths.logsDir,
+    'npx',
+    ['storybook@latest', 'init', '--yes'],
+    projectRoot,
+    { CI: '1' }
+  );
+
+  const postInitInstall = await runCommand(
+    'post-init-install',
+    trialPaths.logsDir,
+    installCommandName,
+    installArgs,
+    repoRoot,
+    installEnv
+  );
+
+  const candidateComponents = await selectCandidateComponents(projectRoot);
+  const baselineCommit = await createBaselineCommit(repoRoot, trialPaths.logsDir);
+
+  return {
+    benchmark,
+    packageManager,
+    repoRoot,
+    projectRoot,
+    targetDirLabel,
+    candidateComponents,
+    cleanup,
+    install,
+    init,
+    postInitInstall,
+    baselineCommit,
+  };
+}
+
+async function createBaselineWorktree(
+  repoRoot: string,
+  baselineCommit: string,
+  trialPaths: TrialPaths
+) {
+  const baselineDir = join(trialPaths.tempDir, 'baseline-worktree');
+  await runCommand(
+    'git-worktree-baseline',
+    trialPaths.logsDir,
+    'git',
+    ['worktree', 'add', '--detach', baselineDir, baselineCommit],
+    repoRoot
+  );
+  return baselineDir;
+}
+
+async function createFinalCopy(preparedProject: PreparedProject, trialPaths: TrialPaths) {
+  const finalDir = join(trialPaths.tempDir, 'final-copy');
+  await cp(preparedProject.repoRoot, finalDir, {
+    recursive: true,
+    filter: (source) => {
+      const relativePath = relative(preparedProject.repoRoot, source);
+      return !relativePath.startsWith('.git') && !relativePath.startsWith('node_modules');
+    },
+  });
+  return finalDir;
+}
+
+async function ensureAddonVitest(projectRoot: string, logsDir: string, label: string) {
+  const mainConfigCandidates = await glob('.storybook/main.@(js|ts|mjs|cjs)', {
+    cwd: projectRoot,
+    absolute: true,
+  });
+  const mainConfigPath = mainConfigCandidates[0];
+  const mainConfig = mainConfigPath ? await readFile(mainConfigPath, 'utf8') : '';
+  if (mainConfig.includes('@storybook/addon-vitest')) {
+    return;
+  }
+
+  await runCommand(
+    `${label}-addon-vitest`,
+    logsDir,
+    'npx',
+    ['storybook@latest', 'add', '@storybook/addon-vitest', '--yes'],
+    projectRoot,
+    { CI: '1' }
+  );
+}
+
+async function getStorybookBuildRunner(
+  projectRoot: string,
+  packageManager: PackageManager
+): Promise<[string, string[]]> {
+  const packageJsonPath = join(projectRoot, 'package.json');
+  if (existsSync(packageJsonPath)) {
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    if (packageJson.scripts?.['build-storybook']) {
+      switch (packageManager) {
+        case 'pnpm':
+          return ['pnpm', ['run', 'build-storybook']];
+        case 'yarn':
+          return ['yarn', ['build-storybook']];
+        default:
+          return ['npm', ['run', 'build-storybook']];
+      }
+    }
+  }
+
+  return ['npx', ['--no-install', 'storybook', 'build']];
+}
+
+async function runGhostStories(
+  _repoRoot: string,
+  projectRoot: string,
+  logsDir: string,
+  label: string
+): Promise<GhostStoriesResult> {
+  try {
+    await ensureAddonVitest(projectRoot, logsDir, label);
+  } catch (error) {
+    return {
+      status: 'skipped',
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  try {
+    const candidatesModule = await import(
+      pathToFileURL(
+        resolve(ROOT_DIRECTORY, 'code/core/src/core-server/utils/ghost-stories/get-candidates.ts')
+      ).href
+    );
+    const runStoryTestsModule = await import(
+      pathToFileURL(
+        resolve(ROOT_DIRECTORY, 'code/core/src/core-server/utils/ghost-stories/run-story-tests.ts')
+      ).href
+    );
+
+    const previousCwd = process.cwd();
+    process.chdir(projectRoot);
+
+    try {
+      const candidatesResult = await candidatesModule.getComponentCandidates({ sampleSize: 20 });
+      if (candidatesResult.error) {
+        return {
+          status: 'failed',
+          reason: candidatesResult.error,
+          summary: {
+            candidateCount: candidatesResult.candidates.length,
+            analyzedCount: candidatesResult.analyzedCount,
+            avgComplexity: candidatesResult.avgComplexity,
+            runError: candidatesResult.error,
+          },
+        };
+      }
+
+      if (candidatesResult.candidates.length === 0) {
+        return {
+          status: 'skipped',
+          reason: 'No candidate components found for ghost-stories.',
+          summary: {
+            candidateCount: 0,
+            analyzedCount: candidatesResult.analyzedCount,
+            avgComplexity: candidatesResult.avgComplexity,
+          },
+        };
+      }
+
+      const runResult = await runStoryTestsModule.runStoryTests(candidatesResult.candidates);
+      return {
+        status: runResult.runError ? 'failed' : 'passed',
+        reason: runResult.runError,
+        summary: {
+          candidateCount: candidatesResult.candidates.length,
+          analyzedCount: candidatesResult.analyzedCount,
+          avgComplexity: candidatesResult.avgComplexity,
+          total: runResult.summary?.total,
+          passed: runResult.summary?.passed,
+          passedButEmptyRender: runResult.summary?.passedButEmptyRender,
+          successRate: runResult.summary?.successRate,
+          successRateWithoutEmptyRender: runResult.summary?.successRateWithoutEmptyRender,
+          uniqueErrorCount: runResult.summary?.uniqueErrorCount,
+          categorizedErrors: runResult.summary?.categorizedErrors,
+          runError: runResult.runError,
+        },
+      };
+    } finally {
+      process.chdir(previousCwd);
+    }
+  } catch (error) {
+    return {
+      status: 'skipped',
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function runStorybookBuild(
+  projectRoot: string,
+  packageManager: PackageManager,
+  logsDir: string
+): Promise<StepResult> {
+  try {
+    const [commandName, commandArgs] = await getStorybookBuildRunner(projectRoot, packageManager);
+    const command = await runCommand(
+      'storybook-build',
+      logsDir,
+      commandName,
+      commandArgs,
+      projectRoot,
+      { CI: '1' }
+    );
+    return {
+      status: 'passed',
+      command,
+    };
+  } catch (error) {
+    return {
+      status: 'failed',
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function readInterestingFiles(repoRoot: string, changedFiles: ChangedFileSummary[]) {
+  const interestingFiles = changedFiles
+    .map((entry) => join(repoRoot, entry.path))
+    .filter((filePath) => {
+      const lower = filePath.toLowerCase();
+      return (
+        lower.includes('.storybook/') ||
+        lower.endsWith('package.json') ||
+        lower.includes('preview.') ||
+        lower.includes('manager.') ||
+        lower.includes('.stories.') ||
+        lower.includes('.story.') ||
+        lower.endsWith('.css') ||
+        lower.endsWith('.scss')
+      );
+    });
+
+  return Array.from(new Set(interestingFiles));
+}
+
+async function cleanTemporaryDirectories(repoRoot: string, baselineWorktree?: string) {
+  if (baselineWorktree) {
+    await x('git', ['worktree', 'remove', '--force', baselineWorktree], {
+      nodeOptions: { cwd: repoRoot },
+    });
+  }
+}
+
+export async function runEval(options: RunOptions) {
+  const benchmark = getBenchmarkById(options.benchmarkId);
+  const variant = getVariantById(options.variantId);
+  const modelConfig = resolveModel(options.agent, options.tier, options.model);
+  const trialId = createTrialId(benchmark.id, variant.id, options.agent, modelConfig.id);
+  const workspaceRoot = getWorkspaceRoot(options.workspaceRoot);
+  const trialPaths: TrialPaths = {
+    trialDir: join(workspaceRoot, 'trials', trialId),
+    repoDir: join(workspaceRoot, 'trials', trialId, 'repo'),
+    logsDir: join(workspaceRoot, 'trials', trialId, 'logs'),
+    artifactsDir: join(workspaceRoot, 'trials', trialId, 'artifacts'),
+    promptPath: join(workspaceRoot, 'trials', trialId, 'artifacts', 'prompt.md'),
+    resultPath: join(workspaceRoot, 'trials', trialId, 'artifacts', 'result.json'),
+    tempDir: join(workspaceRoot, 'trials', trialId, 'tmp'),
+  };
+
+  const preparedProject = await prepareProject(benchmark, trialPaths);
+  const prompt = await buildPrompt(
+    variant,
+    benchmark,
+    preparedProject.projectRoot,
+    preparedProject.targetDirLabel,
+    preparedProject.candidateComponents
+  );
+  await writeFile(trialPaths.promptPath, prompt);
+
+  const cliVersions = {
+    claude: await detectCliVersion('claude'),
+    codex: await detectCliVersion('codex'),
+  };
+
+  if (options.prepareOnly) {
+    const result: EvalResult = {
+      schemaVersion: 1,
+      benchmark: {
+        id: benchmark.id,
+        name: benchmark.name,
+        repo: benchmark.repo,
+        branch: benchmark.branch ?? 'default',
+        projectDir: benchmark.projectDir ?? '.',
+        tags: benchmark.tags,
+      },
+      variant: {
+        id: variant.id,
+        label: variant.label,
+        description: variant.description,
+      },
+      agent: {
+        name: options.agent,
+        model: modelConfig.id,
+        tier: modelConfig.tier,
+      },
+      environment: {
+        nodeVersion: process.version,
+        packageManager: preparedProject.packageManager,
+        repoRoot: preparedProject.repoRoot,
+        projectRoot: preparedProject.projectRoot,
+        cliVersions,
+      },
+      preparation: {
+        cleanup: preparedProject.cleanup,
+        install: preparedProject.install,
+        init: preparedProject.init,
+        postInitInstall: preparedProject.postInitInstall,
+        baselineCommit: preparedProject.baselineCommit,
+        candidateComponents: preparedProject.candidateComponents,
+      },
+      changes: {
+        files: [],
+        storybookFiles: [],
+        setupPatterns: [],
+      },
+      grading: {
+        storybookBuild: {
+          status: 'skipped',
+          reason: 'Preparation-only run.',
+        },
+        ghostStories: {
+          before: {
+            status: 'skipped',
+            reason: 'Preparation-only run.',
+          },
+          after: {
+            status: 'skipped',
+            reason: 'Preparation-only run.',
+          },
+        },
+      },
+      artifacts: {
+        trialDir: trialPaths.trialDir,
+        logsDir: trialPaths.logsDir,
+        promptPath: trialPaths.promptPath,
+        resultPath: trialPaths.resultPath,
+      },
+    };
+
+    await writeFile(trialPaths.resultPath, `${JSON.stringify(result, null, 2)}\n`);
+    return result;
+  }
+
+  const execution = await executeAgent({
+    agent: options.agent,
+    model: modelConfig.id,
+    prompt,
+    repoRoot: preparedProject.repoRoot,
+    logsDir: trialPaths.logsDir,
+  });
+
+  const changedFiles = await getChangedFiles(preparedProject.repoRoot, preparedProject.baselineCommit);
+  const storybookFiles = filterStorybookFiles(changedFiles);
+  const setupPatterns = await detectSetupPatterns(
+    preparedProject.repoRoot,
+    await readInterestingFiles(preparedProject.repoRoot, changedFiles)
+  );
+  const storybookBuild = await runStorybookBuild(
+    preparedProject.projectRoot,
+    preparedProject.packageManager,
+    trialPaths.logsDir
+  );
+
+  let baselineWorktree: string | undefined;
+  try {
+    baselineWorktree = await createBaselineWorktree(
+      preparedProject.repoRoot,
+      preparedProject.baselineCommit,
+      trialPaths
+    );
+    const baselineProjectRoot = resolve(baselineWorktree, benchmark.projectDir ?? '.');
+    const finalCopyRoot = await createFinalCopy(preparedProject, trialPaths);
+    const finalProjectRoot = resolve(finalCopyRoot, benchmark.projectDir ?? '.');
+
+    const beforeGhostStories = await runGhostStories(
+      baselineWorktree,
+      baselineProjectRoot,
+      trialPaths.logsDir,
+      'ghost-stories-before'
+    );
+    const afterGhostStories = await runGhostStories(
+      finalCopyRoot,
+      finalProjectRoot,
+      trialPaths.logsDir,
+      'ghost-stories-after'
+    );
+
+    const result: EvalResult = {
+      schemaVersion: 1,
+      benchmark: {
+        id: benchmark.id,
+        name: benchmark.name,
+        repo: benchmark.repo,
+        branch: benchmark.branch ?? 'default',
+        projectDir: benchmark.projectDir ?? '.',
+        tags: benchmark.tags,
+      },
+      variant: {
+        id: variant.id,
+        label: variant.label,
+        description: variant.description,
+      },
+      agent: {
+        name: options.agent,
+        model: modelConfig.id,
+        tier: modelConfig.tier,
+      },
+      environment: {
+        nodeVersion: process.version,
+        packageManager: preparedProject.packageManager,
+        repoRoot: preparedProject.repoRoot,
+        projectRoot: preparedProject.projectRoot,
+        cliVersions,
+      },
+      preparation: {
+        cleanup: preparedProject.cleanup,
+        install: preparedProject.install,
+        init: preparedProject.init,
+        postInitInstall: preparedProject.postInitInstall,
+        baselineCommit: preparedProject.baselineCommit,
+        candidateComponents: preparedProject.candidateComponents,
+      },
+      execution,
+      changes: {
+        files: changedFiles,
+        storybookFiles,
+        setupPatterns,
+      },
+      grading: {
+        storybookBuild,
+        ghostStories: {
+          before: beforeGhostStories,
+          after: afterGhostStories,
+        },
+      },
+      artifacts: {
+        trialDir: trialPaths.trialDir,
+        logsDir: trialPaths.logsDir,
+        promptPath: trialPaths.promptPath,
+        resultPath: trialPaths.resultPath,
+      },
+    };
+
+    await writeFile(trialPaths.resultPath, `${JSON.stringify(result, null, 2)}\n`);
+    return result;
+  } finally {
+    await cleanTemporaryDirectories(preparedProject.repoRoot, baselineWorktree);
+  }
+}
+
+export function getDefaultWorkspaceRoot() {
+  return DEFAULT_WORKSPACE_ROOT;
+}

--- a/scripts/evals/storybook-setup/run.ts
+++ b/scripts/evals/storybook-setup/run.ts
@@ -1,7 +1,7 @@
 import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import process from 'node:process';
 
 // eslint-disable-next-line depend/ban-dependencies
@@ -12,6 +12,7 @@ import { ROOT_DIRECTORY } from '../../utils/constants';
 import { getBenchmarkById } from './benchmarks';
 import { selectCandidateComponents } from './candidate-components';
 import { executeAgent } from './agents';
+import { runGhostStoriesEval } from './ghost-stories';
 import { resolveModel } from './models';
 import { detectSetupPatterns } from './setup-patterns';
 import type {
@@ -582,68 +583,12 @@ async function runGhostStories(
   }
 
   try {
-    const candidatesModule = await import(
-      pathToFileURL(
-        resolve(ROOT_DIRECTORY, 'code/core/src/core-server/utils/ghost-stories/get-candidates.ts')
-      ).href
-    );
-    const runStoryTestsModule = await import(
-      pathToFileURL(
-        resolve(ROOT_DIRECTORY, 'code/core/src/core-server/utils/ghost-stories/run-story-tests.ts')
-      ).href
-    );
-
-    const previousCwd = process.cwd();
-    process.chdir(projectRoot);
-
-    try {
-      const candidatesResult = await candidatesModule.getComponentCandidates({ sampleSize: 20 });
-      if (candidatesResult.error) {
-        return {
-          status: 'failed',
-          reason: candidatesResult.error,
-          summary: {
-            candidateCount: candidatesResult.candidates.length,
-            analyzedCount: candidatesResult.analyzedCount,
-            avgComplexity: candidatesResult.avgComplexity,
-            runError: candidatesResult.error,
-          },
-        };
-      }
-
-      if (candidatesResult.candidates.length === 0) {
-        return {
-          status: 'skipped',
-          reason: 'No candidate components found for ghost-stories.',
-          summary: {
-            candidateCount: 0,
-            analyzedCount: candidatesResult.analyzedCount,
-            avgComplexity: candidatesResult.avgComplexity,
-          },
-        };
-      }
-
-      const runResult = await runStoryTestsModule.runStoryTests(candidatesResult.candidates);
-      return {
-        status: runResult.runError ? 'failed' : 'passed',
-        reason: runResult.runError,
-        summary: {
-          candidateCount: candidatesResult.candidates.length,
-          analyzedCount: candidatesResult.analyzedCount,
-          avgComplexity: candidatesResult.avgComplexity,
-          total: runResult.summary?.total,
-          passed: runResult.summary?.passed,
-          passedButEmptyRender: runResult.summary?.passedButEmptyRender,
-          successRate: runResult.summary?.successRate,
-          successRateWithoutEmptyRender: runResult.summary?.successRateWithoutEmptyRender,
-          uniqueErrorCount: runResult.summary?.uniqueErrorCount,
-          categorizedErrors: runResult.summary?.categorizedErrors,
-          runError: runResult.runError,
-        },
-      };
-    } finally {
-      process.chdir(previousCwd);
-    }
+    const runResult = await runGhostStoriesEval(projectRoot);
+    return {
+      status: runResult.ok ? 'passed' : 'failed',
+      reason: runResult.summary.runError,
+      summary: runResult.summary,
+    };
   } catch (error) {
     return {
       status: 'skipped',

--- a/scripts/evals/storybook-setup/setup-patterns.test.ts
+++ b/scripts/evals/storybook-setup/setup-patterns.test.ts
@@ -1,0 +1,31 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { detectSetupPatterns } from './setup-patterns';
+
+const TEST_ROOT = join(process.cwd(), '.tmp-storybook-setup-eval-patterns');
+
+afterEach(async () => {
+  await import('node:fs/promises').then((fs) => fs.rm(TEST_ROOT, { recursive: true, force: true }));
+});
+
+describe('detectSetupPatterns', () => {
+  it('detects common Storybook setup patterns from changed files', async () => {
+    const previewPath = join(TEST_ROOT, '.storybook', 'preview.tsx');
+    await mkdir(dirname(previewPath), { recursive: true });
+    await writeFile(
+      previewPath,
+      `import '../src/index.css';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+`
+    );
+
+    const patterns = await detectSetupPatterns(TEST_ROOT, [previewPath]);
+    expect(patterns.map((entry) => entry.id)).toEqual(
+      expect.arrayContaining(['global-css', 'redux-provider', 'router-provider'])
+    );
+  });
+});

--- a/scripts/evals/storybook-setup/setup-patterns.ts
+++ b/scripts/evals/storybook-setup/setup-patterns.ts
@@ -1,0 +1,95 @@
+import { readFile } from 'node:fs/promises';
+
+import type { SetupPattern } from './types';
+
+const PATTERN_RULES = [
+  {
+    id: 'global-css',
+    label: 'Global CSS import',
+    pattern: /import\s+['"].+\.(css|scss|sass|less)['"]/,
+  },
+  {
+    id: 'router-provider',
+    label: 'Router provider/decorator',
+    pattern: /react-router-dom|MemoryRouter|RouterProvider/,
+  },
+  {
+    id: 'redux-provider',
+    label: 'Redux provider/decorator',
+    pattern: /react-redux|<Provider\b|configureStore|createStore/,
+  },
+  {
+    id: 'styled-components',
+    label: 'Styled-components theme or globals',
+    pattern: /styled-components|createGlobalStyle|ThemeProvider/,
+  },
+  {
+    id: 'tailwind',
+    label: 'Tailwind pipeline or stylesheet',
+    pattern: /tailwind|@tailwind|tailwindcss/,
+  },
+  {
+    id: 'headlessui',
+    label: 'Headless UI integration',
+    pattern: /@headlessui\/react/,
+  },
+  {
+    id: 'graphql',
+    label: 'GraphQL/Apollo provider or mocks',
+    pattern: /apollo|graphql|MockedProvider|urql|relay/,
+  },
+  {
+    id: 'zustand',
+    label: 'Zustand state wiring',
+    pattern: /zustand/,
+  },
+  {
+    id: 'vite-alias',
+    label: 'Vite alias or builder config',
+    pattern: /viteFinal|resolve:\s*\{|alias:/,
+  },
+  {
+    id: 'theme-provider',
+    label: 'App theme provider',
+    pattern: /\bThemeProvider\b|theme:/,
+  },
+];
+
+export async function detectSetupPatterns(
+  repoRoot: string,
+  candidateFiles: string[]
+): Promise<SetupPattern[]> {
+  const patternMap = new Map<string, SetupPattern>();
+  const uniqueFiles = Array.from(new Set(candidateFiles));
+
+  for (const filePath of uniqueFiles) {
+    try {
+      const source = await readFile(filePath, 'utf8');
+      const relativePath = filePath.startsWith(repoRoot)
+        ? filePath.slice(repoRoot.length + 1)
+        : filePath;
+
+      for (const rule of PATTERN_RULES) {
+        if (!rule.pattern.test(source)) {
+          continue;
+        }
+
+        const existing = patternMap.get(rule.id);
+        if (existing) {
+          if (!existing.sourceFiles.includes(relativePath)) {
+            existing.sourceFiles.push(relativePath);
+          }
+          continue;
+        }
+
+        patternMap.set(rule.id, {
+          id: rule.id,
+          label: rule.label,
+          sourceFiles: [relativePath],
+        });
+      }
+    } catch {}
+  }
+
+  return Array.from(patternMap.values()).sort((left, right) => left.id.localeCompare(right.id));
+}

--- a/scripts/evals/storybook-setup/types.ts
+++ b/scripts/evals/storybook-setup/types.ts
@@ -215,4 +215,5 @@ export type RunOptions = {
   variantId: string;
   workspaceRoot: string;
   prepareOnly?: boolean;
+  promptFile?: string;
 };

--- a/scripts/evals/storybook-setup/types.ts
+++ b/scripts/evals/storybook-setup/types.ts
@@ -1,6 +1,7 @@
 export type AgentName = 'claude-code' | 'codex-cli';
 
 export type ModelTier = 'opus' | 'sonnet' | 'haiku';
+export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 
 export type PackageManager = 'npm' | 'pnpm' | 'yarn';
 
@@ -37,6 +38,7 @@ export type ModelConfig = {
   cliModel: string;
   tier: ModelTier;
   label: string;
+  reasoningEffort: ReasoningEffort;
   notes?: string;
 };
 

--- a/scripts/evals/storybook-setup/types.ts
+++ b/scripts/evals/storybook-setup/types.ts
@@ -1,0 +1,216 @@
+export type AgentName = 'claude-code' | 'codex-cli';
+
+export type ModelTier = 'opus' | 'sonnet' | 'haiku';
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn';
+
+export type PromptVariant = {
+  id: string;
+  label: string;
+  description: string;
+  promptFiles: string[];
+};
+
+export type BenchmarkProject = {
+  id: string;
+  name: string;
+  repo: string;
+  branch?: string;
+  projectDir?: string;
+  description: string;
+  tags: string[];
+};
+
+export type SupportedModel =
+  | 'claude-opus-4.6'
+  | 'claude-sonnet-4.6'
+  | 'claude-haiku-4.5'
+  | 'gpt-5.4'
+  | 'gpt-5-codex'
+  | 'gpt-5-codex-mini'
+  | 'gpt-5.4-mini'
+  | 'gpt-5.2-codex';
+
+export type ModelConfig = {
+  id: SupportedModel;
+  agent: AgentName;
+  cliModel: string;
+  tier: ModelTier;
+  label: string;
+  notes?: string;
+};
+
+export type CommandRecord = {
+  name: string;
+  command: string;
+  cwd: string;
+  durationMs: number;
+  exitCode: number;
+  logPath: string;
+};
+
+export type StepResult = {
+  status: 'passed' | 'failed' | 'skipped';
+  reason?: string;
+  command?: CommandRecord;
+};
+
+export type PackageJsonCleanup = {
+  path: string;
+  removedDependencies: string[];
+  removedScripts: string[];
+};
+
+export type CleanupSummary = {
+  removedFiles: string[];
+  removedDirectories: string[];
+  updatedPackageJsons: PackageJsonCleanup[];
+};
+
+export type CandidateComponent = {
+  path: string;
+  complexity: number;
+};
+
+export type SetupPattern = {
+  id: string;
+  label: string;
+  sourceFiles: string[];
+};
+
+export type ChangedFileSummary = {
+  path: string;
+  status: 'A' | 'M' | 'D' | 'R';
+  addedLines: number;
+  removedLines: number;
+};
+
+export type GhostStoriesSummary = {
+  candidateCount: number;
+  analyzedCount?: number;
+  avgComplexity?: number;
+  total?: number;
+  passed?: number;
+  passedButEmptyRender?: number;
+  successRate?: number;
+  successRateWithoutEmptyRender?: number;
+  uniqueErrorCount?: number;
+  categorizedErrors?: Record<
+    string,
+    {
+      count: number;
+      uniqueCount: number;
+      matchedDependencies: string[];
+    }
+  >;
+  runError?: string;
+};
+
+export type GhostStoriesResult = StepResult & {
+  summary?: GhostStoriesSummary;
+};
+
+export type AgentExecutionSummary = {
+  durationMs: number;
+  apiDurationMs?: number;
+  turns?: number;
+  costUsd?: number;
+  promptTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  finalMessage?: string;
+  commandExecutions: Array<{
+    command: string;
+    exitCode?: number;
+  }>;
+  toolCalls: Array<{
+    name: string;
+    input?: Record<string, unknown>;
+  }>;
+  validationCommands: string[];
+  transcriptPath: string;
+  stderrPath: string;
+};
+
+export type PreparedProject = {
+  benchmark: BenchmarkProject;
+  packageManager: PackageManager;
+  repoRoot: string;
+  projectRoot: string;
+  targetDirLabel: string;
+  candidateComponents: CandidateComponent[];
+  cleanup: CleanupSummary;
+  install: CommandRecord;
+  init: CommandRecord;
+  postInitInstall: CommandRecord;
+  baselineCommit: string;
+};
+
+export type EvalResult = {
+  schemaVersion: 1;
+  benchmark: {
+    id: string;
+    name: string;
+    repo: string;
+    branch: string;
+    projectDir: string;
+    tags: string[];
+  };
+  variant: {
+    id: string;
+    label: string;
+    description: string;
+  };
+  agent: {
+    name: AgentName;
+    model: SupportedModel;
+    tier: ModelTier;
+  };
+  environment: {
+    nodeVersion: string;
+    packageManager: PackageManager;
+    repoRoot: string;
+    projectRoot: string;
+    cliVersions: {
+      claude?: string;
+      codex?: string;
+    };
+  };
+  preparation: {
+    cleanup: CleanupSummary;
+    install: CommandRecord;
+    init: CommandRecord;
+    postInitInstall: CommandRecord;
+    baselineCommit: string;
+    candidateComponents: CandidateComponent[];
+  };
+  execution?: AgentExecutionSummary;
+  changes: {
+    files: ChangedFileSummary[];
+    storybookFiles: ChangedFileSummary[];
+    setupPatterns: SetupPattern[];
+  };
+  grading: {
+    storybookBuild: StepResult;
+    ghostStories: {
+      before: GhostStoriesResult;
+      after: GhostStoriesResult;
+    };
+  };
+  artifacts: {
+    trialDir: string;
+    logsDir: string;
+    promptPath: string;
+    resultPath: string;
+  };
+};
+
+export type RunOptions = {
+  benchmarkId: string;
+  agent: AgentName;
+  model?: SupportedModel;
+  tier?: ModelTier;
+  variantId: string;
+  workspaceRoot: string;
+  prepareOnly?: boolean;
+};

--- a/scripts/evals/storybook-setup/variants.ts
+++ b/scripts/evals/storybook-setup/variants.ts
@@ -1,0 +1,31 @@
+import type { PromptVariant } from './types';
+
+export const PROMPT_VARIANTS: PromptVariant[] = [
+  {
+    id: 'baseline',
+    label: 'Baseline setup prompt',
+    description: 'The default setup prompt with provider/style/story guidance and a verification loop.',
+    promptFiles: ['base.md'],
+  },
+  {
+    id: 'strict-self-heal',
+    label: 'Strict self-heal loop',
+    description: 'Adds a stricter fix-verify-repeat loop for experiments around self-healing behavior.',
+    promptFiles: ['base.md', 'strict-self-heal.md'],
+  },
+  {
+    id: 'doctor-hints',
+    label: 'Doctor-first diagnostics',
+    description: 'Encourages Storybook diagnostic commands before the first config edit.',
+    promptFiles: ['base.md', 'doctor-hints.md'],
+  },
+];
+
+export function getVariantById(id: string) {
+  const variant = PROMPT_VARIANTS.find((entry) => entry.id === id);
+  if (!variant) {
+    throw new Error(`Unknown prompt variant "${id}".`);
+  }
+
+  return variant;
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -9,6 +9,7 @@
     "check": "jiti ./check/check-package.ts",
     "check-package": "jiti ./check-package.ts",
     "docs:codemod": "jiti ./snippets/codemod.ts",
+    "eval:storybook-setup": "jiti ./evals/storybook-setup/cli.ts",
     "generate-sandboxes": "jiti ./sandbox/generate.ts",
     "get-report-message": "jiti ./get-report-message.ts",
     "get-sandbox-dir": "jiti ./get-sandbox-dir.ts",


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Added the first Storybook setup eval harness for the agentic setup work tracked in #34295.

This adds a new `scripts/evals/storybook-setup/` runner that:
- clones real benchmark repos
- removes existing Storybook state
- runs `npx storybook@latest init --yes`
- checkpoints that post-init baseline
- normalizes Claude Code and Codex model/tier selection
- generates setup prompts with benchmark context and candidate components
- records structured JSON artifacts for preparation, execution, file diffs, setup patterns, and grading

It also wires in the benchmark set discussed in the issue, adds prompt variants, documents the harness, and updates `AGENTS.md` with the new command flow.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Run `yarn eval:storybook-setup list` and verify the benchmark, variant, tier, and explicit model lists render.
2. Run `yarn exec vitest run -c scripts/vitest.config.ts scripts/evals/storybook-setup` and verify the new helper tests pass.
3. Run `yarn eval:storybook-setup run --benchmark mealdrop --agent codex-cli --prepare-only` and verify it writes a structured artifact under `../storybook-setup-evals/` with clone/install/init/post-init-install/baseline metadata.
4. Run `yarn eval:storybook-setup run --benchmark wikitok --agent codex-cli --prepare-only` and verify nested `projectDir` handling works and the candidate list does not include the generated `Button` or `Header` samples.
5. In the prepared `mealdrop` trial repo, run `yarn build-storybook` and verify the fresh post-init baseline builds successfully.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
