### PR TITLE
CLI: Explicitly tell whether smoke tests passed or failed

### DIFF
--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -308,7 +308,7 @@ export async function buildDevStandalone(
       );
 
     if (problems.length > 0) {
-      logger.error(CLI_COLORS.error('Smoke tests failed.'));
+      logger.error('Smoke tests failed.');
       logger.log(problems.map((p) => p.stack).join('\n'));
     } else {
       logger.step(CLI_COLORS.success('Smoke tests passed, exiting.'));

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -13,7 +13,7 @@ import {
   validateFrameworkName,
   versions,
 } from 'storybook/internal/common';
-import { deprecate, logger, prompt } from 'storybook/internal/node-logger';
+import { CLI_COLORS, deprecate, logger, prompt } from 'storybook/internal/node-logger';
 import { MissingBuilderError, NoStatsForViteDevError } from 'storybook/internal/server-errors';
 import { oneWayHash, telemetry } from 'storybook/internal/telemetry';
 import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook/internal/types';
@@ -307,7 +307,13 @@ export async function buildDevStandalone(
         (warning) => !warning.message.includes(`Conflicting values for 'process.env.NODE_ENV'`)
       );
 
-    logger.log(problems.map((p) => p.stack).join('\n'));
+    if (problems.length > 0) {
+      logger.error(CLI_COLORS.error('Smoke tests failed.'));
+      logger.log(problems.map((p) => p.stack).join('\n'));
+    } else {
+      logger.step(CLI_COLORS.success('Smoke tests passed, exiting.'));
+    }
+    logger.outro('');
     process.exit(problems.length > 0 ? 1 : 0);
   } else {
     const name =


### PR DESCRIPTION
## What I did

Ensured smoke test output is clear and legible, especially when no problems are found.

This helps agents run smoke tests and conclude all is well.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

ø

#### Manual testing

Run `storybook dev --smoke-test` on the monorepo

<img width="854" height="559" alt="image" src="https://github.com/user-attachments/assets/7b137169-ca83-4e4b-87f7-9f48f5a3ad63" />

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke-test reporting: failures now emit an error and detailed logs, while successful runs show a clear success message.

* **Chores**
  * Standardized build output formatting to ensure a consistent outro/message is printed for both pass and fail outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->