### PR TITLE
fix(a11y): improve Object control keyboard nav and ARIA markup

### DIFF
--- a/code/addons/docs/src/blocks/controls/Object.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.tsx
@@ -31,6 +31,11 @@ const Wrapper = styled.div(({ theme }) => ({
       opacity: 1,
     },
   },
+  '.rejt-value-node:focus-within': {
+    '& > button': {
+      opacity: 1,
+    },
+  },
   '.rejt-add-form': {
     marginLeft: 10,
   },
@@ -58,6 +63,10 @@ const Wrapper = styled.div(({ theme }) => ({
     padding: '0 4px',
     cursor: 'text',
     color: theme.color.defaultText,
+    '&:focus-visible': {
+      outline: `1px solid ${theme.color.secondary}`,
+      outlineOffset: 1,
+    },
   },
   '.rejt-value-node:hover > .rejt-value': {
     background: theme.base === 'light' ? theme.color.lighter : 'hsl(0 0 100 / 0.02)',
@@ -98,7 +107,13 @@ const ActionButton = styled.button(({ theme }) => ({
   ':disabled': {
     cursor: 'not-allowed',
   },
-  ':hover, :focus-visible': {
+  ':focus-visible': {
+    opacity: 1,
+    outline: `1px solid ${theme.color.secondary}`,
+    outlineOffset: 2,
+    borderRadius: 2,
+  },
+  ':hover': {
     opacity: 1,
   },
   '&:hover:not(:disabled), &:focus-visible:not(:disabled)': {
@@ -226,6 +241,8 @@ export const ObjectControl: FC<ObjectProps> = ({ name, storyId, value, onChange,
       defaultValue={jsonString}
       onBlur={(event: FocusEvent<HTMLTextAreaElement>) => updateRaw(event.target.value)}
       placeholder="Edit JSON string..."
+      aria-label={`${name} JSON editor`}
+      aria-invalid={parseError ? true : undefined}
       autoFocus={forceVisible}
       valid={parseError ? 'error' : undefined}
       readOnly={readonly}

--- a/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodeAccordion.tsx
+++ b/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodeAccordion.tsx
@@ -85,9 +85,10 @@ export function JsonNodeAccordion({
   };
 
   const containerTag = keyPath.length > 0 ? 'li' : 'div';
+  const containerRole = keyPath.length > 0 ? 'treeitem' : undefined;
 
   return (
-    <Container as={containerTag}>
+    <Container as={containerTag} role={containerRole} aria-expanded={!collapsed}>
       <Trigger
         type="button"
         aria-expanded={!collapsed}

--- a/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodes.tsx
+++ b/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodes.tsx
@@ -392,7 +392,7 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
       <>
         <span className="rejt-not-collapsed-delimiter">{startObject}</span>
         {!addFormVisible && addItemButton}
-        <ul className="rejt-not-collapsed-list">
+        <ul className="rejt-not-collapsed-list" role="group">
           {data.map((item, index) => (
             <JsonNode
               key={index}
@@ -636,7 +636,23 @@ export class JsonFunctionValue extends Component<JsonFunctionValueProps, JsonFun
       minusElement = null;
     } else {
       result = (
-        <span className="rejt-value" onClick={resultOnlyResult ? undefined : this.handleEditMode}>
+        <span
+          className="rejt-value"
+          role={resultOnlyResult ? undefined : 'button'}
+          tabIndex={resultOnlyResult ? undefined : 0}
+          onClick={resultOnlyResult ? undefined : this.handleEditMode}
+          onKeyDown={
+            resultOnlyResult
+              ? undefined
+              : (e: any) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    this.handleEditMode();
+                  }
+                }
+          }
+          aria-label={resultOnlyResult ? undefined : `Edit value of ${name}`}
+        >
           {value}
         </span>
       );
@@ -656,7 +672,7 @@ export class JsonFunctionValue extends Component<JsonFunctionValueProps, JsonFun
     }
 
     return (
-      <li className="rejt-value-node">
+      <li className="rejt-value-node" role="treeitem" aria-label={`${name}: function`}>
         <span className="rejt-name">{name} : </span>
         {result}
         {minusElement}
@@ -1269,7 +1285,7 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
       <>
         <span className="rejt-not-collapsed-delimiter">{startObject}</span>
         {!isReadOnly && addItemButton}
-        <ul className="rejt-not-collapsed-list">{list}</ul>
+        <ul className="rejt-not-collapsed-list" role="group">{list}</ul>
         {!isReadOnly && addFormVisible && (
           <div className="rejt-add-form">
             <JsonAddValue
@@ -1491,7 +1507,7 @@ export class JsonValue extends Component<JsonValueProps, JsonValueState> {
       });
 
     return (
-      <li className="rejt-value-node">
+      <li className="rejt-value-node" role="treeitem" aria-label={`${name}: ${String(value)}`}>
         <span className="rejt-name">
           {name}
           {' : '}
@@ -1499,7 +1515,23 @@ export class JsonValue extends Component<JsonValueProps, JsonValueState> {
         {isEditing ? (
           <span className="rejt-edit-form">{inputElementLayout}</span>
         ) : (
-          <span className="rejt-value" onClick={isReadOnly ? undefined : this.handleEditMode}>
+          <span
+            className="rejt-value"
+            role={isReadOnly ? undefined : 'button'}
+            tabIndex={isReadOnly ? undefined : 0}
+            onClick={isReadOnly ? undefined : this.handleEditMode}
+            onKeyDown={
+              isReadOnly
+                ? undefined
+                : (e: any) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      this.handleEditMode();
+                    }
+                  }
+            }
+            aria-label={isReadOnly ? undefined : `Edit value of ${name}`}
+          >
             {String(value)}
           </span>
         )}

--- a/code/addons/docs/src/blocks/controls/react-editable-json-tree/index.tsx
+++ b/code/addons/docs/src/blocks/controls/react-editable-json-tree/index.tsx
@@ -84,7 +84,7 @@ export class JsonTree extends Component<JsonTreeProps, JsonTreeState> {
 
     if (dataType === 'Object' || dataType === 'Array') {
       return (
-        <div className="rejt-tree">
+        <div className="rejt-tree" role="tree" aria-label={`${rootName || 'root'} JSON editor`}>
           <JsonNode
             data={data}
             name={rootName || 'root'}


### PR DESCRIPTION
## Summary

Fixes #24150 — Object control not accessible via keyboard navigation and missing ARIA attributes.

## Changes

### Keyboard Navigation
- Value spans (editable JSON values) are now focusable with `tabIndex=0` and respond to Enter/Space to enter edit mode
- Action buttons (add/remove) become visible on `:focus-within` of parent nodes, not just on hover
- Action buttons show a visible focus indicator via `:focus-visible` outline

### ARIA Markup
- Added `role="tree"` with `aria-label` to the JSON tree container
- Added `role="treeitem"` to value nodes and accordion containers (nested objects/arrays)
- Added `role="group"` to nested `<ul>` lists for proper tree hierarchy
- Added `aria-expanded` to treeitem containers for expand/collapse state
- Added `aria-label` to the raw JSON textarea (instead of relying solely on placeholder text)
- Added `aria-invalid` to the textarea when a JSON parse error occurs

### Focus Visibility
- Added `:focus-visible` outline styles to `.rejt-value` spans so keyboard users can see their current position
- Separated `:hover` and `:focus-visible` styles on action buttons with a proper outline indicator

## Testing
- Verified no new TypeScript compilation errors introduced
- Changes are limited to the Object control component in `code/addons/docs/src/blocks/controls/`

## Files Modified
- `code/addons/docs/src/blocks/controls/Object.tsx`
- `code/addons/docs/src/blocks/controls/react-editable-json-tree/index.tsx`
- `code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodes.tsx`
- `code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodeAccordion.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation for JSON object and array editors
  * Enhanced screen reader support with semantic structure and descriptive labels
  * Better focus visibility for interactive elements in JSON editing controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->