### PR TITLE
fix(core-server): preserve indexer relative importPath

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -413,7 +413,6 @@ export class StoryIndexGenerator {
     const indexer = this.options.indexers.find((ind) => ind.test.exec(absolutePath));
 
     invariant(indexer, `No matching indexer found for ${absolutePath}`);
-
     const indexInputs = (await indexer.createIndex(absolutePath, {
       makeTitle: defaultMakeTitle,
     })) as StoryIndexInput[]; // we don't actually support DocsIndexInputs at runtime, although types say we do
@@ -437,6 +436,9 @@ export class StoryIndexGenerator {
       }
       if (path.startsWith('virtual:')) {
         return path;
+      }
+      if (/^\.{1,2}[\\/]/.test(path)) {
+        return slash(normalizeStoryPath(path));
       }
       return slash(normalizeStoryPath(relative(this.options.workingDir, path)));
     };

--- a/code/core/src/core-server/utils/__tests__/index-extraction.test.ts
+++ b/code/core/src/core-server/utils/__tests__/index-extraction.test.ts
@@ -418,6 +418,54 @@ describe('story extraction', () => {
       }
     `);
   });
+
+  it('preserves custom relative importPath values from indexers', async () => {
+    const relativePath = './src/A.stories.js';
+    const absolutePath = join(options.workingDir, relativePath);
+    const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
+
+    const generator = new StoryIndexGenerator([specifier], {
+      ...options,
+      indexers: [
+        {
+          test: /\.stories\.(m?js|ts)x?$/,
+          createIndex: async () => [
+            {
+              exportName: 'StoryOne',
+              importPath: './src/generated/VirtualA.stories.ts',
+              type: 'story',
+              subtype: 'story',
+            },
+          ],
+        },
+      ],
+    });
+    const result = await generator.extractStories(specifier, absolutePath);
+
+    expect(result).toMatchInlineSnapshot(`
+			{
+			  "dependents": [],
+			  "entries": [
+			    {
+			      "componentPath": undefined,
+			      "exportName": "StoryOne",
+			      "extra": {
+			        "metaId": undefined,
+			        "stats": {},
+			      },
+			      "id": "a--story-one",
+			      "importPath": "./src/generated/VirtualA.stories.ts",
+			      "name": "Story One",
+			      "subtype": "story",
+			      "tags": [],
+			      "title": "A",
+			      "type": "story",
+			    },
+			  ],
+			  "type": "stories",
+			}
+		`);
+  });
 });
 describe('docs entries from story extraction', () => {
   it(`adds docs entry when autodocs is "tag" and an entry has the "${Tag.AUTODOCS}" tag`, async () => {


### PR DESCRIPTION
Fixes #25554.

## Summary
- preserve relative custom `importPath` values returned by custom indexers
- avoid treating already-relative indexer paths as absolute filesystem paths during normalization
- add a regression test covering custom relative `importPath` handling in story extraction

## Testing
- yarn test code/core/src/core-server/utils/__tests__/index-extraction.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed story indexing to preserve custom relative import paths beginning with `.` or `..`, preventing unintended path recomputation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->