### PR TITLE
ReactNative: AppRegistry component name in template

### DIFF
--- a/code/lib/create-storybook/src/generators/REACT_NATIVE/generateEntrypoint.test.ts
+++ b/code/lib/create-storybook/src/generators/REACT_NATIVE/generateEntrypoint.test.ts
@@ -34,8 +34,10 @@ describe('generateReactNativeEntrypoint', () => {
       expect(output).toMatchInlineSnapshot(`
         "import { AppRegistry } from 'react-native';
         import AsyncStorage from '@react-native-async-storage/async-storage';
+        import { LiteUI } from '@storybook/react-native-ui-lite';
 
         import { view } from './storybook.requires';
+        import { name as appName } from '../app.json';
 
         /**
          * This file is user-editable.
@@ -49,9 +51,10 @@ describe('generateReactNativeEntrypoint', () => {
             getItem: AsyncStorage.getItem,
             setItem: AsyncStorage.setItem,
           },
+          CustomUIComponent: LiteUI,
         });
 
-        AppRegistry.registerComponent('main', () => StorybookUIRoot);
+        AppRegistry.registerComponent(appName, () => StorybookUIRoot);
 
         export default StorybookUIRoot;
         "
@@ -78,8 +81,10 @@ describe('generateReactNativeEntrypoint', () => {
       expect(output).toMatchInlineSnapshot(`
         "import { AppRegistry } from 'react-native';
         import AsyncStorage from '@react-native-async-storage/async-storage';
+        import { LiteUI } from '@storybook/react-native-ui-lite';
 
         import { view } from './storybook.requires';
+        import { name as appName } from '../app.json';
 
         /**
          * This file is user-editable.
@@ -93,9 +98,10 @@ describe('generateReactNativeEntrypoint', () => {
             getItem: AsyncStorage.getItem,
             setItem: AsyncStorage.setItem,
           },
+          CustomUIComponent: LiteUI,
         });
 
-        AppRegistry.registerComponent('main', () => StorybookUIRoot);
+        AppRegistry.registerComponent(appName, () => StorybookUIRoot);
 
         export default StorybookUIRoot;
         "
@@ -165,8 +171,10 @@ describe('generateReactNativeEntrypoint', () => {
       expect(output).toMatchInlineSnapshot(`
         "import { AppRegistry } from 'react-native';
         import AsyncStorage from '@react-native-async-storage/async-storage';
+        import { LiteUI } from '@storybook/react-native-ui-lite';
 
         import { view } from './storybook.requires';
+        import { name as appName } from '../app.json';
 
         /**
          * This file is user-editable.
@@ -180,9 +188,10 @@ describe('generateReactNativeEntrypoint', () => {
             getItem: AsyncStorage.getItem,
             setItem: AsyncStorage.setItem,
           },
+          CustomUIComponent: LiteUI,
         });
 
-        AppRegistry.registerComponent('main', () => StorybookUIRoot);
+        AppRegistry.registerComponent(appName, () => StorybookUIRoot);
 
         export default StorybookUIRoot;
         "
@@ -216,8 +225,10 @@ describe('generateReactNativeEntrypoint', () => {
       expect(generated).toMatchInlineSnapshot(`
         "import { AppRegistry } from 'react-native';
         import AsyncStorage from '@react-native-async-storage/async-storage';
+        import { LiteUI } from '@storybook/react-native-ui-lite';
 
         import { view } from './storybook.requires';
+        import { name as appName } from '../app.json';
 
         /**
          * This file is user-editable.
@@ -231,9 +242,10 @@ describe('generateReactNativeEntrypoint', () => {
             getItem: AsyncStorage.getItem,
             setItem: AsyncStorage.setItem,
           },
+          CustomUIComponent: LiteUI,
         });
 
-        AppRegistry.registerComponent('main', () => StorybookUIRoot);
+        AppRegistry.registerComponent(appName, () => StorybookUIRoot);
 
         export default StorybookUIRoot;
         "

--- a/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
+++ b/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
@@ -73,6 +73,7 @@ export default defineGeneratorModule({
       '@storybook/addon-ondevice-controls',
       '@storybook/addon-ondevice-actions',
       '@storybook/react-native',
+      '@storybook/react-native-ui-lite',
       'storybook',
     ];
 

--- a/code/lib/create-storybook/templates/react-native/index.js
+++ b/code/lib/create-storybook/templates/react-native/index.js
@@ -2,7 +2,7 @@ import { AppRegistry } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { view } from './storybook.requires';
-import { name as appName } from './app.json';
+import { name as appName } from '../app.json';
 
 /**
  * This file is user-editable.

--- a/code/lib/create-storybook/templates/react-native/index.js
+++ b/code/lib/create-storybook/templates/react-native/index.js
@@ -2,6 +2,7 @@ import { AppRegistry } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { view } from './storybook.requires';
+import { name as appName } from './app.json';
 
 /**
  * This file is user-editable.
@@ -17,6 +18,6 @@ const StorybookUIRoot = view.getStorybookUI({
   },
 });
 
-AppRegistry.registerComponent('main', () => StorybookUIRoot);
+AppRegistry.registerComponent(appName, () => StorybookUIRoot);
 
 export default StorybookUIRoot;

--- a/code/lib/create-storybook/templates/react-native/index.js
+++ b/code/lib/create-storybook/templates/react-native/index.js
@@ -1,5 +1,6 @@
 import { AppRegistry } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LiteUI } from '@storybook/react-native-ui-lite';
 
 import { view } from './storybook.requires';
 import { name as appName } from './app.json';
@@ -16,6 +17,7 @@ const StorybookUIRoot = view.getStorybookUI({
     getItem: AsyncStorage.getItem,
     setItem: AsyncStorage.setItem,
   },
+  CustomUIComponent: LiteUI,
 });
 
 AppRegistry.registerComponent(appName, () => StorybookUIRoot);


### PR DESCRIPTION
## What I did

Correct a template for noon-expo index files to correctly import the appName

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storybook generator now includes a lightweight React Native UI option for an improved in-app preview experience.

* **Bug Fixes**
  * Storybook entry now registers the app using the project's configured app name instead of a hardcoded default, ensuring correct app startup and registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->