### PR TITLE
fix(vue3): update reactive globals before calling storyFn

### DIFF
--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -57,6 +57,16 @@ export async function renderToCanvas(
 
   // if the story is already rendered and we are not forcing a remount, we just update the reactive args
   if (existingApp && !forceRemount) {
+    // Update the reactive proxies before calling storyFn so that decorators
+    // and the story function see the already-reactive objects instead of new
+    // plain objects.  This prevents globals (and args) from getting out of
+    // sync with the Vue reactivity system (see #34319).
+    updateArgs<Globals>(existingApp.reactiveGlobals, storyContext.globals);
+    storyContext.globals = existingApp.reactiveGlobals;
+
+    updateArgs<Args>(existingApp.reactiveArgs, storyContext.args);
+    storyContext.args = existingApp.reactiveArgs;
+
     // normally storyFn should be call once only in setup function,but because the nature of react and how storybook rendering the decorators
     // we need to call here to run the decorators again
     // i may wrap each decorator in memoized function to avoid calling it if the args are not changed
@@ -64,7 +74,6 @@ export async function renderToCanvas(
     const args = getArgs(element, storyContext); // get args in case they are altered by decorators otherwise use the args from the context
 
     updateArgs<Args>(existingApp.reactiveArgs, args);
-    updateArgs<Globals>(existingApp.reactiveGlobals, storyContext.globals);
     return () => {
       teardown(existingApp.vueApp, canvasElement);
     };


### PR DESCRIPTION
When a story re-renders without a full remount, globals were being updated after storyFn ran. Decorators would see stale plain objects instead of the reactive proxies, causing the globals state to desync from Vue's reactivity system.

Moved the updateArgs calls for globals and args to happen before storyFn is called, and swapped the context references to use the reactive versions. This way the entire decorator chain sees the same reactive objects that Vue is tracking.

Fixes #34319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reactive state synchronization for Vue3 component rendering to ensure proper update ordering when reusing component instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->