### PR TITLE
Fix: `preset-server-webpack` fails to load stories with `あ` in name

### DIFF
--- a/code/presets/server-webpack/src/lib/compiler/__testfixtures__/story-name.json
+++ b/code/presets/server-webpack/src/lib/compiler/__testfixtures__/story-name.json
@@ -1,0 +1,10 @@
+{
+  "title": "Story Name",
+  "stories": [
+    {
+      "name": "あ in story name",
+      "parameters": {
+        "server": { "id": "demo/story-name" } }
+    }
+  ]
+}

--- a/code/presets/server-webpack/src/lib/compiler/__testfixtures__/story-name.snapshot
+++ b/code/presets/server-webpack/src/lib/compiler/__testfixtures__/story-name.snapshot
@@ -1,0 +1,13 @@
+
+export default {
+  title: "Story Name",
+};
+
+export const _in_story_name = {
+  name: "あ in story name",
+  parameters: {
+    server: {
+      id: "demo/story-name"
+    }
+  }
+};

--- a/test-storybooks/server-kitchen-sink/stories/demo.stories.json
+++ b/test-storybooks/server-kitchen-sink/stories/demo.stories.json
@@ -17,6 +17,11 @@
       "parameters": {
         "server": { "id": "demo/button" }
       }
+    },
+    {
+      "name": "あ in story name",
+      "parameters": {
+        "server": { "id": "demo/story-name" } }
     }
   ]
 }

--- a/test-storybooks/server-kitchen-sink/views/demo/story-name.pug
+++ b/test-storybooks/server-kitchen-sink/views/demo/story-name.pug
@@ -1,0 +1,1 @@
+h1 あ in Story name!


### PR DESCRIPTION
Proper upstream fix for https://github.com/chromaui/chromatic-e2e/issues/365


<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Use local Storybook `next`
2. Add changes from this PR's `test-storybooks/server-kitchen-sink/stories/demo.stories.json`  locally
3. `cd test-storybooks/server-kitchen-sink; yarn start` (You might need `yarn install` here before `start` 👀)
4. Notice how the new story fails to open
  <img width="1166" height="1032" alt="image" src="https://github.com/user-attachments/assets/6149f62b-f876-4363-a356-f8ee086fd3e4" />
5. <fill in once fixed>

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
