### PR TITLE
Agentic Setup: Show Discord and human docs only to humans

### DIFF
--- a/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
@@ -117,7 +117,7 @@ describe('FinalizationCommand', () => {
       const agentCommand = new FinalizationCommand({
         logfile: undefined,
         showAgentFollowUp: true,
-        showAiInstructions: false,
+        showAiInstructions: true,
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
@@ -127,6 +127,9 @@ describe('FinalizationCommand', () => {
         expect.stringContaining('is not entirely set up yet')
       );
       expect(logger.step).toHaveBeenCalledWith(expect.stringContaining('npx storybook ai setup'));
+      const logCalls = vi.mocked(logger.log).mock.calls.map((c) => String(c[0]));
+      expect(logCalls.some((msg) => msg.includes('https://storybook.js.org/llms.txt'))).toBe(true);
+      expect(logCalls.some((msg) => msg.includes('https://discord.gg/storybook/'))).toBe(false);
     });
 
     it('should show standard success message when showAgentFollowUp=false with AI instructions', async () => {
@@ -163,6 +166,10 @@ describe('FinalizationCommand', () => {
       // Ensure the agent message is NOT shown
       const stepCalls = vi.mocked(logger.step).mock.calls.map((c) => String(c[0]));
       expect(stepCalls.some((msg) => msg.includes('is not entirely set up yet'))).toBe(false);
+      const logCalls = vi.mocked(logger.log).mock.calls.map((c) => String(c[0]));
+      expect(logCalls.some((msg) => msg.includes('https://storybook.js.org/'))).toBe(true);
+      expect(logCalls.some((msg) => msg.includes('https://discord.gg/storybook/'))).toBe(true);
+      expect(logCalls.some((msg) => msg.includes('https://storybook.js.org/llms.txt'))).toBe(false);
     });
   });
 

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.ts
@@ -104,7 +104,7 @@ export class FinalizationCommand {
     }
 
     // We don't want to tell agents about Discord, and we want to customise their docs URL.
-    if (this.options.showAgentFollowUp) {
+    if (this.options.showAiInstructions) {
       logger.log(dedent`
       Official documentation reference: ${CLI_COLORS.cta('https://storybook.js.org/llms.txt')}
     `);

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.ts
@@ -103,10 +103,17 @@ export class FinalizationCommand {
       logger.log(`To run Storybook, run ${CLI_COLORS.cta(storybookCommand)}. CTRL+C to stop.`);
     }
 
-    logger.log(dedent`
+    // We don't want to tell agents about Discord, and we want to customise their docs URL.
+    if (this.options.showAgentFollowUp) {
+      logger.log(dedent`
+      Official documentation reference: ${CLI_COLORS.cta('https://storybook.js.org/llms.txt')}
+    `);
+    } else {
+      logger.log(dedent`
       Want to learn more about Storybook? ${CLI_COLORS.cta('https://storybook.js.org/')}
       Having trouble or want to chat? ${CLI_COLORS.cta('https://discord.gg/storybook/')}
     `);
+    }
 
     if (this.options.showAiInstructions) {
       logger.step(dedent`To finalize setting up with AI, paste this prompt to your AI agent:


### PR DESCRIPTION
ø

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Finalization messaging now conditionally shows either an official documentation reference or the standard documentation plus community chat link, depending on the configured follow-up mode.

* **Tests**
  * Updated tests to verify the correct follow-up messaging and links are emitted for each configuration, ensuring users see the intended documentation and support links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->