### PR TITLE
Add Stories block support for of and docs.stories options

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Stories.stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Stories.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import * as DefaultButtonStories from '../examples/Button.stories';
+import * as StoriesBlockParametersStories from '../examples/StoriesBlockParameters.stories';
 import { Stories } from './Stories';
 
 const meta = {
@@ -26,6 +28,28 @@ export const WithoutPrimary: Story = {
   args: { includePrimary: false },
   parameters: {
     relativeCsfPaths: ['../examples/Button.stories'],
+  },
+};
+export const WithoutPrimaryStory: Story = {
+  args: { includePrimaryStory: false },
+  parameters: {
+    relativeCsfPaths: ['../examples/Button.stories'],
+  },
+};
+export const OfCSFFile: Story = {
+  args: {
+    of: DefaultButtonStories,
+  },
+  parameters: {
+    relativeCsfPaths: ['../examples/Button.stories'],
+  },
+};
+export const WithDocsStoriesParameters: Story = {
+  args: {
+    of: StoriesBlockParametersStories,
+  },
+  parameters: {
+    relativeCsfPaths: ['../examples/StoriesBlockParameters.stories'],
   },
 };
 export const DifferentToolbars: Story = {

--- a/code/addons/docs/src/blocks/blocks/Stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Stories.tsx
@@ -2,17 +2,26 @@ import type { FC, ReactElement } from 'react';
 import React, { useContext } from 'react';
 
 import { Tag } from 'storybook/internal/preview-api';
+import { InvalidBlockOfPropError } from 'storybook/internal/preview-errors';
+import type { ResolvedModuleExportFromType } from 'storybook/internal/types';
 
 import { styled } from 'storybook/theming';
 
 import { DocsContext } from './DocsContext';
 import { DocsStory } from './DocsStory';
 import { Heading } from './Heading';
+import type { Of } from './useOf';
+import { useOf } from './useOf';
 import { withMdxComponentOverride } from './with-mdx-component-override';
 
 interface StoriesProps {
+  /** Specify which CSF file's stories are displayed. */
+  of?: Of;
   title?: ReactElement | string;
+  /** @deprecated Use `includePrimaryStory` instead. */
   includePrimary?: boolean;
+  includePrimaryStory?: boolean;
+  forceInitialArgs?: boolean;
 }
 
 const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
@@ -31,10 +40,37 @@ const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
   },
 }));
 
