### PR TITLE
React: Scope example starter styles with CSS modules

### DIFF
--- a/code/frameworks/nextjs-vite/template/cli/js/Button.jsx
+++ b/code/frameworks/nextjs-vite/template/cli/js/Button.jsx
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types';
 
-import './button.css';
+import styles from './button.module.css';
 
 /** Primary UI component for user interaction */
 export const Button = ({ primary, backgroundColor, size, label, ...props }) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       {...props}
     >
       {label}

--- a/code/frameworks/nextjs-vite/template/cli/js/Header.jsx
+++ b/code/frameworks/nextjs-vite/template/cli/js/Header.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
 
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -28,7 +28,7 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/nextjs-vite/template/cli/js/Page.jsx
+++ b/code/frameworks/nextjs-vite/template/cli/js/Page.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 export const Page = () => {
   const [user, setUser] = React.useState();
@@ -14,7 +14,7 @@ export const Page = () => {
         onLogout={() => setUser(undefined)}
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -49,8 +49,8 @@ export const Page = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/frameworks/nextjs-vite/template/cli/ts/Button.tsx
+++ b/code/frameworks/nextjs-vite/template/cli/ts/Button.tsx
@@ -1,4 +1,4 @@
-import './button.css';
+import styles from './button.module.css';
 
 export interface ButtonProps {
   /** Is this the principal call to action on the page? */
@@ -21,11 +21,11 @@ export const Button = ({
   label,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       {...props}
     >
       {label}

--- a/code/frameworks/nextjs-vite/template/cli/ts/Header.tsx
+++ b/code/frameworks/nextjs-vite/template/cli/ts/Header.tsx
@@ -1,5 +1,5 @@
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 type User = {
   name: string;
@@ -14,7 +14,7 @@ export interface HeaderProps {
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -37,7 +37,7 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/nextjs-vite/template/cli/ts/Page.tsx
+++ b/code/frameworks/nextjs-vite/template/cli/ts/Page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 type User = {
   name: string;
@@ -19,7 +19,7 @@ export const Page: React.FC = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -54,8 +54,8 @@ export const Page: React.FC = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/frameworks/nextjs/template/cli/js/Button.jsx
+++ b/code/frameworks/nextjs/template/cli/js/Button.jsx
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types';
 
-import './button.css';
+import styles from './button.module.css';
 
 /** Primary UI component for user interaction */
 export const Button = ({ primary, backgroundColor, size, label, ...props }) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       {...props}
     >
       {label}

--- a/code/frameworks/nextjs/template/cli/js/Header.jsx
+++ b/code/frameworks/nextjs/template/cli/js/Header.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
 
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -28,7 +28,7 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/nextjs/template/cli/js/Page.jsx
+++ b/code/frameworks/nextjs/template/cli/js/Page.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 export const Page = () => {
   const [user, setUser] = React.useState();
@@ -14,7 +14,7 @@ export const Page = () => {
         onLogout={() => setUser(undefined)}
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -49,8 +49,8 @@ export const Page = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/frameworks/nextjs/template/cli/ts/Button.tsx
+++ b/code/frameworks/nextjs/template/cli/ts/Button.tsx
@@ -1,4 +1,4 @@
-import './button.css';
+import styles from './button.module.css';
 
 export interface ButtonProps {
   /** Is this the principal call to action on the page? */
@@ -21,11 +21,11 @@ export const Button = ({
   label,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       {...props}
     >
       {label}

--- a/code/frameworks/nextjs/template/cli/ts/Header.tsx
+++ b/code/frameworks/nextjs/template/cli/ts/Header.tsx
@@ -1,5 +1,5 @@
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 type User = {
   name: string;
@@ -14,7 +14,7 @@ export interface HeaderProps {
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -37,7 +37,7 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/nextjs/template/cli/ts/Page.tsx
+++ b/code/frameworks/nextjs/template/cli/ts/Page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 type User = {
   name: string;
@@ -19,7 +19,7 @@ export const Page: React.FC = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -54,8 +54,8 @@ export const Page: React.FC = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/frameworks/preact-vite/template/cli/Button.jsx
+++ b/code/frameworks/preact-vite/template/cli/Button.jsx
@@ -1,4 +1,4 @@
-import './button.css';
+import styles from './button.module.css';
 
 /**
  * Primary UI component for user interaction
@@ -17,11 +17,11 @@ export const Button = ({
   label,
   ...props
 }) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       style={backgroundColor && { backgroundColor }}
       {...props}
     >

--- a/code/frameworks/preact-vite/template/cli/Header.jsx
+++ b/code/frameworks/preact-vite/template/cli/Header.jsx
@@ -1,5 +1,5 @@
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 /**
  * Header component
@@ -13,7 +13,7 @@ import './header.css';
  */
 export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -36,7 +36,7 @@ export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/preact-vite/template/cli/Page.jsx
+++ b/code/frameworks/preact-vite/template/cli/Page.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'preact/hooks';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 /** Simple page component */
 export const Page = () => {
@@ -16,7 +16,7 @@ export const Page = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -51,8 +51,8 @@ export const Page = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/frameworks/react-vite/template/cli/js/Button.jsx
+++ b/code/frameworks/react-vite/template/cli/js/Button.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
-import './button.css';
+import styles from './button.module.css';
 
 /** Primary UI component for user interaction */
 export const Button = ({
@@ -12,11 +12,11 @@ export const Button = ({
   label,
   ...props
 }) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       style={backgroundColor && { backgroundColor }}
       {...props}
     >

--- a/code/frameworks/react-vite/template/cli/js/Header.jsx
+++ b/code/frameworks/react-vite/template/cli/js/Header.jsx
@@ -3,11 +3,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -30,7 +30,7 @@ export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/react-vite/template/cli/js/Page.jsx
+++ b/code/frameworks/react-vite/template/cli/js/Page.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 export const Page = () => {
   const [user, setUser] = React.useState();
@@ -15,7 +15,7 @@ export const Page = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -50,8 +50,8 @@ export const Page = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/frameworks/react-vite/template/cli/ts/Button.tsx
+++ b/code/frameworks/react-vite/template/cli/ts/Button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import './button.css';
+import styles from './button.module.css';
 
 export interface ButtonProps {
   /** Is this the principal call to action on the page? */
@@ -23,11 +23,11 @@ export const Button = ({
   label,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       style={{ backgroundColor }}
       {...props}
     >

--- a/code/frameworks/react-vite/template/cli/ts/Header.tsx
+++ b/code/frameworks/react-vite/template/cli/ts/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 type User = {
   name: string;
@@ -16,7 +16,7 @@ export interface HeaderProps {
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -39,7 +39,7 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/react-vite/template/cli/ts/Page.tsx
+++ b/code/frameworks/react-vite/template/cli/ts/Page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 type User = {
   name: string;
@@ -19,7 +19,7 @@ export const Page: React.FC = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -54,8 +54,8 @@ export const Page: React.FC = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/frameworks/react-webpack5/template/cli/js/Button.jsx
+++ b/code/frameworks/react-webpack5/template/cli/js/Button.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import './button.css';
+import styles from './button.module.css';
 
 /** Primary UI component for user interaction */
 export const Button = ({
@@ -10,11 +10,11 @@ export const Button = ({
   label,
   ...props
 }) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       style={backgroundColor && { backgroundColor }}
       {...props}
     >

--- a/code/frameworks/react-webpack5/template/cli/js/Header.jsx
+++ b/code/frameworks/react-webpack5/template/cli/js/Header.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
 
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -28,7 +28,7 @@ export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/react-webpack5/template/cli/js/Page.jsx
+++ b/code/frameworks/react-webpack5/template/cli/js/Page.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 export const Page = () => {
   const [user, setUser] = React.useState();
@@ -15,7 +15,7 @@ export const Page = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -50,8 +50,8 @@ export const Page = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/frameworks/react-webpack5/template/cli/ts/Button.tsx
+++ b/code/frameworks/react-webpack5/template/cli/ts/Button.tsx
@@ -1,4 +1,4 @@
-import './button.css';
+import styles from './button.module.css';
 
 export interface ButtonProps {
   /** Is this the principal call to action on the page? */
@@ -21,11 +21,11 @@ export const Button = ({
   label,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       style={{ backgroundColor }}
       {...props}
     >

--- a/code/frameworks/react-webpack5/template/cli/ts/Header.tsx
+++ b/code/frameworks/react-webpack5/template/cli/ts/Header.tsx
@@ -1,5 +1,5 @@
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 type User = {
   name: string;
@@ -14,7 +14,7 @@ export interface HeaderProps {
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -37,7 +37,7 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/react-webpack5/template/cli/ts/Page.tsx
+++ b/code/frameworks/react-webpack5/template/cli/ts/Page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 type User = {
   name: string;
@@ -19,7 +19,7 @@ export const Page: React.FC = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -54,8 +54,8 @@ export const Page: React.FC = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/frameworks/tanstack-react/template/cli/ts/Button.tsx
+++ b/code/frameworks/tanstack-react/template/cli/ts/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import './button.css';
+import styles from './button.module.css';
 
 export interface ButtonProps {
   /** Is this the principal call to action on the page? */
@@ -22,11 +22,11 @@ export const Button = ({
   label,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       style={{ backgroundColor }}
       {...props}
     >

--- a/code/frameworks/tanstack-react/template/cli/ts/Header.tsx
+++ b/code/frameworks/tanstack-react/template/cli/ts/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 type User = {
   name: string;
@@ -16,7 +16,7 @@ export interface HeaderProps {
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -39,7 +39,7 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/frameworks/tanstack-react/template/cli/ts/Page.stories.ts
+++ b/code/frameworks/tanstack-react/template/cli/ts/Page.stories.ts
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/tanstack-react';
 import { expect, userEvent, within } from 'storybook/test';
 
 import { Route } from './Page';
-import './page.css';
+import styles from './page.module.css';
 
 const meta = {
   title: 'Example/Page',

--- a/code/frameworks/tanstack-react/template/cli/ts/Page.tsx
+++ b/code/frameworks/tanstack-react/template/cli/ts/Page.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 
 import { Header } from './Header';
+import styles from './page.module.css';
 
 type User = {
   name: string;
@@ -24,7 +25,7 @@ const Page: React.FC = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -60,8 +61,8 @@ const Page: React.FC = () => {
           .
         </p>
 
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/lib/create-storybook/rendererAssets/common/button.module.css
+++ b/code/lib/create-storybook/rendererAssets/common/button.module.css
@@ -1,0 +1,30 @@
+.storybook-button {
+  display: inline-block;
+  cursor: pointer;
+  border: 0;
+  border-radius: 3em;
+  font-weight: 700;
+  line-height: 1;
+  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+.storybook-button--primary {
+  background-color: #555ab9;
+  color: white;
+}
+.storybook-button--secondary {
+  box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
+  background-color: transparent;
+  color: #333;
+}
+.storybook-button--small {
+  padding: 10px 16px;
+  font-size: 12px;
+}
+.storybook-button--medium {
+  padding: 11px 20px;
+  font-size: 14px;
+}
+.storybook-button--large {
+  padding: 12px 24px;
+  font-size: 16px;
+}

--- a/code/lib/create-storybook/rendererAssets/common/header.module.css
+++ b/code/lib/create-storybook/rendererAssets/common/header.module.css
@@ -1,0 +1,32 @@
+.storybook-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 15px 20px;
+  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+.storybook-header svg {
+  display: inline-block;
+  vertical-align: top;
+}
+
+.storybook-header h1 {
+  display: inline-block;
+  vertical-align: top;
+  margin: 6px 0 6px 10px;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.storybook-header button + button {
+  margin-left: 10px;
+}
+
+.welcome {
+  margin-right: 10px;
+  color: #333;
+  font-size: 14px;
+}

--- a/code/lib/create-storybook/rendererAssets/common/page.module.css
+++ b/code/lib/create-storybook/rendererAssets/common/page.module.css
@@ -1,0 +1,68 @@
+.storybook-page {
+  margin: 0 auto;
+  padding: 48px 20px;
+  max-width: 600px;
+  color: #333;
+  font-size: 14px;
+  line-height: 24px;
+  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+.storybook-page h2 {
+  display: inline-block;
+  vertical-align: top;
+  margin: 0 0 4px;
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1;
+}
+
+.storybook-page p {
+  margin: 1em 0;
+}
+
+.storybook-page a {
+  color: inherit;
+}
+
+.storybook-page ul {
+  margin: 1em 0;
+  padding-left: 30px;
+}
+
+.storybook-page li {
+  margin-bottom: 8px;
+}
+
+.storybook-page .tip {
+  display: inline-block;
+  vertical-align: top;
+  margin-right: 10px;
+  border-radius: 1em;
+  background: #e7fdd8;
+  padding: 4px 12px;
+  color: #357a14;
+  font-weight: 700;
+  font-size: 11px;
+  line-height: 12px;
+}
+
+.storybook-page .tip-wrapper {
+  margin-top: 40px;
+  margin-bottom: 40px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.storybook-page .tip-wrapper svg {
+  display: inline-block;
+  vertical-align: top;
+  margin-top: 3px;
+  margin-right: 4px;
+  width: 12px;
+  height: 12px;
+}
+
+.storybook-page .tip-wrapper svg path {
+  fill: #1ea7fd;
+}

--- a/code/renderers/preact/template/cli/Button.jsx
+++ b/code/renderers/preact/template/cli/Button.jsx
@@ -1,4 +1,4 @@
-import './button.css';
+import styles from './button.module.css';
 
 /**
  * Primary UI component for user interaction
@@ -17,11 +17,11 @@ export const Button = ({
   label,
   ...props
 }) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       style={backgroundColor && { backgroundColor }}
       {...props}
     >

--- a/code/renderers/preact/template/cli/Header.jsx
+++ b/code/renderers/preact/template/cli/Header.jsx
@@ -1,5 +1,5 @@
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 /**
  * Header component
@@ -13,7 +13,7 @@ import './header.css';
  */
 export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -36,7 +36,7 @@ export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/renderers/preact/template/cli/Page.jsx
+++ b/code/renderers/preact/template/cli/Page.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'preact/hooks';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 /** Simple page component */
 export const Page = () => {
@@ -16,7 +16,7 @@ export const Page = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -51,8 +51,8 @@ export const Page = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/renderers/react/template/cli/js/Button.jsx
+++ b/code/renderers/react/template/cli/js/Button.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
-import './button.css';
+import styles from './button.module.css';
 
 /** Primary UI component for user interaction */
 export const Button = ({
@@ -12,11 +12,11 @@ export const Button = ({
   label,
   ...props
 }) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       style={backgroundColor && { backgroundColor }}
       {...props}
     >

--- a/code/renderers/react/template/cli/js/Header.jsx
+++ b/code/renderers/react/template/cli/js/Header.jsx
@@ -3,11 +3,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -30,7 +30,7 @@ export const Header = ({ user = null, onLogin, onLogout, onCreateAccount }) => (
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/renderers/react/template/cli/js/Page.jsx
+++ b/code/renderers/react/template/cli/js/Page.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 export const Page = () => {
   const [user, setUser] = React.useState();
@@ -15,7 +15,7 @@ export const Page = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -50,8 +50,8 @@ export const Page = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path

--- a/code/renderers/react/template/cli/ts/Button.tsx
+++ b/code/renderers/react/template/cli/ts/Button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import './button.css';
+import styles from './button.module.css';
 
 export interface ButtonProps {
   /** Is this the principal call to action on the page? */
@@ -23,11 +23,11 @@ export const Button = ({
   label,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary ? styles['storybook-button--primary'] : styles['storybook-button--secondary'];
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={[styles['storybook-button'], styles[`storybook-button--${size}`], mode].join(' ')}
       style={{ backgroundColor }}
       {...props}
     >

--- a/code/renderers/react/template/cli/ts/Header.tsx
+++ b/code/renderers/react/template/cli/ts/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button } from './Button';
-import './header.css';
+import styles from './header.module.css';
 
 type User = {
   name: string;
@@ -16,7 +16,7 @@ export interface HeaderProps {
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
   <header>
-    <div className="storybook-header">
+    <div className={styles['storybook-header']}>
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">
@@ -39,7 +39,7 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
       <div>
         {user ? (
           <>
-            <span className="welcome">
+            <span className={styles.welcome}>
               Welcome, <b>{user.name}</b>!
             </span>
             <Button size="small" onClick={onLogout} label="Log out" />

--- a/code/renderers/react/template/cli/ts/Page.tsx
+++ b/code/renderers/react/template/cli/ts/Page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Header } from './Header';
-import './page.css';
+import styles from './page.module.css';
 
 type User = {
   name: string;
@@ -19,7 +19,7 @@ export const Page: React.FC = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section className="storybook-page">
+      <section className={styles['storybook-page']}>
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}
@@ -54,8 +54,8 @@ export const Page: React.FC = () => {
           </a>
           .
         </p>
-        <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
+        <div className={styles['tip-wrapper']}>
+          <span className={styles.tip}>Tip</span> Adjust the width of the canvas with the{' '}
           <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">
               <path


### PR DESCRIPTION
## Summary

Replace global `page.css` / `header.css` / `button.css` imports in React and Preact CLI starter templates with CSS module imports so example styles no longer leak into unrelated stories after visiting the Page example.

Adds shared `*.module.css` assets next to the existing renderer assets copied by `create-storybook`.

Related to #23862 (complements #34910 for Svelte and #34571 for Vue).

#### Manual testing

- [ ] Run `npx create-storybook@next` in a fresh React + Vite app and confirm Page/Header/Button render correctly
- [ ] Open the Page story, then another story using `<section>` and confirm example styles do not leak globally

Fixes #23862

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Migrated component templates from global CSS stylesheets to CSS modules across supported frameworks (Next.js, React, Preact, TanStack React) and build configurations. This improves style scoping and prevents potential class name conflicts in generated projects while maintaining identical component behavior and appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->