### PR TITLE
Maintenance: Fix self healing payload

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/agent-telemetry-reporter.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/agent-telemetry-reporter.test.ts
@@ -128,12 +128,12 @@ describe('AgentTelemetryReporter', () => {
         expect.objectContaining({
           agent: { name: 'claude' },
           analysis: expect.objectContaining({
-            runTotal: 3,
-            runPassed: 2,
-            runPassedButEmptyRender: 1,
-            runSuccessRate: 0.67,
-            runSuccessRateWithoutEmptyRender: 0.33,
-            runUniqueErrorCount: 1,
+            total: 3,
+            passed: 2,
+            passedButEmptyRender: 1,
+            successRate: 0.67,
+            successRateWithoutEmptyRender: 0.33,
+            uniqueErrorCount: 1,
           }),
           unhandledErrorCount: 0,
           watch: false,
@@ -167,8 +167,8 @@ describe('AgentTelemetryReporter', () => {
         'ai-setup-self-healing-scoring',
         expect.objectContaining({
           analysis: expect.objectContaining({
-            runTotal: 1,
-            runPassed: 0,
+            total: 1,
+            passed: 0,
             cumulativeTotal: 3,
             cumulativePassed: 2,
           }),
@@ -218,8 +218,8 @@ describe('AgentTelemetryReporter', () => {
         'ai-setup-self-healing-scoring',
         expect.objectContaining({
           analysis: expect.objectContaining({
-            runTotal: 1,
-            runPassed: 1,
+            total: 1,
+            passed: 1,
           }),
         }),
         expect.anything()
@@ -262,8 +262,8 @@ describe('AgentTelemetryReporter', () => {
       expect(secondCall[1]).toEqual(
         expect.objectContaining({
           analysis: expect.objectContaining({
-            runTotal: 1,
-            runPassed: 0,
+            total: 1,
+            passed: 0,
           }),
         })
       );

--- a/code/core/src/core-server/server-channel/ai-setup-channel.test.ts
+++ b/code/core/src/core-server/server-channel/ai-setup-channel.test.ts
@@ -209,14 +209,14 @@ describe('initAIAnalyticsChannel', () => {
       vi.mocked(mockRunStoryTests.runStoryTests).mockResolvedValue({
         duration: 1234,
         summary: {
-          runTotal: 2,
-          runPassed: 2,
-          runSuccessRate: 1,
-          runSuccessRateWithoutEmptyRender: 1,
-          runCategorizedErrors: {},
-          runCssCheck: 'not-run',
-          runUniqueErrorCount: 0,
-          runPassedButEmptyRender: 0,
+          total: 2,
+          passed: 2,
+          successRate: 1,
+          successRateWithoutEmptyRender: 1,
+          categorizedErrors: {},
+          cssCheck: 'not-run',
+          uniqueErrorCount: 0,
+          passedButEmptyRender: 0,
         },
       } as any);
       vi.mocked(mockAiChecklistFlags.getAiSetupRunId).mockResolvedValue('session-B');
@@ -250,7 +250,7 @@ describe('initAIAnalyticsChannel', () => {
             testRunDuration: 1234,
           }),
           runId: 'session-B',
-          results: expect.objectContaining({ runTotal: 2, runPassed: 2 }),
+          results: expect.objectContaining({ total: 2, passed: 2 }),
         })
       );
     });

--- a/code/core/src/core-server/server-channel/ghost-stories-channel.test.ts
+++ b/code/core/src/core-server/server-channel/ghost-stories-channel.test.ts
@@ -214,14 +214,14 @@ describe('ghostStoriesChannel', () => {
           testRunDuration: expect.any(Number),
         },
         results: {
-          runTotal: 2,
-          runPassed: 2,
-          runSuccessRate: 1,
-          runSuccessRateWithoutEmptyRender: 1,
-          runCategorizedErrors: expect.any(Object),
-          runCssCheck: 'not-run',
-          runUniqueErrorCount: 0,
-          runPassedButEmptyRender: 0,
+          total: 2,
+          passed: 2,
+          successRate: 1,
+          successRateWithoutEmptyRender: 1,
+          categorizedErrors: expect.any(Object),
+          cssCheck: 'not-run',
+          uniqueErrorCount: 0,
+          passedButEmptyRender: 0,
         },
       });
     });
@@ -314,14 +314,14 @@ describe('ghostStoriesChannel', () => {
             testRunDuration: expect.any(Number),
           },
           results: expect.objectContaining({
-            runTotal: 2,
-            runPassed: 0,
-            runSuccessRate: 0,
-            // runCategorizedErrors is an object keyed by error category
-            runCategorizedErrors: expect.any(Object),
-            runCssCheck: 'not-run',
-            runUniqueErrorCount: expect.any(Number),
-            runPassedButEmptyRender: 0,
+            total: 2,
+            passed: 0,
+            successRate: 0,
+            // categorizedErrors is an object keyed by error category
+            categorizedErrors: expect.any(Object),
+            cssCheck: 'not-run',
+            uniqueErrorCount: expect.any(Number),
+            passedButEmptyRender: 0,
           }),
         })
       );

--- a/code/core/src/core-server/utils/ghost-stories/parse-vitest-report.test.ts
+++ b/code/core/src/core-server/utils/ghost-stories/parse-vitest-report.test.ts
@@ -42,14 +42,14 @@ describe('parse-vitest-report', () => {
       const result = parseVitestResults(mockVitestResults);
 
       expect(result.summary).toEqual({
-        runTotal: 3,
-        runPassed: 3,
-        runPassedButEmptyRender: 0,
-        runSuccessRate: 1.0,
-        runSuccessRateWithoutEmptyRender: 1.0,
-        runUniqueErrorCount: 0,
-        runCategorizedErrors: {},
-        runCssCheck: 'not-run',
+        total: 3,
+        passed: 3,
+        passedButEmptyRender: 0,
+        successRate: 1.0,
+        successRateWithoutEmptyRender: 1.0,
+        uniqueErrorCount: 0,
+        categorizedErrors: {},
+        cssCheck: 'not-run',
       });
     });
 
@@ -86,10 +86,10 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.runTotal).toBe(3);
-      expect(result.summary?.runPassed).toBe(1);
-      expect(result.summary?.runSuccessRate).toBe(0.33);
-      expect(result.summary?.runUniqueErrorCount).toBe(2);
+      expect(result.summary?.total).toBe(3);
+      expect(result.summary?.passed).toBe(1);
+      expect(result.summary?.successRate).toBe(0.33);
+      expect(result.summary?.uniqueErrorCount).toBe(2);
     });
 
     it('should categorize errors and include them in the summary', () => {
@@ -137,10 +137,10 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.runTotal).toBe(5);
-      expect(result.summary?.runPassed).toBe(1);
-      expect(result.summary?.runUniqueErrorCount).toBe(3);
-      expect(result.summary?.runCategorizedErrors).toEqual({
+      expect(result.summary?.total).toBe(5);
+      expect(result.summary?.passed).toBe(1);
+      expect(result.summary?.uniqueErrorCount).toBe(3);
+      expect(result.summary?.categorizedErrors).toEqual({
         HOOK_USAGE_ERROR: {
           uniqueCount: 1,
           count: 1,
@@ -199,9 +199,9 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.runPassedButEmptyRender).toBe(2);
-      expect(result.summary?.runSuccessRate).toBe(1.0);
-      expect(result.summary?.runSuccessRateWithoutEmptyRender).toBe(0.33);
+      expect(result.summary?.passedButEmptyRender).toBe(2);
+      expect(result.summary?.successRate).toBe(1.0);
+      expect(result.summary?.successRateWithoutEmptyRender).toBe(0.33);
     });
 
     it('should handle multiple test suites', () => {
@@ -244,8 +244,8 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.runTotal).toBe(4);
-      expect(result.summary?.runPassed).toBe(3);
+      expect(result.summary?.total).toBe(4);
+      expect(result.summary?.passed).toBe(3);
     });
 
     it('should handle zero total tests', () => {
@@ -259,11 +259,11 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.runTotal).toBe(0);
-      expect(result.summary?.runSuccessRate).toBe(0);
+      expect(result.summary?.total).toBe(0);
+      expect(result.summary?.successRate).toBe(0);
     });
 
-    it('surfaces the CssCheck story outcome via summary.runCssCheck', () => {
+    it('surfaces the CssCheck story outcome via summary.cssCheck', () => {
       const mockVitestResults = {
         success: false,
         numTotalTests: 2,
@@ -291,7 +291,7 @@ describe('parse-vitest-report', () => {
 
       const result = parseVitestResults(mockVitestResults);
 
-      expect(result.summary?.runCssCheck).toBe('fail');
+      expect(result.summary?.cssCheck).toBe('fail');
     });
   });
 });

--- a/code/core/src/shared/utils/analyze-test-results.test.ts
+++ b/code/core/src/shared/utils/analyze-test-results.test.ts
@@ -70,14 +70,14 @@ describe('analyze-test-results', () => {
       ];
       const analysis = analyzeTestResults(results);
       expect(analysis).toEqual({
-        runTotal: 3,
-        runPassed: 3,
-        runPassedButEmptyRender: 0,
-        runSuccessRate: 1.0,
-        runSuccessRateWithoutEmptyRender: 1.0,
-        runUniqueErrorCount: 0,
-        runCategorizedErrors: {},
-        runCssCheck: 'not-run',
+        total: 3,
+        passed: 3,
+        passedButEmptyRender: 0,
+        successRate: 1.0,
+        successRateWithoutEmptyRender: 1.0,
+        uniqueErrorCount: 0,
+        categorizedErrors: {},
+        cssCheck: 'not-run',
       });
     });
 
@@ -88,10 +88,10 @@ describe('analyze-test-results', () => {
         { storyId: 's3', status: 'FAIL', error: 'Error: Module not found', stack: '' },
       ];
       const analysis = analyzeTestResults(results);
-      expect(analysis.runTotal).toBe(3);
-      expect(analysis.runPassed).toBe(1);
-      expect(analysis.runSuccessRate).toBe(0.33);
-      expect(analysis.runUniqueErrorCount).toBe(2);
+      expect(analysis.total).toBe(3);
+      expect(analysis.passed).toBe(1);
+      expect(analysis.successRate).toBe(0.33);
+      expect(analysis.uniqueErrorCount).toBe(2);
     });
 
     it('should count passedButEmptyRender', () => {
@@ -101,16 +101,16 @@ describe('analyze-test-results', () => {
         { storyId: 's3', status: 'PASS', emptyRender: true },
       ];
       const analysis = analyzeTestResults(results);
-      expect(analysis.runPassedButEmptyRender).toBe(2);
-      expect(analysis.runSuccessRate).toBe(1.0);
-      expect(analysis.runSuccessRateWithoutEmptyRender).toBe(0.33);
+      expect(analysis.passedButEmptyRender).toBe(2);
+      expect(analysis.successRate).toBe(1.0);
+      expect(analysis.successRateWithoutEmptyRender).toBe(0.33);
     });
 
     it('should handle zero tests', () => {
       const analysis = analyzeTestResults([]);
-      expect(analysis.runTotal).toBe(0);
-      expect(analysis.runSuccessRate).toBe(0);
-      expect(analysis.runSuccessRateWithoutEmptyRender).toBe(0);
+      expect(analysis.total).toBe(0);
+      expect(analysis.successRate).toBe(0);
+      expect(analysis.successRateWithoutEmptyRender).toBe(0);
       expect(analysis.cumulativeTotal).toBeUndefined();
     });
 
@@ -120,9 +120,9 @@ describe('analyze-test-results', () => {
         { storyId: 's2', status: 'PENDING' },
       ];
       const analysis = analyzeTestResults(results);
-      expect(analysis.runTotal).toBe(2);
-      expect(analysis.runPassed).toBe(1);
-      expect(analysis.runSuccessRate).toBe(0.5);
+      expect(analysis.total).toBe(2);
+      expect(analysis.passed).toBe(1);
+      expect(analysis.successRate).toBe(0.5);
     });
 
     describe('cumulative stats', () => {
@@ -154,8 +154,8 @@ describe('analyze-test-results', () => {
           { storyId: 's5', status: 'PASS' },
         ];
         const analysis = analyzeTestResults(run, cumulative);
-        expect(analysis.runTotal).toBe(3);
-        expect(analysis.runPassed).toBe(0);
+        expect(analysis.total).toBe(3);
+        expect(analysis.passed).toBe(0);
         expect(analysis.cumulativeTotal).toBe(5);
         expect(analysis.cumulativePassed).toBe(4);
         expect(analysis.cumulativeSuccessRate).toBe(0.8);
@@ -168,7 +168,7 @@ describe('analyze-test-results', () => {
           { storyId: 'components-button--primary', status: 'PASS' },
           { storyId: 'components-button--css-check', status: 'PASS' },
         ];
-        expect(analyzeTestResults(results).runCssCheck).toBe('pass');
+        expect(analyzeTestResults(results).cssCheck).toBe('pass');
       });
 
       it("is 'fail' when a --css-check story failed", () => {
@@ -179,14 +179,14 @@ describe('analyze-test-results', () => {
             error: 'expected rgb(37, 99, 235) but got rgba(0, 0, 0, 0)',
           },
         ];
-        expect(analyzeTestResults(results).runCssCheck).toBe('fail');
+        expect(analyzeTestResults(results).cssCheck).toBe('fail');
       });
 
       it("is 'not-run' when no --css-check story is present", () => {
         const results: StoryTestResult[] = [
           { storyId: 'components-button--primary', status: 'PASS' },
         ];
-        expect(analyzeTestResults(results).runCssCheck).toBe('not-run');
+        expect(analyzeTestResults(results).cssCheck).toBe('not-run');
       });
 
       it("is 'not-run' when the --css-check story was skipped / pending / todo", () => {
@@ -196,11 +196,11 @@ describe('analyze-test-results', () => {
         const results: StoryTestResult[] = [
           { storyId: 'components-button--css-check', status: 'PENDING' },
         ];
-        expect(analyzeTestResults(results).runCssCheck).toBe('not-run');
+        expect(analyzeTestResults(results).cssCheck).toBe('not-run');
       });
 
       it("is 'not-run' for an empty result list", () => {
-        expect(analyzeTestResults([]).runCssCheck).toBe('not-run');
+        expect(analyzeTestResults([]).cssCheck).toBe('not-run');
       });
 
       it('uses the first match when multiple --css-check stories exist', () => {
@@ -210,7 +210,7 @@ describe('analyze-test-results', () => {
           { storyId: 'components-button--css-check', status: 'PASS' },
           { storyId: 'components-card--css-check', status: 'FAIL', error: 'style mismatch' },
         ];
-        expect(analyzeTestResults(results).runCssCheck).toBe('pass');
+        expect(analyzeTestResults(results).cssCheck).toBe('pass');
       });
 
       it('is case-insensitive on the suffix (defensive)', () => {
@@ -219,7 +219,7 @@ describe('analyze-test-results', () => {
         const results: StoryTestResult[] = [
           { storyId: 'components-button--CSS-CHECK', status: 'PASS' },
         ];
-        expect(analyzeTestResults(results).runCssCheck).toBe('pass');
+        expect(analyzeTestResults(results).cssCheck).toBe('pass');
       });
     });
   });

--- a/code/core/src/shared/utils/analyze-test-results.ts
+++ b/code/core/src/shared/utils/analyze-test-results.ts
@@ -118,8 +118,8 @@ function summarizeResults(results: StoryTestResult[]): ResultSummary {
  *
  * @param results Story results from the current run.
  * @param cumulativeResults Optional aggregated results across runs (latest outcome per story).
- *   Only the agent self-healing flow tracks history and passes this; when omitted the returned
- *   analysis only contains `run*` fields and no `cumulative*` fields are emitted.
+ *   Only the agent self-healing flow tracks history and passes this; when omitted no
+ *   `cumulative*` fields are emitted.
  */
 export function analyzeTestResults(
   results: StoryTestResult[],
@@ -128,14 +128,14 @@ export function analyzeTestResults(
   const run = summarizeResults(results);
 
   const analysis: TestRunAnalysis = {
-    runTotal: run.total,
-    runPassed: run.passed,
-    runPassedButEmptyRender: run.passedButEmptyRender,
-    runSuccessRate: run.successRate,
-    runSuccessRateWithoutEmptyRender: run.successRateWithoutEmptyRender,
-    runUniqueErrorCount: run.uniqueErrorCount,
-    runCategorizedErrors: run.categorizedErrors,
-    runCssCheck: run.cssCheck,
+    total: run.total,
+    passed: run.passed,
+    passedButEmptyRender: run.passedButEmptyRender,
+    successRate: run.successRate,
+    successRateWithoutEmptyRender: run.successRateWithoutEmptyRender,
+    uniqueErrorCount: run.uniqueErrorCount,
+    categorizedErrors: run.categorizedErrors,
+    cssCheck: run.cssCheck,
   };
 
   if (cumulativeResults) {

--- a/code/core/src/shared/utils/test-result-types.ts
+++ b/code/core/src/shared/utils/test-result-types.ts
@@ -50,14 +50,14 @@ export type CssCheckOutcome = 'pass' | 'fail' | 'not-run';
 
 export interface TestRunAnalysis {
   /** Stats for the current run (only stories executed in this run). */
-  runTotal: number;
-  runPassed: number;
-  runPassedButEmptyRender: number;
-  runSuccessRate: number;
-  runSuccessRateWithoutEmptyRender: number;
-  runUniqueErrorCount: number;
-  runCategorizedErrors: Record<string, CategorizedError>;
-  runCssCheck: CssCheckOutcome;
+  total: number;
+  passed: number;
+  passedButEmptyRender: number;
+  successRate: number;
+  successRateWithoutEmptyRender: number;
+  uniqueErrorCount: number;
+  categorizedErrors: Record<string, CategorizedError>;
+  cssCheck: CssCheckOutcome;
 
   /**
    * Stats accumulated across runs: for every story we've ever seen, we

--- a/scripts/eval/lib/grade.ts
+++ b/scripts/eval/lib/grade.ts
@@ -322,7 +322,7 @@ export async function collectGhostStoriesGrade(
 
     const rawReport = JSON.parse(await readFile(outputFile, 'utf8'));
     const parsed = parseVitestResults(rawReport);
-    const emptyRenders = parsed.summary?.runPassedButEmptyRender ?? 0;
+    const emptyRenders = parsed.summary?.passedButEmptyRender ?? 0;
 
     // Suite-level: each file either loaded and rendered or it didn't.
     const total: number = rawReport.numTotalTestSuites ?? 0;

--- a/scripts/eval/lib/story-render.ts
+++ b/scripts/eval/lib/story-render.ts
@@ -209,10 +209,10 @@ async function readStoryRenderSummary(reportPath: string, storyFiles: number) {
     }
 
     return {
-      total: parsed.runTotal,
-      passed: parsed.runPassed,
+      total: parsed.total,
+      passed: parsed.passed,
       storyFiles,
-      cssCheck: parsed.runCssCheck,
+      cssCheck: parsed.cssCheck,
     } satisfies StoryRenderGrade;
   } catch {
     return undefined;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR removes the "run" prefix from the payload for the test events, an unintentional breaking change.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal naming conventions for test result analysis fields, removing legacy prefixes to improve code consistency and maintainability.

* **Tests**
  * Updated test coverage across telemetry reporting and result processing systems to validate refactored internal data structures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34782)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->