### PR TITLE
CLI: Run `npx expo install --fix` after init for Expo projects

### DIFF
--- a/code/lib/create-storybook/src/commands/GeneratorExecutionCommand.ts
+++ b/code/lib/create-storybook/src/commands/GeneratorExecutionCommand.ts
@@ -45,7 +45,7 @@ export class GeneratorExecutionCommand {
     language,
   }: ExecuteProjectGeneratorOptions) {
     // Get and execute generator (supports both old and new style)
-    const generatorResult = await this.executeProjectGenerator({
+    const { postInstall, ...generatorResult } = await this.executeProjectGenerator({
       projectType,
       frameworkInfo,
       options,
@@ -62,6 +62,11 @@ export class GeneratorExecutionCommand {
         generatorResult.storybookCommand !== undefined
           ? generatorResult.storybookCommand
           : this.jsPackageManager.getRunCommand('storybook'),
+      /**
+       * Hook to run after dependencies are installed. Optional — only the generators that need to do
+       * something after `installDependencies` will set this.
+       */
+      postInstall,
     };
   }
 
@@ -113,6 +118,12 @@ export class GeneratorExecutionCommand {
       dependencyCollector: this.dependencyCollector,
     } as GeneratorOptions;
 
+    const postInstall = generatorModule.postInstall
+      ? async () => {
+          await generatorModule.postInstall?.({ packageManager: this.jsPackageManager });
+        }
+      : undefined;
+
     if (frameworkOptions.skipGenerator) {
       if (generatorModule.postConfigure) {
         await generatorModule.postConfigure({ packageManager: this.jsPackageManager });
@@ -122,6 +133,7 @@ export class GeneratorExecutionCommand {
         shouldRunDev: frameworkOptions.shouldRunDev,
         storybookCommand: frameworkOptions.storybookCommand,
         extraAddons: [],
+        postInstall,
       };
     }
 
@@ -145,6 +157,7 @@ export class GeneratorExecutionCommand {
     return {
       ...generatorResult,
       extraAddons,
+      postInstall,
     };
   };
 }

--- a/code/lib/create-storybook/src/generators/REACT_NATIVE/index.test.ts
+++ b/code/lib/create-storybook/src/generators/REACT_NATIVE/index.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { copyTemplateFiles, getBabelDependencies } from 'storybook/internal/cli';
-import { logger } from 'storybook/internal/node-logger';
+import { executeCommand } from 'storybook/internal/common';
+import { logger, prompt } from 'storybook/internal/node-logger';
 import { SupportedLanguage } from 'storybook/internal/types';
 
 import { DependencyCollector } from '../../dependency-collector.ts';
@@ -12,6 +13,7 @@ import { runMetroCodemodOrFallback } from './metroConfig.ts';
 import { detectReactNativeEntrypointTemplateVariant } from './index.ts';
 
 vi.mock('storybook/internal/cli', { spy: true });
+vi.mock('storybook/internal/common', { spy: true });
 vi.mock('storybook/internal/node-logger', { spy: true });
 vi.mock('./generateEntrypoint', { spy: true });
 vi.mock('./metroConfig', { spy: true });
@@ -178,6 +180,70 @@ describe('REACT_NATIVE generator module', () => {
     expect(packageManager.getVersionedPackages).toHaveBeenCalledWith(
       expect.not.arrayContaining(['cross-env'])
     );
+  });
+});
+
+describe('REACT_NATIVE generator postInstall', () => {
+  const createPackageManagerWithDeps = (allDependencies: Record<string, string>) =>
+    ({
+      getAllDependencies: vi.fn().mockReturnValue(allDependencies),
+    }) as any;
+
+  beforeEach(() => {
+    vi.mocked(prompt.taskLog).mockReturnValue({
+      message: vi.fn(),
+      success: vi.fn(),
+      error: vi.fn(),
+    } as unknown as ReturnType<typeof prompt.taskLog>);
+    vi.mocked(executeCommand).mockReturnValue({
+      stdout: '',
+    } as unknown as ReturnType<typeof executeCommand>);
+    vi.mocked(logger.warn).mockImplementation(() => {});
+  });
+
+  it('runs `npx expo install --fix` when expo is a dependency', async () => {
+    const packageManager = createPackageManagerWithDeps({ expo: '^54.0.0' });
+
+    await reactNativeGenerator.postInstall?.({ packageManager });
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'npx',
+        args: ['expo', 'install', '--fix'],
+      })
+    );
+  });
+
+  it('runs `npx expo install --fix` when only expo-router is a dependency', async () => {
+    const packageManager = createPackageManagerWithDeps({ 'expo-router': '^4.0.0' });
+
+    await reactNativeGenerator.postInstall?.({ packageManager });
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'npx',
+        args: ['expo', 'install', '--fix'],
+      })
+    );
+  });
+
+  it('skips `npx expo install --fix` for plain (non-expo) React Native projects', async () => {
+    const packageManager = createPackageManagerWithDeps({ 'react-native': '0.76.0' });
+
+    await reactNativeGenerator.postInstall?.({ packageManager });
+
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when `npx expo install --fix` fails and prints a warning instead', async () => {
+    const packageManager = createPackageManagerWithDeps({ expo: '^54.0.0' });
+    vi.mocked(executeCommand).mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+
+    await expect(reactNativeGenerator.postInstall?.({ packageManager })).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('npx expo install --fix'));
   });
 });
 

