### PR TITLE
CLI: Handle existing query params in --preview-url

### DIFF
--- a/code/core/src/manager-api/modules/url.ts
+++ b/code/core/src/manager-api/modules/url.ts
@@ -282,10 +282,15 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
       globalsParam = globalsParam && `&globals=${globalsParam}`;
       customManagerParams = customManagerParams && `&${customManagerParams}`;
       customPreviewParams = customPreviewParams && `&${customPreviewParams}`;
-      const separator = previewBase.includes('?') ? '&' : '?';
+      const hashIndex = previewBase.indexOf('#');
+      const previewBaseWithoutHash =
+        hashIndex === -1 ? previewBase : previewBase.slice(0, hashIndex);
+      const previewHash = hashIndex === -1 ? '' : previewBase.slice(hashIndex);
+      const separator = previewBaseWithoutHash.includes('?') ? '&' : '?';
+
       return {
         managerHref: `${managerBase}?path=/${viewMode}/${refId ? `${refId}_` : ''}${storyId}${argsParam}${globalsParam}${customManagerParams}`,
-        previewHref: `${previewBase}${separator}id=${storyId}&viewMode=${viewMode}${refParam}${argsParam}${refId ? '' : globalsParam}${customPreviewParams}`,
+        previewHref: `${previewBaseWithoutHash}${separator}id=${storyId}&viewMode=${viewMode}${refParam}${argsParam}${refId ? '' : globalsParam}${customPreviewParams}${previewHash}`,
       };
     },
     getQueryParam(key) {

--- a/code/core/src/manager-api/modules/url.ts
+++ b/code/core/src/manager-api/modules/url.ts
@@ -282,10 +282,10 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
       globalsParam = globalsParam && `&globals=${globalsParam}`;
       customManagerParams = customManagerParams && `&${customManagerParams}`;
       customPreviewParams = customPreviewParams && `&${customPreviewParams}`;
-
+      const separator = previewBase.includes('?') ? '&' : '?';
       return {
         managerHref: `${managerBase}?path=/${viewMode}/${refId ? `${refId}_` : ''}${storyId}${argsParam}${globalsParam}${customManagerParams}`,
-        previewHref: `${previewBase}?id=${storyId}&viewMode=${viewMode}${refParam}${argsParam}${refId ? '' : globalsParam}${customPreviewParams}`,
+        previewHref: `${previewBase}${separator}id=${storyId}&viewMode=${viewMode}${refParam}${argsParam}${refId ? '' : globalsParam}${customPreviewParams}`,
       };
     },
     getQueryParam(key) {


### PR DESCRIPTION
## What I changed

This fixes malformed preview iframe URLs when `--preview-url` already contains query parameters.

Previously, `previewHref` always appended Storybook params with a hardcoded `?`, which produced invalid URLs like:

`iframe.html?foo=bar?id=<story-id>&viewMode=story`

This change uses the correct separator based on whether `previewBase` already includes a query string:

- `?` when no query params exist yet
- `&` when query params are already present

## Example

Before:
`iframe.html?foo=bar?id=button--primary&viewMode=story`

After:
`iframe.html?foo=bar&id=button--primary&viewMode=story`

## Why

`--preview-url` can be set to a URL that already includes query params. In that case, additional params must be appended with `&` instead of `?`.

Closes #34615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL generation to correctly handle query string delimiters, preventing invalid URLs when appending parameters to URLs that already contain query strings.
  * Preserved URL fragments (hashes) when adding query parameters so anchors remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->