### PR TITLE
Change-Detection: Set GIT_OPTIONAL_LOCKS=0 to avoid blocking commits

### DIFF
--- a/code/core/src/core-server/change-detection/GitDiffProvider.ts
+++ b/code/core/src/core-server/change-detection/GitDiffProvider.ts
@@ -52,6 +52,11 @@ export class GitDiffProvider {
       const { stdout } = await execa('git', ['rev-parse', '--show-toplevel'], {
         cwd: this.cwd,
         stdio: 'pipe',
+        // Prevent git from acquiring .git/index.lock for stat-cache refreshes
+        // during read-only operations. Without this, parallel scans can race
+        // an interactive `git commit` and break the user's commit with
+        // "Unable to create '.git/index.lock': File exists".
+        env: { GIT_OPTIONAL_LOCKS: '0' },
       });
 
       this.repoRoot = stdout.trim();
@@ -270,7 +275,17 @@ export class GitDiffProvider {
 
   private async runGitCommand(repoRoot: string, args: string[]) {
     try {
-      return await execa('git', args, { cwd: repoRoot, stdio: 'pipe' });
+      return await execa('git', args, {
+        cwd: repoRoot,
+        stdio: 'pipe',
+        // GIT_OPTIONAL_LOCKS=0 disables the stat-cache refresh that
+        // `git status` and `git diff` would otherwise write into
+        // .git/index.lock. The diff/status output stays correct; we only
+        // skip the optional cache update. This prevents change detection
+        // scans from racing an interactive `git commit` running in the
+        // user's shell.
+        env: { GIT_OPTIONAL_LOCKS: '0' },
+      });
     } catch (error) {
       throw this.toGitError(error, `git ${args.join(' ')}`);
     }


### PR DESCRIPTION
Closes #

## What I did

When the Storybook dev server runs with change detection enabled, the user's shell `git add`/`git commit` intermittently fails with:

```
fatal: Unable to create '.git/index.lock': File exists.
```

`GitDiffProvider` (in `code/core/src/core-server/change-detection/`) shells out to git frequently — every file change debounces into a scan that runs five `git diff`/`ls-files` commands in parallel, and every git ref change re-runs `isWorkingTreeClean()` (`git status --porcelain`). Both `git status` and `git diff` opportunistically refresh the index stat cache, which means git briefly takes `.git/index.lock` during what looks like a read-only call. When the user types `git commit` in another terminal, it races the dev server and loses.

This PR sets `GIT_OPTIONAL_LOCKS=0` on the execa env for every git invocation in `GitDiffProvider`. That env var tells git to skip the optional stat-cache refresh during read-only commands. The diff/status output stays correct; we only skip the cache update. This is the standard fix VSCode and other editors use for the same reason.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

The existing `GitDiffProvider.test.ts` continues to pass (13/13). No new tests are added because the assertion would be "execa was called with a specific env" which over-specifies an implementation detail; the user-visible behavior is "concurrent commits no longer fail," which is verified manually.

#### Manual testing

1. `cd code && yarn storybook:ui` (or run any sandbox dev server in a repo).
2. In another terminal, repeatedly run `touch code/core/src/foo.ts && git add code/core/src/foo.ts && git commit -m wip` while the dev server is running.
3. Before this fix: occasionally fails with `fatal: Unable to create '.git/index.lock': File exists.`
4. After this fix: commits always succeed regardless of dev server activity.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved stability of git operations by preventing lock file conflicts that could temporarily disrupt repository indexing and analysis during intensive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->