### PR TITLE
Build: NX resource-class eval (cohort 2) — linux-browsers-js = large

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -82,7 +82,7 @@ launch-templates:
     init-steps: *linux-init-steps
     env: *common-env-vars
   linux-browsers-js:
-    resource-class: 'docker_linux_amd64/medium+'
+    resource-class: 'docker_linux_amd64/large'
     image: 'ubuntu22.04-node20.19-v2'
     init-steps: *linux-browsers-init-steps
     env: *common-env-vars

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T16:30:12.799Z"
+  "codexCacheBust": "2026-04-17T16:49:59.396Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T12:52:33.526Z"
+  "codexCacheBust": "2026-04-17T13:12:20.810Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T15:30:51.076Z"
+  "codexCacheBust": "2026-04-17T15:50:37.353Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T10:10:16.779Z"
+  "codexCacheBust": "2026-04-17T10:30:02.842Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T13:51:54.671Z"
+  "codexCacheBust": "2026-04-17T14:11:41.487Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T11:53:12.000Z"
+  "codexCacheBust": "2026-04-17T12:12:59.302Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T09:31:32.132Z"
+  "codexCacheBust": "2026-04-17T09:50:28.696Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T10:30:02.842Z"
+  "codexCacheBust": "2026-04-17T10:49:49.343Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T17:09:47.497Z"
+  "codexCacheBust": "2026-04-17T17:29:35.101Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T16:49:59.396Z"
+  "codexCacheBust": "2026-04-17T17:09:47.497Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T13:32:08.550Z"
+  "codexCacheBust": "2026-04-17T13:51:54.671Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T13:12:20.810Z"
+  "codexCacheBust": "2026-04-17T13:32:08.550Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T15:50:37.353Z"
+  "codexCacheBust": "2026-04-17T16:10:24.794Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T10:49:49.343Z"
+  "codexCacheBust": "2026-04-17T11:09:36.728Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T17:49:22.582Z"
+  "codexCacheBust": "2026-04-17T18:09:10.258Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T14:11:41.487Z"
+  "codexCacheBust": "2026-04-17T14:31:29.440Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T14:31:29.440Z"
+  "codexCacheBust": "2026-04-17T14:51:16.088Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T17:29:35.101Z"
+  "codexCacheBust": "2026-04-17T17:49:22.582Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T12:12:59.302Z"
+  "codexCacheBust": "2026-04-17T12:32:47.906Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T11:09:36.728Z"
+  "codexCacheBust": "2026-04-17T11:53:12.000Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T12:32:47.906Z"
+  "codexCacheBust": "2026-04-17T12:52:33.526Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T15:11:03.549Z"
+  "codexCacheBust": "2026-04-17T15:30:51.076Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T00:00:00Z"
+  "codexCacheBust": "2026-04-17T09:31:32.132Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T16:10:24.794Z"
+  "codexCacheBust": "2026-04-17T16:30:12.799Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T14:51:16.088Z"
+  "codexCacheBust": "2026-04-17T15:11:03.549Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T09:50:28.696Z"
+  "codexCacheBust": "2026-04-17T10:10:16.779Z"
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

NX Cloud resource-class sweep — **cohort 2, branch 4 of 6**. **Do not merge.**

Second cohort of 6 PRs that mirror the first cohort (#34572-#34576 + #34578). Doubles the data volume per class and lets variance between identical-class branches act as a flake sanity check. Each cohort-2 PR varies exactly one line: `.nx/workflows/agents.yaml` → `linux-browsers-js.resource-class = docker_linux_amd64/large` (20 credits/min).

| Class | Cohort 1 | Cohort 2 |
| --- | --- | --- |
| `extra_large+` (60) | [`nx-rc-xlarge-plus`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge-plus) | [`nx-rc-xlarge-plus-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge-plus-2) |
| `extra_large` (40)  | [`nx-rc-xlarge`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge) | [`nx-rc-xlarge-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge-2) |
| `large+` (30)       | [`nx-rc-large-plus`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large-plus) | [`nx-rc-large-plus-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large-plus-2) |
| `large` (20)        | [`nx-rc-large`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large) | [`nx-rc-large-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large-2) |
| `medium+` (15)      | [`nx-rc-medium-plus`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium-plus) | [`nx-rc-medium-plus-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium-plus-2) |
| `medium` (10)       | [`nx-rc-medium`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium) | [`nx-rc-medium-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium-2) |

Traffic: cohort 2 is driven by a separate retrigger loop (`scripts/retrigger-ci.ts` on `kasper/nx-rc-retrigger-2`) on a 30-min cadence, so per-PR concurrency queues don't stack. `linux-js` stays at `extra_large+` across all branches.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual test necessary — this PR exists only to exercise CI traffic. Verify by opening the PR's NX Cloud CIPE (GH check `nx: normal`) and confirming the `linux-browsers-js` agents are running on `docker_linux_amd64/large` (visible in the agent metadata on cloud.nx.app). The sync script `scripts/evaluate-ci.ts` records `credit_multiplier = 20` per CIPE in `scripts/ci-eval.db`.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->