### PR TITLE
fix: add generic type parameter to manager-api 

### DIFF
--- a/code/core/src/manager-api/root.tsx
+++ b/code/core/src/manager-api/root.tsx
@@ -459,7 +459,7 @@ export function useAddonState<S>(addonId: string, defaultState?: S) {
   return useSharedState<S>(addonId, defaultState);
 }
 
-export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: string[]) => void, Args] {
+export function useArgs<TArgs extends Args = Args>(): [TArgs, (newArgs: Partial<TArgs>) => void, (argNames?: (keyof TArgs)[]) => void, TArgs] {
   const { getCurrentStoryData, updateStoryArgs, resetStoryArgs } = useStorybookApi();
 
   const data = getCurrentStoryData();
@@ -467,15 +467,15 @@ export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: string[])
   const initialArgs = data?.type === 'story' ? data.initialArgs : {};
 
   const updateArgs = useCallback(
-    (newArgs: Args) => updateStoryArgs(data as API_StoryEntry, newArgs),
+    (newArgs: Partial<TArgs>) => updateStoryArgs(data as API_StoryEntry, newArgs),
     [data, updateStoryArgs]
   );
   const resetArgs = useCallback(
-    (argNames?: string[]) => resetStoryArgs(data as API_StoryEntry, argNames),
+    (argNames?: (keyof TArgs)[]) => resetStoryArgs(data as API_StoryEntry, argNames),
     [data, resetStoryArgs]
   );
 
-  return [args!, updateArgs, resetArgs, initialArgs!];
+  return [args as TArgs, updateArgs, resetArgs, initialArgs as TArgs];
 }
 
 export function useGlobals(): [


### PR DESCRIPTION
## What I did

Added `<TArgs extends Args = Args>` generic type parameter to the manager-api `useArgs` function in `root.tsx`.

## How to test

```ts
// Before: TypeScript error - useArgs is not generic
const [args] = useArgs<{ name: string }>();

// After: works correctly
const [args, updateArgs, resetArgs, initialArgs] = useArgs<{ name: string }>();
// args is typed as { name: string }
// updateArgs accepts Partial<{ name: string }>
// resetArgs accepts (keyof { name: string })[]
```

## Why

The preview-api `useArgs` in `code/core/src/preview-api/modules/addons/hooks.ts` already accepts a generic `TArgs` parameter, but the manager-api version in `code/core/src/manager-api/root.tsx` was hardcoded to `Args`. Users importing from `storybook/manager-api` couldn't type their args.

Fixes #25070

## Changes

- `code/core/src/manager-api/root.tsx`: Added `TArgs extends Args = Args` generic to `useArgs`, updated internal types to use `TArgs`, and changed return type casts from `args!` to `args as TArgs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety and flexibility for internal hook configuration, improving reliability of argument handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->