### PR TITLE
Open-service: idempotent registration and a leaner service handle

### DIFF
--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -167,17 +167,6 @@ export class OpenServiceValidationError extends StorybookError {
   }
 }
 
-export class OpenServiceDuplicateRegistrationError extends StorybookError {
-  constructor(public data: { serviceId: string }) {
-    super({
-      name: 'OpenServiceDuplicateRegistrationError',
-      category: Category.CORE_COMMON,
-      code: 6,
-      message: `A service with id "${data.serviceId}" is already registered.`,
-    });
-  }
-}
-
 export class OpenServiceMissingServiceError extends StorybookError {
   constructor(public data: { serviceId: string }) {
     super({

--- a/code/core/src/shared/open-service/service-registration.test.ts
+++ b/code/core/src/shared/open-service/service-registration.test.ts
@@ -61,19 +61,12 @@ describe('service registration', () => {
     expect(descriptor.commands.assignRecordField.output).toBe(voidOutputSchema);
   });
 
-  it('throws when registering the same service id twice', () => {
-    registerService(mutableRecordLookupServiceDef);
+  it('returns the existing registration when the same service id is registered twice', () => {
+    const first = registerService(mutableRecordLookupServiceDef);
+    const second = registerService(mutableRecordLookupServiceDef);
 
-    try {
-      registerService(mutableRecordLookupServiceDef);
-      expect.unreachable('Expected duplicate registration to throw');
-    } catch (error) {
-      expect(error).toMatchObject({
-        fromStorybook: true,
-        code: 6,
-        message: 'A service with id "test/mutable-record-lookup" is already registered.',
-      });
-    }
+    expect(second).toBe(first);
+    expect(getRegisteredServices()).toHaveLength(1);
   });
 
   it('throws a Storybook error when resolving a missing registered service id', async () => {

--- a/code/core/src/shared/open-service/service-registration.ts
+++ b/code/core/src/shared/open-service/service-registration.ts
@@ -1,8 +1,5 @@
 import { createServiceRuntime } from './service-runtime.ts';
-import {
-  OpenServiceDuplicateRegistrationError,
-  OpenServiceMissingServiceError,
-} from '../../server-errors.ts';
+import { OpenServiceMissingServiceError } from '../../server-errors.ts';
 import type {
   Commands,
   Queries,
@@ -109,6 +106,14 @@ export const registryApi: ServiceRegistryApi = {
   getService,
 };
 
+/**
+ * Registers a service for the current server process and returns its runtime instance.
+ *
+ * Registration is idempotent by service id: if a service with the same id is already registered,
+ * the existing instance is returned and the new definition (including any registration-time
+ * overrides) is ignored. This lets the same definition be registered safely from more than one
+ * server entrypoint without the caller having to guard against duplicate registration.
+ */
 export function registerService<
   TState,
   TQueries extends Queries<TState>,
@@ -116,20 +121,20 @@ export function registerService<
 >(
   definition: ServiceDefinition<TState, TQueries, TCommands>,
   registration?: ServiceRegistrationOptions<TState, TQueries, TCommands>
-): ServiceInstance<TState, TQueries, TCommands> & ServiceRegistryApi {
+): ServiceInstance<TState, TQueries, TCommands> {
   const registry = getRegistry();
+  const existing = registry.get(definition.id);
 
-  if (registry.has(definition.id)) {
-    throw new OpenServiceDuplicateRegistrationError({ serviceId: definition.id });
+  if (existing) {
+    return existing.runtime as ServiceInstance<TState, TQueries, TCommands>;
   }
 
   const resolvedDefinition = applyRegistration(definition, registration);
   const runtime = createServiceRuntime(resolvedDefinition, { registryApi });
-  const registeredRuntime = {
+  const registeredRuntime: ServiceInstance<TState, TQueries, TCommands> = {
     queries: runtime.queries,
     commands: runtime.commands,
-    ...registryApi,
-  } as ServiceInstance<TState, TQueries, TCommands> & ServiceRegistryApi;
+  };
   const descriptor = describeDefinition(resolvedDefinition as AnyServiceDefinition);
 
   registry.set(definition.id, {

--- a/code/core/src/shared/open-service/types.ts
+++ b/code/core/src/shared/open-service/types.ts
@@ -84,8 +84,8 @@ export interface ServiceRegistryApi {
   getService(serviceId: string): Promise<RuntimeService>;
 }
 
-export type RuntimeService = ServiceInstance<unknown, Queries<unknown>, Commands<unknown>> &
-  ServiceRegistryApi;
+/** A resolved service handle exposing only its own queries and commands. */
+export type RuntimeService = ServiceInstance<unknown, Queries<unknown>, Commands<unknown>>;
 
 /** Context passed to query handlers and static preload helpers. */
 export type QueryCtx<TState> = {


### PR DESCRIPTION
> 🤖 **This PR was prepared by an AI agent** (Claude Code) as a follow-up to the review of #34875. A human should validate before merging.

## What I did

Telescoping follow-up stacked on `valentin/open-service-review-fixes` (#34880). It addresses **two of the four design items** that #34880 deliberately deferred — the two confirmed as in-scope. The remaining two (`globalThis` registry, deterministic static builds) are intentionally still left to the author.

### 1. `registerService` is idempotent by service id

Previously `registerService` threw `OpenServiceDuplicateRegistrationError` when a service id was already registered. Because the `experimental_services` preset can be applied from more than one server entrypoint (`build-dev`, `build-static`, `load`), the documented contract — "call `registerService(...)` directly in your hook" — was fragile: a second application in the same process would throw.

`registerService` now returns the **existing instance** when the same id is already registered, and ignores the second definition (including any registration-time overrides). The same definition can be registered safely from multiple entrypoints without the caller guarding against it. This matches how `UniversalStore` treats duplicate ids.

`OpenServiceDuplicateRegistrationError` is removed since it is now unused. (Error codes 7–10 are left as-is rather than shifted — error codes shouldn't be renumbered, and a gap at 6 is harmless.)

### 2. A service handle is no longer also a registry

`RuntimeService` was `ServiceInstance & ServiceRegistryApi`, so every resolved service handle — everything returned by `getService()`, `registerService()`, and `ctx.getService()` — also carried `listServices` / `describeService` / `getService`. That conflated "a service" with "the process-wide registry".

`RuntimeService` is now just the `ServiceInstance` (queries + commands). The registry functions remain available as standalone exports from `server.ts`; nothing consumed the registry methods off a service handle, so this is dead surface removed with no behavior change.

### Still deferred (author's call)

- `globalThis` registry vs. a module-local map
- deterministic static builds (per-build fresh registry)

## Verification

- `yarn nx compile core` — ✅
- `yarn nx check core` — ✅ no type errors
- open-service + `server-errors` unit tests — ✅ 51/51 pass (duplicate-registration test rewritten as an idempotency test)
- `oxfmt` — ✅ clean

## Manual testing

This is an internal API/typing change with no user-facing behavior. Covered by the unit tests above; the rewritten `service registration` test asserts that registering the same id twice returns the same instance and leaves a single registry entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Service registration now idempotently handles duplicate registrations by returning the existing service instance instead of throwing an error.

* **Refactor**
  * Simplified the service registry API by streamlining public interface methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->