### PR TITLE
test: add unit tests for React renderer applyDecorators

### DIFF
--- a/code/renderers/react/src/applyDecorators.test.tsx
+++ b/code/renderers/react/src/applyDecorators.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { DecoratorFunction, LegacyStoryFn, StoryContext } from 'storybook/internal/types';
 
-import { applyDecorators } from './applyDecorators';
-import type { ReactRenderer } from './types';
+import { applyDecorators } from './applyDecorators.ts';
+import type { ReactRenderer } from './types.ts';
 
 const makeContext = (overrides: Partial<StoryContext<ReactRenderer>> = {}): StoryContext<ReactRenderer> =>
   ({

--- a/code/renderers/react/src/applyDecorators.test.tsx
+++ b/code/renderers/react/src/applyDecorators.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DecoratorFunction, LegacyStoryFn, StoryContext } from 'storybook/internal/types';
+
+import { applyDecorators } from './applyDecorators';
+import type { ReactRenderer } from './types';
+
+const makeContext = (overrides: Partial<StoryContext<ReactRenderer>> = {}): StoryContext<ReactRenderer> =>
+  ({
+    args: {},
+    argTypes: {},
+    globals: {},
+    hooks: { current: null },
+    parameters: {},
+    initialArgs: {},
+    componentId: 'test',
+    title: 'Test',
+    kind: 'Test',
+    id: 'test--story',
+    name: 'Story',
+    story: 'Story',
+    tags: [],
+    abortSignal: new AbortController().signal,
+    canvasElement: document.createElement('div'),
+    ...overrides,
+  } as unknown as StoryContext<ReactRenderer>);
+
+describe('applyDecorators (React renderer)', () => {
+  it('renders the story when no decorators are provided', () => {
+    const storyFn: LegacyStoryFn<ReactRenderer> = () =>
+      React.createElement('div', null, 'hello');
+    const decorated = applyDecorators(storyFn, []);
+    const result = decorated(makeContext());
+    expect(result).toBeDefined();
+  });
+
+  it('passes the context through to the story function', () => {
+    const storyFn = vi.fn(() => React.createElement('div')) as unknown as LegacyStoryFn<ReactRenderer>;
+    const decorated = applyDecorators(storyFn, []);
+    decorated(makeContext({ id: 'custom--story' }));
+    expect(storyFn).toHaveBeenCalledWith(expect.objectContaining({ id: 'custom--story' }));
+  });
+
+  it('applies a single decorator that wraps the story', () => {
+    const storyFn: LegacyStoryFn<ReactRenderer> = () =>
+      React.createElement('span', null, 'inner');
+    const wrapper: DecoratorFunction<ReactRenderer> = (story) =>
+      React.createElement('div', { 'data-wrapped': 'true' }, story());
+    const decorated = applyDecorators(storyFn, [wrapper]);
+    const result = decorated(makeContext()) as React.ReactElement<{ 'data-wrapped': string }>;
+    expect(result.props['data-wrapped']).toBe('true');
+  });
+
+  it('applies multiple decorators in the correct nested order', () => {
+    const order: string[] = [];
+    const storyFn: LegacyStoryFn<ReactRenderer> = () => {
+      order.push('story');
+      return React.createElement('span');
+    };
+    const outer: DecoratorFunction<ReactRenderer> = (story) => { order.push('outer'); return story(); };
+    const inner: DecoratorFunction<ReactRenderer> = (story) => { order.push('inner'); return story(); };
+    const decorated = applyDecorators(storyFn, [outer, inner]);
+    decorated(makeContext());
+    expect(order).toEqual(['outer', 'inner', 'story']);
+  });
+
+  it('returns a function so the result can be invoked later', () => {
+    const storyFn: LegacyStoryFn<ReactRenderer> = () => React.createElement('div');
+    const decorated = applyDecorators(storyFn, []);
+    expect(typeof decorated).toBe('function');
+  });
+});


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Adds unit tests for `code/renderers/react/src/applyDecorators.ts`, which previously had zero test coverage. The helper is invoked on every React story render to wrap the story function with the decorator chain.

The new test file covers:

- No decorators — the story renders unchanged
- Context propagation — `StoryContext` is forwarded to the inner story function
- Single decorator — the decorator correctly wraps the story
- Multiple decorators — applied in the correct nested order
- Return type — confirms the helper returns a function, not a React element

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual testing necessary. The change is a pure test addition with no behaviour change to production code.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

No public API change, no documentation update needed.

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the React renderer’s decorator behavior: verifies rendering when no decorators are present, that story context is forwarded correctly, single-decorator wrapping, correct nested ordering for multiple decorators (outer → inner → story), and that the decorator pipeline produces an invokable result.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->