### PR TITLE
fix(web-components): preserve HTML in Show code for string stories

### DIFF
--- a/code/renderers/web-components/src/docs/sourceDecorator.test.ts
+++ b/code/renderers/web-components/src/docs/sourceDecorator.test.ts
@@ -82,6 +82,18 @@ describe('sourceDecorator', () => {
     expect(mockChannel.emit).not.toHaveBeenCalled();
   });
 
+  it('should use plain HTML string stories directly for source', async () => {
+    const storyFn = () => '<deepgram-header active="playground" debug="false"></deepgram-header>';
+    sourceDecorator(storyFn, mockContext as any);
+    await tick();
+
+    expect(render).not.toHaveBeenCalled();
+    expect(emitTransformCode).toHaveBeenCalledWith(
+      '<deepgram-header active="playground" debug="false"></deepgram-header>',
+      mockContext
+    );
+  });
+
   it('should handle DocumentFragment stories', async () => {
     const fragment = document.createDocumentFragment();
     const element = document.createElement('test-element');

--- a/code/renderers/web-components/src/docs/sourceDecorator.ts
+++ b/code/renderers/web-components/src/docs/sourceDecorator.ts
@@ -41,13 +41,20 @@ export function sourceDecorator(
   });
 
   if (!skipSourceRender(context)) {
-    const container = window.document.createElement('div');
-    if (renderedForSource instanceof DocumentFragment) {
-      render(renderedForSource.cloneNode(true), container);
+    if (typeof renderedForSource === 'string') {
+      // Plain HTML string stories (common in web-components) should not be
+      // rendered into a container just to read innerHTML — lit treats strings
+      // as text nodes, which escapes tags into entities in the source panel.
+      source = renderedForSource.replace(LIT_EXPRESSION_COMMENTS, '');
     } else {
-      render(renderedForSource, container);
+      const container = window.document.createElement('div');
+      if (renderedForSource instanceof DocumentFragment) {
+        render(renderedForSource.cloneNode(true), container);
+      } else {
+        render(renderedForSource, container);
+      }
+      source = container.innerHTML.replace(LIT_EXPRESSION_COMMENTS, '');
     }
-    source = container.innerHTML.replace(LIT_EXPRESSION_COMMENTS, '');
   }
 
   return story;


### PR DESCRIPTION
## Summary

Fixes #30705

When a Web Components story uses a plain HTML string as `render`, the Docs "Show code" panel displayed escaped entities (`&lt;tag&gt;`) instead of readable HTML.

The source decorator was routing string stories through `lit`'s `render()`, which treats strings as text content and escapes them in `innerHTML`. This change uses plain string stories directly as source output.

## Changes

- `sourceDecorator.ts`: skip lit rendering when `renderedForSource` is already a string
- `sourceDecorator.test.ts`: regression test for string HTML stories

## Surface area

- Web Components renderer docs source generation only
- No runtime story rendering changes

## Validation

- Added unit test: `should use plain HTML string stories directly for source`
- Pre-commit lint/format passed locally

Closes #30705

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved source code display for web component stories using plain HTML strings, ensuring accurate rendering and proper marker removal.

* **Tests**
  * Added test coverage for source decorator handling of HTML string stories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->