### PR TITLE
Build: Sanitize publish-time .yarnrc.yml in after-storybook sandboxes

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,6 +14,12 @@ logFilters:
 
 nodeLinker: node-modules
 
+# Refuse to resolve versions published less than 7 days ago, so a compromised
+# release has time to be detected and unpublished before it can enter the tree.
+# Only affects new or updated resolutions; installs from the committed lockfile
+# are unaffected. Matches the gate used for generated sandboxes.
+npmMinimalAgeGate: 10080
+
 npmPublishAccess: public
 
 tsEnableAutoTypes: true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,10 +14,6 @@ logFilters:
 
 nodeLinker: node-modules
 
-# Refuse to resolve versions published less than 7 days ago, so a compromised
-# release has time to be detected and unpublished before it can enter the tree.
-# Only affects new or updated resolutions; installs from the committed lockfile
-# are unaffected. Matches the gate used for generated sandboxes.
 npmMinimalAgeGate: 10080
 
 npmPublishAccess: public

--- a/scripts/sandbox/publish.ts
+++ b/scripts/sandbox/publish.ts
@@ -11,6 +11,7 @@ import { dirname, join, relative } from 'path';
 import { temporaryDirectory } from '../../code/core/src/common/utils/cli.ts';
 import { REPROS_DIRECTORY } from '../utils/constants.ts';
 import { commitAllToGit } from './utils/git.ts';
+import { sanitizePublishedSandboxes } from './utils/sanitize-published-sandbox.ts';
 import { getTemplatesData, renderTemplate } from './utils/template.ts';
 
 export const logger = console;
