### PR TITLE
Service architecture — Stage 2: registration, abstract/concrete commands, public ServiceStore

### DIFF
--- a/code/core/src/service/README.md
+++ b/code/core/src/service/README.md
@@ -5,7 +5,7 @@ A small schema-driven service system for Storybook internals. A service is a sta
 The main audience for this README is agents and maintainers who need to understand how the pieces fit together, where behavior lives, and how to define new services correctly.
 
 > [!NOTE]
-> This document covers **stage 1**: definition, runtime, query subscriptions, static-build writer, static-load transport. **Service registration** with abstract-command overrides, **cross-runtime channel sync**, and the **React hook** are tracked separately and land in follow-up stages — see the *Coming in later stages* section.
+> This document covers stages 1–2: definition, runtime, query subscriptions, static-build writer, static-load transport, service registration with abstract-command overrides. **Cross-runtime channel sync** and the **React hook** are tracked separately and land in follow-up stages — see the *Coming in later stages* section.
 
 ## Goals
 
@@ -22,8 +22,9 @@ External callers should import from [index.ts](./index.ts).
 The public API consists of:
 
 - `defineService` (with the `query` / `command` helpers exposed via the callback form).
-- `createService(def)` — build a fresh runtime instance.
-- `getService(def)` — lazy singleton per `definition.id`; `clearRegistry()` for tests.
+- `registerService(def, registration?)` — activate the definition; returns a public-only `ServiceStore`. Idempotent on the definition reference; supplies handlers for abstract commands. `__resetServiceRegistry()` for tests.
+- `getService(def)` (or `getService(id)`) — look up an already-registered service.
+- `createService(def, registration?)` — build a fresh runtime without touching the global registry. Prefer `registerService` for production code.
 - `buildServiceArtifacts(def)` — produce the JSON-shaped state diffs for a service's preloads.
 - `setStaticTransport` / `clearStaticTransport` / `createBrowserStaticTransport` — install the runtime-side loader.
 - `ServiceValidationError` and the exported type aliases from [types.ts](./types.ts).
@@ -37,6 +38,8 @@ Internal tests and implementation code may import from the individual modules di
 - [define-service.ts](./define-service.ts) — `defineService` curried builder plus the `query` / `command` per-entry helpers.
 - [service-validation.ts](./service-validation.ts) — Standard Schema validation, `ServiceValidationError`, sync and async paths.
 - [service-runtime.ts](./service-runtime.ts) — the `ServiceRuntime` class. Owns state, runs commands, fires query preloads, drives subscriptions.
+- [register-service.ts](./register-service.ts) — `registerService`, `getService`, `__resetServiceRegistry`. The public entry into the global registry.
+- [instances.ts](./instances.ts) — the global registry map. Separate module so it can be mocked in tests.
 - [build-artifacts.ts](./build-artifacts.ts) — `buildServiceArtifacts`. The static-build writer.
 - [static-transport.ts](./static-transport.ts) — the global static-load transport.
 - [__examples__/docgen-service.ts](./__examples__/docgen-service.ts) — worked example for the docgen pattern.
@@ -49,11 +52,14 @@ flowchart LR
   C[types.ts\ncore types]
   D[service-runtime.ts\nlive runtime]
   E[service-validation.ts\nschema validation + error]
+  R[register-service.ts\nglobal registry entry]
+  I[instances.ts\nregistry map]
   G[build-artifacts.ts\nstatic-build writer]
   T[static-transport.ts\nclient-side loader]
   H[tests + __examples__\ncoverage and usage]
 
   A --> B
+  A --> R
   A --> D
   A --> G
   A --> T
@@ -62,6 +68,9 @@ flowchart LR
   D --> C
   D --> E
   D --> T
+  D --> B
+  R --> D
+  R --> I
   G --> D
   G --> C
   H --> A
@@ -75,7 +84,7 @@ flowchart LR
 
 Concretely:
 
-- The public `ServiceInstance` exposes `id`, `definition`, `queries`, `commands`. State, mutation, and whole-state subscription are infrastructure-facing (used by the build pipeline and transport sync) and never appear on the public surface.
+- The public `ServiceStore` returned from `registerService` / `getService` exposes `id`, `definition`, `queries`, `commands`. State, mutation, and whole-state subscription are infrastructure-facing (used by the build pipeline and transport sync) and never appear on the public surface.
 - Inside a command body or a query's `preload`, `ctx.self.getState()` and `ctx.self.setState(...)` are how handlers touch state.
 - To read from another service, use its queries — not its state. (Cross-service composition via `ctx.runtime[serviceId]` is planned; not built yet.)
 - A related feature that needs a different on-disk shape is a different service. There is no "different file format for the same service."