-const StoriesImpl: FC<StoriesProps> = ({ title = 'Stories', includePrimary = true }) => {
-  const { componentStories, projectAnnotations, getStoryContext } = useContext(DocsContext);
+const StoriesImpl: FC<StoriesProps> = (props) => {
+  const { of, includePrimary, includePrimaryStory } = props;
+  const context = useContext(DocsContext);
+  const { componentStories, componentStoriesFromCSFFile, projectAnnotations, getStoryContext } =
+    context;
 
-  let stories = componentStories();
+  if ('of' in props && of === undefined) {
+    throw new InvalidBlockOfPropError();
+  }
+
+  let resolvedOf: ResolvedModuleExportFromType<'meta'> | undefined;
+  try {
+    resolvedOf = useOf(of || 'meta', ['meta']);
+  } catch (error: unknown) {
+    if (
+      of ||
+      !(error instanceof Error) ||
+      !error.message.includes('did you forget to use <Meta of={} />?')
+    ) {
+      throw error;
+    }
+  }
+
+  const docsStoriesParameters = resolvedOf?.preparedMeta.parameters.docs?.stories || {};
+  const title = props.title ?? docsStoriesParameters.title ?? 'Stories';
+  const showPrimaryStory =
+    includePrimaryStory ?? includePrimary ?? docsStoriesParameters.includePrimaryStory ?? true;
+  const forceInitialArgs = props.forceInitialArgs ?? docsStoriesParameters.forceInitialArgs ?? true;
+
+  let stories =
+    of && resolvedOf ? componentStoriesFromCSFFile(resolvedOf.csfFile) : componentStories();
   const { stories: { filter } = { filter: undefined } } = projectAnnotations.parameters?.docs || {};
   if (filter) {
     stories = stories.filter((story) => filter(story, getStoryContext(story)));
@@ -53,7 +89,7 @@ const StoriesImpl: FC<StoriesProps> = ({ title = 'Stories', includePrimary = tru
     stories = stories.filter((story) => story.tags?.includes(Tag.AUTODOCS) && !story.usesMount);
   }
 
-  if (!includePrimary) {
+  if (!showPrimaryStory) {
     stories = stories.slice(1);
   }
 
@@ -65,7 +101,14 @@ const StoriesImpl: FC<StoriesProps> = ({ title = 'Stories', includePrimary = tru
       {typeof title === 'string' ? <StyledHeading>{title}</StyledHeading> : title}
       {stories.map(
         (story) =>
-          story && <DocsStory key={story.id} of={story.moduleExport} expanded __forceInitialArgs />
+          story && (
+            <DocsStory
+              key={story.id}
+              of={story.moduleExport}
+              expanded
+              __forceInitialArgs={forceInitialArgs}
+            />
+          )
       )}
     </>
   );

--- a/code/addons/docs/src/blocks/blocks/Stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Stories.tsx
@@ -2,7 +2,7 @@ import type { FC, ReactElement } from 'react';
 import React, { useContext } from 'react';
 
 import { Tag } from 'storybook/internal/preview-api';
-import { InvalidBlockOfPropError } from 'storybook/internal/preview-errors';
+import { InvalidBlockOfPropError, NoMetaAttachedError } from 'storybook/internal/preview-errors';
 import type { ResolvedModuleExportFromType } from 'storybook/internal/types';
 
 import { styled } from 'storybook/theming';
@@ -54,11 +54,7 @@ const StoriesImpl: FC<StoriesProps> = (props) => {
   try {
     resolvedOf = useOf(of || 'meta', ['meta']);
   } catch (error: unknown) {
-    if (
-      of ||
-      !(error instanceof Error) ||
-      !error.message.includes('did you forget to use <Meta of={} />?')
-    ) {
+    if (of || !(error instanceof NoMetaAttachedError)) {
       throw error;
     }
   }

--- a/code/addons/docs/src/blocks/blocks/Stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Stories.tsx
@@ -10,8 +10,8 @@ import { styled } from 'storybook/theming';
 import { DocsContext } from './DocsContext';
 import { DocsStory } from './DocsStory';
 import { Heading } from './Heading';
-import type { Of } from './useOf';
-import { useOf } from './useOf';
+import type { Of } from './useOf.ts';
+import { useOf } from './useOf.ts';
 import { withMdxComponentOverride } from './with-mdx-component-override';
 
 interface StoriesProps {

--- a/code/addons/docs/src/blocks/examples/StoriesBlockParameters.stories.tsx
+++ b/code/addons/docs/src/blocks/examples/StoriesBlockParameters.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { EmptyExample } from './EmptyExample';
+
+const meta = {
+  title: 'examples/Stories block parameters',
+  component: EmptyExample,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      stories: {
+        title: 'Configured stories',
+        includePrimaryStory: false,
+        forceInitialArgs: false,
+      },
+    },
+  },
+} satisfies Meta<typeof EmptyExample>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+export const Secondary: Story = {};
+export const Tertiary: Story = {};

--- a/code/addons/docs/src/blocks/examples/StoriesBlockParameters.stories.tsx
+++ b/code/addons/docs/src/blocks/examples/StoriesBlockParameters.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { EmptyExample } from './EmptyExample';
+import { EmptyExample } from './EmptyExample.tsx';
 
 const meta = {
   title: 'examples/Stories block parameters',

--- a/code/addons/docs/src/types.ts
+++ b/code/addons/docs/src/types.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 
-import type { ModuleExport, ModuleExports } from 'storybook/internal/types';
+import type { Args, Renderer, StoryContext } from 'storybook/internal/csf';
+import type { ModuleExport, ModuleExports, PreparedStory } from 'storybook/internal/types';
 
 import type { ThemeVars } from 'storybook/theming';
 
@@ -33,7 +34,7 @@ type StoryBlockParameters = {
 
 type StoriesBlockParameters = {
   /** Filter which stories are rendered by the Stories block */
-  filter?: (story: any, context: any) => boolean;
+  filter?: (story: PreparedStory<Renderer>, context: StoryContext<Renderer, Args>) => boolean;
   /** When rendering stories, whether the first story should be included */
   includePrimaryStory?: boolean;
   /** Whether to force initial args when rendering stories */

--- a/code/addons/docs/src/types.ts
+++ b/code/addons/docs/src/types.ts
@@ -31,6 +31,17 @@ type StoryBlockParameters = {
   of: ModuleExport;
 };
 
+type StoriesBlockParameters = {
+  /** Filter which stories are rendered by the Stories block */
+  filter?: (story: any, context: any) => boolean;
+  /** When rendering stories, whether the first story should be included */
+  includePrimaryStory?: boolean;
+  /** Whether to force initial args when rendering stories */
+  forceInitialArgs?: boolean;
+  /** The title displayed above the stories list */
+  title?: string;
+};
+
 type ControlsBlockParameters = {
   /** Exclude specific properties from the Controls panel */
   exclude?: string[] | RegExp;
@@ -220,6 +231,13 @@ export interface DocsParameters {
      * @see https://storybook.js.org/docs/api/doc-blocks/doc-block-story
      */
     story?: Partial<StoryBlockParameters>;
+
+    /**
+     * Stories configuration
+     *
+     * @see https://storybook.js.org/docs/api/doc-blocks/doc-block-stories
+     */
+    stories?: StoriesBlockParameters;
 
     /**
      * The subtitle displayed when shown in docs page

--- a/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { Channel } from 'storybook/internal/channels';
+import { NoMetaAttachedError } from 'storybook/internal/preview-errors';
 import type { CSFFile, Renderer } from 'storybook/internal/types';
 
 import type { StoryStore } from '../../store/index.ts';
@@ -310,7 +311,7 @@ describe('resolveOf', () => {
     });
 
     it('throws for attached CSF file', () => {
-      expect(() => context.resolveOf('meta')).toThrow('No CSF file attached');
+      expect(() => context.resolveOf('meta')).toThrow(NoMetaAttachedError);
     });
 
     it('throws for attached component', () => {

--- a/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.ts
@@ -14,6 +14,7 @@ import type {
 
 import { dedent } from 'ts-dedent';
 
+import { NoMetaAttachedError } from '../../../../preview-errors.ts';
 import { type StoryStore } from '../../store/index.ts';
 import type { DocsContextProps } from './DocsContextProps.ts';
 
@@ -131,9 +132,7 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
     }
 
     if (this.attachedCSFFiles.size === 0) {
-      throw new Error(
-        `No CSF file attached to this docs file, did you forget to use <Meta of={} />?`
-      );
+      throw new NoMetaAttachedError();
     }
 
     const firstAttachedCSFFile = Array.from(this.attachedCSFFiles)[0];

--- a/code/core/src/preview-errors.ts
+++ b/code/core/src/preview-errors.ts
@@ -373,6 +373,17 @@ export class InvalidBlockOfPropError extends StorybookError {
   }
 }
 
+export class NoMetaAttachedError extends StorybookError {
+  constructor() {
+    super({
+      name: 'NoMetaAttachedError',
+      category: Category.BLOCKS,
+      code: 2,
+      message: 'No CSF file attached to this docs file, did you forget to use <Meta of={} />?',
+    });
+  }
+}
+
 export class UnsupportedViewportDimensionError extends StorybookError {
   constructor(public data: { dimension: string; value: string }) {
     super({


### PR DESCRIPTION
Closes #22490

## What I did

Added v7-style API support to the `Stories` docs block.

- Added `of` support so `Stories` can render stories from a specified CSF file
- Added `includePrimaryStory`, while preserving the legacy `includePrimary` prop
- Added `forceInitialArgs` support instead of always forcing initial args
- Read default `title`, `includePrimaryStory`, and `forceInitialArgs` from `parameters.docs.stories`
- Added `docs.stories` typing, including the existing `filter` option
- Added Storybook examples covering the new `Stories` block behavior

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Validated locally with:

1. `git diff --check`
2. `oxfmt --check code/addons/docs/src/blocks/blocks/Stories.tsx code/addons/docs/src/blocks/blocks/Stories.stories.tsx code/addons/docs/src/blocks/examples/StoriesBlockParameters.stories.tsx code/addons/docs/src/types.ts`
3. A surgical TypeScript check on the changed files with docs/react package typings included

I was not able to run the full local ESLint suite because this checkout requires built Storybook core output for the internal `eslint-plugin-storybook` workspace package.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stories docs block can reference story modules via an `of` prop and now supports options to include/exclude the primary story, filter which stories show, set a title, and force initial args.
  * Added several example story variants demonstrating these behaviors.

* **Documentation**
  * Docs parameters/types updated to expose story-block configuration (filtering, primary visibility, title, and force-initial-args).

* **Bug Fixes**
  * Improved validation and clearer handling when a docs file lacks an attached story/meta.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34775)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->