@@ -69,6 +70,13 @@ const publish = async (options: PublishOptions & { tmpFolder: string }) => {
 
   logger.log(`🚛 Moving all the repros into the repository`);
   await cp(REPROS_DIRECTORY, tmpFolder, { recursive: true });
+
+  logger.log(`🧼 Sanitizing published sandboxes (after-storybook .yarnrc.yml + install artifacts)`);
+  const sanitizeResult = await sanitizePublishedSandboxes(tmpFolder);
+  logger.log(
+    `🧼 Sanitize summary: stripped ${sanitizeResult.strippedKeyCount} key(s) from ` +
+      `${sanitizeResult.filteredYarnrcCount} .yarnrc.yml file(s); removed ${sanitizeResult.removedPaths} excluded path(s)`
+  );
 
   await commitAllToGit({ cwd: tmpFolder, branch });
 

--- a/scripts/sandbox/publish.ts
+++ b/scripts/sandbox/publish.ts
@@ -11,7 +11,10 @@ import { dirname, join, relative } from 'path';
 import { temporaryDirectory } from '../../code/core/src/common/utils/cli.ts';
 import { REPROS_DIRECTORY } from '../utils/constants.ts';
 import { commitAllToGit } from './utils/git.ts';
-import { sanitizePublishedSandboxes } from './utils/sanitize-published-sandbox.ts';
+import {
+  ensureLockfilePublishRules,
+  sanitizePublishedSandboxes,
+} from './utils/sanitize-published-sandbox.ts';
 import { getTemplatesData, renderTemplate } from './utils/template.ts';
 
 export const logger = console;
@@ -76,6 +79,13 @@ const publish = async (options: PublishOptions & { tmpFolder: string }) => {
   logger.log(
     `🧼 Sanitize summary: stripped ${sanitizeResult.strippedKeyCount} key(s) from ` +
       `${sanitizeResult.filteredYarnrcCount} .yarnrc.yml file(s); removed ${sanitizeResult.removedPaths} excluded path(s)`
+  );
+
+  const gitignoreUpdated = await ensureLockfilePublishRules(tmpFolder);
+  logger.log(
+    gitignoreUpdated
+      ? `🧼 Added the before-storybook lockfile exception to .gitignore`
+      : `🧼 .gitignore already publishes the before-storybook lockfile`
   );
 
   await commitAllToGit({ cwd: tmpFolder, branch });

--- a/scripts/sandbox/utils/sanitize-published-sandbox.test.ts
+++ b/scripts/sandbox/utils/sanitize-published-sandbox.test.ts
@@ -1,0 +1,161 @@
+import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  EXCLUDE_GLOBS,
+  STRIP_KEYS,
+  sanitizePublishedSandboxes,
+} from './sanitize-published-sandbox.ts';
+
+const exists = async (path: string) => {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe('STRIP_KEYS', () => {
+  it('contains exactly the documented host-local / verdaccio keys', () => {
+    // Mutating this list requires deliberate code review — if you are touching it,
+    // make sure the published sandboxes repository contract is intentional.
+    expect([...STRIP_KEYS]).toEqual([
+      'npmRegistryServer',
+      'unsafeHttpWhitelist',
+      'enableImmutableInstalls',
+      'enableMirror',
+      'logFilters',
+      'npmMinimalAgeGate',
+      'pnpFallbackMode',
+      'enableGlobalCache',
+      'checksumBehavior',
+    ]);
+  });
+});
+
+describe('EXCLUDE_GLOBS', () => {
+  it('targets only known install / build artifacts', () => {
+    expect([...EXCLUDE_GLOBS]).toEqual([
+      '**/.yarn/cache/**',
+      '**/.yarn/install-state.gz',
+      '**/.yarn/build-state.yml',
+      '**/.yarn/unplugged/**',
+      '**/.pnp.cjs',
+      '**/.pnp.loader.mjs',
+      '**/node_modules/**',
+      '**/.cache/**',
+      '**/storybook-static/**',
+    ]);
+  });
+});
+
+describe('sanitizePublishedSandboxes', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'sanitize-sandbox-'));
+  });
+
+  afterEach(async () => {
+    // tmpdir cleanup is best-effort; not strictly required for correctness
+  });
+
+  it('strips every STRIP_KEYS entry from after-storybook/.yarnrc.yml', async () => {
+    const afterDir = join(root, 'react-vite', 'default-ts', 'after-storybook');
+    await mkdir(afterDir, { recursive: true });
+    const yarnrc = [
+      'nodeLinker: node-modules',
+      'npmRegistryServer: "http://localhost:6001/"',
+      'unsafeHttpWhitelist: "localhost"',
+      'enableImmutableInstalls: false',
+      'enableMirror: false',
+      'logFilters: []',
+      'npmMinimalAgeGate: 0',
+      'pnpFallbackMode: none',
+      'enableGlobalCache: true',
+      'checksumBehavior: ignore',
+      '',
+    ].join('\n');
+    await writeFile(join(afterDir, '.yarnrc.yml'), yarnrc);
+
+    const result = await sanitizePublishedSandboxes(root);
+
+    expect(result.filteredYarnrcCount).toBe(1);
+    expect(result.strippedKeyCount).toBe(STRIP_KEYS.length);
+
+    const sanitized = await readFile(join(afterDir, '.yarnrc.yml'), 'utf-8');
+    for (const key of STRIP_KEYS) {
+      expect(sanitized).not.toContain(key);
+    }
+    // Non-stripped keys are preserved
+    expect(sanitized).toContain('nodeLinker');
+  });
+
+  it('leaves before-storybook/.yarnrc.yml untouched', async () => {
+    const beforeDir = join(root, 'react-vite', 'default-ts', 'before-storybook');
+    await mkdir(beforeDir, { recursive: true });
+    const yarnrc = ['nodeLinker: node-modules', 'enableGlobalCache: true', ''].join('\n');
+    await writeFile(join(beforeDir, '.yarnrc.yml'), yarnrc);
+
+    const result = await sanitizePublishedSandboxes(root);
+
+    expect(result.filteredYarnrcCount).toBe(0);
+    const preserved = await readFile(join(beforeDir, '.yarnrc.yml'), 'utf-8');
+    expect(preserved).toContain('enableGlobalCache');
+    expect(preserved).toContain('nodeLinker');
+  });
+
+  it('removes EXCLUDE_GLOBS matches from the tree', async () => {
+    const afterDir = join(root, 'react-vite', 'default-ts', 'after-storybook');
+    const beforeDir = join(root, 'react-vite', 'default-ts', 'before-storybook');
+    const afterCache = join(afterDir, '.yarn', 'cache');
+    const beforeNodeModules = join(beforeDir, 'node_modules', 'some-pkg');
+
+    await mkdir(afterCache, { recursive: true });
+    await writeFile(join(afterCache, 'pkg.zip'), 'binary blob');
+    await mkdir(beforeNodeModules, { recursive: true });
+    await writeFile(join(beforeNodeModules, 'index.js'), 'export {}');
+    await writeFile(join(afterDir, '.pnp.cjs'), '/* zero install */');
+    await writeFile(join(afterDir, 'README.md'), '# kept');
+
+    const result = await sanitizePublishedSandboxes(root);
+
+    expect(result.removedPaths).toBeGreaterThan(0);
+    expect(await exists(afterCache)).toBe(false);
+    expect(await exists(beforeNodeModules)).toBe(false);
+    expect(await exists(join(afterDir, '.pnp.cjs'))).toBe(false);
+    // Non-excluded files survive
+    expect(await exists(join(afterDir, 'README.md'))).toBe(true);
+  });
+
+  it('writes an empty file when stripping leaves no keys', async () => {
+    const afterDir = join(root, 'svelte-vite', 'default-ts', 'after-storybook');
+    await mkdir(afterDir, { recursive: true });
+    await writeFile(join(afterDir, '.yarnrc.yml'), 'npmRegistryServer: "http://localhost:6001/"\n');
+
+    await sanitizePublishedSandboxes(root);
+
+    const sanitized = await readFile(join(afterDir, '.yarnrc.yml'), 'utf-8');
+    expect(sanitized).toBe('');
+  });
+
+  it('is idempotent — a second run is a no-op', async () => {
+    const afterDir = join(root, 'react-vite', 'default-ts', 'after-storybook');
+    await mkdir(afterDir, { recursive: true });
+    await writeFile(
+      join(afterDir, '.yarnrc.yml'),
+      'nodeLinker: node-modules\nnpmRegistryServer: "http://localhost:6001/"\n'
+    );
+
+    await sanitizePublishedSandboxes(root);
+    const second = await sanitizePublishedSandboxes(root);
+
+    expect(second.filteredYarnrcCount).toBe(0);
+    expect(second.strippedKeyCount).toBe(0);
+    expect(second.removedPaths).toBe(0);
+  });
+});

