### PR TITLE
fix(core): categorize UniversalStore internal errors

### DIFF
--- a/code/core/src/manager-errors.ts
+++ b/code/core/src/manager-errors.ts
@@ -18,6 +18,7 @@ export enum Category {
   MANAGER_CORE_EVENTS = 'MANAGER_CORE-EVENTS',
   MANAGER_ROUTER = 'MANAGER_ROUTER',
   MANAGER_THEMING = 'MANAGER_THEMING',
+  MANAGER_UNIVERSAL_STORE = 'MANAGER_UNIVERSAL-STORE',
 }
 
 export class ProviderDoesNotExtendBaseProviderError extends StorybookError {
@@ -46,6 +47,14 @@ export class UncaughtManagerError extends StorybookError {
     this.stack = data.error.stack;
   }
 }
+
+export {
+  UniversalStoreFollowerTimeoutError,
+  UniversalStoreIdRequiredError,
+  UniversalStoreMissingSubscribeArgumentError,
+  UniversalStoreNotConstructableError,
+  UniversalStoreNotReadyError,
+} from './shared/universal-store/errors';
 
 export class StatusTypeIdMismatchError extends StorybookError {
   constructor(

--- a/code/core/src/manager-errors.ts
+++ b/code/core/src/manager-errors.ts
@@ -54,7 +54,7 @@ export {
   UniversalStoreMissingSubscribeArgumentError,
   UniversalStoreNotConstructableError,
   UniversalStoreNotReadyError,
-} from './shared/universal-store/errors';
+} from './shared/universal-store/errors.ts';
 
 export class StatusTypeIdMismatchError extends StorybookError {
   constructor(

--- a/code/core/src/shared/universal-store/errors.ts
+++ b/code/core/src/shared/universal-store/errors.ts
@@ -1,0 +1,60 @@
+import { StorybookError } from '../../storybook-error';
+
+export abstract class UniversalStoreError extends StorybookError {
+  constructor(props: { code: number; message: string; name: string }) {
+    super({
+      ...props,
+      category: 'MANAGER_UNIVERSAL-STORE',
+    });
+  }
+}
+
+export class UniversalStoreFollowerTimeoutError extends UniversalStoreError {
+  constructor(public data: { id: string }) {
+    super({
+      name: 'UniversalStoreFollowerTimeoutError',
+      code: 1,
+      message: `No existing state found for follower with id: '${data.id}'. Make sure a leader with the same id exists before creating a follower.`,
+    });
+  }
+}
+
+export class UniversalStoreNotConstructableError extends UniversalStoreError {
+  constructor() {
+    super({
+      name: 'UniversalStoreNotConstructableError',
+      code: 1001,
+      message: 'UniversalStore is not constructable - use UniversalStore.create() instead',
+    });
+  }
+}
+
+export class UniversalStoreIdRequiredError extends UniversalStoreError {
+  constructor() {
+    super({
+      name: 'UniversalStoreIdRequiredError',
+      code: 1002,
+      message: 'id is required and must be a string, when creating a UniversalStore',
+    });
+  }
+}
+
+export class UniversalStoreNotReadyError extends UniversalStoreError {
+  constructor(public data: { id: string; action: 'set state' | 'send event' }) {
+    super({
+      name: 'UniversalStoreNotReadyError',
+      code: 1003,
+      message: `Cannot ${data.action} before store with id '${data.id}' is ready. You can get the current status with store.status, or await store.readyPromise to wait for the store to be ready before sending events.`,
+    });
+  }
+}
+
+export class UniversalStoreMissingSubscribeArgumentError extends UniversalStoreError {
+  constructor(public data: { id: string }) {
+    super({
+      name: 'UniversalStoreMissingSubscribeArgumentError',
+      code: 1004,
+      message: `Missing first subscribe argument, or second if first is the event type, when subscribing to a UniversalStore with id '${data.id}'`,
+    });
+  }
+}

--- a/code/core/src/shared/universal-store/errors.ts
+++ b/code/core/src/shared/universal-store/errors.ts
@@ -1,4 +1,4 @@
-import { StorybookError } from '../../storybook-error';
+import { StorybookError } from '../../storybook-error.ts';
 
 export abstract class UniversalStoreError extends StorybookError {
   constructor(props: { code: number; message: string; name: string }) {
@@ -44,7 +44,7 @@ export class UniversalStoreNotReadyError extends UniversalStoreError {
     super({
       name: 'UniversalStoreNotReadyError',
       code: 1003,
-      message: `Cannot ${data.action} before store with id '${data.id}' is ready. You can get the current status with store.status, or await store.readyPromise to wait for the store to be ready before sending events.`,
+      message: `Cannot ${data.action} before store with id '${data.id}' is ready. You can get the current status with store.status, or await store.untilReady() to wait for the store to be ready before sending events.`,
     });
   }
 }

--- a/code/core/src/shared/universal-store/index.test.ts
+++ b/code/core/src/shared/universal-store/index.test.ts
@@ -92,14 +92,14 @@ describe('UniversalStore', () => {
               leader: true,
             })
         ).toThrowErrorMatchingInlineSnapshot(
-          `[TypeError: UniversalStore is not constructable - use UniversalStore.create() instead]`
+          `[SB_MANAGER_UNIVERSAL-STORE_1001 (UniversalStoreNotConstructableError): UniversalStore is not constructable - use UniversalStore.create() instead]`
         );
       });
 
       it('should throw when id is not provided', () => {
         // Arrange, Act, Assert - creating an instance without an id and expect it to throw
         expect(() => (UniversalStore as any).create()).toThrowErrorMatchingInlineSnapshot(
-          `[TypeError: id is required and must be a string, when creating a UniversalStore]`
+          `[SB_MANAGER_UNIVERSAL-STORE_1002 (UniversalStoreIdRequiredError): id is required and must be a string, when creating a UniversalStore]`
         );
       });
 
@@ -691,7 +691,7 @@ You should reuse the existing instance instead of trying to create a new one.`);
         // Assert - eventually the follower.untilReady() promise should throw an error when the timeout is reached
         vi.advanceTimersToNextTimer();
         await expect(follower.untilReady()).rejects.toThrowErrorMatchingInlineSnapshot(
-          `[TypeError: No existing state found for follower with id: 'env1:test'. Make sure a leader with the same id exists before creating a follower.]`
+          `[SB_MANAGER_UNIVERSAL-STORE_0001 (UniversalStoreFollowerTimeoutError): No existing state found for follower with id: 'env1:test'. Make sure a leader with the same id exists before creating a follower.]`
         );
         expect(follower.status).toBe(UniversalStore.Status.ERROR);
       });
@@ -942,22 +942,7 @@ You should reuse the existing instance instead of trying to create a new one.`);
       expect(follower.status).toBe(UniversalStore.Status.SYNCING);
 
       // Act & Assert - set state on the follower before it is ready and expect it to throw
