### PR TITLE
Build: NX resource-class eval — linux-browsers-js = medium+

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -82,6 +82,7 @@ launch-templates:
     init-steps: *linux-init-steps
     env: *common-env-vars
   linux-browsers-js:
+    # Resource-class sweep branch: explicitly medium+ (matches kasper/nx-ai baseline).
     resource-class: 'docker_linux_amd64/medium+'
     image: 'ubuntu22.04-node20.19-v2'
     init-steps: *linux-browsers-init-steps

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T13:35:10.181Z"
+  "codexCacheBust": "2026-04-17T13:55:10.939Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T09:57:34.002Z"
+  "codexCacheBust": "2026-04-17T10:17:34.663Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T10:37:32.938Z"
+  "codexCacheBust": "2026-04-17T10:57:34.357Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T17:35:10.614Z"
+  "codexCacheBust": "2026-04-17T17:55:10.186Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T11:54:10.111Z"
+  "codexCacheBust": "2026-04-17T12:15:09.025Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T09:42:28.785Z"
+  "codexCacheBust": "2026-04-17T09:57:34.002Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T14:15:09.995Z"
+  "codexCacheBust": "2026-04-17T14:35:12.206Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T12:15:09.025Z"
+  "codexCacheBust": "2026-04-17T12:35:09.552Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T12:55:09.791Z"
+  "codexCacheBust": "2026-04-17T13:15:09.793Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T15:55:10.569Z"
+  "codexCacheBust": "2026-04-17T16:15:09.380Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T10:57:34.357Z"
+  "codexCacheBust": "2026-04-17T11:54:10.111Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T16:35:10.497Z"
+  "codexCacheBust": "2026-04-17T16:55:09.660Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T17:15:09.862Z"
+  "codexCacheBust": "2026-04-17T17:35:10.614Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T16:15:09.380Z"
+  "codexCacheBust": "2026-04-17T16:35:10.497Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T14:35:12.206Z"
+  "codexCacheBust": "2026-04-17T14:55:10.674Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T15:15:09.857Z"
+  "codexCacheBust": "2026-04-17T15:35:09.551Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T10:17:34.663Z"
+  "codexCacheBust": "2026-04-17T10:37:32.938Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T15:35:09.551Z"
+  "codexCacheBust": "2026-04-17T15:55:10.569Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T13:15:09.793Z"
+  "codexCacheBust": "2026-04-17T13:35:10.181Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T13:55:10.939Z"
+  "codexCacheBust": "2026-04-17T14:15:09.995Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T14:55:10.674Z"
+  "codexCacheBust": "2026-04-17T15:15:09.857Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T12:35:09.552Z"
+  "codexCacheBust": "2026-04-17T12:55:09.791Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T16:55:09.660Z"
+  "codexCacheBust": "2026-04-17T17:15:09.862Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T09:12:36.058Z"
+  "codexCacheBust": "2026-04-17T09:42:28.785Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T00:00:00Z"
+  "codexCacheBust": "2026-04-17T09:12:36.058Z"
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

NX Cloud resource-class sweep — branch 5 of 6. **Do not merge.**

Changes exactly one line: `.nx/workflows/agents.yaml` → `linux-browsers-js.resource-class = docker_linux_amd64/medium+` (15 credits/min).

Part of measuring the real cost / duration / flake curve across `linux-browsers-js` resource classes on real `ci:normal` traffic. Replaces the single linearly-extrapolated "medium+ projected" column in the NX-vs-CircleCI findings canvas with a 6-point data-backed curve. `linux-js` stays at `extra_large+` across all branches. Parent branch `kasper/nx-ai` ([#34282](https://github.com/storybookjs/storybook/pull/34282)) strips CircleCI + `NX_EXPERIMENT` so these 6 PRs only exercise NX Cloud.

Sweep matrix:

| Branch | linux-browsers-js | credits/min |
| --- | --- | --- |
| [`kasper/nx-rc-xlarge-plus`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge-plus) | `extra_large+` | 60 |
| [`kasper/nx-rc-xlarge`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge) | `extra_large` | 40 |
| [`kasper/nx-rc-large-plus`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large-plus) | `large+` | 30 |
| [`kasper/nx-rc-large`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large) | `large` | 20 |
| [`kasper/nx-rc-medium-plus`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium-plus) | `medium+` | 15 |
| [`kasper/nx-rc-medium`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium) | `medium` | 10 |

Traffic plan: cache-bust every ~10 min per branch until 30 runs/branch or Enterprise trial expiry (2026-04-19). Data → `scripts/ci-eval.db` → new "Resource class sweep" section in the findings canvas with cost + duration bar charts and a measured recommendation.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual test necessary — this PR exists only to exercise CI traffic. Verify by opening the PR's NX Cloud CIPE (GH check `nx: normal`) and confirming the `linux-browsers-js` agents are running on `docker_linux_amd64/medium+` (visible in the agent metadata on cloud.nx.app). The sync script `scripts/evaluate-ci.ts` records `credit_multiplier = 15` per CIPE in `scripts/ci-eval.db`.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->