### PR TITLE
CLI: Correct sb package metadata links

### DIFF
--- a/code/lib/cli-sb/package.json
+++ b/code/lib/cli-sb/package.json
@@ -10,14 +10,14 @@
     "upgrade",
     "init"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/lib/cli-sb",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/lib/cli-storybook",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/storybookjs/storybook.git",
-    "directory": "code/lib/cli-sb"
+    "directory": "code/lib/cli-storybook"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
## Problem

The `sb` package metadata points GitHub users to `code/lib/cli-sb`, while the related `@storybook/cli` package lives under `code/lib/cli-storybook`. This leaves the package homepage and repository directory inconsistent with the source package referenced in #31800.

## Solution

Updated `code/lib/cli-sb/package.json` so both `homepage` and `repository.directory` point to `code/lib/cli-storybook`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I validated `code/lib/cli-sb/package.json` as JSON and reviewed the package metadata diff manually.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes.
- [ ] Make sure this PR contains one of the labels below: `bug`, `maintenance`, `dependencies`, `build`, `cleanup`, `documentation`, `feature request`, `BREAKING CHANGE`, `other`.

Closes #31800