--- a/scripts/sandbox/utils/sanitize-published-sandbox.test.ts
+++ b/scripts/sandbox/utils/sanitize-published-sandbox.test.ts
@@ -4,9 +4,13 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+// eslint-disable-next-line depend/ban-dependencies
+import { execaCommand } from 'execa';
+
 import {
   EXCLUDE_GLOBS,
   STRIP_KEYS,
+  ensureLockfilePublishRules,
   sanitizePublishedSandboxes,
 } from './sanitize-published-sandbox.ts';
 
@@ -157,5 +161,69 @@ describe('sanitizePublishedSandboxes', () => {
     expect(second.filteredYarnrcCount).toBe(0);
     expect(second.strippedKeyCount).toBe(0);
     expect(second.removedPaths).toBe(0);
+  });
+});
+
+describe('ensureLockfilePublishRules', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'sandbox-gitignore-'));
+  });
+
+  const stagedFiles = async () => {
+    await execaCommand('git init -q .', { cwd: root });
+    await execaCommand('git add .', { cwd: root });
+    const { stdout } = await execaCommand('git diff --cached --name-only', { cwd: root });
+    return stdout.split('\n').filter(Boolean);
+  };
+
+  const seedSandbox = async () => {
+    for (const dir of ['before-storybook', 'after-storybook']) {
+      await mkdir(join(root, 'angular-cli-default-ts', dir), { recursive: true });
+      await writeFile(join(root, 'angular-cli-default-ts', dir, 'yarn.lock'), '# lockfile\n');
+    }
+  };
+
+  it('publishes the before-storybook lockfile and still withholds the after-storybook one', async () => {
+    // The sandboxes repository ignores lockfiles wholesale.
+    await writeFile(join(root, '.gitignore'), 'node_modules\n\nyarn.lock\npackage-lock.json\n');
+    await seedSandbox();
+
+    await ensureLockfilePublishRules(root);
+
+    const staged = await stagedFiles();
+    expect(staged).toContain('angular-cli-default-ts/before-storybook/yarn.lock');
+    expect(staged).not.toContain('angular-cli-default-ts/after-storybook/yarn.lock');
+  });
+
+  it('withholds the after-storybook lockfile even when nothing was ignored before', async () => {
+    await seedSandbox();
+
+    await ensureLockfilePublishRules(root);
+
+    const staged = await stagedFiles();
+    expect(staged).toContain('angular-cli-default-ts/before-storybook/yarn.lock');
+    expect(staged).not.toContain('angular-cli-default-ts/after-storybook/yarn.lock');
+  });
+
+  it('is idempotent', async () => {
+    await writeFile(join(root, '.gitignore'), 'yarn.lock\n');
+
+    expect(await ensureLockfilePublishRules(root)).toBe(true);
+    const afterFirst = await readFile(join(root, '.gitignore'), 'utf-8');
+
+    expect(await ensureLockfilePublishRules(root)).toBe(false);
+    expect(await readFile(join(root, '.gitignore'), 'utf-8')).toBe(afterFirst);
+  });
+
+  it('keeps the repository’s existing ignore rules', async () => {
+    await writeFile(join(root, '.gitignore'), 'node_modules\n.angular\nyarn.lock\n');
+
+    await ensureLockfilePublishRules(root);
+
+    const contents = await readFile(join(root, '.gitignore'), 'utf-8');
+    expect(contents).toContain('node_modules');
+    expect(contents).toContain('.angular');
   });
 });

