### PR TITLE
Service architecture — Stage 3: channel sync (cross-runtime state mirroring)

### DIFF
--- a/code/core/src/service/README.md
+++ b/code/core/src/service/README.md
@@ -5,7 +5,7 @@ A small schema-driven service system for Storybook internals. A service is a sta
 The main audience for this README is agents and maintainers who need to understand how the pieces fit together, where behavior lives, and how to define new services correctly.
 
 > [!NOTE]
-> This document covers stages 1–2: definition, runtime, query subscriptions, static-build writer, static-load transport, service registration with abstract-command overrides. **Cross-runtime channel sync** and the **React hook** are tracked separately and land in follow-up stages — see the *Coming in later stages* section.
+> This document covers stages 1–3: definition, runtime, query subscriptions, static-build writer, static-load transport, service registration with abstract-command overrides, and cross-runtime channel sync. The **React hook** is tracked separately and lands in a follow-up stage — see the *Coming in later stages* section.
 
 ## Goals
 
@@ -27,6 +27,7 @@ The public API consists of:
 - `createService(def, registration?)` — build a fresh runtime without touching the global registry. Prefer `registerService` for production code.
 - `buildServiceArtifacts(def)` — produce the JSON-shaped state diffs for a service's preloads.
 - `setStaticTransport` / `clearStaticTransport` / `createBrowserStaticTransport` — install the runtime-side loader.
+- `setServiceChannel` / `clearServiceChannel` — install the cross-runtime sync channel.
 - `ServiceValidationError` and the exported type aliases from [types.ts](./types.ts).
 
 Internal tests and implementation code may import from the individual modules directly.
@@ -42,6 +43,7 @@ Internal tests and implementation code may import from the individual modules di
 - [instances.ts](./instances.ts) — the global registry map. Separate module so it can be mocked in tests.
 - [build-artifacts.ts](./build-artifacts.ts) — `buildServiceArtifacts`. The static-build writer.
 - [static-transport.ts](./static-transport.ts) — the global static-load transport.
+- [channel-transport.ts](./channel-transport.ts) — `setServiceChannel` / `clearServiceChannel`, event constants, payload types for cross-runtime sync.
 - [__examples__/docgen-service.ts](./__examples__/docgen-service.ts) — worked example for the docgen pattern.
 - `*.test.ts` — focused tests for runtime behavior, validation behavior, and static builds. Tests assert against the public API only, so they double as usage examples.
 
