### PR TITLE
CLI: Improve self-healing scoring observability

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/agent-story-history-cache.ts
+++ b/code/addons/vitest/src/vitest-plugin/agent-story-history-cache.ts
@@ -1,0 +1,37 @@
+import { createFileSystemCache, resolvePathInStorybookCache } from 'storybook/internal/common';
+import type { StoryTestResult, StoryTestResultHistory } from 'storybook/internal/core-server';
+
+const CACHE_KEY = 'agent-self-healing-story-history';
+
+const historyCache = createFileSystemCache({
+  basePath: resolvePathInStorybookCache('agent-self-healing'),
+  ns: 'storybook',
+});
+
+export async function readStoryHistory(): Promise<StoryTestResultHistory> {
+  return (await historyCache.get<StoryTestResultHistory>(CACHE_KEY)) ?? {};
+}
+
+/**
+ * Merge the current run's results into the persisted history (keeping the most
+ * recent result per storyId) and return the full set of stories ever observed.
+ * The history lives only on disk in the Storybook cache — its entries (which
+ * include storyIds) are never sent in telemetry.
+ */
+export async function mergeAndWriteStoryHistory(
+  results: StoryTestResult[]
+): Promise<StoryTestResult[]> {
+  const history = await readStoryHistory();
+  const now = Date.now();
+
+  for (const result of results) {
+    const existing = history[result.storyId];
+    if (!existing || existing.timestamp <= now) {
+      history[result.storyId] = { ...result, timestamp: now };
+    }
+  }
+
+  await historyCache.set(CACHE_KEY, history);
+
+  return Object.values(history).map(({ timestamp, ...rest }) => rest);
+}

--- a/code/addons/vitest/src/vitest-plugin/agent-telemetry-reporter.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/agent-telemetry-reporter.test.ts
@@ -12,7 +12,12 @@ vi.mock('storybook/internal/telemetry', () => ({
   ),
 }));
 
+vi.mock('./agent-story-history-cache.ts', () => ({
+  mergeAndWriteStoryHistory: vi.fn(async (results) => results),
+}));
+
 const { telemetry } = await import('storybook/internal/telemetry');
