### PR TITLE
AgentScan: Move label map to agent-san parameters

### DIFF
--- a/.github/scripts/agent-scan-label-pr.mjs
+++ b/.github/scripts/agent-scan-label-pr.mjs
@@ -2,33 +2,29 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 
 /**
- * agent scan classification rename
+ * agent scan classification name
  * - organic -> human
- * - automated
- * - mixed
  */
 const CLASSIFICATION_MAP = {
   organic: 'human',
-  automation: 'automated',
 };
 
 async function main() {
   const classification = core.getInput('classification', { required: true });
   const token = core.getInput('token', { required: true });
-  const isCommunityFlagged = core.getInput('community-flagged') === 'true';
 
   const octokit = github.getOctokit(token);
   const prNumber = github.context.payload.pull_request.number;
 
-  const labels = [`agent-scan:${CLASSIFICATION_MAP[classification] ?? classification}`];
-  if (isCommunityFlagged) {
-    labels.push('agent-scan:community-flagged');
+  if (classification === 'organic') {
+    const labels = [`agent-scan:${CLASSIFICATION_MAP[classification] ?? classification}`];
+
+    await octokit.rest.issues.addLabels({
+      ...github.context.repo,
+      issue_number: prNumber,
+      labels: labels,
+    });
   }
-  await octokit.rest.issues.addLabels({
-    ...github.context.repo,
-    issue_number: prNumber,
-    labels: labels,
-  });
 }
 
 main().catch((error) => {

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -46,7 +46,7 @@ jobs:
       - name: AgentScan
         if: steps.membership.outputs.should-scan == 'true'
         id: agentscan
-        uses: MatteoGabriele/agentscan-action@f41545309db947a68e22ed2643f182e754f4d41a
+        uses: MatteoGabriele/agentscan-action@f41545309db947a68e22ed2643f182e754f4d41a # v1.8.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           agent-scan-comment: false

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -46,11 +46,15 @@ jobs:
       - name: AgentScan
         if: steps.membership.outputs.should-scan == 'true'
         id: agentscan
-        uses: MatteoGabriele/agentscan-action@a584774dd15cabe6df4c6ab45fc43514a3b56b2d
+        uses: MatteoGabriele/agentscan-action@f41545309db947a68e22ed2643f182e754f4d41a
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           agent-scan-comment: false
           cache-path: .agentscan-cache
+          label-community-flagged: "agent-scan:community-flagged"
+          label-mixed: "agent-scan:mixed"
+          label-automation: "agent-scan:automated"
+
       - name: Label PR with classification
         if: steps.membership.outputs.should-scan == 'true' && steps.agentscan.outputs.classification
         env:


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

UPdate agent scan action and move the label rename to agent scan for mixed and automated signal. 
Agent-scan doesn't label organic account, so we need to keep the script to label `agen-scan: human`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Needs to be merged prior to testing due to the nature of the action.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to extend PR classification label mappings used by automated scanning.
  * Adjusted labeling behavior so automated "agent-scan:<label>" tags are applied only for organic classifications; removed the previous unconditional community-flagged labeling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->