### PR TITLE
Agentic Setup: Allow failed stories to persist

### DIFF
--- a/code/lib/cli-storybook/src/ai/setup-prompts/index.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/index.ts
@@ -7,8 +7,9 @@ import { getProjectOverview } from '../utils/project-overview.ts';
  * The single prompt variant that ships to real users. Running
  * `npx storybook ai setup` without any overrides always produces this prompt.
  */
-import * as currentlyUsedPrompt from './pattern-copy-play.ts';
-export const DEFAULT_PROMPT_NAME: PromptName = 'pattern-copy-play';
+import * as currentlyUsedPrompt from './monorepo-optimized-tests-relaxed-limits-no-story-deletion.ts';
+export const DEFAULT_PROMPT_NAME: PromptName =
+  'monorepo-optimized-tests-relaxed-limits-no-story-deletion';
 
 /**
  * Main prompt used currently in `npx storybook ai setup` command. If you promote a new prompt to be default, move this to the FORMERLY_USED_PROMPTS object below.
@@ -28,6 +29,8 @@ const FORMERLY_USED_PROMPTS: Record<string, () => Promise<(projectInfo: ProjectI
   'relaxed-limits': async () => (await import('./relaxed-limits.ts')).instructions,
   setup: async () => (await import('./setup.ts')).instructions,
   'pattern-copy-play': async () => (await import('./pattern-copy-play.ts')).instructions,
+  'monorepo-optimized-tests-relaxed-limits-no-story-deletion': async () =>
+    (await import('./monorepo-optimized-tests-relaxed-limits-no-story-deletion.ts')).instructions,
 };
 
 export type PromptName = string;

--- a/code/lib/cli-storybook/src/ai/setup-prompts/index.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/index.ts
@@ -7,9 +7,8 @@ import { getProjectOverview } from '../utils/project-overview.ts';
  * The single prompt variant that ships to real users. Running
  * `npx storybook ai setup` without any overrides always produces this prompt.
  */
