### PR TITLE
Next.js-Vite: Bump vite-plugin-storybook-nextjs to ^3.3.0

### DIFF
--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -92,7 +92,7 @@
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
     "styled-jsx": "5.1.6",
-    "vite-plugin-storybook-nextjs": "^3.2.4"
+    "vite-plugin-storybook-nextjs": "^3.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8762,7 +8762,7 @@ __metadata:
     semver: "npm:^7.7.3"
     styled-jsx: "npm:5.1.6"
     typescript: "npm:^5.9.3"
-    vite-plugin-storybook-nextjs: "npm:^3.2.4"
+    vite-plugin-storybook-nextjs: "npm:^3.3.0"
   peerDependencies:
     "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     "@types/react-dom": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -31979,9 +31979,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-storybook-nextjs@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "vite-plugin-storybook-nextjs@npm:3.2.4"
+"vite-plugin-storybook-nextjs@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "vite-plugin-storybook-nextjs@npm:3.3.0"
   dependencies:
     "@next/env": "npm:16.0.0"
     image-size: "npm:^2.0.0"
@@ -31991,9 +31991,9 @@ __metadata:
     vite-tsconfig-paths: "npm:^5.1.4"
   peerDependencies:
     next: ^14.1.0 || ^15.0.0 || ^16.0.0
-    storybook: ^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+    storybook: ^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0
     vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 10c0/74c4969ec5f19e3045d301cfc72c2702134c19223851a81f955ae2f26252305a6f5ebe101d21e91bd2d88fd76d2ed10b7ae22a5c63b47f085328b87864a63664
+  checksum: 10c0/4582deb9566f5ffa05b15ac3544e32ec9058aec63893569ecd5d7c64f5c400f5f4c03c7c7ecdb114fba9bcacd0ae83cdec6ff6d4e61069832667f8c5124ca2e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #34778

## What I did

Fixed a regression where stories and docs pages using `next/image` threw `Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. Check the render method of NextImage.` under `@storybook/nextjs-vite` with Next.js 16 + Vite 8 + pnpm. This broke the auto-generated "Configure your project" docs page that `pnpm create storybook@latest` ships in every fresh Next.js project.

Root cause: Vite 8 swapped esbuild for Rolldown as the dep pre-bundler. Rolldown wraps CJS modules differently, so `import * as NextImageNamespace from "next/image"` ends up with `NextImageNamespace.default === { __esModule: true, default: <Image>, getImageProps }` (the CJS exports object) instead of the Image component itself. The `MockedNextImage` wrapper then rendered an object, triggering the React "Element type is invalid" error.

The actual code fix landed upstream in `vite-plugin-storybook-nextjs@3.3.0` ([storybookjs/vite-plugin-storybook-nextjs#117](https://github.com/storybookjs/vite-plugin-storybook-nextjs/pull/117)) — it defensively unwraps the `__esModule` object before rendering. The previous `^3.2.4` range in `@storybook/nextjs-vite` permitted 3.3.0, but pnpm 11's default `minimumReleaseAge` silently downgrades freshly-published versions to the previous one (3.2.5), so users on pnpm keep hitting the bug. Raising the floor to `^3.3.0` forces resolution to the fixed version regardless of the maturity gate.

Changes:
- Bumped `vite-plugin-storybook-nextjs` from `^3.2.4` to `^3.3.0` in `code/frameworks/nextjs-vite/package.json`
- Updated `yarn.lock` to resolve `vite-plugin-storybook-nextjs@npm:3.3.0`

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing
1. `pnpm create storybook@latest` in a fresh Next.js 16 project (or reproduce with the exact `package.json` from the issue)
2. Run `pnpm storybook`
3. Open the auto-generated "Configure your project" docs page
4. Before the fix: page renders the Storybook error overlay with "Element type is invalid... Check the render method of NextImage."
5. After the fix: page renders cleanly with all images visible
6. Also verify a plain `<Image src="..." />` story renders without console errors

### Documentation
- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers
- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below: `bug`, `maintenance`, `dependencies`, `feature request`, `BREAKING CHANGE`, `other`

## 🦋 Canary release

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vite-plugin-storybook-nextjs dependency to version 3.3.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->