### PR TITLE
CLI: Remove extensive prompt option 

### DIFF
--- a/code/lib/cli-storybook/src/ai/index.ts
+++ b/code/lib/cli-storybook/src/ai/index.ts
@@ -14,7 +14,7 @@ import { getAiSetupMarkdownOutput } from './setup-prompts/index.ts';
 import type { ProjectInfo, AiSetupOptions } from './types.ts';
 
 export async function aiSetup(options: AiSetupOptions): Promise<void> {
-  const { configDir: userConfigDir, extensive, packageManager, output } = options;
+  const { configDir: userConfigDir, packageManager, output } = options;
 
   let projectInfo: ProjectInfo;
 
@@ -80,7 +80,7 @@ export async function aiSetup(options: AiSetupOptions): Promise<void> {
     return;
   }
 
-  const result = await getAiSetupMarkdownOutput(projectInfo, extensive);
+  const result = await getAiSetupMarkdownOutput(projectInfo);
   const markdownOutput = result.markdown;
 
   // Persist the fact that `storybook ai setup` ran in this project, scoped to

--- a/code/lib/cli-storybook/src/ai/setup-prompts/index.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/index.ts
@@ -4,21 +4,17 @@ import type { ProjectInfo } from '../types.ts';
 import { getProjectOverview } from '../utils/project-overview.ts';
 
 /**
- * The prompt variants that ship to real users. Running `npx storybook ai setup`
- * without environment variable overrides uses either of these prompts.
+ * The single prompt variant that ships to real users. Running
+ * `npx storybook ai setup` without any overrides always produces this prompt.
  */
 import * as currentlyUsedPrompt from './optimized-tests.ts';
 export const DEFAULT_PROMPT_NAME: PromptName = 'optimized-tests';
 
-import * as extensivePrompt from './pattern-copy-play.ts';
-export const EXTENSIVE_PROMPT_NAME: PromptName = 'pattern-copy-play';
-
 /**
  * Main prompt used currently in `npx storybook ai setup` command. If you promote a new prompt to be default, move this to the FORMERLY_USED_PROMPTS object below.
  */
-const BUNDLED_PROMPTS: Record<string, (projectInfo: ProjectInfo) => string> = {
+const CURRENTLY_USED_PROMPT: Record<string, (projectInfo: ProjectInfo) => string> = {
   [DEFAULT_PROMPT_NAME]: currentlyUsedPrompt.instructions,
-  [EXTENSIVE_PROMPT_NAME]: extensivePrompt.instructions,
 };
 
 /**
@@ -26,10 +22,7 @@ const BUNDLED_PROMPTS: Record<string, (projectInfo: ProjectInfo) => string> = {
  * from sibling files so the bundler can code|-split them away from the
  * default-only path that real users hit.
  */
-const DYNAMICALLY_IMPORTED_PROMPTS: Record<
-  string,
-  () => Promise<(projectInfo: ProjectInfo) => string>
-> = {
+const FORMERLY_USED_PROMPTS: Record<string, () => Promise<(projectInfo: ProjectInfo) => string>> = {
   monorepo: async () => (await import('./monorepo.ts')).instructions,
   'optimized-tests': async () => (await import('./optimized-tests.ts')).instructions,
   'relaxed-limits': async () => (await import('./relaxed-limits.ts')).instructions,
@@ -43,8 +36,8 @@ export type PromptName = string;
 
 /** Names available to the eval harness — defaults plus experimental variants. */
 export const PROMPT_NAMES: PromptName[] = [
-  ...Object.keys(BUNDLED_PROMPTS),
-  ...Object.keys(DYNAMICALLY_IMPORTED_PROMPTS),
+  ...Object.keys(CURRENTLY_USED_PROMPT),
+  ...Object.keys(FORMERLY_USED_PROMPTS),
 ];
 
 /**
@@ -55,36 +48,32 @@ export const PROMPT_NAMES: PromptName[] = [
  */
 const EVAL_SETUP_PROMPT_ENV = 'EVAL_SETUP_PROMPT';
 
-function resolvePromptName(extensive?: boolean): PromptName {
+function resolvePromptName(): PromptName {
   const requested = process.env[EVAL_SETUP_PROMPT_ENV]?.trim();
   if (
     requested &&
-    (Object.hasOwn(BUNDLED_PROMPTS, requested) ||
-      Object.hasOwn(DYNAMICALLY_IMPORTED_PROMPTS, requested))
+    (Object.hasOwn(CURRENTLY_USED_PROMPT, requested) ||
+      Object.hasOwn(FORMERLY_USED_PROMPTS, requested))
   ) {
     return requested;
   }
-  return extensive ? EXTENSIVE_PROMPT_NAME : DEFAULT_PROMPT_NAME;
+  return DEFAULT_PROMPT_NAME;
 }
 
 export async function getAiSetupPrompt(
-  projectInfo: ProjectInfo,
-  extensive?: boolean
+  projectInfo: ProjectInfo
 ): Promise<{ content: string; name: PromptName }> {
-  const name = resolvePromptName(extensive);
-  const builder = BUNDLED_PROMPTS[name] ?? (await DYNAMICALLY_IMPORTED_PROMPTS[name]());
+  const name = resolvePromptName();
+  const builder = CURRENTLY_USED_PROMPT[name] ?? (await FORMERLY_USED_PROMPTS[name]());
 
   return { content: builder(projectInfo), name };
 }
 
-export async function getAiSetupMarkdownOutput(
-  projectInfo: ProjectInfo,
-  extensive?: boolean
-): Promise<{
+export async function getAiSetupMarkdownOutput(projectInfo: ProjectInfo): Promise<{
   markdown: string;
   prompt: PromptName;
 }> {
-  const { content, name } = await getAiSetupPrompt(projectInfo, extensive);
+  const { content, name } = await getAiSetupPrompt(projectInfo);
 
   return {
     markdown: dedent`

--- a/code/lib/cli-storybook/src/ai/setup-prompts/pattern-copy-play.ts
+++ b/code/lib/cli-storybook/src/ai/setup-prompts/pattern-copy-play.ts
@@ -2,7 +2,8 @@
  * Prompt variant: `pattern-copy-play` (current default for `npx storybook ai setup`)
  *
  * - Created: 2026-04-22 (eval iteration 2, default since this PR)
- * - Status: produced by `ai setup` invocation when --extensive is true and `EVAL_SETUP_PROMPT` is unset.
+ * - Status: shipping default — produced by every `ai setup` invocation
+ *   without `EVAL_SETUP_PROMPT` set.
  * - Reference eval results:
  *   https://github.com/search?q=is:pr label:"prompt:pattern-copy-play" org:storybook-tmp&type=pullrequests
  *

--- a/code/lib/cli-storybook/src/ai/types.ts
+++ b/code/lib/cli-storybook/src/ai/types.ts
@@ -14,9 +14,6 @@ export interface AiSetupOptions {
   /** Populated from the program-level `--disable-telemetry` flag (defaults from `STORYBOOK_DISABLE_TELEMETRY`). */
   disableTelemetry?: boolean;
 
-  /** Whether to use the extensive prompt instead of the default prompt. */
-  extensive?: boolean;
-
   /** A random ID attributed by the CLI when running `ai setup` to identify the setup session. */
   runId: string;
 }

--- a/code/lib/cli-storybook/src/bin/run.ts
+++ b/code/lib/cli-storybook/src/bin/run.ts
@@ -315,10 +315,6 @@ aiCommand
     )
   )
   .option('-c, --config-dir <dir-name>', 'Directory of Storybook configuration')
-  .option(
-    '-e, --extensive',
-    'Use the extensive setup prompt (takes longer, explores your codebase further, and generates more complex stories)'
-  )
   .action(async (options, cmd) => {
     const parentOptions = cmd.parent?.opts() ?? {};
     const runId = Math.random().toString(36);


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Removal of the --extensive CLI option

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Added `--disable-telemetry` flag to `storybook ai setup` command, enabling users to opt out of diagnostic data collection.

**Refactor**
* Removed the `--extensive` flag from `storybook ai setup`. The command now uses a single, optimized prompt variant by default, simplifying the AI setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->