### PR TITLE
Eval: Add Codex model matrix support

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -91,6 +91,8 @@ node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --agents claude
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --claude-effort max
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --claude-efforts max,high
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --agents codex --codex-effort xhigh
+node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --agents codex --codex-model gpt-5.5
+node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --agents codex --codex-models gpt-5.5 --codex-efforts high,xhigh
 
 # Restrict to specific projects (works with both agents)
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes --projects mealdrop,edgy,echarts
@@ -107,6 +109,13 @@ node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes \
 node scripts/eval/run-batch.ts --prompt pattern-copy-play --yes \
   --agents codex --codex-effort high \
   --projects mealdrop,edgy,echarts --repetitions 2
+
+# GPT 5.5 comparison over two prompt variants
+node scripts/eval/run-batch.ts \
+  --prompts monorepo-optimized-tests-relaxed-limits-no-story-deletion,pattern-copy-play \
+  --agents codex --codex-models gpt-5.5 --codex-efforts high,xhigh \
+  --projects wikitok,evergreen-ci,mealdrop \
+  --repetitions 3 --yes
 
 # Different prompt or concurrency
 node scripts/eval/run-batch.ts --prompt setup --yes

--- a/scripts/eval/lib/agents/codex.test.ts
+++ b/scripts/eval/lib/agents/codex.test.ts
@@ -67,7 +67,25 @@ describe('codexAgent.execute', () => {
     );
   });
 
