### PR TITLE
React-Docgen: Try .tsx fallback when resolving .js ESM imports in docgen resolvers

### DIFF
--- a/code/frameworks/react-vite/src/plugins/docgen-resolver.ts
+++ b/code/frameworks/react-vite/src/plugins/docgen-resolver.ts
@@ -55,9 +55,16 @@ export function defaultLookupModule(filename: string, basedir: string): string {
     switch (ext) {
       case '.js':
       case '.mjs':
-      case '.cjs':
-        newFilename = `${filename.slice(0, -2)}ts`;
+      case '.cjs': {
+        // Try .ts first, then fall back to .tsx (for React components using ESM-style .js imports)
+        const base = filename.slice(0, -2);
+        try {
+          return resolve.sync(`${base}ts`, { ...resolveOptions, extensions: [] });
+        } catch {
+          newFilename = `${base}tsx`;
+        }
         break;
+      }
 
       case '.jsx':
         newFilename = `${filename.slice(0, -3)}tsx`;

--- a/code/presets/react-webpack/src/loaders/docgen-resolver.ts
+++ b/code/presets/react-webpack/src/loaders/docgen-resolver.ts
@@ -55,9 +55,16 @@ export function defaultLookupModule(filename: string, basedir: string): string {
     switch (ext) {
       case '.js':
       case '.mjs':
-      case '.cjs':
-        newFilename = `${filename.slice(0, -2)}ts`;
+      case '.cjs': {
+        // Try .ts first, then fall back to .tsx (for React components using ESM-style .js imports)
+        const base = filename.slice(0, -2);
+        try {
+          return resolve.sync(`${base}ts`, { ...resolveOptions, extensions: [] });
+        } catch {
+          newFilename = `${base}tsx`;
+        }
         break;
+      }
 
       case '.jsx':
         newFilename = `${filename.slice(0, -3)}tsx`;

--- a/code/renderers/react/src/componentManifest/reactDocgen/docgenResolver.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/docgenResolver.ts
@@ -38,9 +38,16 @@ export function defaultLookupModule(filename: string, basedir: string): string {
     switch (ext) {
       case '.js':
       case '.mjs':
-      case '.cjs':
-        newFilename = `${filename.slice(0, -2)}ts`;
+      case '.cjs': {
+        // Try .ts first, then fall back to .tsx (for React components using ESM-style .js imports)
+        const base = filename.slice(0, -2); // removes "js" keeping the dot, e.g. "Chip." or "Chip.m"
+        try {
+          return resolve.sync(`${base}ts`, { ...resolveOptions, extensions: [] });
+        } catch {
+          newFilename = `${base}tsx`;
+        }
         break;
+      }
 
       case '.jsx':
         newFilename = `${filename.slice(0, -3)}tsx`;


### PR DESCRIPTION
## What

When resolving ESM-style `.js` imports that point to TypeScript files, the docgen resolver tried `.ts` as a fallback but never tried `.tsx`. This means React components using `.tsx` extension with ESM-style imports fail MCP manifest generation with "No component file found".

Fixes #34387

## Changes

Updated the `.js`/`.mjs`/`.cjs` fallback logic in all three copies of the docgen resolver pattern to try `.ts` first, then fall back to `.tsx`:

- `code/frameworks/react-vite/src/plugins/docgen-resolver.ts`
- `code/presets/react-webpack/src/loaders/docgen-resolver.ts`
- `code/renderers/react/src/componentManifest/reactDocgen/docgenResolver.ts`

**Before:**
```ts
case '.js': newFilename = `${filename.slice(0, -2)}ts`; // Chip.js → Chip.ts (fails if Chip.tsx)
```

**After:**
```ts
case '.js': {
  try { return resolve.sync(`${base}ts`, ...); } // try Chip.ts first
  catch { newFilename = `${base}tsx`; }          // fall back to Chip.tsx
  break;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module resolution fallback mechanisms across multiple framework packages to provide more robust handling of CommonJS imports in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->