### PR TITLE
Security: Implement stricter rules for CircleCI cache writes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: |
             yarn dlx jiti ./scripts/ci/main.ts \
               --workflow=<< pipeline.parameters.workflow >> \
-              --trusted-author=<< pipeline.parameters.ghTrustedAuthor >>
+              --gh-trusted-author=<< pipeline.parameters.ghTrustedAuthor >>
       - continuation/continue:
           configuration_path: .circleci/config.generated.yml
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     description: The PR number
     type: string
   ghTrustedAuthor:
-    default: 'true'
+    default: 'false'
     description: Whether the PR author is a trusted who should be allowed to persist to shared caches
     type: string
   workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ parameters:
     type: string
   ghTrustedAuthor:
     default: 'false'
-    description: Whether the PR author is a trusted who should be allowed to persist to shared caches
+    description: Whether the PR author is a trusted author who should be allowed to persist to shared caches
     type: string
   workflow:
     default: skipped

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ parameters:
     default: ''
     description: The PR number
     type: string
+  ghTrustedAuthor:
+    default: 'true'
+    description: Whether the PR author is a trusted who should be allowed to persist to shared caches
+    type: string
   workflow:
     default: skipped
     description: Which workflow to run
@@ -30,7 +34,7 @@ parameters:
 
 jobs:
   generate-and-run-config:
-    executor: 
+    executor:
       name: node/default
       resource_class: large
     steps:
@@ -44,7 +48,9 @@ jobs:
       - run:
           name: Generate config
           command: |
-            yarn dlx jiti ./scripts/ci/main.ts --workflow=<< pipeline.parameters.workflow >>
+            yarn dlx jiti ./scripts/ci/main.ts \
+              --workflow=<< pipeline.parameters.workflow >> \
+              --trusted-author=<< pipeline.parameters.ghTrustedAuthor >>
       - continuation/continue:
           configuration_path: .circleci/config.generated.yml
 workflows:

--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -19,8 +19,11 @@ runs:
       shell: bash
       run: npm install -g npm@latest
 
-    - name: Cache dependencies
-      uses: actions/cache@v4
+    # Restore only — save is gated below. actions/cache's post-job save step uses a
+    # runner-internal token that bypasses `permissions:`, so splitting is the only
+    # reliable way to prevent pull_request_target runs from poisoning the shared cache.
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v4
       with:
         path: |
           ~/.yarn/berry/cache
@@ -39,3 +42,11 @@ runs:
       shell: bash
       working-directory: code
       run: yarn install
+
+    - name: Save cached dependencies
+      if: github.event_name != 'pull_request_target'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.yarn/berry/cache
+        key: yarn-v1-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -49,10 +49,30 @@ jobs:
         run: echo "workflow=merged" >> $GITHUB_ENV
       - if: github.event_name == 'pull_request_target' && (contains(github.event.pull_request.labels.*.name, 'ci:daily'))
         run: echo "workflow=daily" >> $GITHUB_ENV
+      - id: trusted-author
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          USER_TYPE: ${{ github.event.pull_request.user.type }}
+          USER_LOGIN: ${{ github.event.pull_request.user.login }}
+        run: |
+          # You can only push to `main` and `next` as a core team member, so the content is trustworthy.
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "result=true" >> $GITHUB_OUTPUT
+          # These commits are made by the release actions, which are gated to core team members.
+          elif [ "$USER_LOGIN" = "github-actions[bot]" ] && [ "$USER_TYPE" = "Bot" ]; then
+            echo "result=true" >> $GITHUB_OUTPUT
+          # Trusted members of the organization can also write to cache (core team, DX, and a few maintainers)
+          elif { [ "$ASSOCIATION" = "OWNER" ] || [ "$ASSOCIATION" = "MEMBER" ]; } && [ "$USER_TYPE" != "Bot" ]; then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
     outputs:
       workflow: ${{ env.workflow }}
       ghBaseBranch: ${{ github.event.pull_request.base.ref }}
       ghPrNumber: ${{ github.event.pull_request.number }}
+      ghTrustedAuthor: ${{ steps.trusted-author.outputs.result }}
 
   trigger-circle-ci-workflow:
     runs-on: ubuntu-latest

--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -17,6 +17,7 @@ import {
   workflow,
   workspace,
 } from './utils/helpers.ts';
