### PR TITLE
fix(core): add .tsx fallback in manifest resolveImport

### DIFF
--- a/code/core/src/common/utils/__tests__/resolve-import.test.ts
+++ b/code/core/src/common/utils/__tests__/resolve-import.test.ts
@@ -1,0 +1,28 @@
+import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveImport } from '../interpret-files.ts';
+
+describe('resolveImport', () => {
+  it('resolves .js imports to .tsx files when .ts is missing', () => {
+    const basedir = mkdtempSync(join(tmpdir(), 'storybook-resolve-import-'));
+    writeFileSync(join(basedir, 'Chip.tsx'), 'export const Chip = () => null;');
+
+    const resolved = resolveImport('./Chip.js', { basedir });
+
+    expect(resolved).toEqual(join(realpathSync(basedir), 'Chip.tsx'));
+  });
+
+  it('prefers .ts over .tsx when both exist for a .js import', () => {
+    const basedir = mkdtempSync(join(tmpdir(), 'storybook-resolve-import-'));
+    writeFileSync(join(basedir, 'Chip.ts'), 'export const Chip = () => null;');
+    writeFileSync(join(basedir, 'Chip.tsx'), 'export const Chip = () => null;');
+
+    const resolved = resolveImport('./Chip.js', { basedir });
+
+    expect(resolved).toEqual(join(realpathSync(basedir), 'Chip.ts'));
+  });
+});

--- a/code/core/src/common/utils/interpret-files.ts
+++ b/code/core/src/common/utils/interpret-files.ts
@@ -32,16 +32,21 @@ export function resolveImport(id: string, options: ResolveImportOptions): string
     // a TypeScript file. This can happen in ES modules as TypeScript requires to import other
     // TypeScript files with .js extensions
     // https://www.typescriptlang.org/docs/handbook/esm-node.html#type-in-packagejson-and-new-extensions
-    const newId = ['.js', '.mjs', '.cjs'].includes(ext)
-      ? `${id.slice(0, -2)}ts`
-      : ext === '.jsx'
-        ? `${id.slice(0, -3)}tsx`
-        : null;
+    if (['.js', '.mjs', '.cjs'].includes(ext)) {
+      const base = id.slice(0, -2);
 
-    if (!newId) {
-      throw error;
+      try {
+        return resolveSync(`${base}ts`, options.basedir);
+      } catch {
+        return resolveSync(`${base}tsx`, options.basedir);
+      }
     }
-    return resolveSync(newId, options.basedir);
+
+    if (ext === '.jsx') {
+      return resolveSync(`${id.slice(0, -3)}tsx`, options.basedir);
+    }
+
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #34812

PR #34393 added a `.ts`-then-`.tsx` fallback for docgen resolvers, but the same pattern was missing in `resolveImport()` used by the manifest's `getComponents()`.

When a story imports `./Chip.js` but the component file is `Chip.tsx`, the manifest debugger reported "No component file found" even though the story rendered correctly.

## Changes

- `interpret-files.ts`: try `.ts` then `.tsx` when resolving `.js`/`.mjs`/`.cjs` imports
- `resolve-import.test.ts`: regression tests for `.tsx` fallback and `.ts` preference

## Surface area

- Manifest component resolution (`storybook/internal/common`)
- No change to webpack/vite story rendering

## Validation

- `vitest run src/common/utils/__tests__/resolve-import.test.ts` — 2 tests pass
- Pre-commit lint/format passed locally

Closes #34812

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced import resolution with intelligent fallback handling for TypeScript file variants. The system now more reliably resolves imports across different module formats and file extensions.

* **Tests**
  * Added test coverage for import path resolution behavior, verifying correct resolution across multiple file type scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->