@@ -132,6 +141,13 @@ bump: command({
 
 Commands can be async. A no-op `setState` (empty patch list) is detected and skips all notifications.
 
+#### Abstract vs concrete commands
+
+- **Concrete** — `handler` is present on the definition object. The definition owns the implementation; registration **cannot** override it. The key is excluded from `CommandOverrides` at the type level, and the runtime throws if an override slips through.
+- **Abstract** — `handler` is omitted from the definition. A registration **may** supply a handler, but isn't required to: the same definition is registered in multiple runtimes (manager, preview, server) and typically only one of them implements a given abstract command. Calling an abstract command in a runtime that has no local handler throws today; once cross-runtime command routing lands it will defer to a peer runtime that does.
+
+The use case is one shared definition imported into multiple environments, with environment-specific bodies provided per environment for the **abstract** commands. Concrete commands have a single shared body that lives in the definition.
+
 ### Validation
 
 Every query and command must declare both `input` and `output` schemas. Both must be Standard Schema v1 compatible (zod, valibot, arktype). The runtime validates:
@@ -152,14 +168,16 @@ Validation has two entry points: `validateSync` (fast path for query selectors) 
 
 ## Runtime Flow
 
-When `createService(def)` is called (or `getService(def)` on first access):
+When `registerService(def, registration?)` is called for the first time for a given `def.id`:
 
 1. [service-runtime.ts](./service-runtime.ts) creates a signal-backed state container from `def.state`.
-2. It builds the `ctx.self` reference around that state (`getState`, `setState`, `commands`, `queries`).
-3. It builds commands that validate input, run handlers (sync or async), and validate output.
-4. It builds queries with a callable form and a `.subscribe` form. Both validate input and route through the same internal `_runQuery(name, input)` that runs `select` and validates output.
+2. It resolves command handlers — registration overrides beat definition handlers for **abstract** commands. Concrete commands cannot be overridden; the runtime throws if an override is supplied.
+3. It builds the `ctx.self` reference around the state (`getState`, `setState`, `commands`, `queries`).
+4. It builds commands that validate input, run the resolved handler (sync or async), and validate output. Abstract commands with no resolved handler throw with an actionable message at call time.
+5. It builds queries with a callable form and a `.subscribe` form. Both validate input and route through the same internal `_runQuery(name, input)` that runs `select` and validates output.
+6. It freezes a `publicStore` view exposing only `id`, `definition`, `queries`, `commands`. That's what callers see.
 
-The singleton helper `getService(def)` keeps one instance per `definition.id` within the current process. Tests should call `clearRegistry()` in teardown to avoid cross-test leakage. Re-registering a different definition under the same id throws.
+The registry keeps one instance per `definition.id` within the current process. Tests should call `__resetServiceRegistry()` in teardown to avoid cross-test leakage. Re-registering a different definition under the same id throws.
 
 ```mermaid
 sequenceDiagram
@@ -395,7 +413,7 @@ it('reads from a pre-built artifact file', async () => {
   });
   setStaticTransport(transport);
 
-  const service = getService(MyService);
+  const service = registerService(MyService);
   const listener = vi.fn();
   service.queries.getComponentDocgenInfo.subscribe('Button', listener);
   await new Promise((r) => setTimeout(r, 0));
@@ -406,6 +424,53 @@ it('reads from a pre-built artifact file', async () => {
 
 `createBrowserStaticTransport` composes the same `${serviceId}/${filename}` key in production and asks `globalThis.fetch` with it. The transport receives `(serviceId, filename)` as separate arguments — the runtime never composes URLs or paths; it passes the pair to whatever transport is installed.
 
+## Definition vs Registration
+
+### Definition
+
+```ts
+const DocgenService = defineService<DocgenState>()(({ query, command }) => ({
+  id: 'core/docgen',
+  state: { byComponentId: {}, somethingElse: 42 },
+  queries: {
+    getComponentDocgenInfo: query({ /* ...with preload+inputs+path... */ }),
+    somethingElse: query({ input: z.void(), output: z.number(), select: (s) => s.somethingElse }),
+  },
+  commands: {
+    generateDocgen: command({ input: z.string(), output: z.void() }),       // abstract
+    modifySomethingElse: command({
+      input: z.void(),
+      output: z.void(),
+      handler: (ctx) => { /* ... */ },                                       // concrete
+    }),
+  },
+}));
+```
+
+A definition is environment-agnostic — shape only, no running runtime. It can be imported into manager, preview, server, or test code. Definitions are singletons: re-importing the same module yields the same reference, and the registry's identity check is based on definition reference (not just `id`).
+
+### Registration
+
+```ts
+const store = registerService(DocgenService, {
+  commands: {
+    generateDocgen: async (componentId, ctx) => {
+      const result = await callTheAnalyzer(componentId);
+      ctx.self.setState((d: DocgenState) => {
+        d.byComponentId[componentId] = result;
+      });
+    },
+  },
+});
+```
+
+Registration activates the definition and returns the `ServiceStore`. It supplies:
+
+- **Abstract command implementations.** Any command without a `handler` in the definition that this runtime needs to invoke must be implemented here.
+- Per-environment behaviour that's specific to where the runtime runs.
+
+Whether a service loads from JSON is decided architecture-wide via `setStaticTransport`, not per-service. Re-registering the same definition returns the same `ServiceStore`.
+
 ## How To Define A Service
 
 Recommended — the callback form, where `query` and `command` per-entry helpers infer types from each entry's schemas:
@@ -413,7 +478,7 @@ Recommended — the callback form, where `query` and `command` per-entry helpers
 ```ts
 import { z } from 'zod';
 
-import { defineService, getService } from 'storybook/internal/service';
+import { defineService, registerService } from 'storybook/internal/service';
 
 type ExampleState = {
   values: Record<string, string | undefined>;
@@ -454,7 +519,7 @@ export const ExampleService = defineService<ExampleState>()(({ query, command })
   },
 }));
 
