### PR TITLE
fix(a11y): correct ARIA accordion structure in Object control

### DIFF
--- a/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodeAccordion.tsx
+++ b/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodeAccordion.tsx
@@ -56,6 +56,13 @@ const Trigger = styled.button(({ theme }) => ({
   },
 }));
 
+const Heading = styled.h3({
+  margin: 0,
+  display: 'inline',
+  fontSize: 'inherit',
+  fontWeight: 'normal',
+});
+
 const Region = styled.div({
   display: 'inline',
 });
@@ -88,18 +95,20 @@ export function JsonNodeAccordion({
 
   return (
     <Container as={containerTag}>
-      <Trigger
-        type="button"
-        aria-expanded={!collapsed}
-        id={ids.trigger}
-        aria-controls={ids.region}
-        className="rejt-accordion-button"
-        {...props}
-      >
-        {name} :
-      </Trigger>
+      <Heading role="heading" aria-level={deep + 2}>
+        <Trigger
+          type="button"
+          aria-expanded={!collapsed}
+          id={ids.trigger}
+          aria-controls={ids.region}
+          className="rejt-accordion-button"
+          {...props}
+        >
+          {name} :
+        </Trigger>
+      </Heading>
       <Region
-        role="group"
+        role="region"
         id={ids.region}
         aria-labelledby={ids.trigger}
         className="rejt-accordion-region"


### PR DESCRIPTION
## What
Fix the ARIA structure of the JSON tree accordion component used in the Object control to follow the WAI-ARIA Accordion Pattern.

## Why
Closes #24150. The Object control JSON tree was failing accessibility checks because:
- The accordion trigger button was not wrapped in a heading element as required by the WAI-ARIA Accordion Pattern
- The accordion panel used `role="group"` instead of the correct `role="region"`
- This caused issues with keyboard navigation and screen reader announcements

## How
- Wrapped the accordion trigger button in a `h3` element with `role="heading"` and dynamic `aria-level` based on nesting depth
- Changed the panel role from `group` to `region`
- Added minimal CSS to the heading wrapper to maintain existing visual appearance

## Testing
- [ ] Verify accordion expand/collapse still works with keyboard (Enter/Space)
- [ ] Verify screen readers announce headings correctly when navigating the JSON tree
- [ ] Run Accessibility Insights for Web to confirm no ARIA structure violations
- [ ] Verify visual appearance is unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced accessibility of the JSON tree accordion with improved heading semantics and region labeling for better screen reader compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->