### PR TITLE
Maintenance: Extract createPreviewAnnotations factory to reduce dupli…

### DIFF
--- a/code/core/src/common/index.ts
+++ b/code/core/src/common/index.ts
@@ -48,6 +48,7 @@ export * from './utils/get-addon-names.ts';
 export * from './utils/utils.ts';
 export * from './utils/command.ts';
 export * from './node-version.ts';
+export * from './utils/create-preview-annotations.ts';
 
 export { versions };
 

--- a/code/core/src/common/utils/create-preview-annotations.test.ts
+++ b/code/core/src/common/utils/create-preview-annotations.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPreviewAnnotations } from './create-preview-annotations';
+
+const mockOptions = (docsPreset: Record<string, unknown> = {}) =>
+  ({
+    presets: {
+      apply: vi.fn().mockResolvedValue(docsPreset),
+    },
+  }) as any;
+
+describe('createPreviewAnnotations', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('includes entry-preview', async () => {
+    const fn = createPreviewAnnotations('@storybook/html');
+    const result = await fn([], mockOptions());
+    expect(result?.some((p: string) => p.includes('entry-preview'))).toBe(true);
+  });
+
+  it('does NOT include entry-preview-docs when docs is disabled', async () => {
+    const fn = createPreviewAnnotations('@storybook/html');
+    const result = await fn([], mockOptions({}));
+    expect(result?.some((p: string) => p.includes('entry-preview-docs'))).toBe(false);
+  });
+
+  it('includes entry-preview-docs when docs is enabled', async () => {
+    const fn = createPreviewAnnotations('@storybook/html');
+    const result = await fn([], mockOptions({ someDocsConfig: true }));
+    expect(result?.some((p: string) => p.includes('entry-preview-docs'))).toBe(true);
+  });
+
+  it('preserves user input at the start', async () => {
+    const fn = createPreviewAnnotations('@storybook/html');
+    const result = await fn(['/user/custom.js'], mockOptions());
+    expect(result?.[0]).toBe('/user/custom.js');
+  });
+
+  it('includes extraEntries before entry-preview', async () => {
+    const fn = createPreviewAnnotations('@storybook/web-components', [
+      '@storybook/web-components/entry-preview-argtypes',
+    ]);
+    const result = await fn([], mockOptions());
+    const argtypesIdx =
+      result?.findIndex((p: string) => p.includes('entry-preview-argtypes')) ?? -1;
+    const previewIdx =
+      result?.findIndex(
+        (p: string) => p.includes('entry-preview') && !p.includes('argtypes') && !p.includes('docs')
+      ) ?? -1;
+    expect(argtypesIdx).toBeGreaterThan(-1);
+    expect(previewIdx).toBeGreaterThan(-1);
+    expect(argtypesIdx).toBeLessThan(previewIdx);
+  });
+});

--- a/code/core/src/common/utils/create-preview-annotations.ts
+++ b/code/core/src/common/utils/create-preview-annotations.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url';
+
+import type { PresetPropertyFn } from 'storybook/internal/types';
+
+export function createPreviewAnnotations(
+  packageName: string,
+  extraEntries: string[] = []
+): PresetPropertyFn<'previewAnnotations'> {
+  return async (input = [], options) => {
+    const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
+    const result: string[] = [];
+
+    return result
+      .concat(input)
+      .concat(extraEntries.map((e) => fileURLToPath(import.meta.resolve(e))))
+      .concat([fileURLToPath(import.meta.resolve(`${packageName}/entry-preview`))])
+      .concat(
+        docsEnabled ? [fileURLToPath(import.meta.resolve(`${packageName}/entry-preview-docs`))] : []
+      );
+  };
+}

--- a/code/renderers/html/src/preset.ts
+++ b/code/renderers/html/src/preset.ts
@@ -1,18 +1,6 @@
-import { fileURLToPath } from 'node:url';
-
 import type { PresetProperty } from 'storybook/internal/types';
 
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-  return result
-    .concat(input)
-    .concat([fileURLToPath(import.meta.resolve('@storybook/html/entry-preview'))])
-    .concat(
-      docsEnabled ? [fileURLToPath(import.meta.resolve('@storybook/html/entry-preview-docs'))] : []
-    );
-};
+export const previewAnnotations: PresetProperty<'previewAnnotations'> =
+  createPreviewAnnotations('@storybook/html');

