### PR TITLE
Docs: Add bootstrapApplication and moduleMetadata doc to Angular

### DIFF
--- a/docs/get-started/frameworks/angular.mdx
+++ b/docs/get-started/frameworks/angular.mdx
@@ -300,58 +300,78 @@ The full list of options can be found in the Angular builder schemas:
 Storybook for Angular supports both standalone components (using `bootstrapApplication`) and
 NgModule-based setups (using `moduleMetadata`).
 
-### Using `bootstrapApplication` (standalone)
+<CodeSnippets snippets={{
+  js: `
+    // src/main.js
+    import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+    import { AppModule } from './app/app.module';
 
-If you're using Angular's standalone API with `bootstrapApplication`, Storybook will
-automatically detect and use your application's bootstrap configuration. No additional
-configuration is needed in most cases.
+    platformBrowserDynamic().bootstrapModule(AppModule);
+  `,
+  ts: `
+    // src/main.ts
+    import { bootstrapApplication } from '@angular/platform-browser';
+    import { AppComponent } from './app/app.component';
+    import { appConfig } from './app/app.config';
 
-```ts title="src/main.ts"
-import { bootstrapApplication } from '@angular/platform-browser';
-import { AppComponent } from './app/app.component';
-import { appConfig } from './app/app.config';
+    bootstrapApplication(AppComponent, appConfig);
+  `,
+}} />
 
-bootstrapApplication(AppComponent, appConfig);
-```
+Storybook will auto-detect the `appConfig` used by `bootstrapApplication` in most cases.
+For per-story or test-specific overrides, use the `applicationConfig` decorator as
+described in the [Application-wide providers](#application-wide-providers) section above.
 
-Storybook will use the same `appConfig` that your application uses, ensuring consistency
-between your Storybook stories and your actual application.
+<CodeSnippets snippets={{
+  js: `
+    // src/app/button/button.component.stories.js
+    import { moduleMetadata } from '@storybook/angular';
+    import { ButtonComponent } from './button.component';
+    import { CommonModule } from '@angular/common';
 
-### Using `moduleMetadata` (NgModule)
+    export default {
+      title: 'Button',
+      component: ButtonComponent,
+      decorators: [
+        moduleMetadata({
+          imports: [CommonModule],
+        }),
+      ],
+    };
 
-For NgModule-based Angular applications, you can use the `moduleMetadata` parameter in your
-stories to provide the necessary module configuration:
+    export const Primary = { args: { label: 'Click me' } };
+  `,
+  ts: `
+    // src/app/button/button.component.stories.ts
+    import type { Meta, StoryObj } from '@storybook/angular';
+    import { moduleMetadata } from '@storybook/angular';
+    import { ButtonComponent } from './button.component';
+    import { CommonModule } from '@angular/common';
 
-```ts title="src/app/button/button.component.stories.ts"
-import type { Meta, StoryObj } from '@storybook/angular';
-import { moduleMetadata } from '@storybook/angular';
-import { ButtonComponent } from './button.component';
-import { CommonModule } from '@angular/common';
+    const meta: Meta<ButtonComponent> = {
+      title: 'Button',
+      component: ButtonComponent,
+      decorators: [
+        moduleMetadata({
+          imports: [CommonModule],
+          providers: [],
+        }),
+      ],
+    };
+    export default meta;
+    type Story = StoryObj<ButtonComponent>;
 
-const meta: Meta<ButtonComponent> = {
-  title: 'Button',
-  component: ButtonComponent,
-  decorators: [
-    moduleMetadata({
-      imports: [CommonModule],
-      providers: [],
-    }),
-  ],
-};
-export default meta;
-type Story = StoryObj<ButtonComponent>;
-
-export const Primary: Story = {
-  args: {
-    label: 'Click me',
-  },
-};
-```
+    export const Primary: Story = { args: { label: 'Click me' } };
+  `,
+}} />
 
 The `moduleMetadata` decorator allows you to configure:
 - **imports** - Angular modules to import (e.g., `CommonModule`, `FormsModule`)
 - **providers** - Services to provide at the story level
 - **declarations** - Components, directives, and pipes to declare
+
+For more comprehensive examples including story-level configuration, see the
+[Angular dependencies](#angular-dependencies) section above.
 
 :::tip
 

--- a/docs/get-started/frameworks/angular.mdx
+++ b/docs/get-started/frameworks/angular.mdx
@@ -294,6 +294,72 @@ The full list of options can be found in the Angular builder schemas:
 - [Build Storybook](https://github.com/storybookjs/storybook/blob/next/code/frameworks/angular/build-schema.json)
 - [Start Storybook](https://github.com/storybookjs/storybook/blob/next/code/frameworks/angular/start-schema.json)
 
+
+## Angular standalone and NgModule configuration
+
+Storybook for Angular supports both standalone components (using `bootstrapApplication`) and
+NgModule-based setups (using `moduleMetadata`).
+
+### Using `bootstrapApplication` (standalone)
+
+If you're using Angular's standalone API with `bootstrapApplication`, Storybook will
+automatically detect and use your application's bootstrap configuration. No additional
+configuration is needed in most cases.
+
+```ts title="src/main.ts"
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(AppComponent, appConfig);
+```
+
+Storybook will use the same `appConfig` that your application uses, ensuring consistency
+between your Storybook stories and your actual application.
+
+### Using `moduleMetadata` (NgModule)
+
+For NgModule-based Angular applications, you can use the `moduleMetadata` parameter in your
+stories to provide the necessary module configuration:
+
+```ts title="src/app/button/button.component.stories.ts"
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { ButtonComponent } from './button.component';
+import { CommonModule } from '@angular/common';
+
+const meta: Meta<ButtonComponent> = {
+  title: 'Button',
+  component: ButtonComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule],
+      providers: [],
+    }),
+  ],
+};
+export default meta;
+type Story = StoryObj<ButtonComponent>;
+
+export const Primary: Story = {
+  args: {
+    label: 'Click me',
+  },
+};
+```
+
+The `moduleMetadata` decorator allows you to configure:
+- **imports** - Angular modules to import (e.g., `CommonModule`, `FormsModule`)
+- **providers** - Services to provide at the story level
+- **declarations** - Components, directives, and pipes to declare
+
+:::tip
+
+When using standalone components, you generally don't need `moduleMetadata`. Only use it
+when your standalone component depends on imports from NgModules.
+
+:::
+
 ## API
 
 ### Options


### PR DESCRIPTION
## Description

Adds missing documentation for Angular-specific configuration APIs to the Angular framework getting started guide.

### What this adds

- **bootstrapApplication** - How Storybook works with Angular standalone API
- **moduleMetadata** - How to configure NgModule-based stories with imports, providers, and declarations
- Code examples for both approaches
- Tip about when to use each approach

This addresses the issue where users couldn't find documentation for these Angular-specific Storybook APIs in the main documentation (only in the framework README).

Fixes #22237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Angular guide covering standalone vs. NgModule setups, how Storybook detects app configuration, how to override configuration per story/test, and practical guidance for using story-level configuration. Includes examples and a checklist of what story-level configuration controls (imports, providers, declarations) and when standalone components need extra setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->