### PR TITLE
Docs: Improve `fn` details for Actions

### DIFF
--- a/docs/essentials/actions.mdx
+++ b/docs/essentials/actions.mdx
@@ -12,15 +12,21 @@ Actions are used to show that an event handler (callback) has been called, and t
 
 Actions work via supplying special Storybook-generated mock functions to your story's event handler args. There are two ways to get an action arg:
 
-### Via storybook/test fn spies
+### Via `storybook/test` `fn` spies
 
-The recommended way to write actions is to use the `fn` utility from `storybook/test` to mock and spy args. This is very useful for writing [interaction tests](../writing-tests/interaction-testing.mdx). You can mock your component's methods by assigning them to the `fn()` function:
+The recommended way is to assign an arg to `fn()`, which creates a mock function that is automatically spied by Storybook. This is very useful for writing [interaction tests](../writing-tests/interaction-testing.mdx).
 
 <CodeSnippets path="button-story-onclick-action-spy.md" />
 
-If your component calls an arg (because of either the user's interaction or the `play` function) and that arg is spied on, the event will show up in the action panel:
+When your component calls an arg (because of either the user's interaction or the `play` function) with an `fn()` assignment, the event will show up in the actions panel:
 
 ![Actions usage](../_assets/essentials/addon-actions-screenshot.png)
+
+If you are defining a mock function with `fn()` outside of `args`, you must provide a name for it to automatically log to the actions panel:
+
+```js
+const handleClick = fn().mockName('handleClick');
+```
 
 ### Automatically matching args
 
@@ -40,9 +46,9 @@ This will bind a standard HTML event handler to the outermost HTML element rende
 
 You can still use the actions panel if you need to log function calls that are unrelated to any story. This can be helpful for debugging or logging purposes. There are two main ways to do this: `spyOn` from `storybook/test` or the `action` function from `storybook/actions`. For basic logging, we recommend creating a function spy, and for more complex scenarios, you can use the `action` function directly.
 
-### Via storybook/test spyOn
+### Via `storybook/test` `spyOn`
 
-Mocks and spies from `storybook/test` are automatically logged as actions. The easiest way to show function calls in the actions panel is to use the `spyOn` utility function. Spies appear with a default name, which you can customize by calling the `mockName` method.
+Mocks and spies from `storybook/test` are automatically logged as actions (when [applied as `arg` values or when given a name](#via-storybooktest-fn-spies)). The easiest way to show function calls in the actions panel is to use the `spyOn` utility function. Spies appear with a default name, which you can customize by calling the `mockName` method.
 
 <CodeSnippets path="actions-spyon-basic-example.md" />
 

--- a/docs/essentials/actions.mdx
+++ b/docs/essentials/actions.mdx
@@ -14,7 +14,7 @@ Actions work via supplying special Storybook-generated mock functions to your st
 
 ### Via `storybook/test` `fn` spies
 
-The recommended way is to assign an arg to `fn()`, which creates a mock function that is automatically spied by Storybook. This is very useful for writing [interaction tests](../writing-tests/interaction-testing.mdx).
+The recommended way is to assign `fn()` to an arg, which creates a mock function that is automatically spied on by Storybook. This is very useful for writing [interaction tests](../writing-tests/interaction-testing.mdx).
 
 <CodeSnippets path="button-story-onclick-action-spy.md" />
 


### PR DESCRIPTION
## What I did

See title

## Checklist for Contributors

### Testing

#### Manual testing

N/A — docs-only change

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how mocks and spies are handled in the actions panel.
  * Added guidance on naming mocks so they appear correctly in action logs.
  * Explained when automatic action logging occurs for test-provided mocks/spies and how to ensure visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->