-import * as currentlyUsedPrompt from './monorepo-optimized-tests-relaxed-limits-no-story-deletion.ts';
-export const DEFAULT_PROMPT_NAME: PromptName =
-  'monorepo-optimized-tests-relaxed-limits-no-story-deletion';
+import * as currentlyUsedPrompt from './optimized-tests.ts';
+export const DEFAULT_PROMPT_NAME: PromptName = 'optimized-tests';
 
 /**
  * Main prompt used currently in `npx storybook ai setup` command. If you promote a new prompt to be default, move this to the FORMERLY_USED_PROMPTS object below.

--- a/code/lib/cli-storybook/src/ai/setup-prompts/monorepo-optimized-tests-relaxed-limits-no-story-deletion.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/monorepo-optimized-tests-relaxed-limits-no-story-deletion.ts
@@ -8,12 +8,12 @@ import {
   buildPortalStep,
   buildSharedPreviewStep,
   cleanupStep,
-  discoveryStepStrict,
+  discoveryStepRelaxed,
   interactionPlayStep,
   monorepoStep,
   mswStep,
-  verifyStep,
-  writeStoriesStep,
+  verifyWithAllowedFailureStep,
+  writeStoriesWithAllowedFailuresStep,
 } from './partials/steps.ts';
 import {
   batchTestsRule,
@@ -23,15 +23,15 @@ import {
   noPolishRule,
   packageManagerRule,
   preferSharedFixesRule,
-  readBudgetRule,
+  readBudgetRuleRelaxed,
   toolsVsShellRule,
 } from './partials/rules.ts';
 import {
   cssCheckDOD,
   sharedPreviewDOD,
-  storyTagsV1DOD,
-  typeCheckPassesStrictDOD,
-  vitestPassesStrictDOD,
+  storyTagsV2DOD,
+  typeCheckPassesWhenExpectedDOD,
+  vitestPassesWhenExpectedDOD,
 } from './partials/dod.ts';
 
 export function instructions(projectInfo: ProjectInfo): string {
@@ -65,7 +65,7 @@ export function instructions(projectInfo: ProjectInfo): string {
       toolsVsShellRule(ctx),
       nodeModuleReadsRule(ctx),
       monorepoRule(ctx),
-      readBudgetRule(ctx),
+      readBudgetRuleRelaxed(ctx),
       editOverWriteRule(ctx),
       batchTestsRule(ctx),
       packageManagerRule(ctx),
@@ -77,26 +77,26 @@ export function instructions(projectInfo: ProjectInfo): string {
 
     ${listSteps(
       [
-        discoveryStepStrict(projectInfo, ctx),
+        discoveryStepRelaxed(projectInfo, ctx),
         monorepoStep(projectInfo, ctx),
         buildSharedPreviewStep(projectInfo, ctx),
         buildPortalStep(projectInfo, ctx),
         mswStep(projectInfo, ctx),
-        writeStoriesStep(projectInfo, ctx),
+        writeStoriesWithAllowedFailuresStep(projectInfo, ctx),
         interactionPlayStep(projectInfo, ctx),
-        verifyStep(projectInfo, ctx),
+        verifyWithAllowedFailureStep(projectInfo, ctx),
         cleanupStep(projectInfo, ctx),
       ],
       { level: 3 }
     )}
 
     ## Done when
-    
+
     ${listDOD([
       cssCheckDOD(ctx),
-      storyTagsV1DOD(ctx),
-      vitestPassesStrictDOD(ctx),
-      typeCheckPassesStrictDOD(ctx),
+      storyTagsV2DOD(ctx),
+      vitestPassesWhenExpectedDOD(ctx),
+      typeCheckPassesWhenExpectedDOD(ctx),
       sharedPreviewDOD(ctx),
     ])}
 

--- a/code/lib/cli-storybook/src/ai/setup-prompts/optimized-tests.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/optimized-tests.ts
@@ -3,7 +3,7 @@ import { dedent } from 'ts-dedent';
 import type { ProjectInfo, SetupInstructionsContext } from '../types.ts';
 import { getDocsMarkdownUrl } from '../utils/docs-markdown-url.ts';
 import { ext } from '../utils/ext.ts';
-import { listRules, listSteps } from '../utils/markdown.ts';
+import { listDOD, listRules, listSteps } from '../utils/markdown.ts';
 import {
   buildPortalStep,
   buildSharedPreviewStep,
@@ -24,6 +24,13 @@ import {
   readBudgetRule,
   toolsVsShellRule,
 } from './partials/rules.ts';
+import {
+  cssCheckDOD,
+  sharedPreviewDOD,
+  storyTagsV1DOD,
+  typeCheckPassesStrictDOD,
+  vitestPassesStrictDOD,
+} from './partials/dod.ts';
 
 export function instructions(projectInfo: ProjectInfo): string {
   const { configDir, language, needsUserOnboarding, packageManager, packageManagerName } =
@@ -80,12 +87,14 @@ export function instructions(projectInfo: ProjectInfo): string {
     )}
 
     ## Done when
-
-    - **Exactly one \`CssCheck\` story exists** somewhere in the new stories, asserting a concrete computed style value read from the component's source (added at the end of Step 5).
-    - Every story file you wrote that vitest confirmed passing has had \`'needs-work'\` stripped, leaving \`tags: ['ai-generated']\`. Anything still failing keeps \`['ai-generated', 'needs-work']\`.
-    - \`npx vitest --project storybook run\` passes for the new files.
-    - The project's TypeScript check passes for changed files.
-    - The shared preview is strong enough that stories don't need per-story fetch/provider workarounds.
+        
+    ${listDOD([
+      cssCheckDOD(ctx),
+      storyTagsV1DOD(ctx),
+      vitestPassesStrictDOD(ctx),
+      typeCheckPassesStrictDOD(ctx),
+      sharedPreviewDOD(ctx),
+    ])}
 
     ## Reference (only fetch if stuck)
 

--- a/code/lib/cli-storybook/src/ai/setup-prompts/partials/dod.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/partials/dod.ts
@@ -1,0 +1,34 @@
+import { dedent } from 'ts-dedent';
+import type { SetupInstructionsContext } from '../../types.ts';
+
+export function cssCheckDOD(ctx: SetupInstructionsContext): string {
+  return dedent`**Exactly one \`CssCheck\` story exists** somewhere in the new stories, asserting a concrete computed style value read from the component's source (added at the end of Step 5).`;
+}
+
+export function storyTagsV1DOD(ctx: SetupInstructionsContext): string {
+  return dedent`Every story file you wrote that vitest confirmed passing has had \`'needs-work'\` stripped, leaving \`tags: ['ai-generated']\`. Anything still failing keeps \`['ai-generated', 'needs-work']\`.`;
+}
+
+export function storyTagsV2DOD(ctx: SetupInstructionsContext): string {
+  return dedent`Every story file that passes vitest tests has had \`'needs-work'\` stripped, leaving \`tags: ['ai-generated']\`.Story files with vitest failures keep \`['ai-generated', 'needs-work']\`.`;
+}
+
+export function vitestPassesStrictDOD(ctx: SetupInstructionsContext): string {
+  return dedent`\`npx vitest --project storybook run\` passes for the new files.`;
+}
+
+export function vitestPassesWhenExpectedDOD(ctx: SetupInstructionsContext): string {
+  return dedent`\`npx vitest --project storybook run\` passes for the new files that don't have \`'needs-work'\` in their tags. Files with \`'needs-work'\` may still fail.`;
+}
+
+export function typeCheckPassesStrictDOD(ctx: SetupInstructionsContext): string {
+  return dedent`The project's TypeScript check passes for changed files.`;
+}
+
+export function typeCheckPassesWhenExpectedDOD(ctx: SetupInstructionsContext): string {
+  return dedent`The project's TypeScript check passes for the new files that don't have \`'needs-work'\` in their tags. Files with \`'needs-work'\` may still fail.`;
+}
+
+export function sharedPreviewDOD(ctx: SetupInstructionsContext): string {
+  return dedent`The shared preview is strong enough that stories don't need per-story fetch/provider workarounds.`;
+}

--- a/code/lib/cli-storybook/src/ai/setup-prompts/partials/dod.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/partials/dod.ts
@@ -2,7 +2,7 @@ import { dedent } from 'ts-dedent';
 import type { SetupInstructionsContext } from '../../types.ts';
 
 export function cssCheckDOD(ctx: SetupInstructionsContext): string {
-  return dedent`**Exactly one \`CssCheck\` story exists** somewhere in the new stories, asserting a concrete computed style value read from the component's source (added at the end of Step 5).`;
+  return dedent`**Exactly one \`CssCheck\` story exists** somewhere in the new stories, asserting a concrete computed style value read from the component's source.`;
 }
 
 export function storyTagsV1DOD(ctx: SetupInstructionsContext): string {
@@ -10,7 +10,7 @@ export function storyTagsV1DOD(ctx: SetupInstructionsContext): string {
 }
 
 export function storyTagsV2DOD(ctx: SetupInstructionsContext): string {
-  return dedent`Every story file that passes vitest tests has had \`'needs-work'\` stripped, leaving \`tags: ['ai-generated']\`.Story files with vitest failures keep \`['ai-generated', 'needs-work']\`.`;
+  return dedent`Every story file that passes vitest tests has had \`'needs-work'\` stripped, leaving \`tags: ['ai-generated']\`. Story files with vitest failures keep \`['ai-generated', 'needs-work']\`.`;
 }
 
 export function vitestPassesStrictDOD(ctx: SetupInstructionsContext): string {

--- a/code/lib/cli-storybook/src/ai/setup-prompts/partials/steps.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/partials/steps.ts
@@ -100,10 +100,10 @@ export function verifyWithAllowedFailureStep(
 
     1. Read the error.
     2. If multiple stories share the failure, fix the shared preview setup, not the stories.
-    3. Re-run vitest **only for the affected file(s)**: \`npx vitest --project storybook run path/to/Foo.stories.${tsx}\`.
-    4. Repeat until the file passes, or until you have tried 5 times — if it still fails, leave \`'needs-work'\` tag to inform the user.
-    5. When you keep failing on a story, play function, etc., do not substitute it for easier content that contributes less to codebase understanding.
-
+    3. In subsequent runs, re-run Vitest **only for the affected file(s)**: \`npx vitest --project storybook run path/to/Foo.stories.${tsx}\`.
+    4. Fix any TypeScript issues needed for story files to pass, then re-run TS and Vitest only for those files. Repeat until files pass, or until you have tried 5 times.
+    5. If a story file still fails after those retries, leave the file tagged \`'needs-work'\` and move on — do not keep chasing project-wide TS errors caused by preserved \`'needs-work'\` files.
+    6. When you keep failing on a story, play function, etc., do not substitute it for easier content that contributes less to codebase understanding.
     **After a file passes**, edit its meta and remove \`'needs-work'\` so its tags become \`['ai-generated']\`. Files you couldn't fix keep \`['ai-generated', 'needs-work']\` — move on, don't loop forever.`,
   };
 }

--- a/code/lib/cli-storybook/src/ai/setup-prompts/partials/steps.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/partials/steps.ts
@@ -82,6 +82,32 @@ export function verifyStep(
   };
 }
 
+export function verifyWithAllowedFailureStep(
+  projectInfo: ProjectInfo,
+  { packageManager, tsx }: InstructionsContext
+): { title: string; body: string } {
+  return {
+    title: `Verify in one batch, then iterate only on failures`,
+    body: dedent`**Read this rule once before running anything:** the first vitest invocation must run **all** the new stories together. No single-file runs before the batch.
+
+    \`\`\`bash
+    npx vitest --project storybook run
+    \`\`\`
+
+    Then run the project's TypeScript check (use the script from \`package.json\` — typically \`tsc --noEmit\` or \`${packageManager.getRunCommand('typecheck')}\`). Read the raw output once; don't pipe it through repeated \`grep\`/\`head\` invocations to slice it.
+
+    For each failure:
+
+    1. Read the error.
+    2. If multiple stories share the failure, fix the shared preview setup, not the stories.
+    3. Re-run vitest **only for the affected file(s)**: \`npx vitest --project storybook run path/to/Foo.stories.${tsx}\`.
+    4. Repeat until the file passes, or until you have tried 5 times — if it still fails, leave \`'needs-work'\` tag to inform the user.
+    5. When you keep failing on a story, play function, etc., do not substitute it for easier content that contributes less to codebase understanding.
+
+    **After a file passes**, edit its meta and remove \`'needs-work'\` so its tags become \`['ai-generated']\`. Files you couldn't fix keep \`['ai-generated', 'needs-work']\` — move on, don't loop forever.`,
+  };
+}
+
 export function cleanupStep(
   { needsUserOnboarding }: ProjectInfo,
   ctx: InstructionsContext
@@ -196,6 +222,55 @@ export function writeStoriesStep(
     Each story file: ~3 exports for typical components, up to ~10 when warranted by real usage. Copy JSX patterns from real pages/routes/tests.
 
     **Tag every new story file with \`['ai-generated', 'needs-work']\` from the start.** You will remove \`'needs-work'\` only after vitest confirms the file passes. This way, anything not yet verified — including stories you ran out of time to fix — stays correctly marked.
+
+    ${getStoryExample(projectInfo)}
+
+    Story rules:
+
+    - Start every meta with \`tags: ['ai-generated', 'needs-work']\`.
+    - Show all imports explicitly.
+    - Don't add a custom \`title\`.
+    - Don't build large story-specific harnesses — fix preview instead.
+    - Don't create new app components.
+
+    **Substep b — add the single \`CssCheck\` story.** Before you finish this step, pick **one** visually distinctive component from the files you just wrote and add a \`CssCheck\` export to that file. Exactly **one** \`CssCheck\` across the whole project — not one per file. This step is not complete until the story exists.
+
+    Why it's mandatory: \`toBeVisible\` passes on an unstyled component. A concrete \`getComputedStyle\` value is the only proof that the shared preview actually loaded the app's CSS — without it, you have no idea whether your stories are rendering correctly.
+
+    How: read a real styling value from the component's source (e.g. a hex color in styled-components, a Tailwind class like \`bg-blue-600\`, a CSS variable from the theme), and assert the resolved \`getComputedStyle\` value:
+
+    \`\`\`${tsx}
+    export const CssCheck: Story = {
+      args: { children: 'Submit' },
+      play: async ({ canvas }) => {
+        const button = canvas.getByRole('button', { name: /submit/i });
+        // PrimaryButton uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+        await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+      },
+    };
+    \`\`\`
+    `,
+  };
+}
+
+export function writeStoriesWithAllowedFailuresStep(
+  projectInfo: ProjectInfo,
+  { tsx }: InstructionsContext
+): { title: string; body: string } {
+  return {
+    title: 'Write up to 10 story files (in one batch)',
+    body: dedent`
+
+    This step has **two required deliverables**:
+
+    a. Up to 10 colocated \`*.stories.${tsx}\` files for meaningful targets in the codebase.
+    b. **Exactly one \`CssCheck\` story** added to one of those files (spec below). This step is not complete without it.
+
+    **Substep a — pick targets and write the files.** Pick ~10 meaningful targets from the real codebase (low-level reusable → page components). Skip subcomponents, hooks, contexts, helpers, and \`App\` itself when real page components exist.
+
+    Each story file: ~3 exports for typical components, up to ~10 when warranted by real usage. Copy JSX patterns from real pages/routes/tests.
+
+    **Tag every new story file with \`['ai-generated', 'needs-work']\` from the start.** You will remove \`'needs-work'\` only after vitest confirms the file passes, and you will leave the tag if the file is not fully functional at the end of your self-healing loop.
 
     ${getStoryExample(projectInfo)}
 

--- a/code/lib/cli-storybook/src/ai/setup-prompts/relaxed-limits.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/relaxed-limits.ts
@@ -3,7 +3,7 @@ import { dedent } from 'ts-dedent';
 import type { ProjectInfo, SetupInstructionsContext } from '../types.ts';
 import { getDocsMarkdownUrl } from '../utils/docs-markdown-url.ts';
 import { ext } from '../utils/ext.ts';
-import { listRules, listSteps } from '../utils/markdown.ts';
+import { listDOD, listRules, listSteps } from '../utils/markdown.ts';
 import {
   buildPortalStep,
   buildSharedPreviewStep,
@@ -24,6 +24,13 @@ import {
   readBudgetRuleRelaxed,
   toolsVsShellRule,
 } from './partials/rules.ts';
+import {
+  cssCheckDOD,
+  sharedPreviewDOD,
+  storyTagsV1DOD,
+  typeCheckPassesStrictDOD,
+  vitestPassesStrictDOD,
+} from './partials/dod.ts';
 
 export function instructions(projectInfo: ProjectInfo): string {
   const { configDir, language, needsUserOnboarding, packageManager, packageManagerName } =
@@ -80,12 +87,14 @@ export function instructions(projectInfo: ProjectInfo): string {
     )}
 
     ## Done when
-
-    - **Exactly one \`CssCheck\` story exists** somewhere in the new stories, asserting a concrete computed style value read from the component's source (added at the end of Step 5).
-    - Every story file you wrote that vitest confirmed passing has had \`'needs-work'\` stripped, leaving \`tags: ['ai-generated']\`. Anything still failing keeps \`['ai-generated', 'needs-work']\`.
-    - \`npx vitest --project storybook run\` passes for the new files.
-    - The project's TypeScript check passes for changed files.
-    - The shared preview is strong enough that stories don't need per-story fetch/provider workarounds.
+        
+    ${listDOD([
+      cssCheckDOD(ctx),
+      storyTagsV1DOD(ctx),
+      vitestPassesStrictDOD(ctx),
+      typeCheckPassesStrictDOD(ctx),
+      sharedPreviewDOD(ctx),
+    ])}
 
     ## Reference (only fetch if stuck)
 

--- a/code/lib/cli-storybook/src/ai/utils/markdown.ts
+++ b/code/lib/cli-storybook/src/ai/utils/markdown.ts
@@ -22,3 +22,12 @@ export function listSteps(
       .join('\n\n')}
   `;
 }
+
+export function listDOD(dods: (string | undefined)[]): string {
+  return dedent`
+    ${dods
+      .filter(Boolean)
+      .map((s) => `- ${s}`)
+      .join('\n')}
+  `;
+}

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -92,6 +92,19 @@ node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --claude-effort 
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --claude-efforts max,high
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --agents codex --codex-effort xhigh
 
+# Restrict to specific projects (works with both agents)
+node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --projects mealdrop,edgy,echarts
+
+# Targeted matrix: medium + high effort, 3 projects, 2 reps each (12 Claude trials)
+node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes \
+  --agents claude --claude-efforts medium,high \
+  --projects mealdrop,edgy,echarts --repetitions 2
+
+# Same project subset on Codex
+node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes \
+  --agents codex --codex-effort high \
+  --projects mealdrop,edgy,echarts --repetitions 2
+
 # Different prompt or concurrency
 node scripts/eval/run-batch.ts --prompt setup --yes
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --concurrency 4

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -81,7 +81,7 @@ By default, a batch runs **10 repetitions per (project × variant)** across all 
 # Prompt is required. Confirms interactively unless you pass --yes (CI / automation).
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes
 
-# Smaller batch — 2 reps per project (14 trials with the default Claude-only matrix)
+# Smaller batch — 2 reps per project (16 trials with Claude and Codex)
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --repetitions 2
 
 # Claude only

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -95,6 +95,9 @@ node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --agents codex -
 # Restrict to specific projects (works with both agents)
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --projects mealdrop,edgy,echarts
 
+# Fan out across multiple prompts in one batch
+node scripts/eval/run-batch.ts --prompts pattern-copy-play,optimized-tests --yes --repetitions 2
+
 # Targeted matrix: medium + high effort, 3 projects, 2 reps each (12 Claude trials)
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes \
   --agents claude --claude-efforts medium,high \

--- a/scripts/eval/lib/publish-trial.test.ts
+++ b/scripts/eval/lib/publish-trial.test.ts
@@ -93,6 +93,32 @@ describe('buildTrialLabels', () => {
       'prompt:setup',
     ]);
   });
+
+  it('truncates labels longer than 50 characters', async () => {
+    const { buildTrialLabels } = await import('./publish-trial.ts');
+
+    const longPrompt = 'monorepo-optimized-tests-relaxed-limits-no-story-deletion';
+    const labels = buildTrialLabels(
+      {
+        name: 'mealdrop',
+        repo: 'https://github.com/storybook-tmp/mealdrop',
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+      { agent: 'claude', model: 'sonnet-4.6', effort: 'high' },
+      longPrompt
+    );
+
+    expect(labels).toEqual([
+      'eval',
+      'project:mealdrop',
+      'agent:claude',
+      'model:sonnet-4.6',
+      'effort:high',
+      'prompt:monorepo-optimized-tests-relaxed-limits-no-',
+    ]);
+    expect(labels.every((label) => label.length <= 50)).toBe(true);
+  });
 });
 
 describe('publishTrialBranch', () => {

--- a/scripts/eval/lib/publish-trial.ts
+++ b/scripts/eval/lib/publish-trial.ts
@@ -2,6 +2,8 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { x } from 'tinyexec';
+
+const GITHUB_LABEL_MAX_LENGTH = 50;
 import type { TrialWorkspace } from './prepare-trial.ts';
 import type { EvalData } from './result-docs.ts';
 import {
@@ -32,7 +34,11 @@ export function buildTrialLabels(
     `model:${variant.model}`,
     `effort:${variant.effort}`,
     `prompt:${prompt}`,
-  ];
+  ].map(truncateLabel);
+}
+
+function truncateLabel(label: string) {
+  return label.slice(0, GITHUB_LABEL_MAX_LENGTH);
 }
 
 export async function publishTrialBranch(opts: {

--- a/scripts/eval/run-batch.test.ts
+++ b/scripts/eval/run-batch.test.ts
@@ -18,6 +18,9 @@ import {
   BATCH_VARIANTS,
   buildBatchRunDescriptors,
   buildBatchVariants,
+  formatBatchHeader,
+  formatDuration,
+  formatPerProjectSummary,
   main,
   parseRunBatchArgs,
   runBatch,
@@ -254,6 +257,137 @@ describe('parseRunBatchArgs', () => {
       prompt: TEST_PROMPT,
       claudeEfforts: ['max', 'high'],
     });
+  });
+
+  it('parses a comma-separated --projects list from the CLI', () => {
+    const [first, second] = BATCH_PROJECT_NAMES;
+    expect(
+      parseRunBatchArgs(['--prompt', TEST_PROMPT, '--projects', `${first}, ${second}`])
+    ).toEqual({
+      prompt: TEST_PROMPT,
+      projects: [first, second],
+    });
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats sub-minute durations as seconds', () => {
+    expect(formatDuration(0)).toBe('0s');
+    expect(formatDuration(45_000)).toBe('45s');
+    expect(formatDuration(59_499)).toBe('59s');
+  });
+
+  it('formats minutes and seconds for under-an-hour durations', () => {
+    expect(formatDuration(60_000)).toBe('1m');
+    expect(formatDuration(338_759)).toBe('5m 39s');
+    expect(formatDuration(1_120_358)).toBe('18m 40s');
+  });
+
+  it('formats hours and minutes for long durations', () => {
+    expect(formatDuration(3_600_000)).toBe('1h 0m');
+    expect(formatDuration(3_900_000)).toBe('1h 5m');
+  });
+});
+
+describe('formatBatchHeader', () => {
+  it('summarizes the matrix and lists distinct values', () => {
+    const descriptors = buildBatchRunDescriptors({
+      prompt: TEST_PROMPT,
+      agents: ['claude'],
+      claudeEfforts: ['medium', 'high'],
+      projects: ['mealdrop', 'edgy'],
+      repetitions: 2,
+    });
+
+    const lines = formatBatchHeader({
+      batchTimestamp: '2026-05-05T12-09-55-151Z',
+      descriptors,
+      concurrency: 8,
+      logsDir: '/tmp/logs',
+    });
+
+    expect(lines[0]).toBe('Eval batch 2026-05-05T12-09-55-151Z');
+    expect(lines.join('\n')).toContain('runs:        8 (2 projects × 1 agent(s) × 2 effort(s) × 2 rep(s))');
+    expect(lines.join('\n')).toContain('prompt:      pattern-copy-play');
+    expect(lines.join('\n')).toContain('projects:    edgy, mealdrop');
+    expect(lines.join('\n')).toContain('efforts:     high, medium');
+    expect(lines.join('\n')).toContain('concurrency: 8');
+    expect(lines.join('\n')).toContain('logs:        /tmp/logs');
+  });
+});
+
+describe('formatPerProjectSummary', () => {
+  it('produces a column-aligned table grouped by project', () => {
+    const runs = [
+      makeRun({ project: 'mealdrop', status: 'success', durationMs: 60_000 }),
+      makeRun({ project: 'mealdrop', status: 'success', durationMs: 120_000 }),
+      makeRun({ project: 'mealdrop', status: 'failed', durationMs: 30_000 }),
+      makeRun({ project: 'edgy', status: 'success', durationMs: 240_000 }),
+    ];
+    const lines = formatPerProjectSummary(runs);
+    expect(lines[0]).toBe('');
+    expect(lines[1]).toBe('Per-project summary:');
+    const body = lines.slice(2).join('\n');
+    expect(body).toContain('project');
+    expect(body).toContain('ok');
+    expect(body).toMatch(/edgy\s+1\/1/);
+    expect(body).toMatch(/mealdrop\s+2\/3/);
+    expect(body).toContain('30s');
+    expect(body).toContain('4m');
+  });
+
+  it('returns an empty array when there are no runs', () => {
+    expect(formatPerProjectSummary([])).toEqual([]);
+  });
+});
+
+function makeRun(opts: {
+  project: string;
+  status: 'success' | 'failed';
+  durationMs: number;
+}) {
+  return {
+    project: opts.project,
+    agent: 'claude' as const,
+    model: 'opus-4.6',
+    effort: 'high',
+    prompt: TEST_PROMPT,
+    repetition: 1,
+    label: `${opts.project}-r01`,
+    args: [],
+    startTimestamp: '2026-05-05T12:00:00.000Z',
+    endTimestamp: '2026-05-05T12:01:00.000Z',
+    durationMs: opts.durationMs,
+    exitCode: opts.status === 'success' ? 0 : 1,
+    signal: null,
+    status: opts.status,
+    logPath: `/tmp/${opts.project}.log`,
+  } as Parameters<typeof formatPerProjectSummary>[0][number];
+}
+
+describe('buildBatchRunDescriptors with --projects', () => {
+  it('restricts the matrix to the requested projects, deduplicating', () => {
+    const [first, second] = BATCH_PROJECT_NAMES;
+    const descriptors = buildBatchRunDescriptors({
+      prompt: TEST_PROMPT,
+      agents: ['claude'],
+      claudeEfforts: ['medium', 'high'],
+      projects: [first, second, first],
+      repetitions: 2,
+    });
+
+    expect(descriptors).toHaveLength(2 * 2 * 2); // 2 projects × 2 efforts × 2 reps
+    expect(new Set(descriptors.map((d) => d.project))).toEqual(new Set([first, second]));
+    expect(new Set(descriptors.map((d) => d.effort))).toEqual(new Set(['medium', 'high']));
+  });
+
+  it('throws when an unknown project is requested', () => {
+    expect(() =>
+      buildBatchRunDescriptors({
+        prompt: TEST_PROMPT,
+        projects: ['not-a-real-project'],
+      })
+    ).toThrow(/Unknown project/);
   });
 });
 

--- a/scripts/eval/run-batch.test.ts
+++ b/scripts/eval/run-batch.test.ts
@@ -308,9 +308,9 @@ describe('formatBatchHeader', () => {
 
     expect(lines[0]).toBe('Eval batch 2026-05-05T12-09-55-151Z');
     expect(lines.join('\n')).toContain(
-      'runs:        8 (2 projects × 1 agent(s) × 2 effort(s) × 2 rep(s))'
+      'runs:        8 (2 projects × 1 prompt(s) × 1 agent(s) × 1 model(s) × 2 effort(s) × 2 rep(s))'
     );
-    expect(lines.join('\n')).toContain('prompt:      pattern-copy-play');
+    expect(lines.join('\n')).toContain('prompts:     pattern-copy-play');
     expect(lines.join('\n')).toContain('projects:    edgy, mealdrop');
     expect(lines.join('\n')).toContain('efforts:     high, medium');
     expect(lines.join('\n')).toContain('concurrency: 8');

--- a/scripts/eval/run-batch.test.ts
+++ b/scripts/eval/run-batch.test.ts
@@ -389,6 +389,41 @@ describe('buildBatchRunDescriptors with --projects', () => {
       })
     ).toThrow(/Unknown project/);
   });
+
+  it('fans out across multiple prompts when --prompts is set', () => {
+    const [first] = BATCH_PROJECT_NAMES;
+    const descriptors = buildBatchRunDescriptors({
+      prompts: ['pattern-copy-play', 'setup'],
+      agents: ['claude'],
+      claudeEffort: 'high',
+      projects: [first],
+      repetitions: 2,
+    });
+
+    expect(descriptors).toHaveLength(2 * 1 * 2); // 2 prompts × 1 project × 2 reps
+    expect(new Set(descriptors.map((d) => d.prompt))).toEqual(
+      new Set(['pattern-copy-play', 'setup'])
+    );
+    expect(new Set(descriptors.map((d) => d.label)).size).toBe(descriptors.length);
+  });
+
+  it('throws when an unknown prompt is requested', () => {
+    expect(() =>
+      buildBatchRunDescriptors({
+        prompts: ['pattern-copy-play', 'not-a-real-prompt'],
+      })
+    ).toThrow(/Unknown prompt/);
+  });
+
+  it('parses --prompts from the CLI', () => {
+    expect(
+      parseRunBatchArgs(['--prompts', 'pattern-copy-play, setup'])
+    ).toMatchObject({ prompts: ['pattern-copy-play', 'setup'] });
+  });
+
+  it('rejects CLI invocations with neither --prompt nor --prompts', () => {
+    expect(() => parseRunBatchArgs(['--repetitions', '1'])).toThrow(/--prompt or --prompts/);
+  });
 });
 
 describe('runBatch', () => {

--- a/scripts/eval/run-batch.test.ts
+++ b/scripts/eval/run-batch.test.ts
@@ -307,7 +307,9 @@ describe('formatBatchHeader', () => {
     });
 
     expect(lines[0]).toBe('Eval batch 2026-05-05T12-09-55-151Z');
-    expect(lines.join('\n')).toContain('runs:        8 (2 projects × 1 agent(s) × 2 effort(s) × 2 rep(s))');
+    expect(lines.join('\n')).toContain(
+      'runs:        8 (2 projects × 1 agent(s) × 2 effort(s) × 2 rep(s))'
+    );
     expect(lines.join('\n')).toContain('prompt:      pattern-copy-play');
     expect(lines.join('\n')).toContain('projects:    edgy, mealdrop');
     expect(lines.join('\n')).toContain('efforts:     high, medium');
@@ -341,11 +343,7 @@ describe('formatPerProjectSummary', () => {
   });
 });
 
-function makeRun(opts: {
-  project: string;
-  status: 'success' | 'failed';
-  durationMs: number;
-}) {
+function makeRun(opts: { project: string; status: 'success' | 'failed'; durationMs: number }) {
   return {
     project: opts.project,
     agent: 'claude' as const,
@@ -416,9 +414,9 @@ describe('buildBatchRunDescriptors with --projects', () => {
   });
 
   it('parses --prompts from the CLI', () => {
-    expect(
-      parseRunBatchArgs(['--prompts', 'pattern-copy-play, setup'])
-    ).toMatchObject({ prompts: ['pattern-copy-play', 'setup'] });
+    expect(parseRunBatchArgs(['--prompts', 'pattern-copy-play, setup'])).toMatchObject({
+      prompts: ['pattern-copy-play', 'setup'],
+    });
   });
 
   it('rejects CLI invocations with neither --prompt nor --prompts', () => {

--- a/scripts/eval/run-batch.ts
+++ b/scripts/eval/run-batch.ts
@@ -94,6 +94,8 @@ export interface RunBatchOptions {
   claudeEfforts?: (typeof CLAUDE_EFFORTS)[number][];
   claudeEffort?: (typeof CLAUDE_EFFORTS)[number];
   codexEffort?: (typeof CODEX_EFFORTS)[number];
+  /** Restrict the batch to a subset of projects. Defaults to BATCH_PROJECT_NAMES. */
+  projects?: (typeof BATCH_PROJECT_NAMES)[number][];
   /** Repetitions per (project × variant). Defaults to BATCH_REPETITIONS. */
   repetitions?: number;
   log?: (message: string) => void;
