### PR TITLE
Service architecture — Stage 4: useServiceQuery React hook

### DIFF
--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -652,6 +652,7 @@ export default {
     'ProviderDoesNotExtendBaseProviderError',
     'StatusTypeIdMismatchError',
     'UncaughtManagerError',
+    'UniversalStoreFollowerTimeoutError',
   ],
   'storybook/internal/router': [
     'BaseLocationProvider',

--- a/code/core/src/service/README.md
+++ b/code/core/src/service/README.md
@@ -5,7 +5,7 @@ A small schema-driven service system for Storybook internals. A service is a sta
 The main audience for this README is agents and maintainers who need to understand how the pieces fit together, where behavior lives, and how to define new services correctly.
 
 > [!NOTE]
-> This document covers stages 1–3: definition, runtime, query subscriptions, static-build writer, static-load transport, service registration with abstract-command overrides, and cross-runtime channel sync. The **React hook** is tracked separately and lands in a follow-up stage — see the *Coming in later stages* section.
+> This document covers stages 1–4: definition, runtime, query subscriptions, static-build writer, static-load transport, service registration with abstract-command overrides, cross-runtime channel sync, and the React hook (`useServiceQuery`).
 
 ## Goals
 
@@ -28,6 +28,7 @@ The public API consists of:
 - `buildServiceArtifacts(def)` — produce the JSON-shaped state diffs for a service's preloads.
 - `setStaticTransport` / `clearStaticTransport` / `createBrowserStaticTransport` — install the runtime-side loader.
 - `setServiceChannel` / `clearServiceChannel` — install the cross-runtime sync channel.
+- `useServiceQuery` — React hook for consuming a service query.
 - `ServiceValidationError` and the exported type aliases from [types.ts](./types.ts).
 
 Internal tests and implementation code may import from the individual modules directly.
@@ -44,6 +45,7 @@ Internal tests and implementation code may import from the individual modules di
 - [build-artifacts.ts](./build-artifacts.ts) — `buildServiceArtifacts`. The static-build writer.
 - [static-transport.ts](./static-transport.ts) — the global static-load transport.
 - [channel-transport.ts](./channel-transport.ts) — `setServiceChannel` / `clearServiceChannel`, event constants, payload types for cross-runtime sync.
+- [use-service-query.ts](./use-service-query.ts) — `useServiceQuery(store, queryName, input?)` React hook.
 - [__examples__/docgen-service.ts](./__examples__/docgen-service.ts) — worked example for the docgen pattern.
 - `*.test.ts` — focused tests for runtime behavior, validation behavior, and static builds. Tests assert against the public API only, so they double as usage examples.
 
@@ -603,11 +605,26 @@ sequenceDiagram
 
 All sync events are scoped by `serviceId` and prefixed with `services:` so other channel traffic is unaffected. Runtimes ignore events for service ids they don't own.
 
-## Coming in later stages
+## React
 
-The following are deliberately not in this stage. They land as separate, independently reviewable PRs:
+`useServiceQuery(store, queryName, input?)` is a thin React hook over a service query. It's built on `useSyncExternalStore` so it works in any React 18+ tree without a Babel transform or `useSignals()` opt-in.
 
-- **React hook** (`useServiceQuery`) — a `useSyncExternalStore` wrapper around `query.subscribe`.
+```tsx
+import { useServiceQuery } from 'storybook/internal/service';
+
+import { DocgenService } from './docgen-service';
+
+function ComponentDocs({ componentId }: { componentId: string }) {
+  const docgen = useServiceQuery(DocgenService, 'getComponentDocgenInfo', componentId);
+  return <pre>{JSON.stringify(docgen, null, 2)}</pre>;
+}
+```
+
+Under the hood the hook wraps `query(input)` in a `computed(() => query(input))`. `computed` memoises by reference equality on its output, so the component re-renders only when *this query's* result actually changes — no extra dedup layer needed. Unrelated mutations to the same service (a different slice, a structurally-equal write) don't cause re-renders.
+
+**Memoise object inputs at the call site.** The input is a hook dep; passing a new object literal each render rebuilds the computed and the subscription. For complex inputs wrap them in `useMemo`, or pass primitives.
+
+The hook has a no-input overload that mirrors the runtime — `useServiceQuery(store, 'count')` for `input: z.void()` queries.
 
 ## Agent Notes
 

--- a/code/core/src/service/README.md
+++ b/code/core/src/service/README.md
@@ -106,23 +106,23 @@ Two conventions:
 
 ### Queries
 
-Every query is an object with required `input` and `output` schemas plus a `select` selector. The runtime validates caller input before calling `select`, and validates the selector result before returning it.
+Every query is an object with required `input` and `output` schemas plus a `handler` selector. The runtime validates caller input before calling `handler`, and validates the handler result before returning it.
 
 ```ts
 // no input — use z.void() / v.void() for the input schema
-getCount: query({ input: z.void(), output: z.number(), select: (state) => state.count })
+getCount: query({ input: z.void(), output: z.number(), handler: (state) => state.count })
 
 // input-keyed — `id` is inferred from `input: z.string()`
 getById: query({
   input: z.string(),
   output: z.string().optional(),
-  select: (state, id) => state.byId[id],
+  handler: (state, id) => state.byId[id],
 })
 ```
 
-`select` must not call commands or perform I/O — it's read-only by contract. If a query needs to trigger loading on first read, add optional `preload`, `inputs`, and `path` fields (see *Static Build*).
+A query `handler` must not call commands or perform I/O — it's read-only by contract. If a query needs to trigger loading on first read, add optional `preload`, `inputs`, and `path` fields (see *Static Build*).
 
-Queries are the unit of subscription. Every `query.subscribe(...)` builds an `alien-signals` `computed(() => select(state, input))`. The computed memoises by reference equality on its output, so subscribers re-fire only when this query's result actually changes.
+Queries are the unit of subscription. Every `query.subscribe(...)` builds an `alien-signals` `computed(() => handler(state, input))`. The computed memoises by reference equality on its output, so subscribers re-fire only when this query's result actually changes.
 
 ### Commands
 
@@ -178,7 +178,7 @@ When `registerService(def, registration?)` is called for the first time for a gi
 2. It resolves command handlers — registration overrides beat definition handlers for **abstract** commands. Concrete commands cannot be overridden; the runtime throws if an override is supplied.
 3. It builds the `ctx.self` reference around the state (`getState`, `setState`, `commands`, `queries`).
 4. It builds commands that validate input, run the resolved handler (sync or async), and validate output. Abstract commands with no resolved handler throw with an actionable message at call time.
-5. It builds queries with a callable form and a `.subscribe` form. Both validate input and route through the same internal `_runQuery(name, input)` that runs `select` and validates output.
+5. It builds queries with a callable form and a `.subscribe` form. Both validate input and route through the same internal `_runQuery(name, input)` that runs the query `handler` and validates output.
 6. It freezes a `publicStore` view exposing only `id`, `definition`, `queries`, `commands`. That's what callers see.
 
 The registry keeps one instance per `definition.id` within the current process. Tests should call `__resetServiceRegistry()` in teardown to avoid cross-test leakage. Re-registering a different definition under the same id throws.
@@ -188,7 +188,7 @@ sequenceDiagram
   participant Caller
   participant Runtime as ServiceRuntime
   participant Schema as validateSync / validateAsync
-  participant Op as select or handler
+  participant Op as query or command handler
   participant State as state signal
 
   Caller->>Runtime: createService(def)
@@ -198,7 +198,7 @@ sequenceDiagram
   Caller->>Runtime: query(input) or command(input)
   Runtime->>Schema: validate input
   Schema-->>Runtime: parsed input
-  Runtime->>Op: run select(state, input) or handler(input, ctx)
+  Runtime->>Op: run handler(state, input) or handler(input, ctx)
   Op->>State: read state or setState(...)
   Op-->>Runtime: raw output
   Runtime->>Schema: validate output
@@ -210,7 +210,7 @@ sequenceDiagram
 Subscriptions are powered by `alien-signals`:
 
 1. The query's input is validated once (captured in the subscription closure).
-2. A `computed(() => select(state, input))` re-runs whenever the state signal changes.
+2. A `computed(() => handler(state, input))` re-runs whenever the state signal changes.
 3. An `effect(() => listener(comp()))` observes the computed. The first synchronous fire is **swallowed** so subscribers see changes only — read the initial value via the callable form of the query.
 4. Output validation runs each time the listener is about to be notified.
 5. Reference-equality memoisation on the computed gives "result didn't change → don't re-notify" for free.
@@ -231,7 +231,7 @@ sequenceDiagram
   Subscriber->>Runtime: subscribe(input?, listener)
   Runtime->>Schema: validate input
   Schema-->>Runtime: parsed input
-  Runtime->>Signals: install computed(() => select(state, input))
+  Runtime->>Signals: install computed(() => handler(state, input))
   Runtime->>Preload: kick off preload (fire-and-forget)
   Signals->>Signals: first fire SWALLOWED
   Note over Signals: subscribers see changes only
@@ -273,7 +273,7 @@ queries: {
   getComponentDocgenInfo: query({
     input: z.string(),
     output: docgenSchema.nullable(),
-    select: (state, id) => state.byComponentId[id] ?? null,
+    handler: (state, id) => state.byComponentId[id] ?? null,
     preload: async (id, ctx) => { await ctx.self.commands.generateDocgen(id); },
     inputs: async () => listAllComponentIds(),
     path: (_ctx, id) => `docgen-${id}.json`,
@@ -288,7 +288,7 @@ queries: {
   allStatuses: query({
     input: z.void(),
     output: z.record(z.string(), z.string()),
-    select: (state) => state.byStoryId,
+    handler: (state) => state.byStoryId,
     preload: async (ctx) => {
       const data = await fetchAllStatusesAtBuildTime();
       ctx.self.setState((d) => { d.byStoryId = data; });
@@ -438,7 +438,7 @@ const DocgenService = defineService<DocgenState>()(({ query, command }) => ({
   state: { byComponentId: {}, somethingElse: 42 },
   queries: {
     getComponentDocgenInfo: query({ /* ...with preload+inputs+path... */ }),
-    somethingElse: query({ input: z.void(), output: z.number(), select: (s) => s.somethingElse }),
+    somethingElse: query({ input: z.void(), output: z.number(), handler: (s) => s.somethingElse }),
   },
   commands: {
     generateDocgen: command({ input: z.string(), output: z.void() }),       // abstract
@@ -500,7 +500,7 @@ export const ExampleService = defineService<ExampleState>()(({ query, command })
       description: 'Returns one value by id.',
       input: entryIdSchema,
       output: valueSchema,
-      select: (state, input) => state.values[input.entryId] ?? null,
+      handler: (state, input) => state.values[input.entryId] ?? null,
       preload: async (input, ctx) => {
         if (!(input.entryId in ctx.self.getState().values)) {
           await ctx.self.commands.preloadValue(input);

--- a/code/core/src/service/__examples__/docgen-service.ts
+++ b/code/core/src/service/__examples__/docgen-service.ts
@@ -57,7 +57,7 @@ export const DocgenService = defineService<DocgenState>()(({ query, command }) =
     getComponentDocgenInfo: query({
       input: z.string(),
       output: componentDocgenSchema.nullable(),
-      select: (state, componentId) => state.byComponentId[componentId] ?? null,
+      handler: (state, componentId) => state.byComponentId[componentId] ?? null,
       preload: async (componentId, ctx) => {
         await ctx.self.commands.generateDocgen(componentId);
       },
@@ -68,7 +68,7 @@ export const DocgenService = defineService<DocgenState>()(({ query, command }) =
     somethingElse: query({
       input: z.void(),
       output: z.number(),
-      select: (state) => state.somethingElse,
+      handler: (state) => state.somethingElse,
     }),
   },
 

--- a/code/core/src/service/build-artifacts.test.ts
+++ b/code/core/src/service/build-artifacts.test.ts
@@ -58,7 +58,7 @@ describe('buildServiceArtifacts', () => {
       id: 'test/no-loaders',
       state: { x: 1 },
       queries: {
-        get: { input: z.void(), output: z.number(), select: (s: { x: number }) => s.x },
+        get: { input: z.void(), output: z.number(), handler: (s: { x: number }) => s.x },
       },
       commands: {},
     });
@@ -78,7 +78,7 @@ describe('buildServiceArtifacts', () => {
         getOne: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -122,7 +122,7 @@ describe('buildServiceArtifacts', () => {
         getOne: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -158,7 +158,7 @@ describe('buildServiceArtifacts', () => {
         allStatuses: {
           input: z.void(),
           output: z.any(),
-          select: (s: S) => s.byId,
+          handler: (s: S) => s.byId,
           preload: async (ctx: ServiceCtx<S>) => {
             await ctx.self.commands.loadAll();
           },
@@ -198,7 +198,7 @@ describe('buildServiceArtifacts', () => {
         allCats: {
           input: z.void(),
           output: z.any(),
-          select: (s: S) => s.cats,
+          handler: (s: S) => s.cats,
           preload: async (ctx: ServiceCtx<S>) => {
             await ctx.self.commands.loadCats();
           },
@@ -207,7 +207,7 @@ describe('buildServiceArtifacts', () => {
         allDogs: {
           input: z.void(),
           output: z.any(),
-          select: (s: S) => s.dogs,
+          handler: (s: S) => s.dogs,
           preload: async (ctx: ServiceCtx<S>) => {
             await ctx.self.commands.loadDogs();
           },
@@ -256,7 +256,7 @@ describe('buildServiceArtifacts', () => {
         getItems: {
           input: z.void(),
           output: z.any(),
-          select: (s: S) => s.items,
+          handler: (s: S) => s.items,
           preload: async (ctx: ServiceCtx<S>) => {
             await ctx.self.commands.push(1);
           },
@@ -290,7 +290,7 @@ describe('buildServiceArtifacts', () => {
         getByKey: {
           input: keySchema,
           output: z.string(),
-          select: (s: S, k: z.infer<typeof keySchema>) => s.byKey[`${k.kind}:${k.id}`],
+          handler: (s: S, k: z.infer<typeof keySchema>) => s.byKey[`${k.kind}:${k.id}`],
           preload: async (k: z.infer<typeof keySchema>, ctx: ServiceCtx<S>) => {
             ctx.self.setState((d: S) => {
               d.byKey[`${k.kind}:${k.id}`] = `${k.kind}-${k.id}`;
@@ -327,7 +327,7 @@ describe('buildServiceArtifacts', () => {
         getOne: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -371,7 +371,7 @@ describe('buildServiceArtifacts', () => {
         allStatuses: {
           input: z.void(),
           output: z.any(),
-          select: (s: S) => s.byId,
+          handler: (s: S) => s.byId,
           preload: async (ctx: ServiceCtx<S>) => {
             await ctx.self.commands.loadAll();
           },
@@ -409,7 +409,7 @@ describe('buildServiceArtifacts', () => {
         getOne: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string): true | undefined => s.byId[id],
+          handler: (s: S, id: string): true | undefined => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -453,7 +453,7 @@ describe('runtime loader branching', () => {
         getOne: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -496,7 +496,7 @@ describe('runtime loader branching', () => {
         getOne: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -546,7 +546,7 @@ describe('runtime loader branching', () => {
         getOne: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -590,7 +590,7 @@ describe('runtime loader branching', () => {
         getOne: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -662,7 +662,7 @@ describe('build → load round trip', () => {
         getComponentDocgenInfo: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byComponentId[id],
+          handler: (s: S, id: string) => s.byComponentId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.generate(id);
           },
@@ -717,7 +717,7 @@ describe('build → load round trip', () => {
         allStatuses: {
           input: z.void(),
           output: z.any(),
-          select: (s: S) => s.byStoryId,
+          handler: (s: S) => s.byStoryId,
           preload: async (ctx: ServiceCtx<S>) => {
             await ctx.self.commands.loadAll();
           },
@@ -726,7 +726,7 @@ describe('build → load round trip', () => {
         getStoryStatus: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byStoryId[id],
+          handler: (s: S, id: string) => s.byStoryId[id],
         },
       },
       commands: {
@@ -784,7 +784,7 @@ describe('build-time input validation (Fix #3)', () => {
           // artifact filename matches what the runtime will request after its own validation.
           input: z.string().transform((s) => s.toUpperCase()),
           output: z.any(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             ctx.self.setState((d) => {
               d.byId[id] = { name: `Loaded ${id}` };
@@ -814,7 +814,7 @@ describe('resolvePreloadInputs guard (Fix #4)', () => {
         getOne: {
           input: z.string(),
           output: z.any(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           // Input-keyed preload arity (id, ctx) — but no `inputs: [...]` enumeration. The
           // build can't guess what to pre-render, so this is an authoring bug and must throw.
           preload: async (id: string, ctx: ServiceCtx<S>) => {
@@ -842,7 +842,7 @@ describe('resolvePreloadInputs guard (Fix #4)', () => {
         getAll: {
           input: z.void(),
           output: z.any(),
-          select: (s: S) => s.list,
+          handler: (s: S) => s.list,
           // No-input preload arity (ctx only) — the [undefined] fallback is correct.
           preload: async (ctx: ServiceCtx<S>) => {
             ctx.self.setState((d) => {

--- a/code/core/src/service/channel-sync.test.ts
+++ b/code/core/src/service/channel-sync.test.ts
@@ -55,7 +55,7 @@ describe('isolation — no channel installed', () => {
     const def = defineService<S>()({
       id: 'test/isolation-no-channel',
       state: { n: 0 },
-      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      queries: { get: { input: z.void(), output: z.number(), handler: (s: S) => s.n } },
       commands: {
         bump: {
           input: z.void(),
@@ -90,7 +90,7 @@ describe('welcome handshake', () => {
         get: {
           input: z.void(),
           output: z.object({ counter: z.number(), byId: z.record(z.string(), z.string()) }),
-          select: (s: S) => s,
+          handler: (s: S) => s,
         },
       },
       commands: {
@@ -130,7 +130,7 @@ describe('welcome handshake', () => {
     const def = defineService<S>()({
       id: 'test/welcome-multi-reply',
       state: { n: 0 },
-      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      queries: { get: { input: z.void(), output: z.number(), handler: (s: S) => s.n } },
       commands: {
         set: {
           input: z.number(),
@@ -165,7 +165,7 @@ describe('welcome handshake', () => {
     const def = defineService<S>()({
       id: 'test/welcome-isolated',
       state: { n: 5 },
-      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      queries: { get: { input: z.void(), output: z.number(), handler: (s: S) => s.n } },
       commands: {},
     });
 
@@ -193,7 +193,7 @@ describe('ongoing patch sync', () => {
         getOne: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
         },
       },
       commands: {
@@ -238,7 +238,7 @@ describe('ongoing patch sync', () => {
     const def = defineService<S>()({
       id: 'test/loop-suppression',
       state: { n: 0 },
-      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      queries: { get: { input: z.void(), output: z.number(), handler: (s: S) => s.n } },
       commands: {
         bump: {
           input: z.void(),
@@ -284,7 +284,7 @@ describe('ongoing patch sync', () => {
         getOne: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
         },
       },
       commands: {
@@ -327,7 +327,7 @@ describe('service-id filtering', () => {
     const defA = defineService<S>()({
       id: 'test/svc-A',
       state: { n: 0 },
-      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      queries: { get: { input: z.void(), output: z.number(), handler: (s: S) => s.n } },
       commands: {
         set: {
           input: z.number(),
@@ -342,7 +342,7 @@ describe('service-id filtering', () => {
     const defB = defineService<S>()({
       id: 'test/svc-B',
       state: { n: 100 },
-      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      queries: { get: { input: z.void(), output: z.number(), handler: (s: S) => s.n } },
       commands: {
         set: {
           input: z.number(),

--- a/code/core/src/service/define-service.ts
+++ b/code/core/src/service/define-service.ts
@@ -14,7 +14,7 @@ import type {
  *
  * Recommended: `defineService<MyState>()(({ query, command }) => ({ id, state, queries, commands }))`.
  * The callback receives the `query` / `command` helpers, which provide per-entry inference for
- * `select` / `preload` / `path` / `handler` parameters and return types.
+ * `handler` / `preload` / `path` parameters and return types.
  *
  * Bare entries (without `query()` / `command()`) are accepted but only loosely validated; the
  * runtime still validates `input` / `output` schemas at call time.
@@ -29,7 +29,7 @@ import type {
  *     getComponentDocgenInfo: query({
  *       input: z.string(),
  *       output: componentDocgenSchema.nullable(),
- *       select: (state, componentId) => state.byComponentId[componentId] ?? null,
+ *       handler: (state, componentId) => state.byComponentId[componentId] ?? null,
  *     }),
  *   },
  *   commands: {
@@ -63,7 +63,7 @@ type NarrowCommands<TState, C> = {
  * Type-only helper for a query entry. At runtime this returns its argument unchanged.
  *
  * Required for inference: the object literal is checked as `QueryDef<TState, I, O>` directly,
- * which contextually types `select` / `preload` / `path` from `input` / `output`.
+ * which contextually types `handler` / `preload` / `path` from `input` / `output`.
  */
 export function query<TState>() {
   return <const I extends AnySchema, const O extends AnySchema>(

--- a/code/core/src/service/index.ts
+++ b/code/core/src/service/index.ts
@@ -47,6 +47,7 @@ export {
   createBrowserStaticTransport,
   setStaticTransport,
 } from './static-transport.ts';
+export { useServiceQuery } from './use-service-query.ts';
 
 export type {
   AbstractCommandDef,

--- a/code/core/src/service/service-runtime.test.ts
+++ b/code/core/src/service/service-runtime.test.ts
@@ -31,7 +31,7 @@ describe('queries', () => {
         get: {
           input: z.void(),
           output: z.string(),
-          select: (s: { value: string }) => s.value,
+          handler: (s: { value: string }) => s.value,
         },
       },
       commands: {},
@@ -52,7 +52,7 @@ describe('queries', () => {
         getById: {
           input: z.string(),
           output: z.number().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
         },
       },
       commands: {},
@@ -72,8 +72,8 @@ describe('queries', () => {
       id: 'test/q-subscribe',
       state: { a: 0, b: 0 } as S,
       queries: {
-        getA: { input: z.void(), output: z.number(), select: (s: S) => s.a },
-        getB: { input: z.void(), output: z.number(), select: (s: S) => s.b },
+        getA: { input: z.void(), output: z.number(), handler: (s: S) => s.a },
+        getB: { input: z.void(), output: z.number(), handler: (s: S) => s.b },
       },
       commands: {
         bumpA: {
@@ -122,7 +122,7 @@ describe('queries', () => {
         getName: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id]?.name,
+          handler: (s: S, id: string) => s.byId[id]?.name,
         },
       },
       commands: {
@@ -156,7 +156,7 @@ describe('commands', () => {
     const def = defineService()({
       id: 'test/cmd-noinput',
       state: { count: 0 } as S,
-      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.count } },
+      queries: { get: { input: z.void(), output: z.number(), handler: (s: S) => s.count } },
       commands: {
         increment: {
           input: z.void(),
@@ -185,7 +185,7 @@ describe('commands', () => {
         get: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
         },
       },
       commands: {
@@ -222,7 +222,7 @@ describe('abstract commands', () => {
         get: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
         },
       },
       commands: {
@@ -276,7 +276,7 @@ describe('abstract commands', () => {
     const def = defineService()({
       id: 'test/override-concrete-rejected',
       state: { n: 0 } as S,
-      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.n } },
+      queries: { get: { input: z.void(), output: z.number(), handler: (s: S) => s.n } },
       commands: {
         bump: {
           input: z.void(),
@@ -310,7 +310,7 @@ describe('abstract commands', () => {
     const def = defineService()({
       id: 'test/abstract-noinput',
       state: { ready: false } as S,
-      queries: { isReady: { input: z.void(), output: z.boolean(), select: (s: S) => s.ready } },
+      queries: { isReady: { input: z.void(), output: z.boolean(), handler: (s: S) => s.ready } },
       commands: {
         boot: { input: z.void(), output: z.void() },
       },
@@ -342,7 +342,7 @@ describe('encapsulation', () => {
         get: {
           input: z.void(),
           output: z.number(),
-          select: (s: { secret: number }) => s.secret,
+          handler: (s: { secret: number }) => s.secret,
         },
       },
       commands: {},
@@ -372,7 +372,7 @@ describe('preloads', () => {
         getName: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -421,7 +421,7 @@ describe('preloads', () => {
         getName: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -465,7 +465,7 @@ describe('preloads', () => {
         getName: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },
@@ -513,7 +513,7 @@ describe('preloads', () => {
         get: {
           input: z.void(),
           output: z.string(),
-          select: (s: S) => s.value,
+          handler: (s: S) => s.value,
           preload: async (ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load();
           },
@@ -548,7 +548,7 @@ describe('preloads', () => {
     const def = defineService()({
       id: 'test/preload-absent',
       state: { x: 0 } as S,
-      queries: { get: { input: z.void(), output: z.number(), select: (s: S) => s.x } },
+      queries: { get: { input: z.void(), output: z.number(), handler: (s: S) => s.x } },
       commands: {
         bump: {
           input: z.void(),
@@ -581,7 +581,7 @@ describe('registerService / getService', () => {
       id: 'test/registry-idem',
       state: { v: 1 },
       queries: {
-        get: { input: z.void(), output: z.number(), select: (s: { v: number }) => s.v },
+        get: { input: z.void(), output: z.number(), handler: (s: { v: number }) => s.v },
       },
       commands: {},
     });
@@ -616,7 +616,7 @@ describe('schema validation', () => {
       id: 'test/validate-cmd-in',
       state: { n: 0 },
       queries: {
-        get: { input: z.void(), output: z.number(), select: (s: { n: number }) => s.n },
+        get: { input: z.void(), output: z.number(), handler: (s: { n: number }) => s.n },
       },
       commands: {
         set: {
@@ -644,7 +644,7 @@ describe('schema validation', () => {
         getById: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: { byId: Record<string, string> }, id: string) => s.byId[id],
+          handler: (s: { byId: Record<string, string> }, id: string) => s.byId[id],
         },
       },
       commands: {},
@@ -662,7 +662,7 @@ describe('schema validation', () => {
       id: 'test/validate-q-out',
       state: { v: 'oops' as unknown as number },
       queries: {
-        get: { input: z.void(), output: z.number(), select: (s: { v: number }) => s.v },
+        get: { input: z.void(), output: z.number(), handler: (s: { v: number }) => s.v },
       },
       commands: {},
     });
@@ -686,7 +686,7 @@ describe('runtime defensive guarantees', () => {
       id: 'test/state-isolation',
       state: initial,
       queries: {
-        getAll: { input: z.void(), output: z.any(), select: (s: S) => s.byId },
+        getAll: { input: z.void(), output: z.any(), handler: (s: S) => s.byId },
       },
       commands: {},
     });
@@ -710,7 +710,7 @@ describe('runtime defensive guarantees', () => {
         get: {
           input: z.void(),
           output: z.number(),
-          select: (s: { x: number }) => s.x,
+          handler: (s: { x: number }) => s.x,
           preload: async () => {
             throw new Error('boom');
           },
@@ -731,7 +731,7 @@ describe('runtime defensive guarantees', () => {
         get: {
           input: z.void(),
           output: z.number(),
-          select: (s: { x: number }) => s.x,
+          handler: (s: { x: number }) => s.x,
           preload: async () => {
             throw new Error('boom-fire-and-forget');
           },

--- a/code/core/src/service/service-runtime.ts
+++ b/code/core/src/service/service-runtime.ts
@@ -114,7 +114,7 @@ function fnv1a(str: string): string {
  * mutator (`(draft) => { draft.foo = bar; }`); the runtime hands a real Immer draft to the
  * recipe and gets back the new immutable state plus the minimal patch list. Reactivity is
  * powered by `alien-signals`: the whole state is held in a single `signal<TState>`, and each
- * `query.subscribe(input, listener)` builds a `computed(() => select(state, input))` whose
+ * `query.subscribe(input, listener)` builds a `computed(() => handler(state, input))` whose
  * value is observed by an `effect(() => listener(...))`. Reference-equality memoisation on
  * the computed gives "fire only when the selected slice actually changes" for free.
  */
@@ -322,7 +322,7 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
       throw new Error(`[${this.id}] Unknown query: ${queryName}`);
     }
     const state = this._stateSignal();
-    const raw = (entry.select as (s: unknown, i: unknown) => unknown)(state, parsedInput);
+    const raw = (entry.handler as (s: unknown, i: unknown) => unknown)(state, parsedInput);
     return validateSync(entry.output, raw, {
       serviceId: this.id,
       kind: 'query',
@@ -376,7 +376,7 @@ export class ServiceRuntime<TDef extends ServiceDefinition<any, any, any>> {
   /**
    * Subscribe a listener to a query/input pair. Built on `alien-signals`:
    *
-   *   - `computed(() => select(state, input))` re-runs whenever the state signal changes,
+   *   - `computed(() => handler(state, input))` re-runs whenever the state signal changes,
    *     memoised by reference equality on its output. Two consecutive evaluations that
    *     return `===`-equal values produce no downstream notification — that's where our
    *     "structurally equal? don't re-fire" behaviour for primitive-valued selectors comes

--- a/code/core/src/service/service-validation.test.ts
+++ b/code/core/src/service/service-validation.test.ts
@@ -19,7 +19,7 @@ describe('ServiceValidationError formatting', () => {
         getById: {
           input: z.object({ entryId: z.string() }),
           output: z.string().optional(),
-          select: (s: { byId: Record<string, string> }, { entryId }: { entryId: string }) =>
+          handler: (s: { byId: Record<string, string> }, { entryId }: { entryId: string }) =>
             s.byId[entryId],
         },
       },
@@ -48,7 +48,7 @@ describe('ServiceValidationError formatting', () => {
           output: z.object({
             items: z.array(z.object({ name: z.string() })),
           }),
-          select: () => ({
+          handler: () => ({
             items: [{ name: 1 as unknown as string }],
           }),
         },
@@ -76,7 +76,7 @@ describe('ServiceValidationError formatting', () => {
       id: 'test/validate-cmd-in',
       state: { n: 0 },
       queries: {
-        get: { input: z.void(), output: z.number(), select: (s: { n: number }) => s.n },
+        get: { input: z.void(), output: z.number(), handler: (s: { n: number }) => s.n },
       },
       commands: {
         set: {

--- a/code/core/src/service/service-validation.ts
+++ b/code/core/src/service/service-validation.ts
@@ -3,7 +3,7 @@
  *
  * Every query and command declares Standard Schema v1 `input` and `output` schemas. The
  * runtime calls these helpers at the boundary — incoming caller input is validated before the
- * selector/handler runs; the returned value is validated before it leaves the service. Schema
+ * handler runs; the returned value is validated before it leaves the service. Schema
  * mismatches surface as `ServiceValidationError`s.
  */
 

--- a/code/core/src/service/types.ts
+++ b/code/core/src/service/types.ts
@@ -107,14 +107,14 @@ export interface SelfHandle<TState> {
  * A query is a schema-validated selector over state.
  *
  *  - `input` and `output` are Standard Schema v1 schemas.
- *  - `select` derives the output value from state and (optionally) a parsed input. Pure and sync.
+ *  - `handler` derives the output value from state and (optionally) a parsed input. Pure and sync.
  *  - `preload` (optional) is a read-triggered side effect that populates state; the static
  *    build runs it for every enumerated input.
  *  - `inputs` (optional) enumerates inputs the static build pre-renders.
  *  - `path` (optional) controls the per-input filename.
  *
  * No-input queries are encoded by `input: <void schema>` (e.g. `z.void()`); `InferSchemaOutput`
- * resolves to `void`, and the `select`/`preload`/`path` signatures collapse to their no-input
+ * resolves to `void`, and the `handler`/`preload`/`path` signatures collapse to their no-input
  * variants automatically.
  */
 export interface QueryDef<
@@ -125,7 +125,7 @@ export interface QueryDef<
   readonly description?: string;
   readonly input: TInputSchema;
   readonly output: TOutputSchema;
-  readonly select: IsNoInputSchema<TInputSchema> extends true
+  readonly handler: IsNoInputSchema<TInputSchema> extends true
     ? (state: TState) => InferSchemaOutput<TOutputSchema>
     : (state: TState, input: InferSchemaOutput<TInputSchema>) => InferSchemaOutput<TOutputSchema>;
   readonly preload?: IsNoInputSchema<TInputSchema> extends true
@@ -220,7 +220,7 @@ export type AnyQueryDef<TState = any> = {
   readonly description?: string;
   readonly input: AnySchema;
   readonly output: AnySchema;
-  readonly select: BivariantCallback<[state: TState, input?: unknown], unknown>;
+  readonly handler: BivariantCallback<[state: TState, input?: unknown], unknown>;
   readonly preload?: BivariantCallback<
     [input: unknown, ctx: ServiceCtx<TState>],
     void | Promise<void>
@@ -294,7 +294,7 @@ export type CommandOverrides<TDef extends ServiceDefinition<any, any, any>> = {
 /**
  * What a consumer passes in when calling a query. The raw caller-facing input, inferred from
  * the query's `input` schema via `StandardSchemaV1.InferInput`. The runtime validates this and
- * hands the parsed value to `select`.
+ * hands the parsed value to `handler`.
  */
 export type InputOfQuery<Q> =
   Q extends QueryDef<any, infer TIn, any> ? InferSchemaInput<TIn> : never;

--- a/code/core/src/service/use-service-query.test.tsx
+++ b/code/core/src/service/use-service-query.test.tsx
@@ -25,7 +25,7 @@ describe('useServiceQuery — initial render', () => {
       id: 'test/hook-initial',
       state: { count: 7 } as S,
       queries: {
-        get: { input: z.void(), output: z.number(), select: (s: S) => s.count },
+        get: { input: z.void(), output: z.number(), handler: (s: S) => s.count },
       },
       commands: {},
     });
@@ -46,7 +46,7 @@ describe('useServiceQuery — initial render', () => {
         get: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
         },
       },
       commands: {},
@@ -69,7 +69,7 @@ describe('useServiceQuery — reactivity', () => {
       id: 'test/hook-rerender',
       state: { count: 0 } as S,
       queries: {
-        get: { input: z.void(), output: z.number(), select: (s: S) => s.count },
+        get: { input: z.void(), output: z.number(), handler: (s: S) => s.count },
       },
       commands: {
         bump: {
@@ -110,8 +110,8 @@ describe('useServiceQuery — reactivity', () => {
       id: 'test/hook-no-rerender-unrelated',
       state: { a: 0, b: 0 } as S,
       queries: {
-        getA: { input: z.void(), output: z.number(), select: (s: S) => s.a },
-        getB: { input: z.void(), output: z.number(), select: (s: S) => s.b },
+        getA: { input: z.void(), output: z.number(), handler: (s: S) => s.a },
+        getB: { input: z.void(), output: z.number(), handler: (s: S) => s.b },
       },
       commands: {
         bumpB: {
@@ -152,7 +152,7 @@ describe('useServiceQuery — reactivity', () => {
       id: 'test/hook-no-rerender-equal',
       state: { label: 'hello' } as S,
       queries: {
-        get: { input: z.void(), output: z.string(), select: (s: S) => s.label },
+        get: { input: z.void(), output: z.string(), handler: (s: S) => s.label },
       },
       commands: {
         rewrite: {
@@ -198,7 +198,7 @@ describe('useServiceQuery — input changes', () => {
         get: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
         },
       },
       commands: {},
@@ -234,7 +234,7 @@ describe('useServiceQuery — preloads', () => {
         getName: {
           input: z.string(),
           output: z.string().optional(),
-          select: (s: S, id: string) => s.byId[id],
+          handler: (s: S, id: string) => s.byId[id],
           preload: async (id: string, ctx: ServiceCtx<S>) => {
             await ctx.self.commands.load(id);
           },

--- a/code/core/src/service/use-service-query.test.tsx
+++ b/code/core/src/service/use-service-query.test.tsx
@@ -1,0 +1,272 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { defineService } from './define-service.ts';
+import { __resetServiceRegistry, registerService } from './register-service.ts';
+import type { ServiceCtx } from './types.ts';
+import { useServiceQuery } from './use-service-query.ts';
+
+afterEach(() => {
+  __resetServiceRegistry();
+});
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+// -------------------- initial render --------------------
+
+describe('useServiceQuery — initial render', () => {
+  it('returns the current value on first render', () => {
+    interface S {
+      count: number;
+    }
+    const def = defineService()({
+      id: 'test/hook-initial',
+      state: { count: 7 } as S,
+      queries: {
+        get: { input: z.void(), output: z.number(), select: (s: S) => s.count },
+      },
+      commands: {},
+    });
+    const store = registerService(def);
+
+    const { result } = renderHook(() => useServiceQuery(store, 'get'));
+    expect(result.current).toBe(7);
+  });
+
+  it('returns the current value for an input-keyed query', () => {
+    interface S {
+      byId: Record<string, string>;
+    }
+    const def = defineService()({
+      id: 'test/hook-initial-input',
+      state: { byId: { a: 'alpha' } } as S,
+      queries: {
+        get: {
+          input: z.string(),
+          output: z.string().optional(),
+          select: (s: S, id: string) => s.byId[id],
+        },
+      },
+      commands: {},
+    });
+    const store = registerService(def);
+
+    const { result } = renderHook(() => useServiceQuery(store, 'get', 'a'));
+    expect(result.current).toBe('alpha');
+  });
+});
+
+// -------------------- reactivity --------------------
+
+describe('useServiceQuery — reactivity', () => {
+  it('re-renders when a command changes the selected slice', async () => {
+    interface S {
+      count: number;
+    }
+    const def = defineService()({
+      id: 'test/hook-rerender',
+      state: { count: 0 } as S,
+      queries: {
+        get: { input: z.void(), output: z.number(), select: (s: S) => s.count },
+      },
+      commands: {
+        bump: {
+          input: z.void(),
+          output: z.void(),
+          handler: (ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.count += 1;
+            }),
+        },
+      },
+    });
+    const store = registerService(def);
+
+    const renderCount = vi.fn();
+    const { result } = renderHook(() => {
+      renderCount();
+      return useServiceQuery(store, 'get');
+    });
+
+    expect(result.current).toBe(0);
+    expect(renderCount).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await store.commands.bump();
+    });
+
+    expect(result.current).toBe(1);
+    expect(renderCount).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT re-render when an unrelated slice changes', async () => {
+    interface S {
+      a: number;
+      b: number;
+    }
+    const def = defineService()({
+      id: 'test/hook-no-rerender-unrelated',
+      state: { a: 0, b: 0 } as S,
+      queries: {
+        getA: { input: z.void(), output: z.number(), select: (s: S) => s.a },
+        getB: { input: z.void(), output: z.number(), select: (s: S) => s.b },
+      },
+      commands: {
+        bumpB: {
+          input: z.void(),
+          output: z.void(),
+          handler: (ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.b += 1;
+            }),
+        },
+      },
+    });
+    const store = registerService(def);
+
+    const renderCount = vi.fn();
+    const { result } = renderHook(() => {
+      renderCount();
+      return useServiceQuery(store, 'getA');
+    });
+
+    expect(renderCount).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await store.commands.bumpB();
+    });
+
+    // getA's selected slice didn't change — computed memoisation kept the value identical,
+    // effect never fired, React never re-rendered.
+    expect(result.current).toBe(0);
+    expect(renderCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT re-render when setState writes a structurally-equal value', async () => {
+    interface S {
+      label: string;
+    }
+    const def = defineService()({
+      id: 'test/hook-no-rerender-equal',
+      state: { label: 'hello' } as S,
+      queries: {
+        get: { input: z.void(), output: z.string(), select: (s: S) => s.label },
+      },
+      commands: {
+        rewrite: {
+          input: z.void(),
+          output: z.void(),
+          handler: (ctx: ServiceCtx<S>) =>
+            ctx.self.setState((d) => {
+              d.label = 'hello';
+            }),
+        },
+      },
+    });
+    const store = registerService(def);
+
+    const renderCount = vi.fn();
+    renderHook(() => {
+      renderCount();
+      return useServiceQuery(store, 'get');
+    });
+
+    expect(renderCount).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await store.commands.rewrite();
+    });
+
+    // Same string ('hello' === 'hello') — computed value unchanged, no re-render.
+    expect(renderCount).toHaveBeenCalledTimes(1);
+  });
+});
+
+// -------------------- input changes --------------------
+
+describe('useServiceQuery — input changes', () => {
+  it('returns the value for the new input when input changes between renders', async () => {
+    interface S {
+      byId: Record<string, string>;
+    }
+    const def = defineService()({
+      id: 'test/hook-input-change',
+      state: { byId: { a: 'alpha', b: 'beta' } } as S,
+      queries: {
+        get: {
+          input: z.string(),
+          output: z.string().optional(),
+          select: (s: S, id: string) => s.byId[id],
+        },
+      },
+      commands: {},
+    });
+    const store = registerService(def);
+
+    const { result, rerender } = renderHook(({ id }) => useServiceQuery(store, 'get', id), {
+      initialProps: { id: 'a' },
+    });
+
+    expect(result.current).toBe('alpha');
+
+    rerender({ id: 'b' });
+
+    // Snapshot reflects the new input immediately on the very next render — no stale value.
+    expect(result.current).toBe('beta');
+  });
+});
+
+// -------------------- preload firing --------------------
+
+describe('useServiceQuery — preloads', () => {
+  it('fires the paired preload on subscribe', async () => {
+    interface S {
+      byId: Record<string, string>;
+    }
+    const generate = vi.fn(async (id: string) => `name-${id}`);
+
+    const def = defineService()({
+      id: 'test/hook-preload',
+      state: { byId: {} } as S,
+      queries: {
+        getName: {
+          input: z.string(),
+          output: z.string().optional(),
+          select: (s: S, id: string) => s.byId[id],
+          preload: async (id: string, ctx: ServiceCtx<S>) => {
+            await ctx.self.commands.load(id);
+          },
+        },
+      },
+      commands: {
+        load: {
+          input: z.string(),
+          output: z.void(),
+          handler: async (id: string, ctx: ServiceCtx<S>) => {
+            const name = await generate(id);
+            ctx.self.setState((d) => {
+              d.byId[id] = name;
+            });
+          },
+        },
+      },
+    });
+    const store = registerService(def);
+
+    const { result } = renderHook(() => useServiceQuery(store, 'getName', 'a'));
+
+    // First render: state hasn't loaded yet.
+    expect(result.current).toBeUndefined();
+
+    // Allow the preload to resolve + the resulting setState → signal → effect → React schedule.
+    await act(async () => {
+      await tick();
+    });
+
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(generate).toHaveBeenCalledWith('a');
+    expect(result.current).toBe('name-a');
+  });
+});

--- a/code/core/src/service/use-service-query.ts
+++ b/code/core/src/service/use-service-query.ts
@@ -1,0 +1,81 @@
+import { computed, effect } from 'alien-signals';
+
+import * as React from 'react';
+
+import type { InputOfQuery, OutputOfQuery, ServiceDefinition, ServiceStore } from './types.ts';
+
+/**
+ * React hook: subscribe to a service query.
+ *
+ * Signals-backed. Per `(service, queryName, input)` we build a `computed(() => query(input))`
+ * that closes over the input and re-evaluates whenever the underlying state signal changes.
+ * `computed` memoises by reference equality on its output, so the React component only
+ * re-renders when *this query's* result actually changes — no extra dedup layer needed.
+ *
+ * Subscription is wired through `useSyncExternalStore` so the hook works in any React 18+
+ * tree without a Babel transform or `useSignals()` opt-in. The `effect` we install reads the
+ * computed (which registers the dependency) and forwards change notifications to React's
+ * listener. The effect's mandatory first synchronous fire is swallowed so React doesn't see
+ * a no-op store update on mount.
+ *
+ * **Memoise object inputs at the call site.** The input participates in the hook's React
+ * deps; passing a new object literal each render rebuilds the computed + subscription each
+ * render. For complex inputs wrap them in `useMemo` (or pass primitives).
+ *
+ * @example
+ *
+ * ```tsx
+ * const docgen = useServiceQuery(DocgenService, 'getComponentDocgenInfo', componentId);
+ * ```
+ */
+export function useServiceQuery<
+  TDef extends ServiceDefinition<any, any, any>,
+  TQueries extends TDef['queries'] = TDef['queries'],
+  TKey extends keyof TQueries & string = keyof TQueries & string,
+>(
+  service: ServiceStore<TDef>,
+  queryName: TKey,
+  ...inputArg: [InputOfQuery<TQueries[TKey]>] extends [void] ? [] : [InputOfQuery<TQueries[TKey]>]
+): OutputOfQuery<TQueries[TKey]> {
+  const query = service.queries[queryName] as unknown as {
+    (input?: unknown): unknown;
+    subscribe: (...args: unknown[]) => () => void;
+  };
+  const input = inputArg[0] as unknown;
+  const hasInput = inputArg.length > 0;
+
+  // One computed per (query, input). Calling `query(input)` inside the computed runs the
+  // selector (which reads the state signal — registering the dependency) AND fires the
+  // paired preload on first read (idempotent thereafter). When `input` changes between
+  // renders this useMemo re-creates the computed, which closes over the new input.
+  const comp = React.useMemo(
+    () => computed(() => (hasInput ? query(input) : query())),
+    [query, hasInput, input]
+  );
+
+  // Subscribe via an effect that touches `comp` to register the dependency and forwards
+  // change notifications to React. `effect()` always fires once synchronously at install
+  // time; swallow that so React doesn't observe a phantom store update on mount.
+  const subscribe = React.useCallback(
+    (listener: () => void) => {
+      let initial = true;
+      return effect(() => {
+        comp();
+        if (initial) {
+          initial = false;
+          return;
+        }
+        listener();
+      });
+    },
+    [comp]
+  );
+
+  // Snapshot is just "read the computed." Called outside of any tracked context, so this
+  // is an untracked read of the memoised result — no subscription side-effect.
+  const getSnapshot = React.useCallback(() => comp(), [comp]);
+
+  return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot) as OutputOfQuery<
+    TQueries[TKey]
+  >;
+}


### PR DESCRIPTION
Final of four stacked PRs aligning the service architecture work. **Base: [#34914](https://github.com/storybookjs/storybook/pull/34914) (Stage 3).**

## Stack

\`\`\`
next
 └── jeppe/service-arch-explorations
      └── norbert/service-stage-1-core               (Stage 1 — #34912)
           └── norbert/service-stage-2-register      (Stage 2 — #34913)
                └── norbert/service-stage-3-channel  (Stage 3 — #34914)
                     └── norbert/service-stage-4-react-hook ← THIS PR
\`\`\`

## Summary

Stage 4 adds the React consumer-side surface. Tiny module, but worth landing on its own so it can be reviewed independently of the runtime / sync changes.

- **\`useServiceQuery(store, queryName, input?)\`** — \`useSyncExternalStore\` wrapper over a service query. No Babel transform, no \`useSignals()\` opt-in, works in any React 18+ tree. Two overloads: tuple form requires input, no-input form mirrors the runtime for \`input: z.void()\` queries.
- **Reactivity model.** Per \`(query, input)\` we build a \`computed(() => query(input))\`. \`computed\` memoises by reference equality on its output, so the component re-renders only when *this query's* result actually changes — no extra dedup layer needed. Unrelated mutations to the same service (a different slice, a structurally-equal write) don't trigger renders. The \`effect()\` we install reads the computed (registering the dependency) and forwards changes to React's listener; the effect's mandatory synchronous first-fire is swallowed so React doesn't see a phantom store update on mount.
- **\`getSnapshot\` is an untracked read** of the memoised computed value, called outside of any tracked context — no subscription side-effect from \`useSyncExternalStore\`'s snapshot reads.
- **Memoise object inputs at the call site.** The input participates in the hook's deps; passing a new object literal each render rebuilds the computed + subscription. For complex inputs wrap in \`useMemo\`, or pass primitives. README documents this.

## Test plan

- [x] \`yarn test src/service/\` passes — \`use-service-query.test.tsx\` covers initial render (no-input + input-keyed), reactivity (re-render on relevant change, no re-render on unrelated slice, no re-render on structurally-equal write), input changes between renders (immediate snapshot for new input), and preload firing on subscribe.
- [x] No lints across \`code/core/src/service/\`.
- [ ] Review the call-site memoisation guidance — could we add a lint rule, or is README documentation enough?
- [ ] Confirm we want \`useServiceQuery\` exported from \`storybook/internal/service\` and not behind a separate React entry point.

## README

"Coming in later stages" is replaced with a "React" section documenting the hook, the no-input overload, and the call-site memoisation guidance. This closes out the stack — README now covers stages 1–4 in full.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the useServiceQuery React hook for subscribing to service query results in components.

* **Documentation**
  * Service docs updated with a dedicated React section, usage examples, memoization/input guidance, no-input overload, and the public surface listing.
  * Examples and docs now use the "handler" terminology for query definitions.

* **Tests**
  * Added/updated test coverage validating initial value, re-render behavior, input-change handling, and preload-on-subscribe behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->