### PR TITLE
fix: restore generic type parameter to useArgs in manager-api

### DIFF
--- a/code/core/src/manager-api/root.tsx
+++ b/code/core/src/manager-api/root.tsx
@@ -459,7 +459,12 @@ export function useAddonState<S>(addonId: string, defaultState?: S) {
   return useSharedState<S>(addonId, defaultState);
 }
 
-export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: string[]) => void, Args] {
+export function useArgs<TArgs extends Args = Args>(): [
+  TArgs,
+  (newArgs: Partial<TArgs>) => void,
+  (argNames?: (keyof TArgs)[]) => void,
+  TArgs,
+] {
   const { getCurrentStoryData, updateStoryArgs, resetStoryArgs } = useStorybookApi();
 
   const data = getCurrentStoryData();
@@ -467,15 +472,15 @@ export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: string[])
   const initialArgs = data?.type === 'story' ? data.initialArgs : {};
 
   const updateArgs = useCallback(
-    (newArgs: Args) => updateStoryArgs(data as API_StoryEntry, newArgs),
+    (newArgs: Partial<TArgs>) => updateStoryArgs(data as API_StoryEntry, newArgs as Args),
     [data, updateStoryArgs]
   );
   const resetArgs = useCallback(
-    (argNames?: string[]) => resetStoryArgs(data as API_StoryEntry, argNames),
+    (argNames?: (keyof TArgs)[]) => resetStoryArgs(data as API_StoryEntry, argNames as string[]),
     [data, resetStoryArgs]
   );
 
-  return [args!, updateArgs, resetArgs, initialArgs!];
+  return [args as TArgs, updateArgs, resetArgs, initialArgs as TArgs];
 }
 
 export function useGlobals(): [


### PR DESCRIPTION
Closes #25070

## Problem

`useArgs` in `@storybook/manager-api` lost its `<TArgs>` generic type parameter during the `@storybook/addons` → `code/core` migration (between v7.4.6 and v7.6.2). This means addon authors can't get type-safe args:

```ts
// ❌ Current — no generic, everything is 'any'
const [args, updateArgs] = useArgs();
args.label; // type: any

// ✅ After fix — full type safety restored
const [args, updateArgs] = useArgs<{ label: string }>();
args.label; // type: string
updateArgs({ label: 'Click me' }); // type-checked
```

## Fix

Restore `<TArgs extends Args = Args>` to the `useArgs` function in `code/core/src/manager-api/root.tsx`. The return tuple, `updateArgs`, and `resetArgs` all flow `TArgs` through. Internal casts (`as Args`, `as string[]`) maintain compatibility with the untyped `updateStoryArgs`/`resetStoryArgs` API.

Note: The `preview-api` version of `useArgs` (used inside stories) is already correct and fully generic. This fix brings `manager-api` to parity.

> Builds on the approach from stalled PR #34689, with improved type safety (`Partial<TArgs>` for `updateArgs`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for story argument operations. The story management API now provides stronger type checking and better IDE support, enabling more flexible partial argument updates without requiring complete argument objects. This enhances the developer experience when working with story configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34753)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->