### PR TITLE
Angular: Fix single-quoted literal union types not inferring select control

### DIFF
--- a/code/frameworks/angular/src/client/compodoc.test.ts
+++ b/code/frameworks/angular/src/client/compodoc.test.ts
@@ -111,6 +111,8 @@ describe('extractType', () => {
       // ['T[]', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       ['[]', { name: 'other', value: 'empty-enum' }],
       ['"primary" | "secondary"', { name: 'enum', value: ['primary', 'secondary'] }],
+      ["'primary' | 'secondary'", { name: 'enum', value: ['primary', 'secondary'] }],
+      ["'S' | 'M' | 'L'", { name: 'enum', value: ['S', 'M', 'L'] }],
       ['TypeAlias', { name: 'enum', value: ['Type Alias 1', 'Type Alias 2', 'Type Alias 3'] }],
       // ['EnumNumeric', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       // ['EnumNumericInitial', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT

--- a/code/frameworks/angular/src/client/compodoc.ts
+++ b/code/frameworks/angular/src/client/compodoc.ts
@@ -122,19 +122,30 @@ const extractEnumValues = (compodocType: any) => {
   const compodocJson = getCompodocJson();
   const enumType = compodocJson?.miscellaneous?.enumerations?.find((x) => x.name === compodocType);
 
-  if (enumType?.childs.every((x) => x.value)) {
-    return enumType.childs.map((x) => x.value);
+  if (enumType?.childs?.every((x: any) => x?.value != null)) {
+    return enumType.childs.map((x: any) => x.value);
   }
 
-  if (typeof compodocType !== 'string' || compodocType.indexOf('|') === -1) {
+  if (typeof compodocType !== 'string' || !compodocType.includes('|')) {
     return null;
   }
 
-  try {
-    return compodocType.split('|').map((value) => JSON.parse(value));
-  } catch (e) {
-    return null;
-  }
+  const segments = compodocType.split('|').map((segment: string) => segment.trim());
+  const parsed = segments.map((segment: string) => {
+    if (
+      (segment.startsWith("'") && segment.endsWith("'")) ||
+      (segment.startsWith('"') && segment.endsWith('"'))
+    ) {
+      return segment.slice(1, -1);
+    }
+    try {
+      return JSON.parse(segment);
+    } catch {
+      return segment;
+    }
+  });
+
+  return parsed.length > 0 ? parsed : null;
 };
 
 export const extractType = (property: Property, defaultValue: any): SBType => {


### PR DESCRIPTION
## Problem

Fixes #12641, Fixes #33779

Angular's Compodoc emits TypeScript literal union types using single-quoted strings (e.g. `'S' | 'M' | 'L'`). The previous `extractEnumValues` implementation called `JSON.parse()` on each segment without pre-processing, but single-quoted strings are not valid JSON — causing the entire parse to throw and fall back to `null`, resulting in an `object` control instead of the expected `select`/`radio`.

Double-quoted unions like `"primary" | "secondary"` already worked correctly.

## Root Cause

```typescript
// Before (broken for single-quoted literals)
return compodocType.split('|').map((value) => JSON.parse(value));
//  JSON.parse("'S'") throws → catch returns null → object control
```

## Fix

Parse each pipe-delimited segment individually:
1. Trim whitespace from each segment
2. Strip matching surrounding single **or** double quotes to extract the bare string literal
3. Fall back to `JSON.parse` for non-string literals (numbers, booleans, `null`)
4. Fall back to the raw segment string if `JSON.parse` also fails

Also strengthens the enum `childs` guard with optional chaining (`?.value != null` instead of `.value` truthiness, which excluded the string `"0"`).

## Regression tests added

Two new test cases in `compodoc.test.ts`:
- `"'primary' | 'secondary'"` → `{ name: 'enum', value: ['primary', 'secondary'] }` (single-quoted, 2 items → radio)
- `"'S' | 'M' | 'L'"` → `{ name: 'enum', value: ['S', 'M', 'L'] }` (single-quoted, 3 items → radio)

The existing `'"primary" | "secondary"'` test (double-quoted) continues to pass.

## Manual Testing

With Angular `input<'S' | 'M' | 'L'>()` or `@Input() size: 'S' | 'M' | 'L'`:
- **Before**: Controls panel shows an `object` input box
- **After**: Controls panel shows radio buttons (≤5 options) or a select dropdown (>5 options) with the correct values

**Bounty:** $110 on [Opire.dev](https://app.opire.dev)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added test coverage for enum union types expressed with single quotes.

## Bug Fixes
* Improved enum value extraction to correctly handle null and falsy values (`0`, `false`).
* Enhanced string union parsing with better quote unwrapping and fallback handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->