### PR TITLE
Docs: Fix tanstack documentation to move from loaders to beforeEach

### DIFF
--- a/docs/_snippets/tanstack-react-query-in-story.md
+++ b/docs/_snippets/tanstack-react-query-in-story.md
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const LoggedIn: Story = {
-  loaders: [
+  beforeEach: [
     async ({ parameters }) => {
       const qc: QueryClient = parameters.tanstack?.router?.context?.queryClient;
       qc?.setQueryData(['currentUser'], {
@@ -40,7 +40,7 @@ const meta = preview.meta({
 export const Default = meta.story();
 
 export const LoggedIn = meta.story({
-  loaders: [
+  beforeEach: [
     async ({ parameters }) => {
       const qc: QueryClient = parameters.tanstack?.router?.context?.queryClient;
       qc?.setQueryData(['currentUser'], {

--- a/docs/_snippets/tanstack-react-query-in-story.md
+++ b/docs/_snippets/tanstack-react-query-in-story.md
@@ -14,15 +14,13 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const LoggedIn: Story = {
-  beforeEach: [
-    async ({ parameters }) => {
-      const qc: QueryClient = parameters.tanstack?.router?.context?.queryClient;
-      qc?.setQueryData(['currentUser'], {
-        id: 'user-1',
-        name: 'Ada Lovelace',
-      });
-    },
-  ],
+  beforeEach: async ({ parameters }) => {
+    const qc: QueryClient = parameters.tanstack?.router?.context?.queryClient;
+    qc?.setQueryData(['currentUser'], {
+      id: 'user-1',
+      name: 'Ada Lovelace',
+    });
+  },
 };
 ```
 
@@ -40,15 +38,13 @@ const meta = preview.meta({
 export const Default = meta.story();
 
 export const LoggedIn = meta.story({
-  beforeEach: [
-    async ({ parameters }) => {
-      const qc: QueryClient = parameters.tanstack?.router?.context?.queryClient;
-      qc?.setQueryData(['currentUser'], {
-        id: 'user-1',
-        name: 'Ada Lovelace',
-      });
-    },
-  ],
+  beforeEach: async ({ parameters }) => {
+    const qc: QueryClient = parameters.tanstack?.router?.context?.queryClient;
+    qc?.setQueryData(['currentUser'], {
+      id: 'user-1',
+      name: 'Ada Lovelace',
+    });
+  },
 });
 ```
 

--- a/docs/_snippets/tanstack-react-query-setup.md
+++ b/docs/_snippets/tanstack-react-query-setup.md
@@ -12,7 +12,7 @@ const queryClient = new QueryClient({
 });
 
 export default {
-  loaders: [
+  beforeEach: [
     // 👇 Clear the cache between stories so each story starts fresh
     () => {
       queryClient.clear();
@@ -52,7 +52,7 @@ const queryClient = new QueryClient({
 });
 
 export default definePreview({
-  loaders: [
+  beforeEach: [
     // 👇 Clear the cache between stories so each story starts fresh
     () => {
       queryClient.clear();

--- a/docs/_snippets/tanstack-react-query-setup.md
+++ b/docs/_snippets/tanstack-react-query-setup.md
@@ -12,12 +12,10 @@ const queryClient = new QueryClient({
 });
 
 export default {
-  beforeEach: [
+  beforeEach: () => {
     // 👇 Clear the cache between stories so each story starts fresh
-    () => {
-      queryClient.clear();
-    },
-  ],
+    queryClient.clear();
+  },
   parameters: {
     tanstack: {
       router: {
@@ -52,12 +50,10 @@ const queryClient = new QueryClient({
 });
 
 export default definePreview({
-  beforeEach: [
+  beforeEach: () => {
     // 👇 Clear the cache between stories so each story starts fresh
-    () => {
-      queryClient.clear();
-    },
-  ],
+    queryClient.clear();
+  },
   parameters: {
     tanstack: {
       router: {

--- a/docs/get-started/frameworks/tanstack-react.mdx
+++ b/docs/get-started/frameworks/tanstack-react.mdx
@@ -179,13 +179,13 @@ You can use this framework together with [TanStack Query](https://tanstack.com/q
 
 #### Project setup
 
-TanStack Query is not automatically set up. The recommended approach is to create a single [`QueryClient`](https://tanstack.com/query/latest/docs/reference/QueryClient) in your preview file, clear it between stories via [`loaders`](../../writing-stories/loaders.mdx), and share the same instance through both `parameters.tanstack.router.context` and a `QueryClientProvider` decorator.
+TanStack Query is not automatically set up. The recommended approach is to create a single [`QueryClient`](https://tanstack.com/query/latest/docs/reference/QueryClient) in your preview file, clear it between stories via [`beforeEach`](../../writing-tests/interaction-testing.mdx#beforeeach), and share the same instance through both `parameters.tanstack.router.context` and a `QueryClientProvider` decorator.
 
 <CodeSnippets path="tanstack-react-query-setup.md" />
 
 #### Seeding query data per story
 
-In individual stories, use [`loaders`](../../writing-stories/loaders.mdx) to call [`setQueryData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetquerydata) on the shared `QueryClient` before the component renders. Access it from `parameters.tanstack.router.context`:
+In individual stories, use [`beforeEach`](../../writing-tests/interaction-testing.mdx#beforeeach) to call [`setQueryData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetquerydata) on the shared `QueryClient` before the component renders. Access it from `parameters.tanstack.router.context`:
 
 <CodeSnippets path="tanstack-react-query-in-story.md" />
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did


This PR moves the Tanstack documentation from `loaders` to `beforeEach`
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

no testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised TanStack React Query guidance for Storybook with updated story-level setup for cache seeding and clearing
  * Clarified how to create and share a single QueryClient instance across stories
  * Applies to both CSF 3 and CSF Next documentation snippets

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34764)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->