### PR TITLE
fix(vue3): clear stale reactive globals and args on reset

### DIFF
--- a/code/renderers/vue3/src/render.test.ts
+++ b/code/renderers/vue3/src/render.test.ts
@@ -109,4 +109,20 @@ describe('Render Story', () => {
     expect(observedTheme).toBe('dark');
     expect(reactiveGlobals).toEqual({ theme: 'dark', locale: 'en' });
   });
+
+  it('clears reactive Args when nextArgs is empty', () => {
+    const reactiveArgs = reactive({ argFoo: 'foo', argBar: 'bar' });
+
+    updateArgs(reactiveArgs, {});
+
+    expect(reactiveArgs).toEqual({});
+  });
+
+  it('clears reactive Globals when nextGlobals is empty', () => {
+    const reactiveGlobals = reactive<Globals>({ theme: 'light', locale: 'en' });
+
+    updateArgs<Globals>(reactiveGlobals, {});
+
+    expect(reactiveGlobals).toEqual({});
+  });
 });

--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -153,9 +153,6 @@ export function updateArgs<
     [name: string]: unknown;
   },
 >(reactiveArgs: T, nextArgs: T) {
-  if (Object.keys(nextArgs).length === 0) {
-    return;
-  }
   const currentArgs = isReactive(reactiveArgs) ? reactiveArgs : reactive(reactiveArgs);
   // delete all args in currentArgs that are not in nextArgs
   Object.keys(currentArgs).forEach((key) => {


### PR DESCRIPTION
## Problem

`updateArgs` in `code/renderers/vue3/src/render.ts` had an early return when `nextArgs` is empty:

```ts
if (Object.keys(nextArgs).length === 0) {
  return;
}
```

This means when Storybook resets globals or clears args to `{}`, the reactive objects from the previous story are **never cleaned up**. The stale keys hang around and bleed into the next rendered story — anything downstream reading `reactiveGlobals` or `reactiveArgs` via Vue's reactivity system sees leftover values instead of the reset state.

## Fix

Remove the early return. The code below it already handles the empty-next-args case correctly — it deletes every key in `currentArgs` that isn't present in `nextArgs`, then copies new keys over. When `nextArgs` is `{}` that means all keys get deleted, which is exactly what a reset should do.

Two tests added to cover the cleared-args and cleared-globals paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vue 3 renderer now correctly clears reactive state when updated with empty arguments instead of leaving it unchanged.

* **Tests**
  * Added test coverage to verify reactive state clearing behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->