### PR TITLE
OpenService: Fix registration for empty init

### DIFF
--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -295,7 +295,10 @@ export async function buildDevStandalone(
 
   const features = await presets.apply('features');
   global.FEATURES = features;
-  await presets.apply('services');
+  if (!globalThis.STORYBOOK_SERVICES_LOADED) {
+    await presets.apply('services');
+    globalThis.STORYBOOK_SERVICES_LOADED = true;
+  }
   await presets.apply('experimental_serverChannel', channel);
 
   const fullOptions: Options = {

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -296,8 +296,8 @@ export async function buildDevStandalone(
   const features = await presets.apply('features');
   global.FEATURES = features;
   if (!globalThis.STORYBOOK_SERVICES_LOADED) {
-    await presets.apply('services');
     globalThis.STORYBOOK_SERVICES_LOADED = true;
+    await presets.apply('services');
   }
   await presets.apply('experimental_serverChannel', channel);
 

--- a/code/core/src/core-server/build-static.ts
+++ b/code/core/src/core-server/build-static.ts
@@ -130,7 +130,10 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
   const effects: Promise<void>[] = [];
 
   global.FEATURES = features;
-  await presets.apply('services');
+  if (!globalThis.STORYBOOK_SERVICES_LOADED) {
+    await presets.apply('services');
+    globalThis.STORYBOOK_SERVICES_LOADED = true;
+  }
 
   if (!options.previewOnly) {
     await buildOrThrow(async () =>

--- a/code/core/src/core-server/build-static.ts
+++ b/code/core/src/core-server/build-static.ts
@@ -131,8 +131,8 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
 
   global.FEATURES = features;
   if (!globalThis.STORYBOOK_SERVICES_LOADED) {
-    await presets.apply('services');
     globalThis.STORYBOOK_SERVICES_LOADED = true;
+    await presets.apply('services');
   }
 
   if (!options.previewOnly) {

--- a/code/core/src/core-server/load.ts
+++ b/code/core/src/core-server/load.ts
@@ -98,8 +98,8 @@ export async function loadStorybook(
   global.FEATURES = features;
 
   if (!globalThis.STORYBOOK_SERVICES_LOADED) {
-    await presets.apply('services');
     globalThis.STORYBOOK_SERVICES_LOADED = true;
+    await presets.apply('services');
   }
 
   return {


### PR DESCRIPTION
## What I did

Prevent redundant service loading in buildDevStandalone and buildStaticStandalone functions when loadStorybook was called prior.

This happens when initializing storybook from an empty directory, and running it immediately as part of onboarding

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

None, needed, the CI being green should be validation enough.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Services initialization now runs only once per process, avoiding redundant reprocessing and improving build performance.
  * Adjusted initialization ordering so the process-level flag is set earlier; this reduces repeated work but may affect the timing of related startup side effects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->