### PR TITLE
Core: Only show modified/affected icons on components and groups

### DIFF
--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -217,7 +217,7 @@ const getDisplayStatus = (
   itemType: Item['type'],
   status: StatusValue
 ): { status: StatusValue; label: string } =>
-  itemType === 'story' && HIDDEN_STORY_STATUSES.has(status)
+  (itemType === 'story' || itemType === 'docs') && HIDDEN_STORY_STATUSES.has(status)
     ? { status: 'status-value:unknown', label: 'Unknown' }
     : { status, label: status.split(':')[1].replace(/^./, (char) => char.toUpperCase()) };
 

--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -3,12 +3,12 @@ import React, { useCallback, useMemo, useRef } from 'react';
 
 import { Button, ListItem } from 'storybook/internal/components';
 import { PRELOAD_ENTRIES } from 'storybook/internal/core-events';
-import type { StatusValue } from 'storybook/internal/types';
-import {
-  type API_HashEntry,
-  type StatusByTypeId,
-  type StatusesByStoryIdAndTypeId,
-  type StoryId,
+import type {
+  API_HashEntry,
+  StatusByTypeId,
+  StatusesByStoryIdAndTypeId,
+  StatusValue,
+  StoryId,
 } from 'storybook/internal/types';
 
 import {
@@ -208,6 +208,19 @@ const statusOrder: StatusValue[] = [
   'status-value:unknown',
 ];
 
+const HIDDEN_STORY_STATUSES: ReadonlySet<StatusValue> = new Set([
+  'status-value:modified',
+  'status-value:affected',
+]);
+
+const getDisplayStatus = (
+  itemType: Item['type'],
+  status: StatusValue
+): { status: StatusValue; label: string } =>
+  itemType === 'story' && HIDDEN_STORY_STATUSES.has(status)
+    ? { status: 'status-value:unknown', label: 'Unknown' }
+    : { status, label: status.split(':')[1].replace(/^./, (char) => char.toUpperCase()) };
+
 const Node = React.memo<NodeProps>(function Node(props) {
   const {
     item,
@@ -227,10 +240,6 @@ const Node = React.memo<NodeProps>(function Node(props) {
   } = props;
   const theme = useTheme();
   const { isDesktop, isMobile, setMobileMenuOpen } = useLayout();
-
-  if (!isDisplayed) {
-    return null;
-  }
 
   const statusLinks = useMemo<Link[]>(() => {
     if (item.type === 'story' || item.type === 'docs') {
@@ -253,11 +262,16 @@ const Node = React.memo<NodeProps>(function Node(props) {
     return [];
   }, [item.id, item.type, onSelectStoryId, statuses]);
 
+  let contextMenu = useContextMenu(item, statusLinks, api);
+  if (refId !== 'storybook_internal') {
+    contextMenu = { node: null, onMouseEnter: () => {} };
+  }
+
+  if (!isDisplayed) {
+    return null;
+  }
+
   const id = createId(item.id, refId);
-  const contextMenu =
-    refId === 'storybook_internal'
-      ? useContextMenu(item, statusLinks, api)
-      : { node: null, onMouseEnter: () => {} };
 
   if (
     (item.type === 'story' &&
@@ -270,7 +284,8 @@ const Node = React.memo<NodeProps>(function Node(props) {
     const statusValue = getMostCriticalStatusValue(
       Object.values(statuses || {}).map((s) => s.value)
     );
-    const { icon, textColor } = getStatus(theme, statusValue);
+    const { status, label } = getDisplayStatus(item.type, statusValue);
+    const { icon, textColor } = getStatus(theme, status);
 
     return (
       <LeafNodeStyleWrapper
@@ -311,10 +326,10 @@ const Node = React.memo<NodeProps>(function Node(props) {
         {contextMenu.node}
         {icon ? (
           <StatusButton
-            ariaLabel={`Status: ${statusValue.replace('status-value:', '')}`}
+            ariaLabel={`Status: ${label}`}
             data-testid="tree-status-button"
             type="button"
-            status={statusValue}
+            status={status}
             selectedItem={isSelected}
           >
             {icon}
@@ -369,14 +384,15 @@ const Node = React.memo<NodeProps>(function Node(props) {
   }
 
   const itemStatus = getMostCriticalStatusValue(Object.values(statuses || {}).map((s) => s.value));
-  const { icon: itemIcon, textColor: itemColor } = getStatus(theme, itemStatus);
+  const { status, label } = getDisplayStatus(item.type, itemStatus);
+  const { icon: itemIcon, textColor: itemColor } = getStatus(theme, status);
   const itemStatusButton = itemIcon ? (
     <StatusButton
-      ariaLabel={`Status: ${itemStatus.replace('status-value:', '')}`}
+      ariaLabel={`Status: ${label}`}
       data-testid="tree-status-button"
       role="status"
       type="button"
-      status={itemStatus}
+      status={status}
       selectedItem={isSelected}
     >
       {itemIcon}
@@ -393,7 +409,8 @@ const Node = React.memo<NodeProps>(function Node(props) {
       item.type
     ];
     const status = getMostCriticalStatusValue([itemStatus, groupStatus?.[item.id]]);
-    const color = status ? getStatus(theme, status).textColor : null;
+    const { status: displayedStatus, label } = getDisplayStatus(item.type, status);
+    const color = displayedStatus ? getStatus(theme, displayedStatus).textColor : null;
     const showBranchStatus = (
       [
         'status-value:modified',
@@ -402,7 +419,7 @@ const Node = React.memo<NodeProps>(function Node(props) {
         'status-value:warning',
         'status-value:error',
       ] as StatusValue[]
-    ).includes(status);
+    ).includes(displayedStatus);
 
     return (
       <LeafNodeStyleWrapper
@@ -460,18 +477,19 @@ const Node = React.memo<NodeProps>(function Node(props) {
         {contextMenu.node}
         {showBranchStatus ? (
           <StatusButton
-            ariaLabel={`Status: ${status.replace('status-value:', '')}`}
+            ariaLabel={`Status: ${label}`}
             data-testid="tree-status-button"
             type="button"
-            status={status}
+            status={displayedStatus}
             selectedItem={isSelected}
           >
-            {status === 'status-value:error' || status === 'status-value:warning' ? (
+            {displayedStatus === 'status-value:error' ||
+            displayedStatus === 'status-value:warning' ? (
               <svg key="icon" viewBox="0 0 6 6" width="6" height="6" type="dot">
                 <UseSymbol type="dot" />
               </svg>
             ) : (
-              getStatus(theme, status).icon
+              getStatus(theme, displayedStatus).icon
             )}
           </StatusButton>
         ) : (


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Showing a "modified" or "affected" icon on a story can be confusing, because when only a single story is changed, all siblings will be marked "modified" as well, due to the fact that change detection is file-based. By hiding the status dot on the story level, we avoid this confusion.

<img width="299" height="370" alt="Screenshot 2026-04-01 at 13 33 13" src="https://github.com/user-attachments/assets/ffdc73a4-212e-4771-b5fe-c389e65f1912" />

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Story and docs statuses previously shown as "modified" or "affected" now display as "Unknown" in the sidebar tree.

* **Refactor**
  * Reworked status mapping and display logic so icons, colors, labels, and branch-status visibility reflect the remapped status.
  * Simplified component control flow around context menu setup and display checks for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->