### PR TITLE
Angular: Fix single-quoted union types in compodoc control inference

### DIFF
--- a/code/frameworks/angular/src/client/compodoc.test.ts
+++ b/code/frameworks/angular/src/client/compodoc.test.ts
@@ -111,6 +111,8 @@ describe('extractType', () => {
       // ['T[]', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       ['[]', { name: 'other', value: 'empty-enum' }],
       ['"primary" | "secondary"', { name: 'enum', value: ['primary', 'secondary'] }],
+      ["'primary' | 'secondary'", { name: 'enum', value: ['primary', 'secondary'] }],
+      ["'S' | 'M' | 'L'", { name: 'enum', value: ['S', 'M', 'L'] }],
       ['TypeAlias', { name: 'enum', value: ['Type Alias 1', 'Type Alias 2', 'Type Alias 3'] }],
       // ['EnumNumeric', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       // ['EnumNumericInitial', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT

--- a/code/frameworks/angular/src/client/compodoc.ts
+++ b/code/frameworks/angular/src/client/compodoc.ts
@@ -122,7 +122,7 @@ const extractEnumValues = (compodocType: any) => {
   const compodocJson = getCompodocJson();
   const enumType = compodocJson?.miscellaneous?.enumerations?.find((x) => x.name === compodocType);
 
-  if (enumType?.childs.every((x) => x.value)) {
+  if (enumType?.childs.every((x) => x.value != null)) {
     return enumType.childs.map((x) => x.value);
   }
 
@@ -130,11 +130,21 @@ const extractEnumValues = (compodocType: any) => {
     return null;
   }
 
-  try {
-    return compodocType.split('|').map((value) => JSON.parse(value));
-  } catch (e) {
-    return null;
-  }
+  const values = compodocType.split('|').map((segment): unknown => {
+    const s = segment.trim();
+    // Compodoc emits TypeScript literal unions with single-quoted strings (e.g. 'S' | 'M' | 'L'),
+    // which JSON.parse rejects. Strip the surrounding quotes and unescape inner escaped quotes.
+    if (s.length >= 2 && s[0] === "'" && s[s.length - 1] === "'") {
+      return s.slice(1, -1).replace(/\\'/g, "'");
+    }
+    try {
+      return JSON.parse(s);
+    } catch {
+      return undefined;
+    }
+  });
+
+  return values.some((v) => v === undefined) ? null : values;
 };
 
 export const extractType = (property: Property, defaultValue: any): SBType => {


### PR DESCRIPTION
## What changed

`extractEnumValues` in `code/frameworks/angular/src/client/compodoc.ts` now handles TypeScript literal union types that Compodoc emits with single-quoted strings (e.g. `'S' | 'M' | 'L'`).

Previously, `JSON.parse("'S'")` would throw, causing the entire union to be treated as an opaque type and fall back to an `object` control. Users had to manually declare `options` in their stories to get a `select`/`radio` control — defeating the purpose of automatic control inference.

## Root cause

Compodoc serialises Angular `input<'S' | 'M' | 'L'>()` as the raw TypeScript string `'S' | 'M' | 'L'` (single-quoted), while `JSON.parse` only accepts double-quoted strings. The catch branch silently returned `null`, hiding the inference failure.

## Fix

Parse each pipe-delimited segment individually:

1. If the segment is surrounded by single quotes, strip them and unescape `\'` sequences.
2. Otherwise fall back to `JSON.parse` (handles double-quoted strings, numbers, booleans, `null`).
3. If any segment cannot be parsed, return `null` for the whole union — preserving the existing behaviour for opaque or complex types.

Also tightened the enum-child guard from `x.value` (truthiness) to `x.value != null`, so enum values like `""` are included correctly.

## Tests

Added two test cases to the existing `extractType` table in `compodoc.test.ts`:

- `"'primary' | 'secondary'"` → `{ name: 'enum', value: ['primary', 'secondary'] }`
- `"'S' | 'M' | 'L'"` → `{ name: 'enum', value: ['S', 'M', 'L'] }`

The existing `'"primary" | "secondary"'` case continues to pass unchanged.

#### Manual testing

1. Create an Angular component with a single-quoted string union input:
   ```ts
   @Component({ ... })
   export class ButtonComponent {
     size = input<'S' | 'M' | 'L'>('M');
   }
   ```
2. Run Storybook with Compodoc (`--docs` or equivalent).
3. Open the story — the `size` arg should display as a **select** control with options `S`, `M`, `L` instead of an empty object control.

Fixes #33779


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of enum value parsing for TypeScript union types, including better handling of quoted string literals and null/undefined values.

* **Tests**
  * Expanded test coverage for enum type extraction with additional string-union scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->