### PR TITLE
fix: constrain preview canvas height

### DIFF
--- a/code/core/src/manager/components/preview/utils/components.ts
+++ b/code/core/src/manager/components/preview/utils/components.ts
@@ -28,7 +28,7 @@ export const CanvasWrap = styled.div<{ show: boolean }>(
     gridTemplateRows: '100%',
     position: 'relative',
     minWidth: '100%',
-    minHeight: '100%',
+    height: '100%',
   },
   ({ show }) => ({ display: show ? 'grid' : 'none' })
 );


### PR DESCRIPTION
## Summary
- change the manager preview canvas wrapper from `min-height: 100%` to `height: 100%`
- keeps the canvas constrained to the preview container instead of allowing Waterfox to size it taller than the available area

Fixes #34626

## Verification
- `git diff --check` ✅
- `yarn --cwd code lint:js:cmd core/src/manager/components/preview/utils/components.ts` could not run before install (`Couldn't find the node_modules state file`)
- `yarn install --immutable` was attempted but failed locally with `ENOSPC: no space left on device` while linking `node_modules`; no source files were changed by the failed install and generated files were cleaned

## Duplicate PR check
- Searched open and closed PRs for `34626`, `Waterfox canvas height`, `CanvasWrap minHeight`, `height for canvas Waterfox`, and `components.ts minHeight`; no existing PR for this issue was found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted preview canvas sizing to ensure proper display height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->