@@ -562,11 +564,49 @@ Read it alongside [`service-runtime.test.ts`](./service-runtime.test.ts) and [`b
 
 When adding validation tests, prefer asserting the full exact error message — that keeps the tests useful as executable documentation for callers and agents.
 
+## Cross-runtime sync
+
+A single architecture-global channel — typically Storybook's existing manager↔preview↔server channel — lets peer runtimes converge on the same state view. Install it once at app startup:
+
+```ts
+import { setServiceChannel } from 'storybook/internal/service';
+
+setServiceChannel(channel); // any { on, off, emit } shape
+```
+
+Without a channel, sync is disabled — each runtime runs with whatever state local activity produces (plus any static-build JSON the static transport pulls in). This is the *isolation* case: iframe popouts, unit tests, CLI scripts.
+
+Two parts:
+
+1. **Welcome handshake.** On registration, a runtime emits `services:welcome-request` for its service id. Any peer that already has a runtime for the same id replies with `services:welcome-reply` carrying its current state. The joiner deep-merges that state in. Multiple replies are idempotent (deep-merge of identical state is a no-op).
+2. **Ongoing patch broadcast.** Every `setState` that produces patches emits a `services:patches` event carrying the Immer patch list. Peers receive the patches and apply them via Immer's `applyPatches` so removals and other patch ops are preserved (the state-shaped diff format used for files would lose them). Loop suppression: applying remote patches sets an `_applyingRemote` flag so the resulting `setState` does NOT re-broadcast.
+
+```mermaid
+sequenceDiagram
+  participant Joiner as Joiner runtime
+  participant Channel as Service channel
+  participant Peer as Peer runtime (already has state)
+
+  Joiner->>Channel: emit services:welcome-request {serviceId}
+  Channel->>Peer: deliver welcome-request
+  Peer->>Channel: emit services:welcome-reply {serviceId, state}
+  Channel->>Joiner: deliver welcome-reply
+  Joiner->>Joiner: deep-merge state (no re-broadcast)
+
+  Note over Joiner,Peer: ...later, joiner mutates state...
+
+  Joiner->>Joiner: setState produces patches
+  Joiner->>Channel: emit services:patches {serviceId, patches}
+  Channel->>Peer: deliver patches
+  Peer->>Peer: applyPatches (no re-broadcast)
+```
+
+All sync events are scoped by `serviceId` and prefixed with `services:` so other channel traffic is unaffected. Runtimes ignore events for service ids they don't own.
+
 ## Coming in later stages
 
 The following are deliberately not in this stage. They land as separate, independently reviewable PRs:
 
-- **Cross-runtime channel sync.** A `ServiceChannel` so peer runtimes (manager ⇄ preview, etc.) exchange a welcome handshake + ongoing patch broadcast and converge on a shared state view.
 - **React hook** (`useServiceQuery`) — a `useSyncExternalStore` wrapper around `query.subscribe`.
 
 ## Agent Notes

--- a/code/core/src/service/channel-sync.test.ts
+++ b/code/core/src/service/channel-sync.test.ts
@@ -1,0 +1,373 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import {
+  clearServiceChannel,
+  setServiceChannel,
+  type ServiceChannel,
+} from './channel-transport.ts';
+import { defineService } from './define-service.ts';
+import { __resetServiceRegistry, registerService } from './register-service.ts';
+import { ServiceRuntime } from './service-runtime.ts';
+import type { ServiceCtx } from './types.ts';
+
+/**
+ * Minimal in-process channel implementation. Synchronous fanout: every listener fires before
+ * `emit` returns. Matches the surface of Storybook's `Channel` (`on`/`off`/`emit`) without
+ * pulling that dep into the test.
+ */
+function makeChannel(): ServiceChannel & { _listeners: Map<string, Set<(d: any) => void>> } {
+  const listeners = new Map<string, Set<(d: any) => void>>();
+  return {
+    _listeners: listeners,
+    on(event, listener) {
+      let set = listeners.get(event);
+      if (!set) {
+        set = new Set();
+        listeners.set(event, set);
+      }
+      set.add(listener);
+    },
+    off(event, listener) {
+      listeners.get(event)?.delete(listener);
+    },
+    emit(event, data) {
+      const set = listeners.get(event);
+      if (!set) return;
+      // Copy to allow handlers to mutate the set (add/remove) without breaking iteration.
+      for (const l of [...set]) l(data);
+    },
+  };
+}
+
+afterEach(() => {
+  __resetServiceRegistry();
+  clearServiceChannel();
+});
+
+// -------------------- isolation (no channel installed) --------------------
+
+describe('isolation — no channel installed', () => {
+  it('registration emits nothing and the runtime works exactly as before', async () => {
+    interface S {
+      n: number;
+    }
+    const def = defineService<S>()({
+      id: 'test/isolation-no-channel',
+      state: { n: 0 },
+      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      commands: {
+        bump: {
+          input: z.void(),
+          output: z.void(),
+          handler: (ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.n += 1;
+            }),
+        },
+      },
+    });
+
+    const store = registerService(def);
+    expect(store.queries.get()).toBe(0);
+    await store.commands.bump();
+    expect(store.queries.get()).toBe(1);
+  });
+});
+
+// -------------------- welcome handshake --------------------
+
+describe('welcome handshake', () => {
+  it('a runtime joining late receives current state from a peer that already has it', async () => {
+    interface S {
+      counter: number;
+      byId: Record<string, string>;
+    }
+    const def = defineService<S>()({
+      id: 'test/welcome-handshake',
+      state: { counter: 0, byId: {} },
+      queries: {
+        get: {
+          input: z.void(),
+          output: z.object({ counter: z.number(), byId: z.record(z.string(), z.string()) }),
+          select: (s: S) => s,
+        },
+      },
+      commands: {
+        seed: {
+          input: z.void(),
+          output: z.void(),
+          handler: (ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.counter = 7;
+              d.byId.a = 'alpha';
+            }),
+        },
+      },
+    });
+
+    const channel = makeChannel();
+    setServiceChannel(channel);
+
+    // First runtime: mutate state so it has something to offer.
+    const seeded = new ServiceRuntime(def);
+    await seeded.commands.seed();
+    expect(seeded.getState()).toEqual({ counter: 7, byId: { a: 'alpha' } });
+
+    // Late joiner: should announce, receive the welcome, and merge.
+    const joiner = new ServiceRuntime(def);
+
+    expect(joiner.getState()).toEqual({ counter: 7, byId: { a: 'alpha' } });
+
+    seeded.dispose();
+    joiner.dispose();
+  });
+
+  it('multiple peers replying is idempotent — deep-merge of identical state is a no-op', async () => {
+    interface S {
+      n: number;
+    }
+    const def = defineService<S>()({
+      id: 'test/welcome-multi-reply',
+      state: { n: 0 },
+      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      commands: {
+        set: {
+          input: z.number(),
+          output: z.void(),
+          handler: (n: number, ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.n = n;
+            }),
+        },
+      },
+    });
+
+    const channel = makeChannel();
+    setServiceChannel(channel);
+
+    const peerA = new ServiceRuntime(def);
+    const peerB = new ServiceRuntime(def);
+    await peerA.commands.set(42);
+    // peerB receives the ongoing patch and now also has 42.
+    expect(peerB.getState()).toEqual({ n: 42 });
+
+    // Late joiner: both peerA and peerB reply with welcome carrying {n: 42}. The deep-merge
+    // is applied twice but is idempotent — final state is what we'd expect.
+    const joiner = new ServiceRuntime(def);
+    expect(joiner.getState()).toEqual({ n: 42 });
+  });
+
+  it('does nothing when no peer is connected (isolated runtime)', async () => {
+    interface S {
+      n: number;
+    }
+    const def = defineService<S>()({
+      id: 'test/welcome-isolated',
+      state: { n: 5 },
+      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      commands: {},
+    });
+
+    const channel = makeChannel();
+    setServiceChannel(channel);
+
+    // Sole runtime, no peers. Welcome request goes out and is ignored (no listeners yet on
+    // any other runtime). State stays at initial.
+    const lonely = new ServiceRuntime(def);
+    expect(lonely.getState()).toEqual({ n: 5 });
+  });
+});
+
+// -------------------- ongoing patch sync --------------------
+
+describe('ongoing patch sync', () => {
+  it('a setState on one runtime propagates as patches to the other', async () => {
+    interface S {
+      byId: Record<string, string>;
+    }
+    const def = defineService<S>()({
+      id: 'test/ongoing-sync',
+      state: { byId: {} },
+      queries: {
+        getOne: {
+          input: z.string(),
+          output: z.string().optional(),
+          select: (s: S, id: string) => s.byId[id],
+        },
+      },
+      commands: {
+        set: {
+          input: z.object({ id: z.string(), name: z.string() }),
+          output: z.void(),
+          handler: (input: { id: string; name: string }, ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.byId[input.id] = input.name;
+            }),
+        },
+      },
+    });
+
+    const channel = makeChannel();
+    setServiceChannel(channel);
+
+    const a = new ServiceRuntime(def);
+    const b = new ServiceRuntime(def);
+
+    const aListener = vi.fn();
+    const bListener = vi.fn();
+    a.queries.getOne.subscribe('x', aListener);
+    b.queries.getOne.subscribe('x', bListener);
+
+    await a.commands.set({ id: 'x', name: 'on-a' });
+
+    // a saw its own mutation; b saw the propagated patch and notified its subscriber.
+    expect(a.queries.getOne('x')).toBe('on-a');
+    expect(b.queries.getOne('x')).toBe('on-a');
+    expect(aListener).toHaveBeenLastCalledWith('on-a');
+    expect(bListener).toHaveBeenLastCalledWith('on-a');
+
+    a.dispose();
+    b.dispose();
+  });
+
+  it('loop suppression: receiving patches does NOT re-broadcast them', async () => {
+    interface S {
+      n: number;
+    }
+    const def = defineService<S>()({
+      id: 'test/loop-suppression',
+      state: { n: 0 },
+      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      commands: {
+        bump: {
+          input: z.void(),
+          output: z.void(),
+          handler: (ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.n += 1;
+            }),
+        },
+      },
+    });
+
+    const channel = makeChannel();
+    const emitSpy = vi.spyOn(channel, 'emit');
+    setServiceChannel(channel);
+
+    const a = new ServiceRuntime(def);
+    const b = new ServiceRuntime(def);
+
+    // Welcome-request emissions from a and b plus their welcome-replies happen during
+    // construction. Reset the count so we can isolate the next mutation's broadcasts.
+    emitSpy.mockClear();
+
+    await a.commands.bump();
+
+    // Exactly one patches event went over the wire: a's broadcast. b applied it locally
+    // but did NOT re-broadcast (loop-suppression worked).
+    const patchEvents = emitSpy.mock.calls.filter((c) => c[0] === 'services:patches');
+    expect(patchEvents).toHaveLength(1);
+
+    a.dispose();
+    b.dispose();
+  });
+
+  it('removals propagate via Immer applyPatches (state-shaped diffs would lose them)', async () => {
+    interface S {
+      byId: Record<string, string>;
+    }
+    const def = defineService<S>()({
+      id: 'test/removal-sync',
+      state: { byId: { a: 'alpha', b: 'beta' } },
+      queries: {
+        getOne: {
+          input: z.string(),
+          output: z.string().optional(),
+          select: (s: S, id: string) => s.byId[id],
+        },
+      },
+      commands: {
+        remove: {
+          input: z.string(),
+          output: z.void(),
+          handler: (id: string, ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              delete d.byId[id];
+            }),
+        },
+      },
+    });
+
+    const channel = makeChannel();
+    setServiceChannel(channel);
+
+    const a = new ServiceRuntime(def);
+    const b = new ServiceRuntime(def);
+
+    expect(b.queries.getOne('a')).toBe('alpha');
+
+    await a.commands.remove('a');
+
+    expect(a.queries.getOne('a')).toBe(undefined);
+    expect(b.queries.getOne('a')).toBe(undefined);
+
+    a.dispose();
+    b.dispose();
+  });
+});
+
+// -------------------- service-id filtering --------------------
+
+describe('service-id filtering', () => {
+  it('a runtime ignores welcome-requests and patches for other service ids', async () => {
+    interface S {
+      n: number;
+    }
+    const defA = defineService<S>()({
+      id: 'test/svc-A',
+      state: { n: 0 },
+      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      commands: {
+        set: {
+          input: z.number(),
+          output: z.void(),
+          handler: (n: number, ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.n = n;
+            }),
+        },
+      },
+    });
+    const defB = defineService<S>()({
+      id: 'test/svc-B',
+      state: { n: 100 },
+      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      commands: {
+        set: {
+          input: z.number(),
+          output: z.void(),
+          handler: (n: number, ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.n = n;
+            }),
+        },
+      },
+    });
+
+    const channel = makeChannel();
+    setServiceChannel(channel);
+
+    const a = new ServiceRuntime(defA);
+    const b = new ServiceRuntime(defB);
+
+    await a.commands.set(42);
+
+    // A changed; B did NOT change because the patch's serviceId didn't match.
+    expect(a.queries.get()).toBe(42);
+    expect(b.queries.get()).toBe(100);
+
+    a.dispose();
+    b.dispose();
+  });
+});

--- a/code/core/src/service/channel-transport.ts
+++ b/code/core/src/service/channel-transport.ts
@@ -1,0 +1,79 @@
+/**
+ * Channel-based transport for service state synchronisation.
+ *
+ * Services use a single architecture-global channel — typically Storybook's existing
+ * manager↔preview↔server channel — to:
+ *
+ *   1. Announce on registration ("I just registered service X, anyone got state for it?")
+ *   2. Reply to other clients' announcements with current state.
+ *   3. Broadcast ongoing state mutations as patches so peers stay in sync.
+ *
+ * The channel itself is installed once per app via `setServiceChannel()`. Without one, sync
+ * is disabled — services run with whatever state local activity produces, plus any
+ * static-build JSON the static transport pulls in. That's the "isolation" case: an iframe
+ * popout, a unit test, a CLI script.
+ *
+ * Event names are prefixed with `services:` so a downstream Node SDK or filter can drop them
+ * without inspecting payloads.
+ */
+
+/**
+ * Minimal channel shape we depend on. Matches `Pick<Channel, 'on' | 'off' | 'emit'>` from
+ * Storybook's existing channel implementation, but typed structurally so this module doesn't
+ * have to import from `storybook/internal/channels`.
+ */
+export interface ServiceChannel {
+  on(event: string, listener: (data: any) => void): void;
+  off(event: string, listener: (data: any) => void): void;
+  emit(event: string, data: any): void;
+}
+
+// Event name prefix and constants. Single source of truth.
+export const SERVICE_EVENT_PREFIX = 'services:' as const;
+export const SERVICE_WELCOME_REQUEST = `${SERVICE_EVENT_PREFIX}welcome-request` as const;
+export const SERVICE_WELCOME_REPLY = `${SERVICE_EVENT_PREFIX}welcome-reply` as const;
+export const SERVICE_PATCHES = `${SERVICE_EVENT_PREFIX}patches` as const;
+
+/** Payload of `services:welcome-request`. Scoped to a single service id. */
+export interface WelcomeRequestPayload {
+  readonly serviceId: string;
+}
+
+/** Payload of `services:welcome-reply`. Carries the full current state of the service. */
+export interface WelcomeReplyPayload {
+  readonly serviceId: string;
+  readonly state: Record<string, unknown>;
+}
+
+/**
+ * Payload of `services:patches`. Carries the Immer patch list that the originating client
+ * produced via its `setState`. Peers apply these via Immer's `applyPatches`.
+ */
+export interface PatchesPayload {
+  readonly serviceId: string;
+  readonly patches: readonly unknown[]; // Immer Patch[] but kept opaque at this layer.
+}
+
+/**
+ * The global channel. `null` means "no cross-client sync." This is the right default for
+ * unit tests and for hosts that have no channel infrastructure.
+ */
+let currentChannel: ServiceChannel | null = null;
+
+/**
+ * Install the channel used by all service runtimes for sync. Call once at app startup —
+ * typically from the manager or preview entry point with Storybook's existing channel.
+ */
+export function setServiceChannel(channel: ServiceChannel): void {
+  currentChannel = channel;
+}
+
+/** Remove the channel. Subsequent registrations won't emit or listen. */
+export function clearServiceChannel(): void {
+  currentChannel = null;
+}
+
+/** @internal Used by `ServiceRuntime` to wire its sync handlers. */
+export function getServiceChannel(): ServiceChannel | null {
+  return currentChannel;
+}

--- a/code/core/src/service/index.ts
+++ b/code/core/src/service/index.ts
@@ -22,6 +22,18 @@
  */
 
 export { buildServiceArtifacts } from './build-artifacts.ts';
+export {
+  SERVICE_EVENT_PREFIX,
+  SERVICE_PATCHES,
+  SERVICE_WELCOME_REPLY,
+  SERVICE_WELCOME_REQUEST,
+  clearServiceChannel,
+  setServiceChannel,
+  type PatchesPayload,
+  type ServiceChannel,
+  type WelcomeReplyPayload,
+  type WelcomeRequestPayload,
+} from './channel-transport.ts';
 export { command, defineService, query } from './define-service.ts';
 export { __resetServiceRegistry, getService, registerService } from './register-service.ts';
 export { ServiceRuntime, createService } from './service-runtime.ts';

--- a/code/core/src/service/service-runtime.ts
+++ b/code/core/src/service/service-runtime.ts
@@ -1,6 +1,16 @@
 import { computed, effect, endBatch, signal, startBatch } from 'alien-signals';
-import { enablePatches, produceWithPatches, type Patch } from 'immer';
+import { applyPatches, enablePatches, produceWithPatches, type Patch } from 'immer';
 
+import {
+  type PatchesPayload,
+  SERVICE_PATCHES,
+  SERVICE_WELCOME_REPLY,
+  SERVICE_WELCOME_REQUEST,
+  type ServiceChannel,
+  type WelcomeReplyPayload,
+  type WelcomeRequestPayload,
+  getServiceChannel,
+} from './channel-transport.ts';
 import { isAbstractCommand } from './define-service.ts';
 import { instances } from './instances.ts';
 import { rethrowAsync, validateAsync, validateSync } from './service-validation.ts';
@@ -117,6 +127,22 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
   private _lastPatches: readonly Patch[] = [];
   /** Resolved command handlers: definition handler or registration override. */
   private _commandHandlers: Record<string, (...args: any[]) => any>;
+  /**
+   * Set to true while applying state that arrived from outside (welcome reply, ongoing patch
+   * from a peer, JSON file fetch). Suppresses re-broadcast of the resulting setState so we
+   * don't loop. Always reset in a try/finally to survive thrown handlers.
+   */
+  private _applyingRemote = false;
+  /**
+   * Channel listeners we own, kept here so they can be detached in `dispose()`. Null when no
+   * channel was installed at construction time.
+   */
+  private _channelBindings: {
+    readonly channel: ServiceChannel;
+    readonly onWelcomeRequest: (data: WelcomeRequestPayload) => void;
+    readonly onWelcomeReply: (data: WelcomeReplyPayload) => void;
+    readonly onPatches: (data: PatchesPayload) => void;
+  } | null = null;
 
   public readonly definition: TDef;
   public readonly id: string;
@@ -155,6 +181,11 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
 
     this.queries = this._buildQueriesApi();
     this.commands = this._buildCommandsApi();
+
+    // Wire channel-based sync if a channel has been installed at the architecture level.
+    // No-op if no channel exists (isolation case: tests without a channel, popped-out
+    // iframes, CLI scripts).
+    this._wireChannel();
 
     this.publicStore = Object.freeze({
       id: this.id,
@@ -223,6 +254,17 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
       this._stateSignal(next);
     } finally {
       endBatch();
+    }
+
+    // Broadcast the patches over the channel so peers stay in sync — unless we're applying
+    // state that just arrived from outside (welcome reply, ongoing patch from a peer, JSON
+    // file fetch). That would cause an infinite re-broadcast loop.
+    if (!this._applyingRemote) {
+      const channel = getServiceChannel();
+      if (channel) {
+        const payload: PatchesPayload = { serviceId: this.id, patches };
+        channel.emit(SERVICE_PATCHES, payload);
+      }
     }
 
     for (const listener of this._stateListeners) {
@@ -465,15 +507,99 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
   }
 
   /**
-   * Apply a state-shaped diff to state. Used when restoring state from a fetched static
-   * artifact — a JSON-Merge-Patch-flavoured nested object. Operation is a deep-merge.
+   * Apply a state-shaped diff to state. Used both when restoring state from a fetched static
+   * artifact AND when applying a welcome reply from a peer — files and welcome replies share
+   * the same on-the-wire shape (a JSON-Merge-Patch-flavoured nested object). Operation is a
+   * deep-merge. Sets `_applyingRemote` so the resulting `setState` doesn't re-broadcast.
    */
   private _applyStateDiff(diff: unknown): void {
     if (diff === null || typeof diff !== 'object' || Array.isArray(diff)) return;
     if (Object.keys(diff as object).length === 0) return;
-    this.setState((draft) => {
-      deepMerge(draft as Record<string, unknown>, diff as Record<string, unknown>);
-    });
+    this._applyingRemote = true;
+    try {
+      this.setState((draft) => {
+        deepMerge(draft as Record<string, unknown>, diff as Record<string, unknown>);
+      });
+    } finally {
+      this._applyingRemote = false;
+    }
+  }
+
+  /**
+   * Apply a list of Immer patches received from a peer over the channel. Uses Immer's
+   * `applyPatches` directly so removals and other patch ops are preserved (the state-shaped
+   * diff format loses removals). Sets `_applyingRemote` to suppress re-broadcast.
+   */
+  private _applyExternalPatches(patches: readonly Patch[]): void {
+    if (patches.length === 0) return;
+    this._applyingRemote = true;
+    try {
+      const previous = this._stateSignal();
+      const next = applyPatches(previous as object, patches as Patch[]) as typeof previous;
+      if (next === previous) return;
+      this._lastPatches = patches;
+      startBatch();
+      try {
+        this._stateSignal(next);
+      } finally {
+        endBatch();
+      }
+      for (const listener of this._stateListeners) {
+        listener(next, previous, patches);
+      }
+    } finally {
+      this._applyingRemote = false;
+    }
+  }
+
+  /**
+   * Subscribe to channel events for this service's id, and emit the initial welcome-request.
+   * Listeners are stored on `_channelBindings` so they can be detached in `dispose()`.
+   */
+  private _wireChannel(): void {
+    const channel = getServiceChannel();
+    if (!channel) return;
+
+    const onWelcomeRequest = (data: WelcomeRequestPayload) => {
+      if (data.serviceId !== this.id) return;
+      const payload: WelcomeReplyPayload = {
+        serviceId: this.id,
+        state: this._stateSignal() as Record<string, unknown>,
+      };
+      channel.emit(SERVICE_WELCOME_REPLY, payload);
+    };
+    const onWelcomeReply = (data: WelcomeReplyPayload) => {
+      if (data.serviceId !== this.id) return;
+      this._applyStateDiff(data.state);
+    };
+    const onPatches = (data: PatchesPayload) => {
+      if (data.serviceId !== this.id) return;
+      this._applyExternalPatches(data.patches as readonly Patch[]);
+    };
+
+    channel.on(SERVICE_WELCOME_REQUEST, onWelcomeRequest);
+    channel.on(SERVICE_WELCOME_REPLY, onWelcomeReply);
+    channel.on(SERVICE_PATCHES, onPatches);
+
+    this._channelBindings = { channel, onWelcomeRequest, onWelcomeReply, onPatches };
+
+    // Announce that we just joined. Any peer with state for this service replies; the rest
+    // ignore the event because the serviceId doesn't match theirs.
+    const requestPayload: WelcomeRequestPayload = { serviceId: this.id };
+    channel.emit(SERVICE_WELCOME_REQUEST, requestPayload);
+  }
+
+  /**
+   * @internal Detach channel listeners. Used by tests that swap out the channel between
+   * runs; not part of the application-facing API.
+   */
+  dispose(): void {
+    if (!this._channelBindings) return;
+    const { channel, onWelcomeRequest, onWelcomeReply, onPatches } = this._channelBindings;
+    channel.off(SERVICE_WELCOME_REQUEST, onWelcomeRequest);
+    channel.off(SERVICE_WELCOME_REPLY, onWelcomeReply);
+    channel.off(SERVICE_PATCHES, onPatches);
+    this._channelBindings = null;
   }
 
   /**


### PR DESCRIPTION
Third of four stacked PRs aligning the service architecture work. **Base: [#34913](https://github.com/storybookjs/storybook/pull/34913) (Stage 2).**

## Stack

\`\`\`
next
 └── jeppe/service-arch-explorations
      └── norbert/service-stage-1-core         (Stage 1 — #34912)
           └── norbert/service-stage-2-register    (Stage 2 — #34913)
                └── norbert/service-stage-3-channel ← THIS PR
                     └── norbert/service-stage-4-react-hook
\`\`\`

## Summary

Stages 1–2 give us one runtime per registration, in one process. Stage 3 wires those runtimes together across processes (manager ⇄ preview, manager ⇄ server, etc.) so they converge on a shared state view.

- **New module [\`channel-transport.ts\`](https://github.com/storybookjs/storybook/blob/norbert/service-stage-3-channel/code/core/src/service/channel-transport.ts).** Defines the minimal \`ServiceChannel\` shape (\`on\` / \`off\` / \`emit\` — structurally compatible with Storybook's existing \`Channel\` without importing from \`storybook/internal/channels\`). Exports event constants \`services:welcome-request | welcome-reply | patches\`, typed payloads, and \`setServiceChannel\` / \`clearServiceChannel\` / \`getServiceChannel\`. The channel is global — install it once at app startup.
- **Welcome handshake.** On registration, a runtime emits \`services:welcome-request\` scoped to its service id. Any peer that already has a runtime for the same id replies with \`services:welcome-reply\` carrying its current state. The joiner deep-merges that state in via the existing state-shaped diff path. Multiple replies are idempotent (deep-merge of identical state is a no-op).
- **Ongoing patch broadcast.** Every \`setState\` that produces patches emits \`services:patches\` with the Immer patch list. Peers apply via Immer's \`applyPatches\` so removals survive (the file-friendly state-shaped diff format would lose them).
- **Loop suppression.** A \`_applyingRemote\` re-entry guard wraps any inbound application path. Resulting \`setState\` doesn't re-broadcast and we don't get a feedback loop.
- **\`dispose()\`.** New runtime method that detaches the channel listeners. Used in tests to swap the channel between runs without leaks; not part of the application-facing API in normal flow (registry-owned runtimes live for the process lifetime).
- **Isolation case.** No channel installed → registration emits nothing, no listeners, runtime works exactly as before. Test coverage explicitly asserts this so we never regress the "popped-out iframe / CLI script / unit test" path.

## Test plan

- [x] \`yarn test src/service/\` passes — \`channel-sync.test.ts\` covers welcome handshake (incl. multi-reply idempotency + isolated-runtime no-op), ongoing patch sync (incl. loop suppression + removal propagation), service-id filtering, and the "no channel installed" case.
- [x] No lints across \`code/core/src/service/\`.
- [ ] Review the event name prefix (\`services:\`) — downstream filters / Node SDKs can drop the namespace without inspecting payloads. Reasonable, but worth confirming no naming collision exists with current channel traffic.
- [ ] Review the \`PatchesPayload.patches\` typed as \`readonly unknown[]\` — kept opaque at the channel boundary on purpose so this module doesn't depend on \`immer\`, but means the receiver has to trust the producer. Acceptable for an in-process channel; flagging.

## README

Adds a "Cross-runtime sync" section with a mermaid sequence diagram covering both the welcome handshake and the ongoing patch broadcast. "Coming in later stages" drops channel sync.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-runtime service state synchronization with automatic state propagation between connected clients.
  * Implemented welcome handshake for late-joining runtimes to receive current state.
  * Added loop suppression to prevent infinite state synchronization cycles.

* **Documentation**
  * Updated service documentation to cover the new cross-runtime sync protocol.

* **Tests**
  * Added comprehensive test suite for cross-runtime state synchronization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->