-  it('starts the thread with the expected working directory and approval policy', async () => {
+  it('forces Codex fast service tier for eval runs', async () => {
+    await codexAgent.execute({
+      prompt: 'prompt',
+      projectPath: '/repo',
+      variant: { agent: 'codex', model: 'gpt-5.4', effort: 'medium' },
+      resultsDir: '/results',
+      logger,
+    });
+
+    expect(codexCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {
+          service_tier: 'fast',
+        },
+      })
+    );
+  });
+
+  it('starts the thread with the expected working directory and sandbox settings', async () => {
     await codexAgent.execute({
       prompt: 'prompt',
       projectPath: '/repo',
@@ -80,6 +98,7 @@ describe('codexAgent.execute', () => {
       expect.objectContaining({
         model: 'gpt-5.4',
         modelReasoningEffort: 'medium',
+        sandboxMode: 'danger-full-access',
         workingDirectory: '/repo',
         approvalPolicy: 'never',
       })

--- a/scripts/eval/lib/agents/codex.ts
+++ b/scripts/eval/lib/agents/codex.ts
@@ -28,6 +28,9 @@ export const codexAgent: AgentDriver = {
     const { model, effort } = variant;
 
     const codex = new Codex({
+      config: {
+        service_tier: settings.serviceTier,
+      },
       env: {
         ...process.env,
         ...env,
@@ -37,6 +40,7 @@ export const codexAgent: AgentDriver = {
     const thread = codex.startThread({
       model,
       modelReasoningEffort: effort as ModelReasoningEffort,
+      sandboxMode: settings.sandboxMode,
       workingDirectory: projectPath,
       approvalPolicy: settings.approvalPolicy,
     });

--- a/scripts/eval/lib/agents/config.test.ts
+++ b/scripts/eval/lib/agents/config.test.ts
@@ -35,12 +35,19 @@ describe('AGENTS', () => {
       execution: {
         approvalPolicy: 'never',
         permissionModel: 'approval-policy-never',
+        sandboxMode: 'danger-full-access',
+        serviceTier: 'fast',
       },
       pricing: {
         'gpt-5.4': {
           input: 2.5,
           cachedInput: 0.25,
           output: 15,
+        },
+        'gpt-5.5': {
+          input: 5,
+          cachedInput: 0.5,
+          output: 30,
         },
       },
     });

--- a/scripts/eval/lib/agents/config.ts
+++ b/scripts/eval/lib/agents/config.ts
@@ -5,7 +5,7 @@
 import type { Logger } from '../utils.ts';
 
 export const CLAUDE_MODELS = ['sonnet-4.6', 'opus-4.6', 'haiku-4.5'] as const;
-export const CODEX_MODELS = ['gpt-5.4'] as const;
+export const CODEX_MODELS = ['gpt-5.4', 'gpt-5.5'] as const;
 export const ALL_MODELS = [...CLAUDE_MODELS, ...CODEX_MODELS] as const;
 
 export const CLAUDE_EFFORTS = ['low', 'medium', 'high', 'max'] as const;
@@ -91,6 +91,9 @@ export interface CodexExecutionConfig {
   /** Codex runs non-interactively so benchmark runs never block on approval prompts. */
   approvalPolicy: 'never';
   permissionModel: 'approval-policy-never';
+  /** Eval worktrees are disposable and must be writable for story setup. */
+  sandboxMode: 'danger-full-access';
+  serviceTier: 'fast';
 }
 
 export interface AgentDefinition<TModel extends string, TEffort extends string, TExecution> {
@@ -138,12 +141,15 @@ export const AGENTS: AgentDefinitions = {
     sdkModelIds: {},
     pricing: {
       'gpt-5.4': { input: 2.5, cachedInput: 0.25, output: 15.0 },
+      'gpt-5.5': { input: 5.0, cachedInput: 0.5, output: 30.0 },
     },
     efforts: CODEX_EFFORTS,
     defaultEffort: 'medium',
     execution: {
       approvalPolicy: 'never',
       permissionModel: 'approval-policy-never',
+      sandboxMode: 'danger-full-access',
+      serviceTier: 'fast',
     },
   },
 };

--- a/scripts/eval/lib/run-trial.test.ts
+++ b/scripts/eval/lib/run-trial.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -272,6 +272,34 @@ describe('runTrial pipeline', () => {
 
     expect(() => readFileSync(join(resultsDir, 'summary.json'), 'utf-8')).toThrow();
     expect(() => readFileSync(join(resultsDir, 'transcript.json'), 'utf-8')).toThrow();
+  });
+
+  it('restores eval-results artifacts if the agent deletes them', async () => {
+    setupMocks();
+    vi.mocked(claudeAgent.execute).mockImplementation(async () => {
+      rmSync(join(TMP, '.storybook', 'eval-results'), { recursive: true, force: true });
+      return {
+        execution: { cost: 0.42, duration: 45.2, turns: 12 },
+        transcript: [],
+      };
+    });
+
+    await runTrial(baseConfig);
+
+    const resultsDir = join(TMP, '.storybook', 'eval-results');
+    expect(existsSync(join(resultsDir, 'data.json'))).toBe(true);
+    expect(readFileSync(join(resultsDir, 'prompt.md'), 'utf-8')).toMatch(/dispatcher\.js ai setup/);
+    expect(readFileSync(join(resultsDir, 'setup-prompt.md'), 'utf-8')).toContain(
+      'Full project-aware instructions'
+    );
+    expect(vi.mocked(x)).toHaveBeenCalledWith(
+      'git',
+      ['restore', '--source', 'deadbeef', '--', '.storybook/eval-results/data.json'],
+      expect.objectContaining({
+        throwOnError: false,
+        nodeOptions: expect.objectContaining({ cwd: TMP }),
+      })
+    );
   });
 
   it('propagates failed build into result', async () => {

--- a/scripts/eval/lib/run-trial.test.ts
+++ b/scripts/eval/lib/run-trial.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -295,6 +295,51 @@ describe('runTrial pipeline', () => {
     expect(vi.mocked(x)).toHaveBeenCalledWith(
       'git',
       ['restore', '--source', 'deadbeef', '--', '.storybook/eval-results/data.json'],
+      expect.objectContaining({
+        throwOnError: false,
+        nodeOptions: expect.objectContaining({ cwd: TMP }),
+      })
+    );
+  });
+
+  it('restores eval-support artifacts if the agent deletes them', async () => {
+    setupMocks();
+    const storybookDir = join(TMP, '.storybook');
+    mkdirSync(join(storybookDir, 'eval-support'), { recursive: true });
+    writeFileSync(
+      join(storybookDir, 'main.ts'),
+      ['export default {', '  stories: [', "    '../src/**/*.stories.tsx',", '  ],', '};', ''].join(
+        '\n'
+      )
+    );
+
+    vi.mocked(claudeAgent.execute).mockImplementation(async () => {
+      rmSync(join(storybookDir, 'eval-support'), { recursive: true, force: true });
+      writeFileSync(
+        join(storybookDir, 'main.ts'),
+        [
+          'export default {',
+          '  stories: [',
+          "    '../src/**/*.stories.tsx',",
+          '  ],',
+          '};',
+          '',
+        ].join('\n')
+      );
+      return {
+        execution: { cost: 0.42, duration: 45.2, turns: 12 },
+        transcript: [],
+      };
+    });
+
+    await runTrial(baseConfig);
+
+    expect(readFileSync(join(storybookDir, 'main.ts'), 'utf-8')).toContain(
+      "'./eval-support/*.mdx'"
+    );
+    expect(vi.mocked(x)).toHaveBeenCalledWith(
+      'git',
+      ['restore', '--source', 'deadbeef', '--', '.storybook/eval-support'],
       expect.objectContaining({
         throwOnError: false,
         nodeOptions: expect.objectContaining({ cwd: TMP }),

--- a/scripts/eval/lib/run-trial.ts
+++ b/scripts/eval/lib/run-trial.ts
@@ -1,4 +1,5 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join, relative } from 'pathe';
 import { x } from 'tinyexec';
 import type { Logger } from './utils.ts';
@@ -14,7 +15,9 @@ import {
   captureEnvironment,
   createLogger,
   generateTrialId,
+  getEvalSupportDir,
   getEvalResultsRelativePath,
+  getStorybookDir,
   loadPrompt,
   resolveDispatcherPath,
 } from './utils.ts';
@@ -40,6 +43,8 @@ const drivers: Record<AgentId, AgentDriver> = {
   claude: claudeAgent,
   codex: codexAgent,
 };
+const EVAL_SUPPORT_STORY_GLOB = './eval-support/*.mdx';
+const STORYBOOK_MAIN_FILES = ['main.ts', 'main.js', 'main.mts', 'main.mjs', 'main.cjs'] as const;
 
 /**
  * Run a full eval trial: prepare -> execute agent -> grade -> save.
@@ -100,7 +105,7 @@ export async function runTrial(config: TrialConfig, logger?: Logger): Promise<Ru
     `Agent completed (${Math.round(execution.duration)}s, ${execution.cost ? `$${execution.cost.toFixed(2)}` : 'cost N/A'}, ${execution.turns} turns)`
   );
 
-  await restoreTrackedEvalData(workspace, log);
+  await restoreHarnessOwnedArtifacts(workspace, log);
   await writeEvalResultsArtifacts(workspace.resultsDir, prompt, promptContent);
 
   const provisionalArtifacts = {
@@ -198,6 +203,90 @@ async function restoreTrackedEvalData(workspace: TrialWorkspace, log: Logger) {
       `Could not restore ${dataPath} from ${workspace.baselineCommit}; regenerating eval data.`
     );
   }
+}
+
+async function restoreHarnessOwnedArtifacts(workspace: TrialWorkspace, log: Logger) {
+  await restoreTrackedEvalData(workspace, log);
+  await restoreTrackedEvalSupport(workspace, log);
+  await ensureEvalSupportStoryGlob(workspace, log);
+}
+
+async function restoreTrackedEvalSupport(workspace: TrialWorkspace, log: Logger) {
+  const supportPath = relative(workspace.repoRoot, getEvalSupportDir(workspace.projectPath));
+  const result = await x(
+    'git',
+    ['restore', '--source', workspace.baselineCommit, '--', supportPath],
+    {
+      throwOnError: false,
+      nodeOptions: { cwd: workspace.repoRoot },
+    }
+  );
+
+  if (result.exitCode !== 0) {
+    log.logError(
+      `Could not restore ${supportPath} from ${workspace.baselineCommit}; eval support validation may fail.`
+    );
+  }
+}
+
+async function ensureEvalSupportStoryGlob(workspace: TrialWorkspace, log: Logger) {
+  const configPath = findStorybookMainFile(workspace.projectPath);
+  if (configPath == null) {
+    log.logError('Could not find .storybook/main.* to preserve the eval-support story glob.');
+    return;
+  }
+
+  const content = await readFile(configPath, 'utf-8');
+  if (content.includes(EVAL_SUPPORT_STORY_GLOB)) {
+    return;
+  }
+
+  const updated = addEvalSupportStoryGlob(content);
+  if (updated == null) {
+    log.logError(
+      `Could not add ${EVAL_SUPPORT_STORY_GLOB} to ${relative(workspace.repoRoot, configPath)}.`
+    );
+    return;
+  }
+
+  await writeFile(configPath, updated);
+}
+
+function findStorybookMainFile(projectPath: string) {
+  const storybookDir = getStorybookDir(projectPath);
+  return STORYBOOK_MAIN_FILES.map((file) => join(storybookDir, file)).find((file) =>
+    existsSync(file)
+  );
+}
+
+function addEvalSupportStoryGlob(content: string) {
+  const match = /stories\s*:\s*\[([\s\S]*?)\]/m.exec(content);
+  if (match == null || match.index == null) {
+    return null;
+  }
+
+  const [fullMatch, body] = match;
+  const before = content.slice(0, match.index);
+  const after = content.slice(match.index + fullMatch.length);
+
+  if (body.includes(EVAL_SUPPORT_STORY_GLOB)) {
+    return content;
+  }
+
+  if (!body.includes('\n')) {
+    const trimmedBody = body.trim();
+    const nextBody = trimmedBody
+      ? `'${EVAL_SUPPORT_STORY_GLOB}', ${trimmedBody}`
+      : `'${EVAL_SUPPORT_STORY_GLOB}'`;
+    return `${before}stories: [${nextBody}]${after}`;
+  }
+
+  const closingIndent = fullMatch.match(/\n([ \t]*)\]$/)?.[1] ?? '';
+  const entryIndent = body.match(/\n([ \t]*)['"`]/)?.[1] ?? `${closingIndent}  `;
+  const trimmedBody = body.replace(/\s*$/, '');
+  const separator = trimmedBody.endsWith(',') ? '' : ',';
+
+  return `${before}stories: [${trimmedBody}${separator}\n${entryIndent}'${EVAL_SUPPORT_STORY_GLOB}',\n${closingIndent}]${after}`;
 }
 
 async function writeEvalResultsArtifacts(

--- a/scripts/eval/lib/run-trial.ts
+++ b/scripts/eval/lib/run-trial.ts
@@ -1,5 +1,5 @@
-import { writeFile } from 'node:fs/promises';
-import { join } from 'pathe';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, relative } from 'pathe';
 import { x } from 'tinyexec';
 import type { Logger } from './utils.ts';
 import type { AgentId, AgentDriver, AgentVariant } from './agents/config.ts';
@@ -8,7 +8,7 @@ import { collectGhostStoriesGrade, grade } from './grade.ts';
 import { claudeAgent } from './agents/claude-code.ts';
 import { codexAgent } from './agents/codex.ts';
 import { publishTrialBranch, type PublishMetadata } from './publish-trial.ts';
-import { prepareTrial } from './prepare-trial.ts';
+import { prepareTrial, type TrialWorkspace } from './prepare-trial.ts';
 import { buildEvalData, type EvalData } from './result-docs.ts';
 import {
   captureEnvironment,
@@ -72,7 +72,6 @@ export async function runTrial(config: TrialConfig, logger?: Logger): Promise<Ru
   //    Storybook checkout so the trial exercises in-tree changes rather than
   //    whatever version the benchmark project has installed.
   const prompt = loadPrompt(promptName);
-  await writeFile(join(workspace.resultsDir, 'prompt.md'), prompt);
 
   // 5. Capture the full markdown the agent will receive from `ai setup` so
   //    the trial record contains a reproducible, project-aware snapshot of
@@ -81,7 +80,7 @@ export async function runTrial(config: TrialConfig, logger?: Logger): Promise<Ru
   //    a separate file so the resulting PR diff shows the exact instructions
   //    the agent was given for this trial.
   const promptContent = await captureAiSetupMarkdown(workspace.projectPath, promptName, log);
-  await writeFile(join(workspace.resultsDir, 'setup-prompt.md'), promptContent);
+  await writeEvalResultsArtifacts(workspace.resultsDir, prompt, promptContent);
 
   // 6. Execute the agent. EVAL_SETUP_PROMPT is forwarded into the agent's
   //    environment so its `ai setup` tool call resolves to the selected
@@ -100,6 +99,9 @@ export async function runTrial(config: TrialConfig, logger?: Logger): Promise<Ru
   log.logSuccess(
     `Agent completed (${Math.round(execution.duration)}s, ${execution.cost ? `$${execution.cost.toFixed(2)}` : 'cost N/A'}, ${execution.turns} turns)`
   );
+
+  await restoreTrackedEvalData(workspace, log);
+  await writeEvalResultsArtifacts(workspace.resultsDir, prompt, promptContent);
 
   const provisionalArtifacts = {
     buildOutput: {
@@ -144,10 +146,7 @@ export async function runTrial(config: TrialConfig, logger?: Logger): Promise<Ru
     artifacts: provisionalArtifacts,
   });
 
-  await writeFile(
-    join(workspace.resultsDir, 'data.json'),
-    JSON.stringify(provisionalData, null, 2)
-  );
+  await writeEvalData(workspace.resultsDir, provisionalData);
 
   // 8. Grade the results using story-render preview gain as the score.
   const { grade: trialGrade, score } = await grade(workspace, log, baselineGhostStories);
@@ -170,10 +169,7 @@ export async function runTrial(config: TrialConfig, logger?: Logger): Promise<Ru
     },
   });
 
-  await writeFile(
-    join(workspace.resultsDir, 'data.json'),
-    JSON.stringify(reportForCommit, null, 2)
-  );
+  await writeEvalData(workspace.resultsDir, reportForCommit);
 
   // 10. Commit, push, and open the benchmark PR
   const publish = await publishTrialBranch({
@@ -188,6 +184,37 @@ export async function runTrial(config: TrialConfig, logger?: Logger): Promise<Ru
     ...reportForCommit,
     publish,
   };
+}
+
+async function restoreTrackedEvalData(workspace: TrialWorkspace, log: Logger) {
+  const dataPath = relative(workspace.repoRoot, join(workspace.resultsDir, 'data.json'));
+  const result = await x('git', ['restore', '--source', workspace.baselineCommit, '--', dataPath], {
+    throwOnError: false,
+    nodeOptions: { cwd: workspace.repoRoot },
+  });
+
+  if (result.exitCode !== 0) {
+    log.logError(
+      `Could not restore ${dataPath} from ${workspace.baselineCommit}; regenerating eval data.`
+    );
+  }
+}
+
+async function writeEvalResultsArtifacts(
+  resultsDir: string,
+  prompt: string,
+  promptContent: string
+) {
+  await mkdir(resultsDir, { recursive: true });
+  await Promise.all([
+    writeFile(join(resultsDir, 'prompt.md'), prompt),
+    writeFile(join(resultsDir, 'setup-prompt.md'), promptContent),
+  ]);
+}
+
+async function writeEvalData(resultsDir: string, data: EvalData) {
+  await mkdir(resultsDir, { recursive: true });
+  await writeFile(join(resultsDir, 'data.json'), JSON.stringify(data, null, 2));
 }
 
 /**

--- a/scripts/eval/run-batch.test.ts
+++ b/scripts/eval/run-batch.test.ts
@@ -136,6 +136,26 @@ describe('buildBatchRunDescriptors', () => {
     ).toEqual(new Set(['medium']));
   });
 
+  it('supports multiple Codex efforts and model overrides in a single batch', () => {
+    const descriptors = buildBatchRunDescriptors({
+      prompt: TEST_PROMPT,
+      agents: ['codex'],
+      codexModels: ['gpt-5.5'],
+      codexEfforts: ['high', 'xhigh'],
+      projects: ['wikitok', 'evergreen-ci', 'mealdrop'],
+      repetitions: 3,
+    });
+
+    expect(descriptors).toHaveLength(3 * 2 * 3);
+    expect(new Set(descriptors.map((descriptor) => descriptor.agent))).toEqual(new Set(['codex']));
+    expect(new Set(descriptors.map((descriptor) => descriptor.model))).toEqual(
+      new Set(['gpt-5.5'])
+    );
+    expect(new Set(descriptors.map((descriptor) => descriptor.effort))).toEqual(
+      new Set(['high', 'xhigh'])
+    );
+  });
+
   it('uses a prompt override for every batch run descriptor', () => {
     const descriptors = buildBatchRunDescriptors({ prompt: TEST_PROMPT });
 
@@ -226,6 +246,19 @@ describe('buildBatchVariants', () => {
       { agent: 'claude', model: BATCH_MATRIX_MODELS.claude, effort: 'high' },
     ]);
   });
+
+  it('supports multiple Codex variants when model and effort matrices are requested', () => {
+    expect(
+      buildBatchVariants({
+        agents: ['codex'],
+        codexModels: ['gpt-5.5'],
+        codexEfforts: ['high', 'xhigh'],
+      })
+    ).toEqual([
+      { agent: 'codex', model: 'gpt-5.5', effort: 'high' },
+      { agent: 'codex', model: 'gpt-5.5', effort: 'xhigh' },
+    ]);
+  });
 });
 
 describe('parseRunBatchArgs', () => {
@@ -256,6 +289,32 @@ describe('parseRunBatchArgs', () => {
     expect(parseRunBatchArgs(['--prompt', TEST_PROMPT, '--claude-efforts', 'max,high'])).toEqual({
       prompt: TEST_PROMPT,
       claudeEfforts: ['max', 'high'],
+    });
+  });
+
+  it('parses multiple Codex efforts and models from the CLI', () => {
+    expect(
+      parseRunBatchArgs([
+        '--prompts',
+        'monorepo-optimized-tests-relaxed-limits-no-story-deletion,pattern-copy-play',
+        '--agents',
+        'codex',
+        '--codex-models',
+        'gpt-5.5',
+        '--codex-efforts',
+        'high,xhigh',
+        '--projects',
+        'wikitok,evergreen-ci,mealdrop',
+        '--repetitions',
+        '3',
+      ])
+    ).toEqual({
+      prompts: ['monorepo-optimized-tests-relaxed-limits-no-story-deletion', 'pattern-copy-play'],
+      agents: ['codex'],
+      codexModels: ['gpt-5.5'],
+      codexEfforts: ['high', 'xhigh'],
+      projects: ['wikitok', 'evergreen-ci', 'mealdrop'],
+      repetitions: 3,
     });
   });
 

--- a/scripts/eval/run-batch.ts
+++ b/scripts/eval/run-batch.ts
@@ -12,7 +12,13 @@ import { z } from 'zod';
 import { createInterface } from 'node:readline/promises';
 
 import { esMain } from '../utils/esmain.ts';
-import { AGENTS, CLAUDE_EFFORTS, CODEX_EFFORTS, type AgentVariant } from './lib/agents/config.ts';
+import {
+  AGENTS,
+  CLAUDE_EFFORTS,
+  CODEX_EFFORTS,
+  CODEX_MODELS,
+  type AgentVariant,
+} from './lib/agents/config.ts';
 import { PROJECTS } from './lib/projects.ts';
 import {
   EVAL_ROOT,
@@ -30,14 +36,16 @@ export const BATCH_PROJECT_NAMES = PROJECTS.filter((project) => project.name !==
 export const BATCH_AGENT_IDS = ['claude', 'codex'] as const;
 export const BATCH_DEFAULT_AGENT_IDS = ['claude', 'codex'] as const;
 export const BATCH_DEFAULT_CLAUDE_EFFORTS = ['high'] as const;
+export const BATCH_DEFAULT_CODEX_EFFORTS = ['high'] as const;
 export const BATCH_DEFAULT_EFFORTS = {
-  codex: 'high',
+  codex: BATCH_DEFAULT_CODEX_EFFORTS[0],
 } as const;
 /** Default models for the batch matrix — single place to change (codex follows AGENTS). */
 export const BATCH_MATRIX_MODELS = {
   claude: 'opus-4.6',
   codex: AGENTS.codex.defaultModel,
 } as const satisfies Record<'claude' | 'codex', string>;
+export const BATCH_DEFAULT_CODEX_MODELS = [BATCH_MATRIX_MODELS.codex] as const;
 
 export const BATCH_VARIANTS = buildBatchVariants();
 export const BATCH_REPETITIONS = 10;
@@ -95,7 +103,10 @@ export interface RunBatchOptions {
   agents?: (typeof BATCH_AGENT_IDS)[number][];
   claudeEfforts?: (typeof CLAUDE_EFFORTS)[number][];
   claudeEffort?: (typeof CLAUDE_EFFORTS)[number];
+  codexEfforts?: (typeof CODEX_EFFORTS)[number][];
   codexEffort?: (typeof CODEX_EFFORTS)[number];
+  codexModels?: (typeof CODEX_MODELS)[number][];
+  codexModel?: (typeof CODEX_MODELS)[number];
   /** Restrict the batch to a subset of projects. Defaults to BATCH_PROJECT_NAMES. */
   projects?: (typeof BATCH_PROJECT_NAMES)[number][];
   /** Repetitions per (project × variant). Defaults to BATCH_REPETITIONS. */
@@ -159,7 +170,10 @@ export async function runBatch(
       agents: options.agents,
       claudeEfforts: options.claudeEfforts,
       claudeEffort: options.claudeEffort,
+      codexEfforts: options.codexEfforts,
       codexEffort: options.codexEffort,
+      codexModels: options.codexModels,
+      codexModel: options.codexModel,
       projects: options.projects,
       repetitions: options.repetitions,
     });
@@ -293,11 +307,16 @@ export function buildBatchVariants(
     agents?: RunBatchOptions['agents'];
     claudeEfforts?: RunBatchOptions['claudeEfforts'];
     claudeEffort?: RunBatchOptions['claudeEffort'];
+    codexEfforts?: RunBatchOptions['codexEfforts'];
     codexEffort?: RunBatchOptions['codexEffort'];
+    codexModels?: RunBatchOptions['codexModels'];
+    codexModel?: RunBatchOptions['codexModel'];
   } = {}
 ): AgentVariant[] {
   const agents = resolveBatchAgents(options.agents);
   const claudeEfforts = resolveClaudeEfforts(options);
+  const codexEfforts = resolveCodexEfforts(options);
+  const codexModels = resolveCodexModels(options);
   const variants: AgentVariant[] = [];
 
   for (const agent of agents) {
@@ -312,11 +331,15 @@ export function buildBatchVariants(
       continue;
     }
 
-    variants.push({
-      agent: 'codex',
-      model: BATCH_MATRIX_MODELS.codex,
-      effort: options.codexEffort ?? BATCH_DEFAULT_EFFORTS.codex,
-    });
+    for (const model of codexModels) {
+      for (const effort of codexEfforts) {
+        variants.push({
+          agent: 'codex',
+          model,
+          effort,
+        });
+      }
+    }
   }
 
   return variants;
@@ -328,7 +351,10 @@ export function buildBatchRunDescriptors(options: {
   agents?: RunBatchOptions['agents'];
   claudeEfforts?: RunBatchOptions['claudeEfforts'];
   claudeEffort?: RunBatchOptions['claudeEffort'];
+  codexEfforts?: RunBatchOptions['codexEfforts'];
   codexEffort?: RunBatchOptions['codexEffort'];
+  codexModels?: RunBatchOptions['codexModels'];
+  codexModel?: RunBatchOptions['codexModel'];
   projects?: RunBatchOptions['projects'];
   repetitions?: number;
 }): BatchRunDescriptor[] {
@@ -348,7 +374,10 @@ export function buildBatchRunDescriptors(options: {
     options.agents == null &&
     options.claudeEfforts == null &&
     options.claudeEffort == null &&
-    options.codexEffort == null
+    options.codexEfforts == null &&
+    options.codexEffort == null &&
+    options.codexModels == null &&
+    options.codexModel == null
       ? BATCH_VARIANTS
       : buildBatchVariants(options);
 
@@ -546,7 +575,10 @@ const runBatchArgsSchema = z
     agents: z.array(z.enum(BATCH_AGENT_IDS)).nonempty().optional(),
     claudeEfforts: z.array(z.enum(CLAUDE_EFFORTS)).nonempty().optional(),
     claudeEffort: z.enum(CLAUDE_EFFORTS).optional(),
+    codexEfforts: z.array(z.enum(CODEX_EFFORTS)).nonempty().optional(),
     codexEffort: z.enum(CODEX_EFFORTS).optional(),
+    codexModels: z.array(z.enum(CODEX_MODELS)).nonempty().optional(),
+    codexModel: z.enum(CODEX_MODELS).optional(),
     projects: z.array(z.string().min(1)).nonempty().optional(),
     repetitions: z.coerce.number().int().positive().optional(),
   })
@@ -575,7 +607,16 @@ const runBatchOptions = {
     description: 'Comma-separated Claude effort levels',
   },
   'claude-effort': { type: 'string' as const, description: 'Single Claude effort level' },
+  'codex-efforts': {
+    type: 'string' as const,
+    description: 'Comma-separated Codex effort levels',
+  },
   'codex-effort': { type: 'string' as const, description: 'Single Codex effort level' },
+  'codex-models': {
+    type: 'string' as const,
+    description: 'Comma-separated Codex models',
+  },
+  'codex-model': { type: 'string' as const, description: 'Single Codex model' },
   projects: {
     type: 'string' as const,
     description: 'Comma-separated project names to run (default: all batch projects)',
@@ -600,7 +641,10 @@ export function parseRunBatchArgs(
       | 'agents'
       | 'claudeEfforts'
       | 'claudeEffort'
+      | 'codexEfforts'
       | 'codexEffort'
+      | 'codexModels'
+      | 'codexModel'
       | 'concurrency'
       | 'prompt'
       | 'prompts'
@@ -627,7 +671,10 @@ export function parseRunBatchArgs(
     agents: parseAgentArgs(values.agents),
     claudeEfforts: parseClaudeEfforts(values['claude-efforts']),
     claudeEffort: values['claude-effort'],
+    codexEfforts: parseCodexEfforts(values['codex-efforts']),
     codexEffort: values['codex-effort'],
+    codexModels: parseCodexModels(values['codex-models']),
+    codexModel: values['codex-model'],
     projects: parseProjects(values.projects),
     repetitions: values.repetitions,
   });
@@ -654,14 +701,15 @@ function parseAgentArgs(value?: string) {
 }
 
 function parseClaudeEfforts(value?: string) {
-  if (value == null) {
-    return undefined;
-  }
+  return parseList(value);
+}
 
-  return value
-    .split(',')
-    .map((effort) => effort.trim())
-    .filter(Boolean);
+function parseCodexEfforts(value?: string) {
+  return parseList(value);
+}
+
+function parseCodexModels(value?: string) {
+  return parseList(value);
 }
 
 function parseProjects(value?: string) {
@@ -672,6 +720,7 @@ function parseList(value?: string) {
   if (value == null) {
     return undefined;
   }
+
   const items = value
     .split(',')
     .map((item) => item.trim())
@@ -700,6 +749,36 @@ function resolveClaudeEfforts(options: {
   }
 
   return [...BATCH_DEFAULT_CLAUDE_EFFORTS];
+}
+
+function resolveCodexEfforts(options: {
+  codexEfforts?: RunBatchOptions['codexEfforts'];
+  codexEffort?: RunBatchOptions['codexEffort'];
+}) {
+  if (options.codexEfforts != null && options.codexEfforts.length > 0) {
+    return [...new Set(options.codexEfforts)];
+  }
+
+  if (options.codexEffort != null) {
+    return [options.codexEffort];
+  }
+
+  return [...BATCH_DEFAULT_CODEX_EFFORTS];
+}
+
+function resolveCodexModels(options: {
+  codexModels?: RunBatchOptions['codexModels'];
+  codexModel?: RunBatchOptions['codexModel'];
+}) {
+  if (options.codexModels != null && options.codexModels.length > 0) {
+    return [...new Set(options.codexModels)];
+  }
+
+  if (options.codexModel != null) {
+    return [options.codexModel];
+  }
+
+  return [...BATCH_DEFAULT_CODEX_MODELS];
 }
 
 function formatBatchTimestamp(date: Date) {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -52,7 +52,7 @@
     "@google-cloud/bigquery": "^6.2.1",
     "@octokit/graphql": "^5.0.6",
     "@octokit/request": "^8.4.1",
-    "@openai/codex-sdk": "^0.117.0",
+    "@openai/codex-sdk": "0.128.0",
     "@polka/parse": "^1.0.0-next.28",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4771,67 +4771,67 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openai/codex-darwin-arm64@npm:@openai/codex@0.117.0-darwin-arm64":
-  version: 0.117.0-darwin-arm64
-  resolution: "@openai/codex@npm:0.117.0-darwin-arm64"
+"@openai/codex-darwin-arm64@npm:@openai/codex@0.128.0-darwin-arm64":
+  version: 0.128.0-darwin-arm64
+  resolution: "@openai/codex@npm:0.128.0-darwin-arm64"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@openai/codex-darwin-x64@npm:@openai/codex@0.117.0-darwin-x64":
-  version: 0.117.0-darwin-x64
-  resolution: "@openai/codex@npm:0.117.0-darwin-x64"
+"@openai/codex-darwin-x64@npm:@openai/codex@0.128.0-darwin-x64":
+  version: 0.128.0-darwin-x64
+  resolution: "@openai/codex@npm:0.128.0-darwin-x64"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@openai/codex-linux-arm64@npm:@openai/codex@0.117.0-linux-arm64":
-  version: 0.117.0-linux-arm64
-  resolution: "@openai/codex@npm:0.117.0-linux-arm64"
+"@openai/codex-linux-arm64@npm:@openai/codex@0.128.0-linux-arm64":
+  version: 0.128.0-linux-arm64
+  resolution: "@openai/codex@npm:0.128.0-linux-arm64"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@openai/codex-linux-x64@npm:@openai/codex@0.117.0-linux-x64":
-  version: 0.117.0-linux-x64
-  resolution: "@openai/codex@npm:0.117.0-linux-x64"
+"@openai/codex-linux-x64@npm:@openai/codex@0.128.0-linux-x64":
+  version: 0.128.0-linux-x64
+  resolution: "@openai/codex@npm:0.128.0-linux-x64"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@openai/codex-sdk@npm:^0.117.0":
-  version: 0.117.0
-  resolution: "@openai/codex-sdk@npm:0.117.0"
+"@openai/codex-sdk@npm:0.128.0":
+  version: 0.128.0
+  resolution: "@openai/codex-sdk@npm:0.128.0"
   dependencies:
-    "@openai/codex": "npm:0.117.0"
-  checksum: 10c0/96f86890fd45a4030a8e9b6f8466389a015d0ee534b1661b56463a1fd210c6fc3af0ea1f3ce57306a13a9b6ff6197d6409a4d5af7f6d7c90e672009eee15e3fd
+    "@openai/codex": "npm:0.128.0"
+  checksum: 10c0/cf05be90ff8f5d479006161d26156df16b41c234db8fba6c0ddc2961213e5cc3661b763b58f9487a686f3689e951123d58f2b11040de64b6edb2dd5b2726aa52
   languageName: node
   linkType: hard
 
-"@openai/codex-win32-arm64@npm:@openai/codex@0.117.0-win32-arm64":
-  version: 0.117.0-win32-arm64
-  resolution: "@openai/codex@npm:0.117.0-win32-arm64"
+"@openai/codex-win32-arm64@npm:@openai/codex@0.128.0-win32-arm64":
+  version: 0.128.0-win32-arm64
+  resolution: "@openai/codex@npm:0.128.0-win32-arm64"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@openai/codex-win32-x64@npm:@openai/codex@0.117.0-win32-x64":
-  version: 0.117.0-win32-x64
-  resolution: "@openai/codex@npm:0.117.0-win32-x64"
+"@openai/codex-win32-x64@npm:@openai/codex@0.128.0-win32-x64":
+  version: 0.128.0-win32-x64
+  resolution: "@openai/codex@npm:0.128.0-win32-x64"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@openai/codex@npm:0.117.0":
-  version: 0.117.0
-  resolution: "@openai/codex@npm:0.117.0"
+"@openai/codex@npm:0.128.0":
+  version: 0.128.0
+  resolution: "@openai/codex@npm:0.128.0"
   dependencies:
-    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.117.0-darwin-arm64"
-    "@openai/codex-darwin-x64": "npm:@openai/codex@0.117.0-darwin-x64"
-    "@openai/codex-linux-arm64": "npm:@openai/codex@0.117.0-linux-arm64"
-    "@openai/codex-linux-x64": "npm:@openai/codex@0.117.0-linux-x64"
-    "@openai/codex-win32-arm64": "npm:@openai/codex@0.117.0-win32-arm64"
-    "@openai/codex-win32-x64": "npm:@openai/codex@0.117.0-win32-x64"
+    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.128.0-darwin-arm64"
+    "@openai/codex-darwin-x64": "npm:@openai/codex@0.128.0-darwin-x64"
+    "@openai/codex-linux-arm64": "npm:@openai/codex@0.128.0-linux-arm64"
+    "@openai/codex-linux-x64": "npm:@openai/codex@0.128.0-linux-x64"
+    "@openai/codex-win32-arm64": "npm:@openai/codex@0.128.0-win32-arm64"
+    "@openai/codex-win32-x64": "npm:@openai/codex@0.128.0-win32-x64"
   dependenciesMeta:
     "@openai/codex-darwin-arm64":
       optional: true
@@ -4847,7 +4847,7 @@ __metadata:
       optional: true
   bin:
     codex: bin/codex.js
-  checksum: 10c0/a5104a396f0f33558c9a402012bf2dd954f5d3465d3b0bb5fe780d265760a3c72b64af4a2d42a0012f661b7e4a274a42c5d4f5582de115613557f480dbec3b5b
+  checksum: 10c0/17266f6b0e17382acce6a1137467d5a62f2b0cc84a15843d191a9d311f67b20975abbdf3f56f63329b0c9465a6a7e9fb072773b61edcd82d83d89a3aceba80dc
   languageName: node
   linkType: hard
 
@@ -9113,7 +9113,7 @@ __metadata:
     "@google-cloud/bigquery": "npm:^6.2.1"
     "@octokit/graphql": "npm:^5.0.6"
     "@octokit/request": "npm:^8.4.1"
-    "@openai/codex-sdk": "npm:^0.117.0"
+    "@openai/codex-sdk": "npm:0.128.0"
     "@polka/parse": "npm:^1.0.0-next.28"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.9.1"


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

- Added Codex model matrix support to eval batch runs via `--codex-model`, `--codex-models`, `--codex-effort`, and `--codex-efforts`.
- Added GPT-5.5 to Codex eval configuration and pricing, and upgraded `@openai/codex-sdk` to `0.128.0`.
- Forced Codex eval runs onto the fast service tier with writable sandbox settings, plus updated README examples and tests.
- Hardened trial result writing so harness-owned `.storybook/eval-results` and `.storybook/eval-support` files are restored or recreated after agent runs, while preserving legitimate agent edits to `.storybook/main.*`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Ran `NODE_OPTIONS=--max_old_space_size=4096 yarn vitest run --project scripts scripts/eval/lib/run-trial.test.ts scripts/eval/run-batch.test.ts scripts/eval/lib/agents/codex.test.ts scripts/eval/lib/agents/config.test.ts`.
1. Ran `yarn fmt:check`.
1. Ran `yarn --cwd scripts lint:js:cmd eval/lib/run-trial.ts eval/lib/run-trial.test.ts eval/run-batch.ts eval/lib/agents/codex.ts eval/lib/agents/config.ts eval/run-batch.test.ts eval/lib/agents/codex.test.ts eval/lib/agents/config.test.ts`.
1. Ran a GPT-5.5 eval smoke batch: `node scripts/eval/run-batch.ts --prompts monorepo-optimized-tests-relaxed-limits-no-story-deletion --agents codex --codex-models gpt-5.5 --codex-efforts high,xhigh --projects mealdrop,wikitok --repetitions 1 --yes --concurrency 4`.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