--- a/scripts/sandbox/utils/sanitize-published-sandbox.ts
+++ b/scripts/sandbox/utils/sanitize-published-sandbox.ts
@@ -1,0 +1,108 @@
+import { readFile, rm, writeFile } from 'node:fs/promises';
+
+// eslint-disable-next-line depend/ban-dependencies
+import { glob } from 'glob';
+import yml from 'yaml';
+
+/**
+ * Keys stripped from `after-storybook/.yarnrc.yml` before publishing to the public sandboxes
+ * repository. These are host-local or Verdaccio-bootstrap settings that would either break a
+ * consumer's install (e.g. `npmRegistryServer: http://localhost:6001/`) or weaken their default
+ * supply-chain protections (e.g. `npmMinimalAgeGate: 0`).
+ *
+ * Mutating this list requires a deliberate code review (the integrity test asserts the exact set).
+ */
+export const STRIP_KEYS = [
+  'npmRegistryServer',
+  'unsafeHttpWhitelist',
+  'enableImmutableInstalls',
+  'enableMirror',
+  'logFilters',
+  'npmMinimalAgeGate',
+  'pnpFallbackMode',
+  'enableGlobalCache',
+  'checksumBehavior',
+] as const;
+
+/**
+ * Paths excluded from the published sandbox copy. These are install artifacts or build outputs
+ * that bloat the repo without providing value to consumers (who will re-run `yarn install` against
+ * the committed lockfile).
+ */
+export const EXCLUDE_GLOBS = [
+  '**/.yarn/cache/**',
+  '**/.yarn/install-state.gz',
+  '**/.yarn/build-state.yml',
+  '**/.yarn/unplugged/**',
+  '**/.pnp.cjs',
+  '**/.pnp.loader.mjs',
+  '**/node_modules/**',
+  '**/.cache/**',
+  '**/storybook-static/**',
+] as const;
+
+export type SanitizeResult = {
+  filteredYarnrcCount: number;
+  strippedKeyCount: number;
+  removedPaths: number;
+};
+
+/**
+ * Sanitize a directory tree that is about to be published to `storybookjs/sandboxes`.
+ *
+ * - Removes `STRIP_KEYS` from every `**\/after-storybook/.yarnrc.yml` (verdaccio/host config).
+ * - Removes paths matching `EXCLUDE_GLOBS` from the tree (install artifacts, build output).
+ *
+ * `before-storybook/.yarnrc.yml` is intentionally left untouched: it contains only the
+ * user-facing Yarn setup we want consumers to reproduce.
+ */
+export const sanitizePublishedSandboxes = async (rootDir: string): Promise<SanitizeResult> => {
+  const yarnrcFiles = await glob('**/after-storybook/.yarnrc.yml', {
+    cwd: rootDir,
+    absolute: true,
+    dot: true,
+  });
+
+  let filteredYarnrcCount = 0;
+  let strippedKeyCount = 0;
+
+  for (const file of yarnrcFiles) {
+    const original = await readFile(file, 'utf-8');
+    if (!original.trim()) {
+      continue;
+    }
+
+    const doc = (yml.parse(original) ?? {}) as Record<string, unknown>;
+    let modified = false;
+
+    for (const key of STRIP_KEYS) {
+      if (key in doc) {
+        delete doc[key];
+        modified = true;
+        strippedKeyCount++;
+      }
+    }
+
+    if (modified) {
+      const updated = Object.keys(doc).length === 0 ? '' : yml.stringify(doc);
+      await writeFile(file, updated);
+      filteredYarnrcCount++;
+    }
+  }
+
+  const excluded = await glob([...EXCLUDE_GLOBS], {
+    cwd: rootDir,
+    absolute: true,
+    dot: true,
+  });
+
+  for (const target of excluded) {
+    await rm(target, { recursive: true, force: true });
+  }
+
+  return {
+    filteredYarnrcCount,
+    strippedKeyCount,
+    removedPaths: excluded.length,
+  };
+};

