### PR TITLE
Actions: Warn instead of throw for implicit actions in docs renders

### DIFF
--- a/code/core/src/actions/runtime/action.test.ts
+++ b/code/core/src/actions/runtime/action.test.ts
@@ -2,23 +2,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { global } from '@storybook/global';
 
-import { action } from './action';
+import { action } from './action.ts';
 
 vi.mock('storybook/preview-api', () => ({
   addons: { getChannel: () => ({ emit: vi.fn() }) },
 }));
 
 describe('action handler — implicit actions', () => {
+  const hadPreview = '__STORYBOOK_PREVIEW__' in (global as any);
+  const hadFeatures = 'FEATURES' in (globalThis as any);
   const originalPreview = (global as any).__STORYBOOK_PREVIEW__;
   const originalFeatures = (globalThis as any).FEATURES;
 
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     (globalThis as any).FEATURES = { disallowImplicitActionsInRenderV8: true };
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    (global as any).__STORYBOOK_PREVIEW__ = originalPreview;
-    (globalThis as any).FEATURES = originalFeatures;
+    if (hadPreview) {
+      (global as any).__STORYBOOK_PREVIEW__ = originalPreview;
+    } else {
+      delete (global as any).__STORYBOOK_PREVIEW__;
+    }
+    if (hadFeatures) {
+      (globalThis as any).FEATURES = originalFeatures;
+    } else {
+      delete (globalThis as any).FEATURES;
+    }
     vi.restoreAllMocks();
   });
 
@@ -36,10 +49,9 @@ describe('action handler — implicit actions', () => {
 
   it('warns instead of throwing when the render is in docs viewMode', () => {
     setRender({ phase: 'rendering', viewMode: 'docs' });
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const handler = action('onBlabla', { implicit: true });
     expect(() => handler()).not.toThrow();
-    expect(warn).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
   });
 
   it('does not throw when there is no active render', () => {

--- a/code/core/src/actions/runtime/action.test.ts
+++ b/code/core/src/actions/runtime/action.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { global } from '@storybook/global';
+
+import { action } from './action';
+
+vi.mock('storybook/preview-api', () => ({
+  addons: { getChannel: () => ({ emit: vi.fn() }) },
+}));
+
+describe('action handler — implicit actions', () => {
+  const originalPreview = (global as any).__STORYBOOK_PREVIEW__;
+  const originalFeatures = (globalThis as any).FEATURES;
+
+  beforeEach(() => {
+    (globalThis as any).FEATURES = { disallowImplicitActionsInRenderV8: true };
+  });
+
+  afterEach(() => {
+    (global as any).__STORYBOOK_PREVIEW__ = originalPreview;
+    (globalThis as any).FEATURES = originalFeatures;
+    vi.restoreAllMocks();
+  });
+
+  const setRender = (render: { phase: string; viewMode: string } | null) => {
+    (global as any).__STORYBOOK_PREVIEW__ = {
+      storyRenders: render ? [render] : [],
+    };
+  };
+
+  it('throws when an implicit action fires during a story render', () => {
+    setRender({ phase: 'rendering', viewMode: 'story' });
+    const handler = action('onClick', { implicit: true });
+    expect(() => handler()).toThrow(/implicit/i);
+  });
+
+  it('warns instead of throwing when the render is in docs viewMode', () => {
+    setRender({ phase: 'rendering', viewMode: 'docs' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = action('onBlabla', { implicit: true });
+    expect(() => handler()).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('does not throw when there is no active render', () => {
+    setRender(null);
+    const handler = action('onClick', { implicit: true });
+    expect(() => handler()).not.toThrow();
+  });
+});

--- a/code/core/src/actions/runtime/action.ts
+++ b/code/core/src/actions/runtime/action.ts
@@ -1,3 +1,4 @@
+import { logger } from 'storybook/internal/client-logger';
 import { ImplicitActionsDuringRendering } from 'storybook/internal/preview-errors';
 import type { Renderer } from 'storybook/internal/types';
 
@@ -76,7 +77,7 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
           deprecated,
         });
         if (deprecated) {
-          console.warn(error);
+          logger.warn(error);
         } else {
           throw error;
         }

--- a/code/core/src/actions/runtime/action.ts
+++ b/code/core/src/actions/runtime/action.ts
@@ -64,7 +64,12 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
       );
 
       if (storyRenderer) {
-        const deprecated = !globalThis?.FEATURES?.disallowImplicitActionsInRenderV8;
+        // Stories embedded in a docs page render with viewMode === 'docs'.
+        // There's no play-function semantics in docs rendering, so an implicit
+        // action firing during a lifecycle hook should warn rather than throw —
+        // otherwise it crashes the entire docs page (see #33758).
+        const inDocs = storyRenderer.viewMode === 'docs';
+        const deprecated = inDocs || !globalThis?.FEATURES?.disallowImplicitActionsInRenderV8;
         const error = new ImplicitActionsDuringRendering({
           phase: storyRenderer.phase!,
           name,


### PR DESCRIPTION
Closes #33758

## What I did

When a story is embedded in a docs page (`viewMode: 'docs'`) and an arg matched by `actions.argTypesRegex` (e.g. `^on.*`) fires during render — for example a Vue 3 component emitting an event from `onMounted` — the implicit action handler currently throws `ImplicitActionsDuringRendering`, which crashes the entire docs page.

The throw exists to protect play functions from accidentally relying on implicit actions, but docs renders have no play-function semantics. This PR downgrades the throw to a `console.warn` when the active `StoryRender` has `viewMode === 'docs'`. Story view (`viewMode === 'story'`) is unchanged, so play-function safety is preserved.

The discriminator is reliable: docs-embedded stories are mounted via `Preview.renderStoryToElement`, which hard-codes `'docs'` as the `StoryRender` view mode, and `ViewMode` is exhaustively `'story' | 'docs'`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

New unit tests in `code/core/src/actions/runtime/action.test.ts`:
- `viewMode: 'story'` + `phase: 'rendering'` → throws (preserves play-function safety)
- `viewMode: 'docs'` + `phase: 'rendering'` → warns, no throw
- no active render → no-op

#### Manual testing

1. Use the reporter's repro: https://repro-storybook-implicit-action.vercel.app/
2. Reproduce locally with a Vue 3 sandbox:
   - `yarn task sandbox --template vue3-vite/default-ts --start-from auto`
   - Add a component that emits an event from `onMounted` and a story with an `onBlabla` argType (no matching `args` entry).
   - Open the story's docs page; before this fix it crashes with `ImplicitActionsDuringRendering`, after this fix the docs page renders and the warning shows in the console.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

This is a behavior fix, not a deprecation — no migration entry added. Happy to add a note if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering implicit action behavior across story, docs, and no-render scenarios to ensure correct warn/throw behavior and global-state isolation.

* **Bug Fixes**
  * Implicit actions during docs rendering now emit warnings instead of throwing errors; implicit actions during story rendering still throw, and actions with no active render remain allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->