### PR TITLE
fix(builder-vite): avoid preview annotation alias collisions

### DIFF
--- a/code/builders/builder-vite/src/codegen-project-annotations.test.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('storybook/internal/common', () => ({}), { virtual: true });
+vi.mock('storybook/internal/csf-tools', () => ({}), { virtual: true });
+
+describe('generateProjectAnnotationsCodeFromPreviews', () => {
+  it('suffixes preview annotation identifiers when the generated name collides', async () => {
+    const { generateProjectAnnotationsCodeFromPreviews } =
+      await import('./codegen-project-annotations');
+
+    const result = generateProjectAnnotationsCodeFromPreviews({
+      previewAnnotations: [
+        '/virtual/addons/000r/preview.js',
+        '/virtual/addons/0020/preview.js',
+        '/virtual/project/.storybook/preview.ts',
+      ],
+      projectRoot: '/virtual/project',
+      frameworkName: 'test-framework',
+      isCsf4: false,
+    });
+
+    expect(result).toContain(
+      'import * as preview_51981552 from "/virtual/addons/000r/preview.js";'
+    );
+    expect(result).toContain(
+      'import * as preview_51981552_1 from "/virtual/addons/0020/preview.js";'
+    );
+    expect(result).toContain('hmrPreviewAnnotationModules[0] ?? preview_51981552');
+    expect(result).toContain('hmrPreviewAnnotationModules[1] ?? preview_51981552_1');
+  });
+});

--- a/code/builders/builder-vite/src/codegen-project-annotations.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.ts
@@ -44,11 +44,9 @@ export function generateProjectAnnotationsCodeFromPreviews(options: {
 
   const variables: string[] = [];
   const imports: string[] = [];
+  const usedVariables = new Map<string, number>();
   for (const previewAnnotation of previewAnnotationURLs) {
-    const variable =
-      genSafeVariableName(filename(previewAnnotation)).replace(/_(45|46|47)/g, '_') +
-      '_' +
-      hash(previewAnnotation);
+    const variable = getUniquePreviewAnnotationVariableName(previewAnnotation, usedVariables);
     variables.push(variable);
     imports.push(genImport(previewAnnotation, { name: '*', as: variable }));
   }
@@ -103,6 +101,26 @@ export function generateProjectAnnotationsCodeFromPreviews(options: {
       });
     }
   `.trim();
+}
+
+function getUniquePreviewAnnotationVariableName(
+  previewAnnotation: string,
+  usedVariables: Map<string, number>
+) {
+  const baseVariableName = getPreviewAnnotationVariableName(previewAnnotation);
+  const duplicateCount = usedVariables.get(baseVariableName) ?? 0;
+  usedVariables.set(baseVariableName, duplicateCount + 1);
+
+  // Hash collisions are rare but possible, so suffix any repeated identifier.
+  return duplicateCount === 0 ? baseVariableName : `${baseVariableName}_${duplicateCount}`;
+}
+
+function getPreviewAnnotationVariableName(previewAnnotation: string) {
+  return (
+    genSafeVariableName(filename(previewAnnotation)).replace(/_(45|46|47)/g, '_') +
+    '_' +
+    hash(previewAnnotation)
+  );
 }
 
 /** djb2 hash — http://www.cse.yorku.ca/~oz/hash.html */


### PR DESCRIPTION
## Summary
- suffix duplicate generated preview import identifiers only when the hashed base name collides
- keep the existing generated naming scheme for the non-collision case
- add a focused builder-vite regression covering a deterministic preview hash collision on current `next`

## Testing
- `corepack yarn vitest run --config code/builders/builder-vite/vitest.config.ts code/builders/builder-vite/src/codegen-project-annotations.test.ts`
- `corepack yarn oxfmt --check code/builders/builder-vite/src/codegen-project-annotations.ts code/builders/builder-vite/src/codegen-project-annotations.test.ts`
- `git diff --check`

Fixes #34372.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview annotation module handling to prevent naming conflicts when multiple preview files are present.

* **Tests**
  * Added test coverage for preview annotation code generation to ensure proper handling of duplicate module names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->