### PR TITLE
docs: clarify sidebar group header theme color

### DIFF
--- a/docs/configure/user-interface/theming.mdx
+++ b/docs/configure/user-interface/theming.mdx
@@ -70,6 +70,8 @@ Above, we're updating the theme with the following changes:
 - A custom color palette (defined in the `app` and `color` variables).
 - Custom fonts (defined in the `font` and `text` variables).
 
+The `textMutedColor` variable is also used for less prominent UI labels, including the top-level group headers in the sidebar.
+
 With the new changes introduced, the custom theme should yield a similar result.
 
 ![Storybook custom theme loaded](../../_assets/configure/storybook-custom-theme.png)


### PR DESCRIPTION
## What I did

Adds a short note to the theming docs that `textMutedColor` controls less prominent UI labels, including the top-level group headers in the sidebar.

## Why

Closes #17260. The sidebar group header color is already themeable via `textMutedColor`, but the theming docs did not make that discoverable.

## Checklist

- [x] Documentation only
- [x] `git diff --check`