### PR TITLE
A11y: Fix MDX heading anchors not keyboard accessible

### DIFF
--- a/code/addons/docs/src/blocks/blocks/mdx.tsx
+++ b/code/addons/docs/src/blocks/blocks/mdx.tsx
@@ -2,7 +2,7 @@ import type { FC, MouseEvent, PropsWithChildren, SyntheticEvent } from 'react';
 import React, { useContext } from 'react';
 
 import type { SupportedLanguage } from 'storybook/internal/components';
-import { Code, components, nameSpaceClassNames } from 'storybook/internal/components';
+import { Button, Code, components, nameSpaceClassNames } from 'storybook/internal/components';
 import { NAVIGATE_URL } from 'storybook/internal/core-events';
 
 import { LinkIcon } from '@storybook/icons';
@@ -149,7 +149,7 @@ const OcticonHeaders = SUPPORTED_MDX_HEADERS.reduce(
         top: '-0.1em',
         visibility: 'hidden',
       },
-      '&:hover svg': {
+      '&:hover svg, &:focus-within svg': {
         visibility: 'visible',
       },
     }),
@@ -157,17 +157,18 @@ const OcticonHeaders = SUPPORTED_MDX_HEADERS.reduce(
   {}
 );
 
-const OcticonAnchor = styled.a(
-  () =>
-    ({
-      float: 'left',
-      lineHeight: 'inherit',
-      paddingRight: '10px',
-      marginLeft: '-24px',
-      // Allow the theme's text color to override the default link color.
-      color: 'inherit',
-    }) as const
-);
+const OcticonAnchorWrapper = styled.span(() => ({
+  float: 'left',
+  lineHeight: 'inherit',
+  paddingRight: '10px',
+  marginLeft: '-24px',
+  // Allow the theme's text color to override the default link color.
+  color: 'inherit',
+  '& a': {
+    color: 'inherit',
+    textDecoration: 'none',
+  },
+}));
 
 interface HeaderWithOcticonAnchorProps {
   as: string;
@@ -188,20 +189,23 @@ const HeaderWithOcticonAnchor: FC<PropsWithChildren<HeaderWithOcticonAnchorProps
 
   return (
     <OcticonHeader id={id} {...rest}>
-      <OcticonAnchor
-        aria-hidden="true"
-        href={hash}
-        tabIndex={-1}
-        target="_self"
-        onClick={(event: SyntheticEvent) => {
-          const element = document.getElementById(id);
-          if (element) {
-            navigate(context, hash);
-          }
-        }}
-      >
-        <LinkIcon />
-      </OcticonAnchor>
+      <OcticonAnchorWrapper>
+        <Button asChild variant="ghost" size="small" ariaLabel="Copy heading URL to address bar">
+          <a
+            href={hash}
+            target="_self"
+            onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+              event.preventDefault();
+              const element = document.getElementById(id);
+              if (element) {
+                navigate(context, hash);
+              }
+            }}
+          >
+            <LinkIcon />
+          </a>
+        </Button>
+      </OcticonAnchorWrapper>
       {children}
     </OcticonHeader>
   );

--- a/code/addons/docs/src/blocks/blocks/mdx.tsx
+++ b/code/addons/docs/src/blocks/blocks/mdx.tsx
@@ -144,6 +144,7 @@ const OcticonHeaders = SUPPORTED_MDX_HEADERS.reduce(
   (acc, headerType) => ({
     ...acc,
     [headerType]: styled(headerType)({
+      position: 'relative',
       '& svg': {
         position: 'relative',
         top: '-0.1em',
@@ -158,10 +159,14 @@ const OcticonHeaders = SUPPORTED_MDX_HEADERS.reduce(
 );
 
 const OcticonAnchorWrapper = styled.span({
-  float: 'left',
+  // Position the anchor in the heading's left gutter instead of floating it, so the
+  // Button's dimensions never shift the heading text. The parent header is relatively
+  // positioned to anchor this.
+  position: 'absolute',
+  top: 0,
+  right: '100%',
   lineHeight: 'inherit',
   paddingRight: '10px',
-  marginLeft: '-24px',
   // Allow the theme's text color to override the default link color.
   color: 'inherit',
   '& a': {

--- a/code/addons/docs/src/blocks/blocks/mdx.tsx
+++ b/code/addons/docs/src/blocks/blocks/mdx.tsx
@@ -157,7 +157,7 @@ const OcticonHeaders = SUPPORTED_MDX_HEADERS.reduce(
   {}
 );
 
-const OcticonAnchorWrapper = styled.span(() => ({
+const OcticonAnchorWrapper = styled.span({
   float: 'left',
   lineHeight: 'inherit',
   paddingRight: '10px',
@@ -168,7 +168,7 @@ const OcticonAnchorWrapper = styled.span(() => ({
     color: 'inherit',
     textDecoration: 'none',
   },
-}));
+});
 
 interface HeaderWithOcticonAnchorProps {
   as: string;


### PR DESCRIPTION
## Description                                                                                                                                                                            
  Makes MDX heading anchors keyboard accessible by replacing the inaccessible styled anchor with a Button component.                                                                        
                                                                                                                                                                                            
  ## Related Issue                                                                                                                                                                          
  Fixes #33240
                                                                                                                                                                                            
  ## Changes Made                                                                                                                                                                           
  - Replaced `styled.a` (`OcticonAnchor`) with `Button asChild` wrapping an `<a>` element for consistent styling and built-in accessibility                                                 
  - Removed `aria-hidden="true"` and `tabIndex={-1}` so the anchor is reachable by keyboard and screen readers                                                                              
  - Added `ariaLabel="Copy heading URL to address bar"` which also provides an automatic tooltip on hover/focus                                                                             
  - Added `&:focus-within svg` style to show the link icon on keyboard focus (alongside existing `:hover`)                                                                                  
  - Anchor remains an `<a>` with `href` so tocbot Table of Contents continues to work                                                                                                       
                                                                                                                                                                                            
  ## How it works                                                                                                                                                                           
  - `Button asChild` uses Radix Slot to render an `<a>` element with button styles — visually a button, semantically a link                                                                 
  - `ariaLabel` on Button automatically creates a tooltip via `InteractiveTooltipWrapper`                                                                                                   
  - `:focus-within` on the heading container makes the SVG icon visible when the anchor inside receives keyboard focus                                                                      
                                                                                                                                                                                            
 #### Manual testing                                                                                                                                                                         
  1. Open any MDX docs page with headings                                                                                                                                                   
  2. Press Tab — anchor icons should become visible on focus                                                                                                                                
  3. Tooltip "Copy heading URL to address bar" should appear on focus/hover                                                                                                                 
  4. Enter navigates to the heading anchor                                                                                                                                                  
  5. Hover still works as before                                                                                                                                                            
                                                                                                                                                                                            
  ## Checklist                                                                                                                                                                              
  - [x] Linter passes (0 errors)                                                                                                                                                            
  - [x] Tested manually in sandbox 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header icons now appear on both hover and keyboard focus, improving discoverability and keyboard navigation.

* **Bug Fixes**
  * Copy-heading control updated for more reliable activation and target validation; accessibility labels and visual behavior improved for keyboard and assistive‑tech users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->