### PR TITLE
Open-service: address server registration review feedback

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -154,8 +154,10 @@ const config = defineMain({
     experimentalTestSyntax: true,
     changeDetection: true,
   },
-  services: async (_value: void, options: Options) => {
-    if (true) {
+  experimental_services: async (_value: void, options: Options) => {
+    const logLevel = await options.presets.apply('logLevel');
+
+    if (logLevel === 'debug') {
       await registerOpenServiceDebugService(
         options.presets.apply<NonNullable<StorybookConfigRaw['storyIndexGenerator']>>(
           'storyIndexGenerator'

--- a/code/.storybook/open-service-debug-service.ts
+++ b/code/.storybook/open-service-debug-service.ts
@@ -4,11 +4,12 @@ import type { StorybookConfigRaw } from 'storybook/internal/types';
 import { logger } from 'storybook/internal/node-logger';
 
 import {
-  describeService,
-  defineCommand,
-  defineQuery,
-  defineService,
-  registerService,
+  experimental_defineCommand as defineCommand,
+  experimental_defineQuery as defineQuery,
+  experimental_defineService as defineService,
+  experimental_describeService as describeService,
+  experimental_listServices as listServices,
+  experimental_registerService as registerService,
 } from 'storybook/internal/core-server';
 
 const DEBUG_SERVICE_ID = 'storybook/internal/open-service-debug';
@@ -94,9 +95,7 @@ function createDebugServiceDef(storyIndexGeneratorPromise: Promise<StoryIndexGen
         handler: async (input, ctx) => {
           const value = ctx.self.state.preloadedByEntryId[input.entryId] ?? null;
 
-          logger.info(
-            `[open-service debug] query getPreloadedValue(${input.entryId}) => ${value}`
-          );
+          logger.info(`[open-service debug] query getPreloadedValue(${input.entryId}) => ${value}`);
           return value;
         },
       }),
@@ -140,8 +139,7 @@ function createDebugServiceDef(storyIndexGeneratorPromise: Promise<StoryIndexGen
         input: preloadVisitInputSchema,
         output: v.undefined(),
         handler: async (input, ctx) => {
-          const selfService = await ctx.getService(DEBUG_SERVICE_ID);
-          const summary = (await selfService.queries.getStoryIndexSummary({
+          const summary = (await ctx.self.queries.getStoryIndexSummary({
             includeSampleIds: false,
           })) as { entryCount: number; sampleIds: string[] };
           const value = `${input.source}:${input.entryId}:${summary.entryCount}`;
@@ -172,12 +170,11 @@ function createDebugServiceDef(storyIndexGeneratorPromise: Promise<StoryIndexGen
 export async function registerOpenServiceDebugService(
   storyIndexGeneratorPromise: Promise<StoryIndexGeneratorInstance>
 ): Promise<void> {
-  try {
-    await describeService(DEBUG_SERVICE_ID);
+  const registeredServices = await listServices();
+
+  if (registeredServices.some((service) => service.id === DEBUG_SERVICE_ID)) {
     logger.info('[open-service debug] debug service already registered');
     return;
-  } catch {
-    // The service is not registered yet in this process.
   }
 
   const service = registerService(createDebugServiceDef(storyIndexGeneratorPromise));

--- a/code/core/src/__tests/server-errors.test.ts
+++ b/code/core/src/__tests/server-errors.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  WebpackCompilationError,
-} from '../server-errors.ts';
+import { WebpackCompilationError } from '../server-errors.ts';
 
 describe('WebpackCompilationError', () => {
   it('should correctly handle error with stats.compilation.errors', () => {

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -290,7 +290,7 @@ export async function buildDevStandalone(
 
   const features = await presets.apply('features');
   global.FEATURES = features;
-  await presets.apply('services');
+  await presets.apply('experimental_services');
   await presets.apply('experimental_serverChannel', channel);
 
   const fullOptions: Options = {

--- a/code/core/src/core-server/build-static.ts
+++ b/code/core/src/core-server/build-static.ts
@@ -130,7 +130,7 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
   const effects: Promise<void>[] = [];
 
   global.FEATURES = features;
-  await presets.apply('services');
+  await presets.apply('experimental_services');
 
   if (!options.previewOnly) {
     await buildOrThrow(async () =>

--- a/code/core/src/core-server/index.ts
+++ b/code/core/src/core-server/index.ts
@@ -17,7 +17,11 @@ export { loadStorybook as experimental_loadStorybook } from './load.ts';
 
 export { Tag } from '../shared/constants/tags.ts';
 export { analyzeMdx } from './utils/analyze-mdx.ts';
-export { defineCommand, defineQuery, defineService } from '../shared/open-service/index.ts';
+export {
+  defineCommand as experimental_defineCommand,
+  defineQuery as experimental_defineQuery,
+  defineService as experimental_defineService,
+} from '../shared/open-service/index.ts';
 export type {
   Command,
   CommandCtx,
@@ -37,10 +41,10 @@ export type {
   ServerServiceRegistration,
 } from '../shared/open-service/index.ts';
 export {
-  describeService,
-  getService,
-  listServices,
-  registerService,
+  describeService as experimental_describeService,
+  getService as experimental_getService,
+  listServices as experimental_listServices,
+  registerService as experimental_registerService,
 } from '../shared/open-service/server.ts';
 
 export { UniversalStore as experimental_UniversalStore } from '../shared/universal-store/index.ts';

--- a/code/core/src/core-server/load.ts
+++ b/code/core/src/core-server/load.ts
@@ -95,7 +95,7 @@ export async function loadStorybook(
   const features = await presets.apply('features');
   global.FEATURES = features;
 
-  await presets.apply('services');
+  await presets.apply('experimental_services');
 
   return {
     ...options,

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -149,9 +149,9 @@ than rejecting them.
 
 ## Server Registration Flow
 
-Server-side registration happens through the `services` preset hook. Storybook calls
-`await presets.apply('services')` during both dev startup and static builds, and each service
-author's preset implementation is responsible for calling `registerService(...)` directly.
+Server-side registration happens through the `experimental_services` preset hook. Storybook calls
+`await presets.apply('experimental_services')` during both dev startup and static builds, and each
+service author's preset implementation is responsible for calling `registerService(...)` directly.
 
 That split is intentional:
 
@@ -176,7 +176,7 @@ When a server registers a service definition:
 
 ```mermaid
 sequenceDiagram
-  participant Preset as services preset
+  participant Preset as experimental_services preset
   participant Registry as registerService
   participant Runtime as createServiceRuntime
   participant Schema as validateSchema

--- a/code/core/src/shared/open-service/server.ts
+++ b/code/core/src/shared/open-service/server.ts
@@ -11,6 +11,7 @@ import {
   getService,
   listServices,
   registerService,
+  registryApi,
 } from './service-registration.ts';
 import { createServiceRuntime, resolveStaticPath } from './service-runtime.ts';
 import { validateSchema } from './service-validation.ts';
@@ -21,18 +22,11 @@ import type {
   Queries,
   QueryDefinition,
   ServiceDefinition,
-  ServiceRegistryApi,
   StaticStore,
 } from './types.ts';
 
 type RuntimeServiceDefinition = ServiceDefinition<unknown, Queries<unknown>, Commands<unknown>>;
 type RuntimeQueryDefinition = QueryDefinition<unknown, AnySchema, AnySchema>;
-
-const serverRegistryApi: ServiceRegistryApi = {
-  listServices,
-  describeService,
-  getService,
-};
 
 export {
   clearRegistry,
@@ -66,7 +60,7 @@ export async function buildStaticFiles(services: RuntimeServiceDefinition[]): Pr
 
       const inputsRuntime = createServiceRuntime(
         service,
-        { registryApi: serverRegistryApi },
+        { registryApi },
         structuredClone(service.initialState)
       );
       const inputs = await query.static.inputs(inputsRuntime.queryCtx);
@@ -77,7 +71,7 @@ export async function buildStaticFiles(services: RuntimeServiceDefinition[]): Pr
           // the one path this task is responsible for.
           const buildRuntime = createServiceRuntime(
             service,
-            { registryApi: serverRegistryApi },
+            { registryApi },
             structuredClone(service.initialState)
           );
           const validatedInput = await validateSchema(query.input, input, {

--- a/code/core/src/shared/open-service/service-registration.ts
+++ b/code/core/src/shared/open-service/service-registration.ts
@@ -102,7 +102,8 @@ function applyRegistration<
   };
 }
 
-const registryApi: ServiceRegistryApi = {
+/** Shared registry-facing API handed to every runtime so handlers can resolve other services. */
+export const registryApi: ServiceRegistryApi = {
   listServices,
   describeService,
   getService,

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -114,8 +114,8 @@ export interface Presets {
     args?: any
   ): Promise<StorybookConfigRaw['staticDirs']>;
   apply(
-    extension: 'services',
-    config?: StorybookConfigRaw['services'],
+    extension: 'experimental_services',
+    config?: StorybookConfigRaw['experimental_services'],
     args?: any
   ): Promise<void>;
 
@@ -644,7 +644,7 @@ export interface StorybookConfigRaw {
 
   tags?: TagsOptions;
 
-  services?: void;
+  experimental_services?: void;
 }
 
 /**
@@ -752,7 +752,7 @@ export interface StorybookConfig {
   tags?: PresetValue<StorybookConfigRaw['tags']>;
 
   /** Run open-service registration side effects for the server environment. */
-  services?: PresetValue<StorybookConfigRaw['services']>;
+  experimental_services?: PresetValue<StorybookConfigRaw['experimental_services']>;
 }
 
 export type PresetValue<T> = T | ((config: T, options: Options) => T | Promise<T>);


### PR DESCRIPTION
> 🤖 **This PR was prepared by an AI agent** (Claude Code) as a follow-up to the review of #34875. A human should validate before merging.

## What I did

Telescoping follow-up stacked on `jeppe/service-registration` (the head branch of #34875). It applies the **low-risk** fixes raised in the review of #34875, leaving the deeper design decisions to the author.

### Fixes

- **`experimental_` prefix on the new public API.** `registerService`, `defineService`, `defineQuery`, `defineCommand`, `getService`, `listServices`, `describeService` are now exported from `core-server/index.ts` as `experimental_*`, and the `services` preset hook is renamed to `experimental_services`. This matches the convention every other unstable core-server export already uses (`experimental_UniversalStore`, `experimental_loadStorybook`, …). Internal module names are unchanged — only the public barrel aliases and the preset key.
- **Real gate for the internal debug service.** The `if (true)` block in `code/.storybook/main.ts` is replaced with a `logLevel === 'debug'` check. The open-service debug service no longer registers (or logs) on every dev start and static build, and the code now matches what the open-service README already documents.
- **DRY: single `registryApi`.** `server.ts` and `service-registration.ts` each defined an identical `{ listServices, describeService, getService }` object; `service-registration.ts` now exports the one shared instance.
- **No exceptions for control flow.** `registerOpenServiceDebugService` used `try/catch` around `describeService()` to test existence (which also swallowed unrelated errors). It now uses a non-throwing `listServices()` check.
- **Law of Demeter.** `recordPreloadVisit` reads `ctx.self` directly instead of resolving its own service through the global registry.
- **Diff hygiene.** Reverted an unrelated multiline-import reformat in `server-errors.test.ts`.

### Deliberately *not* changed (author's call)

These are design decisions flagged in the review but intentionally left for @JReinhold to decide, since changing them would reverse intentional, tested behavior:

- `globalThis` registry vs. a module-local map (à la `UniversalStore`)
- `registerService` throwing vs. idempotent on duplicate id
- static-snapshot determinism when `ctx.getService` reads live registry state
- the `RuntimeService = ServiceInstance & ServiceRegistryApi` conflation

## Verification

- `yarn nx compile core` — ✅
- `yarn nx check core` — ✅ no type errors
- open-service + `server-errors` unit tests — ✅ 51/51 pass
- `.storybook` files typecheck clean

> [!NOTE]
> Two **pre-existing**, unrelated issues surfaced while verifying (neither is in this diff): `nextjs-vite:check` fails with a `storybookNextJsPlugin` redeclaration, and `immer` (declared in `code/core/package.json`) needed a `yarn install` to land in `node_modules`.

## Manual testing

1. `yarn nx compile core`
2. `cd code && yarn run storybook:ui` — debug-service logs no longer appear at the default log level
3. Set `logLevel: 'debug'` in `code/.storybook/main.ts` and restart — the open-service debug output appears, confirming the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked open-service API exports as experimental with `experimental_` prefix (`experimental_defineService`, `experimental_defineQuery`, `experimental_defineCommand`, and related utilities).
  * Updated Storybook configuration to use `experimental_services` preset hook for service registration.
  * Refactored debug service registration to use newer experimental APIs.

* **Documentation**
  * Updated service registration documentation to reflect API naming changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->