### PR TITLE
ESLint-plugin: Fix csf-strict extends resolution after bundling

### DIFF
--- a/code/lib/eslint-plugin/scripts/update-lib-configs.ts
+++ b/code/lib/eslint-plugin/scripts/update-lib-configs.ts
@@ -43,9 +43,7 @@ function formatCategory(category: TCategory) {
     * in order to update its content, execute "yarn update-rules" or rebuild this package.
     */
     export default {
-      // This file is bundled in an index.js file at the root
-      // so the reference is relative to the src directory
-      extends: './configs/${extendsCategoryId}',
+      extends: 'plugin:storybook/${extendsCategoryId}',
       overrides: [{
         files: [${STORIES_GLOBS.join(', ')}],
         rules: ${formatRules(category.rules)}

--- a/code/lib/eslint-plugin/src/configs/csf-strict.ts
+++ b/code/lib/eslint-plugin/src/configs/csf-strict.ts
@@ -4,9 +4,7 @@
  * in order to update its content, execute "yarn update-rules" or rebuild this package.
  */
 export default {
-  // This file is bundled in an index.js file at the root
-  // so the reference is relative to the src directory
-  extends: './configs/csf',
+  extends: 'plugin:storybook/csf',
   overrides: [
     {
       files: ['**/*.stories.@(ts|tsx|js|jsx|mjs|cjs)', '**/*.story.@(ts|tsx|js|jsx|mjs|cjs)'],


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The `csf-strict` config was [using a relative path (`./configs/csf`) to extend the `csf` config](https://github.com/storybookjs/storybook/blob/v10.3.6/code/lib/eslint-plugin/src/configs/csf-strict.ts#L7-L9). This path is relative to the source directory structure, but [after bundling the file ends up at the package root](https://github.com/storybookjs/storybook/blob/v10.3.6/code/lib/eslint-plugin/package.json#L29-L36) — causing the extends resolution to fail at runtime.

Changed the extends path to use the plugin format (`plugin:storybook/csf`), which resolves correctly regardless of where the bundled file is located.

- `scripts/update-lib-configs.ts`: Fixed the template that generates legacy configs
- `src/configs/csf-strict.ts`: Applied the fix via `yarn update-rules`

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

Tested with a local project ([csf-plugin-demo](https://github.com/ShebangDog/csf-plugin-demo)) that uses `plugin:storybook/csf-strict`:

Confirmation steps
1. In [csf-plugin-demo](https://github.com/ShebangDog/csf-plugin-demo): run `npm run lint` → fails (cannot resolve `./configs/csf`)
2. In [code/lib/eslint-plugin/](https://github.com/ShebangDog/storybook/tree/fix/csf-strict-extends-path/code/lib/eslint-plugin): run `yalc publish` to publish the fixed package locally
3. In [csf-plugin-demo](https://github.com/ShebangDog/csf-plugin-demo): run `yalc add eslint-plugin-storybook@10.4.0-alpha.17` to install the fixed version
4. In [csf-plugin-demo](https://github.com/ShebangDog/csf-plugin-demo): run `npm run lint` → succeeds


### Error

Error in Confirmation steps 1

```
npm run lint

> my-app@0.1.0 lint
> eslint .


Oops! Something went wrong! :(

ESLint: 8.57.1

ESLint couldn't find the config "./configs/csf" to extend from. Please check that the name of the config is correct.

The config "./configs/csf" was referenced from the config file in "/Users/<hoge>/Projects/typescript/my-app/node_modules/eslint-plugin-storybook/dist/index.js".

If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.
```


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated ESLint configuration references to use plugin-based preset notation instead of relative file paths. This improves configuration maintainability while preserving all existing linting behavior and rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->