### PR TITLE
Core: Add handled interaction error regression test

### DIFF
--- a/code/core/src/instrumenter/instrumenter.test.ts
+++ b/code/core/src/instrumenter/instrumenter.test.ts
@@ -502,6 +502,36 @@ describe('Instrumenter', () => {
     );
   });
 
+  it('keeps logging interactions after a handled async error', async () => {
+    const fn = async () => {};
+    const failingFn = async () => {
+      throw new Error('handled');
+    };
+    const { fn1, fn2, fn3 } = instrument({ fn1: fn, fn2: failingFn, fn3: fn }, { intercept: true });
+
+    setRenderPhase('playing');
+    await fn1();
+    let handledError: unknown;
+    try {
+      await fn2();
+    } catch (err) {
+      handledError = err;
+    }
+    expect(handledError).toEqual(new Error('handled'));
+    await fn3();
+    await tick();
+
+    expect(mocks.syncSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        logItems: [
+          { callId: 'kind--story [0] fn1', status: 'done', ancestors: [] },
+          { callId: 'kind--story [1] fn2', status: 'error', ancestors: [] },
+          { callId: 'kind--story [2] fn3', status: 'done', ancestors: [] },
+        ],
+      })
+    );
+  });
+
   it('emits a "sync" event with debounce after a patched function is invoked', () => {
     const { fn } = instrument({ fn: (...args: any) => {} }, { intercept: true });
     vi.useFakeTimers();


### PR DESCRIPTION
Closes #21746

## What I did

Added regression coverage for handled async interaction errors so the interactions log keeps later calls after a rejected instrumented function is caught by the play function.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual testing was needed; this change adds focused unit test coverage for the instrumenter log behavior.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes.
- [ ] Make sure this PR contains one of the labels below: `bug`, `maintenance`, `dependencies`, `build`, `cleanup`, `documentation`, `feature request`, `BREAKING CHANGE`, `other`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to verify interaction logging continues correctly when intercepted async functions encounter and handle errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->