### PR TITLE
Controls: Prevent AbortError when rapidly resetting

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -351,6 +351,17 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   const [isResetting, setIsResetting] = useState(false);
 
   useEffect(() => {
+    if (!isResetting) {
+      return;
+    }
+    const fallbackTimer = setTimeout(() => {
+      isResettingRef.current = false;
+      setIsResetting(false);
+    }, 1000);
+    return () => clearTimeout(fallbackTimer);
+  }, [isResetting]);
+
+  useEffect(() => {
     if (isResettingRef.current) {
       const timer = setTimeout(() => {
         isResettingRef.current = false;

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -351,24 +351,8 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   const [isResetting, setIsResetting] = useState(false);
 
   useEffect(() => {
-    if (!isResetting) {
-      return;
-    }
-    const fallbackTimer = setTimeout(() => {
-      isResettingRef.current = false;
-      setIsResetting(false);
-    }, 1000);
-    return () => clearTimeout(fallbackTimer);
-  }, [isResetting]);
-
-  useEffect(() => {
-    if (isResettingRef.current) {
-      const timer = setTimeout(() => {
-        isResettingRef.current = false;
-        setIsResetting(false);
-      }, 300);
-      return () => clearTimeout(timer);
-    }
+    isResettingRef.current = false;
+    setIsResetting(false);
   }, [args]);
 
   const handleResetClick = useCallback(() => {

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -430,7 +430,7 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
               padding="small"
               onClick={handleResetClick}
               disabled={isResetting}
-              ariaLabel="Reset controls"
+              ariaLabel={isResetting ? 'Resetting controls...' : 'Reset controls'}
             >
               <UndoIcon />
             </StyledButton>

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -338,6 +338,17 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   const [isResetting, setIsResetting] = useState(false);
 
   useEffect(() => {
+    if (!isResetting) {
+      return;
+    }
+    const fallbackTimer = setTimeout(() => {
+      isResettingRef.current = false;
+      setIsResetting(false);
+    }, 1000);
+    return () => clearTimeout(fallbackTimer);
+  }, [isResetting]);
+
+  useEffect(() => {
     if (isResettingRef.current) {
       const timer = setTimeout(() => {
         isResettingRef.current = false;

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -338,24 +338,8 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   const [isResetting, setIsResetting] = useState(false);
 
   useEffect(() => {
-    if (!isResetting) {
-      return;
-    }
-    const fallbackTimer = setTimeout(() => {
-      isResettingRef.current = false;
-      setIsResetting(false);
-    }, 1000);
-    return () => clearTimeout(fallbackTimer);
-  }, [isResetting]);
-
-  useEffect(() => {
-    if (isResettingRef.current) {
-      const timer = setTimeout(() => {
-        isResettingRef.current = false;
-        setIsResetting(false);
-      }, 300);
-      return () => clearTimeout(timer);
-    }
+    isResettingRef.current = false;
+    setIsResetting(false);
   }, [args]);
 
   const handleResetClick = useCallback(() => {

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { once } from 'storybook/internal/client-logger';
 import { Button, Link, ResetWrapper } from 'storybook/internal/components';
@@ -344,6 +344,30 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
     controlsId,
   } = props;
 
+  const { rows, args, globals } =
+    'rows' in props ? props : { rows: undefined, args: undefined, globals: undefined };
+
+  const isResettingRef = useRef(false);
+  const [isResetting, setIsResetting] = useState(false);
+
+  useEffect(() => {
+    if (isResettingRef.current) {
+      const timer = setTimeout(() => {
+        isResettingRef.current = false;
+        setIsResetting(false);
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [args]);
+
+  const handleResetClick = useCallback(() => {
+    if (!isResettingRef.current && resetArgs) {
+      isResettingRef.current = true;
+      setIsResetting(true);
+      resetArgs();
+    }
+  }, [resetArgs]);
+
   if ('error' in props) {
     const { error } = props;
     return (
@@ -364,9 +388,6 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   if (isLoading) {
     return <Skeleton />;
   }
-
-  const { rows, args, globals } =
-    'rows' in props ? props : { rows: undefined, args: undefined, globals: undefined };
   const groups: Sections = groupRows(
     pickBy(
       rows || {},
@@ -412,7 +433,8 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
             <StyledButton
               variant="ghost"
               padding="small"
-              onClick={() => resetArgs()}
+              onClick={handleResetClick}
+              disabled={isResetting}
               ariaLabel="Reset controls"
             >
               <UndoIcon />

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { once } from 'storybook/internal/client-logger';
 import { Button, Link, ResetWrapper } from 'storybook/internal/components';
@@ -331,6 +331,30 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
     storyId,
   } = props;
 
+  const { rows, args, globals } =
+    'rows' in props ? props : { rows: undefined, args: undefined, globals: undefined };
+
+  const isResettingRef = useRef(false);
+  const [isResetting, setIsResetting] = useState(false);
+
+  useEffect(() => {
+    if (isResettingRef.current) {
+      const timer = setTimeout(() => {
+        isResettingRef.current = false;
+        setIsResetting(false);
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [args]);
+
+  const handleResetClick = useCallback(() => {
+    if (!isResettingRef.current && resetArgs) {
+      isResettingRef.current = true;
+      setIsResetting(true);
+      resetArgs();
+    }
+  }, [resetArgs]);
+
   if ('error' in props) {
     const { error } = props;
     return (
@@ -351,9 +375,6 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   if (isLoading) {
     return <Skeleton />;
   }
-
-  const { rows, args, globals } =
-    'rows' in props ? props : { rows: undefined, args: undefined, globals: undefined };
   const groups: Sections = groupRows(
     pickBy(
       rows || {},
@@ -392,7 +413,8 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
             <StyledButton
               variant="ghost"
               padding="small"
-              onClick={() => resetArgs()}
+              onClick={handleResetClick}
+              disabled={isResetting}
               ariaLabel="Reset controls"
             >
               <UndoIcon />


### PR DESCRIPTION
Closes #31797

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Rapidly clicking the "Reset controls" button in the Controls panel could trigger an `AbortError` due to a race condition — multiple `resetArgs()` calls firing before the previous one completes.

This PR adds a ref-based guard (`useRef`) to synchronously block duplicate calls, combined with a `useState` + `disabled` prop to visually disable the button during the reset. A 300ms debounce via `setTimeout` ensures the button stays disabled until args have settled, and the guard is cleared when the `args` prop updates.

Related: #31952 (previous attempt at this fix)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Run `cd code && yarn storybook:ui`
2. Open any story with Controls (e.g. Argtype > String)
3. Modify a control value (e.g. change the `label` field)
4. Rapidly click the "Reset controls" (undo) button multiple times
5. **Before fix**: `AbortError` appears in the browser console
6. **After fix**: Button becomes briefly disabled (300ms), preventing duplicate calls. No errors in console.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

### Mov
https://github.com/user-attachments/assets/92bfa1ff-641b-46b4-8d32-7fc7518e07e0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the ArgsTable reset flow: the Reset button is now disabled while a reset is in progress to prevent double-clicks and re-entrancy.
  * Reset UI state is tracked more reliably, with the resetting indicator automatically cleared after argument updates.
  * Reset action behavior was refined to ensure consistent visual feedback during and after the reset operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->