### PR TITLE
React: Fix manifest RDT for referenced tsconfig projects

### DIFF
--- a/code/core/src/common/index.ts
+++ b/code/core/src/common/index.ts
@@ -31,6 +31,7 @@ export * from './utils/remove';
 export * from './utils/resolve-path-in-sb-cache';
 export * from './utils/symlinks';
 export * from './utils/template';
+export * from './utils/tsconfig';
 export * from './utils/validate-config';
 export * from './utils/validate-configuration-files';
 export * from './utils/satisfies';

--- a/code/core/src/common/utils/__tests__/tsconfig.test.ts
+++ b/code/core/src/common/utils/__tests__/tsconfig.test.ts
@@ -1,0 +1,78 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { findTsconfigPathForFile } from '../tsconfig';
+import * as paths from '../paths';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('findTsconfigPathForFile', () => {
+  it('uses the referenced app tsconfig for Vite-style project references', () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        files: [],
+        references: [{ path: './tsconfig.app.json' }, { path: './tsconfig.node.json' }],
+      }),
+      'tsconfig.app.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@ui/*': ['src/*'],
+          },
+        },
+        include: ['src'],
+      }),
+      'tsconfig.node.json': JSON.stringify({
+        include: ['vite.config.ts'],
+      }),
+      'src/Button.tsx': 'export const Button = () => null;',
+    });
+
+    vi.spyOn(paths, 'getProjectRoot').mockReturnValue(dir);
+
+    expect(findTsconfigPathForFile(dir, join(dir, 'src/Button.tsx'))).toBe(
+      join(dir, 'tsconfig.app.json')
+    );
+  });
+
+  it('falls back to the nearest discovered tsconfig when no reference matches the file', () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+        },
+      }),
+      'src/Button.tsx': 'export const Button = () => null;',
+    });
+
+    vi.spyOn(paths, 'getProjectRoot').mockReturnValue(dir);
+
+    expect(findTsconfigPathForFile(dir, join(dir, 'src/Button.tsx'))).toBe(
+      join(dir, 'tsconfig.json')
+    );
+  });
+});
+
+function createTempProject(files: Record<string, string>) {
+  const dir = mkdtempSync(join(tmpdir(), 'storybook-tsconfig-'));
+  tempDirs.push(dir);
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const fullPath = join(dir, relativePath);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, content, 'utf-8');
+  }
+
+  return dir;
+}

--- a/code/core/src/common/utils/__tests__/tsconfig.test.ts
+++ b/code/core/src/common/utils/__tests__/tsconfig.test.ts
@@ -46,6 +46,33 @@ describe('findTsconfigPathForFile', () => {
     );
   });
 
