### PR TITLE
Addon-Docs: Resolve providerImportSource to a path instead of a file:// URL

### DIFF
--- a/code/addons/docs/src/mdx-plugin.ts
+++ b/code/addons/docs/src/mdx-plugin.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import type { Options } from 'storybook/internal/types';
 
 import { createFilter } from '@rollup/pluginutils';
@@ -36,7 +38,9 @@ export async function mdxPlugin(options: Options): Promise<Plugin> {
         const mdxLoaderOptions: CompileOptions = await presets.apply('mdxLoaderOptions', {
           ...mdxPluginOptions,
           mdxCompileOptions: {
-            providerImportSource: import.meta.resolve('@storybook/addon-docs/mdx-react-shim'),
+            providerImportSource: fileURLToPath(
+              import.meta.resolve('@storybook/addon-docs/mdx-react-shim')
+            ),
             ...mdxPluginOptions?.mdxCompileOptions,
             rehypePlugins: [
               ...(mdxPluginOptions?.mdxCompileOptions?.rehypePlugins ?? []),

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -49,7 +49,9 @@ async function webpack(
   const mdxLoaderOptions: CompileOptions = await options.presets.apply('mdxLoaderOptions', {
     ...mdxPluginOptions,
     mdxCompileOptions: {
-      providerImportSource: import.meta.resolve('@storybook/addon-docs/mdx-react-shim'),
+      providerImportSource: fileURLToPath(
+        import.meta.resolve('@storybook/addon-docs/mdx-react-shim')
+      ),
       ...mdxPluginOptions.mdxCompileOptions,
       rehypePlugins: [
         ...(mdxPluginOptions?.mdxCompileOptions?.rehypePlugins ?? []),


### PR DESCRIPTION
Closes #34545

## What I did

`providerImportSource` for the MDX compiler was set directly from `import.meta.resolve('@storybook/addon-docs/mdx-react-shim')`. In Node ESM, `import.meta.resolve()` returns a `file://` URL, and the MDX compiler uses that value verbatim as the import specifier in its output:

```js
import { useMDXComponents as _provideComponents } from "file:///.../addon-docs/dist/mdx-react-shim.js";
```

Vite's `vite:import-analysis` plugin cannot resolve `file://` URL specifiers, so every `.mdx` file fails to compile.

`providerImportSource` was the only `import.meta.resolve()` call in these files not wrapped in `fileURLToPath()` — `mdx` and the MDX `loader` in `preset.ts` already convert to a path. This applies the same treatment in both the Vite plugin (`mdx-plugin.ts`) and the webpack preset (`preset.ts`).

#### Manual testing

Minimal repro — a `@storybook/react-vite` project with one `.mdx` file, on Vite 5:

**Before** — `storybook dev` fails immediately with a `vite:import-analysis` error:

<img width="1914" height="1029" alt="before-fix" src="https://github.com/user-attachments/assets/b40c1d6b-6002-449c-909e-64d2bb382432" />


**After** — the MDX docs page renders:

<img width="1917" height="1031" alt="after-fix" src="https://github.com/user-attachments/assets/7c8a22fa-c542-48f6-9475-19144c4dbde0" />


## What I changed

- `code/addons/docs/src/mdx-plugin.ts` — import `fileURLToPath`, wrap `providerImportSource`
- `code/addons/docs/src/preset.ts` — wrap `providerImportSource` (`fileURLToPath` already imported)

## Checklist

- [x] Verified end-to-end against a Vite 5 reproduction (before/after above)
- [x] `addon-docs` compiles (`yarn nx compile addon-docs`)
- [x] No new lint warnings

No unit test added: `providerImportSource` is build-time preset wiring around `import.meta.resolve()`, which is environment-dependent and not meaningfully isolatable. The end-to-end repro is the verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MDX documentation processing now uses filesystem-style paths for provider imports, improving reliability of doc compilation.
  * Reduces path-resolution related build errors and ensures more consistent documentation rendering across environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->