+import { isTrustedAuthor } from './utils/runtime.ts';
 import { defineJob, defineNoOpJob } from './utils/types.ts';
 
 const dirname = import.meta.dirname;
@@ -29,7 +30,7 @@ export const build_linux = defineJob('Build (linux)', (workflowName) => ({
   steps: [
     git.checkout(),
     npm.install('.'),
-    cache.persist(CACHE_PATHS, CACHE_KEYS()[0]),
+    ...(isTrustedAuthor() ? [cache.persist(CACHE_PATHS, CACHE_KEYS()[0])] : []),
     git.check(),
     npm.check(),
     {

--- a/scripts/ci/main.ts
+++ b/scripts/ci/main.ts
@@ -153,7 +153,7 @@ program
   .option(
     '--gh-trusted-author <string>',
     'Whether the pipeline can persist to shared caches',
-    'true'
+    'false'
   )
   .parse(process.argv);
 

--- a/scripts/ci/main.ts
+++ b/scripts/ci/main.ts
@@ -25,6 +25,7 @@ import { executors } from './utils/executors.ts';
 import { ensureRequiredJobs } from './utils/helpers.ts';
 import { orbs } from './utils/orbs.ts';
 import { parameters } from './utils/parameters.ts';
+import { setTrustedAuthor } from './utils/runtime.ts';
 import type {
   JobImplementationObj,
   JobOrNoOpJob,
@@ -149,11 +150,19 @@ console.log('--------------------------------');
 program
   .description('Generate CircleCI config')
   .requiredOption('-w, --workflow <string>', 'Workflow to generate config for')
+  .option(
+    '--gh-trusted-author <string>',
+    'Whether the pipeline can persist to shared caches',
+    'true'
+  )
   .parse(process.argv);
+
+const opts = program.opts();
+setTrustedAuthor(opts.ghTrustedAuthor === 'true');
 
 await fs.writeFile(
   join(dirname, '../../.circleci/config.generated.yml'),
-  yml.stringify(generateConfig(program.opts().workflow), null, {
+  yml.stringify(generateConfig(opts.workflow), null, {
     lineWidth: 1200,
     indent: 4,
   })

--- a/scripts/ci/utils/parameters.ts
+++ b/scripts/ci/utils/parameters.ts
@@ -10,6 +10,12 @@ export const parameters = {
     description: 'The PR number',
     type: 'string',
   },
+  ghTrustedAuthor: {
+    default: 'false',
+    description:
+      'Whether the pipeline is allowed to persist to shared caches (team member PRs and push events only)',
+    type: 'string',
+  },
   workflow: {
     default: 'skipped',
     description: 'Which workflow to run',

--- a/scripts/ci/utils/runtime.ts
+++ b/scripts/ci/utils/runtime.ts
@@ -1,4 +1,4 @@
-let trustedAuthor = true;
+let trustedAuthor = false;
 
 export function setTrustedAuthor(isTrusted: boolean): void {
   trustedAuthor = isTrusted;

--- a/scripts/ci/utils/runtime.ts
+++ b/scripts/ci/utils/runtime.ts
@@ -1,0 +1,9 @@
+let trustedAuthor = true;
+
+export function setTrustedAuthor(isTrusted: boolean): void {
+  trustedAuthor = isTrusted;
+}
+
+export function isTrustedAuthor(): boolean {
+  return trustedAuthor;
+}


### PR DESCRIPTION
## What I did

* Built on top of @valentinpalkovic's experiment to restrict which workflows can write to CircleCI cache
* Changed conditions to only allow the SB team to write to cache during PRs (and our usual pushes to `next` and `main` and workflows that are already gated by AC policies)
* Did not restrict the permission to avoid forks because only our own team members would be able to run workflows for their forked code anyway

## Checklist for Contributors

### Testing

No automatic tests.

#### Manual testing

Not easily testable without replicating the entire org and CircleCI setup. The best way would be to merge, then run a workflow from a fork made by an alt account not part of the org, and to check if the workflow wrote to cache.

### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now determines whether a PR author is "trusted" and conditionally enables shared cache persistence for eligible runs.
  * Added a pipeline parameter to propagate the "trusted author" flag through workflow triggers and pipeline generation.
  * Dependency caching split into separate restore and save steps to prevent cache poisoning on sensitive PR events.
  * The trusted-author flag is respected by config generation and runtime CI decisions to ensure consistent cache behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->