### PR TITLE
Docs: Clarify Copilot agent setup mode

### DIFF
--- a/docs/ai/setup.mdx
+++ b/docs/ai/setup.mdx
@@ -20,7 +20,9 @@ The command analyzes your Storybook configuration (framework, renderer, builder,
 
 ## Starting from `storybook init`
 
-When an agent runs [`storybook init`](../api/cli-options.mdx#init) to add Storybook to a new project, the output instructs the agent to continue with `storybook ai setup`. No extra prompting is needed; the agent will pick up the agentic setup flow automatically.
+When an agent runs [`storybook init`](../api/cli-options.mdx#init) to add Storybook to a new project, the output instructs the agent to continue with `storybook ai setup`. Storybook automatically enables this flow when it detects a supported AI agent environment.
+
+Some agents, including GitHub Copilot cloud agents and local VS Code Copilot agents, may not expose a reliable agent signal to terminal commands. In those environments, run `storybook init --agent` to force the non-interactive agent flow. You can also set `AI_AGENT=copilot` in the agent environment, for example by configuring a repository variable in [GitHub's `copilot` environment](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment#setting-environment-variables-in-copilots-environment) for Copilot cloud agent sessions.
 
 If Storybook is already installed, you can kick off the flow yourself using one of the two approaches below.
 
@@ -34,7 +36,7 @@ Use Storybook's agentic setup command to configure Storybook for this project an
 
 The agent will run the command from your project root, read the generated prompt from stdout, and follow the steps in order: analyzing your codebase, updating `preview.tsx`, and writing stories. After each story, it runs Vitest to verify that the story renders and fixes any failures before moving on.
 
-This flow works best when your agent has access to a terminal in your project (most modern coding agents do). No flags or additional configuration is required. The generated instructions are self-contained.
+This flow works best when your agent has access to a terminal in your project (most modern coding agents do). The generated instructions are self-contained.
 
 ## User-initiated setup
 

--- a/docs/api/cli-options.mdx
+++ b/docs/api/cli-options.mdx
@@ -140,6 +140,8 @@ Options include:
 | `--loglevel <level>`     | Controls level of logging during initialization.<br />Available options: `trace`, `debug`, `info` (default), `warn`, `error`, `silent`<br />`storybook init --loglevel debug`                  |
 | `--logfile [path]`       | Write all debug logs to the specified file at the end of the run. Defaults to debug-storybook.log when [path] is not provided.<br />`storybook init --logfile /tmp/debug-storybook.log`        |
 | `--no-dev`               | Complete the initialization of Storybook without running the Storybook dev server.<br />`storybook init --no-dev`                                                                              |
+| `--agent`                | Forces agent mode for non-interactive AI setup, including the follow-up instructions for `storybook ai setup`.<br />`storybook init --agent`                                                   |
+| `--no-agent`             | Disables agent mode even when Storybook detects an AI agent.<br />`storybook init --no-agent`                                                                                                  |
 
 ### `add`
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Documented the explicit `storybook init --agent` fallback for AI agents that don't expose a reliable terminal-level agent signal, including GitHub Copilot cloud agents and local VS Code Copilot agents. Also added the existing `--agent` and `--no-agent` flags to the `storybook init` CLI options reference.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Run `yarn fmt:write docs/ai/setup.mdx docs/api/cli-options.mdx`
2. Run `yarn docs:check`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
