### PR TITLE
React: Show explicit false boolean props in Show Code source

### DIFF
--- a/code/renderers/react/src/docs/jsxDecorator.test.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.test.tsx
@@ -89,6 +89,14 @@ describe('renderJsx', () => {
       renderJsx(<Button disabled={true} />, { useBooleanShorthandSyntax: false })
     ).toMatchInlineSnapshot(`<Button disabled={true} />`);
   });
+  it('false boolean values are rendered explicitly by default options', () => {
+    function Button({ disabled }: { disabled?: boolean }) {
+      return <button disabled={disabled}>click</button>;
+    }
+    expect(renderJsx(<Button disabled={false} />, {})).toMatchInlineSnapshot(
+      `<Button disabled={false} />`
+    );
+  });
   it('large objects', () => {
     const obj = Array.from({ length: 20 }).reduce((acc, _, i) => {
       // @ts-expect-error (Converted from ts-ignore)

--- a/code/renderers/react/src/docs/jsxDecorator.test.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.test.tsx
@@ -71,6 +71,24 @@ describe('renderJsx', () => {
       </div>
     `);
   });
+  it('false boolean values are rendered explicitly (useBooleanShorthandSyntax: false)', () => {
+    function Button({ disabled }: { disabled?: boolean }) {
+      return <button disabled={disabled}>click</button>;
+    }
+    // useBooleanShorthandSyntax: false mirrors defaultOpts — ensures false props
+    // are never silently omitted when a component has no static defaultProps entry
+    expect(
+      renderJsx(<Button disabled={false} />, { useBooleanShorthandSyntax: false })
+    ).toMatchInlineSnapshot(`<Button disabled={false} />`);
+  });
+  it('true boolean values are rendered as explicit value when useBooleanShorthandSyntax is false', () => {
+    function Button({ disabled }: { disabled?: boolean }) {
+      return <button disabled={disabled}>click</button>;
+    }
+    expect(
+      renderJsx(<Button disabled={true} />, { useBooleanShorthandSyntax: false })
+    ).toMatchInlineSnapshot(`<Button disabled={true} />`);
+  });
   it('large objects', () => {
     const obj = Array.from({ length: 20 }).reduce((acc, _, i) => {
       // @ts-expect-error (Converted from ts-ignore)

--- a/code/renderers/react/src/docs/jsxDecorator.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.tsx
@@ -200,6 +200,12 @@ const defaultOpts = {
   showFunctions: false,
   enableBeautify: true,
   showDefaultProps: false,
+  // Disable boolean shorthand so that explicit `false` props are always rendered.
+  // The underlying library (react-element-to-jsx-string) suppresses props whose
+  // value is `false` when no React.defaultProps entry exists for that prop, which
+  // is the norm for modern TypeScript components. Setting this to false ensures
+  // `<Button loading={false} />` appears in Show Code rather than being omitted.
+  useBooleanShorthandSyntax: false,
 };
 
 export const skipJsxRender = (context: StoryContext<ReactRenderer>) => {

--- a/code/renderers/react/template/stories/jsx-boolean.stories.tsx
+++ b/code/renderers/react/template/stories/jsx-boolean.stories.tsx
@@ -50,7 +50,7 @@ export const BooleanTrueProps = {
     label: 'Submit',
     primary: true,
     loading: true,
-    disabled: false,
+    disabled: true,
   },
 };
 

--- a/code/renderers/react/template/stories/jsx-boolean.stories.tsx
+++ b/code/renderers/react/template/stories/jsx-boolean.stories.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+
+interface ButtonProps {
+  label: string;
+  primary?: boolean;
+  loading?: boolean;
+  disabled?: boolean;
+}
+
+// A minimal component with several boolean props to exercise the jsxDecorator
+// source rendering. React.defaultProps is intentionally omitted, which is the
+// pattern that previously caused `false` props to be silently dropped.
+const Button = ({ label, primary = false, loading = false, disabled = false }: ButtonProps) => (
+  <button
+    className={primary ? 'storybook-button--primary' : 'storybook-button--secondary'}
+    disabled={disabled}
+    aria-busy={loading}
+    type="button"
+  >
+    {label}
+  </button>
+);
+
+export default {
+  component: Button,
+  tags: ['autodocs'],
+};
+
+// All boolean props set to false.
+// Regression: with useBooleanShorthandSyntax: true (the old default), every
+// explicit `false` prop was silently dropped from Show Code because the
+// underlying library suppresses props whose value is `false` and have no
+// matching React.defaultProps entry. After the fix the source must show:
+//   <Button disabled={false} label="Submit" loading={false} />
+export const BooleanFalseProps = {
+  args: {
+    label: 'Submit',
+    primary: false,
+    loading: false,
+    disabled: false,
+  },
+};
+
+// All boolean props set to true.
+// With useBooleanShorthandSyntax: true (old default) these were shown as
+// `primary loading disabled` (shorthand). After the fix the source must show
+// explicit values: `primary={true} loading={true} disabled={true}`.
+export const BooleanTrueProps = {
+  args: {
+    label: 'Submit',
+    primary: true,
+    loading: true,
+    disabled: false,
+  },
+};
+
+// Mixed true and false boolean props.
+// Verifies that explicit rendering is consistent regardless of value.
+export const BooleanMixedProps = {
+  args: {
+    label: 'Submit',
+    primary: true,
+    loading: false,
+    disabled: false,
+  },
+};
+
+// Per-story opt-in to the old shorthand syntax via parameters.jsx.
+// When a story explicitly sets useBooleanShorthandSyntax: true, `true` props
+// should use shorthand (`primary`) and `false` props should be omitted —
+// preserving the opt-in escape hatch while the safe default is off.
+export const BooleanShorthandOptIn = {
+  args: {
+    label: 'Submit',
+    primary: true,
+    loading: false,
+    disabled: false,
+  },
+  parameters: {
+    jsx: { useBooleanShorthandSyntax: true },
+  },
+};


### PR DESCRIPTION
Fixes #30704

## What

Boolean props explicitly set to `false` are silently omitted from the **Show Code** source snippet in React stories, even though they are meaningfully different from not passing the prop at all.

**Before:**
```jsx
// Story args: { loading: false, disabled: false }
<Button />   // all false props are silently dropped
```

**After:**
```jsx
<Button loading={false} disabled={false} />
```

## Visual Proof — Before / After

### Animated comparison (bug → fix)
> Controls show all three toggles set to `false`. **Before:** the Show Code panel renders only `<Button />`. **After:** every `false` prop appears explicitly.

![Animated before/after](https://raw.githubusercontent.com/creazyfrog/storybook/next/pr-assets/storybook_pr34661_animated.gif)

### Static side-by-side
> **Left (BEFORE):** `loading={false}`, `disabled={false}`, `rounded={false}` all set in Controls — Show Code emits `<Button />` with no props.
> **Right (AFTER):** same controls — Show Code correctly emits all three explicit `false` props.
> **Bottom strip:** the one-line diff in `jsxDecorator.tsx` adding `useBooleanShorthandSyntax: false`.

![Static before/after comparison](https://raw.githubusercontent.com/creazyfrog/storybook/next/pr-assets/storybook_pr34661_comparison.png)

## Root cause

Storybook uses `@7rulnik/react-element-to-jsx-string` to render the JSX source string. Inside `formatProp.js` this condition silently drops any `false` boolean prop that has no matching entry in the component's static `React.defaultProps`:

```js
if (useBooleanShorthandSyntax && formattedPropValue === '{false}' && !hasDefaultValue) {
  attributeFormattedInline = '';   // ← dropped
}
```

Modern TypeScript components use function-parameter defaults instead of `Component.defaultProps`, so `!hasDefaultValue` is almost always `true`, meaning **every** explicit `false` prop is discarded.

## Fix

Set `useBooleanShorthandSyntax: false` in `defaultOpts` inside `jsxDecorator.tsx`. This tells the library to always emit boolean props as explicit JSX values (`disabled={false}`, `disabled={true}`) instead of applying shorthand rules.

Users who prefer the shorthand (`disabled` instead of `disabled={true}`) can still opt in per-story:

```js
parameters: {
  jsx: { useBooleanShorthandSyntax: true },
}
```

## Changes

- `code/renderers/react/src/docs/jsxDecorator.tsx` — add `useBooleanShorthandSyntax: false` to `defaultOpts`
- `code/renderers/react/src/docs/jsxDecorator.test.tsx` — add two tests: `false` prop rendered explicitly, `true` prop rendered explicitly

#### Manual testing

1. Open any React story that has boolean props (e.g. a `Button` with `disabled`, `loading`, or `rounded`).
2. In the **Controls** panel, toggle one or more boolean props to `false`.
3. Click **Show Code** in the story toolbar.
4. **Before the fix:** the source snippet omits all `false` props — you see `<Button />` with no attributes.
5. **After the fix:** every `false` prop is shown explicitly — e.g. `<Button loading={false} disabled={false} />`.

To verify the opt-in escape hatch still works, add `parameters: { jsx: { useBooleanShorthandSyntax: true } }` to a story and confirm `disabled` renders as the shorthand `disabled` (no `={true}`) and `false` props are dropped as before.

## AI disclosure

This fix was developed with the assistance of Claude (AI). The root-cause analysis, code change, and tests were reviewed by a human contributor before submission.