### PR TITLE
Maintenance: Remove `parser` re-export from `storybook/internal/babel`

### DIFF
--- a/code/core/src/babel/babelParse.ts
+++ b/code/core/src/babel/babelParse.ts
@@ -49,6 +49,18 @@ export const babelPrint = (ast: ASTNode): string => {
   }).code;
 };
 
-export const babelParseExpression = (code: string): parser.ParseResult<t.Expression> => {
-  return parser.parseExpression(code, parserOptions);
-};
+/**
+ * Thin wrapper around `@babel/parser`'s `parse` so callers do not have to import the parser
+ * namespace directly. Use this for parsing arbitrary source files; for recast-compatible parsing
+ * (source-preserving transforms) use {@link babelParse} instead.
+ */
+export const parseAst = (
+  code: string,
+  options?: parser.ParserOptions
+): parser.ParseResult<t.File> => parser.parse(code, options);
+
+/** Thin wrapper around `@babel/parser`'s `parseExpression`. */
+export const parseAstExpression = (
+  code: string,
+  options?: parser.ParserOptions
+): parser.ParseResult<t.Expression> => parser.parseExpression(code, options);

--- a/code/core/src/babel/index.ts
+++ b/code/core/src/babel/index.ts
@@ -8,7 +8,6 @@ import * as core from '@babel/core';
 // @ts-expect-error File is not yet exposed, see https://github.com/babel/babel/issues/11350#issuecomment-644118606
 import { File } from '@babel/core';
 import bg from '@babel/generator';
-import * as parser from '@babel/parser';
 import bt from '@babel/traverse';
 import * as types from '@babel/types';
 import * as recast from 'recast';
@@ -38,7 +37,6 @@ export {
   generate,
   traverse,
   types,
-  parser,
   transformSync,
   BabelFileClass,
 

--- a/code/core/src/core-server/utils/parser/generic-parser.ts
+++ b/code/core/src/core-server/utils/parser/generic-parser.ts
@@ -1,4 +1,4 @@
-import { parser, types as t } from 'storybook/internal/babel';
+import { parseAst, types as t } from 'storybook/internal/babel';
 
 import type { Parser, ParserResult } from './types.ts';
 
@@ -11,7 +11,7 @@ export class GenericParser implements Parser {
    * @returns The exports of the file
    */
   async parse(content: string): Promise<ParserResult> {
-    const ast = parser.parse(content, {
+    const ast = parseAst(content, {
       allowImportExportEverywhere: true,
       allowAwaitOutsideFunction: true,
       allowNewTargetOutsideFunction: true,

--- a/code/core/src/core-server/utils/save-story/valueToAST.ts
+++ b/code/core/src/core-server/utils/save-story/valueToAST.ts
@@ -1,4 +1,4 @@
-import { parser, types as t } from 'storybook/internal/babel';
+import { parseAst, types as t } from 'storybook/internal/babel';
 
 export function valueToAST<T>(literal: T): any {
   if (literal === null) {
@@ -6,7 +6,7 @@ export function valueToAST<T>(literal: T): any {
   }
   switch (typeof literal) {
     case 'function':
-      const ast = parser.parse(literal.toString(), {
+      const ast = parseAst(literal.toString(), {
         allowReturnOutsideFunction: true,
         allowSuperOutsideMethod: true,
       });

--- a/code/core/src/mocking-utils/extract.ts
+++ b/code/core/src/mocking-utils/extract.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 
-import { generate, parser, types as t } from 'storybook/internal/babel';
+import { generate, parseAst, types as t } from 'storybook/internal/babel';
 import { logger } from 'storybook/internal/node-logger';
 import { telemetry } from 'storybook/internal/telemetry';
 import type { CoreConfig } from 'storybook/internal/types';
@@ -42,7 +42,7 @@ interface ExtractMockCallsOptions {
  * @returns The parsed code.
  */
 export const babelParser = (code: string) => {
-  return parser.parse(code, {
+  return parseAst(code, {
     sourceType: 'module',
     // Enable plugins to handle modern JavaScript features, including TSX.
     plugins: ['typescript', 'jsx', 'classProperties', 'objectRestSpread'],

--- a/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { types as t } from 'storybook/internal/babel';
-import { generate, parser } from 'storybook/internal/babel';
+import { generate, parseAst } from 'storybook/internal/babel';
 
 import {
   cleanupTypeImports,
@@ -23,7 +23,7 @@ expect.addSnapshotSerializer({
 });
 
 function parseCodeToProgramNode(code: string): t.Program {
-  return parser.parse(code, { sourceType: 'unambiguous', plugins: ['typescript'] }).program;
+  return parseAst(code, { sourceType: 'unambiguous', plugins: ['typescript'] }).program;
 }
 
 function generateCodeFromAST(node: t.Program) {


### PR DESCRIPTION
Closes #

## What I did

Stacked on top of #34692 (resolve → oxc-resolver), which is itself stacked on #34625 (change-detection oxc adoption).

This PR slims the `storybook/internal/babel` re-export barrel by removing the raw `parser` namespace export from `@babel/parser`. Two thin helpers replace it:

- `parseAst(code, options)` — wraps `parser.parse`
- `parseAstExpression(code, options)` — wraps `parser.parseExpression`

Both helpers live in `code/core/src/babel/babelParse.ts` and are re-exported from `storybook/internal/babel`. The single-Babel-version guarantee is preserved — callers continue to route through the bundled core entry instead of pulling their own `@babel/parser` copy.

### Migrated callers (4)

- `code/core/src/mocking-utils/extract.ts`
- `code/core/src/core-server/utils/save-story/valueToAST.ts`
- `code/core/src/core-server/utils/parser/generic-parser.ts`
- `code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.test.ts`

Each call site previously did `parser.parse(code, opts).program` (or `.parseExpression`); they now use `parseAst` / `parseAstExpression` with identical options. No behavioural changes.

### Cleanup

- Removed `babelParseExpression` from `babelParse.ts` — zero callers in the repo, and superseded by `parseAstExpression`.

### Why now

The `parser` re-export was a leaky abstraction over `@babel/parser`'s API. Migrating off it is a prerequisite for the long-term Phase 3 plan: replacing the Babel+recast stack with `oxc-transform` / `oxc-codegen` once those tools support source-preserving transforms. With the named helpers in place, future swaps need only change the helper bodies — no widespread call-site refactor.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

The pre-existing unit tests for `mocking-utils`, `core-server/utils/save-story`, `core-server/utils/parser`, `babel/`, and `lib/cli-storybook/codemod/helpers` exercise every migrated call site (77 tests pass).

#### Manual testing

1. `yarn nx compile core` — should succeed.
2. `yarn nx run-many -t check` — type-check is clean.
3. Run an existing Storybook sandbox; story indexing, save-from-controls, and codemods all exercise the migrated parsers.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

`parser` and `babelParseExpression` were on the `storybook/internal/babel` barrel and are technically removed. \`storybook/internal/*\` paths are documented as internal/unsupported, so a MIGRATION.md entry is not strictly required, but a one-line note could be added if maintainers want to be explicit.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes.
- [ ] Make sure this PR contains **one** of the labels below:

Suggested label: `maintenance` or `cleanup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed direct `parser` export from Babel utilities—use convenience functions instead.

* **New Features**
  * Added `parseAst` and `parseAstExpression` convenience functions with optional parser configuration support.

* **Refactor**
  * Consolidated Babel parsing calls across the codebase to use unified convenience wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->