### PR TITLE
Controls: Fix Legacy Select Options Mapping

### DIFF
--- a/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.test.ts
@@ -108,6 +108,76 @@ describe('normalizeInputType', () => {
       defaultValue: 'defaultValue',
     });
   });
+
+  it('lifts legacy control.options arrays to top-level options', () => {
+    expect(
+      normalizeInputType(
+        {
+          control: { type: 'select', options: ['Alpha', 'Beta'] },
+        },
+        'icon'
+      )
+    ).toEqual({
+      name: 'icon',
+      control: { type: 'select', disable: false },
+      options: ['Alpha', 'Beta'],
+    });
+  });
+
+  it('defaults to select controls when top-level options are present', () => {
+    expect(
+      normalizeInputType(
+        {
+          options: ['Alpha', 'Beta'],
+          control: {},
+        },
+        'icon'
+      )
+    ).toEqual({
+      name: 'icon',
+      control: { type: 'select', disable: false },
+      options: ['Alpha', 'Beta'],
+    });
+  });
+
+  it('converts legacy control.options objects to serializable options and a mapping', () => {
+    const Alpha = { type: 'div', props: { children: 'alpha' } };
+    const Beta = { type: 'div', props: { children: 'beta' } };
+
+    expect(
+      normalizeInputType(
+        {
+          control: { options: { Alpha, Beta } },
+        },
+        'endIcon'
+      )
+    ).toEqual({
+      name: 'endIcon',
+      control: { type: 'select', disable: false },
+      options: ['Alpha', 'Beta'],
+      mapping: { Alpha, Beta },
+    });
+  });
+
+  it('preserves explicit mapping when normalizing legacy control.options objects', () => {
+    const Alpha = { type: 'div', props: { children: 'alpha' } };
+    const explicitMapping = { Alpha: 'mapped-alpha' };
+
+    expect(
+      normalizeInputType(
+        {
+          control: { type: 'select', options: { Alpha } },
+          mapping: explicitMapping,
+        },
+        'endIcon'
+      )
+    ).toEqual({
+      name: 'endIcon',
+      control: { type: 'select', disable: false },
+      options: ['Alpha'],
+      mapping: explicitMapping,
+    });
+  });
 });
 
 describe('normalizeInputTypes', () => {

--- a/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeInputTypes.ts
@@ -7,6 +7,15 @@ import type {
 
 import { mapValues } from 'es-toolkit/object';
 
+type ControlWithOptions = Exclude<InputType['control'], string | false | undefined> & {
+  options?: InputType['options'] | Record<string, any>;
+};
+type OptionsInput = Pick<InputType, 'control' | 'options' | 'mapping'>;
+type NormalizedOptions = Pick<InputType, 'options' | 'mapping'>;
+
+const getControlOptions = (control: InputType['control']) =>
+  control && typeof control === 'object' ? (control as ControlWithOptions).options : undefined;
+
 const normalizeType = (type: InputType['type']): StrictInputType['type'] => {
   return typeof type === 'string' ? { name: type } : type;
 };
@@ -25,18 +34,51 @@ const normalizeControl = (control: InputType['control']): StrictInputType['contr
   return control;
 };
 
+const normalizeOptions = ({ control, options, mapping }: OptionsInput): NormalizedOptions => {
+  const inputOptions = options ?? getControlOptions(control);
+
+  if (!inputOptions || Array.isArray(inputOptions)) {
+    return {
+      ...(inputOptions && { options: inputOptions }),
+      ...(mapping && { mapping }),
+    };
+  }
+
+  return {
+    options: Object.keys(inputOptions),
+    mapping: mapping ?? inputOptions,
+  };
+};
+
 export const normalizeInputType = (inputType: InputType, key: string): StrictInputType => {
-  const { type, control, ...rest } = inputType;
+  const { type, control, options, mapping, ...rest } = inputType;
+  const controlOptions = getControlOptions(control);
+  const hasOptions = options !== undefined || controlOptions !== undefined;
   const normalized: StrictInputType = {
     name: key,
     ...rest,
+    ...normalizeOptions({ control, options, mapping }),
   };
 
   if (type) {
     normalized.type = normalizeType(type);
   }
   if (control) {
-    normalized.control = normalizeControl(control);
+    const normalizedControl = normalizeControl(control);
+    if (normalizedControl && typeof normalizedControl === 'object') {
+      const controlWithoutOptions = { ...normalizedControl } as ControlWithOptions;
+      delete controlWithoutOptions.options;
+      normalized.control =
+        hasOptions && !controlWithoutOptions.type
+          ? {
+              type: 'select',
+              ...controlWithoutOptions,
+              ...(!('disable' in controlWithoutOptions) && { disable: false }),
+            }
+          : controlWithoutOptions;
+    } else {
+      normalized.control = normalizedControl;
+    }
   } else if (control === false) {
     normalized.control = { disable: true };
   }


### PR DESCRIPTION
## Summary

- Normalize deprecated `control.options` into top-level `options`.
- Convert object-valued legacy options into serializable option keys plus `mapping`, so select controls update args with keys while the preview receives the mapped complex values.
- Default option-backed controls to `select` when no explicit control type is provided, matching the legacy dropdown shape from the issue.

Fixes #12145

#### Manual testing

I added focused normalization coverage for legacy array options, object-valued options, explicit mappings, and option-backed controls without an explicit type.

Local dependency installation could not complete in this checkout because the disk filled during `corepack yarn install --immutable` with `ENOSPC`, so Vitest has not been run locally yet. I did run `git diff --check` successfully.

## Payment

Payment method: Opire bounty-platform payout to GitHub user @jamilahmadzai.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for option normalization in argument controls, covering legacy and modern option formats.

* **Improvements**
  * Consistent normalization and serialization of option lists and mappings across input formats.
  * Preservation of explicitly provided mappings during normalization.
  * Improved inference of a select-style control when options are present but no control type is specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->