### PR TITLE
Debug: Debug Dangerfile PR data content (Kasper)

### DIFF
--- a/scripts/dangerfile.js
+++ b/scripts/dangerfile.js
@@ -166,6 +166,10 @@ const checkTargetBranch = () => {
   const author = danger.github.pr.user;
   const authorAssociation = danger.github.pr.author_association;
 
+  console.log('authorAssociation', authorAssociation);
+  console.log('author', author);
+  console.log(JSON.stringify(danger.github.pr, null, 2));
+
   // Only check for non-team members (not OWNER, MEMBER) and skip GitHub Actions bot
   if (
     ['OWNER', 'MEMBER'].includes(authorAssociation) ||
@@ -173,6 +177,8 @@ const checkTargetBranch = () => {
   ) {
     return;
   }
+
+  fail(JSON.stringify(danger.github.pr, null, 2));
 
   if (targetBranch === 'main' || targetBranch.includes('release')) {
     fail(


### PR DESCRIPTION
## Summary

- Adds debug `console.log` statements and a `fail()` call to the `checkTargetBranch` function in `scripts/dangerfile.js` to inspect the `author_association` value DangerJS receives for Kasper's PRs.
- Includes an empty `foo` file to ensure there is a file change for CI to pick up.

This replicates the exact debug approach Steve used in PR #34398 to investigate the DangerJS `author_association` check that incorrectly failed on PR #34365. The goal is to verify whether DangerJS correctly recognizes Kasper's `author_association` as `MEMBER`.

## Test plan

- [ ] Observe the DangerJS CI check output on this PR
- [ ] Verify the logged `authorAssociation` value is `MEMBER`
- [ ] Confirm the `fail()` call is or is not triggered based on the association

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR validation checks to fail earlier for unauthorized pull request authors, with additional debug output added for troubleshooting purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->