### PR TITLE
CSF: Fix parsing of string literal export names

### DIFF
--- a/code/core/src/csf-tools/CsfFile.test.ts
+++ b/code/core/src/csf-tools/CsfFile.test.ts
@@ -766,8 +766,9 @@ describe('CsfFile', () => {
           import type { Meta, StoryFn } from '@storybook/react';
           type PropTypes = {};
           const meta = { title: 'foo/bar/baz' } satisfies Meta<PropTypes> as Meta<PropTypes>;
-          const story = { name: 'Story A' };
-          export { meta as default, story as A };
+          const story1 = { name: 'Story A' };
+          const story2 = { name: 'Story B' };
+          export { meta as default, story1 as A, story2 as 'あ' };
         `,
           true
         )
@@ -777,9 +778,24 @@ describe('CsfFile', () => {
         stories:
           - id: foo-bar-baz--a
             name: A
-            localName: story
+            localName: story1
             parameters:
               __id: foo-bar-baz--a
+            __stats:
+              play: false
+              render: false
+              loaders: false
+              beforeEach: false
+              globals: false
+              tags: false
+              storyFn: false
+              mount: false
+              moduleMock: false
+          - id: foo-bar-baz--あ
+            name: あ
+            localName: story2
+            parameters:
+              __id: foo-bar-baz--あ
             __stats:
               play: false
               render: false

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -682,8 +682,13 @@ export class CsfFile {
           } else if (node.specifiers.length > 0) {
             // export { X as Y }
             node.specifiers.forEach((specifier) => {
-              if (t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported)) {
-                const { name: exportName } = specifier.exported;
+              if (
+                t.isExportSpecifier(specifier) &&
+                (t.isIdentifier(specifier.exported) || t.isStringLiteral(specifier.exported))
+              ) {
+                const exportName = t.isIdentifier(specifier.exported)
+                  ? specifier.exported.name
+                  : specifier.exported.value;
                 const { name: localName } = specifier.local;
                 const decl = t.isProgram(parent)
                   ? findVarInitialization(localName, parent)


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed a bug where stories exported via `export { X as 'string-literal' }` were silently dropped during CSF parsing.

In `CsfFile.ts`, the `export { X as Y }` handler only checked for `t.isIdentifier(specifier.exported)`. When using a string literal as an export alias (e.g. `export { story2 as 'あ' }`), Babel produces a `StringLiteral` node for `specifier.exported` instead of an `Identifier`, causing the story to be skipped entirely.

The fix extends the check to also accept `t.isStringLiteral(specifier.exported)`, extracting the name via `.value`.

NOTE: Unicode IDs are already supported in SB https://github.com/storybookjs/storybook/blob/5cb36266852c9ce5c35b51e234545b3fe4743f1d/code/core/src/csf/index.test.ts#L14-L15

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual testing required — the bug is fully covered by the updated unit test in `CsfFile.test.ts` (the `typescript satisfies as export specifier` test case now includes `story2 as 'あ'` and asserts it is parsed correctly).

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed export specifier parsing to support string literal names in addition to identifiers
  * Improved support for Unicode characters in exported story names

* **Tests**
  * Enhanced test coverage for Unicode export names and string literal export specifiers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->