### PR TITLE
Fix Docs zoom wrapper transform at actual size

### DIFF
--- a/code/core/src/components/components/Zoom/ZoomElement.test.tsx
+++ b/code/core/src/components/components/Zoom/ZoomElement.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import React from 'react';
+
+import { ThemeProvider, convert, themes } from 'storybook/theming';
+
+import { ZoomElement } from './ZoomElement.tsx';
+
+function renderZoomElement(scale: number) {
+  return render(
+    <ThemeProvider theme={convert(themes.light)}>
+      <ZoomElement scale={scale}>
+        <div>Zoom content</div>
+      </ZoomElement>
+    </ThemeProvider>
+  );
+}
+
+describe('ZoomElement', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not create a transformed containing block at actual size', () => {
+    const { container } = renderZoomElement(1);
+
+    expect(window.getComputedStyle(container.firstElementChild!).transform).toBe('');
+  });
+
+  it('applies transform when zoomed', () => {
+    const { container } = renderZoomElement(2);
+
+    expect(window.getComputedStyle(container.firstElementChild!).transform).toBe('scale(0.5)');
+  });
+});

--- a/code/core/src/components/components/Zoom/ZoomElement.tsx
+++ b/code/core/src/components/components/Zoom/ZoomElement.tsx
@@ -8,8 +8,12 @@ import useResizeObserver from 'use-resize-observer';
 const ZoomElementWrapper = styled.div<{ centered?: boolean; scale: number; elementHeight: number }>(
   ({ centered = false, scale = 1, elementHeight }) => ({
     height: elementHeight || 'auto',
-    transformOrigin: centered ? 'center top' : 'left top',
-    transform: `scale(${1 / scale})`,
+    ...(scale !== 1
+      ? {
+          transformOrigin: centered ? 'center top' : 'left top',
+          transform: `scale(${1 / scale})`,
+        }
+      : {}),
   })
 );
 


### PR DESCRIPTION
## Summary
- Avoid applying a CSS transform to ZoomElement when scale is 1, so Firefox does not treat Docs examples as transformed containing blocks for position: fixed content.
- Add coverage for the unzoomed and zoomed wrapper transform behavior.

Fixes #16774

## Validation
- corepack yarn install --immutable
- corepack yarn nx run addon-vitest:compile
- CI=1 corepack yarn vitest run code\\core\\src\\components\\components\\Zoom\\ZoomElement.test.tsx --project core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Zoom component to verify scale transformations render correctly at different zoom levels
* **Performance**
  * Optimized Zoom component styling to conditionally apply CSS transform properties only when zoom scale is adjusted from its default state, reducing unnecessary styling calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->