### PR TITLE
Docs: Support explicit id prop on <Meta> for standalone MDX

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -1958,6 +1958,39 @@ describe('StoryIndexGenerator', () => {
         `);
       });
 
+      it('uses the explicit id prop on <Meta> for standalone mdx docs', async () => {
+        const docsSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
+          './docs-id-generation/Standalone.docs.mdx',
+          options
+        );
+
+        const generator = new StoryIndexGenerator([docsSpecifier], options);
+        await generator.initialize();
+
+        const { storyIndex } = await generator.getIndexAndStats();
+        expect(storyIndex).toMatchInlineSnapshot(`
+          {
+            "entries": {
+              "custom-standalone-id--docs": {
+                "id": "custom-standalone-id--docs",
+                "importPath": "./docs-id-generation/Standalone.docs.mdx",
+                "name": "docs",
+                "storiesImports": [],
+                "tags": [
+                  "dev",
+                  "test",
+                  "manifest",
+                  "unattached-mdx",
+                ],
+                "title": "Standalone Page Title",
+                "type": "docs",
+              },
+            },
+            "v": 5,
+          }
+        `);
+      });
+
       it('puts the Meta of stories file first in storiesImports even when it is not the last import', async () => {
         const csfSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
           './src/*.stories.(js|ts)',

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -606,7 +606,7 @@ export class StoryIndexGenerator {
         result.name ||
         (csfEntry ? autoName(importPath, csfEntry.importPath, defaultName) : defaultName);
 
-      const id = toId(csfEntry?.extra.metaId || title, name);
+      const id = toId(csfEntry?.extra.metaId || result.id || title, name);
 
       const tags = combineTags(
         ...projectTags,

--- a/code/core/src/core-server/utils/__mockdata__/docs-id-generation/Standalone.docs.mdx
+++ b/code/core/src/core-server/utils/__mockdata__/docs-id-generation/Standalone.docs.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Standalone Page Title" id="custom-standalone-id" />
+
+# Standalone docs with explicit id
+
+hello docs

--- a/code/core/src/core-server/utils/analyze-mdx.test.ts
+++ b/code/core/src/core-server/utils/analyze-mdx.test.ts
@@ -48,6 +48,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [],
           "isTemplate": false,
           "metaTags": undefined,
@@ -79,6 +80,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [],
           "isTemplate": false,
           "metaTags": undefined,
@@ -101,6 +103,38 @@ describe('analyzeMdx', () => {
     });
   });
 
+  describe('id', () => {
+    it('string literal id', async () => {
+      const input = dedent`
+        # hello
+
+        <Meta title="foobar" id="custom-id" />
+      `;
+      await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
+        {
+          "id": "custom-id",
+          "imports": [],
+          "isTemplate": false,
+          "metaTags": undefined,
+          "name": undefined,
+          "of": undefined,
+          "summary": undefined,
+          "title": "foobar",
+        }
+      `);
+    });
+    it('template literal id', async () => {
+      const input = dedent`
+        # hello
+
+        <Meta id={\`foobar\`} />
+      `;
+      await expect(analyzeMdx(input)).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Expected string literal id, received JSXExpressionContainer]`
+      );
+    });
+  });
+
   describe('of', () => {
     it('basic', async () => {
       const input = dedent`
@@ -111,6 +145,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [
             "@storybook/blocks",
             "./Button.stories",
@@ -152,6 +187,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [
             "@storybook/blocks",
             "./Button.stories",
@@ -182,6 +218,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [
             "../src/A.stories",
           ],
@@ -214,6 +251,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [],
           "isTemplate": false,
           "metaTags": undefined,
@@ -241,6 +279,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [],
           "isTemplate": true,
           "metaTags": undefined,
@@ -257,6 +296,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [],
           "isTemplate": true,
           "metaTags": undefined,
@@ -273,6 +313,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [],
           "isTemplate": false,
           "metaTags": undefined,
@@ -312,6 +353,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [
             "./Button.stories",
           ],
@@ -361,6 +403,7 @@ describe('analyzeMdx', () => {
     `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [],
           "isTemplate": false,
           "metaTags": undefined,
@@ -379,6 +422,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [
             "./Button.stories",
           ],
@@ -423,6 +467,7 @@ describe('analyzeMdx', () => {
       `;
       await expect(analyzeMdx(input)).resolves.toMatchInlineSnapshot(`
         {
+          "id": undefined,
           "imports": [
             "./Button.stories",
           ],

--- a/code/core/src/core-server/utils/analyze-mdx.ts
+++ b/code/core/src/core-server/utils/analyze-mdx.ts
@@ -15,6 +15,7 @@ export type MdxAnalysisResult = {
   title: string | undefined;
   of: string | undefined;
   name: string | undefined;
+  id: string | undefined;
   summary: string | undefined;
   isTemplate: boolean;
   metaTags?: string[];
@@ -43,6 +44,7 @@ const createEmptyMdxMetadata = (): MdxMetadata => ({
   title: undefined,
   of: undefined,
   name: undefined,
+  id: undefined,
   summary: undefined,
   isTemplate: false,
   metaTags: undefined,
@@ -182,6 +184,7 @@ const extractMeta = (metaElement: MdxJsxFlowElement, importMap: ImportMap): MdxM
   title: getStringAttribute(metaElement, 'title'),
   of: getOfImportPath(metaElement, importMap),
   name: getStringAttribute(metaElement, 'name'),
+  id: getStringAttribute(metaElement, 'id'),
   summary: getStringAttribute(metaElement, 'summary'),
   isTemplate: getIsTemplate(metaElement),
   metaTags: getMetaTags(metaElement),


### PR DESCRIPTION
## What I did

Adds support for the `id` prop on `<Meta>` in standalone MDX files. Previously the prop was silently ignored — the docs entry id was always derived from `title` via `toId()`, so `<Meta title="Foundations/Accessibility" id="accessibility-overview" />` produced `foundations-accessibility--docs` instead of the expected `accessibility-overview--docs`. The `id` field is already extracted on CSF meta exports (`code/core/src/csf-tools/CsfFile.ts`); this PR brings the MDX path to parity.

Changes:

- **`code/core/src/core-server/utils/analyze-mdx.ts`** — added `id` to `MdxAnalysisResult`, `createEmptyMdxMetadata`, and `extractMeta` (re-using the existing `getStringAttribute` helper). Same string-literal rules as the other string attributes.
- **`code/core/src/core-server/utils/StoryIndexGenerator.ts`** — at line 609, added `result.id` to the precedence chain used to build the docs entry id:
  ```diff
  - const id = toId(csfEntry?.extra.metaId || title, name);
  + const id = toId(csfEntry?.extra.metaId || result.id || title, name);
  ```
  Order: attached CSF's `meta.id` &gt; MDX `<Meta id>` &gt; title fallback. Existing attached-MDX behaviour is unchanged when `<Meta>` doesn't set `id`.
- Tests:
  - `analyze-mdx.test.ts` — added a `describe('id')` block (string literal + template literal rejection, mirroring `title`/`name`). Existing inline snapshots regenerated to include `id: undefined`.
  - `StoryIndexGenerator.test.ts` — added `'uses the explicit id prop on <Meta> for standalone mdx docs'` with a new fixture `__mockdata__/docs-id-generation/Standalone.docs.mdx`. The fixture is intentionally placed in `docs-id-generation/` rather than `src/docs2/` to avoid disturbing the docs2 caching-count tests.

Fixes #34684

## How to test

```bash
cd code && yarn storybook:ui
```

Or run the unit tests directly:

```bash
yarn vitest run code/core/src/core-server/utils/analyze-mdx.test.ts
yarn vitest run code/core/src/core-server/utils/StoryIndexGenerator.test.ts
```

Manual repro from the issue:

```mdx
<Meta title="Foundations/Accessibility/Overview" id="accessibility-overview" />
```

Before: URL is `?path=/docs/foundations-accessibility-overview--docs`
After: URL is `?path=/docs/accessibility-overview--docs`

#### Manual testing

- `yarn fmt:write`
- `yarn nx run-many -t check` (clean for changed projects; one pre-existing `nextjs-vite` duplicate-export failure unrelated to this change)
- `yarn lint:js:cmd` on the modified files (0 errors)
- `yarn vitest` for both affected test files — all snapshots regenerated, new id-related tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone MDX docs can now use an explicit Meta id; IDs will be respected and normalized with a consistent fallback when omitted.

* **Validation**
  * MDX Meta id now accepts only string literals; non-literal/template ids produce a clear error.

* **Tests**
  * Added and updated unit tests to cover id extraction, validation, and generation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->