### PR TITLE
Docs-Blocks: Improve ArgsTable border visibility in dark mode

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -8,6 +8,7 @@ import { includeConditionalArg } from 'storybook/internal/csf';
 import { DocumentIcon, UndoIcon } from '@storybook/icons';
 
 import { pickBy } from 'es-toolkit/object';
+import { opacify } from 'polished';
 import { styled } from 'storybook/theming';
 
 import { EmptyBlock } from '../EmptyBlock';
@@ -22,7 +23,13 @@ export const TableWrapper = styled.table<{
   inAddonPanel?: boolean;
   inTabPanel?: boolean;
   isLoading?: boolean;
-}>(({ theme, compact, inAddonPanel, inTabPanel }) => ({
+}>(({ theme, compact, inAddonPanel, inTabPanel }) => {
+  // In dark mode, appBorderColor (white at 10% opacity) is nearly invisible.
+  // Boost opacity so table borders are distinguishable from the background.
+  const tableBorderColor =
+    theme.base === 'dark' ? opacify(0.1, theme.appBorderColor) : theme.appBorderColor;
+
+  return {
   '&&': {
     // Resets for cascading/system styles
     borderSpacing: 0,
@@ -119,13 +126,13 @@ export const TableWrapper = styled.table<{
             filter:
               theme.base === 'light'
                 ? `drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.10))`
-                : `drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.20))`,
+                : `drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.40))`,
           }),
 
       '> tr > *': {
         // For filter to work properly, the table cells all need to be opaque.
         background: theme.background.content,
-        borderTop: `1px solid ${theme.appBorderColor}`,
+        borderTop: `1px solid ${tableBorderColor}`,
       },
 
       ...(inAddonPanel
@@ -133,16 +140,16 @@ export const TableWrapper = styled.table<{
         : {
             // This works and I don't know why. :)
             '> tr:first-of-type > *': {
-              borderBlockStart: `1px solid ${theme.appBorderColor}`,
+              borderBlockStart: `1px solid ${tableBorderColor}`,
             },
             '> tr:last-of-type > *': {
-              borderBlockEnd: `1px solid ${theme.appBorderColor}`,
+              borderBlockEnd: `1px solid ${tableBorderColor}`,
             },
             '> tr > *:first-of-type': {
-              borderInlineStart: `1px solid ${theme.appBorderColor}`,
+              borderInlineStart: `1px solid ${tableBorderColor}`,
             },
             '> tr > *:last-of-type': {
-              borderInlineEnd: `1px solid ${theme.appBorderColor}`,
+              borderInlineEnd: `1px solid ${tableBorderColor}`,
             },
 
             // Thank you, Safari, for making me write code like this.
@@ -173,6 +180,7 @@ export const TableWrapper = styled.table<{
 
     // End awesome table styling
   },
+};
 }));
 
 const TablePositionWrapper = styled.div({


### PR DESCRIPTION
Refs #34000

## What I did

`appBorderColor` uses white at 10% opacity, which is nearly invisible against dark backgrounds. The ArgsTable borders disappear in dark mode.

Boost the border opacity in dark mode using `polished/opacify` so table borders are distinguishable from the background. Also increase the dark-mode drop-shadow strength from 0.20 to 0.40 for better depth separation.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox with `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook, switch to dark theme
3. Navigate to any Docs page with an ArgsTable
4. Before: table borders are invisible against the dark background
5. After: borders are visible with slightly boosted opacity

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update MIGRATION.MD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Arguments table styling for better visual appearance in dark mode with enhanced border rendering and contrast
  * Updated table border colors to improve visibility across light and dark themes
  * Enhanced drop-shadow effects to render appropriately for both light and dark theme modes
  * Refined overall table row styling for consistent visual presentation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34756)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->