-      expect(() => follower.setState({ count: 1 })).toThrowErrorMatchingInlineSnapshot(`
-        [TypeError: Cannot set state before store is ready. You can get the current status with store.status,
-        or await store.readyPromise to wait for the store to be ready before sending events.
-        {
-          "newState": {
-            "count": 1
-          },
-          "id": "env2:test",
-          "actor": {
-            "id": "m7405c0077777777778",
-            "type": "FOLLOWER",
-            "environment": "MANAGER"
-          },
-          "environment": "MANAGER"
-        }]
-      `);
+      expect(() => follower.setState({ count: 1 })).toThrowErrorMatchingInlineSnapshot(`[SB_MANAGER_UNIVERSAL-STORE_1003 (UniversalStoreNotReadyError): Cannot set state before store with id 'env2:test' is ready. You can get the current status with store.status, or await store.readyPromise to wait for the store to be ready before sending events.]`);
     });
   });
 
@@ -1127,22 +1112,7 @@ You should reuse the existing instance instead of trying to create a new one.`);
       expect(follower.status).toBe(UniversalStore.Status.SYNCING);
 
       // Act & Assert - send an event with the follower before it is ready and expect it to throw
-      expect(() => follower.send({ type: 'TOO_EARLY' })).toThrowErrorMatchingInlineSnapshot(`
-        [TypeError: Cannot send event before store is ready. You can get the current status with store.status,
-        or await store.readyPromise to wait for the store to be ready before sending events.
-        {
-          "event": {
-            "type": "TOO_EARLY"
-          },
-          "id": "env2:test",
-          "actor": {
-            "id": "m7405c0077777777778",
-            "type": "FOLLOWER",
-            "environment": "MANAGER"
-          },
-          "environment": "MANAGER"
-        }]
-      `);
+      expect(() => follower.send({ type: 'TOO_EARLY' })).toThrowErrorMatchingInlineSnapshot(`[SB_MANAGER_UNIVERSAL-STORE_1003 (UniversalStoreNotReadyError): Cannot send event before store with id 'env2:test' is ready. You can get the current status with store.status, or await store.readyPromise to wait for the store to be ready before sending events.]`);
     });
   });
 

--- a/code/core/src/shared/universal-store/index.ts
+++ b/code/core/src/shared/universal-store/index.ts
@@ -1,6 +1,13 @@
 import { dedent } from 'ts-dedent';
 
 import { instances } from './instances.ts';
+import {
+  UniversalStoreFollowerTimeoutError,
+  UniversalStoreIdRequiredError,
+  UniversalStoreMissingSubscribeArgumentError,
+  UniversalStoreNotConstructableError,
+  UniversalStoreNotReadyError,
+} from './errors.ts';
 import type {
   Actor,
   ChannelEvent,
@@ -251,9 +258,7 @@ export class UniversalStore<
     // it can only be called from within the static factory method create()
     // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_propertiessimulating_private_constructors
     if (!UniversalStore.isInternalConstructing) {
-      throw new TypeError(
-        'UniversalStore is not constructable - use UniversalStore.create() instead'
-      );
+      throw new UniversalStoreNotConstructableError();
     }
     UniversalStore.isInternalConstructing = false;
 
@@ -336,7 +341,7 @@ export class UniversalStore<
     CustomEvent extends { type: string; payload?: any } = { type: string; payload?: any },
   >(options: StoreOptions<State>): UniversalStore<State, CustomEvent> {
     if (!options || typeof options?.id !== 'string') {
-      throw new TypeError('id is required and must be a string, when creating a UniversalStore');
+      throw new UniversalStoreIdRequiredError();
     }
     if (options.debug) {
       console.debug(
@@ -390,24 +395,11 @@ export class UniversalStore<
     this.debug('setState', { newState, previousState, updater });
 
     if (this.status !== UniversalStore.Status.READY) {
-      throw new TypeError(
-        dedent`Cannot set state before store is ready. You can get the current status with store.status,
-        or await store.readyPromise to wait for the store to be ready before sending events.
-        ${JSON.stringify(
-          {
-            newState,
-            id: this.id,
-            actor: this.actor,
-            environment: this.environment,
-          },
-          null,
-          2
-        )}`
-      );
+      throw new UniversalStoreNotReadyError({ id: this.id, action: 'set state' });
     }
 
     this.state = newState;
-    const event = {
+    const event: SetStateEvent<State> = {
       type: UniversalStore.InternalEventType.SET_STATE,
       payload: {
         state: newState,
@@ -442,9 +434,7 @@ export class UniversalStore<
     this.debug('subscribe', { eventType, listener });
 
     if (!listener) {
-      throw new TypeError(
-        `Missing first subscribe argument, or second if first is the event type, when subscribing to a UniversalStore with id '${this.id}'`
-      );
+      throw new UniversalStoreMissingSubscribeArgumentError({ id: this.id });
     }
 
     if (!this.listeners.has(eventType)) {
@@ -485,20 +475,7 @@ export class UniversalStore<
   public send = (event: CustomEvent) => {
     this.debug('send', { event });
     if (this.status !== UniversalStore.Status.READY) {
-      throw new TypeError(
-        dedent`Cannot send event before store is ready. You can get the current status with store.status,
-        or await store.readyPromise to wait for the store to be ready before sending events.
-        ${JSON.stringify(
-          {
-            event,
-            id: this.id,
-            actor: this.actor,
-            environment: this.environment,
-          },
-          null,
-          2
-        )}`
-      );
+      throw new UniversalStoreNotReadyError({ id: this.id, action: 'send event' });
     }
     this.emitToListeners(event, { actor: this.actor });
     this.emitToChannel(event, { actor: this.actor });
@@ -544,11 +521,7 @@ export class UniversalStore<
       setTimeout(() => {
         // if the state is already resolved by a response before this timeout,
         // rejecting it doesn't do anything, it will be ignored
-        this.syncing!.reject!(
-          new TypeError(
-            `No existing state found for follower with id: '${this.id}'. Make sure a leader with the same id exists before creating a follower.`
-          )
-        );
+        this.syncing!.reject!(new UniversalStoreFollowerTimeoutError({ id: this.id }));
       }, 1000);
     }
   }


### PR DESCRIPTION
Closes #34566

## What I did

Categorized internal `UniversalStore` failures by replacing generic `TypeError` occurrences with a granular `UniversalStoreError` hierarchy.

Currently, when a `UniversalStore` follower times out or is misused, it throws a plain `TypeError`. These are caught by `prepareForTelemetry.ts` and bucketed generically as
`SB_MANAGER_UNCAUGHT_0001`, making it impossible to distinguish store-specific failures from other uncaught manager errors in telemetry.

Specifically, I:
- Defined an abstract `UniversalStoreError` and 5 specialized subclasses in the `shared/universal-store` layer.
- Refactored `UniversalStore` to throw these specific errors with codes `1` and `1001` through `1004` (Timeout, NotConstructable, IdRequired, NotReady, MissingSubscribeArgument).
- Registered the `MANAGER_UNIVERSAL-STORE` category in `manager-errors.ts` and re-exported the errors to completely avoid circular dependencies between the `shared` and `manager`
bundles.
- Updated all affected inline snapshots in `index.test.ts`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!
 
 **No manual testing is necessary.**

This PR fixes a telemetry categorization bug where internal `UniversalStore` failures were being generically reported as uncaught manager errors. It does not alter any user-facing features, UI components, or public APIs.

Because manually reproducing these specific store initialization and timeout failures in a browser requires intentionally breaking core configurations, manual testing provides no practical diagnostic value. Instead, the updated `index.test.ts` suite exhaustively simulates these edge cases and verifies that the new error classes are thrown with the correct category, code, and `fromStorybook` flag required by the telemetry handler.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

*(Note: No public documentation changes were required as this is an internal telemetry/error architecture improvement).*

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes
can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo
storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved universal store error handling: operations now surface clearer, categorized error messages for construction, missing/invalid id, pre-ready actions, subscription arguments, and follower timeouts.
* **Tests**
  * Updated inline snapshots and tests to expect the new, standardized error messages and formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->