### PR TITLE
Core: Add "Clear filters" button and improve filter tooltips

### DIFF
--- a/code/core/src/manager-api/modules/stories.ts
+++ b/code/core/src/manager-api/modules/stories.ts
@@ -61,6 +61,7 @@ import {
 } from '../lib/stories.ts';
 import type { ModuleFn } from '../lib/types.tsx';
 import { buildNavigationUrl } from '../lib/url.ts';
+import { hasActiveFilters } from '../../shared/utils/story-index-filters.ts';
 import type { ComposedRef } from '../root.tsx';
 import { fullStatusStore } from '../stores/status.ts';
 import { BUILT_IN_FILTERS } from '../../shared/constants/tags.ts';
@@ -596,21 +597,11 @@ export const init: ModuleFn<SubAPI, SubState> = ({
       }
     },
     selectFirstStory: () => {
-      const {
-        index,
-        filteredIndex,
-        includedTagFilters,
-        excludedTagFilters,
-        includedStatusFilters,
-        excludedStatusFilters,
-      } = store.getState();
-      const hasActiveFilters =
-        includedTagFilters.length > 0 ||
-        excludedTagFilters.length > 0 ||
-        (includedStatusFilters?.length ?? 0) > 0 ||
-        (excludedStatusFilters?.length ?? 0) > 0;
+      const state = store.getState();
+      const hasAnyActiveFilters = hasActiveFilters(state);
 
-      if (hasActiveFilters) {
+      if (hasAnyActiveFilters) {
+        const { filteredIndex } = state;
         if (!filteredIndex) {
           return;
         }
@@ -624,6 +615,7 @@ export const init: ModuleFn<SubAPI, SubState> = ({
         return;
       }
 
+      const { index } = state;
       if (!index) {
         return;
       }
@@ -1044,20 +1036,10 @@ export const init: ModuleFn<SubAPI, SubState> = ({
          * - If the user started storybook with a specific page-URL like "/settings/about"
          */
         if (isCanvasRoute) {
-          const {
-            includedTagFilters,
-            excludedTagFilters,
-            includedStatusFilters,
-            excludedStatusFilters,
-            filteredIndex,
-          } = state;
-          const hasActiveFilters =
-            (includedTagFilters?.length ?? 0) > 0 ||
-            (excludedTagFilters?.length ?? 0) > 0 ||
-            (includedStatusFilters?.length ?? 0) > 0 ||
-            (excludedStatusFilters?.length ?? 0) > 0;
+          const hasAnyActiveFilters = hasActiveFilters(state);
 
-          if (hasActiveFilters && !stateHasSelection) {
+          if (hasAnyActiveFilters && !stateHasSelection) {
+            const { filteredIndex } = state;
             const storyPassesFilter = filteredIndex && filteredIndex[storyId]?.type === 'story';
 
             if (!storyPassesFilter) {

--- a/code/core/src/manager/components/sidebar/Filter.tsx
+++ b/code/core/src/manager/components/sidebar/Filter.tsx
@@ -9,6 +9,7 @@ import { FilterIcon } from '@storybook/icons';
 import { type API, type Combo, Consumer, experimental_useStatusStore } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
+import { getActiveFilterCount } from '../../../shared/utils/story-index-filters.ts';
 import { FilterPanel } from './FilterPanel.tsx';
 
 const StyledButton = styled(Button)<{ $isHighlighted: boolean }>(({ $isHighlighted, theme }) => ({
@@ -42,11 +43,7 @@ const TagSelected = styled(Badge)(({ theme }) => ({
 const filterMapper = ({ api, state }: Combo) => ({
   api,
   indexJson: state.internal_index as StoryIndex | undefined,
-  activeFilterCount:
-    (state.includedTagFilters?.length ?? 0) +
-    (state.excludedTagFilters?.length ?? 0) +
-    (state.includedStatusFilters?.length ?? 0) +
-    (state.excludedStatusFilters?.length ?? 0),
+  activeFilterCount: getActiveFilterCount(state),
   defaultIncludedFilters: state.defaultIncludedTagFilters,
   defaultExcludedFilters: state.defaultExcludedTagFilters,
   includedFilters: state.includedTagFilters,

--- a/code/core/src/manager/components/sidebar/FilterPanel.tsx
+++ b/code/core/src/manager/components/sidebar/FilterPanel.tsx
@@ -140,9 +140,7 @@ export const FilterPanel = ({
   );
 
   const setAllFilters = useCallback(
-    (selected: boolean) => {
-      api.setAllTagFilters(selected ? filterIds : [], []);
-    },
+    (selected: boolean) => api.setAllTagFilters(selected ? filterIds : [], []),
     [api, filterIds]
   );
 
@@ -181,9 +179,9 @@ export const FilterPanel = ({
                 ariaLabel={false}
                 id="deselect-all"
                 key="deselect-all"
-                onClick={() => {
-                  setAllFilters(false);
-                  api.resetStatusFilters();
+                onClick={async () => {
+                  await setAllFilters(false);
+                  await api.resetStatusFilters();
                 }}
               >
                 <SweepIcon />

--- a/code/core/src/manager/components/sidebar/FilterPanel.tsx
+++ b/code/core/src/manager/components/sidebar/FilterPanel.tsx
@@ -94,6 +94,7 @@ export const FilterPanel = ({
         id: shortName,
         type: 'status',
         title: shortName.charAt(0).toUpperCase() + shortName.slice(1),
+        tooltip: entry.description,
         count: entry.count,
         icon: statusIconEl ? <StatusIcon $iconColor={iconColor}>{statusIconEl}</StatusIcon> : null,
         isIncluded,

--- a/code/core/src/manager/components/sidebar/FilterPanel.utils.ts
+++ b/code/core/src/manager/components/sidebar/FilterPanel.utils.ts
@@ -4,12 +4,17 @@ import type { FilterFunction, StatusValue, Tag } from 'storybook/internal/types'
 
 import { BUILT_IN_FILTERS, USER_TAG_FILTER } from '../../../shared/constants/tags.ts';
 
-export { countStatusesByValue, statusValueShortName } from '../../../shared/status-store/index.ts';
+export {
+  countStatusesByValue,
+  statusValueShortName,
+  statusValueDescription,
+} from '../../../shared/status-store/index.ts';
 
 export type FilterItem = {
   id: string;
   type: string;
   title: string;
+  tooltip?: string;
   count: number;
   icon: ReactElement | null;
   isIncluded: boolean;

--- a/code/core/src/manager/components/sidebar/FilterPanelLink.tsx
+++ b/code/core/src/manager/components/sidebar/FilterPanelLink.tsx
@@ -25,6 +25,7 @@ export const createFilterLink = ({
   id,
   type,
   title,
+  tooltip,
   count,
   icon,
   isIncluded,
@@ -34,7 +35,7 @@ export const createFilterLink = ({
 }: FilterItem): Link => {
   const isChecked = isIncluded || isExcluded;
   const toggleLabel = `${type} filter: ${isExcluded ? `exclude ${title}` : title}`;
-  const toggleTooltip = `${isChecked ? 'Remove' : 'Add'} ${type} filter: ${title}`;
+  const toggleTooltip = tooltip ?? `${isChecked ? 'Remove' : 'Add'} ${type} filter: ${title}`;
   const invertButtonLabel = `${isExcluded ? 'Include' : 'Exclude'} ${type}: ${title}`;
 
   return {

--- a/code/core/src/manager/components/sidebar/NoResults.tsx
+++ b/code/core/src/manager/components/sidebar/NoResults.tsx
@@ -14,4 +14,8 @@ export const NoResults = styled.div(({ theme }) => ({
     color: theme.textMutedColor,
     fontSize: `${theme.typography.size.s1}px`,
   },
+  button: {
+    marginTop: 8,
+    alignSelf: 'center',
+  },
 }));

--- a/code/core/src/manager/components/sidebar/RefBlocks.tsx
+++ b/code/core/src/manager/components/sidebar/RefBlocks.tsx
@@ -11,8 +11,9 @@ import {
 } from 'storybook/internal/components';
 
 import { global } from '@storybook/global';
-import { ChevronDownIcon, LockIcon, SyncIcon } from '@storybook/icons';
+import { ChevronDownIcon, LockIcon, SweepIcon, SyncIcon } from '@storybook/icons';
 
+import { useStorybookApi } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
 import { useLayout } from '../layout/LayoutProvider.tsx';
@@ -157,52 +158,68 @@ const WideSpaced = styled(Spaced)({
   flex: 1,
 });
 
-export const EmptyBlock = ({ isMain, hasEntries }: { isMain: boolean; hasEntries: boolean }) => (
-  <Contained>
-    <FlexSpaced col={1}>
-      <WideSpaced>
-        {hasEntries ? (
-          <NoResults>
-            <strong>No stories found</strong>
-            <small>Your selected filters did not match any stories.</small>
-          </NoResults>
-        ) : isMain ? (
-          <Text>
-            Oh no! Your Storybook is empty. This can happen when:
-            <ul>
-              <li>
-                Your{' '}
-                <Link
-                  href="https://storybook.js.org/docs/api/main-config/main-config-stories?ref=ui"
-                  cancel={false}
-                  target="_blank"
-                >
-                  stories glob configuration
-                </Link>{' '}
-                does not match any files.{' '}
-              </li>
-              <li>
-                You have{' '}
-                <Link
-                  href="https://storybook.js.org/docs/writing-stories?ref=ui"
-                  cancel={false}
-                  target="_blank"
-                >
-                  no stories defined
-                </Link>{' '}
-                in your story files.{' '}
-              </li>
-            </ul>
-          </Text>
-        ) : (
-          <Text>
-            This composed Storybook is empty. Perhaps no stories match your selected filters.
-          </Text>
-        )}
-      </WideSpaced>
-    </FlexSpaced>
-  </Contained>
-);
+export const EmptyBlock = ({ isMain, hasEntries }: { isMain: boolean; hasEntries: boolean }) => {
+  const api = useStorybookApi();
+
+  return (
+    <Contained>
+      <FlexSpaced col={1}>
+        <WideSpaced>
+          {hasEntries ? (
+            <NoResults>
+              <strong>No stories found</strong>
+              <small>Your selected filters did not match any stories.</small>
+              <Button
+                ariaLabel={false}
+                size="small"
+                variant="outline"
+                onClick={() => {
+                  api.setAllTagFilters([], []);
+                  api.resetStatusFilters();
+                }}
+              >
+                <SweepIcon />
+                Clear filters
+              </Button>
+            </NoResults>
+          ) : isMain ? (
+            <Text>
+              Oh no! Your Storybook is empty. This can happen when:
+              <ul>
+                <li>
+                  Your{' '}
+                  <Link
+                    href="https://storybook.js.org/docs/api/main-config/main-config-stories?ref=ui"
+                    cancel={false}
+                    target="_blank"
+                  >
+                    stories glob configuration
+                  </Link>{' '}
+                  does not match any files.{' '}
+                </li>
+                <li>
+                  You have{' '}
+                  <Link
+                    href="https://storybook.js.org/docs/writing-stories?ref=ui"
+                    cancel={false}
+                    target="_blank"
+                  >
+                    no stories defined
+                  </Link>{' '}
+                  in your story files.{' '}
+                </li>
+              </ul>
+            </Text>
+          ) : (
+            <Text>
+              This composed Storybook is empty. Perhaps no stories match your selected filters.
+            </Text>
+          )}
+        </WideSpaced>
+      </FlexSpaced>
+    </Contained>
+  );
+};
 
 export const LoaderBlock: FC<{ isMain: boolean }> = ({ isMain }) => (
   <Contained>

--- a/code/core/src/manager/components/sidebar/RefBlocks.tsx
+++ b/code/core/src/manager/components/sidebar/RefBlocks.tsx
@@ -173,9 +173,9 @@ export const EmptyBlock = ({ isMain, hasEntries }: { isMain: boolean; hasEntries
                 ariaLabel={false}
                 size="small"
                 variant="outline"
-                onClick={() => {
-                  api.setAllTagFilters([], []);
-                  api.resetStatusFilters();
+                onClick={async () => {
+                  await api.setAllTagFilters([], []);
+                  await api.resetStatusFilters();
                 }}
               >
                 <SweepIcon />

--- a/code/core/src/manager/components/sidebar/RefBlocks.tsx
+++ b/code/core/src/manager/components/sidebar/RefBlocks.tsx
@@ -158,7 +158,15 @@ const WideSpaced = styled(Spaced)({
   flex: 1,
 });
 
-export const EmptyBlock = ({ isMain, hasEntries }: { isMain: boolean; hasEntries: boolean }) => {
+export const EmptyBlock = ({
+  isMain,
+  hasEntries,
+  activeFilterCount,
+}: {
+  isMain: boolean;
+  hasEntries: boolean;
+  activeFilterCount: number;
+}) => {
   const api = useStorybookApi();
 
   return (
@@ -168,19 +176,25 @@ export const EmptyBlock = ({ isMain, hasEntries }: { isMain: boolean; hasEntries
           {hasEntries ? (
             <NoResults>
               <strong>No stories found</strong>
-              <small>Your selected filters did not match any stories.</small>
-              <Button
-                ariaLabel={false}
-                size="small"
-                variant="outline"
-                onClick={async () => {
-                  await api.setAllTagFilters([], []);
-                  await api.resetStatusFilters();
-                }}
-              >
-                <SweepIcon />
-                Clear filters
-              </Button>
+              {activeFilterCount > 0 ? (
+                <small>Your selected filters did not match any stories.</small>
+              ) : (
+                <small>Try adding some stories!</small>
+              )}
+              {activeFilterCount > 0 ? (
+                <Button
+                  ariaLabel={false}
+                  size="small"
+                  variant="outline"
+                  onClick={async () => {
+                    await api.setAllTagFilters([], []);
+                    await api.resetStatusFilters();
+                  }}
+                >
+                  <SweepIcon />
+                  Clear filters
+                </Button>
+              ) : null}
             </NoResults>
           ) : isMain ? (
             <Text>

--- a/code/core/src/manager/components/sidebar/Refs.tsx
+++ b/code/core/src/manager/components/sidebar/Refs.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useStorybookApi, useStorybookState } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
+import { getActiveFilterCount } from '../../../shared/utils/story-index-filters.ts';
 import { getStateType } from '../../utils/tree.ts';
 import { AuthBlock, EmptyBlock, ErrorBlock, LoaderBlock } from './RefBlocks.tsx';
 import { RefIndicator } from './RefIndicator.tsx';
@@ -73,13 +74,7 @@ const CollapseButton = styled.button(({ theme }) => ({
 }));
 
 export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
-  const {
-    docsOptions,
-    includedTagFilters,
-    excludedTagFilters,
-    includedStatusFilters,
-    excludedStatusFilters,
-  } = useStorybookState();
+  const storybookState = useStorybookState();
   const api = useStorybookApi();
   const {
     filteredIndex: index,
@@ -109,11 +104,7 @@ export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
   const isError = !!indexError;
   const isEmpty = !isLoading && length === 0;
   const isAuthRequired = !!loginUrl && length === 0;
-  const activeFilterCount =
-    (includedTagFilters?.length ?? 0) +
-    (excludedTagFilters?.length ?? 0) +
-    (includedStatusFilters?.length ?? 0) +
-    (excludedStatusFilters?.length ?? 0);
+  const activeFilterCount = getActiveFilterCount(storybookState);
 
   const state = getStateType(isLoading, isAuthRequired, isError, isEmpty);
   const [isExpanded, setExpanded] = useState<boolean>(expanded);
@@ -173,7 +164,7 @@ export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
               // @ts-expect-error (non strict)
               data={index}
               // @ts-expect-error (non strict)
-              docsMode={docsOptions.docsMode}
+              docsMode={storybookState.docsOptions.docsMode}
               selectedStoryId={selectedStoryId}
               onSelectStoryId={onSelectStoryId}
               highlightedRef={highlightedRef}

--- a/code/core/src/manager/components/sidebar/Refs.tsx
+++ b/code/core/src/manager/components/sidebar/Refs.tsx
@@ -73,7 +73,13 @@ const CollapseButton = styled.button(({ theme }) => ({
 }));
 
 export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
-  const { docsOptions } = useStorybookState();
+  const {
+    docsOptions,
+    includedTagFilters,
+    excludedTagFilters,
+    includedStatusFilters,
+    excludedStatusFilters,
+  } = useStorybookState();
   const api = useStorybookApi();
   const {
     filteredIndex: index,
@@ -103,6 +109,11 @@ export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
   const isError = !!indexError;
   const isEmpty = !isLoading && length === 0;
   const isAuthRequired = !!loginUrl && length === 0;
+  const activeFilterCount =
+    (includedTagFilters?.length ?? 0) +
+    (excludedTagFilters?.length ?? 0) +
+    (includedStatusFilters?.length ?? 0) +
+    (excludedStatusFilters?.length ?? 0);
 
   const state = getStateType(isLoading, isAuthRequired, isError, isEmpty);
   const [isExpanded, setExpanded] = useState<boolean>(expanded);
@@ -111,9 +122,9 @@ export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
     if (index && selectedStoryId && index[selectedStoryId]) {
       setExpanded(true);
     }
-  }, [setExpanded, index, selectedStoryId]);
+  }, [index, selectedStoryId]);
 
-  const handleClick = useCallback(() => setExpanded((value) => !value), [setExpanded]);
+  const handleClick = useCallback(() => setExpanded((value) => !value), []);
 
   const setHighlightedItemId = useCallback(
     (itemId: string) => setHighlighted({ itemId, refId }),
@@ -146,7 +157,13 @@ export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
           {/* @ts-expect-error (non strict) */}
           {state === 'error' && <ErrorBlock error={indexError} />}
           {state === 'loading' && <LoaderBlock isMain={isMain} />}
-          {state === 'empty' && <EmptyBlock isMain={isMain} hasEntries={hasEntries} />}
+          {state === 'empty' && (
+            <EmptyBlock
+              isMain={isMain}
+              hasEntries={hasEntries}
+              activeFilterCount={activeFilterCount}
+            />
+          )}
           {state === 'ready' && (
             <Tree
               allStatuses={allStatuses}

--- a/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
@@ -258,6 +258,45 @@ export const EmptyMobile: Story = {
   play: waitForChecklistWidget,
 };
 
+export const EmptyWithFilters: Story = {
+  args: Empty.args,
+  decorators: [
+    (storyFn, { args, globals, title }) => {
+      const context = managerContext(args);
+      return (
+        <ManagerContext.Provider
+          value={{
+            ...context,
+            state: {
+              ...context.state,
+              includedTagFilters: ['A'],
+              excludedTagFilters: ['B'],
+              includedStatusFilters: [],
+              excludedStatusFilters: [],
+            },
+          }}
+        >
+          <LayoutProvider
+            forceDesktop={
+              globals.viewport?.value === 'desktop' ||
+              globals.viewport?.value === undefined ||
+              title.endsWith('scrolled')
+            }
+          >
+            {storyFn()}
+          </LayoutProvider>
+        </ManagerContext.Provider>
+      );
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    await waitForChecklistWidget();
+    const canvas = within(canvasElement);
+    const clearFiltersButton = await canvas.findByRole('button', { name: 'Clear filters' });
+    await expect(clearFiltersButton).toBeInTheDocument();
+  },
+};
+
 export const EmptyIndex: Story = {
   args: {
     index: {},

--- a/code/core/src/manager/components/sidebar/useFilterData.tsx
+++ b/code/core/src/manager/components/sidebar/useFilterData.tsx
@@ -18,6 +18,7 @@ import {
   countStatusesByValue,
   getFilterFunction,
   statusValueShortName,
+  statusValueDescription,
 } from './FilterPanel.utils.ts';
 
 export interface TagFilterEntry {
@@ -32,6 +33,7 @@ export interface StatusFilterEntry {
   statusValue: StatusValue;
   shortName: string;
   count: number;
+  description?: string;
 }
 
 const BUILT_IN_FILTER_DEFS: Array<{
@@ -92,6 +94,7 @@ export function useStatusFilterEntries(allStatuses: StatusesByStoryIdAndTypeId) 
     return STATUS_DISPLAY_ORDER.map((statusValue) => ({
       statusValue,
       shortName: statusValueShortName(statusValue),
+      description: statusValueDescription(statusValue),
       count: counts[statusValue] ?? 0,
     }));
   }, [allStatuses]);

--- a/code/core/src/shared/status-store/index.ts
+++ b/code/core/src/shared/status-store/index.ts
@@ -42,6 +42,18 @@ export const statusValueShortName = (value: StatusValue): string => {
   return value.slice(STATUS_VALUE_PREFIX.length);
 };
 
+export const statusValueDescription = (value: StatusValue): string =>
+  ({
+    'status-value:pending': 'Stories with pending status',
+    'status-value:success': 'Stories with passing tests',
+    'status-value:new': 'Newly added stories',
+    'status-value:modified': 'Stories closely linked to code changes',
+    'status-value:affected': 'Stories likely to be affected by code changes',
+    'status-value:warning': 'Stories with warnings',
+    'status-value:error': 'Stories with failing tests',
+    'status-value:unknown': 'Stories with unknown status',
+  })[value];
+
 export type StatusTypeId = string;
 export type StatusByTypeId = Record<StatusTypeId, Status>;
 export type StatusesByStoryIdAndTypeId = Record<StoryId, StatusByTypeId>;

--- a/code/core/src/shared/utils/story-index-filters.ts
+++ b/code/core/src/shared/utils/story-index-filters.ts
@@ -1,0 +1,20 @@
+interface ActiveFiltersInput {
+  includedTagFilters?: readonly unknown[];
+  excludedTagFilters?: readonly unknown[];
+  includedStatusFilters?: readonly unknown[];
+  excludedStatusFilters?: readonly unknown[];
+}
+
+export const getActiveFilterCount = ({
+  includedTagFilters,
+  excludedTagFilters,
+  includedStatusFilters,
+  excludedStatusFilters,
+}: ActiveFiltersInput): number =>
+  (includedTagFilters?.length ?? 0) +
+  (excludedTagFilters?.length ?? 0) +
+  (includedStatusFilters?.length ?? 0) +
+  (excludedStatusFilters?.length ?? 0);
+
+export const hasActiveFilters = (filters: ActiveFiltersInput): boolean =>
+  getActiveFilterCount(filters) > 0;


### PR DESCRIPTION
## What I did

When active filters cause the sidebar to have 0 matching stories, show a "Clear filters" button to quickly reset the filters.

Updated the tooltip text for status filters to be more descriptive.

Also I fixed a bug where the existing Clear filters button was not working due to a race condition between `setAllTagFilters` and `resetStatusFilters`.

<img width="290" height="219" alt="Screenshot 2026-05-01 at 17 11 46" src="https://github.com/user-attachments/assets/45f20db6-7d48-4172-aff8-6817c0710112" />

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar shows a contextual "Clear filters" button when no stories match current filters.
  * Status filters now display descriptive tooltips on hover.

* **UI Improvements**
  * Improved spacing and centering for buttons in no-results states.
  * Empty-state messaging adjusts when filters are active.

* **Reliability**
  * Filter-clearing actions now run in order and await completion to ensure consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->