### PR TITLE
Fix: Deduplicate variable names in builder-vite codegen to prevent hash collisions

### DIFF
--- a/code/builders/builder-vite/src/codegen-project-annotations.test.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.test.ts
@@ -17,6 +17,7 @@ describe('generateProjectAnnotationsCodeFromPreviews', () => {
 
     // Extract all "import * as <var>" identifiers
     const importedVars = [...result.matchAll(/import \* as (\w+) from/g)].map((m) => m[1]);
+    expect(importedVars).toHaveLength(2);
     // Every imported variable must be unique
     expect(new Set(importedVars).size).toBe(importedVars.length);
   });
@@ -33,9 +34,10 @@ describe('generateProjectAnnotationsCodeFromPreviews', () => {
     });
 
     const importedVars = [...result.matchAll(/import \* as (\w+) from/g)].map((m) => m[1]);
+    expect(importedVars).toHaveLength(2);
     expect(new Set(importedVars).size).toBe(importedVars.length);
     // Neither variable should have a dedup suffix
-    expect(importedVars.every((v) => !/_\d+$/.test(v) || /^\w+_\d+$/.test(v))).toBe(true);
+    expect(importedVars.every((v) => /^\w+(?:_[1-9]\d*)?$/.test(v))).toBe(true);
   });
 
   it('handles three-way collisions', () => {
@@ -53,6 +55,7 @@ describe('generateProjectAnnotationsCodeFromPreviews', () => {
     });
 
     const importedVars = [...result.matchAll(/import \* as (\w+) from/g)].map((m) => m[1]);
+    expect(importedVars).toHaveLength(3);
     expect(new Set(importedVars).size).toBe(importedVars.length);
   });
 });

--- a/code/builders/builder-vite/src/codegen-project-annotations.test.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateProjectAnnotationsCodeFromPreviews } from './codegen-project-annotations';
+
+describe('generateProjectAnnotationsCodeFromPreviews', () => {
+  it('generates unique variable names for annotations that hash-collide', () => {
+    // These two addon preview paths are known to produce the same djb2 hash.
+    const result = generateProjectAnnotationsCodeFromPreviews({
+      previewAnnotations: [
+        '/node_modules/@storybook/addon-links/dist/preview.js',
+        '/node_modules/@storybook/addon-a11y/dist/preview.js',
+      ],
+      projectRoot: '/',
+      frameworkName: '@storybook/react-vite',
+      isCsf4: false,
+    });
+
+    // Extract all "import * as <var>" identifiers
+    const importedVars = [...result.matchAll(/import \* as (\w+) from/g)].map((m) => m[1]);
+    // Every imported variable must be unique
+    expect(new Set(importedVars).size).toBe(importedVars.length);
+  });
+
+  it('does not alter variable names when there is no collision', () => {
+    const result = generateProjectAnnotationsCodeFromPreviews({
+      previewAnnotations: [
+        '/node_modules/@storybook/addon-links/dist/preview.js',
+        '/node_modules/@storybook/addon-essentials/dist/preview.js',
+      ],
+      projectRoot: '/',
+      frameworkName: '@storybook/react-vite',
+      isCsf4: false,
+    });
+
+    const importedVars = [...result.matchAll(/import \* as (\w+) from/g)].map((m) => m[1]);
+    expect(new Set(importedVars).size).toBe(importedVars.length);
+    // Neither variable should have a dedup suffix
+    expect(importedVars.every((v) => !/_\d+$/.test(v) || /^\w+_\d+$/.test(v))).toBe(true);
+  });
+
+  it('handles three-way collisions', () => {
+    // Force three identical variable names by using the same path three times.
+    // In practice this can't happen, but it exercises the while-loop.
+    const result = generateProjectAnnotationsCodeFromPreviews({
+      previewAnnotations: [
+        '/node_modules/pkg-a/dist/preview.js',
+        '/node_modules/pkg-a/dist/preview.js',
+        '/node_modules/pkg-a/dist/preview.js',
+      ],
+      projectRoot: '/',
+      frameworkName: '@storybook/react-vite',
+      isCsf4: false,
+    });
+
+    const importedVars = [...result.matchAll(/import \* as (\w+) from/g)].map((m) => m[1]);
+    expect(new Set(importedVars).size).toBe(importedVars.length);
+  });
+});

--- a/code/builders/builder-vite/src/codegen-project-annotations.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.ts
@@ -44,11 +44,21 @@ export function generateProjectAnnotationsCodeFromPreviews(options: {
 
   const variables: string[] = [];
   const imports: string[] = [];
+  const seen = new Set<string>();
   for (const previewAnnotation of previewAnnotationURLs) {
-    const variable =
+    let variable =
       genSafeVariableName(filename(previewAnnotation)).replace(/_(45|46|47)/g, '_') +
       '_' +
       hash(previewAnnotation);
+    // Disambiguate when two different paths produce the same variable name
+    if (seen.has(variable)) {
+      let suffix = 2;
+      while (seen.has(`${variable}_${suffix}`)) {
+        suffix++;
+      }
+      variable = `${variable}_${suffix}`;
+    }
+    seen.add(variable);
     variables.push(variable);
     imports.push(genImport(previewAnnotation, { name: '*', as: variable }));
   }


### PR DESCRIPTION
## Description

Adds a collision-proof deduplication mechanism to the project annotations codegen in `@storybook/builder-vite`.

When two different addon preview paths produce the same hash value (e.g., `addon-links` and `addon-a11y` both generating hash `22070`), the generated virtual module contains duplicate variable names:

```js
import * as preview_22070 from "...addon-links...";
import * as preview_22070 from "...addon-a11y...";  // Duplicate!
```

This causes `Uncaught SyntaxError: Identifier 'preview_22070' has already been declared` and prevents Storybook from loading.

**Fixes #34372**

## Changes

**`codegen-project-annotations.ts`**:
- Track generated variable names in a `Set`
- When a collision is detected, append `_2`, `_3`, etc. to make the name unique
- The while-loop handles arbitrary N-way collisions

**`codegen-project-annotations.test.ts`** (new):
- Test that two paths producing the same hash get unique variable names
- Test that non-colliding paths are unaffected
- Test that three-way collisions are handled correctly

## Context

PR #34274 improved the hash function from a simple character-code sum to djb2, which greatly reduces collision probability. However, djb2 can still theoretically collide, and the original simple hash is what's deployed in Storybook 10.3.x. This PR adds a defensive dedup layer that guarantees correctness regardless of the hash function used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented import alias collisions in generated project annotations so all generated variable names are unique across collision scenarios.

* **Tests**
  * Added tests covering multiple collision cases to verify generated import name uniqueness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->