### PR TITLE
CSF: Index stories exported under string-literal names

### DIFF
--- a/code/core/src/csf-tools/CsfFile.test.ts
+++ b/code/core/src/csf-tools/CsfFile.test.ts
@@ -1153,6 +1153,104 @@ describe('CsfFile', () => {
       `);
     });
 
+    it('renamed export with a non-identifier string-literal name', () => {
+      // Repro: a story exported via `export { Local as '<string literal>' }` used to be
+      // silently dropped by the indexer instead of being picked up like any other story.
+      expect(
+        parse(
+          dedent`
+          export default { title: 'foo/bar' };
+          const ThisDoesNotWork = { args: { label: 'Button' } };
+          export { ThisDoesNotWork as 'あ' };
+        `,
+          true
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--あ
+            name: あ
+            localName: ThisDoesNotWork
+            parameters:
+              __id: foo-bar--あ
+            __stats:
+              play: false
+              render: false
+              loaders: false
+              beforeEach: false
+              globals: false
+              tags: false
+              storyFn: false
+              mount: false
+              moduleMock: false
+      `);
+    });
+
+    it('renamed export with a string-literal name containing spaces', () => {
+      expect(
+        parse(
+          dedent`
+          export default { title: 'foo/bar' };
+          const story = { render: () => {} };
+          export { story as 'With Spaces' };
+        `,
+          true
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--with-spaces
+            name: With Spaces
+            localName: story
+            parameters:
+              __id: foo-bar--with-spaces
+            __stats:
+              play: false
+              render: true
+              loaders: false
+              beforeEach: false
+              globals: false
+              tags: false
+              storyFn: false
+              mount: false
+              moduleMock: false
+      `);
+    });
+
+    it('meta exported via a string-literal default specifier', () => {
+      expect(
+        parse(
+          dedent`
+          const meta = { title: 'foo/bar' };
+          const story = {};
+          export { meta as 'default', story as A };
+        `,
+          true
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+            localName: story
+            parameters:
+              __id: foo-bar--a
+            __stats:
+              play: false
+              render: false
+              loaders: false
+              beforeEach: false
+              globals: false
+              tags: false
+              storyFn: false
+              mount: false
+              moduleMock: false
+      `);
+    });
+
     it('support for parameter decorators', () => {
       expect(
         parse(dedent`
@@ -2158,6 +2256,38 @@ describe('CsfFile', () => {
           type: story
           subtype: story
           name: B
+      `);
+    });
+
+    it('generates index inputs for renamed string-literal exports', () => {
+      const { indexInputs } = loadCsf(
+        dedent`
+      export default { title: 'custom foo title' };
+
+      const ThisDoesNotWork = { args: { label: 'Button' } };
+      export { ThisDoesNotWork as 'あ' };
+    `,
+        { makeTitle, fileName: 'foo/bar.stories.js' }
+      ).parse();
+
+      expect(indexInputs).toMatchInlineSnapshot(`
+        - exportName: あ
+          title: custom foo title
+          tags: []
+          __id: custom-foo-title--あ
+          __stats:
+            play: false
+            render: false
+            loaders: false
+            beforeEach: false
+            globals: false
+            tags: false
+            storyFn: false
+            mount: false
+            moduleMock: false
+          type: story
+          subtype: story
+          name: あ
       `);
     });
 

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -113,6 +113,14 @@ const formatLocation = (node: t.Node, fileName?: string) => {
   return `${fileName || ''} ${loc}`.trim();
 };
 
+/**
+ * Resolve the exported name of an export specifier. The exported binding can be a string literal
+ * (`export { Story as 'あ' }`) as well as an identifier (`export { Story as Renamed }`). Both are
+ * valid ESM and must be indexed identically rather than silently dropped.
+ */
+const getExportSpecifierName = (exported: t.Identifier | t.StringLiteral) =>
+  t.isIdentifier(exported) ? exported.name : exported.value;
+
 export const isModuleMock = (importPath: string) => MODULE_MOCK_REGEX.test(importPath);
 
 const isArgsStory = (init: t.Node, parent: t.Node, csf: CsfFile) => {
@@ -680,10 +688,12 @@ export class CsfFile {
               }
             });
           } else if (node.specifiers.length > 0) {
-            // export { X as Y }
+            // export { X as Y } or export { X as 'Y' }
             node.specifiers.forEach((specifier) => {
-              if (t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported)) {
-                const { name: exportName } = specifier.exported;
+              if (t.isExportSpecifier(specifier)) {
+                // The exported name can be a string literal, e.g. `export { X as 'あ' }`.
+                // This is valid ESM, so it must be indexed like any other renamed export.
+                const exportName = getExportSpecifierName(specifier.exported);
                 const { name: localName } = specifier.local;
                 const decl = t.isProgram(parent)
                   ? findVarInitialization(localName, parent)

--- a/code/core/template/stories/renamed-exports.stories.ts
+++ b/code/core/template/stories/renamed-exports.stories.ts
@@ -1,0 +1,27 @@
+import type { PlayFunctionContext } from 'storybook/internal/types';
+
+import { global as globalThis } from '@storybook/global';
+
+import { expect } from 'storybook/test';
+
+export default {
+  component: globalThis.__TEMPLATE_COMPONENTS__.Pre,
+  args: { text: 'No content' },
+};
+
+// A story can be exported under a renamed, string-literal name, e.g. `export { Local as 'あ' }`.
+// This is valid ESM and the CSF indexer must pick it up instead of silently dropping it.
+
+const RenamedStringExport = {
+  play: async ({ name }: PlayFunctionContext<any>) => {
+    await expect(name).toBe('あ');
+  },
+};
+
+const RenamedSpacedExport = {
+  play: async ({ name }: PlayFunctionContext<any>) => {
+    await expect(name).toBe('With Spaces');
+  },
+};
+
+export { RenamedStringExport as 'あ', RenamedSpacedExport as 'With Spaces' };

--- a/code/lib/eslint-plugin/src/rules/story-exports.test.ts
+++ b/code/lib/eslint-plugin/src/rules/story-exports.test.ts
@@ -35,6 +35,11 @@ ruleTester.run('story-exports', rule, {
       export default {}
       export { Primary, Secondary }
     `,
+    dedent`
+      const Primary = {}
+      export default {}
+      export { Primary as 'あ' }
+    `,
     `
       export default {
         title: 'MyComponent',
@@ -129,6 +134,22 @@ ruleTester.run('story-exports', rule, {
 
       //   export const Default = {}
       // `,
+      errors: [
+        {
+          messageId: 'shouldHaveStoryExportWithFilters',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        export default {
+          excludeStories: /.*Data$/,
+        }
+
+        const mockData = {}
+
+        export { mockData as 'mockData' }
+      `,
       errors: [
         {
           messageId: 'shouldHaveStoryExportWithFilters',

--- a/code/lib/eslint-plugin/src/rules/story-exports.ts
+++ b/code/lib/eslint-plugin/src/rules/story-exports.ts
@@ -54,7 +54,7 @@ export default createStorybookRule({
     let hasStoriesOfImport = false;
     let nonStoryExportsConfig: IncludeExcludeOptions = {};
     let meta: TSESTree.ObjectExpression | null;
-    const namedExports: TSESTree.Identifier[] = [];
+    const namedExports: (TSESTree.Identifier | TSESTree.StringLiteral)[] = [];
 
     return {
       ImportSpecifier(node) {

--- a/code/lib/eslint-plugin/src/utils/index.ts
+++ b/code/lib/eslint-plugin/src/utils/index.ts
@@ -79,20 +79,26 @@ export const getDescriptor = (
   }
 };
 
-export const isValidStoryExport = (
-  node: TSESTree.Identifier,
-  nonStoryExportsConfig: IncludeExcludeOptions
-) => isExportStory(node.name, nonStoryExportsConfig) && node.name !== '__namedExportsOrder';
+/** The exported name of a specifier can be an identifier or a string literal (`export { X as 'あ' }`). */
+const getExportName = (node: TSESTree.Identifier | TSESTree.StringLiteral) =>
+  isIdentifier(node) ? node.name : node.value;
 
-export const getAllNamedExports = (node: TSESTree.ExportNamedDeclaration) => {
-  // e.g. `export { MyStory }`
+export const isValidStoryExport = (
+  node: TSESTree.Identifier | TSESTree.StringLiteral,
+  nonStoryExportsConfig: IncludeExcludeOptions
+) => {
+  const name = getExportName(node);
+  return isExportStory(name, nonStoryExportsConfig) && name !== '__namedExportsOrder';
+};
+
+export const getAllNamedExports = (
+  node: TSESTree.ExportNamedDeclaration
+): (TSESTree.Identifier | TSESTree.StringLiteral)[] => {
+  // e.g. `export { MyStory }` or `export { MyStory as 'My Story' }`
   if (!node.declaration && node.specifiers) {
-    return node.specifiers.reduce((acc, specifier) => {
-      if (isIdentifier(specifier.exported)) {
-        acc.push(specifier.exported);
-      }
-      return acc;
-    }, [] as TSESTree.Identifier[]);
+    // `specifier.exported` is an identifier or a string literal (`export { X as 'あ' }`).
+    // Both forms are valid named exports and must be reported as stories, not dropped.
+    return node.specifiers.map((specifier) => specifier.exported);
   }
 
   const decl = node.declaration;


### PR DESCRIPTION
## What I did

`export { Story as 'あ' }` is valid ESM (the [arbitrary module namespace identifier names](https://github.com/tc39/ecma262/pull/2154) feature), but Storybook's CSF AST analyzer silently dropped any story whose export specifier was renamed to a string literal.

The `ExportNamedDeclaration` handler in `CsfFile.ts` only processed export specifiers whose `exported` binding was an `Identifier`:

```ts
if (t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported)) {
```

For `export { ThisDoesNotWork as 'あ' }`, `specifier.exported` is a `StringLiteral`, so the condition failed and the story never made it into the index — no warning, no error, just a missing story.

```ts
// ✅ already worked — export name is a plain identifier
export const ThisWorks: Story = { name: 'あ', /* ... */ };

// ❌ silently dropped — export name is a string literal
const ThisDoesNotWork: Story = { /* ... */ };
export { ThisDoesNotWork as 'あ' };
```

The `eslint-plugin-storybook` `story-exports` rule (`getAllNamedExports`) had the **identical blind spot** and false-positived with _"The file should have at least one story export"_ on files that only export stories under string-literal names.

## How I fixed it

- **`CsfFile.ts`** — resolve the exported name from either an `Identifier` (`.name`) or a `StringLiteral` (`.value`) via a small `getExportSpecifierName` helper, so renamed string-literal exports are indexed like any other story. This also fixes `export { meta as 'default' }` being unrecognized as the meta.
- **`eslint-plugin` (`getAllNamedExports` / `isValidStoryExport`)** — same resolution, so the `story-exports` rule no longer misfires.

No runtime change is needed: `processCSFFile` already iterates the real module export keys, so once the index agrees, the story loads and renders.

### Note on `IndexInput.exportName`

`exportName` is derived automatically by the indexer from the export specifier — it is not something a story author sets. For `export { Local as 'あ' }` it becomes `'あ'`, which matches the key the preview runtime resolves from the module namespace.

## Fixtures / validation

- `code/core/template/stories/renamed-exports.stories.ts` — a template story exercising `export { Local as 'あ' }` and `export { Local as 'With Spaces' }` end-to-end across all sandboxes (index → build → render → test-runner), with `play` functions asserting the resolved story name.
- `CsfFile.test.ts` — unit tests for non-identifier names, names with spaces, string-literal `default` specifiers, and the resulting `indexInputs`.
- `story-exports.test.ts` — valid/invalid cases for the eslint rule.

## Checklist

- [x] `yarn vitest` — `csf-tools` (332) and `story-exports` (16) pass
- [x] `yarn nx check core` / `yarn nx check eslint-plugin` — no type errors
- [x] Lint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stories exported with renamed string-literal aliases (e.g., `export { Story as 'name' }`) are now properly recognized and indexed instead of being dropped
  * Non-ASCII and space-containing story names are now fully supported
  * Export validation rules updated to correctly handle string-literal export specifiers

* **Tests**
  * Added comprehensive test coverage for renamed string-literal exports, including Unicode and spaced names

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->