### PR TITLE
Controls: Fix select controls for optional unions in Flow and nested options

### DIFF
--- a/code/core/src/docs-tools/argTypes/convert/flow/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/flow/convert.ts
@@ -3,7 +3,11 @@ import type { SBType } from 'storybook/internal/types';
 
 import type { FlowLiteralType, FlowSigType, FlowType } from './types.ts';
 
+// Type guards for narrowing FlowType discriminant unions
+type FlowVoidType = Extract<FlowType, { name: 'void' }>;
+
 const isLiteral = (type: FlowType): type is FlowLiteralType => type.name === 'literal';
+const isVoid = (type: FlowType): type is FlowVoidType => type.name === 'void';
 const toEnumOption = (element: FlowLiteralType) => element.value.replace(/['|"]/g, '');
 
 const convertSig = (type: FlowSigType) => {
@@ -45,11 +49,16 @@ export const convert = (type: FlowType): SBType | void => {
     }
     case 'signature':
       return { ...base, ...convertSig(type) };
-    case 'union':
-      if (type.elements?.every(isLiteral)) {
-        return { ...base, name: 'enum', value: type.elements?.map(toEnumOption) };
+    case 'union': {
+      const nonVoidElements = (type.elements ?? []).filter((element) => !isVoid(element));
+      const allLiterals = nonVoidElements.length > 0 && nonVoidElements.every(isLiteral);
+
+      if (allLiterals) {
+        const literalElements = nonVoidElements.filter(isLiteral);
+        return { ...base, name: 'enum', value: literalElements.map(toEnumOption) };
       }
       return { ...base, name, value: type.elements?.map(convert) };
+    }
 
     case 'intersection':
       return { ...base, name, value: type.elements?.map(convert) };

--- a/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
@@ -123,3 +123,36 @@ describe('normalizeInputTypes', () => {
     });
   });
 });
+
+describe("normalizeInputType - options extraction", () => {
+  it("extracts options from inside control object to top level", () => {
+    expect(
+      normalizeInputType(
+        {
+          control: { type: "select", options: ["a", "b", "c"] },
+        },
+        "arg"
+      )
+    ).toEqual({
+      name: "arg",
+      options: ["a", "b", "c"],
+      control: { type: "select", disable: false },
+    });
+  });
+
+  it("does not override existing top-level options with control.options", () => {
+    expect(
+      normalizeInputType(
+        {
+          options: ["x", "y"],
+          control: { type: "select", options: ["a", "b", "c"] },
+        },
+        "arg"
+      )
+    ).toEqual({
+      name: "arg",
+      options: ["x", "y"],
+      control: { type: "select", options: ["a", "b", "c"], disable: false },
+    });
+  });
+});

--- a/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
@@ -124,35 +124,35 @@ describe('normalizeInputTypes', () => {
   });
 });
 
-describe("normalizeInputType - options extraction", () => {
-  it("extracts options from inside control object to top level", () => {
+describe('normalizeInputType - options extraction', () => {
+  it('extracts options from inside control object to top level', () => {
     expect(
       normalizeInputType(
         {
-          control: { type: "select", options: ["a", "b", "c"] },
+          control: { type: 'select', options: ['a', 'b', 'c'] },
         },
-        "arg"
+        'arg'
       )
     ).toEqual({
-      name: "arg",
-      options: ["a", "b", "c"],
-      control: { type: "select", disable: false },
+      name: 'arg',
+      options: ['a', 'b', 'c'],
+      control: { type: 'select', disable: false },
     });
   });
 
-  it("does not override existing top-level options with control.options", () => {
+  it('does not override existing top-level options with control.options', () => {
     expect(
       normalizeInputType(
         {
-          options: ["x", "y"],
-          control: { type: "select", options: ["a", "b", "c"] },
+          options: ['x', 'y'],
+          control: { type: 'select', options: ['a', 'b', 'c'] },
         },
-        "arg"
+        'arg'
       )
     ).toEqual({
-      name: "arg",
-      options: ["x", "y"],
-      control: { type: "select", options: ["a", "b", "c"], disable: false },
+      name: 'arg',
+      options: ['x', 'y'],
+      control: { type: 'select', options: ['a', 'b', 'c'], disable: false },
     });
   });
 });

--- a/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.ts
@@ -36,7 +36,15 @@ export const normalizeInputType = (inputType: InputType, key: string): StrictInp
     normalized.type = normalizeType(type);
   }
   if (control) {
-    normalized.control = normalizeControl(control);
+    // Extract options from control object if present (users may mistakenly nest
+    // options inside control, e.g. control: { type: 'select', options: [...] })
+    if (typeof control === 'object' && 'options' in control && !normalized.options) {
+      const { options: controlOptions, ...controlRest } = control;
+      normalized.options = controlOptions;
+      normalized.control = normalizeControl(controlRest);
+    } else {
+      normalized.control = normalizeControl(control);
+    }
   } else if (control === false) {
     normalized.control = { disable: true };
   }


### PR DESCRIPTION
## What
Closes #12641

This PR addresses two remaining issues with Storybook Controls of type "select" that were not fully resolved by #33200.

## Why

### 1. Flow converter missing `void` filtering
PR #33200 fixed the TypeScript converter to filter out `undefined` from union types before checking if all elements are literals (for enum/select detection). However, the **Flow converter** has the same bug — optional props in Flow add `void` to the union type, causing the enum detection to fail. This results in optional union props displaying as "object" controls instead of "select" dropdowns.

### 2. Options nested inside control object
Users commonly write `control: { type: "select", options: [...] }` instead of the documented `control: { type: "select" }, options: [...]`. The Storybook documentation shows `options` at the argType level, but many users (and even some examples) nest it inside `control`. Previously this silently failed — the control would render as a select but with no options. Now `normalizeInputType` extracts `options` from the control object to the top level when no top-level `options` are already specified.

## How

### Flow converter (`convert/flow/convert.ts`)
- Added `isVoid` type guard to detect Flow `void` types
- Filter out `void` elements from union before checking if all remaining elements are literals
- Use only non-void literal elements for enum value array
- Mirrors the exact same fix pattern applied to TypeScript converter in #33200

### normalizeInputTypes (`normalizeInputTypes.ts`)
- When processing a control object, check if it contains an `options` property
- If `options` exists inside `control` and no top-level `options` is set, extract it to the top level
- If top-level `options` already exists, leave `control.options` as-is (top-level takes precedence)

### Tests (`normalizeInputTypes.test.ts`)
- Added test: extracts `options` from inside control object to top level
- Added test: does not override existing top-level `options` with `control.options`

## How to test

### Flow optional union fix
1. Create a Flow component with optional union type props
2. Verify the Controls panel shows select/radio controls instead of object

### Nested options fix
1. Create a story with `argTypes: { size: { control: { type: "select", options: ["sm", "md", "lg"] } } }`
2. Verify the select control shows the options correctly
3. Also verify that `argTypes: { size: { control: { type: "select" }, options: ["sm", "md", "lg"] } }` still works

## Checklist
- [x] Fix tested locally
- [x] Minimal, focused changes
- [x] Backward compatible
- [x] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of void types during Flow type-to-enum conversion to avoid incorrect enum generation.
  * Improved input-type normalization so control-provided options are promoted to top-level options only when appropriate, preserving existing top-level options.

* **Tests**
  * Added tests covering options extraction behavior in input type normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->