+const { mergeAndWriteStoryHistory } = await import('./agent-story-history-cache.ts');
 
 function createMockTestCase({
   storyId,
@@ -63,6 +68,7 @@ describe('AgentTelemetryReporter', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(mergeAndWriteStoryHistory).mockImplementation(async (results) => results);
     reporter = new AgentTelemetryReporter({
       configDir: '.storybook',
       agent: { name: 'claude' },
@@ -96,7 +102,7 @@ describe('AgentTelemetryReporter', () => {
   });
 
   describe('onTestRunEnd', () => {
-    it('should send telemetry with analysis of collected results', async () => {
+    it('should send telemetry with run analysis of collected results', async () => {
       reporter.onInit({ config: { watch: false } } as any);
 
       reporter.onTestCaseResult(createMockTestCase({ storyId: 's1', status: 'passed' }) as any);
@@ -122,18 +128,78 @@ describe('AgentTelemetryReporter', () => {
         expect.objectContaining({
           agent: { name: 'claude' },
           analysis: expect.objectContaining({
-            total: 3,
-            passed: 2,
-            passedButEmptyRender: 1,
-            successRate: 0.67,
-            successRateWithoutEmptyRender: 0.33,
-            uniqueErrorCount: 1,
+            runTotal: 3,
+            runPassed: 2,
+            runPassedButEmptyRender: 1,
+            runSuccessRate: 0.67,
+            runSuccessRateWithoutEmptyRender: 0.33,
+            runUniqueErrorCount: 1,
           }),
           unhandledErrorCount: 0,
           watch: false,
         }),
         { configDir: '.storybook', stripMetadata: true }
       );
+    });
+
+    it('should include cumulative stats merged from cache history', async () => {
+      reporter.onInit({ config: { watch: false } } as any);
+
+      // Current run: 1 failed story
+      reporter.onTestCaseResult(
+        createMockTestCase({
+          storyId: 'current-run',
+          status: 'failed',
+          errors: [{ message: 'boom' }],
+        }) as any
+      );
+
+      // Cumulative cache returns history with previously-passing stories on top
+      vi.mocked(mergeAndWriteStoryHistory).mockResolvedValueOnce([
+        { storyId: 'current-run', status: 'FAIL', error: 'boom', stack: undefined },
+        { storyId: 'previous-1', status: 'PASS' },
+        { storyId: 'previous-2', status: 'PASS' },
+      ]);
+
+      await reporter.onTestRunEnd(createMockTestModules({ passed: 0, failed: 1 }) as any, []);
+
+      expect(telemetry).toHaveBeenCalledWith(
+        'ai-setup-self-healing-scoring',
+        expect.objectContaining({
+          analysis: expect.objectContaining({
+            runTotal: 1,
+            runPassed: 0,
+            cumulativeTotal: 3,
+            cumulativePassed: 2,
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should pass collected results to mergeAndWriteStoryHistory', async () => {
+      reporter.onInit({ config: { watch: false } } as any);
+
+      reporter.onTestCaseResult(createMockTestCase({ storyId: 's1', status: 'passed' }) as any);
+
+      await reporter.onTestRunEnd(createMockTestModules({ passed: 1, failed: 0 }) as any, []);
+
+      expect(mergeAndWriteStoryHistory).toHaveBeenCalledWith([
+        expect.objectContaining({ storyId: 's1', status: 'PASS' }),
+      ]);
+    });
+
+    it('should not include storyId in the telemetry payload', async () => {
+      reporter.onInit({ config: { watch: false } } as any);
+
+      reporter.onTestCaseResult(
+        createMockTestCase({ storyId: 'my-secret-story-id', status: 'passed' }) as any
+      );
+
+      await reporter.onTestRunEnd(createMockTestModules({ passed: 1, failed: 0 }) as any, []);
+
+      const payload = JSON.stringify(vi.mocked(telemetry).mock.calls[0][1]);
+      expect(payload).not.toContain('my-secret-story-id');
     });
 
     it('should filter out example stories from analysis', async () => {
@@ -152,8 +218,8 @@ describe('AgentTelemetryReporter', () => {
         'ai-setup-self-healing-scoring',
         expect.objectContaining({
           analysis: expect.objectContaining({
-            total: 1,
-            passed: 1,
+            runTotal: 1,
+            runPassed: 1,
           }),
         }),
         expect.anything()
@@ -196,8 +262,8 @@ describe('AgentTelemetryReporter', () => {
       expect(secondCall[1]).toEqual(
         expect.objectContaining({
           analysis: expect.objectContaining({
-            total: 1,
-            passed: 0,
+            runTotal: 1,
+            runPassed: 0,
           }),
         })
       );

--- a/code/addons/vitest/src/vitest-plugin/agent-telemetry-reporter.ts
+++ b/code/addons/vitest/src/vitest-plugin/agent-telemetry-reporter.ts
@@ -9,6 +9,8 @@ import type { StoryTestResult } from 'storybook/internal/core-server';
 import { isExampleStoryId, telemetry } from 'storybook/internal/telemetry';
 import type { AgentInfo } from 'storybook/internal/telemetry';
 
+import { mergeAndWriteStoryHistory } from './agent-story-history-cache.ts';
+
 interface AgentTelemetryReporterOptions {
   configDir: string;
   agent: AgentInfo;
@@ -63,7 +65,11 @@ export class AgentTelemetryReporter implements Reporter {
     testModules: readonly TestModule[],
     unhandledErrors: readonly SerializedError[]
   ) {
-    const analysis = analyzeTestResults(this.testResults);
+    // Merge the current run into the persisted per-story history (kept on
+    // disk only — storyIds never enter telemetry) and use the merged set
+    // to compute cumulative stats across runs.
+    const cumulativeResults = await mergeAndWriteStoryHistory(this.testResults);
+    const analysis = analyzeTestResults(this.testResults, cumulativeResults);
     const duration = Date.now() - this.startTime;
 
     const testModulesErrors = testModules.flatMap((t) => t.errors());

--- a/code/core/src/core-server/index.ts
+++ b/code/core/src/core-server/index.ts
@@ -41,5 +41,9 @@ export { runStoryTests } from './utils/ghost-stories/run-story-tests.ts';
 export { getServerPort } from './utils/server-address.ts';
 
 export { analyzeTestResults } from '../shared/utils/analyze-test-results.ts';
-export type { StoryTestResult } from '../shared/utils/test-result-types.ts';
+export type {
+  StoryTestResult,
+  StoryTestResultHistory,
+  StoryTestResultHistoryEntry,
+} from '../shared/utils/test-result-types.ts';
 export { toStoryTestResult } from '../shared/utils/to-story-test-result.ts';

--- a/code/core/src/core-server/server-channel/ghost-stories-channel.test.ts
+++ b/code/core/src/core-server/server-channel/ghost-stories-channel.test.ts
@@ -213,14 +213,22 @@ describe('ghostStoriesChannel', () => {
           testRunDuration: expect.any(Number),
         },
         results: {
-          total: 2,
-          passed: 2,
-          successRate: 1,
-          successRateWithoutEmptyRender: 1,
-          categorizedErrors: expect.any(Object),
-          cssCheck: 'not-run',
-          uniqueErrorCount: 0,
-          passedButEmptyRender: 0,
+          runTotal: 2,
+          runPassed: 2,
+          runSuccessRate: 1,
+          runSuccessRateWithoutEmptyRender: 1,
+          runCategorizedErrors: expect.any(Object),
+          runCssCheck: 'not-run',
+          runUniqueErrorCount: 0,
+          runPassedButEmptyRender: 0,
+          cumulativeTotal: 2,
+          cumulativePassed: 2,
+          cumulativeSuccessRate: 1,
+          cumulativeSuccessRateWithoutEmptyRender: 1,
+          cumulativeCategorizedErrors: expect.any(Object),
+          cumulativeCssCheck: 'not-run',
+          cumulativeUniqueErrorCount: 0,
+          cumulativePassedButEmptyRender: 0,
         },
       });
     });
@@ -312,14 +320,14 @@ describe('ghostStoriesChannel', () => {
             testRunDuration: expect.any(Number),
           },
           results: expect.objectContaining({
-            total: 2,
-            passed: 0,
-            successRate: 0,
-            // categorizedErrors is now an object with categories as keys
-            categorizedErrors: expect.any(Object),
-            cssCheck: 'not-run',
-            uniqueErrorCount: expect.any(Number),
-            passedButEmptyRender: 0,
+            runTotal: 2,
+            runPassed: 0,
+            runSuccessRate: 0,
+            // runCategorizedErrors is an object keyed by error category
+            runCategorizedErrors: expect.any(Object),
+            runCssCheck: 'not-run',
+            runUniqueErrorCount: expect.any(Number),
+            runPassedButEmptyRender: 0,
           }),
         })
       );

--- a/code/core/src/core-server/utils/ghost-stories/parse-vitest-report.test.ts
+++ b/code/core/src/core-server/utils/ghost-stories/parse-vitest-report.test.ts
@@ -42,14 +42,22 @@ describe('parse-vitest-report', () => {
       const result = parseVitestResults(mockVitestResults);
 
       expect(result.summary).toEqual({
-        total: 3,
-        passed: 3,
-        passedButEmptyRender: 0,
-        successRate: 1.0,
-        successRateWithoutEmptyRender: 1.0,
-        uniqueErrorCount: 0,
-        categorizedErrors: {},
-        cssCheck: 'not-run',
+        runTotal: 3,
+        runPassed: 3,
+        runPassedButEmptyRender: 0,
+        runSuccessRate: 1.0,
+        runSuccessRateWithoutEmptyRender: 1.0,
+        runUniqueErrorCount: 0,
+        runCategorizedErrors: {},
+        runCssCheck: 'not-run',
+        cumulativeTotal: 3,
+        cumulativePassed: 3,
+        cumulativePassedButEmptyRender: 0,
+        cumulativeSuccessRate: 1.0,
+        cumulativeSuccessRateWithoutEmptyRender: 1.0,
+        cumulativeUniqueErrorCount: 0,
+        cumulativeCategorizedErrors: {},
+        cumulativeCssCheck: 'not-run',
       });
     });
 
@@ -86,10 +94,10 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.total).toBe(3);
-      expect(result.summary?.passed).toBe(1);
-      expect(result.summary?.successRate).toBe(0.33);
-      expect(result.summary?.uniqueErrorCount).toBe(2);
+      expect(result.summary?.runTotal).toBe(3);
+      expect(result.summary?.runPassed).toBe(1);
+      expect(result.summary?.runSuccessRate).toBe(0.33);
+      expect(result.summary?.runUniqueErrorCount).toBe(2);
     });
 
     it('should categorize errors and include them in the summary', () => {
@@ -137,10 +145,10 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.total).toBe(5);
-      expect(result.summary?.passed).toBe(1);
-      expect(result.summary?.uniqueErrorCount).toBe(3);
-      expect(result.summary?.categorizedErrors).toEqual({
+      expect(result.summary?.runTotal).toBe(5);
+      expect(result.summary?.runPassed).toBe(1);
+      expect(result.summary?.runUniqueErrorCount).toBe(3);
+      expect(result.summary?.runCategorizedErrors).toEqual({
         HOOK_USAGE_ERROR: {
           uniqueCount: 1,
           count: 1,
@@ -199,9 +207,9 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.passedButEmptyRender).toBe(2);
-      expect(result.summary?.successRate).toBe(1.0);
-      expect(result.summary?.successRateWithoutEmptyRender).toBe(0.33);
+      expect(result.summary?.runPassedButEmptyRender).toBe(2);
+      expect(result.summary?.runSuccessRate).toBe(1.0);
+      expect(result.summary?.runSuccessRateWithoutEmptyRender).toBe(0.33);
     });
 
     it('should handle multiple test suites', () => {
@@ -244,8 +252,8 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.total).toBe(4);
-      expect(result.summary?.passed).toBe(3);
+      expect(result.summary?.runTotal).toBe(4);
+      expect(result.summary?.runPassed).toBe(3);
     });
 
     it('should handle zero total tests', () => {
@@ -259,11 +267,11 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.total).toBe(0);
-      expect(result.summary?.successRate).toBe(0);
+      expect(result.summary?.runTotal).toBe(0);
+      expect(result.summary?.runSuccessRate).toBe(0);
     });
 
-    it('surfaces the CssCheck story outcome via summary.cssCheck', () => {
+    it('surfaces the CssCheck story outcome via summary.runCssCheck', () => {
       const mockVitestResults = {
         success: false,
         numTotalTests: 2,
@@ -291,7 +299,7 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.cssCheck).toBe('fail');
+      expect(result.summary?.runCssCheck).toBe('fail');
     });
   });
 });

--- a/code/core/src/shared/utils/analyze-test-results.test.ts
+++ b/code/core/src/shared/utils/analyze-test-results.test.ts
@@ -70,14 +70,22 @@ describe('analyze-test-results', () => {
       ];
       const analysis = analyzeTestResults(results);
       expect(analysis).toEqual({
-        total: 3,
-        passed: 3,
-        passedButEmptyRender: 0,
-        successRate: 1.0,
-        successRateWithoutEmptyRender: 1.0,
-        uniqueErrorCount: 0,
-        categorizedErrors: {},
-        cssCheck: 'not-run',
+        runTotal: 3,
+        runPassed: 3,
+        runPassedButEmptyRender: 0,
+        runSuccessRate: 1.0,
+        runSuccessRateWithoutEmptyRender: 1.0,
+        runUniqueErrorCount: 0,
+        runCategorizedErrors: {},
+        runCssCheck: 'not-run',
+        cumulativeTotal: 3,
+        cumulativePassed: 3,
+        cumulativePassedButEmptyRender: 0,
+        cumulativeSuccessRate: 1.0,
+        cumulativeSuccessRateWithoutEmptyRender: 1.0,
+        cumulativeUniqueErrorCount: 0,
+        cumulativeCategorizedErrors: {},
+        cumulativeCssCheck: 'not-run',
       });
     });
 
@@ -88,10 +96,10 @@ describe('analyze-test-results', () => {
         { storyId: 's3', status: 'FAIL', error: 'Error: Module not found', stack: '' },
       ];
       const analysis = analyzeTestResults(results);
-      expect(analysis.total).toBe(3);
-      expect(analysis.passed).toBe(1);
-      expect(analysis.successRate).toBe(0.33);
-      expect(analysis.uniqueErrorCount).toBe(2);
+      expect(analysis.runTotal).toBe(3);
+      expect(analysis.runPassed).toBe(1);
+      expect(analysis.runSuccessRate).toBe(0.33);
+      expect(analysis.runUniqueErrorCount).toBe(2);
     });
 
     it('should count passedButEmptyRender', () => {
@@ -101,16 +109,17 @@ describe('analyze-test-results', () => {
         { storyId: 's3', status: 'PASS', emptyRender: true },
       ];
       const analysis = analyzeTestResults(results);
-      expect(analysis.passedButEmptyRender).toBe(2);
-      expect(analysis.successRate).toBe(1.0);
-      expect(analysis.successRateWithoutEmptyRender).toBe(0.33);
+      expect(analysis.runPassedButEmptyRender).toBe(2);
+      expect(analysis.runSuccessRate).toBe(1.0);
+      expect(analysis.runSuccessRateWithoutEmptyRender).toBe(0.33);
     });
 
     it('should handle zero tests', () => {
       const analysis = analyzeTestResults([]);
-      expect(analysis.total).toBe(0);
-      expect(analysis.successRate).toBe(0);
-      expect(analysis.successRateWithoutEmptyRender).toBe(0);
+      expect(analysis.runTotal).toBe(0);
+      expect(analysis.runSuccessRate).toBe(0);
+      expect(analysis.runSuccessRateWithoutEmptyRender).toBe(0);
+      expect(analysis.cumulativeTotal).toBe(0);
     });
 
     it('should handle PENDING tests by not counting them as passed', () => {
@@ -119,9 +128,44 @@ describe('analyze-test-results', () => {
         { storyId: 's2', status: 'PENDING' },
       ];
       const analysis = analyzeTestResults(results);
-      expect(analysis.total).toBe(2);
-      expect(analysis.passed).toBe(1);
-      expect(analysis.successRate).toBe(0.5);
+      expect(analysis.runTotal).toBe(2);
+      expect(analysis.runPassed).toBe(1);
+      expect(analysis.runSuccessRate).toBe(0.5);
+    });
+
+    describe('cumulative stats', () => {
+      it('mirrors run stats when no cumulative results are provided', () => {
+        const results: StoryTestResult[] = [
+          { storyId: 's1', status: 'PASS' },
+          { storyId: 's2', status: 'FAIL', error: 'oops' },
+        ];
+        const analysis = analyzeTestResults(results);
+        expect(analysis.cumulativeTotal).toBe(analysis.runTotal);
+        expect(analysis.cumulativePassed).toBe(analysis.runPassed);
+        expect(analysis.cumulativeSuccessRate).toBe(analysis.runSuccessRate);
+        expect(analysis.cumulativeUniqueErrorCount).toBe(analysis.runUniqueErrorCount);
+      });
+
+      it('reports cumulative stats independently when provided', () => {
+        const run: StoryTestResult[] = [
+          { storyId: 's1', status: 'FAIL', error: 'broken' },
+          { storyId: 's2', status: 'FAIL', error: 'broken' },
+          { storyId: 's3', status: 'FAIL', error: 'broken' },
+        ];
+        const cumulative: StoryTestResult[] = [
+          { storyId: 's1', status: 'PASS' },
+          { storyId: 's2', status: 'PASS' },
+          { storyId: 's3', status: 'FAIL', error: 'broken' },
+          { storyId: 's4', status: 'PASS' },
+          { storyId: 's5', status: 'PASS' },
+        ];
+        const analysis = analyzeTestResults(run, cumulative);
+        expect(analysis.runTotal).toBe(3);
+        expect(analysis.runPassed).toBe(0);
+        expect(analysis.cumulativeTotal).toBe(5);
+        expect(analysis.cumulativePassed).toBe(4);
+        expect(analysis.cumulativeSuccessRate).toBe(0.8);
+      });
     });
 
     describe('cssCheck', () => {
@@ -130,7 +174,7 @@ describe('analyze-test-results', () => {
           { storyId: 'components-button--primary', status: 'PASS' },
           { storyId: 'components-button--css-check', status: 'PASS' },
         ];
-        expect(analyzeTestResults(results).cssCheck).toBe('pass');
+        expect(analyzeTestResults(results).runCssCheck).toBe('pass');
       });
 
       it("is 'fail' when a --css-check story failed", () => {
@@ -141,14 +185,14 @@ describe('analyze-test-results', () => {
             error: 'expected rgb(37, 99, 235) but got rgba(0, 0, 0, 0)',
           },
         ];
-        expect(analyzeTestResults(results).cssCheck).toBe('fail');
+        expect(analyzeTestResults(results).runCssCheck).toBe('fail');
       });
 
       it("is 'not-run' when no --css-check story is present", () => {
         const results: StoryTestResult[] = [
           { storyId: 'components-button--primary', status: 'PASS' },
         ];
-        expect(analyzeTestResults(results).cssCheck).toBe('not-run');
+        expect(analyzeTestResults(results).runCssCheck).toBe('not-run');
       });
 
       it("is 'not-run' when the --css-check story was skipped / pending / todo", () => {
@@ -158,11 +202,11 @@ describe('analyze-test-results', () => {
         const results: StoryTestResult[] = [
           { storyId: 'components-button--css-check', status: 'PENDING' },
         ];
-        expect(analyzeTestResults(results).cssCheck).toBe('not-run');
+        expect(analyzeTestResults(results).runCssCheck).toBe('not-run');
       });
 
       it("is 'not-run' for an empty result list", () => {
-        expect(analyzeTestResults([]).cssCheck).toBe('not-run');
+        expect(analyzeTestResults([]).runCssCheck).toBe('not-run');
       });
 
       it('uses the first match when multiple --css-check stories exist', () => {
@@ -172,7 +216,7 @@ describe('analyze-test-results', () => {
           { storyId: 'components-button--css-check', status: 'PASS' },
           { storyId: 'components-card--css-check', status: 'FAIL', error: 'style mismatch' },
         ];
-        expect(analyzeTestResults(results).cssCheck).toBe('pass');
+        expect(analyzeTestResults(results).runCssCheck).toBe('pass');
       });
 
       it('is case-insensitive on the suffix (defensive)', () => {
@@ -181,7 +225,7 @@ describe('analyze-test-results', () => {
         const results: StoryTestResult[] = [
           { storyId: 'components-button--CSS-CHECK', status: 'PASS' },
         ];
-        expect(analyzeTestResults(results).cssCheck).toBe('pass');
+        expect(analyzeTestResults(results).runCssCheck).toBe('pass');
       });
     });
   });

--- a/code/core/src/shared/utils/analyze-test-results.ts
+++ b/code/core/src/shared/utils/analyze-test-results.ts
@@ -1,6 +1,8 @@
 import type { ErrorCategory } from './categorize-render-errors.ts';
 import { categorizeError } from './categorize-render-errors.ts';
 import type {
+  CategorizedError,
+  CssCheckOutcome,
   ErrorCategorizationResult,
   StoryTestResult,
   TestRunAnalysis,
@@ -62,11 +64,18 @@ export function extractCategorizedErrors(
  */
 const CSS_CHECK_STORY_ID_SUFFIX = '--css-check';
 
-/**
- * Analyze a list of story test results and produce a TestRunAnalysis with pass/fail counts, success
- * rates, empty render detection, and categorized errors.
- */
-export function analyzeTestResults(results: StoryTestResult[]): TestRunAnalysis {
+interface ResultSummary {
+  total: number;
+  passed: number;
+  passedButEmptyRender: number;
+  successRate: number;
+  successRateWithoutEmptyRender: number;
+  uniqueErrorCount: number;
+  categorizedErrors: Record<string, CategorizedError>;
+  cssCheck: CssCheckOutcome;
+}
+
+function summarizeResults(results: StoryTestResult[]): ResultSummary {
   const total = results.length;
   const passed = results.filter((r) => r.status === 'PASS').length;
   const passedButEmptyRender = results.filter((r) => r.status === 'PASS' && r.emptyRender).length;
@@ -84,7 +93,7 @@ export function analyzeTestResults(results: StoryTestResult[]): TestRunAnalysis 
   const cssCheckMatch = results.find((r) =>
     r.storyId.toLowerCase().endsWith(CSS_CHECK_STORY_ID_SUFFIX)
   );
-  const cssCheck: TestRunAnalysis['cssCheck'] =
+  const cssCheck: CssCheckOutcome =
     cssCheckMatch?.status === 'PASS'
       ? 'pass'
       : cssCheckMatch?.status === 'FAIL'
@@ -100,5 +109,41 @@ export function analyzeTestResults(results: StoryTestResult[]): TestRunAnalysis 
     uniqueErrorCount: errorClassification.uniqueErrorCount,
     categorizedErrors: errorClassification.categorizedErrors,
     cssCheck,
+  };
+}
+
+/**
+ * Analyze a list of story test results and produce a TestRunAnalysis with pass/fail counts, success
+ * rates, empty render detection, and categorized errors.
+ *
+ * @param results Story results from the current run.
+ * @param cumulativeResults Optional aggregated results across all runs (latest outcome per story).
+ *   When omitted, cumulative stats mirror the run stats.
+ */
+export function analyzeTestResults(
+  results: StoryTestResult[],
+  cumulativeResults?: StoryTestResult[]
+): TestRunAnalysis {
+  const run = summarizeResults(results);
+  const cumulative = cumulativeResults ? summarizeResults(cumulativeResults) : run;
+
+  return {
+    runTotal: run.total,
+    runPassed: run.passed,
+    runPassedButEmptyRender: run.passedButEmptyRender,
+    runSuccessRate: run.successRate,
+    runSuccessRateWithoutEmptyRender: run.successRateWithoutEmptyRender,
+    runUniqueErrorCount: run.uniqueErrorCount,
+    runCategorizedErrors: run.categorizedErrors,
+    runCssCheck: run.cssCheck,
+
+    cumulativeTotal: cumulative.total,
+    cumulativePassed: cumulative.passed,
+    cumulativePassedButEmptyRender: cumulative.passedButEmptyRender,
+    cumulativeSuccessRate: cumulative.successRate,
+    cumulativeSuccessRateWithoutEmptyRender: cumulative.successRateWithoutEmptyRender,
+    cumulativeUniqueErrorCount: cumulative.uniqueErrorCount,
+    cumulativeCategorizedErrors: cumulative.categorizedErrors,
+    cumulativeCssCheck: cumulative.cssCheck,
   };
 }

--- a/code/core/src/shared/utils/test-result-types.ts
+++ b/code/core/src/shared/utils/test-result-types.ts
@@ -7,6 +7,17 @@ export interface StoryTestResult {
   emptyRender?: boolean;
 }
 
+/**
+ * A `StoryTestResult` augmented with the timestamp at which it was recorded.
+ * Used by the agent self-healing flow to persist the most recent outcome
+ * per story across runs (in cache only — never sent in telemetry).
+ */
+export interface StoryTestResultHistoryEntry extends StoryTestResult {
+  timestamp: number;
+}
+
+export type StoryTestResultHistory = Record<string, StoryTestResultHistoryEntry>;
+
 export interface CategorizedError {
   category: string;
   count: number;
@@ -20,28 +31,45 @@ export interface ErrorCategorizationResult {
   uniqueErrorCount: number;
 }
 
+/**
+ * Outcome of the `CssCheck` story — a story (id suffix `--css-check`)
+ * whose `play` asserts a component-specific computed style via
+ * `getComputedStyle`. Distinguishes "component mounted" from "the
+ * user's CSS actually loaded".
+ *
+ * - `'pass'`    — a `CssCheck` story ran and passed.
+ * - `'fail'`    — a `CssCheck` story ran and failed.
+ * - `'not-run'` — no pass/fail signal available: either no `CssCheck`
+ *                 story is in the suite, or the story existed but was
+ *                 not executed (skipped, pending, todo, filtered out).
+ *
+ * Only the three-valued enum is emitted — no storyId or component
+ * name — so no user-authored data enters telemetry.
+ */
+export type CssCheckOutcome = 'pass' | 'fail' | 'not-run';
+
 export interface TestRunAnalysis {
-  total: number;
-  passed: number;
-  passedButEmptyRender: number;
-  successRate: number;
-  successRateWithoutEmptyRender: number;
-  uniqueErrorCount: number;
-  categorizedErrors: Record<string, CategorizedError>;
+  /** Stats for the current run (only stories executed in this run). */
+  runTotal: number;
+  runPassed: number;
+  runPassedButEmptyRender: number;
+  runSuccessRate: number;
+  runSuccessRateWithoutEmptyRender: number;
+  runUniqueErrorCount: number;
+  runCategorizedErrors: Record<string, CategorizedError>;
+  runCssCheck: CssCheckOutcome;
+
   /**
-   * Outcome of the `CssCheck` story — a story (id suffix `--css-check`)
-   * whose `play` asserts a component-specific computed style via
-   * `getComputedStyle`. Distinguishes "component mounted" from "the
-   * user's CSS actually loaded".
-   *
-   * - `'pass'`    — a `CssCheck` story ran and passed.
-   * - `'fail'`    — a `CssCheck` story ran and failed.
-   * - `'not-run'` — no pass/fail signal available: either no `CssCheck`
-   *                 story is in the suite, or the story existed but was
-   *                 not executed (skipped, pending, todo, filtered out).
-   *
-   * Only the three-valued enum is emitted — no storyId or component
-   * name — so no user-authored data enters telemetry.
+   * Stats accumulated across runs: for every story we've ever seen, we
+   * keep the most recent outcome (by timestamp). When no history is
+   * available these mirror the `run*` fields.
    */
-  cssCheck: 'pass' | 'fail' | 'not-run';
+  cumulativeTotal: number;
+  cumulativePassed: number;
+  cumulativePassedButEmptyRender: number;
+  cumulativeSuccessRate: number;
+  cumulativeSuccessRateWithoutEmptyRender: number;
+  cumulativeUniqueErrorCount: number;
+  cumulativeCategorizedErrors: Record<string, CategorizedError>;
+  cumulativeCssCheck: CssCheckOutcome;
 }

--- a/scripts/eval/lib/grade.ts
+++ b/scripts/eval/lib/grade.ts
@@ -322,7 +322,7 @@ export async function collectGhostStoriesGrade(
 
     const rawReport = JSON.parse(await readFile(outputFile, 'utf8'));
     const parsed = parseVitestResults(rawReport);
-    const emptyRenders = parsed.summary?.passedButEmptyRender ?? 0;
+    const emptyRenders = parsed.summary?.runPassedButEmptyRender ?? 0;
 
     // Suite-level: each file either loaded and rendered or it didn't.
     const total: number = rawReport.numTotalTestSuites ?? 0;

--- a/scripts/eval/lib/story-render.ts
+++ b/scripts/eval/lib/story-render.ts
@@ -209,10 +209,10 @@ async function readStoryRenderSummary(reportPath: string, storyFiles: number) {
     }
 
     return {
-      total: parsed.total,
-      passed: parsed.passed,
+      total: parsed.runTotal,
+      passed: parsed.runPassed,
       storyFiles,
-      cssCheck: parsed.cssCheck,
+      cssCheck: parsed.runCssCheck,
     } satisfies StoryRenderGrade;
   } catch {
     return undefined;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds logic to accumulate self-healing scoring over an agentic session

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34699-sha-a88c0eaa`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34699-sha-a88c0eaa sandbox` or in an existing project with `npx storybook@0.0.0-pr-34699-sha-a88c0eaa upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34699-sha-a88c0eaa`](https://npmjs.com/package/storybook/v/0.0.0-pr-34699-sha-a88c0eaa) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/cummulative-self-healing-score`](https://github.com/storybookjs/storybook/tree/yann/cummulative-self-healing-score) |
| **Commit** | [`a88c0eaa`](https://github.com/storybookjs/storybook/commit/a88c0eaa55ae1a4e5a1d03fe1efbbdc30bf5d59d) |
| **Datetime** | Mon May  4 11:28:43 UTC 2026 (`1777894123`) |
| **Workflow run** | [25316410456](https://github.com/storybookjs/storybook/actions/runs/25316410456) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34699`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story test history is now persisted across runs, enabling cumulative metrics and combined run+cumulative analysis.
  * Telemetry and reports now provide separate run- and cumulative-scoped metrics for clearer trends; telemetry no longer includes raw story identifiers.

* **Tests**
  * Test suites and assertions updated to validate the new run/cumulative metrics shape and cumulative-history behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->