### PR TITLE
Core: Improve ActionBar focus indicator in high contrast mode

### DIFF
--- a/code/core/src/components/components/ActionBar/ActionBar.tsx
+++ b/code/core/src/components/components/ActionBar/ActionBar.tsx
@@ -57,7 +57,8 @@ export const ActionButton = styled.button<{ disabled: boolean }>(
       outline: '0 none',
 
       '@media (forced-colors: active)': {
-        outline: '1px solid highlight',
+        outline: '2px solid CanvasText',
+        outlineOffset: '2px',
       },
     },
   }),

--- a/code/core/src/components/components/ActionBar/ActionBar.tsx
+++ b/code/core/src/components/components/ActionBar/ActionBar.tsx
@@ -57,7 +57,7 @@ export const ActionButton = styled.button<{ disabled: boolean }>(
       outline: '0 none',
 
       '@media (forced-colors: active)': {
-        outline: '2px solid CanvasText',
+        outline: '2px solid ButtonBorder',
         outlineOffset: '2px',
       },
     },


### PR DESCRIPTION
## What I did

Strengthened the focus outline on `ActionBar` buttons (used by the Copy button in code blocks, action items in Preview, etc.) when rendered under `forced-colors: active`.

```diff
 '@media (forced-colors: active)': {
-  outline: '1px solid highlight',
+  outline: '2px solid CanvasText',
+  outlineOffset: '2px',
 },
```

The previous `1px solid highlight` rule did render an outline, but on Windows 11 contrast themes it appears as a thin violet line that's easy to miss next to the button's existing border — failing the spirit of WCAG 2.4.7 (Focus Visible).

Changes:
- `2px` width instead of `1px` for visibility
- `CanvasText` (primary text system color) for guaranteed contrast against any HC background
- `outline-offset: 2px` to separate the focus ring from the button border so they don't merge visually

`CanvasText` is a CSS system color defined by the OS contrast theme, so the fix adapts automatically across Night sky / Desert / Dusk / Aquatic on Windows 11 and the legacy Black/White themes from Windows 10.

Fixes #22707

#### Manual testing

1. Enable a Windows contrast theme: Settings → Accessibility → Contrast themes → Night sky (or any other)
2. `cd code && yarn storybook:ui`
3. Navigate to Components → Syntaxhighlighter → Bordered Copyable
4. Tab to (or click) the Copy button
5. Focus outline should be a clear 2px ring offset from the button border

Same applies to other consumers of `ActionBar`, e.g. the additional actions in the docs Preview block.

## Screenshots

Tested on Windows 11 Night sky theme.

**Before** (`1px solid highlight`): thin violet outline, easy to miss.
<img width="1919" height="1028" alt="before" src="https://github.com/user-attachments/assets/52c306ce-6e66-438a-98e2-dd034b057ec0" />

**After** (`2px solid CanvasText` + `outline-offset: 2px`): thick, well-separated focus ring.
<img width="1919" height="1028" alt="after" src="https://github.com/user-attachments/assets/57b38baa-07ab-4222-96b5-e768007ed93e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus styling for ActionBar buttons in high-contrast/forced-colors mode: thicker, clearer outline and increased offset to make keyboard focus more visible and accessible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->