### PR TITLE
fix(angular): handle single-quoted union types in extractEnumValues

### DIFF
--- a/code/frameworks/angular/src/client/compodoc.test.ts
+++ b/code/frameworks/angular/src/client/compodoc.test.ts
@@ -111,6 +111,8 @@ describe('extractType', () => {
       // ['T[]', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       ['[]', { name: 'other', value: 'empty-enum' }],
       ['"primary" | "secondary"', { name: 'enum', value: ['primary', 'secondary'] }],
+      ["'S' | 'M' | 'L'", { name: 'enum', value: ['S', 'M', 'L'] }],
+      ["'foo bar' | 'baz'", { name: 'enum', value: ['foo bar', 'baz'] }],
       ['TypeAlias', { name: 'enum', value: ['Type Alias 1', 'Type Alias 2', 'Type Alias 3'] }],
       // ['EnumNumeric', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       // ['EnumNumericInitial', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT

--- a/code/frameworks/angular/src/client/compodoc.ts
+++ b/code/frameworks/angular/src/client/compodoc.ts
@@ -131,7 +131,18 @@ const extractEnumValues = (compodocType: any) => {
   }
 
   try {
-    return compodocType.split('|').map((value) => JSON.parse(value));
+    return compodocType.split('|').map((segment) => {
+      const trimmed = segment.trim();
+      // Compodoc may emit single-quoted strings (e.g. 'foo') which are not valid JSON.
+      // Strip surrounding quotes before parsing so both 'foo' and "foo" work correctly.
+      if (
+        (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+        (trimmed.startsWith('"') && trimmed.endsWith('"'))
+      ) {
+        return trimmed.slice(1, -1);
+      }
+      return JSON.parse(trimmed);
+    });
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
## What changed

In `extractEnumValues` (compodoc.ts), the union-type branch did:

```ts
return compodocType.split('|').map((value) => JSON.parse(value));
```

Compodoc emits **single-quoted** strings for literal union types used with Angular input signals — e.g. `'S' | 'M' | 'L'`. `JSON.parse("'S'")` throws because single-quoted strings are not valid JSON, so the entire `map` call throws, falls into the `catch`, and returns `null`. This causes the Controls panel to infer no control type at all.

## Fix

Trim each segment and detect surrounding quotes (single **or** double). If found, slice them off and return the inner string directly, bypassing `JSON.parse`. Segments without quotes (e.g. numeric literals) still go through `JSON.parse` as before.

```ts
return compodocType.split('|').map((segment) => {
  const trimmed = segment.trim();
  if (
    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
    (trimmed.startsWith('"') && trimmed.endsWith('"'))
  ) {
    return trimmed.slice(1, -1);
  }
  return JSON.parse(trimmed);
});
```

## Tests added

Two new rows in the existing `extractType` test table:

| Input | Expected |
|---|---|
| `'S' \| 'M' \| 'L'` | `["S", "M", "L"]` |
| `'foo bar' \| 'baz'` | `["foo bar", "baz"]` |

Existing double-quoted case (`"primary" | "secondary"`) continues to pass.

Closes #33779


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of enum value parsing to correctly handle quoted single-character and multi-word literals.

* **Tests**
  * Added test cases for enum string union parsing with various quoted literal formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->