### PR TITLE
test(docs): assert independent radio groups across duplicate Controls blocks

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Controls.stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Controls.stories.tsx
@@ -4,7 +4,7 @@ import type { PlayFunctionContext } from 'storybook/internal/csf';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { expect, within } from 'storybook/test';
+import { expect, userEvent } from 'storybook/test';
 
 import * as ExampleStories from '../examples/ControlsParameters.stories';
 import * as SubcomponentsExampleStories from '../examples/ControlsWithSubcomponentsParameters.stories';
@@ -185,13 +185,14 @@ export const MultipleControlsOnSamePage: Story = {
 /**
  * When multiple Controls blocks for the SAME story are on the same docs page, each control should
  * still have a unique id (and unique name across blocks, so that radio button groups remain
- * independent). This verifies the fix for https://github.com/storybookjs/storybook/issues/29295.
+ * independent). This verifies the fix for https://github.com/storybookjs/storybook/issues/29295
+ * and https://github.com/storybookjs/storybook/issues/34864.
  */
 export const MultipleControlsForSameStoryOnSamePage: Story = {
   render: () => (
     <>
-      <Controls of={ExampleStories.NoParameters} />
-      <Controls of={ExampleStories.NoParameters} />
+      <Controls of={ExampleStories.WithInlineRadio} />
+      <Controls of={ExampleStories.WithInlineRadio} />
     </>
   ),
   play: async ({ canvasElement }) => {
@@ -201,5 +202,29 @@ export const MultipleControlsForSameStoryOnSamePage: Story = {
     const uniqueIds = new Set(allIds);
     await expect(allIds.length).toBeGreaterThan(0);
     await expect(uniqueIds.size).toBe(allIds.length);
+
+    const radioInputs = Array.from(
+      canvasElement.querySelectorAll<HTMLInputElement>('input[type="radio"]')
+    );
+    const radioNames = radioInputs.map((input) => input.name);
+    await expect(radioNames.length).toBeGreaterThan(0);
+    await expect(new Set(radioNames).size).toBe(radioNames.length);
+
+    const tables = canvasElement.querySelectorAll('.docblock-argstable');
+    await expect(tables.length).toBe(2);
+
+    const getCheckedValues = (table: Element) =>
+      Array.from(table.querySelectorAll<HTMLInputElement>('input[type="radio"]:checked')).map(
+        (input) => input.value
+      );
+
+    const firstBlockRadios = tables[0].querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    const secondBlockRadios = tables[1].querySelectorAll<HTMLInputElement>('input[type="radio"]');
+
+    await userEvent.click(firstBlockRadios[1]);
+    await userEvent.click(secondBlockRadios[2]);
+
+    await expect(getCheckedValues(tables[0])).toEqual(['medium']);
+    await expect(getCheckedValues(tables[1])).toEqual(['large']);
   },
 };

--- a/code/addons/docs/src/blocks/examples/ControlsParameters.stories.tsx
+++ b/code/addons/docs/src/blocks/examples/ControlsParameters.stories.tsx
@@ -33,6 +33,16 @@ export const NoParameters: Story = {
   },
 };
 
+export const WithInlineRadio: Story = {
+  args: { a: 'small' },
+  argTypes: {
+    a: {
+      control: { type: 'inline-radio' },
+      options: ['small', 'medium', 'large'],
+    },
+  },
+};
+
 export const Include: Story = {
   ...NoParameters,
   parameters: { docs: { controls: { include: ['a'] } } },


### PR DESCRIPTION
## Summary

- Extend `MultipleControlsForSameStoryOnSamePage` to render duplicate `<Controls />` blocks with `inline-radio` args
- Assert each radio group's `name` attribute is unique per Controls instance
- Assert selecting a radio in one block does not change the selection in the other

The underlying fix landed in #34793 (`controlsId` via `useId()`); this adds regression coverage for the radio `name` collision reported in #34864 / #29295.

## Test plan

- [x] Story play function covers unique IDs, unique radio `name`s, and independent selection behavior
- [ ] CI (awaiting maintainer `bug` + `ci:normal` labels for Danger JS)

Closes #34864

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new story example demonstrating inline radio control functionality with multiple selection options.

* **Tests**
  * Enhanced test coverage for Controls blocks to verify multiple independent controls work correctly on the same page.
  * Expanded test assertions to validate unique control identifiers and independent state management across controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->