### PR TITLE
Windows: Fix resolution of mdx-react-shim

### DIFF
--- a/code/addons/docs/src/mdx-plugin.ts
+++ b/code/addons/docs/src/mdx-plugin.ts
@@ -5,6 +5,7 @@ import type { Plugin } from 'vite';
 
 import type { CompileOptions } from './compiler';
 import { compile } from './compiler';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Storybook uses a single loader when dealing with MDX:
@@ -36,8 +37,10 @@ export async function mdxPlugin(options: Options): Promise<Plugin> {
         const mdxLoaderOptions: CompileOptions = await presets.apply('mdxLoaderOptions', {
           ...mdxPluginOptions,
           mdxCompileOptions: {
-            providerImportSource: import.meta.resolve('@storybook/addon-docs/mdx-react-shim'),
             ...mdxPluginOptions?.mdxCompileOptions,
+            providerImportSource: fileURLToPath(
+              import.meta.resolve('@storybook/addon-docs/mdx-react-shim')
+            ),
             rehypePlugins: [
               ...(mdxPluginOptions?.mdxCompileOptions?.rehypePlugins ?? []),
               rehypeSlug,

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -49,7 +49,9 @@ async function webpack(
   const mdxLoaderOptions: CompileOptions = await options.presets.apply('mdxLoaderOptions', {
     ...mdxPluginOptions,
     mdxCompileOptions: {
-      providerImportSource: import.meta.resolve('@storybook/addon-docs/mdx-react-shim'),
+      providerImportSource: fileURLToPath(
+        import.meta.resolve('@storybook/addon-docs/mdx-react-shim')
+      ),
       ...mdxPluginOptions.mdxCompileOptions,
       rehypePlugins: [
         ...(mdxPluginOptions?.mdxCompileOptions?.rehypePlugins ?? []),


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/34392

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixing a resolution issue of `providerImportSource` by converting the file URL to a file path.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34476-sha-f8f46a46`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34476-sha-f8f46a46 sandbox` or in an existing project with `npx storybook@0.0.0-pr-34476-sha-f8f46a46 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34476-sha-f8f46a46`](https://npmjs.com/package/storybook/v/0.0.0-pr-34476-sha-f8f46a46) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-mdx-react-shim-path-issue-on-windows`](https://github.com/storybookjs/storybook/tree/valentin/fix-mdx-react-shim-path-issue-on-windows) |
| **Commit** | [`f8f46a46`](https://github.com/storybookjs/storybook/commit/f8f46a469fa5dbb1cf5db5ecdd6e11c53622bea8) |
| **Datetime** | Tue Apr  7 08:07:22 UTC 2026 (`1775549242`) |
| **Workflow run** | [24071156482](https://github.com/storybookjs/storybook/actions/runs/24071156482) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34476`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path resolution in the MDX documentation addon to ensure proper provider import source configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->