### PR TITLE
Ci: Run agent-scan for PR from forks only

### DIFF
--- a/.github/scripts/agent-scan-check-org-membership.mjs
+++ b/.github/scripts/agent-scan-check-org-membership.mjs
@@ -1,0 +1,37 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+async function main() {
+  const token = core.getInput('token', { required: true });
+  const org = core.getInput('org', { required: true });
+  const username = core.getInput('username', { required: true });
+
+  const octokit = github.getOctokit(token);
+
+  let isOrgMember = false;
+
+  try {
+    await octokit.rest.orgs.checkMembershipForUser({
+      org,
+      username,
+    });
+
+    isOrgMember = true;
+  } catch (error) {
+    if (error.status === 404) {
+    } else if (error.status === 302 || error.status === 403) {
+      core.warning(
+        `Unable to verify org membership for ${username}; GitHub API returned ${error.status}. Falling back to scanning this fork PR.`
+      );
+    } else {
+      throw error;
+    }
+  }
+
+  core.setOutput('is-org-member', String(isOrgMember));
+  core.setOutput('should-scan', String(!isOrgMember));
+}
+
+main().catch((error) => {
+  core.setFailed(error.message);
+});

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -17,8 +17,9 @@ jobs:
   agentscan:
     if: |
       github.repository_owner == 'storybookjs' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
       !contains(
-        fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+        fromJSON('["OWNER","MEMBER"]'),
         github.event.pull_request.author_association
       ) && !contains(
         fromJSON('["dependabot[bot]", "github-actions[bot]","storybook-bot"]'),

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -19,9 +19,6 @@ jobs:
       github.repository_owner == 'storybookjs' &&
       github.event.pull_request.head.repo.full_name != github.repository &&
       !contains(
-        fromJSON('["OWNER","MEMBER"]'),
-        github.event.pull_request.author_association
-      ) && !contains(
         fromJSON('["dependabot[bot]", "github-actions[bot]","storybook-bot"]'),
         github.event.pull_request.user.login
       )
@@ -32,13 +29,22 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Install script dependencies
         run: npm install --prefix .github/scripts
+      - name: Check author org membership
+        id: membership
+        env:
+          INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_ORG: ${{ github.repository_owner }}
+          INPUT_USERNAME: ${{ github.event.pull_request.user.login }}
+        run: node .github/scripts/agent-scan-check-org-membership.mjs
       - name: Cache AgentScan analysis
+        if: steps.membership.outputs.should-scan == 'true'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: .agentscan-cache
           key: agentscan-cache-${{ github.actor }}
           restore-keys: agentscan-cache-
       - name: AgentScan
+        if: steps.membership.outputs.should-scan == 'true'
         id: agentscan
         uses: MatteoGabriele/agentscan-action@a584774dd15cabe6df4c6ab45fc43514a3b56b2d
         with:
@@ -46,7 +52,7 @@ jobs:
           agent-scan-comment: false
           cache-path: .agentscan-cache
       - name: Label PR with classification
-        if: steps.agentscan.outputs
+        if: steps.membership.outputs.should-scan == 'true' && steps.agentscan.outputs.classification
         env:
           INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_CLASSIFICATION: ${{ steps.agentscan.outputs.classification }}


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR changes the run conditions from Agent-scan. `author_association` deosn't seems that reliable, GH was marking us as `CONTRIBUTOR` instead of `MEMBERS` of the repo... 

This change the run conditions for agent-scan to run only on PR coming from forks

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

none, I've tested the API manually through Curl which either returns 200 or 404

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined CI workflow to gate automated security scans behind an organization membership check.
  * Tightened eligibility logic so scans no longer run for PRs from the same repo unless membership criteria are met; removed the collaborator association from allowed values.
  * Added a membership-check step that conditionally enables caching, scanning, and labeling when appropriate.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34759)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->