### PR TITLE
open-service [exploration]: drop implicit dep tracking and cycle detection from .loaded()

### DIFF
--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -230,17 +230,6 @@ export class OpenServiceAsyncSchemaError extends StorybookError {
   }
 }
 
-export class OpenServiceLoadedDrainExceededError extends StorybookError {
-  constructor(public data: { serviceId: ServiceId; name: string; iterations: number }) {
-    super({
-      name: 'OpenServiceLoadedDrainExceededError',
-      category: Category.CORE_COMMON,
-      code: 11,
-      message: `Query "${data.serviceId}.${data.name}".loaded(...) did not settle after ${data.iterations} drain iterations. Check for handlers that keep discovering new dependencies after every state change.`,
-    });
-  }
-}
-
 export class WebpackMissingStatsError extends StorybookError {
   constructor() {
     super({

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -158,17 +158,22 @@ When a server registers a service definition:
 
 `service-runtime.ts` owns one process-global in-flight load registry keyed by `${serviceId}::${queryName}::${stableHash(parsedInput)}`. The hash uses stable JSON (sorted keys) computed from the post-validation parsed input, so inputs are expected to be JSON-safe. Two concurrent callers for the same key share one load; once it settles, the entry is removed so future calls can refire it. There is no caller-facing invalidation API.
 
-## `.loaded()` Drain
+## `.loaded()` Semantics
 
-`query.loaded(input)` returns a promise that settles only when the load body and every dependency the handler reads are fully populated:
+`query.loaded(input)` is intentionally narrow: it awaits **only this query's own** `load` (deduped via the in-flight registry), then returns the synchronous handler result.
 
-1. Trigger this query's own `load` (deduped).
-2. Drain the collected loads via `Promise.allSettled`, surfacing any rejection (the rest are attached as `cause.aggregated`).
-3. Run the handler under a session that tracks dependency reads. The handler's sync reads of dependencies fire their loads and register the promises into the session collector — provided the dependency's load key is not already on the session's ancestor chain (cycle detection) and not in the session's settled-keys set (no refire of already-completed loads).
-4. If the discovery pass added more entries, drain again and re-run the handler. Loop until a discovery pass adds nothing new.
-5. Run the handler one final time without the session and return the validated output.
+Dependencies are **not** discovered automatically. A query whose handler reads from another query is responsible for awaiting that dependency inside its own `load`:
 
-The drain loop is capped at 32 iterations. Buggy oscillation (e.g. a handler that reads a query with an ever-changing input key) throws `OpenServiceLoadedDrainExceededError` instead of hanging.
+```ts
+load: async (input, ctx) => {
+  // Explicit chain — must mirror what the handler reads.
+  await ctx.getService('other-service').queries.someQuery.loaded(input);
+}
+```
+
+If a load forgets to chain a dependency, `.loaded()` returns whatever the handler can read from the current state — possibly a partial value (often `null`). Author-side tests that assert the loaded value catch missing chains quickly.
+
+There is no cycle detection. Authors who write self-awaiting load chains (`a.load` awaits `b.loaded`, `b.load` awaits `a.loaded`) get a real promise deadlock — surface those bugs through tests.
 
 ## Subscription Flow
 

--- a/code/core/src/shared/open-service/service-runtime.test.ts
+++ b/code/core/src/shared/open-service/service-runtime.test.ts
@@ -405,12 +405,16 @@ describe('service runtime', () => {
     });
   });
 
-  describe('loaded() drain', () => {
-    it('awaits a transitive dependency before returning', async () => {
+  describe('loaded() — explicit dependency chaining', () => {
+    it('returns a partial value when the load does not explicitly await the dependency', async () => {
+      // This is the "breakage" case after dropping implicit dep tracking:
+      // the handler reads a source query whose data has not been loaded yet, but the load body
+      // does not await it. .loaded() therefore returns whatever the handler reads from the
+      // current (empty) state.
       const sourceService = registerService(awaitedPreloadValueServiceDef);
       const derivedDef = defineService({
-        id: 'test/derived-loaded-from-source',
-        description: 'Reads the loaded value from the source service through a query.',
+        id: 'test/derived-without-explicit-chain',
+        description: 'Handler reads a source query but the load body does not await its .loaded().',
         initialState: {} as Record<string, never>,
         queries: {
           getLength: {
@@ -419,6 +423,39 @@ describe('service runtime', () => {
             handler: (input) => {
               const value = sourceService.queries.getPreloadedValue({ entryId: input.entryId });
               return value === null ? 0 : value.length;
+            },
+            // No load. The runtime cannot discover the source dep on its own.
+          },
+        },
+        commands: {},
+      });
+      const derivedService = registerService(derivedDef);
+
+      // First call reports the partial value (0) because the source's load has not settled yet.
+      await expect(derivedService.queries.getLength.loaded({ entryId: 'entry-a' })).resolves.toBe(
+        0
+      );
+    });
+
+    it('returns the fully resolved value when the load chains the dependency explicitly', async () => {
+      const sourceService = registerService(awaitedPreloadValueServiceDef);
+      const derivedDef = defineService({
+        id: 'test/derived-with-explicit-chain',
+        description: 'Handler reads a source query and the load awaits its .loaded() explicitly.',
+        initialState: {} as Record<string, never>,
+        queries: {
+          getLength: {
+            input: v.object({ entryId: v.string() }),
+            output: v.number(),
+            handler: (input) => {
+              const value = sourceService.queries.getPreloadedValue({ entryId: input.entryId });
+              return value === null ? 0 : value.length;
+            },
+            // Explicit chain — author signals the dependency in the load body.
+            load: async (input, ctx) => {
+              await ctx
+                .getService('test/awaited-preload-value')
+                .queries.getPreloadedValue.loaded(input);
             },
           },
         },
@@ -431,7 +468,7 @@ describe('service runtime', () => {
       );
     });
 
-    it('surfaces rejections from a transitive load through .loaded()', async () => {
+    it('surfaces rejections from this query.load through .loaded()', async () => {
       const failingDef = defineService({
         id: 'test/failing-loaded',
         description: 'Rejects from the load body to exercise .loaded() error propagation.',
@@ -451,105 +488,6 @@ describe('service runtime', () => {
       const service = registerService(failingDef);
 
       await expect(service.queries.getValue.loaded(undefined)).rejects.toThrow('boom');
-    });
-
-    it('breaks a load cycle without deadlocking', async () => {
-      const cycleDef = defineService({
-        id: 'test/load-cycle',
-        description: 'Two queries whose loads call each other through self.queries.',
-        initialState: { aDone: false, bDone: false },
-        queries: {
-          a: {
-            input: v.undefined(),
-            output: v.boolean(),
-            handler: (_input, ctx) => ctx.self.state.aDone,
-            load: async (_input, ctx) => {
-              // Reading b inside a's load would normally also await b's load — but since b's load
-              // would in turn read a (the running ancestor), the runtime must break the cycle.
-              ctx.self.queries.b(undefined);
-              await ctx.self.commands.markA(undefined);
-            },
-          },
-          b: {
-            input: v.undefined(),
-            output: v.boolean(),
-            handler: (_input, ctx) => ctx.self.state.bDone,
-            load: async (_input, ctx) => {
-              ctx.self.queries.a(undefined);
-              await ctx.self.commands.markB(undefined);
-            },
-          },
-        },
-        commands: {
-          markA: {
-            input: v.undefined(),
-            output: v.void(),
-            handler: (_input, ctx) => {
-              ctx.self.setState((draft) => {
-                draft.aDone = true;
-              });
-            },
-          },
-          markB: {
-            input: v.undefined(),
-            output: v.void(),
-            handler: (_input, ctx) => {
-              ctx.self.setState((draft) => {
-                draft.bDone = true;
-              });
-            },
-          },
-        },
-      });
-      const service = registerService(cycleDef);
-
-      await expect(service.queries.a.loaded(undefined)).resolves.toBe(true);
-      expect(service.queries.b(undefined)).toBe(true);
-    });
-
-    it('throws OpenServiceLoadedDrainExceededError on persistent oscillation', async () => {
-      const oscillatingDef = defineService({
-        id: 'test/oscillating-load',
-        description: 'Handler reads a dynamic-keyed query on every discovery pass.',
-        initialState: { counter: 0 },
-        queries: {
-          getCounter: {
-            input: v.undefined(),
-            output: v.number(),
-            handler: (_input, ctx) => {
-              // Each discovery pass produces a fresh input key, so the runtime can never observe
-              // a stable set of dependencies — the drain loop hits its iteration cap.
-              ctx.self.queries.dynamic({ tick: ctx.self.state.counter });
-              return ctx.self.state.counter;
-            },
-          },
-          dynamic: {
-            input: v.object({ tick: v.number() }),
-            output: v.number(),
-            handler: (input) => input.tick,
-            load: async (_input, ctx) => {
-              await ctx.self.commands.bump(undefined);
-            },
-          },
-        },
-        commands: {
-          bump: {
-            input: v.undefined(),
-            output: v.void(),
-            handler: (_input, ctx) => {
-              ctx.self.setState((draft) => {
-                draft.counter += 1;
-              });
-            },
-          },
-        },
-      });
-      const service = registerService(oscillatingDef);
-
-      await expect(service.queries.getCounter.loaded(undefined)).rejects.toMatchObject({
-        fromStorybook: true,
-        code: 11,
-      });
     });
   });
 });

--- a/code/core/src/shared/open-service/service-runtime.ts
+++ b/code/core/src/shared/open-service/service-runtime.ts
@@ -68,6 +68,7 @@ const inFlightLoads = new Map<string, Promise<unknown>>();
 function stableHash(value: unknown): string {
   return JSON.stringify(value, (_key, raw) => {
     if (raw === undefined) {
+      // `JSON.stringify` would otherwise drop `undefined` from object values silently.
       return '__undefined__';
     }
     if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
@@ -97,6 +98,8 @@ function normalizeStaticStoragePath(serviceId: ServiceId, name: string, rawPath:
     .split('/')
     .filter((segment) => segment.length > 0 && segment !== '.');
 
+  // Keep static snapshot keys relative so server-side writers can always anchor them under the
+  // build output, regardless of whether authors used '/', './', or Windows-style separators.
   if (segments.length === 0 || segments.some((segment) => segment === '..')) {
     throw new OpenServiceInvalidStaticPathError({ serviceId, name, path: rawPath });
   }
@@ -128,6 +131,7 @@ function createCommandSelf<TState>(stateSignal: ServiceSignal<TState>): CommandS
       return stateSignal();
     },
     setState(mutate) {
+      // Batch signal writes so one command only triggers subscribers after the full draft update.
       startBatch();
       try {
         stateSignal(produce(stateSignal(), mutate));
@@ -142,6 +146,9 @@ function createCommandSelf<TState>(stateSignal: ServiceSignal<TState>): CommandS
 
 /**
  * Builds the runtime command map from the declarative command definitions.
+ *
+ * Each runtime command validates raw caller input, invokes the handler with parsed values, and
+ * validates the resolved output before returning it to the caller.
  */
 function buildCommands<TState>(
   serviceId: ServiceId,
@@ -181,6 +188,12 @@ function buildCommands<TState>(
   );
 }
 
+/**
+ * Captures the per-runtime data needed by query helpers that operate across multiple queries.
+ *
+ * Bundling the references lets `createDefaultQuery`, `runLoadBody`, and `runLoaded` share the
+ * same closure shape without each one re-deriving the per-service callbacks.
+ */
 type QueryRuntimeRefs<TState> = {
   serviceId: ServiceId;
   commandSelf: CommandSelf<TState>;
@@ -190,6 +203,10 @@ type QueryRuntimeRefs<TState> = {
   defaultQueries: Record<string, Query<unknown, unknown>>;
 };
 
+/**
+ * Validates query input synchronously, falling through to the dedicated async-schema error if a
+ * schema returns a Promise.
+ */
 function validateQueryInput<TState>(
   refs: QueryRuntimeRefs<TState>,
   queryName: string,
@@ -218,6 +235,13 @@ function validateQueryOutput<TState>(
   });
 }
 
+/**
+ * Runs the query handler synchronously and validates the resolved value.
+ *
+ * Handlers always see `refs.defaultQueries` on `ctx.self.queries`; load bodies do not get a
+ * different map here because dependency tracking is explicit in this branch (authors chain
+ * `.loaded()` themselves).
+ */
 function runHandlerSync<TState>(
   refs: QueryRuntimeRefs<TState>,
   queryName: string,
@@ -268,9 +292,15 @@ function triggerLoad<TState>(
     return existing;
   }
 
+  // Register the promise into `inFlightLoads` BEFORE the body runs so any reentrant query call
+  // made inside the body's synchronous prefix sees this load as in-flight and reuses the same
+  // promise instead of starting a duplicate run. The body is wrapped in `Promise.resolve().then`
+  // to enforce a microtask boundary between registration and execution.
   const promise = Promise.resolve()
     .then(() => runLoadBody(refs, queryName, queryDef, validatedInput))
     .finally(() => {
+      // Only clear the entry if it still points at this promise — another caller may have already
+      // overwritten it with a fresh in-flight load for the next round.
       if (inFlightLoads.get(loadKey) === promise) {
         inFlightLoads.delete(loadKey);
       }
@@ -352,6 +382,7 @@ function createDefaultQuery<TState>(
 
     if (queryDef.load) {
       const loadKey = makeLoadKey(refs.serviceId, queryName, validatedInput);
+      // Background fire-and-forget: surface failures so they are not silently swallowed.
       triggerLoad(refs, queryName, queryDef, validatedInput, loadKey).catch(rethrowAsync);
     }
 
@@ -398,6 +429,7 @@ function subscribeToQuery<TState>(
 
     if (queryDef.load) {
       const loadKey = makeLoadKey(refs.serviceId, queryName, validatedInput);
+      // Subscribers do not block on rejections, but we still want them visible to global handlers.
       triggerLoad(refs, queryName, queryDef, validatedInput, loadKey).catch(rethrowAsync);
     }
 
@@ -437,6 +469,8 @@ function buildQueries<TState>(
 
 /**
  * Creates the full runtime backing for a service definition.
+ *
+ * Callers must supply the registry API that query and command contexts should expose.
  */
 export function createServiceRuntime<
   TState,
@@ -449,6 +483,7 @@ export function createServiceRuntime<
   },
   initialState: TState = def.initialState
 ): ServiceRuntime<TState, TQueries, TCommands> {
+  // The signal is the single source of truth that query computations subscribe to.
   const stateSignal = signal<TState>(initialState);
   const commandSelf = createCommandSelf(stateSignal);
   const { registryApi } = runtimeOptions;
@@ -477,6 +512,7 @@ export function createServiceRuntime<
     defaultQueries,
   };
 
+  // Build queries after commands so handler and load ctx surfaces resolve the same command map.
   const builtQueries = buildQueries(refs);
   for (const [name, query] of Object.entries(builtQueries)) {
     defaultQueries[name] = query;
@@ -502,6 +538,13 @@ export function createServiceRuntime<
     getService: registryApi.getService,
   };
 
+  /**
+   * Runs one query's `load` body against this runtime instance.
+   *
+   * Used by the static build pipeline to populate state for a single input without holding the
+   * load in the process-global in-flight registry afterwards. Dependencies inside the load body
+   * are awaited if (and only if) the author explicitly chained them via `.loaded()`.
+   */
   const runLoadOnce = async (queryName: string, validatedInput: unknown): Promise<void> => {
     const queryDef = queryDefinitions.get(queryName);
 

--- a/code/core/src/shared/open-service/service-runtime.ts
+++ b/code/core/src/shared/open-service/service-runtime.ts
@@ -3,7 +3,6 @@ import { computed, effect, endBatch, signal, startBatch } from 'alien-signals';
 
 import {
   OpenServiceInvalidStaticPathError,
-  OpenServiceLoadedDrainExceededError,
   OpenServiceUnimplementedOperationError,
 } from '../../server-errors.ts';
 import { rethrowAsync, validateSchema, validateSchemaSync } from './service-validation.ts';
@@ -50,30 +49,6 @@ export type ServiceRuntime<
   runLoadOnce(queryName: string, validatedInput: unknown): Promise<void>;
 };
 
-/** Max number of drain iterations before `.loaded()` gives up to avoid infinite oscillation. */
-const MAX_DRAIN_ITERATIONS = 32;
-
-/**
- * One pending load promise plus the load key that identifies it for cycle and dedup checks.
- *
- * The key is stored alongside the promise so collectors can be drained and marked settled in one
- * pass without re-deriving the key from the promise after the fact.
- */
-type CollectorEntry = { key: string; promise: Promise<unknown> };
-
-/**
- * State shared by every sync handler call inside one `.loaded()` invocation.
- *
- * The session tracks the set of load keys that are ancestors in the call chain (for cycle
- * detection), the loads collected during this iteration (waiting to be drained), and the load
- * keys that have already settled in this session so re-running the handler does not refire them.
- */
-type LoadedSession = {
-  ancestorChain: ReadonlySet<string>;
-  collector: Set<CollectorEntry>;
-  settledKeys: Set<string>;
-};
-
 /**
  * Process-global registry of in-flight `load` promises keyed by `${serviceId}::${queryName}::${hash}`.
  *
@@ -82,17 +57,6 @@ type LoadedSession = {
  * queries that depend on the same dependency share one load.
  */
 const inFlightLoads = new Map<string, Promise<unknown>>();
-
-/**
- * Active session for `.loaded()` while a sync handler is being re-run for dependency discovery.
- *
- * Default query functions consult this variable to know whether to register their load promise
- * into a caller-owned collector. Sync handlers don't `await`, so the variable is stable for the
- * duration of one handler call and can safely live at module scope.
- */
-let activeHandlerLoadSession: LoadedSession | undefined;
-
-const EMPTY_SET: ReadonlySet<string> = new Set();
 
 /**
  * Returns a deterministic JSON encoding so the same logical input always produces the same key.
@@ -104,7 +68,6 @@ const EMPTY_SET: ReadonlySet<string> = new Set();
 function stableHash(value: unknown): string {
   return JSON.stringify(value, (_key, raw) => {
     if (raw === undefined) {
-      // `JSON.stringify` would otherwise drop `undefined` from object values silently.
       return '__undefined__';
     }
     if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
@@ -134,8 +97,6 @@ function normalizeStaticStoragePath(serviceId: ServiceId, name: string, rawPath:
     .split('/')
     .filter((segment) => segment.length > 0 && segment !== '.');
 
-  // Keep static snapshot keys relative so server-side writers can always anchor them under the
-  // build output, regardless of whether authors used '/', './', or Windows-style separators.
   if (segments.length === 0 || segments.some((segment) => segment === '..')) {
     throw new OpenServiceInvalidStaticPathError({ serviceId, name, path: rawPath });
   }
@@ -156,80 +117,6 @@ export function resolveStaticPath<TState>(
 }
 
 /**
- * Surfaces the first rejected settlement as the thrown error, aggregating the rest under `cause`.
- *
- * Drainers use `Promise.allSettled` so one rejected dependency does not prevent siblings from
- * finishing their work; this helper preserves all rejections without losing the primary one.
- */
-function surfaceRejections(settlements: PromiseSettledResult<unknown>[]): void {
-  const rejections = settlements.filter((s): s is PromiseRejectedResult => s.status === 'rejected');
-
-  if (rejections.length === 0) {
-    return;
-  }
-
-  const [first, ...rest] = rejections.map((r) => r.reason);
-
-  if (rest.length > 0) {
-    if (first instanceof Error) {
-      const aggregated = Reflect.get(first, 'cause');
-
-      if (aggregated === undefined) {
-        try {
-          Reflect.set(first, 'cause', { aggregated: rest });
-        } catch {
-          // Frozen errors keep their primary message; aggregated rejections are still observable
-          // through the `rest` array if a caller decides to traverse it themselves.
-        }
-      }
-    }
-  }
-
-  throw first;
-}
-
-/**
- * Drains a collector of pending load promises until no new entries appear.
- *
- * Each iteration snapshots the current entries, clears the collector, awaits them with
- * `Promise.allSettled`, marks their keys as settled (for caller bookkeeping), then loops if the
- * settled loads' bodies surfaced more entries. Caps at `MAX_DRAIN_ITERATIONS` to avoid hanging on
- * pathological oscillation.
- */
-async function drainCollector(
-  collector: Set<CollectorEntry>,
-  settledKeys: Set<string> | undefined,
-  serviceId: ServiceId,
-  queryName: string
-): Promise<void> {
-  let iterations = 0;
-
-  while (collector.size > 0) {
-    if (iterations++ > MAX_DRAIN_ITERATIONS) {
-      throw new OpenServiceLoadedDrainExceededError({
-        serviceId,
-        name: queryName,
-        iterations: MAX_DRAIN_ITERATIONS,
-      });
-    }
-
-    const pending = [...collector];
-    collector.clear();
-
-    const settlements = await Promise.allSettled(pending.map((entry) => entry.promise));
-
-    if (settledKeys) {
-      // Mark keys as settled even for rejected loads so the discovery loop does not refire them.
-      for (const entry of pending) {
-        settledKeys.add(entry.key);
-      }
-    }
-
-    surfaceRejections(settlements);
-  }
-}
-
-/**
  * Creates the writable `self` object that backs every runtime ctx for one service instance.
  *
  * State writes are wrapped in an alien-signals batch so one command can update multiple fields
@@ -241,7 +128,6 @@ function createCommandSelf<TState>(stateSignal: ServiceSignal<TState>): CommandS
       return stateSignal();
     },
     setState(mutate) {
-      // Batch signal writes so one command only triggers subscribers after the full draft update.
       startBatch();
       try {
         stateSignal(produce(stateSignal(), mutate));
@@ -256,9 +142,6 @@ function createCommandSelf<TState>(stateSignal: ServiceSignal<TState>): CommandS
 
 /**
  * Builds the runtime command map from the declarative command definitions.
- *
- * Each runtime command validates raw caller input, invokes the handler with parsed values, and
- * validates the resolved output before returning it to the caller.
  */
 function buildCommands<TState>(
   serviceId: ServiceId,
@@ -298,12 +181,6 @@ function buildCommands<TState>(
   );
 }
 
-/**
- * Captures the per-runtime data needed by query helpers that operate across multiple queries.
- *
- * Bundling the references lets `createDefaultQuery`, the load body wrapper, and `.loaded()` share
- * the same closure shape without each one re-deriving the per-service callbacks.
- */
 type QueryRuntimeRefs<TState> = {
   serviceId: ServiceId;
   commandSelf: CommandSelf<TState>;
@@ -313,10 +190,6 @@ type QueryRuntimeRefs<TState> = {
   defaultQueries: Record<string, Query<unknown, unknown>>;
 };
 
-/**
- * Validates query input synchronously, falling through to the dedicated async-schema error if a
- * schema returns a Promise.
- */
 function validateQueryInput<TState>(
   refs: QueryRuntimeRefs<TState>,
   queryName: string,
@@ -345,19 +218,11 @@ function validateQueryOutput<TState>(
   });
 }
 
-/**
- * Runs the query handler synchronously and validates the resolved value.
- *
- * The `selfQueries` parameter lets the caller swap in load-aware wrappers when running inside a
- * load body or a `.loaded()` discovery pass; ordinary handler calls pass the default queries.
- */
 function runHandlerSync<TState>(
   refs: QueryRuntimeRefs<TState>,
   queryName: string,
   queryDef: RuntimeQueryDefinition<TState>,
-  validatedInput: unknown,
-  selfQueries: Record<string, Query<unknown, unknown>>,
-  getService: ServiceRegistryApi['getService']
+  validatedInput: unknown
 ): unknown {
   if (!queryDef.handler) {
     throw new OpenServiceUnimplementedOperationError({
@@ -371,9 +236,12 @@ function runHandlerSync<TState>(
     get state() {
       return refs.stateSignal();
     },
-    queries: selfQueries,
+    queries: refs.defaultQueries,
   };
-  const handlerCtx: QueryCtx<TState> = { self: handlerSelf, getService };
+  const handlerCtx: QueryCtx<TState> = {
+    self: handlerSelf,
+    getService: refs.registryApi.getService,
+  };
   const result = queryDef.handler(validatedInput, handlerCtx);
 
   return validateQueryOutput(refs, queryName, queryDef, result);
@@ -382,31 +250,26 @@ function runHandlerSync<TState>(
 /**
  * Triggers a `load` if one is not already in flight for the same key.
  *
- * Returns the in-flight promise (whether newly created or reused). The parent caller passes its
- * own ancestor chain; the dependency runs with that chain extended by its own load key so any
- * transitive read of an ancestor's load short-circuits via cycle detection instead of deadlocking.
+ * Returns the in-flight promise (whether newly created or reused). The promise is registered into
+ * `inFlightLoads` before the body runs so synchronous reentrant calls during the body's prefix
+ * observe the load as in-flight and share the same promise. There is no cycle detection; authors
+ * who write self-awaiting load chains (`a.load` calls `b.loaded()` which calls `a.loaded()`) will
+ * deadlock — surface those bugs through tests.
  */
 function triggerLoad<TState>(
   refs: QueryRuntimeRefs<TState>,
   queryName: string,
   queryDef: RuntimeQueryDefinition<TState>,
   validatedInput: unknown,
-  loadKey: string,
-  parentAncestorChain: ReadonlySet<string>
+  loadKey: string
 ): Promise<unknown> {
   const existing = inFlightLoads.get(loadKey);
   if (existing) {
     return existing;
   }
 
-  const extendedChain = new Set(parentAncestorChain);
-  extendedChain.add(loadKey);
-
-  // Register the promise into `inFlightLoads` BEFORE the load body starts so any recursive query
-  // call made inside the body's synchronous prefix sees this load as in-flight and short-circuits
-  // via cycle detection instead of starting a duplicate run.
   const promise = Promise.resolve()
-    .then(() => runLoadBody(refs, queryName, queryDef, validatedInput, extendedChain))
+    .then(() => runLoadBody(refs, queryName, queryDef, validatedInput))
     .finally(() => {
       if (inFlightLoads.get(loadKey) === promise) {
         inFlightLoads.delete(loadKey);
@@ -418,197 +281,66 @@ function triggerLoad<TState>(
 }
 
 /**
- * Executes one `load` invocation with its own local collector and a wrapped `self`.
+ * Executes one `load` invocation against the runtime's default `self`.
  *
- * The wrapper around `self.queries` registers transitively triggered loads into the local
- * collector so the returned promise only resolves once every dependency the load body touched has
- * also settled. Cross-service `getService(...).queries.*` calls are intentionally not wrapped —
- * authors must use `.loaded()` when they need to await cross-service dependencies inside a load.
+ * The load body sees the same query map as a handler, with one difference: the load is async and
+ * may call `await ctx.self.queries.foo.loaded(input)` (or `ctx.getService(id).queries.foo.loaded()`)
+ * to explicitly await a dependency it needs settled. Sync reads inside the body fire dependent
+ * loads in the background just like any other call site, but they are not awaited automatically.
  */
 async function runLoadBody<TState>(
   refs: QueryRuntimeRefs<TState>,
   queryName: string,
   queryDef: RuntimeQueryDefinition<TState>,
-  validatedInput: unknown,
-  ancestorChain: ReadonlySet<string>
+  validatedInput: unknown
 ): Promise<void> {
   if (!queryDef.load) {
     return;
   }
 
-  const collector = new Set<CollectorEntry>();
-  const wrappedQueries = buildLoadWrappedQueries(refs, ancestorChain, collector);
   const loadSelf: LoadSelf<TState> = {
     get state() {
       return refs.stateSignal();
     },
-    queries: wrappedQueries,
+    queries: refs.defaultQueries,
     commands: refs.commandSelf.commands as LoadSelf<TState>['commands'],
   };
   const loadCtx: LoadCtx<TState> = { self: loadSelf, getService: refs.registryApi.getService };
 
-  await Promise.resolve(queryDef.load(validatedInput, loadCtx));
-  await drainCollector(collector, undefined, refs.serviceId, queryName);
+  await queryDef.load(validatedInput, loadCtx);
 }
 
 /**
- * Wraps each query so calls inside a load body register the dependency's load into the load-local
- * collector.
+ * Implements `query.loaded(input)`: await this query's own `load`, then return the handler result.
  *
- * Wrappers honor cycle detection: a dependency whose key is already in the caller's ancestor chain
- * is skipped (not added to the collector) to prevent self-awaiting deadlocks. Nested handler reads
- * use the same wrappers so transitive dependencies also flow into the same collector. `.loaded()`
- * inherits the ancestor chain so a load-body author can still write `await ctx.self.queries.foo
- * .loaded(input)` without risking deadlock against itself. `.subscribe` passes through unchanged
- * because subscriptions never participate in the load drain.
- */
-function buildLoadWrappedQueries<TState>(
-  refs: QueryRuntimeRefs<TState>,
-  ancestorChain: ReadonlySet<string>,
-  collector: Set<CollectorEntry>
-): Record<string, Query<unknown, unknown>> {
-  const wrappedQueries: Record<string, Query<unknown, unknown>> = {};
-
-  for (const [name, queryDef] of refs.queryDefinitions) {
-    const defaultQuery = refs.defaultQueries[name];
-    const wrapped = ((input: unknown) => {
-      const validatedInput = validateQueryInput(refs, name, queryDef, input);
-      const loadKey = makeLoadKey(refs.serviceId, name, validatedInput);
-
-      if (queryDef.load) {
-        const promise = triggerLoad(refs, name, queryDef, validatedInput, loadKey, ancestorChain);
-
-        if (!ancestorChain.has(loadKey)) {
-          collector.add({ key: loadKey, promise });
-        }
-      }
-
-      return runHandlerSync(
-        refs,
-        name,
-        queryDef,
-        validatedInput,
-        wrappedQueries,
-        refs.registryApi.getService
-      );
-    }) as Query<unknown, unknown>;
-
-    wrapped.loaded = (input: unknown) =>
-      runLoaded(refs, name, queryDef, input, ancestorChain) as Promise<unknown>;
-    wrapped.subscribe = defaultQuery.subscribe;
-    wrappedQueries[name] = wrapped;
-  }
-
-  return wrappedQueries;
-}
-
-/**
- * Implements `query.loaded(input)` by draining all transitively triggered loads before reading.
- *
- * The discovery loop alternates draining the collector with re-running the sync handler. The
- * handler reveals freshly-callable dependencies after each state change; once a discovery pass
- * adds nothing new, the loop terminates and the function returns the final validated output.
+ * Dependencies are *not* discovered automatically. A query whose handler reads another query is
+ * responsible for awaiting that dependency inside its own `load` (`await ctx.self.queries.foo
+ * .loaded(input)`). If it does not, `.loaded()` returns whatever the handler can read from the
+ * current state — possibly a partial value. Authors should add a test that asserts the loaded
+ * value to catch missing dependency awaits.
  */
 async function runLoaded<TState>(
   refs: QueryRuntimeRefs<TState>,
   queryName: string,
   queryDef: RuntimeQueryDefinition<TState>,
-  rawInput: unknown,
-  parentAncestorChain: ReadonlySet<string> = EMPTY_SET
+  rawInput: unknown
 ): Promise<unknown> {
   const validatedInput = validateQueryInput(refs, queryName, queryDef, rawInput);
-  const loadKey = makeLoadKey(refs.serviceId, queryName, validatedInput);
-  const ancestorChain = new Set<string>(parentAncestorChain);
-  ancestorChain.add(loadKey);
 
-  const session: LoadedSession = {
-    ancestorChain,
-    collector: new Set<CollectorEntry>(),
-    settledKeys: new Set<string>(),
-  };
-
-  if (queryDef.load && !parentAncestorChain.has(loadKey)) {
-    const promise = triggerLoad(
-      refs,
-      queryName,
-      queryDef,
-      validatedInput,
-      loadKey,
-      parentAncestorChain
-    );
-    session.collector.add({ key: loadKey, promise });
+  if (queryDef.load) {
+    const loadKey = makeLoadKey(refs.serviceId, queryName, validatedInput);
+    await triggerLoad(refs, queryName, queryDef, validatedInput, loadKey);
   }
 
-  let iterations = 0;
-  let hasMoreWork = true;
-
-  // Always run at least one discovery pass even when this query has no `load` of its own — the
-  // handler may still call other queries whose loads need to be awaited.
-  while (hasMoreWork) {
-    if (iterations++ > MAX_DRAIN_ITERATIONS) {
-      throw new OpenServiceLoadedDrainExceededError({
-        serviceId: refs.serviceId,
-        name: queryName,
-        iterations: MAX_DRAIN_ITERATIONS,
-      });
-    }
-
-    while (session.collector.size > 0) {
-      const pending = [...session.collector];
-      session.collector.clear();
-
-      const settlements = await Promise.allSettled(pending.map((entry) => entry.promise));
-
-      // Mark keys as settled before surfacing rejections so the discovery pass below does not
-      // refire them even when the very first load failed.
-      for (const entry of pending) {
-        session.settledKeys.add(entry.key);
-      }
-
-      surfaceRejections(settlements);
-    }
-
-    // Discovery: run the handler under the session so each sync read of a dependency that is not
-    // settled yet (and not on the ancestor chain) gets registered into the session collector.
-    const previousSession = activeHandlerLoadSession;
-    activeHandlerLoadSession = session;
-
-    try {
-      runHandlerSync(
-        refs,
-        queryName,
-        queryDef,
-        validatedInput,
-        refs.defaultQueries,
-        refs.registryApi.getService
-      );
-    } catch {
-      // Handlers may throw when state isn't fully populated yet; the next drain iteration may fix
-      // it. The final post-loop handler call propagates any persistent failure.
-    } finally {
-      activeHandlerLoadSession = previousSession;
-    }
-
-    hasMoreWork = session.collector.size > 0;
-  }
-
-  return runHandlerSync(
-    refs,
-    queryName,
-    queryDef,
-    validatedInput,
-    refs.defaultQueries,
-    refs.registryApi.getService
-  );
+  return runHandlerSync(refs, queryName, queryDef, validatedInput);
 }
 
 /**
  * Creates the default query function exposed on the service runtime.
  *
  * Every call validates input, fires the dependency's `load` in the background (deduped while in
- * flight), and returns the handler result synchronously. If the call runs inside a `.loaded()`
- * discovery pass, the load promise is also registered into the session collector so the caller
- * can await it before returning.
+ * flight), and returns the handler result synchronously. The background load is fire-and-forget;
+ * rejections are surfaced via `rethrowAsync` so they are not silently swallowed.
  */
 function createDefaultQuery<TState>(
   refs: QueryRuntimeRefs<TState>,
@@ -617,41 +349,13 @@ function createDefaultQuery<TState>(
 ): Query<unknown, unknown> {
   const query = ((input: unknown) => {
     const validatedInput = validateQueryInput(refs, queryName, queryDef, input);
-    const loadKey = makeLoadKey(refs.serviceId, queryName, validatedInput);
 
     if (queryDef.load) {
-      const session = activeHandlerLoadSession;
-      const skip = session
-        ? session.ancestorChain.has(loadKey) || session.settledKeys.has(loadKey)
-        : false;
-
-      if (!skip) {
-        const promise = triggerLoad(
-          refs,
-          queryName,
-          queryDef,
-          validatedInput,
-          loadKey,
-          session?.ancestorChain ?? EMPTY_SET
-        );
-
-        if (session) {
-          session.collector.add({ key: loadKey, promise });
-        } else {
-          // Background fire-and-forget: surface failures so they are not silently swallowed.
-          promise.catch(rethrowAsync);
-        }
-      }
+      const loadKey = makeLoadKey(refs.serviceId, queryName, validatedInput);
+      triggerLoad(refs, queryName, queryDef, validatedInput, loadKey).catch(rethrowAsync);
     }
 
-    return runHandlerSync(
-      refs,
-      queryName,
-      queryDef,
-      validatedInput,
-      refs.defaultQueries,
-      refs.registryApi.getService
-    );
+    return runHandlerSync(refs, queryName, queryDef, validatedInput);
   }) as Query<unknown, unknown>;
 
   query.loaded = (input: unknown) => runLoaded(refs, queryName, queryDef, input);
@@ -694,28 +398,10 @@ function subscribeToQuery<TState>(
 
     if (queryDef.load) {
       const loadKey = makeLoadKey(refs.serviceId, queryName, validatedInput);
-      const pendingLoad = triggerLoad(
-        refs,
-        queryName,
-        queryDef,
-        validatedInput,
-        loadKey,
-        EMPTY_SET
-      );
-      // Subscribers do not block on rejections, but we still want them visible to global handlers.
-      pendingLoad.catch(rethrowAsync);
+      triggerLoad(refs, queryName, queryDef, validatedInput, loadKey).catch(rethrowAsync);
     }
 
-    const comp = computed(() =>
-      runHandlerSync(
-        refs,
-        queryName,
-        queryDef,
-        validatedInput,
-        refs.defaultQueries,
-        refs.registryApi.getService
-      )
-    );
+    const comp = computed(() => runHandlerSync(refs, queryName, queryDef, validatedInput));
     teardown = effect(() => {
       let value: unknown;
       try {
@@ -737,7 +423,6 @@ function subscribeToQuery<TState>(
   };
 }
 
-/** Builds the runtime query map for one service runtime. */
 function buildQueries<TState>(
   refs: QueryRuntimeRefs<TState>
 ): Record<string, Query<unknown, unknown>> {
@@ -752,8 +437,6 @@ function buildQueries<TState>(
 
 /**
  * Creates the full runtime backing for a service definition.
- *
- * Callers must supply the registry API that query and command contexts should expose.
  */
 export function createServiceRuntime<
   TState,
@@ -766,7 +449,6 @@ export function createServiceRuntime<
   },
   initialState: TState = def.initialState
 ): ServiceRuntime<TState, TQueries, TCommands> {
-  // The signal is the single source of truth that query computations subscribe to.
   const stateSignal = signal<TState>(initialState);
   const commandSelf = createCommandSelf(stateSignal);
   const { registryApi } = runtimeOptions;
@@ -795,7 +477,6 @@ export function createServiceRuntime<
     defaultQueries,
   };
 
-  // Build queries after commands so handler/load ctx surfaces resolve the same command map.
   const builtQueries = buildQueries(refs);
   for (const [name, query] of Object.entries(builtQueries)) {
     defaultQueries[name] = query;
@@ -821,12 +502,6 @@ export function createServiceRuntime<
     getService: registryApi.getService,
   };
 
-  /**
-   * Runs one query's `load` body against this runtime instance, drained to completion.
-   *
-   * Used by the static build pipeline to populate state for a single input without holding the
-   * load in the in-flight registry afterwards.
-   */
   const runLoadOnce = async (queryName: string, validatedInput: unknown): Promise<void> => {
     const queryDef = queryDefinitions.get(queryName);
 
@@ -834,10 +509,7 @@ export function createServiceRuntime<
       return;
     }
 
-    const loadKey = makeLoadKey(def.id, queryName, validatedInput);
-    const ancestorChain = new Set<string>([loadKey]) as ReadonlySet<string>;
-
-    await runLoadBody(refs, queryName, queryDef, validatedInput, ancestorChain);
+    await runLoadBody(refs, queryName, queryDef, validatedInput);
   };
 
   return {
@@ -850,9 +522,6 @@ export function createServiceRuntime<
     runLoadOnce,
   };
 }
-
-/** Re-export so external modules can address the in-flight load registry for tests if needed. */
-export const __internalInFlightLoads = inFlightLoads;
 
 /** Type referenced from the registry surface for cross-service callers. */
 export type { RuntimeService };


### PR DESCRIPTION
> [!NOTE]
> This is a comparison branch targeting [#34932](https://github.com/storybookjs/storybook/pull/34932) so the simplification can be diffed against the implementation already proposed there. Not intended to land standalone — pick one or the other.

## What this PR explores

What does the open-service runtime look like if ``.loaded()`` is **narrower**? Specifically, what if it awaits only **this query's own** ``load`` and authors are responsible for chaining dependencies explicitly inside the load body, instead of the runtime discovering them implicitly through handler reads?

## What's removed

- The drain loop in ``runLoaded`` (collector + handler re-runs for dep discovery)
- ``LoadedSession``, ``settledKeys``, ``ancestorChain``, ``activeHandlerLoadSession``
- ``buildLoadWrappedQueries`` (a separate wrapped ``self.queries`` per load body)
- ``drainCollector`` + ``surfaceRejections`` (no parallel deps to aggregate)
- Cycle detection (``ancestorChain`` propagation + register-promise-before-body trick was kept for in-flight dedup but the chain extension is gone)
- ``OpenServiceLoadedDrainExceededError`` (no drain loop to overflow)

Runtime shrinks from **~870 → ~530 lines (40%)**, and the mental model collapses from ‟tracked drain with sessions and ancestor chains" to ‟await your own load, return your handler result."

## What changes for authors

### Before (#34932 — implicit tracking)

```ts
// users service unchanged
export const userPrefsDef = defineService({
  id: 'app/user-prefs',
  initialState: { overrides: {} as Record<string, string | undefined> },
  queries: {
    getEffectiveTheme: {
      input: v.object({ userId: v.string() }),
      output: v.nullable(v.string()),
      handler: (input, ctx) => {
        // Sync read — runtime auto-tracks this for .loaded().
        const users = ctx.getService('app/users');
        const user = users.queries.getUser({ userId: input.userId });
        return ctx.self.state.overrides[input.userId] ?? user?.theme ?? null;
      },
      // No load needed — the dep is discovered through the handler read.
    },
  },
  commands: {},
});
```

### After (this PR — explicit chaining)

```ts
export const userPrefsDef = defineService({
  id: 'app/user-prefs',
  initialState: { overrides: {} as Record<string, string | undefined> },
  queries: {
    getEffectiveTheme: {
      input: v.object({ userId: v.string() }),
      output: v.nullable(v.string()),
      handler: (input, ctx) => {
        // Same sync read — handler doesn't change.
        const users = ctx.getService('app/users');
        const user = users.queries.getUser({ userId: input.userId });
        return ctx.self.state.overrides[input.userId] ?? user?.theme ?? null;
      },
      // NEW: must declare the load chain explicitly for .loaded() to await the dep.
      load: async (input, ctx) => {
        await ctx.getService('app/users').queries.getUser.loaded(input);
      },
    },
  },
  commands: {},
});
```

The diff is **one ``load:`` block added** per compound query. The handler is identical. The dependency service is identical.

### Consumer side is unchanged

```ts
// Same in both branches.
const themeNow = userPrefs.queries.getEffectiveTheme({ userId: 'u-42' });
const unsub = userPrefs.queries.getEffectiveTheme.subscribe(
  { userId: 'u-42' },
  (theme) => updateUI(theme),
);
const themeReady = await userPrefs.queries.getEffectiveTheme.loaded({ userId: 'u-42' });
```

## What breaks

If an author writes a handler that reads a dep and **forgets** to chain it in the load body, ``.loaded()`` returns whatever the handler reads from the current (possibly empty) state. A test asserting the loaded value catches this immediately. See the new ``loaded() — explicit dependency chaining`` block in [service-runtime.test.ts](code/core/src/shared/open-service/service-runtime.test.ts) — two adjacent tests demonstrate the broken (no chain → partial value) and fixed (with chain → correct value) cases side by side.

Cycles also lose their soft landing: self-awaiting load chains deadlock instead of throwing ``OpenServiceLoadedDrainExceededError`` or ``OpenServiceLoadCycleError``. Surface through tests.

## Trade-off summary

| Aspect                                | #34932 (implicit)                           | This PR (explicit)                                    |
| ------------------------------------- | ------------------------------------------- | ----------------------------------------------------- |
| Runtime size                          | ~870 LoC                                    | ~530 LoC                                              |
| Compound query author writes          | only ``handler``                            | ``handler`` + ``load: await dep.loaded(...)``         |
| Forgetting a dep                      | runtime recovers via drain                  | ``.loaded()`` returns partial value (caught by tests) |
| Cyclic load chains                    | drain-exceeded error                        | promise deadlock                                      |
| ``.loaded()`` semantics in one line   | ‟wait until every dep my handler reads is loaded" | ‟await my own load, then return handler"        |

## Manual testing

1. ``yarn nx check core`` — no type errors
2. ``yarn vitest run code/core/src/shared/open-service`` — 50 tests pass (one fewer than #34932 because the drain-exceeded test is gone)
3. Inspect the broken/fixed pair of tests in ``service-runtime.test.ts`` to see the author-facing consequence

## Recommendation

This is a deliberate dial between author cost and runtime complexity. Going with this branch means: ‟we accept one extra block per compound query in exchange for half the runtime." Going with #34932 means: ‟we accept a 40% larger runtime so authors never have to think about declaring deps."

🤖 Generated with [Claude Code](https://claude.com/claude-code)