### PR TITLE
CSF Next: Propagate skip tags to .test children

### DIFF
--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -595,6 +595,62 @@ describe('transformer', () => {
           }
         `);
       });
+
+      it('should pass skip tags to child .test() calls using tags.skip', async () => {
+        const code = `
+          export default {};
+          export const Primary = {};
+          Primary.test("runs", () => {});
+          Primary.test("skipped", { tags: ['skip-me'] }, () => {});
+        `;
+
+        const result = await transform({
+          code,
+          tagsFilter: { include: [Tag.TEST], exclude: [], skip: ['skip-me'] },
+        });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, expect as _expect, describe as _describe } from "vitest";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          const _meta = {
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          export const Primary = {};
+          Primary.test("runs", () => {});
+          Primary.test("skipped", {
+            tags: ['skip-me']
+          }, () => {});
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            _describe("Primary  ", () => {
+              _test("base story", _testStory({
+                exportName: "Primary",
+                story: Primary,
+                meta: _meta,
+                skipTags: ["skip-me"],
+                storyId: "automatic-calculated-title--primary"
+              }));
+              _test("runs", _testStory({
+                exportName: "Primary",
+                story: Primary,
+                meta: _meta,
+                skipTags: ["skip-me"],
+                storyId: "automatic-calculated-title--primary:runs",
+                testName: "runs"
+              }));
+              _test("skipped", _testStory({
+                exportName: "Primary",
+                story: Primary,
+                meta: _meta,
+                skipTags: ["skip-me"],
+                storyId: "automatic-calculated-title--primary:skipped",
+                testName: "skipped"
+              }));
+            });
+          }
+        `);
+      });
     });
 
     describe('component info extraction', () => {
@@ -1184,6 +1240,63 @@ describe('transformer', () => {
               skipTags: ["skip-me"],
               storyId: "automatic-calculated-title--skipped"
             }));
+          }
+        `);
+      });
+
+      it('should pass skip tags to child .test() calls using tags.skip', async () => {
+        const code = `
+          import { config } from '#.storybook/preview';
+          const meta = config.meta({});
+          export const Primary = meta.story({});
+          Primary.test("runs", () => {});
+          Primary.test("skipped", { tags: ['skip-me'] }, () => {});
+        `;
+
+        const result = await transform({
+          code,
+          tagsFilter: { include: [Tag.TEST], exclude: [], skip: ['skip-me'] },
+        });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, expect as _expect, describe as _describe } from "vitest";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          import { config } from '#.storybook/preview';
+          const meta = config.meta({
+            title: "automatic/calculated/title"
+          });
+          export const Primary = meta.story({});
+          Primary.test("runs", () => {});
+          Primary.test("skipped", {
+            tags: ['skip-me']
+          }, () => {});
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            _describe("Primary  ", () => {
+              _test("base story", _testStory({
+                exportName: "Primary",
+                story: Primary,
+                meta: meta,
+                skipTags: ["skip-me"],
+                storyId: "automatic-calculated-title--primary"
+              }));
+              _test("runs", _testStory({
+                exportName: "Primary",
+                story: Primary,
+                meta: meta,
+                skipTags: ["skip-me"],
+                storyId: "automatic-calculated-title--primary:runs",
+                testName: "runs"
+              }));
+              _test("skipped", _testStory({
+                exportName: "Primary",
+                story: Primary,
+                meta: meta,
+                skipTags: ["skip-me"],
+                storyId: "automatic-calculated-title--primary:skipped",
+                testName: "skipped"
+              }));
+            });
           }
         `);
       });

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -309,7 +309,7 @@ export async function vitestTransform({
               t.objectProperty(t.identifier('exportName'), t.stringLiteral(exportName)),
               t.objectProperty(t.identifier('story'), t.identifier(localName)),
               t.objectProperty(t.identifier('meta'), t.identifier(metaExportName)),
-              t.objectProperty(t.identifier('skipTags'), t.arrayExpression([])),
+              t.objectProperty(t.identifier('skipTags'), skipTagsId),
               t.objectProperty(t.identifier('storyId'), t.stringLiteral(storyId)),
             ];
 


### PR DESCRIPTION
Closes #34962

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR is an attempt to close #34962, allow to propagate `skip` tags to the test() story child with csf factories. Original issue explains current behavior - tags are not currently passed through. 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

ø

#### Manual testing

1. Clone repro
2. Install with NPM and then swap Sb for canary version
3. Run npm run test-storybook

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34964-sha-e5a2e62a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34964-sha-e5a2e62a sandbox` or in an existing project with `npx storybook@0.0.0-pr-34964-sha-e5a2e62a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34964-sha-e5a2e62a`](https://npmjs.com/package/storybook/v/0.0.0-pr-34964-sha-e5a2e62a) |
| **Triggered by** | @Sidnioulz |
| **Repository** | [kwonoj/storybook](https://github.com/kwonoj/storybook) |
| **Branch** | [`fix-test-factory-tags`](https://github.com/kwonoj/storybook/tree/fix-test-factory-tags) |
| **Commit** | [`e5a2e62a`](https://github.com/kwonoj/storybook/commit/e5a2e62a75666351fb27d1c953efa76f65963940) |
| **Datetime** | Fri May 29 10:22:56 UTC 2026 (`1780050176`) |
| **Workflow run** | [26631901616](https://github.com/storybookjs/storybook/actions/runs/26631901616) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34964`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed skip tags not being properly forwarded to child story tests, ensuring consistent filtering behavior across all generated test cases.

* **Tests**
  * Added test coverage for skip tags propagation with child tests in both standard and factory-based story patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->