### PR TITLE
CLI: Add --output flag to sb ai

### DIFF
--- a/code/lib/cli-storybook/src/ai/index.ts
+++ b/code/lib/cli-storybook/src/ai/index.ts
@@ -1,3 +1,6 @@
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
 import type { PackageManagerName } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
@@ -6,7 +9,7 @@ import { generateMarkdownOutput } from './prompt';
 import type { ProjectInfo, AiPrepareOptions } from './types';
 
 export async function aiPrepare(options: AiPrepareOptions): Promise<void> {
-  const { configDir: userConfigDir, packageManager: packageManagerName } = options;
+  const { configDir: userConfigDir, packageManager: packageManagerName, output } = options;
 
   let projectInfo: ProjectInfo;
 
@@ -54,7 +57,15 @@ export async function aiPrepare(options: AiPrepareOptions): Promise<void> {
     return;
   }
 
-  logger.log(generateMarkdownOutput(projectInfo));
+  const markdownOutput = generateMarkdownOutput(projectInfo);
+
+  if (output) {
+    const outputPath = resolve(output);
+    await writeFile(outputPath, markdownOutput, 'utf-8');
+    logger.log(`Prompt written to ${outputPath}`);
+  } else {
+    logger.log(markdownOutput);
+  }
 }
 
 function parseMajorVersion(version: string): number | undefined {

--- a/code/lib/cli-storybook/src/ai/types.ts
+++ b/code/lib/cli-storybook/src/ai/types.ts
@@ -1,6 +1,7 @@
 export interface AiPrepareOptions {
   configDir?: string;
   packageManager?: string;
+  output?: string;
 }
 
 export interface ProjectInfo {

--- a/code/lib/cli-storybook/src/bin/run.ts
+++ b/code/lib/cli-storybook/src/bin/run.ts
@@ -306,7 +306,10 @@ command('doctor')
 
 const aiCommand = command('ai')
   .description('AI agent helpers for Storybook')
-  .option('-o, --output <path>', 'Write the prompt output to a file instead of printing it to stdout');
+  .option(
+    '-o, --output <path>',
+    'Write the prompt output to a file instead of printing it to stdout'
+  );
 
 aiCommand
   .command('prepare')

--- a/code/lib/cli-storybook/src/bin/run.ts
+++ b/code/lib/cli-storybook/src/bin/run.ts
@@ -306,7 +306,7 @@ command('doctor')
 
 const aiCommand = command('ai')
   .description('AI agent helpers for Storybook')
-  .option('-o, --output <path>', 'Write the prompt output to a file instead of logging it');
+  .option('-o, --output <path>', 'Write the prompt output to a file instead of printing it to stdout');
 
 aiCommand
   .command('prepare')

--- a/code/lib/cli-storybook/src/bin/run.ts
+++ b/code/lib/cli-storybook/src/bin/run.ts
@@ -304,7 +304,9 @@ command('doctor')
     }).catch(handleCommandFailure(options.logfile));
   });
 
-const aiCommand = command('ai').description('AI agent helpers for Storybook');
+const aiCommand = command('ai')
+  .description('AI agent helpers for Storybook')
+  .option('-o, --output <path>', 'Write the prompt output to a file instead of logging it');
 
 aiCommand
   .command('prepare')
@@ -315,10 +317,12 @@ aiCommand
     )
   )
   .option('-c, --config-dir <dir-name>', 'Directory of Storybook configuration')
-  .action(async (options) => {
-    await withTelemetry('ai-prepare', { cliOptions: options }, async () => {
-      await aiPrepare(options);
-    }).catch(handleCommandFailure(options.logfile));
+  .action(async (options, cmd) => {
+    const parentOptions = cmd.parent?.opts() ?? {};
+    const mergedOptions = { ...parentOptions, ...options };
+    await withTelemetry('ai-prepare', { cliOptions: mergedOptions }, async () => {
+      await aiPrepare(mergedOptions);
+    }).catch(handleCommandFailure(mergedOptions.logfile));
   });
 
 // Show available subcommands when `storybook ai` is run without arguments


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Now you can run `npx storybook ai prepare -o path/to/prompt.md`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `storybook ai prepare` now supports `-o, --output <path>` to write the generated prompt/markdown to a file.
  * If no output path is provided, the generated prompt is printed to the console as before.
  * Command option handling improved so prepare honors combined CLI options when invoked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->