### PR TITLE
fix: support port value with exact-port

### DIFF
--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -15,6 +15,9 @@ import { globalSettings } from '../cli/globalSettings.ts';
 addToGlobalContext('cliVersion', version);
 process.env.STORYBOOK = 'true';
 
+const parsePort = (str: string) => parseInt(str, 10);
+const parseOptionalPort = (str?: string) => (str == null ? true : parsePort(str));
+
 /**
  * Core CLI for Storybook.
  *
@@ -80,7 +83,7 @@ const command = (name: string) =>
     });
 
 command('dev')
-  .option('-p, --port <number>', 'Port to run Storybook', (str) => parseInt(str, 10))
+  .option('-p, --port <number>', 'Port to run Storybook', parsePort)
   .option('-h, --host <string>', 'Host to run Storybook')
   .option('-c, --config-dir <dir-name>', 'Directory where to load Storybook configurations from')
   .option(
@@ -111,7 +114,11 @@ command('dev')
   )
   .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
   .option('--docs', 'Build a documentation-only site using addon-docs')
-  .option('--exact-port', 'Exit early if the desired port is not available')
+  .option(
+    '--exact-port [number]',
+    'Exit early if the desired port is not available',
+    parseOptionalPort
+  )
   .option(
     '--initial-path [path]',
     'URL path to be appended when visiting Storybook for the first time'
@@ -136,6 +143,10 @@ command('dev')
 
     if (parseInt(`${options.port}`, 10)) {
       options.port = parseInt(`${options.port}`, 10);
+    }
+    if (typeof options.exactPort === 'number') {
+      options.port = options.exactPort;
+      options.exactPort = true;
     }
 
     await dev({ ...options, packageJson }).catch(() => {

--- a/code/core/src/core-server/utils/server-address.test.ts
+++ b/code/core/src/core-server/utils/server-address.test.ts
@@ -66,6 +66,26 @@ describe('getServerPort', () => {
 
     expect(result).toBe(expectedFreePort);
   });
+
+  it('should not exit for exact port when no port is requested', async () => {
+    const expectedFreePort = 4000;
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(
+      ((code?: string | number | null) => {
+        throw new Error(`process.exit called with ${code}`);
+      }) as typeof process.exit
+    );
+
+    try {
+      vi.mocked(detectPort).mockResolvedValue(expectedFreePort);
+
+      const result = await getServerPort(undefined, { exactPort: true });
+
+      expect(result).toBe(expectedFreePort);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
 });
 
 describe('getServerChannelUrl', () => {

--- a/code/core/src/core-server/utils/server-address.ts
+++ b/code/core/src/core-server/utils/server-address.ts
@@ -34,7 +34,7 @@ interface PortOptions {
 export const getServerPort = (port?: number, { exactPort }: PortOptions = {}) =>
   detectFreePort(port)
     .then((freePort) => {
-      if (freePort !== port && exactPort) {
+      if (port != null && freePort !== port && exactPort) {
         process.exit(-1);
       }
       return freePort;


### PR DESCRIPTION
## What I did

- Allow `storybook dev --exact-port 6006` by accepting an optional port value on `--exact-port`.
- Normalize that value into `port` while keeping exact-port behavior enabled.
- Avoid exiting from the port resolver when exact mode is enabled but no requested port exists.

Fixes #30187.

## Testing

- git diff --check
- Could not run `yarn test code/core/src/core-server/utils/server-address.test.ts`: this checkout is missing the Yarn node_modules state file.