### PR TITLE
Docs: Fix MDX docs HMR when referenced CSF changes

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/render/MdxDocsRender.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/MdxDocsRender.test.ts
@@ -115,6 +115,46 @@ describe('attaching', () => {
   });
 });
 
+describe('equality', () => {
+  it('treats changed referenced CSF files as a docs render change', async () => {
+    const mdxExports = { default: () => null };
+    const first = csfFileParts('meta--story', 'meta');
+    const second = csfFileParts('meta--story', 'meta');
+    const store = {
+      loadEntry: vi
+        .fn()
+        .mockResolvedValueOnce({
+          entryExports: mdxExports,
+          csfFiles: [first.csfFile],
+        })
+        .mockResolvedValueOnce({
+          entryExports: mdxExports,
+          csfFiles: [second.csfFile],
+        }),
+      storyFromCSFFile: ({ csfFile }: { csfFile: typeof first.csfFile }) =>
+        csfFile === first.csfFile ? first.story : second.story,
+    } as unknown as StoryStore<Renderer>;
+
+    const previousRender = new MdxDocsRender(
+      new Channel({}),
+      store,
+      attachedEntry,
+      {} as RenderContextCallbacks<Renderer>
+    );
+    await previousRender.prepare();
+
+    const nextRender = new MdxDocsRender(
+      new Channel({}),
+      store,
+      attachedEntry,
+      {} as RenderContextCallbacks<Renderer>
+    );
+    await nextRender.prepare();
+
+    expect(nextRender.isEqual(previousRender)).toBe(false);
+  });
+});
+
 describe('docs parameters', () => {
   it('uses the attached CSF story docs parameters for attached MDX docs', async () => {
     const renderPage = vi.fn();

--- a/code/core/src/preview-api/modules/preview-web/render/MdxDocsRender.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/MdxDocsRender.ts
@@ -94,10 +94,16 @@ export class MdxDocsRender<TRenderer extends Renderer> implements Render<TRender
   }
 
   isEqual(other: Render<TRenderer>): boolean {
+    const otherRender = other as MdxDocsRender<TRenderer>;
+    const sameReferencedCsfFiles =
+      this.csfFiles?.length === otherRender.csfFiles?.length &&
+      this.csfFiles?.every((csfFile, index) => csfFile === otherRender.csfFiles?.[index]);
+
     return !!(
       this.id === other.id &&
       this.exports &&
-      this.exports === (other as MdxDocsRender<TRenderer>).exports
+      this.exports === otherRender.exports &&
+      sameReferencedCsfFiles
     );
   }
 


### PR DESCRIPTION
## Summary
Fix MDX docs render equality so referenced CSF file changes trigger a docs rerender.

## Why
When an MDX docs page imports stories, the MDX module can remain unchanged while the referenced CSF module changes via HMR. The previous equality check only compared the MDX exports, so the docs render could be treated as unchanged.

## Changes
- Include referenced CSF files in `MdxDocsRender.isEqual()`.
- Add a unit test covering same MDX exports with changed referenced CSF files.

## Testing
- `git diff --check`
- Targeted unit test not run locally because dependencies are not installed.

## Known Issues
- Full watch/HMR reproduction was not run in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved render equality checking to properly detect changes in referenced component story files, ensuring accurate content updates when source files are modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->