### PR TITLE
fix(addon-vitest): pre-optimize React JSX dev runtime (#32049)

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apply = vi.hoisted(() =>
+  vi.fn(async (key: string, defaultValue?: unknown) => {
+    switch (key) {
+      case 'stories':
+        return ['../src/**/*.stories.tsx'];
+      case 'viteCorePlugins':
+        return [];
+      case 'framework':
+        return '@storybook/react-vite';
+      case 'viteFinal':
+        return { plugins: [], root: process.cwd() };
+      case 'staticDirs':
+        return [];
+      case 'core':
+        return {};
+      case 'features':
+        return {};
+      case 'env':
+        return {};
+      case 'previewHead':
+      case 'previewBody':
+        return '';
+      case 'optimizeViteDeps':
+        return ['react-dom/test-utils', 'react/jsx-dev-runtime'];
+      default:
+        return defaultValue;
+    }
+  })
+);
+
+vi.mock('storybook/internal/common', () => ({
+  DEFAULT_FILES_PATTERN: '**/*.stories.@(ts|tsx|js|jsx|mjs|cjs)',
+  getInterpretedFile: vi.fn(),
+  loadPreviewOrConfigFile: vi.fn(() => undefined),
+  normalizeStories: vi.fn((stories: unknown) => stories),
+  optionalEnvToBoolean: (value: unknown) => value === true || value === 'true',
+  resolvePathInStorybookCache: vi.fn(
+    (name: string, cacheKey: string) => `/cache/${name}/${cacheKey}`
+  ),
+  validateConfigurationFiles: vi.fn(),
+}));
+
+vi.mock('storybook/internal/core-server', () => ({
+  StoryIndexGenerator: {
+    findMatchingFilesForSpecifiers: vi.fn(async () => []),
+    storyFileNames: vi.fn(() => []),
+  },
+  Tag: { TEST: 'test' },
+  experimental_loadStorybook: vi.fn(async () => ({
+    presets: {
+      apply,
+    },
+  })),
+  mapStaticDir: vi.fn(),
+}));
+
+vi.mock('storybook/internal/csf-tools', () => ({
+  componentTransform: vi.fn(),
+  isCsfFactoryPreview: vi.fn(() => false),
+  readConfig: vi.fn(),
+  vitestTransform: vi.fn(),
+}));
+
+vi.mock('storybook/internal/telemetry', () => ({
+  oneWayHash: vi.fn(() => 'project-id'),
+  telemetry: vi.fn(),
+}));
+
+vi.mock('storybook/internal/server-errors', () => ({
+  MainFileMissingError: class MainFileMissingError extends Error {},
+}));
+
+vi.mock('./utils', () => ({
+  requiresProjectAnnotations: vi.fn(async () => false),
+}));
+
+import { storybookTest } from './index';
+
+describe('storybookTest', () => {
+  beforeEach(() => {
+    process.env.VITEST = 'true';
+  });
+
+  afterEach(() => {
+    delete process.env.VITEST;
+    delete process.env.VITEST_STORYBOOK;
+    delete process.env.BUILD_TARGET;
+    vi.clearAllMocks();
+  });
+
+  it('includes preset-provided optimize deps in the Vitest config', async () => {
+    const plugins = await storybookTest({ configDir: '.storybook' });
+    const plugin = plugins.find(({ name }) => name === 'vite-plugin-storybook-test');
+
+    expect(plugin?.config).toBeTypeOf('function');
+
+    const config = await plugin!.config!(
+      { root: process.cwd(), test: {} } as never,
+      {
+        mode: 'test',
+      } as never
+    );
+
+    expect(apply).toHaveBeenCalledWith('optimizeViteDeps', []);
+    expect(config.optimizeDeps?.include).toEqual(
+      expect.arrayContaining(['react-dom/test-utils', 'react/jsx-dev-runtime'])
+    );
+  });
+});

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -213,6 +213,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
     previewLevelTags,
     core,
     features,
+    extraOptimizeDeps,
   ] = await Promise.all([
     presets.apply<PluginOption[]>('viteCorePlugins', []),
     getStoryGlobsAndFiles(presets, directories),
@@ -222,6 +223,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
     extractTagsFromPreview(finalOptions.configDir),
     presets.apply('core'),
     presets.apply('features', {}),
+    presets.apply<string[]>('optimizeViteDeps', []),
   ]);
 
   const pluginsToIgnore = [
@@ -411,15 +413,15 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
         },
 
         optimizeDeps: {
-          include: [
-            '@storybook/addon-vitest/internal/setup-file',
-            '@storybook/addon-vitest/internal/global-setup',
-            '@storybook/addon-vitest/internal/test-utils',
-            'storybook/preview-api',
-            ...(frameworkName?.includes('react') || frameworkName?.includes('nextjs')
-              ? ['react-dom/test-utils']
-              : []),
-          ],
+          include: Array.from(
+            new Set([
+              '@storybook/addon-vitest/internal/setup-file',
+              '@storybook/addon-vitest/internal/global-setup',
+              '@storybook/addon-vitest/internal/test-utils',
+              'storybook/preview-api',
+              ...extraOptimizeDeps,
+            ])
+          ),
         },
 
         define: {

--- a/code/renderers/react/src/preset.test.ts
+++ b/code/renderers/react/src/preset.test.ts
@@ -1,4 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('storybook/internal/common', () => ({
+  getProjectRoot: vi.fn(),
+}));
+
+vi.mock('../../../core/src/shared/utils/module', () => ({
+  resolvePackageDir: vi.fn(),
+}));
+
+vi.mock('./componentManifest/reactDocgen/extractReactDocgenInfo', () => ({
+  extractArgTypesFromDocgen: vi.fn(),
+}));
+
+vi.mock('./componentManifest/reactDocgen/extractReactTypescriptDocgenInfo', () => ({
+  extractArgTypesFromDocgenTypescript: vi.fn(),
+}));
+
+vi.mock('./componentManifest/generator', () => ({
+  manifests: vi.fn(),
+}));
+
+vi.mock('./enrichCsf', () => ({
+  enrichCsf: vi.fn(),
+}));
 
 import { optimizeViteDeps } from './preset';
 
@@ -9,5 +33,11 @@ describe('optimizeViteDeps', () => {
     // so it must be listed explicitly in optimizeViteDeps.
     // If this test fails, add 'react-dom/test-utils' back to the optimizeViteDeps array in preset.ts.
     expect(optimizeViteDeps).toContain('react-dom/test-utils');
+  });
+
+  it('includes react/jsx-dev-runtime', () => {
+    // React stories and tests can import the development JSX runtime on first execution.
+    // If Vite optimizes it lazily during the run, hooks can break until the cache is warm.
+    expect(optimizeViteDeps).toContain('react/jsx-dev-runtime');
   });
 });

