### PR TITLE
Sandboxes: RN add missing `prop-types`

### DIFF
--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -855,6 +855,10 @@ export const baseTemplates = {
     },
     modifications: {
       useCsfFactory: true,
+      // The React renderer's template-stories (e.g. js-argtypes.stories.jsx) import
+      // `prop-types`. Every other React-renderer sandbox declares it explicitly via
+      // extraDependencies; this template was missing it.
+      extraDependencies: ['prop-types'],
       mainConfig: {
         features: {
           experimentalTestSyntax: true,
@@ -882,6 +886,12 @@ export const baseTemplates = {
       framework: '@storybook/react-native-web-vite',
       renderer: '@storybook/react',
       builder: '@storybook/builder-vite',
+    },
+    modifications: {
+      // The React renderer's template-stories (e.g. js-argtypes.stories.jsx) import
+      // `prop-types`. Every other React-renderer sandbox declares it explicitly via
+      // extraDependencies; this template was missing it.
+      extraDependencies: ['prop-types'],
     },
     skipTasks: ['e2e-tests', 'bench', 'vitest-integration'],
     initOptions: {


### PR DESCRIPTION
## What I did

Two of our `react-native-web-vite` sandbox templates were missing `prop-types` from `modifications.extraDependencies`:

- `react-native-web-vite/expo-ts`
- `react-native-web-vite/rn-cli-ts`

The React renderer's template-stories include `js-argtypes.stories.jsx`, which imports `prop-types` directly. Every other React-renderer sandbox in `code/lib/cli-storybook/src/sandbox-templates.ts` already declares `prop-types` explicitly via `extraDependencies` — these two were the only outliers and were relying on a transitive hoist that doesn't reliably survive the RN/Expo install paths.

This surfaced on the `ci:daily` run for the 10.5.0-alpha.1 release PR (#34822) as:

```
Error: [vite]: Rolldown failed to resolve import "prop-types" from "./src/stories/renderers/react/js-argtypes.stories.jsx".
```
See CI log:
https://app.circleci.com/pipelines/github/storybookjs/storybook/122653/workflows/3c6828c3-e3ec-4ca8-9244-f3213b480fb9/jobs/1485401

Only `expo-ts` actually runs in `ci:daily` today (`rn-cli-ts` is commented out of the `daily` array), but both templates have the identical gap, so I'm fixing both to keep the React-renderer sandbox configs consistent and avoid the same trap when `rn-cli-ts` is re-enabled.

This is a sandbox/CI-only fix. Real users of these templates who actually use `PropTypes` in their components already install `prop-types` themselves; this only affects our synthetic test sandboxes that copy the React renderer's template-stories in.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

The change is verified by the existing `react-native-web-vite/expo-ts` sandbox E2E in `ci:daily` — the same job that surfaced the failure on #34822. No new test is needed; the failing job becomes the passing job.

#### Manual testing

I did not manual testing, I'm depending on the CI running this correctly, I ensured it's ran with the `daily` label

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user-facing docs need to change — `prop-types` is only added to internal sandbox templates, not to anything shipped to users.

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`

  Use **`ci:daily`** — the affected templates (`react-native-web-vite/*`) only run in the `daily` cadence, so `ci:normal` / `ci:merged` will not exercise this fix.

- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

  Label: **`build`** — internal sandbox/CI fix; should not appear in the release changelog.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React Native Web Vite sandbox templates to include `prop-types` as a default dependency, ensuring prop validation support is available out of the box for new projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->