@@ -156,6 +158,7 @@ export async function runBatch(
       claudeEfforts: options.claudeEfforts,
       claudeEffort: options.claudeEffort,
       codexEffort: options.codexEffort,
+      projects: options.projects,
       repetitions: options.repetitions,
     });
 
@@ -181,16 +184,27 @@ export async function runBatch(
   const limit = pLimit(concurrency);
   let started = 0;
   let finished = 0;
+  const total = descriptors.length;
+  const padTotal = String(total).length;
+  const shortLabel = (descriptor: BatchRunDescriptor) =>
+    `${descriptor.project} r${String(descriptor.repetition).padStart(2, '0')}`;
 
-  log(
-    `Starting eval batch ${batchTimestamp}: ${descriptors.length} runs, concurrency ${concurrency}, logs ${logsDir}`
-  );
+  for (const line of formatBatchHeader({
+    batchTimestamp,
+    descriptors,
+    concurrency,
+    logsDir,
+  })) {
+    log(line);
+  }
 
   await Promise.all(
     descriptors.map((descriptor, index) =>
       limit(async () => {
         started += 1;
-        log(`[start ${started}/${descriptors.length}] ${descriptor.label}`);
+        log(
+          `[${String(started).padStart(padTotal)}/${total}] start  ${shortLabel(descriptor)}`
+        );
 
         const result = await runBatchDescriptor(descriptor, {
           repoRoot,
@@ -202,8 +216,11 @@ export async function runBatch(
 
         finished += 1;
         const reason = result.status === 'failed' ? await readFailureReason(result.logPath) : '';
+        const tag = result.status === 'success' ? '✓' : '✗';
+        const exitInfo =
+          result.status === 'success' ? '' : ` ${formatExitResult(result)}`;
         log(
-          `[finish ${finished}/${descriptors.length}] ${descriptor.label} ${result.status} ${formatExitResult(result)} ${result.durationMs}ms${reason ? ` — ${reason}` : ''}`
+          `[${String(finished).padStart(padTotal)}/${total}] ${tag} ${shortLabel(descriptor)} ${formatDuration(result.durationMs)}${exitInfo}${reason ? ` — ${reason}` : ''}`
         );
       })
     )
@@ -227,11 +244,17 @@ export async function runBatch(
 
   await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
 
+  log('');
   log(
-    `Finished eval batch ${batchTimestamp}: ${summary.totalRuns} total, ${summary.succeeded} succeeded, ${summary.failed} failed`
+    `Finished eval batch ${batchTimestamp} in ${formatDuration(summary.durationMs)}: ${summary.succeeded}/${summary.totalRuns} succeeded${summary.failed > 0 ? `, ${summary.failed} failed` : ''}`
   );
 
+  for (const line of formatPerProjectSummary(summary.runs)) {
+    log(line);
+  }
+
   if (summary.failed > 0) {
+    log('');
     log('Failures:');
     for (const run of summary.runs) {
       if (run.status === 'success') continue;
@@ -306,6 +329,7 @@ export function buildBatchRunDescriptors(options: {
   claudeEfforts?: RunBatchOptions['claudeEfforts'];
   claudeEffort?: RunBatchOptions['claudeEffort'];
   codexEffort?: RunBatchOptions['codexEffort'];
+  projects?: RunBatchOptions['projects'];
   repetitions?: number;
 }): BatchRunDescriptor[] {
   const knownProjects = new Set(PROJECTS.map((project) => project.name));
@@ -315,6 +339,8 @@ export function buildBatchRunDescriptors(options: {
       throw new Error(`Configured batch project is missing from PROJECTS: ${project}`);
     }
   }
+
+  const projects = resolveBatchProjects(options.projects);
 
   const descriptors: BatchRunDescriptor[] = [];
   const variants =
@@ -328,13 +354,36 @@ export function buildBatchRunDescriptors(options: {
   const totalRepetitions = options.repetitions ?? BATCH_REPETITIONS;
   for (let repetition = 1; repetition <= totalRepetitions; repetition += 1) {
     for (const variant of variants) {
-      for (const project of BATCH_PROJECT_NAMES) {
+      for (const project of projects) {
         descriptors.push(createBatchRunDescriptor(project, variant, repetition, options.prompt));
       }
     }
   }
 
   return descriptors;
+}
+
+function resolveBatchProjects(projects?: RunBatchOptions['projects']) {
+  if (projects == null || projects.length === 0) {
+    return [...BATCH_PROJECT_NAMES];
+  }
+
+  const allowed = new Set<string>(BATCH_PROJECT_NAMES);
+  const unknown = projects.filter((project) => !allowed.has(project));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown project(s): ${unknown.join(', ')}. Available: ${BATCH_PROJECT_NAMES.join(', ')}`
+    );
+  }
+
+  const seen = new Set<string>();
+  const ordered: (typeof BATCH_PROJECT_NAMES)[number][] = [];
+  for (const project of projects) {
+    if (seen.has(project)) continue;
+    seen.add(project);
+    ordered.push(project);
+  }
+  return ordered;
 }
 
 function requireBatchPrompt(options: RunBatchOptions): string {
@@ -471,6 +520,7 @@ const runBatchArgsSchema = z.object({
   claudeEfforts: z.array(z.enum(CLAUDE_EFFORTS)).nonempty().optional(),
   claudeEffort: z.enum(CLAUDE_EFFORTS).optional(),
   codexEffort: z.enum(CODEX_EFFORTS).optional(),
+  projects: z.array(z.string().min(1)).nonempty().optional(),
   repetitions: z.coerce.number().int().positive().optional(),
 });
 
@@ -491,6 +541,10 @@ const runBatchOptions = {
   },
   'claude-effort': { type: 'string' as const, description: 'Single Claude effort level' },
   'codex-effort': { type: 'string' as const, description: 'Single Codex effort level' },
+  projects: {
+    type: 'string' as const,
+    description: 'Comma-separated project names to run (default: all batch projects)',
+  },
   repetitions: {
     type: 'string' as const,
     description: `Repetitions per (project × variant) (default: ${BATCH_REPETITIONS})`,
@@ -514,6 +568,7 @@ export function parseRunBatchArgs(
       | 'codexEffort'
       | 'concurrency'
       | 'prompt'
+      | 'projects'
       | 'yes'
       | 'repetitions'
     >
@@ -536,6 +591,7 @@ export function parseRunBatchArgs(
     claudeEfforts: parseClaudeEfforts(values['claude-efforts']),
     claudeEffort: values['claude-effort'],
     codexEffort: values['codex-effort'],
+    projects: parseProjects(values.projects),
     repetitions: values.repetitions,
   });
 
@@ -571,6 +627,18 @@ function parseClaudeEfforts(value?: string) {
     .filter(Boolean);
 }
 
+function parseProjects(value?: string) {
+  if (value == null) {
+    return undefined;
+  }
+
+  const projects = value
+    .split(',')
+    .map((project) => project.trim())
+    .filter(Boolean);
+  return projects.length > 0 ? projects : undefined;
+}
+
 function resolveBatchAgents(agents?: RunBatchOptions['agents']) {
   if (agents == null || agents.length === 0) {
     return [...BATCH_DEFAULT_AGENT_IDS];
@@ -600,6 +668,87 @@ function formatBatchTimestamp(date: Date) {
 
 function formatExitResult(result: Pick<BatchRunSummaryEntry, 'exitCode' | 'signal'>) {
   return result.signal ? `signal=${result.signal}` : `exit=${result.exitCode ?? 'null'}`;
+}
+
+export function formatDuration(ms: number) {
+  if (!Number.isFinite(ms) || ms < 0) return `${ms}ms`;
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+}
+
+function uniqueSorted(values: readonly string[]) {
+  return [...new Set(values)].sort();
+}
+
+export function formatBatchHeader(opts: {
+  batchTimestamp: string;
+  descriptors: BatchRunDescriptor[];
+  concurrency: number;
+  logsDir: string;
+}): string[] {
+  const { batchTimestamp, descriptors, concurrency, logsDir } = opts;
+  const projects = uniqueSorted(descriptors.map((d) => d.project));
+  const agents = uniqueSorted(descriptors.map((d) => d.agent));
+  const models = uniqueSorted(descriptors.map((d) => d.model));
+  const efforts = uniqueSorted(descriptors.map((d) => d.effort));
+  const prompts = uniqueSorted(descriptors.map((d) => d.prompt));
+  const reps = Math.max(...descriptors.map((d) => d.repetition));
+
+  return [
+    `Eval batch ${batchTimestamp}`,
+    `  runs:        ${descriptors.length} (${projects.length} projects × ${agents.length} agent(s) × ${efforts.length} effort(s) × ${reps} rep(s))`,
+    `  prompt:      ${prompts.join(', ')}`,
+    `  agents:      ${agents.join(', ')}`,
+    `  models:      ${models.join(', ')}`,
+    `  efforts:     ${efforts.join(', ')}`,
+    `  projects:    ${projects.join(', ')}`,
+    `  concurrency: ${concurrency}`,
+    `  logs:        ${logsDir}`,
+    '',
+  ];
+}
+
+export function formatPerProjectSummary(runs: BatchRunSummaryEntry[]): string[] {
+  if (runs.length === 0) return [];
+
+  const byProject = new Map<string, BatchRunSummaryEntry[]>();
+  for (const run of runs) {
+    const list = byProject.get(run.project) ?? [];
+    list.push(run);
+    byProject.set(run.project, list);
+  }
+
+  const projectCol = Math.max('project'.length, ...[...byProject.keys()].map((p) => p.length));
+  const headers = ['project', 'ok', 'min', 'med', 'max'];
+  const rows = [...byProject.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([project, projectRuns]) => {
+      const ok = projectRuns.filter((r) => r.status === 'success').length;
+      const sortedDurations = projectRuns.map((r) => r.durationMs).sort((a, b) => a - b);
+      const median = sortedDurations[Math.floor(sortedDurations.length / 2)];
+      return [
+        project,
+        `${ok}/${projectRuns.length}`,
+        formatDuration(sortedDurations[0]),
+        formatDuration(median),
+        formatDuration(sortedDurations[sortedDurations.length - 1]),
+      ];
+    });
+
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((row) => row[i].length))
+  );
+  widths[0] = Math.max(widths[0], projectCol);
+
+  const fmtRow = (cells: string[]) =>
+    `  ${cells.map((cell, i) => (i === 0 ? cell.padEnd(widths[i]) : cell.padStart(widths[i]))).join('  ')}`;
+
+  return ['', 'Per-project summary:', fmtRow(headers), ...rows.map(fmtRow)];
 }
 
 async function waitForChild(child: SpawnedBatchChild) {

--- a/scripts/eval/run-batch.ts
+++ b/scripts/eval/run-batch.ts
@@ -189,7 +189,7 @@ export async function runBatch(
   const total = descriptors.length;
   const padTotal = String(total).length;
   const shortLabel = (descriptor: BatchRunDescriptor) =>
-    `${descriptor.project} r${String(descriptor.repetition).padStart(2, '0')}`;
+    `${descriptor.project} ${descriptor.agent}/${descriptor.effort} ${descriptor.prompt} r${String(descriptor.repetition).padStart(2, '0')}`;
 
   for (const line of formatBatchHeader({
     batchTimestamp,
@@ -741,8 +741,8 @@ export function formatBatchHeader(opts: {
 
   return [
     `Eval batch ${batchTimestamp}`,
-    `  runs:        ${descriptors.length} (${projects.length} projects × ${agents.length} agent(s) × ${efforts.length} effort(s) × ${reps} rep(s))`,
-    `  prompt:      ${prompts.join(', ')}`,
+    `  runs:        ${descriptors.length} (${projects.length} projects × ${prompts.length} prompt(s) × ${agents.length} agent(s) × ${models.length} model(s) × ${efforts.length} effort(s) × ${reps} rep(s))`,
+    `  prompts:     ${prompts.join(', ')}`,
     `  agents:      ${agents.join(', ')}`,
     `  models:      ${models.join(', ')}`,
     `  efforts:     ${efforts.join(', ')}`,
@@ -770,7 +770,11 @@ export function formatPerProjectSummary(runs: BatchRunSummaryEntry[]): string[] 
     .map(([project, projectRuns]) => {
       const ok = projectRuns.filter((r) => r.status === 'success').length;
       const sortedDurations = projectRuns.map((r) => r.durationMs).sort((a, b) => a - b);
-      const median = sortedDurations[Math.floor(sortedDurations.length / 2)];
+      const mid = Math.floor(sortedDurations.length / 2);
+      const median =
+        sortedDurations.length % 2 === 0
+          ? Math.round((sortedDurations[mid - 1] + sortedDurations[mid]) / 2)
+          : sortedDurations[mid];
       return [
         project,
         `${ok}/${projectRuns.length}`,

--- a/scripts/eval/run-batch.ts
+++ b/scripts/eval/run-batch.ts
@@ -204,9 +204,7 @@ export async function runBatch(
     descriptors.map((descriptor, index) =>
       limit(async () => {
         started += 1;
-        log(
-          `[${String(started).padStart(padTotal)}/${total}] start  ${shortLabel(descriptor)}`
-        );
+        log(`[${String(started).padStart(padTotal)}/${total}] start  ${shortLabel(descriptor)}`);
 
         const result = await runBatchDescriptor(descriptor, {
           repoRoot,
@@ -219,8 +217,7 @@ export async function runBatch(
         finished += 1;
         const reason = result.status === 'failed' ? await readFailureReason(result.logPath) : '';
         const tag = result.status === 'success' ? '✓' : '✗';
-        const exitInfo =
-          result.status === 'success' ? '' : ` ${formatExitResult(result)}`;
+        const exitInfo = result.status === 'success' ? '' : ` ${formatExitResult(result)}`;
         log(
           `[${String(finished).padStart(padTotal)}/${total}] ${tag} ${shortLabel(descriptor)} ${formatDuration(result.durationMs)}${exitInfo}${reason ? ` — ${reason}` : ''}`
         );
@@ -370,10 +367,7 @@ export function buildBatchRunDescriptors(options: {
 }
 
 function resolveBatchPrompts(options: { prompt?: string; prompts?: string[] }): string[] {
-  const merged = [
-    ...(options.prompts ?? []),
-    ...(options.prompt != null ? [options.prompt] : []),
-  ]
+  const merged = [...(options.prompts ?? []), ...(options.prompt != null ? [options.prompt] : [])]
     .map((value) => value.trim())
     .filter(Boolean);
 
@@ -786,9 +780,7 @@ export function formatPerProjectSummary(runs: BatchRunSummaryEntry[]): string[] 
       ];
     });
 
-  const widths = headers.map((h, i) =>
-    Math.max(h.length, ...rows.map((row) => row[i].length))
-  );
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((row) => row[i].length)));
   widths[0] = Math.max(widths[0], projectCol);
 
   const fmtRow = (cells: string[]) =>

--- a/scripts/eval/run-batch.ts
+++ b/scripts/eval/run-batch.ts
@@ -88,6 +88,8 @@ export interface RunBatchOptions {
   batchTimestamp?: string;
   /** Required when `descriptors` are not provided — prompt variant name from the CLI registry. */
   prompt?: string;
+  /** Optional list of prompts to fan out across in a single batch (in addition to or in place of `prompt`). */
+  prompts?: string[];
   /** Skip interactive confirmation (large API / token usage). */
   yes?: boolean;
   agents?: (typeof BATCH_AGENT_IDS)[number][];
@@ -153,7 +155,7 @@ export async function runBatch(
   const descriptors =
     options.descriptors ??
     buildBatchRunDescriptors({
-      prompt: requireBatchPrompt(options),
+      prompts: requireBatchPrompts(options),
       agents: options.agents,
       claudeEfforts: options.claudeEfforts,
       claudeEffort: options.claudeEffort,
@@ -324,7 +326,8 @@ export function buildBatchVariants(
 }
 
 export function buildBatchRunDescriptors(options: {
-  prompt: string;
+  prompt?: string;
+  prompts?: string[];
   agents?: RunBatchOptions['agents'];
   claudeEfforts?: RunBatchOptions['claudeEfforts'];
   claudeEffort?: RunBatchOptions['claudeEffort'];
@@ -341,6 +344,7 @@ export function buildBatchRunDescriptors(options: {
   }
 
   const projects = resolveBatchProjects(options.projects);
+  const prompts = resolveBatchPrompts({ prompt: options.prompt, prompts: options.prompts });
 
   const descriptors: BatchRunDescriptor[] = [];
   const variants =
@@ -353,14 +357,56 @@ export function buildBatchRunDescriptors(options: {
 
   const totalRepetitions = options.repetitions ?? BATCH_REPETITIONS;
   for (let repetition = 1; repetition <= totalRepetitions; repetition += 1) {
-    for (const variant of variants) {
-      for (const project of projects) {
-        descriptors.push(createBatchRunDescriptor(project, variant, repetition, options.prompt));
+    for (const prompt of prompts) {
+      for (const variant of variants) {
+        for (const project of projects) {
+          descriptors.push(createBatchRunDescriptor(project, variant, repetition, prompt));
+        }
       }
     }
   }
 
   return descriptors;
+}
+
+function resolveBatchPrompts(options: { prompt?: string; prompts?: string[] }): string[] {
+  const merged = [
+    ...(options.prompts ?? []),
+    ...(options.prompt != null ? [options.prompt] : []),
+  ]
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (merged.length === 0) {
+    throw new Error(
+      'runBatch: pass `prompt` or `prompts` (prompt template basename) or provide `descriptors` explicitly.'
+    );
+  }
+
+  const available = listPrompts();
+  const lookup = new Map(available.map((name) => [name.toLowerCase(), name]));
+
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  const unknown: string[] = [];
+  for (const value of merged) {
+    const canonical = lookup.get(value.toLowerCase());
+    if (!canonical) {
+      unknown.push(value);
+      continue;
+    }
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    ordered.push(canonical);
+  }
+
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown prompt(s): ${unknown.join(', ')}. Available prompts: ${available.join(', ')}`
+    );
+  }
+
+  return ordered;
 }
 
 function resolveBatchProjects(projects?: RunBatchOptions['projects']) {
@@ -386,23 +432,8 @@ function resolveBatchProjects(projects?: RunBatchOptions['projects']) {
   return ordered;
 }
 
-function requireBatchPrompt(options: RunBatchOptions): string {
-  if (options.prompt == null || options.prompt.trim() === '') {
-    throw new Error(
-      'runBatch: pass `prompt` (prompt template basename) or provide `descriptors` explicitly.'
-    );
-  }
-
-  const prompt = options.prompt.trim();
-  const available = listPrompts();
-
-  const canonical = available.find((name) => name.toLowerCase() === prompt.toLowerCase());
-
-  if (!canonical) {
-    throw new Error(`Unknown prompt "${prompt}". Available prompts: ${available.join(', ')}`);
-  }
-
-  return canonical;
+function requireBatchPrompts(options: RunBatchOptions): string[] {
+  return resolveBatchPrompts({ prompt: options.prompt, prompts: options.prompts });
 }
 
 async function runBatchDescriptor(
@@ -512,24 +543,34 @@ function defaultSpawn(command: string, args: string[], options: SpawnOptions) {
   return spawnChild(command, args, options);
 }
 
-const runBatchArgsSchema = z.object({
-  concurrency: z.coerce.number().int().positive().optional(),
-  prompt: z.string().min(1),
-  yes: z.boolean().optional(),
-  agents: z.array(z.enum(BATCH_AGENT_IDS)).nonempty().optional(),
-  claudeEfforts: z.array(z.enum(CLAUDE_EFFORTS)).nonempty().optional(),
-  claudeEffort: z.enum(CLAUDE_EFFORTS).optional(),
-  codexEffort: z.enum(CODEX_EFFORTS).optional(),
-  projects: z.array(z.string().min(1)).nonempty().optional(),
-  repetitions: z.coerce.number().int().positive().optional(),
-});
+const runBatchArgsSchema = z
+  .object({
+    concurrency: z.coerce.number().int().positive().optional(),
+    prompt: z.string().min(1).optional(),
+    prompts: z.array(z.string().min(1)).nonempty().optional(),
+    yes: z.boolean().optional(),
+    agents: z.array(z.enum(BATCH_AGENT_IDS)).nonempty().optional(),
+    claudeEfforts: z.array(z.enum(CLAUDE_EFFORTS)).nonempty().optional(),
+    claudeEffort: z.enum(CLAUDE_EFFORTS).optional(),
+    codexEffort: z.enum(CODEX_EFFORTS).optional(),
+    projects: z.array(z.string().min(1)).nonempty().optional(),
+    repetitions: z.coerce.number().int().positive().optional(),
+  })
+  .refine((value) => value.prompt != null || value.prompts != null, {
+    message: 'pass --prompt or --prompts',
+    path: ['prompt'],
+  });
 
 const runBatchOptions = {
   concurrency: { type: 'string' as const, description: 'Max concurrent runs (default: 8)' },
   prompt: {
     type: 'string' as const,
     description:
-      'Prompt variant name (required; registered in code/lib/cli-storybook/src/ai/setup-prompts/)',
+      'Prompt variant name (required unless --prompts is set; registered in code/lib/cli-storybook/src/ai/setup-prompts/)',
+  },
+  prompts: {
+    type: 'string' as const,
+    description: 'Comma-separated list of prompt variant names to fan out across',
   },
   agents: {
     type: 'string' as const,
@@ -568,6 +609,7 @@ export function parseRunBatchArgs(
       | 'codexEffort'
       | 'concurrency'
       | 'prompt'
+      | 'prompts'
       | 'projects'
       | 'yes'
       | 'repetitions'
@@ -586,6 +628,7 @@ export function parseRunBatchArgs(
   const parsed = runBatchArgsSchema.safeParse({
     concurrency: values.concurrency,
     prompt: values.prompt,
+    prompts: parseList(values.prompts),
     yes: values.yes,
     agents: parseAgentArgs(values.agents),
     claudeEfforts: parseClaudeEfforts(values['claude-efforts']),
@@ -628,15 +671,18 @@ function parseClaudeEfforts(value?: string) {
 }
 
 function parseProjects(value?: string) {
+  return parseList(value);
+}
+
+function parseList(value?: string) {
   if (value == null) {
     return undefined;
   }
-
-  const projects = value
+  const items = value
     .split(',')
-    .map((project) => project.trim())
+    .map((item) => item.trim())
     .filter(Boolean);
-  return projects.length > 0 ? projects : undefined;
+  return items.length > 0 ? items : undefined;
 }
 
 function resolveBatchAgents(agents?: RunBatchOptions['agents']) {


### PR DESCRIPTION
## What I did

* Parameterised definitions of done in "new" ai setup prompts to help iterate
* Wrote a new prompt bringing over the changes of `relaxed-limits` and `monorepo` plus the new below
* Iterated over DODs and steps to try and force agents to keep partially-working stories rather than delete or replace them

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

 UNTESTED LOL

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Storybook AI setup prompt variant for monorepo-optimized, relaxed-limits workflows; default prompt switched to an optimized-tests variant.
  * Batch runner now supports fan-out across multiple prompts and projects with improved reporting.

* **Improvements**
  * “Done when” criteria are now templated and more modular for clearer completion checks.
  * Batch reporting adds per-project summaries and duration formatting.

* **Documentation**
  * Expanded batch execution examples and guidance.

* **Tests**
  * Added tests including label truncation and expanded batch behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->