### PR TITLE
Tanstack: Treeshake top-level unused functions

### DIFF
--- a/code/frameworks/tanstack-react/src/plugins/server-code-elimination.ts
+++ b/code/frameworks/tanstack-react/src/plugins/server-code-elimination.ts
@@ -439,11 +439,14 @@ function removeDeadTopLevelDeclarations(
     }
 
     if (stmtPath.isVariableDeclaration()) {
-      // Only remove when every declarator in the statement is dead and uses a
-      // plain identifier (not a destructuring pattern that could have effects).
-      const allDead = stmtPath.node.declarations.every(
-        (decl) => t.isIdentifier(decl.id) && !referenced.has(decl.id.name)
-      );
+      // Only remove when every declarator is dead: plain identifier binding,
+      // unreferenced, and initializer absent or provably side-effect-free.
+      const allDead = stmtPath.get('declarations').every((declPath) => {
+        if (!t.isIdentifier(declPath.node.id)) return false;
+        if (referenced.has(declPath.node.id.name)) return false;
+        const initPath = declPath.get('init');
+        return !declPath.node.init || initPath.isPure();
+      });
       if (allDead) {
         stmtPath.remove();
         removed = true;
@@ -468,6 +471,12 @@ function removeDeadImportSpecifiers(
 
   programPath.traverse({
     ImportDeclaration(path) {
+      // Side-effect-only imports (`import './styles.css'`) have no specifiers
+      // and must never be removed by this pass.
+      if (path.node.specifiers.length === 0) {
+        return;
+      }
+
       const specifiers = path.node.specifiers.filter((spec) => referenced.has(spec.local.name));
 
       if (specifiers.length === 0) {

--- a/code/frameworks/tanstack-react/src/plugins/server-code-elimination.ts
+++ b/code/frameworks/tanstack-react/src/plugins/server-code-elimination.ts
@@ -388,39 +388,112 @@ function stripServerOption(options: import('@babel/types').ObjectExpression): bo
 }
 
 /**
- * Remove import specifiers that are no longer referenced in the AST.
- * Drops entire import declarations when all specifiers are unreferenced.
+ * Collect all non-binding identifier references in the program.
+ * Excludes binding sites (declarations) and import specifiers.
  */
-function eliminateDeadImports(programPath: NodePath<import('@babel/types').Program>) {
-  const referencedIdentifiers = new Set<string>();
-
+function collectReferencedIdentifiers(
+  programPath: NodePath<import('@babel/types').Program>
+): Set<string> {
+  const referenced = new Set<string>();
   programPath.traverse({
     enter(path) {
       const { node } = path;
       if (!t.isIdentifier(node) || path.isBindingIdentifier()) {
         return;
       }
-      // Skip identifiers that live inside an import declaration's specifiers.
-      // Both `imported` and `local` are Identifiers, but neither should count
-      // as a real "use" of the binding for the purposes of dead-import removal.
       if (path.findParent((p) => p.isImportDeclaration())) {
         return;
       }
-      referencedIdentifiers.add(node.name);
+      referenced.add(node.name);
     },
   });
+  return referenced;
+}
+
+/**
+ * Remove top-level non-exported declarations whose bound names are never
+ * referenced elsewhere. This handles hoisted helpers that become dead after
+ * server code is eliminated (e.g. `function helper() { ... }` only called
+ * inside a `.handler()` arg that was replaced with `__sb_fn()`).
+ *
+ * Returns true when at least one declaration was removed.
+ */
+function removeDeadTopLevelDeclarations(
+  programPath: NodePath<import('@babel/types').Program>
+): boolean {
+  const referenced = collectReferencedIdentifiers(programPath);
+  let removed = false;
+
+  for (const stmtPath of programPath.get('body')) {
+    if (stmtPath.isImportDeclaration() || stmtPath.isExportDeclaration()) {
+      continue;
+    }
+
+    if (stmtPath.isFunctionDeclaration()) {
+      const id = stmtPath.node.id;
+      if (id && !referenced.has(id.name)) {
+        stmtPath.remove();
+        removed = true;
+      }
+      continue;
+    }
+
+    if (stmtPath.isVariableDeclaration()) {
+      // Only remove when every declarator in the statement is dead and uses a
+      // plain identifier (not a destructuring pattern that could have effects).
+      const allDead = stmtPath.node.declarations.every(
+        (decl) => t.isIdentifier(decl.id) && !referenced.has(decl.id.name)
+      );
+      if (allDead) {
+        stmtPath.remove();
+        removed = true;
+      }
+    }
+  }
+
+  return removed;
+}
+
+/**
+ * Remove import specifiers that are no longer referenced in the AST.
+ * Drops entire import declarations when all specifiers are unreferenced.
+ *
+ * Returns true when at least one specifier was removed.
+ */
+function removeDeadImportSpecifiers(
+  programPath: NodePath<import('@babel/types').Program>
+): boolean {
+  const referenced = collectReferencedIdentifiers(programPath);
+  let removed = false;
 
   programPath.traverse({
     ImportDeclaration(path) {
-      const specifiers = path.node.specifiers.filter((spec) =>
-        referencedIdentifiers.has(spec.local.name)
-      );
+      const specifiers = path.node.specifiers.filter((spec) => referenced.has(spec.local.name));
 
       if (specifiers.length === 0) {
         path.remove();
+        removed = true;
       } else if (specifiers.length !== path.node.specifiers.length) {
         path.node.specifiers = specifiers;
+        removed = true;
       }
     },
   });
+
+  return removed;
+}
+
+/**
+ * Iteratively eliminate dead top-level declarations and dead imports until
+ * the AST reaches a fixed point. The loop is needed because removing a dead
+ * declaration (e.g. a hoisted helper) may expose new dead imports, and
+ * removing a dead import may expose further dead declarations.
+ */
+function eliminateDeadImports(programPath: NodePath<import('@babel/types').Program>) {
+  let changed = true;
+  while (changed) {
+    const d = removeDeadTopLevelDeclarations(programPath);
+    const i = removeDeadImportSpecifiers(programPath);
+    changed = d || i;
+  }
 }


### PR DESCRIPTION
Tanstack QA 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes the tree shake plugin to remove top-level unused functions if it is not used anymore.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- create canary.
- run it with https://github.com/JReinhold/storybook-tanstack-server-repro/tree/main 

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced server-side code elimination to iteratively remove unused top-level declarations, variables, and import entries until stable. Results in cleaner build output, fewer leftover dead code artifacts, and potentially smaller bundles and improved build-time efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34760)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->