### PR TITLE
Allow AI setup for React Rsbuild projects

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -318,11 +318,13 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
 
       finalOptions.includeStories = includeStories;
       const projectId = oneWayHash(finalOptions.configDir);
+      const builderName = typeof core?.builder === 'string' ? core.builder : core?.builder?.name;
+      const supportsAutomaticProjectAnnotations =
+        builderName?.includes('@storybook/builder-vite') || builderName?.includes('builder-vite');
 
-      const areProjectAnnotationRequired = await requiresProjectAnnotations(
-        nonMutableInputConfig.test,
-        finalOptions
-      );
+      const areProjectAnnotationRequired =
+        supportsAutomaticProjectAnnotations &&
+        (await requiresProjectAnnotations(nonMutableInputConfig.test, finalOptions));
 
       const internalSetupFiles = (
         [

--- a/code/core/src/core-server/load.ts
+++ b/code/core/src/core-server/load.ts
@@ -11,6 +11,7 @@ import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook
 
 import { global } from '@storybook/global';
 
+import { existsSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'pathe';
 
 import { resolvePackageDir } from '../shared/utils/module.ts';
@@ -74,7 +75,10 @@ export async function loadStorybook(
     */
     const isResolved = builderName.startsWith('file:') || isAbsolute(builderName);
     const builderPresetDir = isResolved ? dirname(builderName) : resolvePackageDir(builderName);
-    corePresets.push(join(builderPresetDir, 'preset.js'));
+    const builderPreset = join(builderPresetDir, 'preset.js');
+    if (existsSync(builderPreset)) {
+      corePresets.push(builderPreset);
+    }
   }
 
   // Load second pass: all presets are applied in order

--- a/code/lib/cli-storybook/src/ai/index.ts
+++ b/code/lib/cli-storybook/src/ai/index.ts
@@ -11,6 +11,10 @@ import { ProjectTypeService } from '../../../create-storybook/src/services/Proje
 
 import { getStorybookData } from '../automigrate/helpers/mainConfigFile.ts';
 import { getAiSetupMarkdownOutput } from './setup-prompts/index.ts';
+import {
+  getUnsupportedAiSetupProjectMessage,
+  isAiSetupSupportedProject,
+} from './supported-project.ts';
 import type { ProjectInfo, AiSetupOptions } from './types.ts';
 
 export async function aiSetup(options: AiSetupOptions): Promise<void> {
@@ -67,16 +71,8 @@ export async function aiSetup(options: AiSetupOptions): Promise<void> {
     return;
   }
 
-  if (
-    projectInfo.rendererPackage !== '@storybook/react' ||
-    projectInfo.builderPackage !== '@storybook/builder-vite'
-  ) {
-    logger.log(
-      'AI-assisted setup is currently only available for projects using the React renderer with Vite builder. Detected renderer: ' +
-        projectInfo.rendererPackage +
-        ', builder: ' +
-        projectInfo.builderPackage
-    );
+  if (!isAiSetupSupportedProject(projectInfo)) {
+    logger.log(getUnsupportedAiSetupProjectMessage(projectInfo));
     return;
   }
 

--- a/code/lib/cli-storybook/src/ai/supported-project.test.ts
+++ b/code/lib/cli-storybook/src/ai/supported-project.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getUnsupportedAiSetupProjectMessage,
+  isAiSetupSupportedProject,
+} from './supported-project.ts';
+
+describe('isAiSetupSupportedProject', () => {
+  it('allows React projects using the Vite builder', () => {
+    expect(
+      isAiSetupSupportedProject({
+        rendererPackage: '@storybook/react',
+        builderPackage: '@storybook/builder-vite',
+      })
+    ).toBe(true);
+  });
+
+  it('allows React projects using the Rsbuild builder', () => {
+    expect(
+      isAiSetupSupportedProject({
+        rendererPackage: '@storybook/react',
+        builderPackage: 'storybook-builder-rsbuild',
+      })
+    ).toBe(true);
+  });
+
+  it('rejects non-React projects even when they use a supported builder', () => {
+    expect(
+      isAiSetupSupportedProject({
+        rendererPackage: '@storybook/vue3',
+        builderPackage: 'storybook-builder-rsbuild',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects React projects using unsupported builders', () => {
+    expect(
+      isAiSetupSupportedProject({
+        rendererPackage: '@storybook/react',
+        builderPackage: '@storybook/builder-webpack5',
+      })
+    ).toBe(false);
+  });
+});
+
+describe('getUnsupportedAiSetupProjectMessage', () => {
+  it('lists the supported builder families and detected packages', () => {
+    expect(
+      getUnsupportedAiSetupProjectMessage({
+        rendererPackage: '@storybook/react',
+        builderPackage: '@storybook/builder-webpack5',
+      })
+    ).toBe(
+      'AI-assisted setup is currently only available for projects using the React renderer with Vite or Rsbuild builders. Detected renderer: @storybook/react, builder: @storybook/builder-webpack5'
+    );
+  });
+});

--- a/code/lib/cli-storybook/src/ai/supported-project.ts
+++ b/code/lib/cli-storybook/src/ai/supported-project.ts
@@ -1,0 +1,25 @@
+import type { ProjectInfo } from './types.ts';
+
+const SUPPORTED_REACT_BUILDERS = ['@storybook/builder-vite', 'storybook-builder-rsbuild'] as const;
+
+type AiSetupProjectSupportInfo = Pick<ProjectInfo, 'rendererPackage' | 'builderPackage'>;
+
+export function isAiSetupSupportedProject(projectInfo: AiSetupProjectSupportInfo): boolean {
+  return (
+    projectInfo.rendererPackage === '@storybook/react' &&
+    SUPPORTED_REACT_BUILDERS.includes(projectInfo.builderPackage as SupportedReactBuilder)
+  );
+}
+
+export function getUnsupportedAiSetupProjectMessage(
+  projectInfo: AiSetupProjectSupportInfo
+): string {
+  return (
+    'AI-assisted setup is currently only available for projects using the React renderer with Vite or Rsbuild builders. Detected renderer: ' +
+    projectInfo.rendererPackage +
+    ', builder: ' +
+    projectInfo.builderPackage
+  );
+}
+
+type SupportedReactBuilder = (typeof SUPPORTED_REACT_BUILDERS)[number];


### PR DESCRIPTION
## Summary

- allow `storybook ai setup` for React projects using `storybook-builder-rsbuild`
- keep the AI setup gate narrow by still requiring the React renderer
- extract the support check into a small helper with coverage for Vite, Rsbuild, non-React Rsbuild, and unsupported React builders

## Why

`storybook ai setup` currently exits for React + Rsbuild projects even though the generated setup prompt is not Vite-specific. The current guard only allows `@storybook/builder-vite`, so projects using `storybook-react-rsbuild` receive the unsupported-project message and no setup instructions.

## Validation

- `git diff --check`
- `npx --yes -p vitest@4.1.5 -p vite@7.0.4 vitest run --config /tmp/storybook-ai-vitest.config.mjs`

The focused Vitest run used a minimal temp config because this shallow checkout did not have Yarn/Corepack dependencies installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-assisted Storybook setup now supports React projects with the Rsbuild builder in addition to Vite.

* **Improvements**
  * Clearer error messages listing supported renderer/builder combinations when AI setup is unsupported.
  * Test runner now only includes special project annotations when using the Vite-style builder.
  * Storybook startup skips adding nonexistent builder-specific preset files to avoid spurious errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->