### PR TITLE
CLI: Narrow CSF Factories Subpath Imports

### DIFF
--- a/code/core/src/csf-tools/CsfFile.test.ts
+++ b/code/core/src/csf-tools/CsfFile.test.ts
@@ -3137,6 +3137,7 @@ describe('isModuleMock', () => {
 describe('isValidPreviewPath', () => {
   it.each([
     ['#.storybook/preview', true],
+    ['#storybook/preview.ts', true],
     ['../../.storybook/preview', true],
     ['/path/to/.storybook/preview', true],
     ['./preview', true],

--- a/code/lib/cli-storybook/src/codemod/csf-factories.test.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.test.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { getStorybookSubpathImportTarget } from './csf-factories.ts';
+
+describe('csf-factories command', () => {
+  describe('getStorybookSubpathImportTarget', () => {
+    it('scopes the imports map target to the Storybook config directory', () => {
+      const packageJsonDir = path.resolve(path.sep, 'project');
+
+      expect(
+        getStorybookSubpathImportTarget(path.join(packageJsonDir, '.storybook'), packageJsonDir)
+      ).toBe('./.storybook/*');
+      expect(
+        getStorybookSubpathImportTarget(
+          path.join(packageJsonDir, 'config', 'storybook'),
+          packageJsonDir
+        )
+      ).toBe('./config/storybook/*');
+    });
+  });
+});

--- a/code/lib/cli-storybook/src/codemod/csf-factories.test.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import type { JsPackageManager } from 'storybook/internal/common';
+import { syncStorybookAddons, type JsPackageManager } from 'storybook/internal/common';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runCodemod } from '../automigrate/codemod.ts';
@@ -9,21 +9,13 @@ import {
   getStorybookSubpathImportTarget,
   getUpdatedStorybookImportsMap,
 } from './csf-factories.ts';
+import { configToCsfFactory } from './helpers/config-to-csf-factory.ts';
 import { storyToCsfFactory } from './helpers/story-to-csf-factory.ts';
 
-vi.mock('../automigrate/codemod.ts', () => ({
-  runCodemod: vi.fn(),
-}));
-vi.mock('./helpers/story-to-csf-factory.ts', () => ({
-  storyToCsfFactory: vi.fn(async () => 'transformed story'),
-}));
-vi.mock('./helpers/config-to-csf-factory.ts', () => ({
-  configToCsfFactory: vi.fn(async () => 'transformed config'),
-}));
-vi.mock('storybook/internal/common', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('storybook/internal/common')>()),
-  syncStorybookAddons: vi.fn(),
-}));
+vi.mock('../automigrate/codemod.ts', { spy: true });
+vi.mock('./helpers/story-to-csf-factory.ts', { spy: true });
+vi.mock('./helpers/config-to-csf-factory.ts', { spy: true });
+vi.mock('storybook/internal/common', { spy: true });
 
 const createPackageManager = (packageJsonImports: Record<string, unknown>): JsPackageManager =>
   ({
@@ -39,6 +31,10 @@ const createPackageManager = (packageJsonImports: Record<string, unknown>): JsPa
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.IN_STORYBOOK_SANDBOX = '1';
+  vi.mocked(runCodemod).mockResolvedValue(undefined);
+  vi.mocked(storyToCsfFactory).mockResolvedValue('transformed story');
+  vi.mocked(configToCsfFactory).mockResolvedValue('transformed config');
+  vi.mocked(syncStorybookAddons).mockResolvedValue(undefined);
 });
 
 afterEach(() => {

--- a/code/lib/cli-storybook/src/codemod/csf-factories.test.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.test.ts
@@ -1,8 +1,49 @@
 import path from 'path';
 
-import { describe, expect, it } from 'vitest';
+import type { JsPackageManager } from 'storybook/internal/common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getStorybookSubpathImportTarget } from './csf-factories.ts';
+import { runCodemod } from '../automigrate/codemod.ts';
+import {
+  csfFactories,
+  getStorybookSubpathImportTarget,
+  getUpdatedStorybookImportsMap,
+} from './csf-factories.ts';
+import { storyToCsfFactory } from './helpers/story-to-csf-factory.ts';
+
+vi.mock('../automigrate/codemod.ts', () => ({
+  runCodemod: vi.fn(),
+}));
+vi.mock('./helpers/story-to-csf-factory.ts', () => ({
+  storyToCsfFactory: vi.fn(async () => 'transformed story'),
+}));
+vi.mock('./helpers/config-to-csf-factory.ts', () => ({
+  configToCsfFactory: vi.fn(async () => 'transformed config'),
+}));
+vi.mock('storybook/internal/common', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('storybook/internal/common')>()),
+  syncStorybookAddons: vi.fn(),
+}));
+
+const createPackageManager = (packageJsonImports: Record<string, unknown>): JsPackageManager =>
+  ({
+    primaryPackageJson: {
+      packageJson: { imports: packageJsonImports },
+      packageJsonPath: '/monorepo/packages/example/package.json',
+      operationDir: '/monorepo/packages/example',
+    },
+    runPackageCommand: vi.fn(),
+    writePackageJson: vi.fn(),
+  }) as unknown as JsPackageManager;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.IN_STORYBOOK_SANDBOX = '1';
+});
+
+afterEach(() => {
+  delete process.env.IN_STORYBOOK_SANDBOX;
+});
 
 describe('csf-factories command', () => {
   describe('getStorybookSubpathImportTarget', () => {
@@ -19,5 +60,125 @@ describe('csf-factories command', () => {
         )
       ).toBe('./config/storybook/*');
     });
+
+    it('resolves relative config directories from the package.json directory', () => {
+      const packageJsonDir = path.resolve('/repo', 'packages', 'app');
+
+      expect(getStorybookSubpathImportTarget('.storybook', packageJsonDir)).toBe('./.storybook/*');
+      expect(getStorybookSubpathImportTarget('../shared/.storybook', packageJsonDir)).toBe(
+        './../shared/.storybook/*'
+      );
+    });
+  });
+
+  describe('getUpdatedStorybookImportsMap', () => {
+    it('adds the scoped Storybook import target and removes the legacy wildcard', () => {
+      const result = getUpdatedStorybookImportsMap(
+        {
+          '#*': ['./*', './*.ts', './*.tsx', './*.js', './*.jsx'],
+        },
+        './.storybook/*'
+      );
+
+      expect(result).toEqual({
+        imports: {
+          '#storybook/*': './.storybook/*',
+        },
+        shouldWritePackageJson: true,
+      });
+    });
+
+    it('replaces stale scoped Storybook import targets on reruns', () => {
+      const result = getUpdatedStorybookImportsMap(
+        {
+          '#storybook/*': './storybook/*',
+        },
+        './.storybook/*'
+      );
+
+      expect(result).toEqual({
+        imports: {
+          '#storybook/*': './.storybook/*',
+        },
+        shouldWritePackageJson: true,
+      });
+    });
+
+    it('keeps current scoped Storybook import targets unchanged', () => {
+      const result = getUpdatedStorybookImportsMap(
+        {
+          '#storybook/*': './.storybook/*',
+        },
+        './.storybook/*'
+      );
+
+      expect(result).toEqual({
+        imports: {
+          '#storybook/*': './.storybook/*',
+        },
+        shouldWritePackageJson: false,
+      });
+    });
+  });
+
+  it('passes a package-operation-dir-normalized configDir into story transformation helpers', async () => {
+    const mockRunCodemod = vi.mocked(runCodemod);
+    const mockStoryToCsfFactory = vi.mocked(storyToCsfFactory);
+    const packageManager = createPackageManager({});
+
+    await csfFactories.run({
+      dryRun: false,
+      packageManager,
+      mainConfig: {},
+      mainConfigPath: 'main.ts',
+      previewConfigPath: 'preview.ts',
+      configDir: '.storybook',
+      yes: true,
+      glob: '**/*.stories.tsx',
+    });
+
+    const transformStory = mockRunCodemod.mock.calls[0]?.[1];
+    expect(transformStory).toBeDefined();
+
+    await transformStory({
+      path: 'src/stories/Button.stories.tsx',
+      source: 'export {};',
+    });
+
+    expect(mockStoryToCsfFactory).toHaveBeenCalledWith(
+      { path: 'src/stories/Button.stories.tsx', source: 'export {};' },
+      expect.objectContaining({
+        configDir: path.resolve('/monorepo/packages/example', '.storybook'),
+        previewConfigPath: path.resolve('/monorepo/packages/example', 'preview.ts'),
+      })
+    );
+  });
+
+  it('refreshes #storybook/* when stale and removes legacy entries in package.json', async () => {
+    const packageManager = createPackageManager({
+      '#storybook/*': './old/*',
+      '#*': ['./*', './*.ts', './*.tsx', './*.js', './*.jsx'],
+    });
+    await csfFactories.run({
+      dryRun: false,
+      packageManager,
+      mainConfig: {},
+      mainConfigPath: 'main.ts',
+      previewConfigPath: 'preview.ts',
+      configDir: '.storybook',
+      yes: true,
+      glob: '**/*.stories.tsx',
+    });
+
+    expect(packageManager.writePackageJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imports: expect.objectContaining({
+          '#storybook/*': './.storybook/*',
+        }),
+      }),
+      '/monorepo/packages/example'
+    );
+    expect(packageManager.writePackageJson).toHaveBeenCalledTimes(1);
+    expect(packageManager.primaryPackageJson.packageJson.imports['#*']).toBeUndefined();
   });
 });