--- a/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
+++ b/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
@@ -1,6 +1,7 @@
 import { ProjectType, copyTemplateFiles, getBabelDependencies } from 'storybook/internal/cli';
+import { executeCommand } from 'storybook/internal/common';
 import { RN_STORYBOOK_DIR } from '../../../../../core/src/shared/constants/config-folder.ts';
-import { CLI_COLORS, logger } from 'storybook/internal/node-logger';
+import { CLI_COLORS, logger, prompt } from 'storybook/internal/node-logger';
 import { SupportedBuilder, SupportedLanguage, SupportedRenderer } from 'storybook/internal/types';
 
 import { dedent } from 'ts-dedent';
@@ -31,6 +32,58 @@ export const detectReactNativeEntrypointTemplateVariant = (
   }
 
   return 'default';
+};
+
+/**
+ * Expo Go bundles specific native module versions for a given Expo SDK. When dependencies are
+ * installed with the user's package manager (npm/yarn/pnpm/bun) instead of `expo install`, the
+ * latest versions of packages like `@react-native-async-storage/async-storage`,
+ * `react-native-svg`, `@react-native-community/slider`, etc. get pinned in `package.json` — and
+ * those typically don't match what Expo Go has linked natively.
+ *
+ * The symptoms are runtime warnings such as:
+ *
+ *     WARN  storybook-log: error reading from async storage
+ *     [AsyncStorageError: Native module is null, cannot access legacy storage]
+ *
+ * Running `npx expo install --fix` after installation re-aligns those packages to the versions
+ * supported by the installed Expo SDK. It's the recommended fix from the Expo team and what we
+ * would have done implicitly if we shipped via `npx expo install` instead of the user's package
+ * manager.
+ */
+const fixExpoDependencyVersions = async () => {
+  const task = prompt.taskLog({
+    id: 'expo-install-fix',
+    title: 'Aligning Expo SDK dependency versions with `npx expo install --fix`',
+  });
+
+  try {
+    const result = await executeCommand({
+      command: 'npx',
+      args: ['expo', 'install', '--fix'],
+      stdio: 'pipe',
+    });
+
+    if (result.stdout) {
+      task.message(String(result.stdout));
+    }
+    task.success('Expo SDK dependency versions aligned', { showLog: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    task.error('Could not run `npx expo install --fix` automatically');
+    logger.warn(
+      dedent`
+        Could not automatically align Expo SDK package versions.
+
+        To avoid runtime warnings such as "Native module is null, cannot access legacy storage",
+        run the following command in your project root:
+
+          ${CLI_COLORS.cta('npx expo install --fix')}
+
+        Reason: ${message}
+      `
+    );
+  }
 };
 
 export default defineGeneratorModule({
@@ -124,6 +177,16 @@ export default defineGeneratorModule({
       storybookCommand: null,
       shouldRunDev: false, // React Native is started via platform scripts (see postConfigure), not `storybook dev`
     };
+  },
+  postInstall: async ({ packageManager }) => {
+    // Only re-align versions for projects that actually use Expo. Plain React Native CLI projects
+    // are unaffected by the Expo Go SDK <-> native module mismatch this guards against.
+    const variant = detectReactNativeEntrypointTemplateVariant(packageManager.getAllDependencies());
+    if (variant !== 'expo') {
+      return;
+    }
+
+    await fixExpoDependencyVersions();
   },
   postConfigure: ({ packageManager }) => {
     const platformRunGuidance = (() => {

--- a/code/lib/create-storybook/src/generators/REACT_NATIVE_AND_RNW/index.ts
+++ b/code/lib/create-storybook/src/generators/REACT_NATIVE_AND_RNW/index.ts
@@ -28,4 +28,7 @@ export default defineGeneratorModule({
     await reactNativeWebGeneratorModule.postConfigure();
     reactNativeGeneratorModule.postConfigure({ packageManager });
   },
+  postInstall: async ({ packageManager }) => {
+    await reactNativeGeneratorModule.postInstall?.({ packageManager });
+  },
 });

--- a/code/lib/create-storybook/src/generators/types.ts
+++ b/code/lib/create-storybook/src/generators/types.ts
@@ -119,6 +119,13 @@ export interface GeneratorModule {
   }: {
     packageManager: JsPackageManager;
   }) => Promise<void> | void;
+  /**
+   * The function that runs after dependencies have been installed. Use this for tasks that require
+   * the project's dependencies (e.g. CLI tools shipped by a dependency) to be available on disk.
+   *
+   * Examples: re-aligning native package versions in an Expo project with `npx expo install --fix`.
+   */
+  postInstall?: ({ packageManager }: { packageManager: JsPackageManager }) => Promise<void> | void;
 }
 
 export type CommandOptions = {

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -123,7 +123,7 @@ export async function doInitiate(options: CommandOptions): Promise<
 
   // Step 5: Execute generator with dependency collector (now with frameworkInfo)
 
-  const { configDir, storybookCommand, shouldRunDev, extraAddons } =
+  const { configDir, storybookCommand, shouldRunDev, extraAddons, postInstall } =
     await executeGeneratorExecution({
       projectType,
       packageManager,
@@ -144,6 +144,17 @@ export async function doInitiate(options: CommandOptions): Promise<
 
   // After dependencies are installed, we must not use the dependency collector anymore
   dependencyCollector = null;
+
+  // Generators may need to perform tasks once dependencies are installed (e.g. running a CLI that
+  // ships with one of those dependencies). We only run this when the install actually succeeded
+  // and we didn't skip it, otherwise the dependency-provided binary likely isn't available.
+  if (postInstall && !options.skipInstall && dependencyInstallationResult.status === 'success') {
+    try {
+      await postInstall();
+    } catch (err) {
+      logger.warn(`Post-install step failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 
   // Step 7: Configure addons (run postinstall scripts for configuration only)
   await executeAddonConfiguration({


### PR DESCRIPTION
## What I did

Storybook's `init` for React Native projects installs Storybook deps with the user's package manager (npm/yarn/pnpm/bun). For Expo projects this leaves the latest native-module versions pinned in `package.json` — but Expo Go bundles a specific subset of native libraries per SDK, and the JS and native versions must match exactly. The result is runtime warnings like:

```
WARN  storybook-log: error reading from async storage
[AsyncStorageError: Native module is null, cannot access legacy storage]
```

…and Expo's own version-mismatch output, e.g.:

```
The following packages should be updated for best compatibility with the installed expo version:
  @react-native-async-storage/async-storage@3.0.2 - expected version: 2.2.0
  @react-native-community/datetimepicker@9.1.0 - expected version: 8.4.4
  @react-native-community/slider@5.2.0     - expected version: 5.0.1
  react-native-svg@15.15.5                 - expected version: 15.12.1
```

The Expo team's recommendation (from @dannyhw) is to run `npx expo install --fix`, which re-aligns those packages with the installed Expo SDK. This PR runs that command automatically after `storybook init`, only for projects that use Expo.

Implementation:

- Added a generic `postInstall` lifecycle hook to the generator-module system (next to the existing `configure` / `postConfigure`). It runs after `executeDependencyInstallation` — i.e. once the dependencies (and CLIs they ship) are actually on disk — and is skipped when `skipInstall` is true or the install step failed.
- The React Native generator's new `postInstall` calls `npx expo install --fix` only when `expo` or `expo-router` is present (plain React Native CLI projects are unaffected).
- Output is wrapped in a `prompt.taskLog`; failures don't fail init — they print a clear warning telling the user the exact command to run manually.
- The React Native + RNW combo generator forwards `postInstall` to the underlying RN generator so it benefits too.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a fresh Expo project (e.g. `npx create-expo-app@latest my-app`) and `cd` into it.
2. Run `storybook init` from this PR's branch (e.g. via a canary release).
3. Confirm that toward the end of init you see the `Aligning Expo SDK dependency versions with \`npx expo install --fix\`` task succeed and that mismatched packages (e.g. `@react-native-async-storage/async-storage`, `react-native-svg`) are downgraded to the versions expected by the installed Expo SDK.
4. Run the project and confirm the `AsyncStorageError: Native module is null` warnings are gone.
5. Repeat with a plain (non-Expo) React Native CLI project and confirm `npx expo install --fix` is NOT invoked.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with \`gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>\`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a post-install lifecycle hook that executes after package installation completes, enabling generators to perform additional setup tasks.
  * React Native projects with Expo now automatically perform dependency alignment during initialization.

* **Tests**
  * Expanded test coverage for the React Native post-install process, including success and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34803)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->