### PR TITLE
UI: Show sidebar focus ring for selected item

### DIFF
--- a/code/core/src/manager/components/sidebar/HighlightStyles.tsx
+++ b/code/core/src/manager/components/sidebar/HighlightStyles.tsx
@@ -23,6 +23,9 @@ export const HighlightStyles: FC<Highlight> = ({ refId, itemId }) => (
             '&:hover, &:focus': { background },
           },
         },
+        [`[data-ref-id="${refId}"][data-item-id="${itemId}"][data-selected="true"]`]: {
+          boxShadow: `inset 0 0 0 2px ${color.lightest}`,
+        },
       };
     }}
   />

--- a/code/core/src/manager/components/sidebar/__tests__/HighlightStyles.test.tsx
+++ b/code/core/src/manager/components/sidebar/__tests__/HighlightStyles.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import React from 'react';
+
+import { ensure, themes } from 'storybook/theming';
+import type { Theme } from 'storybook/theming';
+
+type GlobalStyles = (theme: Theme) => Record<string, Record<string, unknown>>;
+
+let getGlobalStyles: GlobalStyles | undefined;
+
+vi.mock('storybook/theming', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('storybook/theming')>();
+
+  return {
+    ...actual,
+    Global: ({ styles }: { styles: GlobalStyles }) => {
+      getGlobalStyles = styles;
+      return null;
+    },
+  };
+});
+
+import { HighlightStyles } from '../HighlightStyles.tsx';
+
+describe('HighlightStyles', () => {
+  afterEach(() => {
+    cleanup();
+    getGlobalStyles = undefined;
+  });
+
+  test('keeps the keyboard highlight visible when the highlighted sidebar item is selected', () => {
+    render(<HighlightStyles refId="foo" itemId="bar" />);
+
+    const selector = '[data-ref-id="foo"][data-item-id="bar"][data-selected="true"]';
+    const styles = getGlobalStyles?.(ensure(themes.light));
+
+    expect(styles?.[selector]).toMatchObject({
+      boxShadow: expect.stringContaining('inset 0 0 0 2px'),
+    });
+  });
+});


### PR DESCRIPTION
Closes #24186

## What I did

- Keep the sidebar keyboard highlight visible when it lands on the currently selected item by adding a contrasting inset ring.
- Added a focused regression test for selected highlighted sidebar items.

AI assistance: Codex via Hermes Agent was used to prepare this PR.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No browser manual test was run in this environment. I verified the targeted sidebar styling behavior with the unit test and local checks below:

- `yarn vitest run --config code/core/vitest.config.ts code/core/src/manager/components/sidebar/__tests__/HighlightStyles.test.tsx`
- `yarn --cwd code lint:js:cmd core/src/manager/components/sidebar/HighlightStyles.tsx core/src/manager/components/sidebar/__tests__/HighlightStyles.test.tsx --fix`
- `yarn nx compile core`
- `yarn nx check core`
- `git diff --check HEAD~1..HEAD`

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selected items in the sidebar now display a visual highlight indicator for improved user feedback.

* **Tests**
  * Added test coverage to verify selection styling renders correctly with proper visual indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->