### PR TITLE
React: Respect tsconfigPath option in react-docgen-typescript parser

### DIFF
--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
@@ -193,8 +193,8 @@ async function getParser(userOptions?: ParserOptions) {
 
   if (!parser) {
     // If the user provided a tsconfigPath, use it instead of auto-detecting
-    const { tsconfigPath: customTsconfigPath, ...restUserOptions } = (userOptions ?? {}) as
-      ParserOptions & { tsconfigPath?: string };
+    const { tsconfigPath: customTsconfigPath, ...restUserOptions } = (userOptions ??
+      {}) as ParserOptions & { tsconfigPath?: string };
     const configPath = customTsconfigPath
       ? resolve(process.cwd(), customTsconfigPath)
       : findTsconfigPath(process.cwd());

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 import {
   type ComponentDoc,
@@ -192,7 +192,12 @@ async function getParser(userOptions?: ParserOptions) {
   }
 
   if (!parser) {
-    const configPath = findTsconfigPath(process.cwd());
+    // If the user provided a tsconfigPath, use it instead of auto-detecting
+    const { tsconfigPath: customTsconfigPath, ...restUserOptions } = (userOptions ?? {}) as
+      ParserOptions & { tsconfigPath?: string };
+    const configPath = customTsconfigPath
+      ? resolve(process.cwd(), customTsconfigPath)
+      : findTsconfigPath(process.cwd());
     cachedCompilerOptions = { noErrorTruncation: true, strict: true };
 
     if (configPath) {
@@ -217,7 +222,7 @@ async function getParser(userOptions?: ParserOptions) {
     const parserOptions: ParserOptions = {
       shouldExtractLiteralValuesFromEnum: true,
       shouldRemoveUndefinedFromOptional: true,
-      ...userOptions,
+      ...restUserOptions,
       // Always force savePropValueAsString so default values are in a consistent format
       savePropValueAsString: true,
     };

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
@@ -201,14 +201,16 @@ async function getParser(userOptions?: ParserOptions) {
     cachedCompilerOptions = { noErrorTruncation: true, strict: true };
 
     if (configPath) {
-      const { config } = typescript.readConfigFile(configPath, typescript.sys.readFile);
-      const parsed = typescript.parseJsonConfigFileContent(
-        config,
-        typescript.sys,
-        dirname(configPath)
-      );
-      cachedCompilerOptions = { ...parsed.options, noErrorTruncation: true };
-      cachedFileNames = parsed.fileNames;
+      const { config, error } = typescript.readConfigFile(configPath, typescript.sys.readFile);
+      if (!error && config) {
+        const parsed = typescript.parseJsonConfigFileContent(
+          config,
+          typescript.sys,
+          dirname(configPath)
+        );
+        cachedCompilerOptions = { ...parsed.options, noErrorTruncation: true };
+        cachedFileNames = parsed.fileNames;
+      }
     }
 
     const program = typescript.createProgram(


### PR DESCRIPTION
Closes #34386

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`getParser()` in `reactDocgenTypescript.ts` was hardcoded to always call `findTsconfigPath(process.cwd())` for locating the TypeScript config. It completely ignored the `tsconfigPath` value that users can pass through `reactDocgenTypescriptOptions` in their Storybook config.

This broke monorepo setups where the root `tsconfig.json` uses project references with empty `include`/`files` arrays — the auto-detected tsconfig had no files listed, so `react-docgen-typescript` couldn't extract any component documentation.

The fix pulls `tsconfigPath` out of the user options and resolves it relative to `process.cwd()` when provided. When it's not set, the existing auto-detection behavior kicks in as before. I also made sure `tsconfigPath` gets stripped from the options object before it's forwarded to `react-docgen-typescript`, since it's not part of their `ParserOptions` type.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

No automated tests added — the change is a small conditional branch in config resolution (`tsconfigPath` provided vs auto-detected), and the existing parser behavior is unchanged when the option isn't set. Best verified manually with an actual monorepo setup as described below.

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Set up a monorepo with a solution-style root `tsconfig.json` (empty `include`/`files`, only `references`)
2. Create a separate `tsconfig.storybook.json` that explicitly includes the component source files:
   ```json
   {
     "extends": "./tsconfig.base.json",
     "include": ["packages/*/src/**/*.ts", "packages/*/src/**/*.tsx"]
   }
   ```
3. Configure `.storybook/main.ts`:
   ```ts
   typescript: {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
       tsconfigPath: './tsconfig.storybook.json',
     },
   },
   ```
4. Run Storybook and check the Controls/Docs panel — component props should now be extracted correctly

Without this fix, step 4 shows no props because the auto-detected root tsconfig has no files to parse.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow specifying an optional TypeScript configuration path for component manifest settings so custom tsconfig locations can be used.

* **Improvements**
  * More reliable TS config resolution and loading with safer handling of user-provided options to avoid unintended parser configuration and to apply settings only when the config loads successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->