--- a/code/lib/cli-storybook/src/codemod/csf-factories.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.ts
@@ -62,8 +62,11 @@ const LEGACY_SUBPATH_IMPORT = ['./*', './*.ts', './*.tsx', './*.js', './*.jsx'];
 
 const toPosixPath = (filePath: string) => filePath.replace(/\\/g, '/');
 
+const resolveFromOperationDir = (filePath: string, operationDir: string) =>
+  path.isAbsolute(filePath) ? filePath : path.resolve(operationDir, filePath);
+
 export const getStorybookSubpathImportTarget = (configDir: string, packageJsonDir: string) => {
-  const absoluteConfigDir = path.isAbsolute(configDir) ? configDir : path.resolve(configDir);
+  const absoluteConfigDir = resolveFromOperationDir(configDir, packageJsonDir);
   const configDirFromPackageJson = toPosixPath(path.relative(packageJsonDir, absoluteConfigDir));
 
   if (!configDirFromPackageJson) {
@@ -77,6 +80,26 @@ const isLegacySubpathImport = (value: unknown) =>
   Array.isArray(value) &&
   value.length === LEGACY_SUBPATH_IMPORT.length &&
   value.every((entry, index) => entry === LEGACY_SUBPATH_IMPORT[index]);
+
+export const getUpdatedStorybookImportsMap = (
+  imports: Record<string, unknown> | undefined,
+  storybookImportTarget: string
+) => {
+  const updatedImports = { ...imports };
+  let shouldWritePackageJson = false;
+
+  if (updatedImports['#storybook/*'] !== storybookImportTarget) {
+    updatedImports['#storybook/*'] = storybookImportTarget;
+    shouldWritePackageJson = true;
+  }
+
+  if (isLegacySubpathImport(updatedImports['#*'])) {
+    delete updatedImports['#*'];
+    shouldWritePackageJson = true;
+  }
+
+  return { imports: updatedImports, shouldWritePackageJson };
+};
 
 export const csfFactories: CommandFix = {
   id: 'csf-factories',
@@ -118,24 +141,24 @@ export const csfFactories: CommandFix = {
     }
 
     const { packageJson } = packageManager.primaryPackageJson;
+    const resolvedConfigDir = resolveFromOperationDir(
+      configDir,
+      packageManager.primaryPackageJson.operationDir
+    );
+    const resolvedPreviewConfigPath = resolveFromOperationDir(
+      previewConfigPath!,
+      packageManager.primaryPackageJson.operationDir
+    );
 
     if (useSubPathImports) {
       const storybookImportTarget = getStorybookSubpathImportTarget(
-        configDir,
+        resolvedConfigDir,
         packageManager.primaryPackageJson.operationDir
       );
-      const imports = { ...packageJson.imports };
-      let shouldWritePackageJson = false;
-
-      if (!imports['#storybook/*']) {
-        imports['#storybook/*'] = storybookImportTarget;
-        shouldWritePackageJson = true;
-      }
-
-      if (isLegacySubpathImport(imports['#*'])) {
-        delete imports['#*'];
-        shouldWritePackageJson = true;
-      }
+      const { imports, shouldWritePackageJson } = getUpdatedStorybookImportsMap(
+        packageJson.imports,
+        storybookImportTarget
+      );
 
       if (shouldWritePackageJson) {
         logger.step(
@@ -153,8 +176,8 @@ export const csfFactories: CommandFix = {
       dryRun,
       packageManager,
       useSubPathImports,
-      previewConfigPath: previewConfigPath!,
-      configDir,
+      previewConfigPath: resolvedPreviewConfigPath,
+      configDir: resolvedConfigDir,
       yes,
       glob,
     });

--- a/code/lib/cli-storybook/src/codemod/csf-factories.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.ts
@@ -5,6 +5,7 @@ import {
 } from 'storybook/internal/common';
 import { logger, prompt } from 'storybook/internal/node-logger';
 
+import path from 'path';
 import picocolors from 'picocolors';
 import { dedent } from 'ts-dedent';
 
@@ -19,6 +20,7 @@ async function runStoriesCodemod(options: {
   packageManager: JsPackageManager;
   useSubPathImports: boolean;
   previewConfigPath: string;
+  configDir: string;
   yes: boolean | undefined;
   glob: string | undefined;
 }) {
@@ -56,6 +58,26 @@ async function runStoriesCodemod(options: {
   }
 }
 
+const LEGACY_SUBPATH_IMPORT = ['./*', './*.ts', './*.tsx', './*.js', './*.jsx'];
+
+const toPosixPath = (filePath: string) => filePath.replace(/\\/g, '/');
+
+export const getStorybookSubpathImportTarget = (configDir: string, packageJsonDir: string) => {
+  const absoluteConfigDir = path.isAbsolute(configDir) ? configDir : path.resolve(configDir);
+  const configDirFromPackageJson = toPosixPath(path.relative(packageJsonDir, absoluteConfigDir));
+
+  if (!configDirFromPackageJson) {
+    return './*';
+  }
+
+  return `./${configDirFromPackageJson.replace(/^\.\//, '')}/*`;
+};
+
+const isLegacySubpathImport = (value: unknown) =>
+  Array.isArray(value) &&
+  value.length === LEGACY_SUBPATH_IMPORT.length &&
+  value.every((entry, index) => entry === LEGACY_SUBPATH_IMPORT[index]);
+
 export const csfFactories: CommandFix = {
   id: 'csf-factories',
   promptType: 'command',
@@ -90,22 +112,41 @@ export const csfFactories: CommandFix = {
             label: "Relative imports (import preview from '../../.storybook/preview')",
             value: false,
           },
-          { label: "Subpath imports (import preview from '#.storybook/preview')", value: true },
+          { label: "Subpath imports (import preview from '#storybook/preview.ts')", value: true },
         ],
       });
     }
 
     const { packageJson } = packageManager.primaryPackageJson;
 
-    if (useSubPathImports && !packageJson.imports?.['#*']) {
-      logger.step(
-        `Adding imports map in ${picocolors.cyan(packageManager.primaryPackageJson.packageJsonPath)}`
+    if (useSubPathImports) {
+      const storybookImportTarget = getStorybookSubpathImportTarget(
+        configDir,
+        packageManager.primaryPackageJson.operationDir
       );
-      packageJson.imports = {
-        ...packageJson.imports,
-        '#*': ['./*', './*.ts', './*.tsx', './*.js', './*.jsx'],
-      };
-      packageManager.writePackageJson(packageJson);
+      const imports = { ...packageJson.imports };
+      let shouldWritePackageJson = false;
+
+      if (!imports['#storybook/*']) {
+        imports['#storybook/*'] = storybookImportTarget;
+        shouldWritePackageJson = true;
+      }
+
+      if (isLegacySubpathImport(imports['#*'])) {
+        delete imports['#*'];
+        shouldWritePackageJson = true;
+      }
+
+      if (shouldWritePackageJson) {
+        logger.step(
+          `Adding imports map in ${picocolors.cyan(packageManager.primaryPackageJson.packageJsonPath)}`
+        );
+        packageJson.imports = imports;
+        packageManager.writePackageJson(
+          packageJson,
+          packageManager.primaryPackageJson.operationDir
+        );
+      }
     }
 
     await runStoriesCodemod({
@@ -113,6 +154,7 @@ export const csfFactories: CommandFix = {
       packageManager,
       useSubPathImports,
       previewConfigPath: previewConfigPath!,
+      configDir,
       yes,
       glob,
     });

--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.test.ts
@@ -468,6 +468,59 @@ describe('stories codemod', () => {
       }
     });
 
+    it('uses a scoped Storybook subpath import with the preview file extension', async () => {
+      await expect(
+        formatFileContent(
+          'Component.stories.tsx',
+          await storyToCsfFactory(
+            {
+              source: dedent`
+                export default {};
+                export const A = {};
+              `,
+              path: 'Component.stories.tsx',
+            },
+            {
+              previewConfigPath: '.storybook/preview.ts',
+              configDir: '.storybook',
+              useSubPathImports: true,
+            }
+          )
+        )
+      ).resolves.toMatchInlineSnapshot(`
+        import preview from "#storybook/preview.ts";
+        const meta = preview.meta({});
+        export const A = meta.story();
+      `);
+    });
+
+    it('updates an existing legacy subpath preview import to the scoped Storybook import', async () => {
+      await expect(
+        formatFileContent(
+          'Component.stories.tsx',
+          await storyToCsfFactory(
+            {
+              source: dedent`
+                import preview, { extra } from '#.storybook/preview';
+                export default {};
+                export const A = {};
+              `,
+              path: 'Component.stories.tsx',
+            },
+            {
+              previewConfigPath: '.storybook/preview.ts',
+              configDir: '.storybook',
+              useSubPathImports: true,
+            }
+          )
+        )
+      ).resolves.toMatchInlineSnapshot(`
+        import preview, { extra } from "#storybook/preview.ts";
+        const meta = preview.meta({});
+        export const A = meta.story();
+      `);
+    });
+
     it('converts CSF1 into CSF4 with render', async () => {
       await expect(
         transform(dedent`

--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
@@ -21,11 +21,35 @@ const typesDisallowList = [
 // Name of properties that should not be renamed to `Story.input.xyz`
 const reuseDisallowList = ['play', 'run', 'extends', 'story'];
 
-type Options = { previewConfigPath: string; useSubPathImports: boolean };
+type Options = { previewConfigPath: string; useSubPathImports: boolean; configDir?: string };
+
+const toPosixPath = (filePath: string) => filePath.replace(/\\/g, '/');
+
+const getSubpathPreviewImport = (previewConfigPath: string, configDir?: string) => {
+  if (!configDir) {
+    return '#.storybook/preview';
+  }
+
+  const absoluteConfigDir = path.isAbsolute(configDir) ? configDir : path.resolve(configDir);
+  const absolutePreviewConfigPath = path.isAbsolute(previewConfigPath)
+    ? previewConfigPath
+    : path.resolve(previewConfigPath);
+  let previewPathFromConfig = path.relative(absoluteConfigDir, absolutePreviewConfigPath);
+
+  if (
+    !previewPathFromConfig ||
+    previewPathFromConfig.startsWith('..') ||
+    path.isAbsolute(previewPathFromConfig)
+  ) {
+    previewPathFromConfig = path.basename(previewConfigPath);
+  }
+
+  return `#storybook/${toPosixPath(previewPathFromConfig)}`;
+};
 
 export async function storyToCsfFactory(
   info: FileInfo,
-  { previewConfigPath, useSubPathImports }: Options
+  { previewConfigPath, useSubPathImports, configDir }: Options
 ) {
   const csf = loadCsf(info.source, { makeTitle: () => 'FIXME' });
   try {
@@ -45,7 +69,7 @@ export async function storyToCsfFactory(
   /**
    * Add the preview import if it doesn't exist yet:
    *
-   * `import preview from '#.storybook/preview'`;
+   * `import preview from '#storybook/preview.ts'`;
    */
   const programNode = csf._ast.program;
   let previewImport: t.ImportDeclaration | undefined;
@@ -57,7 +81,7 @@ export async function storyToCsfFactory(
       n.declarations.some((declaration) => t.isIdentifier(declaration.id, { name: 'preview' }))
   );
 
-  let previewPath = '#.storybook/preview';
+  let previewPath = getSubpathPreviewImport(previewConfigPath, configDir);
   if (!useSubPathImports) {
     // calculate relative path from story file to preview file
     const relativePath = path.relative(path.dirname(info.path), previewConfigPath);


### PR DESCRIPTION
## What changed

- Replace the broad CSF factories imports map fallback (`#*`) with a scoped `#storybook/*` import target based on the resolved Storybook config directory.
- Generate and update story preview imports to use `#storybook/<preview filename>` with the preview file extension when subpath imports are selected.
- Add regression coverage for the imports map target, story codemod output, and the new preview import path shape.

Fixes #32935.

## Testing

- `node .yarn\releases\yarn-4.10.3.cjs install --immutable`
- `node .yarn\releases\yarn-4.10.3.cjs nx run-many -t compile -p core cli`
- `$env:CI='true'; node .yarn\releases\yarn-4.10.3.cjs vitest run code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.test.ts code/lib/cli-storybook/src/codemod/csf-factories.test.ts code/core/src/csf-tools/CsfFile.test.ts`
- `node .yarn\releases\yarn-4.10.3.cjs exec oxfmt --check code/lib/cli-storybook/src/codemod/csf-factories.ts code/lib/cli-storybook/src/codemod/csf-factories.test.ts code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.test.ts code/core/src/csf-tools/CsfFile.test.ts`
- `node .yarn\releases\yarn-4.10.3.cjs nx run-many -t check -p core cli`

#### Manual testing

Not run. This changes the CSF factories automigration path generation and package.json imports map logic, covered by targeted unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now respects an explicit config directory when computing and applying Storybook subpath imports.
  * Preview path examples and handling support explicit file extensions (e.g., .ts) and scoped import forms.
  * package.json imports map is updated automatically and removes legacy mappings when detected.

* **Tests**
  * Expanded coverage for subpath import generation, preview-path variants (including .ts), imports-map updates and refresh behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->