--- a/code/renderers/react/src/preset.ts
+++ b/code/renderers/react/src/preset.ts
@@ -136,4 +136,4 @@ export async function internal_getArgTypesData(
   return argTypesData;
 }
 
-export const optimizeViteDeps: string[] = ['react-dom/test-utils'];
+export const optimizeViteDeps: string[] = ['react-dom/test-utils', 'react/jsx-dev-runtime'];


### PR DESCRIPTION
## Summary
- reuse preset-provided `optimizeViteDeps` in `@storybook/addon-vitest` instead of hardcoding a partial React-only list
- add `react/jsx-dev-runtime` to the shared React optimize-deps preset so first-run Vitest browser tests do not trigger a late dependency rebundle
- cover both paths with focused regression tests

Fixes #32049.

## Validation
- `corepack yarn workspace @storybook/addon-vitest exec vitest --config vitest.config.ts --run src/vitest-plugin/index.test.ts`
- `corepack yarn exec vitest --root code/renderers/react --config vitest.config.ts --run src/preset.test.ts`
- `corepack yarn exec oxfmt --check code/renderers/react/src/preset.ts code/renderers/react/src/preset.test.ts code/addons/vitest/src/vitest-plugin/index.ts code/addons/vitest/src/vitest-plugin/index.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Vitest integration dependency optimization with improved extensibility through preset configuration
  * Added `react/jsx-dev-runtime` to optimized dependencies for React projects, improving performance in test environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->