### PR TITLE
fix: reject invalid dates in date control

### DIFF
--- a/code/addons/docs/src/blocks/controls/Date.test.ts
+++ b/code/addons/docs/src/blocks/controls/Date.test.ts
@@ -14,6 +14,14 @@ describe('Date control', () => {
   });
 
   it.each([
+    // name, input
+    ['day does not exist in month', '2022-11-31'],
+    ['month is out of range', '2022-13-01'],
+  ])('marks invalid date as invalid: %s', (name, input) => {
+    expect(parseDate(input).getTime()).toBeNaN();
+  });
+
+  it.each([
     // name, input, expected
     ['same time', '12:00', '12:00'],
     ['hours not padded with a zero', '1:00', '01:00'],
@@ -21,5 +29,13 @@ describe('Date control', () => {
     ['different minutes', '01:30', '01:30'],
   ])('parse and format time: %s', (name, input, expected) => {
     expect(formatTime(parseTime(input))).toBe(expected);
+  });
+
+  it.each([
+    // name, input
+    ['hours are out of range', '24:00'],
+    ['minutes are out of range', '12:60'],
+  ])('marks invalid time as invalid: %s', (name, input) => {
+    expect(parseTime(input).getTime()).toBeNaN();
   });
 });

--- a/code/addons/docs/src/blocks/controls/Date.tsx
+++ b/code/addons/docs/src/blocks/controls/Date.tsx
@@ -10,16 +10,35 @@ import type { ControlProps, DateConfig, DateValue } from './types';
 
 export const parseDate = (value: string) => {
   const [year, month, day] = value.split('-');
-  const result = new Date();
-  result.setFullYear(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
+  const parsedYear = parseInt(year, 10);
+  const parsedMonth = parseInt(month, 10) - 1;
+  const parsedDay = parseInt(day, 10);
+  const result = new Date(0);
+  result.setFullYear(parsedYear, parsedMonth, parsedDay);
+  result.setHours(0, 0, 0, 0);
+
+  if (
+    result.getFullYear() !== parsedYear ||
+    result.getMonth() !== parsedMonth ||
+    result.getDate() !== parsedDay
+  ) {
+    return new Date(Number.NaN);
+  }
+
   return result;
 };
 
 export const parseTime = (value: string) => {
   const [hours, minutes] = value.split(':');
-  const result = new Date();
-  result.setHours(parseInt(hours, 10));
-  result.setMinutes(parseInt(minutes, 10));
+  const parsedHours = parseInt(hours, 10);
+  const parsedMinutes = parseInt(minutes, 10);
+  const result = new Date(0);
+  result.setHours(parsedHours, parsedMinutes, 0, 0);
+
+  if (result.getHours() !== parsedHours || result.getMinutes() !== parsedMinutes) {
+    return new Date(Number.NaN);
+  }
+
   return result;
 };
 


### PR DESCRIPTION
## What I did

Fixes the date control parser so invalid date and time values are rejected instead of being normalized by JavaScript `Date`. This prevents values like `2022-11-31` from rolling over to December 1.

## Why

Closes #15109. When a user edits the month field while the day is 31, browsers can produce an invalid calendar date during input. The old parser normalized that invalid date, which could make month `11` appear as `12`.

## How to test

- `git diff --check`
- Added focused parser tests for invalid dates and times

## Notes

I could not run the focused Vitest file locally because this fresh checkout does not have Yarn node_modules state installed (`Couldn't find the node_modules state file`).