### PR TITLE
Controls: Fix select controls for optional Flow unions and nested options

### DIFF
--- a/code/core/src/docs-tools/argTypes/convert/flow/convert.test.ts
+++ b/code/core/src/docs-tools/argTypes/convert/flow/convert.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { convert } from './convert.ts';
+
+describe('Flow convert', () => {
+  describe('union', () => {
+    it('converts a union of literals to an enum', () => {
+      expect(
+        convert({
+          name: 'union',
+          elements: [
+            { name: 'literal', value: "'sm'" },
+            { name: 'literal', value: "'md'" },
+            { name: 'literal', value: "'lg'" },
+          ],
+        })
+      ).toEqual({ name: 'enum', value: ['sm', 'md', 'lg'] });
+    });
+
+    it('converts an optional literal union (?type) to an enum by filtering void', () => {
+      // Flow represents `?('sm' | 'md' | 'lg')` as a union containing void and null
+      expect(
+        convert({
+          name: 'union',
+          elements: [
+            { name: 'literal', value: "'sm'" },
+            { name: 'literal', value: "'md'" },
+            { name: 'literal', value: "'lg'" },
+            { name: 'void' },
+            { name: 'null' },
+          ],
+        })
+      ).toEqual({ name: 'enum', value: ['sm', 'md', 'lg'] });
+    });
+
+    it('falls back to union when elements are not all literals after filtering', () => {
+      expect(
+        convert({
+          name: 'union',
+          elements: [
+            { name: 'literal', value: "'sm'" },
+            { name: 'string' },
+          ],
+        })
+      ).toMatchObject({ name: 'union' });
+    });
+
+    it('falls back to union when only void/null remain after filtering', () => {
+      expect(
+        convert({
+          name: 'union',
+          elements: [{ name: 'void' }, { name: 'null' }],
+        })
+      ).toMatchObject({ name: 'union' });
+    });
+  });
+});

--- a/code/core/src/docs-tools/argTypes/convert/flow/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/flow/convert.ts
@@ -45,11 +45,17 @@ export const convert = (type: FlowType): SBType | void => {
     }
     case 'signature':
       return { ...base, ...convertSig(type) };
-    case 'union':
-      if (type.elements?.every(isLiteral)) {
-        return { ...base, name: 'enum', value: type.elements?.map(toEnumOption) };
+    case 'union': {
+      // Filter out Flow's nullable markers (void, null) so optional unions like
+      // ?('sm' | 'md' | 'lg') still resolve to an enum control.
+      const meaningfulElements = type.elements?.filter(
+        (element) => element.name !== 'void' && element.name !== 'null'
+      );
+      if (meaningfulElements && meaningfulElements.length > 0 && meaningfulElements.every(isLiteral)) {
+        return { ...base, name: 'enum', value: meaningfulElements.map(toEnumOption) };
       }
       return { ...base, name, value: type.elements?.map(convert) };
+    }
 
     case 'intersection':
       return { ...base, name, value: type.elements?.map(convert) };

--- a/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
@@ -108,6 +108,37 @@ describe('normalizeInputType', () => {
       defaultValue: 'defaultValue',
     });
   });
+
+  it('hoists options nested inside control object to top level', () => {
+    expect(
+      normalizeInputType(
+        {
+          control: { type: 'select', options: ['sm', 'md', 'lg'] } as any,
+        },
+        'arg'
+      )
+    ).toEqual({
+      name: 'arg',
+      options: ['sm', 'md', 'lg'],
+      control: { type: 'select', disable: false },
+    });
+  });
+
+  it('preserves top-level options when control also has options', () => {
+    expect(
+      normalizeInputType(
+        {
+          options: ['xs', 'sm'],
+          control: { type: 'select', options: ['sm', 'md', 'lg'] } as any,
+        },
+        'arg'
+      )
+    ).toEqual({
+      name: 'arg',
+      options: ['xs', 'sm'],
+      control: { type: 'select', options: ['sm', 'md', 'lg'], disable: false },
+    });
+  });
 });
 
 describe('normalizeInputTypes', () => {

--- a/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.ts
@@ -27,17 +27,35 @@ const normalizeControl = (control: InputType['control']): StrictInputType['contr
 
 export const normalizeInputType = (inputType: InputType, key: string): StrictInputType => {
   const { type, control, ...rest } = inputType;
+
+  // Hoist options nested inside the control object to the top level when the
+  // user writes { control: { type: 'select', options: [...] } } instead of the
+  // documented { control: { type: 'select' }, options: [...] } form.
+  let effectiveControl = control;
+  const effectiveRest = { ...rest };
+  if (
+    !effectiveRest.options &&
+    control &&
+    typeof control === 'object' &&
+    !Array.isArray(control) &&
+    'options' in control
+  ) {
+    const { options, ...controlWithoutOptions } = control as Record<string, unknown>;
+    effectiveRest.options = options as InputType['options'];
+    effectiveControl = controlWithoutOptions as InputType['control'];
+  }
+
   const normalized: StrictInputType = {
     name: key,
-    ...rest,
+    ...effectiveRest,
   };
 
   if (type) {
     normalized.type = normalizeType(type);
   }
-  if (control) {
-    normalized.control = normalizeControl(control);
-  } else if (control === false) {
+  if (effectiveControl) {
+    normalized.control = normalizeControl(effectiveControl);
+  } else if (effectiveControl === false) {
     normalized.control = { disable: true };
   }
   return normalized;


### PR DESCRIPTION
## What

Fixes two separate bugs that caused select controls to silently break (issue #12641):

### Bug 1 — Flow optional union types fall back to `object` control

**Root cause:** Flow represents optional types (`?'sm' | 'md' | 'lg'`) as a union containing `void` and `null` elements. The `every(isLiteral)` check failed on these non-literal elements, so the converter fell back to a generic `union`/`object` control instead of a `select`.

**Fix:** Filter out `void` and `null` elements before the `isLiteral` check in `convert/flow/convert.ts`, matching the approach already applied to the TypeScript converter.

**File:** `code/core/src/docs-tools/argTypes/convert/flow/convert.ts`

### Bug 2 — Options nested inside `control` object are silently ignored

**Root cause:** Users commonly write:
```js
argTypes: { size: { control: { type: 'select', options: ['sm', 'md', 'lg'] } } }
```
instead of the documented top-level form:
```js
argTypes: { size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] } }
```
The nested `options` were passed through as part of the `control` object but never surfaced to the controls addon, resulting in an empty select dropdown.

**Fix:** In `normalizeInputType`, when `control` is an object with an `options` property and no top-level `options` is present, hoist `options` to the top level and strip it from the `control` object.

**File:** `code/core/src/preview-api/modules/store/csf/normalizeInputTypes.ts`

## Tests

- New test file `convert/flow/convert.test.ts` with 4 cases covering the void/null filtering
- Two new cases in `normalizeInputTypes.test.ts` covering options hoisting and precedence

#### Manual testing

1. Create a story with a Flow-typed optional union prop: `?('sm' | 'md' | 'lg')`
   - Before fix: Controls panel shows an `object` input
   - After fix: Controls panel shows a `select` dropdown with sm/md/lg options

2. Define argTypes with options nested inside control:
   ```js
   argTypes: { size: { control: { type: 'select', options: ['sm', 'md', 'lg'] } } }
   ```
   - Before fix: select dropdown renders with no options
   - After fix: select dropdown renders with sm/md/lg options

## Checklist

- [x] Unit tests added for both fixes
- [x] No breaking changes (options hoisting only applies when top-level `options` is absent)

Fixes #12641