### PR TITLE
fix(nextjs-vite): add Next.js 16 internal modules to optimizeDeps

### DIFF
--- a/code/frameworks/nextjs-vite/src/preset.ts
+++ b/code/frameworks/nextjs-vite/src/preset.ts
@@ -47,9 +47,6 @@ export const optimizeViteDeps = [
   '@storybook/nextjs-vite > styled-jsx',
   '@storybook/nextjs-vite > styled-jsx/style',
   '@opentelemetry/api',
-  // Next.js 16 internal modules that need pre-bundling for Vite dev mode
-  // Fixes: ServerInsertedHTMLContext, RedirectStatusCode missing exports
-  // See: https://github.com/storybookjs/storybook/issues/34688
   'next/navigation',
   'next/dist/client/components/redirect-error',
 ];

--- a/code/frameworks/nextjs-vite/src/preset.ts
+++ b/code/frameworks/nextjs-vite/src/preset.ts
@@ -47,6 +47,11 @@ export const optimizeViteDeps = [
   '@storybook/nextjs-vite > styled-jsx',
   '@storybook/nextjs-vite > styled-jsx/style',
   '@opentelemetry/api',
+  // Next.js 16 internal modules that need pre-bundling for Vite dev mode
+  // Fixes: ServerInsertedHTMLContext, RedirectStatusCode missing exports
+  // See: https://github.com/storybookjs/storybook/issues/34688
+  'next/navigation',
+  'next/dist/client/components/redirect-error',
 ];
 
 export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, options) => {


### PR DESCRIPTION
## Summary

Fixes the `ServerInsertedHTMLContext` and `RedirectStatusCode` missing exports error when using Storybook with Next.js 16 + Vite 8 in dev mode.

## Problem

Vite 8's esbuild pre-bundler doesn't correctly resolve Next.js 16's internal re-export chains from `next/navigation`. This causes a `SyntaxError` during development:

```
SyntaxError: The requested module '...node_modules/.cache/storybook/...' does not provide an export named 'ServerInsertedHTMLContext'
```

The issue only occurs in dev mode (esbuild pre-bundling) — production builds work fine because Rollup handles CJS/ESM interop differently.

## Root Cause

`next/navigation` and related Next.js internal modules are not included in Storybook's `optimizeViteDeps` configuration, so Vite's pre-bundler doesn't process them correctly.

## Fix

Added `next/navigation` and `next/dist/client/components/redirect-error` to the `optimizeViteDeps` array in `code/frameworks/nextjs-vite/src/preset.ts`.

## Changes

- **File**: `code/frameworks/nextjs-vite/src/preset.ts`
- **Change**: Added 2 Next.js 16 internal modules to `optimizeViteDeps`

## Testing

- Issue reproduction: https://github.com/JaeHye0k/storybook_next_vite_error_reproduction
- The fix forces Vite to pre-bundle Next.js navigation modules correctly
- No changes to production build behavior (Rollup already handles this correctly)

Fixes #34688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Next.js and Vite preset configuration to improve build module handling and performance.
  * Enhanced build optimization for additional Next.js internal modules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34774)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->