### PR TITLE
Core: Infer select control for large optional union types

### DIFF
--- a/code/core/src/preview-api/modules/store/inferControls.test.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.test.ts
@@ -133,4 +133,84 @@ describe('inferControls', () => {
     expect(Object.keys(excludeArray)).toEqual(['labelName', 'borderWidth']);
     expect(Object.keys(excludeRegex)).toEqual(['borderWidth']);
   });
+
+  describe('union type inference', () => {
+    it('should infer select control for literal unions with > 5 items', () => {
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            size: {
+              type: {
+                name: 'union',
+                value: [
+                  { name: 'literal', value: '"small"' },
+                  { name: 'literal', value: '"medium"' },
+                  { name: 'literal', value: '"large"' },
+                  { name: 'literal', value: '"xlarge"' },
+                  { name: 'literal', value: '"xxlarge"' },
+                  { name: 'literal', value: '"xxxlarge"' },
+                  { name: 'other', value: 'undefined' },
+                ],
+              },
+              name: 'size',
+            },
+          },
+        })
+      );
+
+      expect(inferredControls.size.control).toEqual({ type: 'select' });
+      expect(inferredControls.size.options).toEqual([
+        'small',
+        'medium',
+        'large',
+        'xlarge',
+        'xxlarge',
+        'xxxlarge',
+      ]);
+    });
+
+    it('should infer radio control for literal unions with <= 5 items', () => {
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            theme: {
+              type: {
+                name: 'union',
+                value: [
+                  { name: 'literal', value: '"light"' },
+                  { name: 'literal', value: '"dark"' },
+                  { name: 'other', value: 'void' },
+                ],
+              },
+              name: 'theme',
+            },
+          },
+        })
+      );
+
+      expect(inferredControls.theme.control).toEqual({ type: 'radio' });
+      expect(inferredControls.theme.options).toEqual(['light', 'dark']);
+    });
+
+    it('should fallback to object control for complex mixed unions', () => {
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            custom: {
+              type: {
+                name: 'union',
+                value: [
+                  { name: 'literal', value: '"simple"' },
+                  { name: 'object', value: { x: { name: 'number' } } },
+                ],
+              },
+              name: 'custom',
+            },
+          },
+        })
+      );
+
+      expect(inferredControls.custom.control).toEqual({ type: 'object' });
+    });
+  });
 });

--- a/code/core/src/preview-api/modules/store/inferControls.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.ts
@@ -3,6 +3,8 @@ import type {
   ArgTypesEnhancer,
   Renderer,
   SBEnumType,
+  SBUnionType,
+  SBLiteralType,
   StrictInputType,
 } from 'storybook/internal/types';
 
@@ -54,6 +56,51 @@ const inferControl = (argType: StrictInputType, name: string, matchers: Controls
     case 'enum': {
       const { value } = type as SBEnumType;
       return { control: { type: value?.length <= 5 ? 'radio' : 'select' }, options: value };
+    }
+    case 'union': {
+      const { value } = type as SBUnionType;
+      if (!value || !Array.isArray(value)) {
+        return { control: { type: 'object' } };
+      }
+
+      const QUOTE_REGEX = /^['"]|['"]$/g;
+      const trimQuotes = (str: string) => str.replace(QUOTE_REGEX, '');
+      const includesQuotes = (str: string) => QUOTE_REGEX.test(str);
+
+      const inferredOptions = (
+        value.filter((val) => {
+          if (val.name === 'literal') {
+            return val.value !== undefined && val.value !== null;
+          }
+          return false;
+        }) as SBLiteralType[]
+      ).map((val: SBLiteralType) => {
+        const v = val.value;
+        if (typeof v === 'string') {
+          const trimmedValue = trimQuotes(v);
+          return includesQuotes(v) || Number.isNaN(Number(trimmedValue))
+            ? (trimmedValue === 'true' ? true : trimmedValue === 'false' ? false : trimmedValue)
+            : Number(trimmedValue);
+        }
+        return v;
+      });
+
+      const hasComplexTypes = value.some((val) => {
+        if (val.name === 'literal') return false;
+        if (val.name === 'other') {
+          return val.value !== 'undefined' && val.value !== 'void' && val.value !== 'null';
+        }
+        return true;
+      });
+
+      if (inferredOptions.length > 0 && !hasComplexTypes) {
+        return {
+          control: { type: inferredOptions.length <= 5 ? 'radio' : 'select' },
+          options: inferredOptions,
+        };
+      }
+
+      return { control: { type: 'object' } };
     }
     case 'function':
     case 'symbol':


### PR DESCRIPTION
Fixes #12641.

When a TypeScript property is an optional union type (e.g. `size?: 'small' | 'medium' | 'large' | ...`) or a large keyof union, Storybook's `inferControls` would sometimes fall back to an `object` control instead of a `select` or `radio` control. This occurred because optional properties include `undefined` (or `void`/`null`), which was treated as part of a complex union, triggering the fallback.

### Solution
- Updated the `union` case in `inferControls.ts`.
- Extracted and filtered literal options, ignoring auxiliary types like `undefined`, `void`, and `null` when determining if a union is complex.
- Cleaned string literals (removing enclosing quotes).
- If only literal options (and ignorable auxiliary types) are present, correctly infer either `radio` (length <= 5) or `select` (length > 5) control.
- Added comprehensive unit tests in `inferControls.test.ts` covering both simple, large literal unions and fallback logic for truly complex unions.

### Verification
Passed all new and existing unit tests in `inferControls.test.ts` successfully.

#### Manual testing
1. Run the existing and new unit tests in the core-server package:
```bash
yarn test inferControls.test.ts
```
2. Create a story with a component having a property typed as a large optional literal union (e.g., `type?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'warning' | 'success'`).
3. Verify that Storybook correctly infers a `select` control for this property, instead of falling back to an `object` input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inferring controls from union types in component arguments. The system automatically selects radio controls for unions with 5 or fewer members, select controls for larger unions, and falls back to object controls for complex mixed types.

* **Tests**
  * Added test coverage for union type inference scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->