### PR TITLE
fix(builder-vite): disable Vite's publicDir to prevent double-copying static assets

### DIFF
--- a/code/builders/builder-vite/src/preset.ts
+++ b/code/builders/builder-vite/src/preset.ts
@@ -1,5 +1,8 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { findConfigFile } from 'storybook/internal/common';
-import type { Options } from 'storybook/internal/types';
+import type { Options, PresetPropertyFn, StorybookConfigRaw } from 'storybook/internal/types';
 
 import type { PluginOption } from 'vite';
 
@@ -11,6 +14,38 @@ import { viteInjectMockerRuntime } from './plugins/vite-inject-mocker/plugin.ts'
 import { viteMockPlugin } from './plugins/vite-mock/plugin.ts';
 
 export const optimizeViteDeps: string[] = ['storybook/internal/preview/runtime'];
+
+/**
+ * Mirrors Vite's default publicDir behavior via staticDirs so existing projects
+ * that relied on Vite automatically serving ../public continue to work after we
+ * disable publicDir in the Vite config.
+ *
+ * Users can opt out by explicitly setting staticDirs to an array that does not
+ * include ../public, or by pointing it to a different destination with
+ * { from: '../public', to: '/some-other-path' }.
+ */
+export const staticDirs: PresetPropertyFn<'staticDirs'> = async (
+  values: StorybookConfigRaw['staticDirs'] = [],
+  options: Options
+) => {
+  const projectRoot = resolve(options.configDir, '..');
+  const defaultPublicDir = resolve(projectRoot, 'public');
+
+  if (!existsSync(defaultPublicDir)) {
+    return values;
+  }
+
+  const alreadyConfigured = values.some((dir) => {
+    const from = typeof dir === 'string' ? dir : dir.from;
+    return resolve(options.configDir, from) === defaultPublicDir;
+  });
+
+  if (alreadyConfigured) {
+    return values;
+  }
+
+  return [...values, { from: '../public', to: '/' }];
+};
 
 /**
  * Preset that provides the core Storybook Vite plugins shared between `@storybook/builder-vite` and

--- a/code/builders/builder-vite/src/vite-config.ts
+++ b/code/builders/builder-vite/src/vite-config.ts
@@ -63,6 +63,10 @@ export async function commonConfig(
     root: projectRoot,
     // Allow storybook deployed as subfolder. See https://github.com/storybookjs/builder-vite/issues/238
     base: './',
+    // Storybook manages static file copying via staticDirs. Disabling Vite's publicDir
+    // prevents double-copying when users configure a custom destination in staticDirs.
+    // The default ../public behavior is preserved by the staticDirs preset in preset.ts.
+    publicDir: false,
     ...(options.cacheKey
       ? { cacheDir: resolvePathInStorybookCache('sb-vite', options.cacheKey) }
       : {}),


### PR DESCRIPTION
## Summary

- **Root cause**: Vite's built-in `publicDir` mechanism independently copies `../public` to the build output root. When a user routes that same directory to a custom destination via `staticDirs`, it ends up copied twice — once by Vite to `/`, once by Storybook to the configured path. If `../public/index.json` exists, it silently overwrites the Storybook-generated `index.json`, breaking story discovery.
- **Fix**: Set `publicDir: false` in Storybook's shared Vite config (`vite-config.ts`) so Storybook owns all static file copying.
- **Backwards compat**: Export a `staticDirs` preset from `@storybook/builder-vite` that re-adds `../public → /` when the directory exists and the user hasn't already mapped it elsewhere. Existing projects get identical behavior without any config changes.

## Changes

- `code/builders/builder-vite/src/vite-config.ts` — add `publicDir: false` to `sbConfig`
- `code/builders/builder-vite/src/preset.ts` — export `staticDirs` that mirrors Vite's default public dir behavior via Storybook's own copy mechanism

## Test plan

- [ ] Create a Vite + React project with Storybook, add `public/index.json` with `{}`
- [ ] Set `staticDirs: [{ from: '../public', to: '/foo' }]` in `.storybook/main.ts`
- [ ] Run `build-storybook` — `storybook-static/index.json` should contain valid story index data, not `{}`
- [ ] `storybook-static/foo/` should contain the public directory contents
- [ ] Existing project with no `staticDirs` config: `../public` still served at `/` (backwards compat)
- [ ] Existing project with `staticDirs: ['../public']`: no duplicate copy, no regression

Closes #24627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed static file handling in the Vite builder to prevent duplicate copying of public directory contents. Static assets are now managed through the `staticDirs` configuration, with Vite's public directory disabled to avoid conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->