-const service = getService(ExampleService);
+const service = registerService(ExampleService);
 service.queries.getValue({ entryId: 'a' });
 ```
 
@@ -501,7 +566,6 @@ When adding validation tests, prefer asserting the full exact error message — 
 
 The following are deliberately not in this stage. They land as separate, independently reviewable PRs:
 
-- **Service registration** (`registerService(def, registration?)`) with the abstract-command / concrete-command distinction, `ServiceStore` as a public-only view, and registration-time command-handler overrides for environments that share one definition (manager / preview / server). The `getService` singleton today is the temporary stage-1 form; registration replaces it.
 - **Cross-runtime channel sync.** A `ServiceChannel` so peer runtimes (manager ⇄ preview, etc.) exchange a welcome handshake + ongoing patch broadcast and converge on a shared state view.
 - **React hook** (`useServiceQuery`) — a `useSyncExternalStore` wrapper around `query.subscribe`.
 
@@ -510,5 +574,6 @@ The following are deliberately not in this stage. They land as separate, indepen
 - If you need to change runtime behavior, start in [service-runtime.ts](./service-runtime.ts).
 - If you need to change validation wording, start in [service-validation.ts](./service-validation.ts).
 - If you need to change service authoring ergonomics, start in [define-service.ts](./define-service.ts) and [types.ts](./types.ts).
+- If you need to change registration semantics or registry lookup, start in [register-service.ts](./register-service.ts).
 - If you need to change static-preload artifact generation, start in [build-artifacts.ts](./build-artifacts.ts).
 - If you need to change how artifacts are loaded on the client, start in [static-transport.ts](./static-transport.ts).

--- a/code/core/src/service/__examples__/docgen-service.ts
+++ b/code/core/src/service/__examples__/docgen-service.ts
@@ -1,23 +1,25 @@
 /**
  * Worked example: a docgen-shaped service.
  *
- * Demonstrates:
- *  - A query keyed by `componentId` (`getComponentDocgenInfo`) with `preload`, `inputs`, and `path`
- *    for the static build.
- *  - A no-input selector-only query (`somethingElse`) — no static-build fields; just a reactive read.
- *  - Two concrete commands with inline handlers.
+ * Demonstrates the canonical authoring shape:
+ *  - A query keyed by `componentId` (`getComponentDocgenInfo`) with `preload`, `inputs`, and
+ *    `path` for the static build.
+ *  - A no-input selector-only query (`somethingElse`) — no static-build fields; just a
+ *    reactive read.
+ *  - An **abstract** command (`generateDocgen`) — `handler` omitted from the definition. Each
+ *    runtime supplies the body at registration time. A runtime without a handler throws when
+ *    that command is called (until cross-runtime routing lands).
+ *  - A **concrete** command (`modifySomethingElse`) — `handler` is inline; registration
+ *    cannot override.
  *
  * This file lives under `__examples__` and is NOT exported from the package entry. It exists
  * so the public API is exercised by a realistic-shaped service that type-checks.
- *
- * (Abstract commands — definitions without `handler` that registration supplies — arrive in a
- * follow-up stage. Today both commands here are concrete.)
  */
 
 import { z } from 'zod';
 
 import { defineService } from '../define-service.ts';
-import { createService } from '../service-runtime.ts';
+import { registerService } from '../register-service.ts';
 
 const componentDocgenSchema = z.object({
   description: z.string(),
@@ -29,16 +31,19 @@ interface DocgenState {
   somethingElse: number;
 }
 
-// Placeholder for the build-time component-id enumeration.
+// Placeholder for the build-time component-id enumeration. Real callers would scan the
+// project's stories.
 async function listAllComponentIds(): Promise<readonly string[]> {
   return [];
 }
 
 /**
- * Environment-agnostic definition.
+ * Environment-agnostic definition. Same module imported into manager, preview, and server.
  *
- * `defineService<DocgenState>()(({ query, command }) => …)` — state on the generic; schemas
- * and command handlers infer from the callback.
+ * - `getComponentDocgenInfo` is a static-build query — its `preload` calls the abstract
+ *   `generateDocgen` command. That command's body lives wherever docgen analysis can run
+ *   (typically the server build), supplied via `registerService` in that environment.
+ * - `modifySomethingElse` is concrete — its body is shared across all environments.
  */
 export const DocgenService = defineService<DocgenState>()(({ query, command }) => ({
   id: 'core/docgen',
@@ -54,9 +59,6 @@ export const DocgenService = defineService<DocgenState>()(({ query, command }) =
       output: componentDocgenSchema.nullable(),
       select: (state, componentId) => state.byComponentId[componentId] ?? null,
       preload: async (componentId, ctx) => {
-        // Stage 1: the handler lives inline on `generateDocgen`. Once abstract commands land,
-        // this preload will call the abstract command and registration will supply the body
-        // per environment.
         await ctx.self.commands.generateDocgen(componentId);
       },
       inputs: async () => listAllComponentIds(),
@@ -71,19 +73,14 @@ export const DocgenService = defineService<DocgenState>()(({ query, command }) =
   },
 
   commands: {
+    // Abstract: no `handler` on the definition. A registration MUST supply one for the
+    // command to be callable in this runtime.
     generateDocgen: command({
       input: z.string(),
       output: z.void(),
-      handler: async (componentId, ctx) => {
-        ctx.self.setState((draft) => {
-          draft.byComponentId[componentId] = {
-            description: `Docgen for ${componentId}`,
-            props: {},
-          };
-        });
-      },
     }),
 
+    // Concrete: inline `handler`. Registration cannot override.
     modifySomethingElse: command({
       input: z.void(),
       output: z.void(),
@@ -96,7 +93,22 @@ export const DocgenService = defineService<DocgenState>()(({ query, command }) =
   },
 }));
 
-/** Example consumer: build a fresh instance. */
-export function createDocgenService() {
-  return createService(DocgenService);
+/**
+ * Example consumer (server-side): registers with the abstract command body that calls the
+ * real docgen analyser.
+ */
+export function registerServerSideDocgen() {
+  return registerService(DocgenService, {
+    commands: {
+      generateDocgen: async (componentId, ctx) => {
+        // Real call would invoke the analyser; the stub here just writes a placeholder.
+        ctx.self.setState((draft) => {
+          draft.byComponentId[componentId] = {
+            description: `Docgen for ${componentId}`,
+            props: {},
+          };
+        });
+      },
+    },
+  });
 }

--- a/code/core/src/service/build-artifacts.test.ts
+++ b/code/core/src/service/build-artifacts.test.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { buildServiceArtifacts, patchesToStateDiff } from './build-artifacts.ts';
 import { defineService } from './define-service.ts';
-import { clearRegistry, getService } from './service-runtime.ts';
+import { __resetServiceRegistry, registerService } from './register-service.ts';
 import {
   clearStaticTransport,
   createBrowserStaticTransport,
@@ -16,7 +16,7 @@ import type { ServiceCtx } from './types.ts';
 const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 
 afterEach(() => {
-  clearRegistry();
+  __resetServiceRegistry();
   clearStaticTransport();
 });
 
@@ -474,7 +474,7 @@ describe('runtime loader branching', () => {
       },
     });
 
-    const store = getService(def);
+    const store = registerService(def);
     const listener = vi.fn();
     store.queries.getOne.subscribe('a', listener);
 
@@ -523,7 +523,7 @@ describe('runtime loader branching', () => {
     transport.files.set(`${def.id}/entries/a.json`, { byId: { a: 'from-static' } });
     setStaticTransport(transport);
 
-    const store = getService(def);
+    const store = registerService(def);
     const listener = vi.fn();
     store.queries.getOne.subscribe('a', listener);
 
@@ -570,7 +570,7 @@ describe('runtime loader branching', () => {
     // Transport installed but has no entry for this input — fetch returns null.
     setStaticTransport(mockTransport());
 
-    const store = getService(def);
+    const store = registerService(def);
     store.queries.getOne.subscribe('a', vi.fn());
 
     await tick();
@@ -626,11 +626,11 @@ describe('runtime loader branching', () => {
     });
 
     // Registration triggers no fetches — the runtime no longer fetches at registration.
-    getService(def);
+    registerService(def);
     expect(fetched).toEqual([]);
 
     // Subscribing to 'a' triggers exactly one fetch — entries/a.json.
-    const store = getService(def);
+    const store = registerService(def);
     store.queries.getOne.subscribe('a', vi.fn());
     await tick();
     expect(fetched).toEqual(['entries/a.json']);
@@ -692,7 +692,7 @@ describe('build → load round trip', () => {
     // Reload via transport. The loader body must NOT run again.
     realLoadCalls.length = 0;
     installTransportFromArtifacts(def.id, artifacts);
-    const reloaded = getService(def);
+    const reloaded = registerService(def);
 
     const listener = vi.fn();
     reloaded.queries.getComponentDocgenInfo.subscribe('Button', listener);
@@ -749,7 +749,7 @@ describe('build → load round trip', () => {
 
     realLoadCalls.length = 0;
     installTransportFromArtifacts(def.id, artifacts);
-    const reloaded = getService(def);
+    const reloaded = registerService(def);
 
     // First subscription to `allStatuses` fires the loader, which fetches statuses.json.
     const listener = vi.fn();

--- a/code/core/src/service/define-service.ts
+++ b/code/core/src/service/define-service.ts
@@ -1,8 +1,10 @@
 import type {
+  AbstractCommandDef,
   AnyCommandDef,
   AnyQueryDef,
   AnySchema,
   CommandDef,
+  ConcreteCommandDef,
   QueryDef,
   ServiceDefinition,
 } from './types.ts';
@@ -69,11 +71,31 @@ export function query<TState>() {
   ): QueryDef<TState, I, O> => definition;
 }
 
-/** Type-only helper for a command entry. At runtime this returns its argument unchanged. */
+/**
+ * Type-only helper for a command entry. At runtime this returns its argument unchanged.
+ *
+ * Two overloads preserve the abstract/concrete distinction in the returned type:
+ *   - With a `handler` field → {@link ConcreteCommandDef} (registration cannot override).
+ *   - Without a `handler` field → {@link AbstractCommandDef} (registration must supply one).
+ */
+export function command<TState>(): {
+  <const I extends AnySchema, const O extends AnySchema>(
+    definition: ConcreteCommandDef<TState, I, O>
+  ): ConcreteCommandDef<TState, I, O>;
+  <const I extends AnySchema, const O extends AnySchema>(
+    definition: AbstractCommandDef<TState, I, O>
+  ): AbstractCommandDef<TState, I, O>;
+};
 export function command<TState>() {
-  return <const I extends AnySchema, const O extends AnySchema>(
-    definition: CommandDef<TState, I, O>
-  ): CommandDef<TState, I, O> => definition;
+  return (definition: CommandDef<TState>): CommandDef<TState> => definition;
+}
+
+/**
+ * A command is **abstract** when its definition has no `handler` field. The runtime checks
+ * for this at construction time and consults registration overrides if so.
+ */
+export function isAbstractCommand(entry: AnyCommandDef): boolean {
+  return typeof entry.handler !== 'function';
 }
 
 export type QueryHelper<TState> = ReturnType<typeof query<TState>>;

--- a/code/core/src/service/index.ts
+++ b/code/core/src/service/index.ts
@@ -5,10 +5,15 @@
  *   - `defineService<S>()(({ query, command }) => ({ state, queries, commands }))` declares a
  *     service. Schema-driven inference covers definition handlers; the runtime validates
  *     `input` / `output` on every call.
- *   - `createService(def)` builds a fresh runtime instance from the definition.
- *   - `getService(def)` looks up (or lazily creates) a singleton instance.
+ *   - `registerService(def, registration?)` activates the definition and returns a
+ *     `ServiceStore`. Idempotent on the definition; safe to call from multiple modules.
+ *   - `getService(def|id)` looks up an already-registered service.
  *   - `buildServiceArtifacts(def)` writes the per-input JSON files used by the static-build
  *     loader; `setStaticTransport(...)` installs the loader on the client.
+ *
+ * Commands come in two flavours: **concrete** (definition supplies the `handler`, registration
+ * cannot override) and **abstract** (no `handler` on the definition; registration MAY supply
+ * one — same definition typically registered in multiple runtimes).
  *
  * Schemas are required: every query/command declares Standard Schema v1 `input` and `output`.
  * The runtime validates at the boundary; `ServiceValidationError` is thrown on mismatch.
@@ -18,7 +23,8 @@
 
 export { buildServiceArtifacts } from './build-artifacts.ts';
 export { command, defineService, query } from './define-service.ts';
-export { ServiceRuntime, clearRegistry, createService, getService } from './service-runtime.ts';
+export { __resetServiceRegistry, getService, registerService } from './register-service.ts';
+export { ServiceRuntime, createService } from './service-runtime.ts';
 export {
   ServiceValidationError,
   type ValidationKind,
@@ -31,12 +37,15 @@ export {
 } from './static-transport.ts';
 
 export type {
+  AbstractCommandDef,
   AnyCommandDef,
   AnyQueryDef,
   AnySchema,
   BuildCtx,
   CommandDef,
   CommandHandlerFn,
+  CommandOverrides,
+  ConcreteCommandDef,
   InferSchemaInput,
   InferSchemaOutput,
   InputOfCommand,
@@ -47,6 +56,8 @@ export type {
   ServiceCtx,
   ServiceDefinition,
   ServiceInstance,
+  ServiceRegistration,
   ServiceStaticTransport,
+  ServiceStore,
   StateMutator,
 } from './types.ts';

--- a/code/core/src/service/instances.ts
+++ b/code/core/src/service/instances.ts
@@ -1,0 +1,5 @@
+// Global registry of running service instances, keyed by `definition.id`.
+// Lives in its own module so it can be mocked in tests (mirroring the UniversalStore pattern).
+import type { ServiceRuntime } from './service-runtime.ts';
+
+export const instances: Map<string, ServiceRuntime<any>> = new Map();

--- a/code/core/src/service/register-service.ts
+++ b/code/core/src/service/register-service.ts
@@ -1,0 +1,77 @@
+import { instances } from './instances.ts';
+import { ServiceRuntime } from './service-runtime.ts';
+import type { ServiceDefinition, ServiceRegistration, ServiceStore } from './types.ts';
+
+/**
+ * Public-only view of a runtime. Returns the runtime's stable `publicStore` reference, which
+ * was built once at construction and omits the infrastructure-facing methods (getState,
+ * setState, subscribe, getLastPatches). Application code only sees what it should: id,
+ * definition, queries, commands.
+ */
+function asServiceStore<TDef extends ServiceDefinition<any, any, any>>(
+  runtime: ServiceRuntime<TDef>
+): ServiceStore<TDef> {
+  return runtime.publicStore as unknown as ServiceStore<TDef>;
+}
+
+/**
+ * Register a service definition with the global runtime.
+ *
+ * `registration.commands` supplies handlers for the definition's **abstract** commands (those
+ * declared without a `handler`). Abstract handlers are optional — the same definition is
+ * registered in multiple runtimes and typically only one of them implements a given abstract
+ * command. A call to an abstract command in a runtime that has no local handler throws today;
+ * once cross-runtime command routing lands it will defer to a peer runtime that does.
+ *
+ * Concrete commands — those whose definition has a `handler` — are owned by the definition
+ * and **cannot** be overridden here; the type system removes their keys from
+ * {@link ServiceRegistration.commands} and the runtime throws if one slips through.
+ *
+ * Idempotent on the same `definition` reference: calling twice returns the same `ServiceStore`.
+ * If a different definition is registered against an existing id, this throws — the
+ * registry is global and definitions must be consistent across imports.
+ */
+export function registerService<TDef extends ServiceDefinition<any, any, any>>(
+  definition: TDef,
+  registration?: ServiceRegistration<TDef>
+): ServiceStore<TDef> {
+  const existing = instances.get(definition.id);
+  if (existing) {
+    if (existing.definition !== definition) {
+      throw new Error(
+        `[service] A different service definition is already registered for id "${definition.id}". ` +
+          `Service definitions must be singletons across the bundle.`
+      );
+    }
+    return asServiceStore(existing) as ServiceStore<TDef>;
+  }
+  const runtime = new ServiceRuntime(definition, registration);
+  instances.set(definition.id, runtime);
+  return asServiceStore(runtime);
+}
+
+/**
+ * Look up a previously-registered service. Pass the definition for type safety, or just the id
+ * if you don't have the definition in scope (return type widens to `ServiceStore<any>`).
+ *
+ * Throws if no service is registered for the given id.
+ */
+export function getService<TDef extends ServiceDefinition<any, any, any>>(
+  definition: TDef
+): ServiceStore<TDef>;
+export function getService(id: string): ServiceStore<ServiceDefinition<any, any, any>>;
+export function getService(arg: string | ServiceDefinition<any, any, any>): ServiceStore<any> {
+  const id = typeof arg === 'string' ? arg : arg.id;
+  const runtime = instances.get(id);
+  if (!runtime) {
+    throw new Error(
+      `[service] No service is registered for id "${id}". Did you forget to call registerService?`
+    );
+  }
+  return asServiceStore(runtime);
+}
+
+/** Test-only helper. Clear the global registry. */
+export function __resetServiceRegistry(): void {
+  instances.clear();
+}

--- a/code/core/src/service/service-runtime.test.ts
+++ b/code/core/src/service/service-runtime.test.ts
@@ -2,14 +2,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
 import { defineService } from './define-service.ts';
-import { ServiceRuntime, clearRegistry, deepMerge, getService } from './service-runtime.ts';
+import { __resetServiceRegistry, registerService } from './register-service.ts';
+import { ServiceRuntime, deepMerge } from './service-runtime.ts';
 import type { ServiceCtx } from './types.ts';
 
 /** Wait a tick — enough for fire-and-forget preload promises to settle. */
 const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 afterEach(() => {
-  clearRegistry();
+  __resetServiceRegistry();
 });
 
 // All tests below interact with services through the *official* surface:
@@ -35,7 +36,7 @@ describe('queries', () => {
       },
       commands: {},
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     expect(service.queries.get()).toBe('hi');
   });
@@ -56,7 +57,7 @@ describe('queries', () => {
       },
       commands: {},
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     expect(service.queries.getById('a')).toBe(1);
     expect(service.queries.getById('b')).toBe(2);
@@ -93,7 +94,7 @@ describe('queries', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     const aListener = vi.fn();
     const bListener = vi.fn();
@@ -135,7 +136,7 @@ describe('queries', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     const listener = vi.fn();
     service.queries.getName.subscribe('a', listener);
@@ -167,7 +168,7 @@ describe('commands', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     await service.commands.increment();
     expect(service.queries.get()).toBe(1);
@@ -200,10 +201,158 @@ describe('commands', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     await service.commands.setName({ id: 'a', name: 'Alice' });
     expect(service.queries.get('a')).toBe('Alice');
+  });
+});
+
+// -------------------- abstract commands --------------------
+
+describe('abstract commands', () => {
+  it('definition declares abstract command (handler missing); registration supplies handler', async () => {
+    interface S {
+      byId: Record<string, string>;
+    }
+    const def = defineService()({
+      id: 'test/abstract-impl',
+      state: { byId: {} } as S,
+      queries: {
+        get: {
+          input: z.string(),
+          output: z.string().optional(),
+          select: (s: S, id: string) => s.byId[id],
+        },
+      },
+      commands: {
+        load: {
+          input: z.object({ id: z.string(), name: z.string() }),
+          output: z.void(),
+        },
+      },
+    });
+
+    const handlerSpy = vi.fn(async (input: { id: string; name: string }, ctx: ServiceCtx<S>) => {
+      ctx.self.setState((d) => {
+        d.byId[input.id] = input.name;
+      });
+    });
+
+    const service = registerService(def, {
+      commands: {
+        load: handlerSpy,
+      },
+    });
+
+    await service.commands.load({ id: 'a', name: 'Alice' });
+
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+    expect(service.queries.get('a')).toBe('Alice');
+  });
+
+  it('registers an abstract command without a handler (call fails until handler arrives)', async () => {
+    const def = defineService()({
+      id: 'test/abstract-no-handler-registers',
+      state: {},
+      queries: {},
+      commands: {
+        load: {
+          input: z.object({ id: z.string() }),
+          output: z.void(),
+        },
+      },
+    });
+
+    const service = registerService(def);
+
+    await expect(service.commands.load({ id: 'x' })).rejects.toThrow(/no handler in this runtime/);
+  });
+
+  it('throws when registration tries to override a concrete command', () => {
+    interface S {
+      n: number;
+    }
+    const def = defineService()({
+      id: 'test/override-concrete-rejected',
+      state: { n: 0 } as S,
+      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      commands: {
+        bump: {
+          input: z.void(),
+          output: z.void(),
+          handler: (ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.n += 1;
+            }),
+        },
+      },
+    });
+
+    expect(() =>
+      registerService(def, {
+        // Bypass the type system (concrete overrides are excluded from `CommandOverrides`)
+        // to assert the runtime guard fires.
+        commands: {
+          bump: (ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.n += 100;
+            }),
+        } as never,
+      })
+    ).toThrow(/concrete.*cannot be overridden at registration/);
+  });
+
+  it('abstract command with no input arg', async () => {
+    interface S {
+      ready: boolean;
+    }
+    const def = defineService()({
+      id: 'test/abstract-noinput',
+      state: { ready: false } as S,
+      queries: { isReady: { input: z.void(), output: z.boolean(), select: (s: S) => s.ready } },
+      commands: {
+        boot: { input: z.void(), output: z.void() },
+      },
+    });
+
+    const service = registerService(def, {
+      commands: {
+        boot: (ctx) =>
+          (ctx as ServiceCtx<S>).self.setState((d) => {
+            d.ready = true;
+          }),
+      },
+    });
+
+    expect(service.queries.isReady()).toBe(false);
+    await service.commands.boot();
+    expect(service.queries.isReady()).toBe(true);
+  });
+});
+
+// -------------------- encapsulation --------------------
+
+describe('encapsulation', () => {
+  it('public ServiceStore exposes only id/definition/queries/commands', () => {
+    const def = defineService()({
+      id: 'test/encapsulation',
+      state: { secret: 42 },
+      queries: {
+        get: {
+          input: z.void(),
+          output: z.number(),
+          select: (s: { secret: number }) => s.secret,
+        },
+      },
+      commands: {},
+    });
+    const service = registerService(def);
+
+    // The runtime class has getState/setState/subscribe for infrastructure use; the public
+    // store omits them. Object.keys reflects the frozen public view.
+    expect(Object.keys(service).sort()).toEqual(['commands', 'definition', 'id', 'queries']);
+    expect(service.queries.get()).toBe(42);
   });
 });
 
@@ -243,7 +392,7 @@ describe('preloads', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     const listener = vi.fn();
     service.queries.getName.subscribe('a', listener);
@@ -292,7 +441,7 @@ describe('preloads', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     service.queries.getName.subscribe('a', vi.fn());
     service.queries.getName.subscribe('a', vi.fn());
@@ -336,7 +485,7 @@ describe('preloads', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     service.queries.getName.subscribe('a', vi.fn());
     service.queries.getName.subscribe('b', vi.fn());
@@ -383,7 +532,7 @@ describe('preloads', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     // First read returns un-loaded value but kicks the preload off.
     expect(service.queries.get()).toBe('');
@@ -411,7 +560,7 @@ describe('preloads', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     const listener = vi.fn();
     service.queries.get.subscribe(listener);
@@ -426,7 +575,7 @@ describe('preloads', () => {
 
 // -------------------- registry --------------------
 
-describe('getService', () => {
+describe('registerService / getService', () => {
   it('is idempotent on the same definition', () => {
     const def = defineService()({
       id: 'test/registry-idem',
@@ -436,8 +585,8 @@ describe('getService', () => {
       },
       commands: {},
     });
-    const a = getService(def);
-    const b = getService(def);
+    const a = registerService(def);
+    const b = registerService(def);
     expect(a).toBe(b);
   });
 
@@ -454,8 +603,8 @@ describe('getService', () => {
       queries: {},
       commands: {},
     });
-    getService(a);
-    expect(() => getService(b)).toThrow(/different service definition is already registered/);
+    registerService(a);
+    expect(() => registerService(b)).toThrow(/different service definition is already registered/);
   });
 });
 
@@ -480,7 +629,7 @@ describe('schema validation', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     await expect(service.commands.set('not-a-number' as unknown as number)).rejects.toThrow(
       /Invalid input for command/
@@ -500,7 +649,7 @@ describe('schema validation', () => {
       },
       commands: {},
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     expect(() => service.queries.getById(42 as unknown as string)).toThrow(
       /Invalid input for query/
@@ -517,7 +666,7 @@ describe('schema validation', () => {
       },
       commands: {},
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     expect(() => service.queries.get()).toThrow(/Invalid output for query/);
   });
@@ -541,7 +690,7 @@ describe('runtime defensive guarantees', () => {
       },
       commands: {},
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     // External mutation of the source object after the runtime was constructed.
     initial.byId.a.name = 'MUTATED';
@@ -617,7 +766,7 @@ describe('runtime defensive guarantees', () => {
     }
 
     try {
-      const service = getService(def);
+      const service = registerService(def);
       service.queries.get();
       await new Promise((r) => setTimeout(r, 10));
     } finally {

--- a/code/core/src/service/service-runtime.ts
+++ b/code/core/src/service/service-runtime.ts
@@ -1,6 +1,8 @@
 import { computed, effect, endBatch, signal, startBatch } from 'alien-signals';
 import { enablePatches, produceWithPatches, type Patch } from 'immer';
 
+import { isAbstractCommand } from './define-service.ts';
+import { instances } from './instances.ts';
 import { rethrowAsync, validateAsync, validateSync } from './service-validation.ts';
 import { getStaticTransport } from './static-transport.ts';
 import type {
@@ -12,6 +14,7 @@ import type {
   ServiceCtx,
   ServiceDefinition,
   ServiceInstance,
+  ServiceRegistration,
   StateMutator,
   SubscribableQueries,
   SubscribableQuery,
@@ -112,13 +115,27 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
   private _inflightPreloads = new Map<string, Map<string, Promise<void>>>();
   /** Patches accumulated for the most recent setState call. */
   private _lastPatches: readonly Patch[] = [];
+  /** Resolved command handlers: definition handler or registration override. */
+  private _commandHandlers: Record<string, (...args: any[]) => any>;
 
   public readonly definition: TDef;
   public readonly id: string;
   public readonly queries: SubscribableQueries<TDef['queries']>;
   public readonly commands: CallableCommands<TDef['commands']>;
+  /**
+   * Public-facing view of this runtime. Stable reference across calls to
+   * `registerService` / `getService`. State-mutation hooks (`getState`, `setState`,
+   * `subscribe`, `getLastPatches`) are deliberately omitted — they remain on the runtime
+   * class for the build pipeline and transport sync.
+   */
+  public readonly publicStore: {
+    readonly id: string;
+    readonly definition: TDef;
+    readonly queries: SubscribableQueries<TDef['queries']>;
+    readonly commands: CallableCommands<TDef['commands']>;
+  };
 
-  constructor(definition: TDef) {
+  constructor(definition: TDef, registration?: ServiceRegistration<TDef>) {
     this.definition = definition;
     this.id = definition.id;
 
@@ -131,8 +148,53 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
         : never
     );
 
+    // Resolve command handlers: registration override beats definition handler. Abstract
+    // commands with no override remain unresolved — call-time throws with an actionable
+    // message until cross-runtime command routing lands.
+    this._commandHandlers = this._resolveCommandHandlers(definition, registration);
+
     this.queries = this._buildQueriesApi();
     this.commands = this._buildCommandsApi();
+
+    this.publicStore = Object.freeze({
+      id: this.id,
+      definition: this.definition,
+      queries: this.queries,
+      commands: this.commands,
+    });
+  }
+
+  // ------------------------------ command resolution ------------------------------
+
+  private _resolveCommandHandlers(
+    definition: TDef,
+    registration?: ServiceRegistration<TDef>
+  ): Record<string, (...args: any[]) => any> {
+    const out: Record<string, (...args: any[]) => any> = {};
+    const overrides = (registration?.commands ?? {}) as Record<
+      string,
+      ((...args: any[]) => any) | undefined
+    >;
+
+    for (const [name, entry] of Object.entries(definition.commands)) {
+      const cmdDef = entry as AnyCommandDef<unknown>;
+      const override = overrides[name];
+      if (isAbstractCommand(cmdDef)) {
+        if (override) {
+          out[name] = override;
+        }
+        continue;
+      }
+      if (override) {
+        throw new Error(
+          `[service ${definition.id}] command "${name}" is concrete (its definition has a \`handler\`) ` +
+            `and cannot be overridden at registration. ` +
+            `Remove the override, or change the definition to abstract by removing its \`handler\`.`
+        );
+      }
+      out[name] = cmdDef.handler as (...args: any[]) => any;
+    }
+    return out;
   }
 
   // ------------------------------ infrastructure-facing API ------------------------------
