### PR TITLE
Build: NX resource-class eval (cohort 2) — linux-browsers-js = medium

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -82,7 +82,7 @@ launch-templates:
     init-steps: *linux-init-steps
     env: *common-env-vars
   linux-browsers-js:
-    resource-class: 'docker_linux_amd64/medium+'
+    resource-class: 'docker_linux_amd64/medium'
     image: 'ubuntu22.04-node20.19-v2'
     init-steps: *linux-browsers-init-steps
     env: *common-env-vars

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T16:12:29.225Z"
+  "codexCacheBust": "2026-04-17T16:32:17.114Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T12:15:03.942Z"
+  "codexCacheBust": "2026-04-17T12:34:51.870Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T14:53:20.289Z"
+  "codexCacheBust": "2026-04-17T15:13:07.659Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T14:33:33.537Z"
+  "codexCacheBust": "2026-04-17T14:53:20.289Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T10:12:21.265Z"
+  "codexCacheBust": "2026-04-17T10:32:07.361Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T13:53:59.184Z"
+  "codexCacheBust": "2026-04-17T14:13:45.568Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T15:13:07.659Z"
+  "codexCacheBust": "2026-04-17T15:32:55.203Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T09:33:36.182Z"
+  "codexCacheBust": "2026-04-17T09:52:32.937Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T13:34:12.605Z"
+  "codexCacheBust": "2026-04-17T13:53:59.184Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T16:32:17.114Z"
+  "codexCacheBust": "2026-04-17T16:52:03.581Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T17:11:51.862Z"
+  "codexCacheBust": "2026-04-17T17:31:39.247Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T09:52:32.937Z"
+  "codexCacheBust": "2026-04-17T10:12:21.265Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T16:52:03.581Z"
+  "codexCacheBust": "2026-04-17T17:11:51.862Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T17:31:39.247Z"
+  "codexCacheBust": "2026-04-17T17:51:27.169Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T15:52:41.772Z"
+  "codexCacheBust": "2026-04-17T16:12:29.225Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T15:32:55.203Z"
+  "codexCacheBust": "2026-04-17T15:52:41.772Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T11:11:40.897Z"
+  "codexCacheBust": "2026-04-17T11:55:16.093Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T14:13:45.568Z"
+  "codexCacheBust": "2026-04-17T14:33:33.537Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T12:34:51.870Z"
+  "codexCacheBust": "2026-04-17T12:54:37.467Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T13:14:25.146Z"
+  "codexCacheBust": "2026-04-17T13:34:12.605Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T11:55:16.093Z"
+  "codexCacheBust": "2026-04-17T12:15:03.942Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T00:00:00Z"
+  "codexCacheBust": "2026-04-17T09:33:36.182Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T17:51:27.169Z"
+  "codexCacheBust": "2026-04-17T18:11:14.720Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T10:32:07.361Z"
+  "codexCacheBust": "2026-04-17T10:51:53.407Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T12:54:37.467Z"
+  "codexCacheBust": "2026-04-17T13:14:25.146Z"
 }

--- a/nx.json
+++ b/nx.json
@@ -205,5 +205,5 @@
     ]
   },
   "analytics": false,
-  "codexCacheBust": "2026-04-17T10:51:53.407Z"
+  "codexCacheBust": "2026-04-17T11:11:40.897Z"
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

NX Cloud resource-class sweep — **cohort 2, branch 6 of 6**. **Do not merge.**

Second cohort of 6 PRs that mirror the first cohort (#34572-#34576 + #34578). Doubles the data volume per class and lets variance between identical-class branches act as a flake sanity check. Each cohort-2 PR varies exactly one line: `.nx/workflows/agents.yaml` → `linux-browsers-js.resource-class = docker_linux_amd64/medium` (10 credits/min).

| Class | Cohort 1 | Cohort 2 |
| --- | --- | --- |
| `extra_large+` (60) | [`nx-rc-xlarge-plus`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge-plus) | [`nx-rc-xlarge-plus-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge-plus-2) |
| `extra_large` (40)  | [`nx-rc-xlarge`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge) | [`nx-rc-xlarge-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-xlarge-2) |
| `large+` (30)       | [`nx-rc-large-plus`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large-plus) | [`nx-rc-large-plus-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large-plus-2) |
| `large` (20)        | [`nx-rc-large`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large) | [`nx-rc-large-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-large-2) |
| `medium+` (15)      | [`nx-rc-medium-plus`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium-plus) | [`nx-rc-medium-plus-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium-plus-2) |
| `medium` (10)       | [`nx-rc-medium`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium) | [`nx-rc-medium-2`](https://github.com/storybookjs/storybook/tree/kasper/nx-rc-medium-2) |

Traffic: cohort 2 is driven by a separate retrigger loop (`scripts/retrigger-ci.ts` on `kasper/nx-rc-retrigger-2`) on a 30-min cadence, so per-PR concurrency queues don't stack. `linux-js` stays at `extra_large+` across all branches.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual test necessary — this PR exists only to exercise CI traffic. Verify by opening the PR's NX Cloud CIPE (GH check `nx: normal`) and confirming the `linux-browsers-js` agents are running on `docker_linux_amd64/medium` (visible in the agent metadata on cloud.nx.app). The sync script `scripts/evaluate-ci.ts` records `credit_multiplier = 10` per CIPE in `scripts/ci-eval.db`.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->