--- a/scripts/sandbox/utils/sanitize-published-sandbox.ts
+++ b/scripts/sandbox/utils/sanitize-published-sandbox.ts
@@ -1,8 +1,58 @@
 import { readFile, rm, writeFile } from 'node:fs/promises';
 
+import { join } from 'node:path';
+
 // eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 import yml from 'yaml';
+
+/**
+ * Git ignore rules the published sandboxes repository must end up with, in this order.
+ *
+ * The repository ignores `yarn.lock` wholesale, and `commitAllToGit` stages with `git add .`, so
+ * without the negation the generated `before-storybook` lockfile is silently dropped and consumers
+ * still resolve whatever is newest at install time.
+ *
+ * `after-storybook` deliberately stays ignored: it resolves Storybook packages from the local
+ * registry, and in link mode its lockfile carries `portal:`/`file:` resolutions pointing back into
+ * the monorepo, neither of which a consumer can install from.
+ */
+export const GITIGNORE_LOCKFILE_RULES = ['yarn.lock', '!**/before-storybook/yarn.lock'] as const;
+
+const MANAGED_BLOCK_HEADER =
+  '# Managed by publish-sandboxes: publish only the before-storybook lockfile';
+
+/**
+ * Make sure the published tree ships the `before-storybook` lockfile and nothing else lock-shaped.
+ *
+ * Appends the rules rather than editing existing lines, because git ignore precedence is
+ * last-match-wins: appending guarantees the intended outcome regardless of what the repository's
+ * own `.gitignore` already says.
+ */
+export const ensureLockfilePublishRules = async (rootDir: string): Promise<boolean> => {
+  const gitignorePath = join(rootDir, '.gitignore');
+
+  let contents = '';
+  try {
+    contents = await readFile(gitignorePath, 'utf-8');
+  } catch {
+    // No .gitignore in the sandboxes repo: still write the rules, so the after-storybook
+    // lockfile does not start getting published by omission.
+  }
+
+  const lines = contents.split('\n').map((line) => line.trim());
+  if (GITIGNORE_LOCKFILE_RULES.every((rule) => lines.includes(rule))) {
+    return false;
+  }
+
+  const prefix = contents.length > 0 && !contents.endsWith('\n') ? '\n' : '';
+  await writeFile(
+    gitignorePath,
+    `${contents}${prefix}\n${MANAGED_BLOCK_HEADER}\n${GITIGNORE_LOCKFILE_RULES.join('\n')}\n`
+  );
+
+  return true;
+};
 
 /**
  * Keys stripped from `after-storybook/.yarnrc.yml` before publishing to the public sandboxes


### PR DESCRIPTION
## What I did

We publish generated sandboxes to a public repository so people can clone one and reproduce a bug.
Those sandboxes were being published with the Yarn configuration we use internally to build them, which points at a throwaway local registry and switches off several install protections, including the minimum-age check that stops a freshly published (possibly compromised) package from being installed.

Anyone cloning a sandbox inherited that configuration, so their install either broke outright or ran with weaker protections than their own defaults.

This strips those internal settings from the published copy, and drops install artifacts and build output that only bloat the repository.

The Yarn setup a user is meant to reproduce is left untouched, so what people clone still reflects a real project.

#### Manual testing

1. Generate the sandboxes and run the publish step against a scratch remote rather than the public repository.
2. Search the published tree for the local registry address. There should be no matches.
3. Confirm no dependency folders, install caches, or built output were committed.
4. Clone one published sandbox into a clean directory and install it. It should install against the public registry using the cloner's own settings.
