### PR TITLE
Core: Ignore story-like directories in indexer

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -1997,6 +1998,28 @@ describe('StoryIndexGenerator', () => {
     });
 
     describe('warnings', () => {
+      it('does not match directories that have story-like names', async () => {
+        const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
+          './src/**/*.stories.tsx',
+          options
+        );
+
+        const files = await StoryIndexGenerator.findMatchingFiles(
+          specifier,
+          options.workingDir,
+          true
+        );
+        const storyLikeDirectory = join(
+          options.workingDir,
+          './src/__screenshots__/Button.stories.tsx'
+        );
+        const storyLikeDirectoryFile = join(storyLikeDirectory, 'Primary.png');
+
+        expect(existsSync(storyLikeDirectoryFile)).toBe(true);
+        expect(Object.keys(files)).not.toContain(storyLikeDirectory);
+        expect(Object.keys(files)).not.toContain(storyLikeDirectoryFile);
+      });
+
       it('when entries do not match any files', async () => {
         const generator = new StoryIndexGenerator(
           [normalizeStoriesEntry('./src/docs2/wrong.js', options)],

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -168,10 +168,18 @@ export class StoryIndexGenerator {
     const { globby } = await import('globby');
 
     // Execute globby within the new CWD to ensure `ignore` patterns work correctly.
+    const globOptions = commonGlobOptions(globPattern);
+    const ignore = [
+      ...(('ignore' in globOptions && globOptions.ignore) || []),
+      `${globPattern}/**`,
+    ];
+
     const files = await globby(globPattern, {
       absolute: true,
       cwd: globCwd,
-      ...commonGlobOptions(globPattern),
+      ...globOptions,
+      ignore,
+      onlyFiles: true,
     });
 
     if (files.length === 0 && !ignoreWarnings) {

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -167,18 +167,10 @@ export class StoryIndexGenerator {
     // eslint-disable-next-line depend/ban-dependencies
     const { globby } = await import('globby');
 
-    // Execute globby within the new CWD to ensure `ignore` patterns work correctly.
-    const globOptions = commonGlobOptions(globPattern);
-    const ignore = [
-      ...(('ignore' in globOptions && globOptions.ignore) || []),
-      `${globPattern}/**`,
-    ];
-
     const files = await globby(globPattern, {
       absolute: true,
       cwd: globCwd,
-      ...globOptions,
-      ignore,
+      ...commonGlobOptions(globPattern),
       onlyFiles: true,
     });
 

--- a/code/core/src/core-server/utils/__mockdata__/src/__screenshots__/Button.stories.tsx/Primary.png
+++ b/code/core/src/core-server/utils/__mockdata__/src/__screenshots__/Button.stories.tsx/Primary.png
@@ -1,0 +1,1 @@
+mock screenshot fixture


### PR DESCRIPTION
## What I did

- Prevented `StoryIndexGenerator.findMatchingFiles` from returning files nested inside directories whose names match the configured story glob.
- Preserved the existing shared glob options, including the `node_modules` ignore.
- Added a regression fixture for a screenshot directory named `Button.stories.tsx` and assert neither the directory nor its nested `Primary.png` file is indexed.

Fixes #28954.

## Testing

- `git diff --check`
- `yarn oxfmt --check code/core/src/core-server/utils/StoryIndexGenerator.ts code/core/src/core-server/utils/StoryIndexGenerator.test.ts`
- `node --input-type=module` globby check confirming `**/*.stories.tsx/**` ignores nested files under `Button.stories.tsx/`

## Local test note

I installed dependencies with `yarn install --immutable`, then tried the focused Vitest file. The root config failed locally because `@storybook/addon-vitest/dist/vitest-plugin/index.js` was not resolvable, and the direct core config failed to resolve `storybook/internal/common` from the unbuilt workspace. I did not claim the full Vitest suite as passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Matching now returns only file paths (not directories), preventing directory names from being treated as story files during index generation.

* **Tests**
  * Added a test to ensure story-like directories and screenshot files are excluded from matched results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->