### PR TITLE
Maintenance: Use errorToErrorLike in boot-test-runner for consistent stack deduplication

### DIFF
--- a/code/addons/vitest/src/node/boot-test-runner.ts
+++ b/code/addons/vitest/src/node/boot-test-runner.ts
@@ -18,6 +18,7 @@ import {
   TEST_PROVIDER_STORE_CHANNEL_EVENT_NAME,
 } from '../constants';
 import { log } from '../logger';
+import { errorToErrorLike } from '../utils';
 import type { Store } from '../types';
 
 const MAX_START_TIME = 30000;
@@ -144,12 +145,7 @@ const bootTestRunner = async ({
       type: 'FATAL_ERROR',
       payload: {
         message: 'Failed to start test runner process',
-        error: {
-          message: error.message,
-          name: error.name,
-          stack: error.stack,
-          cause: error.cause,
-        },
+        error: error instanceof Error ? errorToErrorLike(error) : { message: String(error) },
       },
     });
     eventQueue.length = 0;


### PR DESCRIPTION
## Summary

Fixes #34143

The `trackInitWithContext` analysis also pointed out that `boot-test-runner.ts`'s `.catch()` handler was constructing an error-like object inline instead of using the canonical `errorToErrorLike()` utility from `../utils`.

### Problem

`boot-test-runner.ts` (line ~147) built the error payload manually:

```ts
error: {
  message: error.message,
  name: error.name,
  stack: error.stack,       // ⚠ No message deduplication from stack
  cause: error.cause,       // ⚠ No recursive ErrorLike conversion
},
```

The canonical `errorToErrorLike()` in `utils.ts` deduplicates the error message from the stack trace and recursively converts `cause` to `ErrorLike`. The inline version skipped both.

### Fix

Import and use `errorToErrorLike()` from `../utils`. Added `error instanceof Error` guard since the catch receives `unknown`.

### What was NOT changed

`reporter.ts` works with `SerializedError` objects from Vitest (already serialized, not raw `Error` instances), so it doesn't use `errorToErrorLike` — that's intentional and left as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the test runner initialization to robustly manage unexpected error types that may not conform to standard Error object structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->