### PR TITLE
UI: Allow manager-head favicon override

### DIFF
--- a/code/core/src/builder-manager/utils/template.test.ts
+++ b/code/core/src/builder-manager/utils/template.test.ts
@@ -1,0 +1,57 @@
+import { expect, it } from 'vitest';
+
+import type { Options } from 'storybook/internal/types';
+
+import { customHeadHasFavicon, renderHTML } from './template.ts';
+
+const template = `
+<head>
+<% if (favicon.endsWith('.svg')) {%>
+<link rel="icon" type="image/svg+xml" href="./<%= favicon %>" />
+<% } else if (favicon.endsWith('.ico')) { %>
+<link rel="icon" type="image/x-icon" href="./<%= favicon %>" />
+<% } %>
+<% if (typeof head !== 'undefined') { %><%- head %><% } %>
+</head>
+`;
+
+const renderManagerHtml = (customHead = '') =>
+  renderHTML(
+    Promise.resolve(template),
+    Promise.resolve('Example'),
+    Promise.resolve('favicon.svg'),
+    Promise.resolve(customHead),
+    [],
+    [],
+    Promise.resolve({}),
+    Promise.resolve({}),
+    Promise.resolve('info'),
+    Promise.resolve({}),
+    Promise.resolve({}),
+    {
+      versionCheck: undefined,
+      previewUrl: undefined,
+      configType: 'DEVELOPMENT',
+      ignorePreview: false,
+    } as Options,
+    {}
+  );
+
+it('renders the default manager favicon when custom head does not provide one', async () => {
+  const html = await renderManagerHtml('<link rel="stylesheet" href="./manager.css" />');
+
+  expect(html).toContain('href="./favicon.svg"');
+  expect(html).toContain('href="./manager.css"');
+});
+
+it('does not render the default manager favicon when custom head provides an icon', async () => {
+  const html = await renderManagerHtml('<link rel="icon" type="image/png" href="./ui.png" />');
+
+  expect(html).not.toContain('href="./favicon.svg"');
+  expect(html).toContain('href="./ui.png"');
+});
+
+it('detects shortcut icon links without treating touch icons as favicons', () => {
+  expect(customHeadHasFavicon('<link rel="shortcut icon" href="./favicon.ico" />')).toBe(true);
+  expect(customHeadHasFavicon('<link rel="apple-touch-icon" href="./touch.png" />')).toBe(false);
+});

--- a/code/core/src/builder-manager/utils/template.ts
+++ b/code/core/src/builder-manager/utils/template.ts
@@ -21,6 +21,17 @@ export async function getManagerMainTemplate() {
   return getTemplatePath(`manager.ejs`);
 }
 
+export const customHeadHasFavicon = (head: string) => {
+  const linkTags = head.match(/<link\b[^>]*>/gi) || [];
+
+  return linkTags.some((tag) => {
+    const rel = tag.match(/\brel\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i);
+    const value = rel?.[1] || rel?.[2] || rel?.[3] || '';
+
+    return value.split(/\s+/).some((token) => token.toLowerCase() === 'icon');
+  });
+};
+
 export const renderHTML = async (
   template: Promise<string>,
   title: Promise<string | false>,
@@ -38,6 +49,7 @@ export const renderHTML = async (
 ) => {
   const titleRef = await title;
   const templateRef = await template;
+  const headRef = (await customHead) || '';
   const stringifiedGlobals = Object.entries(globals).reduce(
     (transformed, [key, value]) => ({ ...transformed, [key]: JSON.stringify(value) }),
     {}
@@ -46,7 +58,7 @@ export const renderHTML = async (
   return render(templateRef, {
     title: titleRef ? `${titleRef} - Storybook` : 'Storybook',
     files: { js: jsFiles, css: cssFiles },
-    favicon: await favicon,
+    favicon: customHeadHasFavicon(headRef) ? '' : await favicon,
     globals: {
       FEATURES: JSON.stringify(await features, null, 2),
       REFS: JSON.stringify(await refs, null, 2),
@@ -59,7 +71,7 @@ export const renderHTML = async (
       TAGS_OPTIONS: JSON.stringify(await tagsOptions, null, 2),
       ...stringifiedGlobals,
     },
-    head: (await customHead) || '',
+    head: headRef,
     ignorePreview,
   });
 };


### PR DESCRIPTION
## What I did
- Detect custom favicon links in manager head HTML.
- Suppress Storybook's default manager favicon when a custom icon is provided through manager-head.html.
- Add unit coverage for default/favicon override behavior.

Fixes #25280.

## Testing
- git diff --check
- yarn test code/core/src/builder-manager/utils/template.test.ts *(fails to start in this checkout: missing Yarn node_modules state file)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved favicon handling in the builder manager to avoid duplicate or missing favicons when custom HTML head content is provided.
* **Tests**
  * Added tests verifying favicon detection behavior, including handling of shortcut icon links and exclusion of apple-touch icons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

#### Manual testing

* Create new project
* Add favicon to manager-head as on GH issue
* Run SB and check the favicon is shown