### PR TITLE
Tanstack: Add unit test for the server code elimination plugin

### DIFF
--- a/code/frameworks/tanstack-react/src/plugins/server-code-elimination.test.ts
+++ b/code/frameworks/tanstack-react/src/plugins/server-code-elimination.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest';
+
+import { serverCodeEliminationPlugin } from './server-code-elimination.ts';
+
+type TransformResult = { code: string; map?: unknown } | null;
+
+async function transform(
+  code: string,
+  id = '/project/src/file.ts',
+  options?: { excludeFiles?: string[] }
+): Promise<TransformResult> {
+  const plugin = serverCodeEliminationPlugin(options);
+  const transformOpt = plugin.transform as any;
+  const handler = typeof transformOpt === 'function' ? transformOpt : transformOpt.handler;
+  // Handler is called with a Rollup PluginContext; the plugin doesn't use `this`.
+  return (await handler.call({}, code, id)) as TransformResult;
+}
+
+describe('serverCodeEliminationPlugin', () => {
+  describe('skipping (returns null)', () => {
+    it('skips non-JS/TS file extensions', async () => {
+      const code = `import { createServerFn } from '@tanstack/react-start';\ncreateServerFn().handler(() => 1);`;
+      const result = await transform(code, '/project/src/file.css');
+      expect(result).toBeNull();
+    });
+
+    it('skips files matching excludeFiles', async () => {
+      const code = `import { createServerFn } from '@tanstack/react-start';\ncreateServerFn().handler(() => 1);`;
+      const result = await transform(code, '/project/src/export-mocks/start.ts', {
+        excludeFiles: ['export-mocks'],
+      });
+      expect(result).toBeNull();
+    });
+
+    it('skips files that do not match any tanstack pattern', async () => {
+      const code = `export const x = 1;\nconst y = () => x + 1;`;
+      const result = await transform(code);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when nothing actually gets transformed', async () => {
+      // contains a string that happens to match the regex but no real calls
+      const code = `const s = "createServerFn was here";`;
+      const result = await transform(code);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createServerOnlyFn', () => {
+    it('replaces createServerOnlyFn(fn) with a no-op spy', async () => {
+      const code = [
+        `import { createServerOnlyFn } from '@tanstack/react-start';`,
+        `export const f = createServerOnlyFn(() => 42);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain(`import { fn as __sb_fn } from "storybook/test"`);
+      expect(result!.code).toContain('__sb_fn()');
+      expect(result!.code).not.toContain('createServerOnlyFn');
+    });
+  });
+
+  describe('createClientOnlyFn', () => {
+    it('wraps original impl in a spy', async () => {
+      const code = [
+        `import { createClientOnlyFn } from '@tanstack/react-start';`,
+        `export const f = createClientOnlyFn((x) => x + 1);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toMatch(/__sb_fn\(\s*\(?x\)?\s*=>\s*x\s*\+\s*1\s*\)/);
+      expect(result!.code).not.toContain('createClientOnlyFn');
+    });
+  });
+
+  describe('createServerFn().handler()', () => {
+    it('replaces inline handler argument with no-op spy', async () => {
+      const code = [
+        `import { createServerFn } from '@tanstack/react-start';`,
+        `export const f = createServerFn().handler(async () => ({ ok: true }));`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain('__sb_fn()');
+      expect(result!.code).not.toMatch(/async\s*\(\)\s*=>\s*\(\{\s*ok:\s*true/);
+    });
+
+    it('removes the dead binding when handler arg is an identifier referenced once', async () => {
+      const code = [
+        `import { createServerFn } from '@tanstack/react-start';`,
+        `const handler = async () => ({ ok: true });`,
+        `export const f = createServerFn().handler(handler);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain('__sb_fn()');
+      expect(result!.code).not.toContain('const handler');
+    });
+
+    it('handles chained .middleware().handler()', async () => {
+      const code = [
+        `import { createServerFn } from '@tanstack/react-start';`,
+        `const mw = {};`,
+        `export const f = createServerFn().middleware([mw]).handler(() => 1);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain('__sb_fn()');
+    });
+  });
+
+  describe('createMiddleware()', () => {
+    it('strips .server(fn) from the chain', async () => {
+      const code = [
+        `import { createMiddleware } from '@tanstack/react-start';`,
+        `export const m = createMiddleware().server(async () => { secret(); });`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).not.toContain('.server(');
+      expect(result!.code).not.toContain('secret()');
+      expect(result!.code).toContain('createMiddleware()');
+    });
+
+    it('strips .inputValidator(fn) from the chain', async () => {
+      const code = [
+        `import { createMiddleware } from '@tanstack/react-start';`,
+        `export const m = createMiddleware().inputValidator((v) => v);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).not.toContain('.inputValidator(');
+    });
+  });
+
+  describe('createIsomorphicFn()', () => {
+    it('wraps .client(fn) with a spy carrying the original impl', async () => {
+      const code = [
+        `import { createIsomorphicFn } from '@tanstack/react-start';`,
+        `export const f = createIsomorphicFn().server(() => 's').client(() => 'c');`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toMatch(/__sb_fn\(\s*\(\)\s*=>\s*['"]c['"]\s*\)/);
+    });
+
+    it('replaces .server(fn) with no-op spy when no .client follows', async () => {
+      const code = [
+        `import { createIsomorphicFn } from '@tanstack/react-start';`,
+        `export const f = createIsomorphicFn().server(() => 's');`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain('__sb_fn()');
+      expect(result!.code).not.toMatch(/['"]s['"]/);
+    });
+  });
+
+  describe('route factories', () => {
+    it('strips the server property from createFileRoute options', async () => {
+      const code = [
+        `import { createFileRoute } from '@tanstack/react-router';`,
+        `export const Route = createFileRoute('/users')({`,
+        `  component: Comp,`,
+        `  server: { handler: async () => ({}) },`,
+        `});`,
+        `function Comp() { return null; }`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).not.toMatch(/\bserver:\s*\{/);
+      expect(result!.code).toContain('component: Comp');
+    });
+
+    it('strips server from createRootRoute', async () => {
+      const code = [
+        `import { createRootRoute } from '@tanstack/react-router';`,
+        `export const Route = createRootRoute({ component: C, server: { handler: () => 1 } });`,
+        `function C() { return null; }`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).not.toMatch(/\bserver:\s*\{/);
+    });
+
+    it('strips server from createRootRouteWithContext curried call', async () => {
+      const code = [
+        `import { createRootRouteWithContext } from '@tanstack/react-router';`,
+        `export const Route = createRootRouteWithContext()({ component: C, server: {} });`,
+        `function C() { return null; }`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).not.toMatch(/\bserver:\s*\{/);
+    });
+
+    it('strips server from createRoute', async () => {
+      const code = [
+        `import { createRoute } from '@tanstack/react-router';`,
+        `export const Route = createRoute({ component: C, server: { handler: () => 1 } });`,
+        `function C() { return null; }`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).not.toMatch(/\bserver:\s*\{/);
+    });
+
+    it('does not strip computed `server` property', async () => {
+      const code = [
+        `import { createRoute } from '@tanstack/react-router';`,
+        `const k = 'server';`,
+        `export const Route = createRoute({ [k]: { handler: () => 1 }, component: C });`,
+        `function C() { return null; }`,
+      ].join('\n');
+      const result = await transform(code);
+      // Should be null because no transformation occurred for the computed prop
+      // and createRoute itself wasn't changed.
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('aliased imports', () => {
+    it('handles `import { createServerFn as csf }`', async () => {
+      const code = [
+        `import { createServerFn as csf } from '@tanstack/react-start';`,
+        `export const f = csf().handler(() => 1);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain('__sb_fn()');
+    });
+
+    it('handles aliased createServerOnlyFn', async () => {
+      const code = [
+        `import { createServerOnlyFn as sOnly } from '@tanstack/react-start';`,
+        `export const f = sOnly(() => 1);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain('__sb_fn()');
+    });
+  });
+
+  describe('dead import elimination', () => {
+    it('removes unused tanstack imports after transform', async () => {
+      const code = [
+        `import { createServerOnlyFn } from '@tanstack/react-start';`,
+        `export const f = createServerOnlyFn(() => 1);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).not.toContain('@tanstack/react-start');
+    });
+
+    it('preserves side-effect-only imports', async () => {
+      const code = [
+        `import './styles.css';`,
+        `import { createServerOnlyFn } from '@tanstack/react-start';`,
+        `export const f = createServerOnlyFn(() => 1);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toMatch(/import\s+['"]\.\/styles\.css['"]/);
+    });
+
+    it('treeshake unused variables if the var is only referenced in the server-only code that gets stripped', async () => {
+      const code = [
+        `import { createServerFn } from '@tanstack/react-start';`,
+        `const secret = () => 1;`,
+        `export const f = createServerFn().handler(secret);`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).not.toContain('secret');
+    });
+
+    it('treeshake unused functions if they are only called in the server-only code that gets stripped', async () => {
+      const code = [
+        `import { createServerFn } from '@tanstack/react-start';`,
+        `function secret() { return 1; }`,
+        `export const f = createServerFn().handler(() => secret());`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).not.toContain('secret');
+    });
+
+    it('keeps still-referenced imports from a partially-used declaration', async () => {
+      const code = [
+        `import { createServerOnlyFn, useSomething } from '@tanstack/react-start';`,
+        `export const f = createServerOnlyFn(() => 1);`,
+        `export const g = useSomething();`,
+      ].join('\n');
+      const result = await transform(code);
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain('useSomething');
+      expect(result!.code).not.toContain('createServerOnlyFn');
+    });
+  });
+});

--- a/code/frameworks/tanstack-react/vitest.config.ts
+++ b/code/frameworks/tanstack-react/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import { vitestCommonConfig } from '../../vitest.shared.ts';
+
+export default mergeConfig(vitestCommonConfig, defineConfig({}));


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR aads a unit test for the vite plugin for tanstack. 

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * New comprehensive test suite for server code elimination plugin validates transformation behavior across multiple TanStack framework patterns, including function handling, handler modifications, middleware processing, route configuration changes, import management, and dead code removal.

* **Chores**
  * Configured Vitest testing framework for TanStack React project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34787)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->