### PR TITLE
Docs: Update AI docs to include `get-changed-stories` tool

### DIFF
--- a/docs/ai/mcp/api.mdx
+++ b/docs/ai/mcp/api.mdx
@@ -51,7 +51,7 @@ Type: `boolean`
 
 Default: `true`
 
-The development toolset includes the [`get-storybook-story-instructions`](./overview.mdx#get-storybook-story-instructions), [`get-changed-stories`](./overview.mdx#get-changed-stories) and [`preview-stories`](./overview.mdx#preview-stories) tools.
+The development toolset includes the [`get-changed-stories`](./overview.mdx#get-changed-stories), [`get-storybook-story-instructions`](./overview.mdx#get-storybook-story-instructions), and [`preview-stories`](./overview.mdx#preview-stories) tools.
 
 #### `docs`
 

--- a/docs/ai/mcp/api.mdx
+++ b/docs/ai/mcp/api.mdx
@@ -51,7 +51,7 @@ Type: `boolean`
 
 Default: `true`
 
-The development toolset includes the [`get-storybook-story-instructions`](./overview.mdx#get-storybook-story-instructions) and [`preview-stories`](./overview.mdx#preview-stories) tools.
+The development toolset includes the [`get-storybook-story-instructions`](./overview.mdx#get-storybook-story-instructions), [`get-changed-stories`](./overview.mdx#get-changed-stories) and [`preview-stories`](./overview.mdx#preview-stories) tools.
 
 #### `docs`
 

--- a/docs/ai/mcp/overview.mdx
+++ b/docs/ai/mcp/overview.mdx
@@ -120,6 +120,10 @@ The development toolset includes the following tools:
 
 Returns instructions on how to write useful stories, including which props to capture and how to write interaction tests for the story (if applicable).
 
+#### `get-changed-stories`
+
+Returns a list of stories that are changed or possibly affected by local file changes (requires change detection to be enabled).
+
 #### `preview-stories`
 
 Returns story previews rendered in the agent's chat interface, if the agent supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview#client-support). Otherwise, it returns links to relevant stories in Storybook.

--- a/docs/ai/mcp/overview.mdx
+++ b/docs/ai/mcp/overview.mdx
@@ -116,13 +116,13 @@ The development toolset provides tools for authoring well-considered stories (in
 
 The development toolset includes the following tools:
 
+#### `get-changed-stories`
+
+Returns a list of stories that are changed or possibly affected by local file changes (requires [change detection](../../configure/user-interface/change-detection.mdx) to be enabled).
+
 #### `get-storybook-story-instructions`
 
 Returns instructions on how to write useful stories, including which props to capture and how to write interaction tests for the story (if applicable).
-
-#### `get-changed-stories`
-
-Returns a list of stories that are changed or possibly affected by local file changes (requires change detection to be enabled).
 
 #### `preview-stories`
 


### PR DESCRIPTION
## What I did

Docs for https://github.com/storybookjs/mcp/pull/219


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP toolset documentation with the new `get-changed-stories` tool for identifying affected stories from local file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->