### PR TITLE
Build: Disable yarn npmMinimalAgeGate inside sandboxes

### DIFF
--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -63,6 +63,10 @@ export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
     `yarn set version berry`,
     `yarn config set enableGlobalCache true`, // Use the global cache so we aren't re-caching dependencies each time we run sandbox
     `yarn config set checksumBehavior ignore`,
+    // Yarn 4.15.0 defaults `npmMinimalAgeGate` to 1d, which quarantines freshly
+    // published Storybook packages from the local Verdaccio registry. Disable
+    // the gate inside sandboxes so installs aren't blocked.
+    `yarn config set npmMinimalAgeGate 0`,
   ];
 
   if (!pnpApiExists) {


### PR DESCRIPTION
## Summary

Yarn 4.15.0 enables `npmMinimalAgeGate: 1d` by default ([yarnpkg/berry#7135](https://github.com/yarnpkg/berry/pull/7135)), which quarantines freshly-published packages from the local Verdaccio registry and breaks every sandbox build on `next`:

```
SB_CLI_0002 (MinimumReleaseAgeHandledError): yarn blocked package installation
because your project uses npmMinimalAgeGate.

Failed package: create-storybook@10.5.0-alpha.0
```

This PR is a minimal, fast-track unblock for the team: set `npmMinimalAgeGate 0` in the sandbox yarn config (`scripts/utils/yarn.ts → installYarn2`) so freshly-published packages from the local Verdaccio registry aren't quarantined.

A follow-up PR (#34842) replaces this with the proper preapproval-based approach (7-day gate for unknown third-party packages, monorepo + satellite packages preapproved). This PR exists so we can ship the unblock immediately without waiting for that one to go green.

## Test plan

- [ ] CI sandbox creation succeeds on previously-failing templates (e.g. `lit-vite/default-ts`)
- [ ] Locally: `yarn task sandbox --template react-vite/default-ts --start-from auto` completes without `YN0016`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Yarn configuration to improve installation compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->