### PR TITLE
fix: add ariaLabel support to ActionItem interface

### DIFF
--- a/code/addons/docs/src/types.ts
+++ b/code/addons/docs/src/types.ts
@@ -73,6 +73,7 @@ type CanvasBlockParameters = {
     disabled?: boolean;
     onClick: () => void;
     title: string | React.JSX.Element;
+    ariaLabel?: string | false;
   }[];
   /** Provide HTML class(es) to the preview element, for custom styling. */
   className?: string;

--- a/code/core/src/components/components/ActionBar/ActionBar.tsx
+++ b/code/core/src/components/components/ActionBar/ActionBar.tsx
@@ -74,6 +74,7 @@ export interface ActionItem {
   className?: string;
   onClick: (e: MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
+  ariaLabel?: string | false;
 }
 
 export interface ActionBarProps {
@@ -89,8 +90,14 @@ export interface ActionBarProps {
 export const ActionBar = ({ actionItems, flexLayout = false, ...props }: ActionBarProps) => {
   return (
     <Container {...props} $flexLayout={flexLayout}>
-      {actionItems.map(({ title, className, onClick, disabled }, index: number) => (
-        <ActionButton key={index} className={className} onClick={onClick} disabled={!!disabled}>
+      {actionItems.map(({ title, className, onClick, disabled, ariaLabel }, index: number) => (
+        <ActionButton
+          key={index}
+          className={className}
+          onClick={onClick}
+          disabled={!!disabled}
+          aria-label={ariaLabel === false ? undefined : ariaLabel}
+        >
           {title}
         </ActionButton>
       ))}


### PR DESCRIPTION
## What I did

Added `ariaLabel` support to the `ActionItem` interface to resolve accessibility warnings when using `canvas.additionalActions` in the docs addon.

## How to test

1. Add custom actions via `additionalActions` in `.storybook/preview.tsx`:

```tsx
export default definePreview({
  parameters: {
    docs: {
      canvas: {
        additionalActions: [
          {
            title: 'View source on GitHub',
            onClick: () => { /* ... */ },
            ariaLabel: 'View source code on GitHub',
          },
        ],
      },
    },
  },
});
```

2. Open a docs page and check the console - no more warnings about missing `ariaLabel`
3. For buttons with text content, use `ariaLabel: false` to opt out

## Checklist for Contributors

### Testing

- [ ] Added/updated unit tests
- [ ] Added/updated e2e tests
- [ ] Verified in a sandbox (see `yarn task sandbox` in AGENTS.md)

### Documentation

- [ ] Updated documentation
- [ ] Updated migration guide

### Versioning

- [ ] This PR contains a breaking change (if yes, provide migration guide above)
- [ ] This PR introduces a new feature (if yes, add feature flag if applicable)

---

## Issue

Fixes #34746

## Problem

The `ActionItem` interface used by `canvas.additionalActions` in the docs addon doesn't include an `ariaLabel` property. Storybook 11 will require `ariaLabel` on Button components, causing console warnings:

```
The 'ariaLabel' prop on 'Button' will become mandatory in Storybook 11...
```

Users had no way to provide `ariaLabel` because the `ActionItem` type doesn't accept it.

## Solution

- Added `ariaLabel?: string | false` to `ActionItem` interface
- Updated `ActionBar` component to pass `ariaLabel` to button elements
- Added `ariaLabel` to `additionalActions` type in docs addon
- `ariaLabel={false}` allows opt-out for buttons with text content (matching Button component behavior)

## Changes

**Modified files:**
- `code/core/src/components/components/ActionBar/ActionBar.tsx`
  - Added `ariaLabel` property to `ActionItem` interface
  - Updated `ActionBar` to destructure and pass `ariaLabel` to buttons
- `code/addons/docs/src/types.ts`
  - Added `ariaLabel` property to `additionalActions` type

## Impact

Users can now:
- Provide meaningful `aria-label` values for accessibility
- Set `ariaLabel={false}` for buttons with text content to suppress warnings
- Prepare for Storybook 11's mandatory `ariaLabel` requirement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizable aria labels on action buttons, enabling improved accessibility. Labels can be configured as a custom string or explicitly disabled using `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->