### PR TITLE
Maintenance: Extract parseFilterParam shared helper from tags and statuses modules

### DIFF
--- a/code/core/src/manager-api/lib/filter-param.ts
+++ b/code/core/src/manager-api/lib/filter-param.ts
@@ -1,0 +1,39 @@
+/**
+ * Parses a semicolon-separated URL filter parameter into included/excluded arrays.
+ *
+ * Items prefixed with `!` are treated as exclusions.
+ * The `transform` callback converts each raw string to the desired type; returning
+ * `null` or `undefined` silently skips the entry (e.g. for unknown enum values).
+ */
+export const parseFilterParam = <T>(
+  param: string | undefined,
+  transform: (raw: string) => T | null | undefined
+): { included: T[]; excluded: T[] } => {
+  if (!param) {
+    return { included: [], excluded: [] };
+  }
+
+  const included: T[] = [];
+  const excluded: T[] = [];
+
+  param.split(';').forEach((raw) => {
+    if (!raw) {
+      return;
+    }
+
+    const isExcluded = raw.startsWith('!');
+    const value = transform(isExcluded ? raw.slice(1) : raw);
+
+    if (value == null) {
+      return;
+    }
+
+    if (isExcluded) {
+      excluded.push(value);
+    } else {
+      included.push(value);
+    }
+  });
+
+  return { included, excluded };
+};

--- a/code/core/src/manager-api/modules/statuses.ts
+++ b/code/core/src/manager-api/modules/statuses.ts
@@ -5,40 +5,13 @@ import type {
 } from 'storybook/internal/types';
 
 import { statusValueShortName, toStatusValue } from '../../shared/status-store/index.ts';
+import { parseFilterParam } from '../lib/filter-param.ts';
 import { fullStatusStore } from '../stores/status.ts';
 
 export const parseStatusesParam = (
   statusesParam: string | undefined
-): { included: StatusValue[]; excluded: StatusValue[] } => {
-  if (!statusesParam) {
-    return { included: [], excluded: [] };
-  }
-
-  const included: StatusValue[] = [];
-  const excluded: StatusValue[] = [];
-
-  statusesParam.split(';').forEach((rawStatus) => {
-    if (!rawStatus) {
-      return;
-    }
-
-    const isExcluded = rawStatus.startsWith('!');
-    const shortName = isExcluded ? rawStatus.slice(1) : rawStatus;
-    const statusValue = toStatusValue(shortName);
-
-    if (!statusValue) {
-      return; // silently ignore unknown short names
-    }
-
-    if (isExcluded) {
-      excluded.push(statusValue);
-    } else {
-      included.push(statusValue);
-    }
-  });
-
-  return { included, excluded };
-};
+): { included: StatusValue[]; excluded: StatusValue[] } =>
+  parseFilterParam(statusesParam, toStatusValue);
 
 export const serializeStatusesParam = (
   included: StatusValue[],

--- a/code/core/src/manager-api/modules/tags.ts
+++ b/code/core/src/manager-api/modules/tags.ts
@@ -7,6 +7,7 @@ import type {
 
 import memoize from 'memoizerific';
 
+import { parseFilterParam } from '../lib/filter-param.ts';
 import { BUILT_IN_FILTERS, Tag as TagEnum, USER_TAG_FILTER } from '../../shared/constants/tags.ts';
 
 export const BUILT_IN_URL_TAG_MAP: Record<string, Tag> = {
@@ -17,32 +18,8 @@ export const BUILT_IN_URL_TAG_MAP: Record<string, Tag> = {
 
 export const parseTagsParam = (
   tagsParam: string | undefined
-): { included: Tag[]; excluded: Tag[] } => {
-  if (!tagsParam) {
-    return { included: [], excluded: [] };
-  }
-
-  const included: Tag[] = [];
-  const excluded: Tag[] = [];
-
-  tagsParam.split(';').forEach((rawTag) => {
-    if (!rawTag) {
-      return;
-    }
-
-    const isExcluded = rawTag.startsWith('!');
-    const normalizedTag = isExcluded ? rawTag.slice(1) : rawTag;
-    const mappedTag = (BUILT_IN_URL_TAG_MAP[normalizedTag] ?? normalizedTag) as Tag;
-
-    if (isExcluded) {
-      excluded.push(mappedTag);
-    } else {
-      included.push(mappedTag);
-    }
-  });
-
-  return { included, excluded };
-};
+): { included: Tag[]; excluded: Tag[] } =>
+  parseFilterParam(tagsParam, (raw) => (BUILT_IN_URL_TAG_MAP[raw] ?? raw) as Tag);
 
 export const serializeTagsParam = (included: Tag[], excluded: Tag[]): string => {
   if (!included.length && !excluded.length) {


### PR DESCRIPTION
Closes #34426

## What I did

`parseTagsParam` (tags.ts) and `parseStatusesParam` (statuses.ts) had identical structure for parsing semicolon-separated URL filter parameters with `!`-negation support — ~25-30 lines each, ~55 lines total of near-duplicate logic.

Extracted a generic `parseFilterParam<T>(param, transform)` helper to `code/core/src/manager-api/lib/filter-param.ts`:
- Handles the `;` splitting, empty-string guard, and `!` prefix detection
- Calls `transform(rawValue)` to convert the string to the target type
- Returns `null`/`undefined` from transform to silently skip unknown values (used by statuses)

Both `parseTagsParam` and `parseStatusesParam` are reduced to one-liners that pass their respective transforms. Public API is unchanged.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests (existing tests for parseTagsParam and parseStatusesParam cover the shared logic)
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual testing required — this is a pure refactor with no behavior changes. Existing unit tests verify correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized filter parameter parsing logic into a shared utility function. Status and tag filtering operations now leverage this unified helper to improve code maintainability and reduce duplication. No changes to filtering behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->