--- a/code/renderers/preact/src/preset.ts
+++ b/code/renderers/preact/src/preset.ts
@@ -1,23 +1,9 @@
-import { fileURLToPath } from 'node:url';
-
 import type { PresetProperty } from 'storybook/internal/types';
 
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-  return result
-    .concat(input)
-    .concat([fileURLToPath(import.meta.resolve('@storybook/preact/entry-preview'))])
-    .concat(
-      docsEnabled
-        ? [fileURLToPath(import.meta.resolve('@storybook/preact/entry-preview-docs'))]
-        : []
-    );
-};
+export const previewAnnotations: PresetProperty<'previewAnnotations'> =
+  createPreviewAnnotations('@storybook/preact');
 
 /**
  * Alias react and react-dom to preact/compat similar to the preact vite preset

--- a/code/renderers/svelte/src/preset.ts
+++ b/code/renderers/svelte/src/preset.ts
@@ -1,20 +1,6 @@
-import { fileURLToPath } from 'node:url';
-
 import type { PresetProperty } from 'storybook/internal/types';
 
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-  return result
-    .concat(input)
-    .concat([fileURLToPath(import.meta.resolve('@storybook/svelte/entry-preview'))])
-    .concat(
-      docsEnabled
-        ? [fileURLToPath(import.meta.resolve('@storybook/svelte/entry-preview-docs'))]
-        : []
-    );
-};
+export const previewAnnotations: PresetProperty<'previewAnnotations'> =
+  createPreviewAnnotations('@storybook/svelte');

--- a/code/renderers/vue3/src/preset.ts
+++ b/code/renderers/vue3/src/preset.ts
@@ -1,18 +1,6 @@
-import { fileURLToPath } from 'node:url';
-
 import type { PresetProperty } from 'storybook/internal/types';
 
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-  return result
-    .concat(input)
-    .concat([fileURLToPath(import.meta.resolve('@storybook/vue3/entry-preview'))])
-    .concat(
-      docsEnabled ? [fileURLToPath(import.meta.resolve('@storybook/vue3/entry-preview-docs'))] : []
-    );
-};
+export const previewAnnotations: PresetProperty<'previewAnnotations'> =
+  createPreviewAnnotations('@storybook/vue3');

--- a/code/renderers/web-components/src/preset.ts
+++ b/code/renderers/web-components/src/preset.ts
@@ -1,23 +1,8 @@
-import { fileURLToPath } from 'node:url';
-
 import type { PresetProperty } from 'storybook/internal/types';
 
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-  return result
-    .concat(input)
-    .concat([
-      fileURLToPath(import.meta.resolve('@storybook/web-components/entry-preview')),
-      fileURLToPath(import.meta.resolve('@storybook/web-components/entry-preview-argtypes')),
-    ])
-    .concat(
-      docsEnabled
-        ? [fileURLToPath(import.meta.resolve('@storybook/web-components/entry-preview-docs'))]
-        : []
-    );
-};
+export const previewAnnotations: PresetProperty<'previewAnnotations'> = createPreviewAnnotations(
+  '@storybook/web-components',
+  ['@storybook/web-components/entry-preview-argtypes']
+);


### PR DESCRIPTION
Closes #34389

## What I did

Extracted the duplicated `previewAnnotations` logic into a shared `createPreviewAnnotations` factory at `code/core/src/common/utils/create-preview-annotations.ts` and refactored 5 renderer presets to use it.

The `previewAnnotations` function was nearly identical across `html`, `preact`, `svelte`, `vue3`, and `web-components` renderer presets, differing only in the package name string. This refactor centralizes the logic into a single factory helper, making future changes to the `docsEnabled` check or entry resolution apply automatically to all renderers.

The `react` renderer was intentionally left out as it contains additional RSC feature-flag logic that goes beyond the scope of this change.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests

#### Manual testing

No manual testing is required. This is a pure refactor with no behavior changes — the same entry files are resolved in the same order as before. The shared logic is covered by the new unit tests in `create-preview-annotations.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated preview annotations logic across HTML, Preact, Svelte, Vue, and Web Components renderers for improved maintainability.

* **Tests**
  * Added comprehensive tests for preview annotations generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->