### PR TITLE
Build: Preapprove Storybook packages for yarn npmMinimalAgeGate in sandboxes

### DIFF
--- a/code/core/src/common/satellite-addons.ts
+++ b/code/core/src/common/satellite-addons.ts
@@ -8,6 +8,7 @@ export default [
   '@storybook/addon-webpack5-compiler-babel',
   '@storybook/addon-webpack5-compiler-swc',
   '@storybook/addon-mcp',
+  'vite-plugin-storybook-nextjs',
   // Storybook for React Native related packages
   // TODO: For Storybook 10, we should check about possible automigrations
   '@storybook/addon-ondevice-actions',

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -1,6 +1,7 @@
 import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import satelliteAddons from '../../code/core/src/common/satellite-addons.ts';
 // TODO -- should we generate this file a second time outside of CLI?
 import storybookVersions from '../../code/core/src/common/versions.ts';
 import { allTemplates } from '../../code/lib/cli-storybook/src/sandbox-templates.ts';
@@ -52,7 +53,7 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
 // our own so sandboxes can install them immediately.
 const SANDBOX_NPM_MINIMAL_AGE_GATE_MINUTES = 7 * 24 * 60;
 const SANDBOX_NPM_PREAPPROVED_PACKAGES = Array.from(
-  new Set([...Object.keys(storybookVersions), '@chromatic-com/storybook'])
+  new Set([...Object.keys(storybookVersions), ...satelliteAddons])
 );
 
 export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -45,6 +45,16 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 };
 
+// Storybook monorepo packages plus known satellite packages. These are freshly
+// published to the local Verdaccio registry on every sandbox run, so they would
+// always be blocked by yarn's `npmMinimalAgeGate` (default 1d since yarn 4.15.0).
+// We tighten the gate to 7 days for unknown third-party packages but preapprove
+// our own so sandboxes can install them immediately.
+const SANDBOX_NPM_MINIMAL_AGE_GATE_MINUTES = 7 * 24 * 60;
+const SANDBOX_NPM_PREAPPROVED_PACKAGES = Array.from(
+  new Set([...Object.keys(storybookVersions), '@chromatic-com/storybook'])
+);
+
 export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
   await rm(join(cwd, '.yarnrc.yml'), { force: true }).catch(() => {});
 
@@ -59,10 +69,14 @@ export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
     ])
   );
 
+  const preapprovedJson = JSON.stringify(JSON.stringify(SANDBOX_NPM_PREAPPROVED_PACKAGES));
+
   const command = [
     `yarn set version berry`,
     `yarn config set enableGlobalCache true`, // Use the global cache so we aren't re-caching dependencies each time we run sandbox
     `yarn config set checksumBehavior ignore`,
+    `yarn config set npmMinimalAgeGate ${SANDBOX_NPM_MINIMAL_AGE_GATE_MINUTES}`,
+    `yarn config set npmPreapprovedPackages --json ${preapprovedJson}`,
   ];
 
   if (!pnpApiExists) {


### PR DESCRIPTION
## Summary

Yarn 4.15.0 enables `npmMinimalAgeGate: 1d` by default ([yarnpkg/berry#7135](https://github.com/yarnpkg/berry/pull/7135)), which quarantines freshly-published packages from the local Verdaccio registry and breaks sandbox creation:

```
SB_CLI_0002 (MinimumReleaseAgeHandledError): yarn blocked package installation
because your project uses npmMinimalAgeGate.

Failed package: create-storybook@10.5.0-alpha.0
```

This PR configures the sandbox yarn install (`scripts/utils/yarn.ts → installYarn2`) to:

- Tighten the gate to **7 days** (`10080` minutes) — stricter than yarn's new `1d` default for unknown third-party packages.
- Preapprove every Storybook monorepo package (derived dynamically from `code/core/src/common/versions.ts`) plus the known satellite `@chromatic-com/storybook`, so freshly-released sandbox packages aren't blocked.

The package list stays in sync as packages are added to or removed from `versions.ts`.

## Test plan

- [ ] CI sandbox creation succeeds (lit-vite/default-ts and others that were failing on `next`)
- [ ] Locally: `yarn task sandbox --template react-vite/default-ts --start-from auto` completes without `YN0016`
- [ ] The generated `.yarnrc.yml` in the sandbox contains `npmMinimalAgeGate: 10080` and `npmPreapprovedPackages` with the Storybook package list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced a 7‑day package age gate for sandbox Yarn installs to improve stability.
  * Preapproved an allowlist of Storybook-related packages (including the new vite-plugin-storybook-nextjs) to speed and stabilize sandbox setup, improving reliability of local development and testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->