+  it('keeps reference order for same-directory sibling tsconfigs that both match the file', () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        files: [],
+        references: [{ path: './tsconfig.app.json' }, { path: './tsconfig.node.json' }],
+      }),
+      'tsconfig.app.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+        },
+        include: ['src'],
+      }),
+      'tsconfig.node.json': JSON.stringify({
+        compilerOptions: {
+          module: 'ESNext',
+        },
+      }),
+      'src/Button.tsx': 'export const Button = () => null;',
+    });
+
+    vi.spyOn(paths, 'getProjectRoot').mockReturnValue(dir);
+
+    expect(findTsconfigPathForFile(dir, join(dir, 'src/Button.tsx'))).toBe(
+      join(dir, 'tsconfig.app.json')
+    );
+  });
+
   it('falls back to the nearest discovered tsconfig when no reference matches the file', () => {
     const dir = createTempProject({
       'tsconfig.json': JSON.stringify({

--- a/code/core/src/common/utils/tsconfig.ts
+++ b/code/core/src/common/utils/tsconfig.ts
@@ -36,6 +36,15 @@ export const findTsconfigPath = (cwd: string): string | undefined => {
   return undefined;
 };
 
+/**
+ * Pick the tsconfig that actually applies to a given file, following project references when the
+ * nearest root config is just a references shell (for example Vite's `files: []` root tsconfig).
+ *
+ * This intentionally follows the same idea as the Volar-inspired selection logic used by
+ * `ComponentMetaManager`: prefer the config that really owns the file instead of stopping at the
+ * first config filename we discover. It extends the simpler fallback-chain fix from #34353 so
+ * docgen-style callers can handle project references too.
+ */
 export const findTsconfigPathForFile = (cwd: string, filePath: string): string | undefined => {
   const rootTsconfigPath = findTsconfigPath(cwd);
   if (!rootTsconfigPath) {

--- a/code/core/src/common/utils/tsconfig.ts
+++ b/code/core/src/common/utils/tsconfig.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { dirname, relative, resolve } from 'node:path';
+import { basename, dirname, relative, resolve } from 'node:path';
 
 import * as find from 'empathic/find';
 import picomatch from 'picomatch';
@@ -157,7 +157,10 @@ function compareTsconfigEntries(filePath: string, left: TsconfigEntry, right: Ts
     return leftDepth - rightDepth;
   }
 
-  return right.path.length - left.path.length;
+  const leftIsPrimaryTsconfig = basename(left.path) === 'tsconfig.json' ? 1 : 0;
+  const rightIsPrimaryTsconfig = basename(right.path) === 'tsconfig.json' ? 1 : 0;
+
+  return rightIsPrimaryTsconfig - leftIsPrimaryTsconfig;
 }
 
 function readTsconfigConfig(configPath: string): TsconfigConfig | undefined {

--- a/code/core/src/common/utils/tsconfig.ts
+++ b/code/core/src/common/utils/tsconfig.ts
@@ -1,0 +1,188 @@
+import { readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+
+import * as find from 'empathic/find';
+import picomatch from 'picomatch';
+import stripJsonComments from 'strip-json-comments';
+
+import { getProjectRoot } from './paths';
+
+const TSCONFIG_CANDIDATES = ['tsconfig.json', 'tsconfig.base.json', 'tsconfig.app.json'] as const;
+const DEFAULT_EXCLUDE_PATTERNS = ['node_modules', 'bower_components', 'jspm_packages'];
+
+type TsconfigReference = { path?: unknown };
+type TsconfigConfig = {
+  exclude?: unknown;
+  files?: unknown;
+  include?: unknown;
+  references?: unknown;
+};
+
+type TsconfigEntry = {
+  config: TsconfigConfig;
+  path: string;
+};
+
+export const findTsconfigPath = (cwd: string): string | undefined => {
+  const projectRoot = getProjectRoot();
+
+  for (const candidate of TSCONFIG_CANDIDATES) {
+    const found = find.up(candidate, { cwd, last: projectRoot });
+    if (found) {
+      return found;
+    }
+  }
+
+  return undefined;
+};
+
+export const findTsconfigPathForFile = (cwd: string, filePath: string): string | undefined => {
+  const rootTsconfigPath = findTsconfigPath(cwd);
+  if (!rootTsconfigPath) {
+    return undefined;
+  }
+
+  const absoluteFilePath = resolve(filePath);
+  const matchingConfigs = collectTsconfigEntries(rootTsconfigPath, new Set()).filter((entry) =>
+    tsconfigIncludesFile(entry, absoluteFilePath)
+  );
+
+  matchingConfigs.sort((left, right) => compareTsconfigEntries(absoluteFilePath, left, right));
+
+  return matchingConfigs[0]?.path ?? rootTsconfigPath;
+};
+
+function collectTsconfigEntries(configPath: string, seen: Set<string>): TsconfigEntry[] {
+  const normalizedConfigPath = resolve(configPath);
+  if (seen.has(normalizedConfigPath)) {
+    return [];
+  }
+  seen.add(normalizedConfigPath);
+
+  const config = readTsconfigConfig(normalizedConfigPath);
+  if (!config) {
+    return [];
+  }
+
+  return [
+    { path: normalizedConfigPath, config },
+    ...getReferencedTsconfigPaths(normalizedConfigPath, config).flatMap((referencePath) =>
+      collectTsconfigEntries(referencePath, seen)
+    ),
+  ];
+}
+
+function getReferencedTsconfigPaths(configPath: string, config: TsconfigConfig) {
+  const references = Array.isArray(config.references)
+    ? (config.references as TsconfigReference[])
+    : [];
+
+  return references
+    .map((reference) => reference.path)
+    .filter((referencePath): referencePath is string => typeof referencePath === 'string')
+    .map((referencePath) => resolve(dirname(configPath), referencePath))
+    .flatMap((referencePath) => resolveReferenceConfigPaths(referencePath));
+}
+
+function resolveReferenceConfigPaths(referencePath: string) {
+  if (referencePath.endsWith('.json')) {
+    return [referencePath];
+  }
+
+  return TSCONFIG_CANDIDATES.map((candidate) => resolve(referencePath, candidate));
+}
+
+function tsconfigIncludesFile(entry: TsconfigEntry, filePath: string) {
+  const configDir = dirname(entry.path);
+  const relativeFilePath = normalizePath(relative(configDir, filePath));
+  if (relativeFilePath.startsWith('../') || relativeFilePath === '..') {
+    return false;
+  }
+
+  const files = asStringArray(entry.config.files);
+  if (files.length > 0) {
+    return files.some((candidatePath) => resolve(configDir, candidatePath) === filePath);
+  }
+
+  const includePatterns = getIncludePatterns(entry.config);
+  if (includePatterns.length === 0) {
+    return false;
+  }
+
+  const excludePatterns = [...DEFAULT_EXCLUDE_PATTERNS, ...asStringArray(entry.config.exclude)].map(
+    normalizeTsconfigPattern
+  );
+
+  if (matchesPatterns(relativeFilePath, excludePatterns)) {
+    return false;
+  }
+
+  return matchesPatterns(relativeFilePath, includePatterns);
+}
+
+function getIncludePatterns(config: TsconfigConfig) {
+  const includes = asStringArray(config.include);
+  if (includes.length > 0) {
+    return includes.map(normalizeTsconfigPattern);
+  }
+
+  const files = asStringArray(config.files);
+  if (files.length > 0) {
+    return files.map(normalizePath);
+  }
+
+  if (Array.isArray(config.references) && files.length === 0) {
+    return [];
+  }
+
+  return ['**/*'];
+}
+
+function compareTsconfigEntries(filePath: string, left: TsconfigEntry, right: TsconfigEntry) {
+  const leftDir = dirname(left.path);
+  const rightDir = dirname(right.path);
+  const leftDepth = normalizePath(relative(leftDir, filePath)).split('/').length;
+  const rightDepth = normalizePath(relative(rightDir, filePath)).split('/').length;
+
+  if (leftDepth !== rightDepth) {
+    return leftDepth - rightDepth;
+  }
+
+  return right.path.length - left.path.length;
+}
+
+function readTsconfigConfig(configPath: string): TsconfigConfig | undefined {
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    return JSON.parse(stripJsonComments(content)) as TsconfigConfig;
+  } catch {
+    return undefined;
+  }
+}
+
+function matchesPatterns(filePath: string, patterns: string[]) {
+  return patterns.some((pattern) => picomatch(pattern, { dot: true })(filePath));
+}
+
+function normalizeTsconfigPattern(pattern: string) {
+  const normalizedPattern = normalizePath(pattern);
+  if (normalizedPattern.endsWith('/')) {
+    return `${normalizedPattern}**/*`;
+  }
+
+  if (!picomatch.scan(normalizedPattern).isGlob && !/\.[^/]+$/.test(normalizedPattern)) {
+    return `${normalizedPattern}/**/*`;
+  }
+
+  return normalizedPattern;
+}
+
+function normalizePath(value: string) {
+  return value.replaceAll('\\', '/');
+}
+
+function asStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}

--- a/code/frameworks/react-vite/src/plugins/react-docgen.ts
+++ b/code/frameworks/react-vite/src/plugins/react-docgen.ts
@@ -1,11 +1,10 @@
 import { existsSync } from 'node:fs';
-import { relative, sep } from 'node:path';
+import { dirname, relative, sep } from 'node:path';
 
-import { getProjectRoot } from 'storybook/internal/common';
+import { findTsconfigPathForFile } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
 import { createFilter } from '@rollup/pluginutils';
-import * as find from 'empathic/find';
 import MagicString from 'magic-string';
 import type { Documentation } from 'react-docgen';
 import {
@@ -44,24 +43,6 @@ export async function reactDocgen({
   const cwd = process.cwd();
   const filter = createFilter(include, exclude);
 
-  const projectRoot = getProjectRoot();
-  const tsconfigPath =
-    find.up('tsconfig.json', { cwd, last: projectRoot }) ??
-    find.up('tsconfig.base.json', { cwd, last: projectRoot }) ??
-    find.up('tsconfig.app.json', { cwd, last: projectRoot });
-  const tsconfig = TsconfigPaths.loadConfig(tsconfigPath);
-
-  let matchPath: TsconfigPaths.MatchPath | undefined;
-
-  if (tsconfig.resultType === 'success') {
-    logger.debug('Using tsconfig paths for react-docgen');
-    matchPath = TsconfigPaths.createMatchPath(tsconfig.absoluteBaseUrl, tsconfig.paths, [
-      'browser',
-      'module',
-      'main',
-    ]);
-  }
-
   return {
     name: 'storybook:react-docgen-plugin',
     enforce: 'pre',
@@ -71,6 +52,7 @@ export async function reactDocgen({
       }
 
       try {
+        const matchPath = createTsconfigMatchPath(id);
         const docgenResults = parse(src, {
           resolver: defaultResolver,
           handlers,
@@ -132,4 +114,19 @@ export function getReactDocgenImporter(matchPath: TsconfigPaths.MatchPath | unde
 
     throw new ReactDocgenResolveError(filename);
   });
+}
+
+function createTsconfigMatchPath(filePath: string) {
+  const tsconfig = TsconfigPaths.loadConfig(findTsconfigPathForFile(dirname(filePath), filePath));
+
+  if (tsconfig.resultType !== 'success') {
+    return undefined;
+  }
+
+  logger.debug('Using tsconfig paths for react-docgen');
+  return TsconfigPaths.createMatchPath(tsconfig.absoluteBaseUrl, tsconfig.paths, [
+    'browser',
+    'module',
+    'main',
+  ]);
 }

--- a/code/presets/react-webpack/src/loaders/react-docgen-loader.ts
+++ b/code/presets/react-webpack/src/loaders/react-docgen-loader.ts
@@ -1,7 +1,8 @@
-import { getProjectRoot } from 'storybook/internal/common';
+import { dirname } from 'node:path';
+
+import { findTsconfigPathForFile } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
-import * as find from 'empathic/find';
 import MagicString from 'magic-string';
 import {
   ERROR_CODES,
@@ -67,9 +68,6 @@ const defaultHandlers = Object.values(docgenHandlers).map((handler) => handler);
 const defaultResolver = new docgenResolver.FindExportedDefinitionsResolver();
 const handlers = [...defaultHandlers, actualNameHandler];
 
-let tsconfigPathsInitialized = false;
-let matchPath: TsconfigPaths.MatchPath | undefined;
-
 export default async function reactDocgenLoader(
   this: LoaderContext<{ debug: boolean }>,
   source: string,
@@ -80,28 +78,8 @@ export default async function reactDocgenLoader(
   const options = this.getOptions() || {};
   const { debug = false } = options;
 
-  if (!tsconfigPathsInitialized) {
-    const projectRoot = getProjectRoot();
-    const cwd = process.cwd();
-    const tsconfigPath =
-      find.up('tsconfig.json', { cwd, last: projectRoot }) ??
-      find.up('tsconfig.base.json', { cwd, last: projectRoot }) ??
-      find.up('tsconfig.app.json', { cwd, last: projectRoot });
-    const tsconfig = TsconfigPaths.loadConfig(tsconfigPath);
-
-    if (tsconfig.resultType === 'success') {
-      logger.debug('Using tsconfig paths for react-docgen');
-      matchPath = TsconfigPaths.createMatchPath(tsconfig.absoluteBaseUrl, tsconfig.paths, [
-        'browser',
-        'module',
-        'main',
-      ]);
-    }
-
-    tsconfigPathsInitialized = true;
-  }
-
   try {
+    const matchPath = createTsconfigMatchPath(this.resourcePath);
     const docgenResults = parse(source, {
       filename: this.resourcePath,
       resolver: defaultResolver,
@@ -172,4 +150,19 @@ export function getReactDocgenImporter(matchingPath: TsconfigPaths.MatchPath | u
 
     throw new ReactDocgenResolveError(filename);
   });
+}
+
+function createTsconfigMatchPath(filePath: string) {
+  const tsconfig = TsconfigPaths.loadConfig(findTsconfigPathForFile(dirname(filePath), filePath));
+
+  if (tsconfig.resultType !== 'success') {
+    return undefined;
+  }
+
+  logger.debug('Using tsconfig paths for react-docgen');
+  return TsconfigPaths.createMatchPath(tsconfig.absoluteBaseUrl, tsconfig.paths, [
+    'browser',
+    'module',
+    'main',
+  ]);
 }

--- a/code/renderers/react/src/componentManifest/generator.react-docgen-typescript.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.react-docgen-typescript.test.ts
@@ -9,10 +9,14 @@ import type { IndexEntry } from 'storybook/internal/types';
 import { dedent } from 'ts-dedent';
 
 import { manifests } from './generator';
-import { invalidateParser } from './reactDocgenTypescript';
+import { type ComponentDocWithExportName, invalidateParser } from './reactDocgenTypescript';
 import { invalidateCache } from './utils';
 
 const repoRoot = process.cwd();
+type ManifestComponentWithReactDocgenTypescript = {
+  error?: { name: string; message: string };
+  reactDocgenTypescript?: ComponentDocWithExportName;
+};
 
 test.sequential('manifests uses the referenced app tsconfig for react-docgen-typescript in Vite-style projects', async () => {
   invalidateCache();
@@ -23,7 +27,9 @@ test.sequential('manifests uses the referenced app tsconfig for react-docgen-typ
 
   try {
     const result = await manifests(undefined, createManifestOptions());
-    const button = result?.components?.components?.['example-button'];
+    const button = result?.components?.components?.['example-button'] as
+      | ManifestComponentWithReactDocgenTypescript
+      | undefined;
 
     expect(button?.error).toBeUndefined();
     expect(button?.reactDocgenTypescript?.displayName).toBe('Button');

--- a/code/renderers/react/src/componentManifest/generator.react-docgen-typescript.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.react-docgen-typescript.test.ts
@@ -1,0 +1,178 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { expect, test, vi } from 'vitest';
+
+import { Tag } from 'storybook/internal/core-server';
+import type { IndexEntry } from 'storybook/internal/types';
+
+import { dedent } from 'ts-dedent';
+
+import { manifests } from './generator';
+import { invalidateParser } from './reactDocgenTypescript';
+import { invalidateCache } from './utils';
+
+const repoRoot = process.cwd();
+
+test.sequential('manifests uses the referenced app tsconfig for react-docgen-typescript in Vite-style projects', async () => {
+  invalidateCache();
+  invalidateParser();
+
+  const tempDir = createTempProject();
+  const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+
+  try {
+    const result = await manifests(undefined, createManifestOptions());
+    const button = result?.components?.components?.['example-button'];
+
+    expect(button?.error).toBeUndefined();
+    expect(button?.reactDocgenTypescript?.displayName).toBe('Button');
+    expect(button?.reactDocgenTypescript?.props.label).toMatchObject({
+      required: true,
+    });
+    expect(button?.reactDocgenTypescript?.props.primary).toMatchObject({
+      required: false,
+    });
+  } finally {
+    cwdSpy.mockRestore();
+    invalidateCache();
+    invalidateParser();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function createManifestOptions() {
+  const manifestEntries: IndexEntry[] = [
+    {
+      type: 'story',
+      subtype: 'story',
+      id: 'example-button--primary',
+      name: 'Primary',
+      title: 'Example/Button',
+      importPath: './src/Button.stories.tsx',
+      componentPath: './src/Button.tsx',
+      tags: [Tag.DEV, Tag.TEST, Tag.MANIFEST],
+      exportName: 'Primary',
+    },
+  ];
+
+  return {
+    watch: false,
+    manifestEntries,
+    presets: {
+      apply: async (extension: string, config?: unknown) => {
+        if (extension === 'typescript') {
+          return { reactDocgen: 'react-docgen-typescript' };
+        }
+        if (extension === 'features') {
+          return {};
+        }
+        return config;
+      },
+    },
+  } as Parameters<typeof manifests>[1];
+}
+
+function createTempProject() {
+  const tempDir = mkdtempSync(join(repoRoot, '.tmp-manifest-rdt-'));
+  const srcDir = join(tempDir, 'src');
+
+  mkdirSync(srcDir, { recursive: true });
+
+  writeFileSync(
+    join(tempDir, 'package.json'),
+    JSON.stringify({ name: 'vite-rdt-manifest-fixture', private: true }, null, 2)
+  );
+  writeFileSync(
+    join(tempDir, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        files: [],
+        references: [{ path: './tsconfig.app.json' }, { path: './tsconfig.node.json' }],
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(
+    join(tempDir, 'tsconfig.app.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2020',
+          useDefineForClassFields: true,
+          lib: ['ES2020', 'DOM', 'DOM.Iterable'],
+          module: 'ESNext',
+          skipLibCheck: true,
+          moduleResolution: 'bundler',
+          allowImportingTsExtensions: true,
+          resolveJsonModule: true,
+          isolatedModules: true,
+          noEmit: true,
+          jsx: 'react-jsx',
+          strict: true,
+        },
+        include: ['src'],
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(
+    join(tempDir, 'tsconfig.node.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          composite: true,
+          skipLibCheck: true,
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+        },
+        include: ['vite.config.ts'],
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(
+    join(srcDir, 'Button.tsx'),
+    dedent`
+      export interface ButtonProps {
+        /** Button contents */
+        label: string;
+        /** Is this the principal call to action on the page? */
+        primary?: boolean;
+      }
+
+      /** Primary UI component for user interaction */
+      export const Button = ({ label, primary = false }: ButtonProps) => (
+        <button data-primary={primary}>{label}</button>
+      );
+    `
+  );
+  writeFileSync(
+    join(srcDir, 'Button.stories.tsx'),
+    dedent`
+      import type { Meta, StoryObj } from '@storybook/react-vite';
+
+      import { Button } from './Button';
+
+      const meta = {
+        title: 'Example/Button',
+        component: Button,
+      } satisfies Meta<typeof Button>;
+
+      export default meta;
+      type Story = StoryObj<typeof meta>;
+
+      export const Primary: Story = {
+        args: {
+          label: 'Button',
+          primary: true,
+        },
+      };
+    `
+  );
+
+  return tempDir;
+}

--- a/code/renderers/react/src/componentManifest/reactDocgen.test.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen.test.ts
@@ -1,12 +1,26 @@
-import { beforeEach, describe, expect, test } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { dedent } from 'ts-dedent';
 
-import { parseWithReactDocgen } from './reactDocgen';
+import { matchPath, parseWithReactDocgen } from './reactDocgen';
 import { invalidateCache } from './utils';
+
+const tempDirs: string[] = [];
 
 beforeEach(() => {
   invalidateCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 async function parse(code: string, name = 'Component.tsx') {
@@ -211,4 +225,45 @@ describe('parseWithReactDocgen exportName coverage', () => {
       ]
     `);
   });
+
+  test('matchPath resolves aliases from a referenced app tsconfig', () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        files: [],
+        references: [{ path: './tsconfig.app.json' }, { path: './tsconfig.node.json' }],
+      }),
+      'tsconfig.app.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@ui/*': ['src/*'],
+          },
+        },
+        include: ['src'],
+      }),
+      'tsconfig.node.json': JSON.stringify({
+        include: ['vite.config.ts'],
+      }),
+      'src/Button.tsx': 'export const Button = () => null;',
+      'src/Entry.tsx': 'export * from "@ui/Button";',
+    });
+
+    const entryPath = join(dir, 'src/Entry.tsx');
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    expect(matchPath('@ui/Button', entryPath)).toBe(join(dir, 'src/Button'));
+  });
 });
+
+function createTempProject(files: Record<string, string>) {
+  const dir = mkdtempSync(join(tmpdir(), 'storybook-react-docgen-'));
+  tempDirs.push(dir);
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const fullPath = join(dir, relativePath);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, content, 'utf-8');
+  }
+
+  return dir;
+}

--- a/code/renderers/react/src/componentManifest/reactDocgen.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { dirname, sep } from 'node:path';
 
 import { babelParse, types as t } from 'storybook/internal/babel';
-import { supportedExtensions } from 'storybook/internal/common';
+import { findTsconfigPathForFile, supportedExtensions } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
 import {
@@ -20,7 +20,7 @@ import { extractJSDocInfo } from './jsdocTags';
 import actualNameHandler from './reactDocgen/actualNameHandler';
 import { ReactDocgenResolveError } from './reactDocgen/docgenResolver';
 import exportNameHandler from './reactDocgen/exportNameHandler';
-import { cached, cachedReadFileSync, cachedResolveImport, findTsconfigPath } from './utils';
+import { cached, cachedReadFileSync, cachedResolveImport } from './utils';
 
 export type DocObj = Documentation & {
   actualName: string;
@@ -58,9 +58,9 @@ export function getMatchingDocgen(docgens: DocObj[], component: ComponentRef) {
   return matchingDocgen ?? docgens[0];
 }
 
-export function matchPath(id: string, basedir?: string) {
-  basedir ??= process.cwd();
-  const tsconfig = getTsConfig(basedir);
+export function matchPath(id: string, importerFilePath?: string) {
+  importerFilePath ??= process.cwd();
+  const tsconfig = getTsConfig(importerFilePath);
 
   if (tsconfig.resultType === 'success') {
     const match = TsconfigPaths.createMatchPath(tsconfig.absoluteBaseUrl, tsconfig.paths, [
@@ -74,8 +74,8 @@ export function matchPath(id: string, basedir?: string) {
 }
 
 export const getTsConfig = cached(
-  (cwd: string) => {
-    const tsconfigPath = findTsconfigPath(cwd);
+  (filePath: string) => {
+    const tsconfigPath = findTsconfigPathForFile(dirname(filePath), filePath);
     return TsconfigPaths.loadConfig(tsconfigPath);
   },
   { name: 'getTsConfig' }
@@ -98,7 +98,7 @@ const getExportPaths = cached(
     let ast;
     try {
       ast = babelParse(code);
-    } catch (_) {
+    } catch {
       return [];
     }
 
@@ -112,7 +112,7 @@ const getExportPaths = cached(
             ? [statement.source.value]
             : []
       )
-      .map((id) => matchPath(id, basedir))
+      .map((id) => matchPath(id, filePath))
       .flatMap((id) => {
         try {
           return [cachedResolveImport(id, { basedir })];

--- a/code/renderers/react/src/componentManifest/reactDocgen/extractReactTypescriptDocgenInfo.test.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/extractReactTypescriptDocgenInfo.test.ts
@@ -1,8 +1,23 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { extractComponentProps } from 'storybook/internal/docs-tools';
 
+import { extractArgTypesFromDocgenTypescript } from './extractReactTypescriptDocgenInfo';
 import { extractProps } from '../../extractProps';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 // TODO: Norbert figure this out thank you
 describe('extractArgTypesFromDocgenTypescript', () => {
@@ -434,4 +449,69 @@ describe('extractArgTypesFromDocgenTypescript', () => {
       ]
     `);
   });
+
+  it('preserves JSDoc descriptions with Vite-style project references', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        files: [],
+        references: [{ path: './tsconfig.app.json' }, { path: './tsconfig.node.json' }],
+      }),
+      'tsconfig.app.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2023',
+          jsx: 'react-jsx',
+          strict: true,
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          noEmit: true,
+        },
+        include: ['src'],
+      }),
+      'tsconfig.node.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2023',
+          module: 'ESNext',
+        },
+        include: ['vite.config.ts'],
+      }),
+      'src/Button.tsx': `
+        export interface ButtonProps {
+          /** Button contents */
+          label: string;
+          /** Is this the principal call to action on the page? */
+          primary?: boolean;
+        }
+
+        /** Primary UI component for user interaction */
+        export const Button = ({ label, primary = false }: ButtonProps) => {
+          return <button data-primary={primary}>{label}</button>;
+        };
+      `,
+    });
+
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    const argTypes = await extractArgTypesFromDocgenTypescript({
+      componentFilePath: path.join(dir, 'src/Button.tsx'),
+      componentExportName: 'Button',
+    });
+
+    expect(argTypes?.label?.description).toBe('Button contents');
+    expect(argTypes?.primary?.description).toBe(
+      'Is this the principal call to action on the page?'
+    );
+  });
 });
+
+function createTempProject(files: Record<string, string>) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sb-rdt-argtypes-'));
+  tempDirs.push(dir);
+
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = path.join(dir, name);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content, 'utf-8');
+  }
+
+  return dir;
+}

--- a/code/renderers/react/src/componentManifest/reactDocgen/extractReactTypescriptDocgenInfo.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/extractReactTypescriptDocgenInfo.ts
@@ -40,7 +40,7 @@ export const extractArgTypesFromDocgenTypescript = async ({
       savePropValueAsString: true,
     };
 
-    const tsConfig = await getTsConfig();
+    const tsConfig = await getTsConfig(componentFilePath);
 
     const mergedOptions = {
       ...defaultOptions,

--- a/code/renderers/react/src/componentManifest/reactDocgen/utils.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/utils.ts
@@ -1,4 +1,5 @@
 import type { SBType } from 'storybook/internal/csf';
+import { findTsconfigPathForFile } from 'storybook/internal/common';
 
 import { dirname } from 'path';
 import type {
@@ -126,11 +127,12 @@ export function mapCommonTypes(typeName: string): SBType | null {
   return null;
 }
 
-export const getTsConfig = async () => {
+export const getTsConfig = async (componentFilePath?: string) => {
   try {
     const ts = await import('typescript');
-    const tsconfigPath = ts.findConfigFile(process.cwd(), ts.sys.fileExists);
-    console.log({ tsconfigPath });
+    const tsconfigPath = componentFilePath
+      ? findTsconfigPathForFile(dirname(componentFilePath), componentFilePath)
+      : ts.findConfigFile(process.cwd(), ts.sys.fileExists);
     if (tsconfigPath === undefined) {
       return {};
     }

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.test.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.test.ts
@@ -1,0 +1,285 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { dedent } from 'ts-dedent';
+
+import {
+  invalidateParser,
+  matchComponentDoc,
+  parseWithReactDocgenTypescript,
+} from './reactDocgenTypescript';
+import { invalidateCache } from './utils';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  invalidateParser();
+  invalidateCache();
+  vi.restoreAllMocks();
+
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('parseWithReactDocgenTypescript', () => {
+  test('parses a simple component with props', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['*.tsx'],
+      }),
+      'Button.tsx': dedent`
+        interface ButtonProps {
+          /** The button label */
+          label: string;
+          disabled?: boolean;
+        }
+
+        export function Button(props: ButtonProps) {
+          return null;
+        }
+      `,
+    });
+
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'Button.tsx'));
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].exportName).toBe('Button');
+    expect(docs[0].props.label).toBeDefined();
+    expect(docs[0].props.label.required).toBe(true);
+    expect(docs[0].props.disabled).toBeDefined();
+    expect(docs[0].props.disabled.required).toBe(false);
+    expect(() => JSON.stringify(docs[0])).not.toThrow();
+  });
+
+  test('parses union and enum prop types', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['*.tsx'],
+      }),
+      'Tag.tsx': dedent`
+        interface TagProps {
+          variant: 'primary' | 'secondary' | 'danger';
+          size?: 'small' | 'large';
+        }
+
+        export function Tag(props: TagProps) {
+          return null;
+        }
+      `,
+    });
+
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'Tag.tsx'));
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].exportName).toBe('Tag');
+    expect(docs[0].props.variant).toBeDefined();
+    expect(docs[0].props.variant.type.name).toBe('enum');
+    expect(() => JSON.stringify(docs[0])).not.toThrow();
+  });
+
+  test('parses component default values', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['*.tsx'],
+      }),
+      'Alert.tsx': dedent`
+        interface AlertProps {
+          message: string;
+          severity?: string;
+        }
+
+        export function Alert({ message, severity = 'info' }: AlertProps) {
+          return null;
+        }
+      `,
+    });
+
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'Alert.tsx'));
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].props.severity?.defaultValue?.value).toBe('info');
+  });
+
+  test('round-trips through manifest JSON serialization', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['*.tsx'],
+      }),
+      'Button.tsx': dedent`
+        interface ButtonProps {
+          label: string;
+          disabled?: boolean;
+          onClick?: () => void;
+          variant?: 'primary' | 'secondary';
+        }
+
+        /** Primary UI component */
+        export function Button(props: ButtonProps) {
+          return null;
+        }
+      `,
+    });
+
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'Button.tsx'));
+    const manifest = {
+      id: 'test-button',
+      name: 'Button',
+      path: './src/Button.tsx',
+      stories: [],
+      import: 'import { Button } from "./Button";',
+      jsDocTags: {},
+      reactDocgenTypescript: docs[0],
+    };
+
+    const json = JSON.stringify(manifest);
+    const parsed = JSON.parse(json);
+
+    expect(json).toBeDefined();
+    expect(parsed.reactDocgenTypescript.exportName).toBe('Button');
+    expect(parsed.reactDocgenTypescript.props.label).toBeDefined();
+    expect(parsed.reactDocgenTypescript.props.label.required).toBe(true);
+  });
+
+  test('matchComponentDoc finds the requested component', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['*.tsx'],
+      }),
+      'Multi.tsx': dedent`
+        interface AProps {
+          a: string;
+        }
+
+        interface BProps {
+          b: number;
+        }
+
+        export function CompA(props: AProps) {
+          return null;
+        }
+
+        export function CompB(props: BProps) {
+          return null;
+        }
+      `,
+    });
+
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'Multi.tsx'));
+    const match = matchComponentDoc(docs, { importName: 'CompB' });
+
+    expect(docs).toHaveLength(2);
+    expect(match?.exportName).toBe('CompB');
+    expect(match?.props.b).toBeDefined();
+  });
+
+  test('filters large non-user prop sources', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['*.tsx'],
+      }),
+      'FancyButton.tsx': dedent`
+        import React from 'react';
+
+        interface FancyButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+          /** Custom label */
+          label: string;
+        }
+
+        export function FancyButton(props: FancyButtonProps) {
+          return null;
+        }
+      `,
+    });
+
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'FancyButton.tsx'));
+    const propNames = Object.keys(docs[0].props);
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].props.label).toBeDefined();
+    expect(propNames).not.toContain('className');
+    expect(propNames).not.toContain('style');
+  });
+
+  test('handles Vite-style project references tsconfig files', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        files: [],
+        references: [{ path: './tsconfig.app.json' }, { path: './tsconfig.node.json' }],
+      }),
+      'tsconfig.app.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2023',
+          jsx: 'react-jsx',
+          strict: true,
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          noEmit: true,
+        },
+        include: ['src'],
+      }),
+      'tsconfig.node.json': JSON.stringify({
+        compilerOptions: { target: 'ES2023', module: 'ESNext' },
+        include: ['vite.config.ts'],
+      }),
+      'src/Button.tsx': dedent`
+        interface ButtonProps {
+          /** The button label */
+          label: string;
+          primary?: boolean;
+          onClick?: () => void;
+        }
+
+        /** Primary UI component for user interaction */
+        export const Button = ({ label, primary = false }: ButtonProps) => {
+          return null;
+        };
+      `,
+    });
+
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'src/Button.tsx'));
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].exportName).toBe('Button');
+    expect(docs[0].props.label).toBeDefined();
+    expect(docs[0].props.label.required).toBe(true);
+    expect(docs[0].props.primary).toBeDefined();
+    expect(docs[0].description).toBe('Primary UI component for user interaction');
+  });
+});
+
+function createTempProject(files: Record<string, string>) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sb-rdt-test-'));
+  tempDirs.push(dir);
+
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = path.join(dir, name);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content, 'utf-8');
+  }
+
+  return dir;
+}

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 import {
   type ComponentDoc,
@@ -162,50 +162,53 @@ function getExportNameMap(
   return result;
 }
 
+type ParserState = { program: ts.Program; fileParser: FileParser };
+
 /**
- * Manages the TS program and react-docgen-typescript parser. On `invalidateParser()` the program is
- * rebuilt incrementally — TypeScript reuses source files that haven't changed on disk, so only
- * modified files are re-parsed. This keeps prop extraction correct across HMR cycles without the
- * cost of a full program rebuild.
+ * Manages TS programs and react-docgen-typescript parsers per tsconfig. On `invalidateParser()` the
+ * parsers are rebuilt incrementally — TypeScript reuses source files that haven't changed on disk,
+ * so only modified files are re-parsed. This keeps prop extraction correct across HMR cycles
+ * without the cost of a full program rebuild.
  */
-let cachedCompilerOptions: ts.CompilerOptions | undefined;
-let cachedFileNames: string[] | undefined;
-let previousProgram: ts.Program | undefined;
-let parser: { program: ts.Program; fileParser: FileParser } | undefined;
-let cachedParserOptionsKey: string | undefined;
+const previousProgramsByConfigKey = new Map<string, ts.Program | undefined>();
+let parserCache = new Map<string, ParserState>();
+let parserBuilds = new Map<string, Promise<ParserState>>();
 
 /** Rebuild the TS program incrementally so that file changes are picked up on the next parse. */
 export function invalidateParser() {
-  parser = undefined;
-  cachedCompilerOptions = undefined;
-  cachedFileNames = undefined;
-  cachedParserOptionsKey = undefined;
+  parserCache = new Map();
+  parserBuilds = new Map();
 }
 
-async function getParser(userOptions?: ParserOptions) {
+async function getParser(filePath: string, userOptions?: ParserOptions) {
   const [typescript, reactDocgenTypescript] = await Promise.all([
     loadTypeScript(),
     loadReactDocgenTypescript(),
   ]);
-  // Rebuild parser if options changed
   const optionsKey = JSON.stringify(userOptions ?? {});
-  if (parser && cachedParserOptionsKey !== optionsKey) {
-    parser = undefined;
+
+  const configPath =
+    findTsconfigPathForFile(typescript, process.cwd(), filePath) ?? findTsconfigPath(process.cwd());
+  const configKey = configPath ?? '<no-tsconfig>';
+  const parserKey = `${configKey}::${optionsKey}`;
+  const cachedParser = parserCache.get(parserKey);
+  if (cachedParser) {
+    return { ...cachedParser, typescript };
   }
 
-  if (!parser) {
-    const configPath = findTsconfigPath(process.cwd());
-    cachedCompilerOptions = { noErrorTruncation: true, strict: true };
+  const pendingParser = parserBuilds.get(parserKey);
+  if (pendingParser) {
+    return { ...(await pendingParser), typescript };
+  }
+
+  const buildParser = (async () => {
+    let compilerOptions: ts.CompilerOptions = { noErrorTruncation: true, strict: true };
+    let fileNames: string[] = [];
 
     if (configPath) {
-      const { config } = typescript.readConfigFile(configPath, typescript.sys.readFile);
-      const parsed = typescript.parseJsonConfigFileContent(
-        config,
-        typescript.sys,
-        dirname(configPath)
-      );
-      cachedCompilerOptions = { ...parsed.options, noErrorTruncation: true };
-      cachedFileNames = parsed.fileNames;
+      const parsed = parseTsconfig(typescript, configPath);
+      compilerOptions = { ...parsed.options, noErrorTruncation: true };
+      fileNames = parsed.fileNames;
     } else {
       logger.warn(
         'No tsconfig.json (or tsconfig.base.json / tsconfig.app.json) found. ' +
@@ -215,12 +218,12 @@ async function getParser(userOptions?: ParserOptions) {
     }
 
     const program = typescript.createProgram(
-      cachedFileNames ?? [],
-      cachedCompilerOptions,
+      fileNames,
+      compilerOptions,
       undefined,
-      previousProgram
+      previousProgramsByConfigKey.get(configKey)
     );
-    previousProgram = program;
+    previousProgramsByConfigKey.set(configKey, program);
 
     const parserOptions: ParserOptions = {
       shouldExtractLiteralValuesFromEnum: true,
@@ -230,13 +233,22 @@ async function getParser(userOptions?: ParserOptions) {
       savePropValueAsString: true,
     };
 
-    parser = {
+    const state = {
       program,
-      fileParser: reactDocgenTypescript.withCompilerOptions(cachedCompilerOptions, parserOptions),
+      fileParser: reactDocgenTypescript.withCompilerOptions(compilerOptions, parserOptions),
     };
-    cachedParserOptionsKey = optionsKey;
+
+    parserCache.set(parserKey, state);
+    return state;
+  })();
+
+  parserBuilds.set(parserKey, buildParser);
+
+  try {
+    return { ...(await buildParser), typescript };
+  } finally {
+    parserBuilds.delete(parserKey);
   }
-  return { ...parser, typescript };
 }
 
 /** Find the component doc that matches the given import/component name. */
@@ -299,7 +311,7 @@ export function getReactDocgenTypescriptError(
  */
 export const parseWithReactDocgenTypescript = asyncCache(
   async (filePath: string, userOptions?: ParserOptions): Promise<ComponentDocWithExportName[]> => {
-    const { program, fileParser, typescript } = await getParser(userOptions);
+    const { program, fileParser, typescript } = await getParser(filePath, userOptions);
     const checker = program.getTypeChecker();
     const sourceFile = program.getSourceFile(filePath);
 
@@ -329,3 +341,87 @@ export const parseWithReactDocgenTypescript = asyncCache(
   },
   { name: 'parseWithReactDocgenTypescript' }
 );
+
+function findTsconfigPathForFile(
+  typescript: TypeScriptRuntime,
+  cwd: string,
+  filePath: string
+): string | undefined {
+  const configPath = findTsconfigPath(cwd);
+  if (!configPath) {
+    return undefined;
+  }
+
+  return findTsconfigPathIncludingFile(typescript, configPath, filePath, new Set()) ?? configPath;
+}
+
+function findTsconfigPathIncludingFile(
+  typescript: TypeScriptRuntime,
+  configPath: string,
+  filePath: string,
+  seenConfigPaths: Set<string>
+): string | undefined {
+  const normalizedConfigPath = normalizeFileName(typescript, configPath);
+  if (seenConfigPaths.has(normalizedConfigPath)) {
+    return undefined;
+  }
+  seenConfigPaths.add(normalizedConfigPath);
+
+  const { config, parsed } = readTsconfig(typescript, configPath);
+  if (parsed.fileNames.some((name) => isSameFileName(typescript, name, filePath))) {
+    return configPath;
+  }
+
+  for (const referencedConfigPath of getReferencedTsconfigPaths(typescript, configPath, config)) {
+    const matchingConfigPath = findTsconfigPathIncludingFile(
+      typescript,
+      referencedConfigPath,
+      filePath,
+      seenConfigPaths
+    );
+    if (matchingConfigPath) {
+      return matchingConfigPath;
+    }
+  }
+
+  return undefined;
+}
+
+function getReferencedTsconfigPaths(
+  typescript: TypeScriptRuntime,
+  configPath: string,
+  config: unknown
+) {
+  const references = Array.isArray((config as { references?: unknown[] })?.references)
+    ? (config as { references: Array<{ path?: unknown }> }).references
+    : [];
+
+  return references
+    .map((reference) => reference.path)
+    .filter((referencePath): referencePath is string => typeof referencePath === 'string')
+    .map((referencePath) => resolve(dirname(configPath), referencePath))
+    .map((referencePath) =>
+      referencePath.endsWith('.json') ? referencePath : join(referencePath, 'tsconfig.json')
+    )
+    .filter((referencePath) => typescript.sys.fileExists(referencePath));
+}
+
+function parseTsconfig(typescript: TypeScriptRuntime, configPath: string) {
+  return readTsconfig(typescript, configPath).parsed;
+}
+
+function readTsconfig(typescript: TypeScriptRuntime, configPath: string) {
+  const { config } = typescript.readConfigFile(configPath, typescript.sys.readFile);
+  return {
+    config,
+    parsed: typescript.parseJsonConfigFileContent(config, typescript.sys, dirname(configPath)),
+  };
+}
+
+function isSameFileName(typescript: TypeScriptRuntime, left: string, right: string) {
+  return normalizeFileName(typescript, left) === normalizeFileName(typescript, right);
+}
+
+function normalizeFileName(typescript: TypeScriptRuntime, fileName: string) {
+  return typescript.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
+}

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
@@ -10,7 +10,7 @@ import type ts from 'typescript';
 
 import { logger } from 'storybook/internal/node-logger';
 
-import { asyncCache, findTsconfigPath } from './utils';
+import { asyncCache, cached, findTsconfigPath } from './utils';
 
 export type ComponentDocWithExportName = ComponentDoc & { exportName: string };
 
@@ -345,18 +345,24 @@ export const parseWithReactDocgenTypescript = asyncCache(
   { name: 'parseWithReactDocgenTypescript' }
 );
 
-function findTsconfigPathForFile(
-  typescript: TypeScriptRuntime,
-  cwd: string,
-  filePath: string
-): string | undefined {
-  const configPath = findTsconfigPath(cwd);
-  if (!configPath) {
-    return undefined;
-  }
+const findTsconfigPathForFile = cached(
+  (typescript: TypeScriptRuntime, cwd: string, filePath: string): string | undefined => {
+    const configPath = findTsconfigPath(cwd);
+    if (!configPath) {
+      return undefined;
+    }
 
-  return findTsconfigPathIncludingFile(typescript, configPath, filePath, new Set()) ?? configPath;
-}
+    return findTsconfigPathIncludingFile(typescript, configPath, filePath, new Set()) ?? configPath;
+  },
+  {
+    key: (typescript, cwd, filePath) =>
+      `${normalizeFileName(typescript, resolve(cwd))}::${normalizeFileName(
+        typescript,
+        resolve(filePath)
+      )}`,
+    name: 'findTsconfigPathForFile',
+  }
+);
 
 function findTsconfigPathIncludingFile(
   typescript: TypeScriptRuntime,

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
@@ -187,6 +187,9 @@ async function getParser(filePath: string, userOptions?: ParserOptions) {
   ]);
   const optionsKey = JSON.stringify(userOptions ?? {});
 
+  // Mirror the Volar-inspired project selection we already use in react-component-meta:
+  // if the nearest root tsconfig is only a project-references shell, follow references and pick
+  // the config that actually includes this file. This is the manifest-side extension of #34353.
   const configPath =
     findTsconfigPathForFile(typescript, process.cwd(), filePath) ?? findTsconfigPath(process.cwd());
   const configKey = configPath ?? '<no-tsconfig>';

--- a/code/renderers/react/src/componentManifest/utils.test.ts
+++ b/code/renderers/react/src/componentManifest/utils.test.ts
@@ -4,10 +4,8 @@ vi.mock('empathic/find', { spy: true });
 vi.mock('storybook/internal/common', { spy: true });
 vi.mock('storybook/internal/node-logger', { spy: true });
 
-import { getProjectRoot } from 'storybook/internal/common';
+import * as common from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
-
-import * as find from 'empathic/find';
 
 import { asyncCache, cached, findTsconfigPath, groupBy, invalidateCache, invariant } from './utils';
 
@@ -190,16 +188,10 @@ test('invalidateCache clears async module-level memo store', async () => {
 describe('findTsconfigPath', () => {
   beforeEach(() => {
     invalidateCache();
-    vi.mocked(getProjectRoot).mockReturnValue('/project-root');
   });
 
   test('returns tsconfig.json when found', () => {
-    vi.mocked(find.up).mockImplementation((name) => {
-      if (name === 'tsconfig.json') {
-        return '/project-root/tsconfig.json';
-      }
-      return undefined;
-    });
+    vi.mocked(common.findTsconfigPath).mockReturnValue('/project-root/tsconfig.json');
 
     const result = findTsconfigPath('/project-root');
 
@@ -208,12 +200,7 @@ describe('findTsconfigPath', () => {
   });
 
   test('falls back to tsconfig.base.json when tsconfig.json is not found', () => {
-    vi.mocked(find.up).mockImplementation((name) => {
-      if (name === 'tsconfig.base.json') {
-        return '/project-root/tsconfig.base.json';
-      }
-      return undefined;
-    });
+    vi.mocked(common.findTsconfigPath).mockReturnValue('/project-root/tsconfig.base.json');
 
     const result = findTsconfigPath('/project-root');
 
@@ -221,12 +208,7 @@ describe('findTsconfigPath', () => {
   });
 
   test('falls back to tsconfig.app.json when neither tsconfig.json nor tsconfig.base.json is found', () => {
-    vi.mocked(find.up).mockImplementation((name) => {
-      if (name === 'tsconfig.app.json') {
-        return '/project-root/tsconfig.app.json';
-      }
-      return undefined;
-    });
+    vi.mocked(common.findTsconfigPath).mockReturnValue('/project-root/tsconfig.app.json');
 
     const result = findTsconfigPath('/project-root');
 
@@ -234,7 +216,7 @@ describe('findTsconfigPath', () => {
   });
 
   test('returns undefined when no tsconfig variant is found', () => {
-    vi.mocked(find.up).mockReturnValue(undefined);
+    vi.mocked(common.findTsconfigPath).mockReturnValue(undefined);
 
     const result = findTsconfigPath('/project-root');
 
@@ -243,15 +225,7 @@ describe('findTsconfigPath', () => {
   });
 
   test('prefers tsconfig.json over fallback variants', () => {
-    vi.mocked(find.up).mockImplementation((name) => {
-      if (name === 'tsconfig.json') {
-        return '/project-root/tsconfig.json';
-      }
-      if (name === 'tsconfig.base.json') {
-        return '/project-root/tsconfig.base.json';
-      }
-      return undefined;
-    });
+    vi.mocked(common.findTsconfigPath).mockReturnValue('/project-root/tsconfig.json');
 
     const result = findTsconfigPath('/project-root');
 

--- a/code/renderers/react/src/componentManifest/utils.ts
+++ b/code/renderers/react/src/componentManifest/utils.ts
@@ -1,7 +1,10 @@
 // Object.groupBy polyfill
 import { readFileSync } from 'node:fs';
 
-import { getProjectRoot, resolveImport } from 'storybook/internal/common';
+import {
+  findTsconfigPath as findTsconfigPathCommon,
+  resolveImport,
+} from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
 import * as find from 'empathic/find';
@@ -169,25 +172,9 @@ export const cachedResolveImport: typeof resolveImport = cached(resolveImport, {
   name: 'resolveImport',
 }) as typeof resolveImport;
 
-/**
- * Tsconfig filenames to try, in order. Monorepo setups (e.g. Nx) often keep only
- * `tsconfig.base.json` at the repository root, so we fall back to common alternatives
- * when `tsconfig.json` is not found.
- */
-const TSCONFIG_CANDIDATES = ['tsconfig.json', 'tsconfig.base.json', 'tsconfig.app.json'] as const;
-
 export const findTsconfigPath = cached(
-  (cwd: string): string | undefined => {
-    const projectRoot = getProjectRoot();
-
-    for (const candidate of TSCONFIG_CANDIDATES) {
-      const found = find.up(candidate, { cwd, last: projectRoot });
-      if (found) {
-        return found;
-      }
-    }
-
-    return undefined;
-  },
-  { name: 'findTsconfigPath' }
+  (cwd: string): string | undefined => findTsconfigPathCommon(cwd),
+  {
+    name: 'findTsconfigPath',
+  }
 );


### PR DESCRIPTION
Closes #34414

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Fixed the React component manifest `react-docgen-typescript` path to follow referenced tsconfig files and choose the config that actually includes the component file. This fixes Vite-style projects whose root `tsconfig.json` only contains `files: []` and references to `tsconfig.app.json`, which previously caused manifest generation to report that no component docs were found.

Added dedicated real-filesystem parser coverage for `react-docgen-typescript` plus an end-to-end manifest regression that reproduces the Vite `tsconfig.json` + `tsconfig.app.json` layout from the bug report.

Extended the same file-aware tsconfig selection strategy to the React docgen alias-resolution paths used by the manifest, the React Vite plugin, the React webpack loader, and the `react-docgen-typescript` argtypes extraction path. This builds on the fallback-chain work from #34353, but goes further by following project references and selecting the config that actually owns the file.

Implementation note: the file-aware selection strategy is intentionally aligned with the Volar-inspired project selection already used by `react-component-meta`'s `ComponentMetaManager`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Validated with:

`yarn exec vitest run code/core/src/common/utils/__tests__/tsconfig.test.ts code/renderers/react/src/componentManifest/reactDocgenTypescript.test.ts code/renderers/react/src/componentManifest/reactDocgen.test.ts code/renderers/react/src/componentManifest/generator.react-docgen-typescript.test.ts code/renderers/react/src/componentManifest/reactDocgen/extractReactTypescriptDocgenInfo.test.ts`

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Started the existing `../storybook-sandboxes/react-vite-default-ts` sandbox with `yarn storybook`. This sandbox already uses the Vite-style referenced-tsconfig layout (`tsconfig.json` with `files: []` plus references to `tsconfig.app.json` and `tsconfig.node.json`) and has `typescript.reactDocgen = 'react-docgen-typescript'` enabled in `.storybook/main.ts`.
2. Opened `http://localhost:6006/manifests/components.html` and confirmed the manifest debugger loaded successfully, reported `Using react-docgen-typescript`, and listed `example-button` / `Button` with `5 prop types` instead of showing `react-docgen-typescript did not return any component docs for this file`.
3. Opened `http://localhost:6006/?path=/docs/example-button--docs` and confirmed the Example/Button docs entry rendered successfully under the same referenced-tsconfig layout.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-file TypeScript configuration resolution to better support monorepo projects with multiple tsconfig files and project references.

* **Improvements**
  * Enhanced component documentation generation for projects using TypeScript path aliases across different configurations.
  * Optimized TypeScript parser caching for improved performance in multi-tsconfig projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->