### PR TITLE
Core: Quiet change-detection regex warning and swap clear icon

### DIFF
--- a/code/core/src/core-server/change-detection/dependency-graph/ResolverFactory.ts
+++ b/code/core/src/core-server/change-detection/dependency-graph/ResolverFactory.ts
@@ -56,7 +56,7 @@ class AliasNormalizer {
         for (const p of newPatterns) {
           this.warnedRegexAliases.add(p);
         }
-        logger.warn(
+        logger.debug(
           `Change detection: ignored ${skippedRegex.length} regex alias(es); related modules tracked as opaque-leaf.`
         );
         logger.debug(

--- a/code/core/src/manager/components/sidebar/ReviewChangesButton.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewChangesButton.tsx
@@ -9,7 +9,7 @@ import type {
   Tag,
 } from 'storybook/internal/types';
 
-import { SweepIcon } from '@storybook/icons';
+import { CloseIcon } from '@storybook/icons';
 
 import {
   experimental_useStatusStore,
@@ -158,7 +158,7 @@ const ReviewChangesButton = () => {
           ariaLabel="Clear"
           tooltip="Clear"
         >
-          <SweepIcon />
+          <CloseIcon />
         </Button>
       )}
     </Wrapper>


### PR DESCRIPTION
## Summary

- Demote the regex-alias log in `ResolverFactory` from `logger.warn` to `logger.debug` so it no longer surfaces in the default terminal output.
- Replace `SweepIcon` with `CloseIcon` next to the "Reviewing … stories" CTA in the sidebar so the clear button reads as an `x`.

## Test plan

- [ ] Start `yarn storybook:ui`, enable change detection, confirm the clear button shows an `x` icon and no longer the sweep icon.
- [ ] Run a sandbox that triggers regex aliases; verify the `Change detection: ignored …` line only appears when `DEBUG` logging is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the icon for the "Clear" action in the review changes interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34758)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->