@@ -315,10 +377,13 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
     const out: Record<string, (input?: unknown) => Promise<unknown>> = {};
     for (const commandName of Object.keys(this.definition.commands)) {
       const cmdDef = this.definition.commands[commandName] as AnyCommandDef<unknown>;
-      const handler = cmdDef.handler as (...args: any[]) => unknown | Promise<unknown>;
+      const handler = this._commandHandlers[commandName] as
+        | ((...args: any[]) => unknown | Promise<unknown>)
+        | undefined;
       // Dispatch by declared arity: `(ctx)` for no-input handlers, `(input, ctx)` for
-      // input-keyed ones.
-      const handlerHasInput = handler.length > 1;
+      // input-keyed ones. We can't unconditionally call `(input, ctx)` because a no-input
+      // handler would receive `input` as its first arg.
+      const handlerHasInput = !!handler && handler.length > 1;
 
       out[commandName] = async (rawInput?: unknown): Promise<unknown> => {
         const parsedInput = await validateAsync(cmdDef.input, rawInput, {
@@ -327,6 +392,17 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
           name: commandName,
           phase: 'input',
         });
+        if (!handler) {
+          // No local handler — definition is abstract and registration didn't supply one.
+          // TODO(cross-runtime): once command-routing lands, defer to a peer runtime that
+          // has registered a handler instead of throwing here.
+          throw new Error(
+            `[service ${this.id}] command "${commandName}" has no handler in this runtime. ` +
+              `Provide one at registration via ` +
+              `registerService(def, { commands: { ${commandName}: (input, ctx) => ... } }), ` +
+              `or run the call against a runtime that has the handler.`
+          );
+        }
         const ctx = this._getCtx();
         const rawOutput = await (handlerHasInput ? handler(parsedInput, ctx) : handler(ctx));
         return validateAsync(cmdDef.output, rawOutput, {
@@ -526,44 +602,15 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
 // ------------------------------ public entry points ------------------------------
 
 /**
- * Build a fresh runtime instance for the definition. Every call creates a new runtime —
- * callers that need a singleton per service id should use {@link getService} instead.
+ * Build a fresh runtime instance for the definition without touching the global registry.
+ *
+ * Prefer {@link './register-service.ts'.registerService} for production code — it is
+ * idempotent on the same definition and returns a public-only `ServiceStore` view.
  */
 export function createService<TDef extends ServiceDefinition<any, any, any>>(
-  definition: TDef
+  definition: TDef,
+  registration?: ServiceRegistration<TDef>
 ): ServiceInstance<TDef> {
-  const runtime = new ServiceRuntime(definition);
-  return runtime as unknown as ServiceInstance<TDef>;
-}
-
-const instances = new Map<string, ServiceRuntime<any>>();
-
-/**
- * Returns a shared singleton instance for the given service definition. Lazy: creates on first
- * access via {@link createService}, reuses thereafter.
- *
- * Throws if a different definition is already registered for the same id (`definition.id` is
- * the registry key, so two distinct definitions sharing an id would silently collide).
- */
-export function getService<TDef extends ServiceDefinition<any, any, any>>(
-  definition: TDef
-): ServiceInstance<TDef> {
-  const existing = instances.get(definition.id);
-  if (existing) {
-    if (existing.definition !== definition) {
-      throw new Error(
-        `[service] A different service definition is already registered for id "${definition.id}". ` +
-          `Service definitions must be singletons across the bundle.`
-      );
-    }
-    return existing as unknown as ServiceInstance<TDef>;
-  }
-  const runtime = new ServiceRuntime(definition);
-  instances.set(definition.id, runtime);
-  return runtime as unknown as ServiceInstance<TDef>;
-}
-
-/** Test-only helper. Clears the global registry. */
-export function clearRegistry(): void {
-  instances.clear();
+  const runtime = new ServiceRuntime(definition, registration);
+  return runtime.publicStore as unknown as ServiceInstance<TDef>;
 }

--- a/code/core/src/service/service-validation.test.ts
+++ b/code/core/src/service/service-validation.test.ts
@@ -3,11 +3,11 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import { defineService } from './define-service.ts';
-import { clearRegistry, getService } from './service-runtime.ts';
+import { __resetServiceRegistry, registerService } from './register-service.ts';
 import { ServiceValidationError } from './service-validation.ts';
 
 afterEach(() => {
-  clearRegistry();
+  __resetServiceRegistry();
 });
 
 describe('ServiceValidationError formatting', () => {
@@ -25,7 +25,7 @@ describe('ServiceValidationError formatting', () => {
       },
       commands: {},
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     try {
       service.queries.getById({} as unknown as { entryId: string });
@@ -55,7 +55,7 @@ describe('ServiceValidationError formatting', () => {
       },
       commands: {},
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     try {
       service.queries.getBrokenTree();
@@ -89,7 +89,7 @@ describe('ServiceValidationError formatting', () => {
         },
       },
     });
-    const service = getService(def);
+    const service = registerService(def);
 
     await expect(service.commands.set('x' as unknown as number)).rejects.toMatchObject({
       name: 'ServiceValidationError',

--- a/code/core/src/service/types.ts
+++ b/code/core/src/service/types.ts
@@ -168,11 +168,12 @@ export type CommandHandlerFn<
       ) => InferSchemaInput<TOutputSchema> | Promise<InferSchemaInput<TOutputSchema>>;
 
 /**
- * A command is a schema-validated writer. `handler` is required at this stage.
- *
- * Abstract commands (no `handler`, supplied at registration) arrive in a follow-up stage.
+ * Abstract command — no `handler` on the definition. A registration MAY supply one, but isn't
+ * required to: the same definition is registered in multiple runtimes and typically only one
+ * of them implements a given abstract command. Calls in runtimes without a handler throw
+ * today, and will defer to a peer runtime once cross-runtime command routing lands.
  */
-export interface CommandDef<
+export interface AbstractCommandDef<
   TState = any,
   TInputSchema extends AnySchema = AnySchema,
   TOutputSchema extends AnySchema = AnySchema,
@@ -180,8 +181,34 @@ export interface CommandDef<
   readonly description?: string;
   readonly input: TInputSchema;
   readonly output: TOutputSchema;
+}
+
+/**
+ * Concrete command — `handler` is required. Cannot be overridden at registration; the
+ * registration type excludes its key, and the runtime throws if an override slips through.
+ */
+export interface ConcreteCommandDef<
+  TState = any,
+  TInputSchema extends AnySchema = AnySchema,
+  TOutputSchema extends AnySchema = AnySchema,
+> extends AbstractCommandDef<TState, TInputSchema, TOutputSchema> {
   readonly handler: CommandHandlerFn<TState, TInputSchema, TOutputSchema>;
 }
+
+/**
+ * A command is a schema-validated writer.
+ *
+ *  - `input` and `output` are Standard Schema v1 schemas.
+ *  - A command without `handler` is **abstract** — registration MUST supply a handler.
+ *  - A command with `handler` is **concrete** — registration CANNOT override it.
+ */
+export type CommandDef<
+  TState = any,
+  TInputSchema extends AnySchema = AnySchema,
+  TOutputSchema extends AnySchema = AnySchema,
+> =
+  | AbstractCommandDef<TState, TInputSchema, TOutputSchema>
+  | ConcreteCommandDef<TState, TInputSchema, TOutputSchema>;
 
 // -------------------- map constraints --------------------
 
@@ -204,12 +231,12 @@ export type AnyQueryDef<TState = any> = {
   readonly path?: BivariantCallback<[ctx: BuildCtx, input?: unknown], string>;
 };
 
-/** Any command definition bound to `TState`. */
+/** Any command definition bound to `TState`. `handler` is optional — absent means abstract. */
 export type AnyCommandDef<TState = any> = {
   readonly description?: string;
   readonly input: AnySchema;
   readonly output: AnySchema;
-  readonly handler: BivariantCallback<
+  readonly handler?: BivariantCallback<
     [input: unknown, ctx: ServiceCtx<TState>],
     unknown | Promise<unknown>
   >;
@@ -236,6 +263,31 @@ export interface ServiceDefinition<
 
 // `ServiceStaticTransport` lives in `static-transport.ts`. Re-export here for convenience.
 export type { ServiceStaticTransport } from './static-transport.ts';
+
+// -------------------- registration --------------------
+
+/**
+ * Registration-time options. Supplies handlers for the definition's **abstract** commands.
+ *
+ * Concrete commands (those with a `handler` in the definition) are NOT overridable — their
+ * keys are removed from {@link CommandOverrides} and the runtime throws if one slips through.
+ */
+export interface ServiceRegistration<TDef extends ServiceDefinition<any, any, any>> {
+  commands?: CommandOverrides<TDef>;
+}
+
+/**
+ * Per-command override map. Only **abstract** commands appear here — concrete commands are
+ * filtered out via key remapping. Abstract overrides are typed from the command's `input` /
+ * `output` schemas.
+ */
+export type CommandOverrides<TDef extends ServiceDefinition<any, any, any>> = {
+  [K in keyof TDef['commands'] as TDef['commands'][K] extends ConcreteCommandDef<any, any, any>
+    ? never
+    : K]?: TDef['commands'][K] extends AbstractCommandDef<TDef['state'], infer TIn, infer TOut>
+    ? CommandHandlerFn<TDef['state'], TIn, TOut>
+    : never;
+};
 
 // -------------------- input/output inference for consumers --------------------
 
@@ -283,14 +335,22 @@ export type CallableCommands<TC extends CommandsMap<any>> = {
 };
 
 /**
- * Runtime handle returned by `createService` / `getService`.
+ * Public-facing handle returned by `registerService` / `getService`.
  *
  * State is *not* on this interface — it's internal to the service. To read data, call a query.
  * To change data, call a command. To react to changes, subscribe to a query.
  */
-export interface ServiceInstance<TDef extends ServiceDefinition<any, any, any>> {
+export interface ServiceStore<TDef extends ServiceDefinition<any, any, any>> {
   readonly id: string;
   readonly definition: TDef;
   readonly queries: SubscribableQueries<TDef['queries']>;
   readonly commands: CallableCommands<TDef['commands']>;
 }
+
+/**
+ * Alias for {@link ServiceStore}. Kept for stage-1 callers that still use the older name.
+ *
+ * `createService(def)` continues to return this shape; new code should prefer
+ * `registerService(def, registration?)` and consume `ServiceStore`.
+ */
+export type ServiceInstance<TDef extends ServiceDefinition<any, any, any>> = ServiceStore<TDef>;


### PR DESCRIPTION
Second of four stacked PRs aligning the service architecture work. **Base: [#34912](https://github.com/storybookjs/storybook/pull/34912) (Stage 1).** Review Stage 1 first; this PR's diff only shows what Stage 2 adds on top.

## Stack

\`\`\`
next
 └── jeppe/service-arch-explorations
      └── norbert/service-stage-1-core           (Stage 1 — #34912)
           └── norbert/service-stage-2-register  ← THIS PR
                └── norbert/service-stage-3-channel
                     └── norbert/service-stage-4-react-hook
\`\`\`

## Summary

Stage 1 had a single \`new ServiceRuntime(def)\` API and assumed every command was concrete. Stage 2 adds the registration layer that the production architecture needs:

- **Global registry.** New \`registerService(def, registration?)\` activates a service definition. \`getService(def | id)\` looks one up. \`__resetServiceRegistry()\` is the test escape hatch. Lives in [\`register-service.ts\`](https://github.com/storybookjs/storybook/blob/norbert/service-stage-2-register/code/core/src/service/register-service.ts), with the shared map in [\`instances.ts\`](https://github.com/storybookjs/storybook/blob/norbert/service-stage-2-register/code/core/src/service/instances.ts) so it can be mocked or swapped per consumer if we ever need to.
- **Abstract vs concrete commands.** \`CommandDef\` splits into \`AbstractCommandDef\` (no \`handler\` on the definition) and \`ConcreteCommandDef\` (required \`handler\`). The same definition is typically registered in multiple runtimes; abstract commands let each runtime supply its own handler at registration time (e.g. server-side docgen vs client-side stub). The \`command<S>()\` authoring helper gains overloads that preserve the abstract/concrete distinction in the returned type.
- **Overrides API.** \`ServiceRegistration<TDef>\` carries an optional \`commands: CommandOverrides<TDef>\` where \`CommandOverrides\` is key-remapped to drop the concrete keys — so trying to override a concrete command is a compile-time error, not a runtime one.
- **Runtime enforcement.** \`_resolveCommandHandlers\` enforces the three invariants at runtime too: abstract command MAY be overridden, concrete command MAY NOT, missing concrete handler throws with a clear message. The static-type check and the runtime check are intentionally both there — defence in depth for a security-sensitive boundary.
- **\`ServiceStore<TDef>\` public view.** Runtimes are now created via \`registerService\` and consumers receive a frozen \`ServiceStore\` exposing only \`id\` / \`definition\` / \`queries\` / \`commands\`. State signals, internal handlers, and the patch buffer stay private. The runtime holds the store as a \`publicStore\` field that's referentially stable.
- **Worked example.** The abstract-command leg of \`__examples__/docgen-service.ts\` returns — \`generateDocgen\` is declared abstract on the definition, and \`registerServerSideDocgen\` shows how to plug a handler in at registration time.
- **README.** "Coming in later stages" drops registration; new "Definition vs Registration" subsection covers the model.

## Test plan

- [x] \`yarn test src/service/\` passes — added cases for abstract command with handler at registration, abstract command without handler (throws at registration), concrete command override rejection, no-input abstract command, and \`ServiceStore\` encapsulation.
- [x] No lints across \`code/core/src/service/\`.
- [ ] Review the abstract/concrete split — is the static \`CommandOverrides\` key-remap enough, or should the runtime check also produce a different error type to make the dynamic case discoverable?
- [ ] Review the registry being a module-level Map — fine for now, but worth flagging if we expect multiple isolated registries in the same process (e.g. tests, multi-tenant SDK).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service registration now distinguishes abstract vs. concrete commands, allowing implementations to be supplied at registration time.

* **API Changes**
  * Registration is the primary way to create/lookup services and is idempotent per definition reference.
  * Runtime creation can accept optional registration overrides; the public service handle has been renamed for clearer encapsulation.

* **Tests**
  * Added a test-only registry reset utility and updated tests to use registration-based lifecycle.

* **Documentation**
  * Docs and examples updated to reflect registration workflows and abstract/override semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->