### PR TITLE
Fix preview scroll reset between docs

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/WebView.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WebView } from './WebView.ts';
+
+vi.mock('storybook/internal/client-logger', () => ({
+  logger: { error: vi.fn(), log: vi.fn(), warn: vi.fn() },
+}));
+
+const setupPreviewRoots = () => {
+  document.body.className = '';
+  document.body.innerHTML = '<div id="storybook-root"></div><div id="storybook-docs"></div>';
+};
+
+const setScrollPosition = (element: Element) => {
+  element.scrollTop = 100;
+  element.scrollLeft = 50;
+};
+
+const expectScrollReset = (element: Element) => {
+  expect(element.scrollTop).toBe(0);
+  expect(element.scrollLeft).toBe(0);
+};
+
+describe('WebView', () => {
+  beforeEach(() => {
+    setupPreviewRoots();
+  });
+
+  describe('prepareForDocs', () => {
+    it('resets the document and docs root scroll positions', () => {
+      const docsRoot = document.getElementById('storybook-docs')!;
+      setScrollPosition(document.documentElement);
+      setScrollPosition(document.body);
+      setScrollPosition(docsRoot);
+
+      const root = new WebView().prepareForDocs();
+
+      expect(root).toBe(docsRoot);
+      expectScrollReset(document.documentElement);
+      expectScrollReset(document.body);
+      expectScrollReset(docsRoot);
+    });
+  });
+
+  describe('prepareForStory', () => {
+    it('resets the document and story root scroll positions', () => {
+      const storyRoot = document.getElementById('storybook-root')!;
+      setScrollPosition(document.documentElement);
+      setScrollPosition(document.body);
+      setScrollPosition(storyRoot);
+
+      const root = new WebView().prepareForStory({
+        parameters: { layout: 'padded' },
+      } as Parameters<WebView['prepareForStory']>[0]);
+
+      expect(root).toBe(storyRoot);
+      expectScrollReset(document.documentElement);
+      expectScrollReset(document.body);
+      expectScrollReset(storyRoot);
+    });
+  });
+});

--- a/code/core/src/preview-api/modules/preview-web/WebView.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.ts
@@ -35,6 +35,15 @@ const layoutClassMap = {
 } as const;
 type Layout = keyof typeof layoutClassMap | 'none';
 
+const resetScroll = (element: Element | null) => {
+  if (!element) {
+    return;
+  }
+
+  element.scrollTop = 0;
+  element.scrollLeft = 0;
+};
+
 const ansiConverter = new AnsiToHtml({
   escapeXML: true,
 });
@@ -71,8 +80,7 @@ export class WebView implements View<HTMLElement> {
     this.showStory();
     this.applyLayout(story.parameters.layout);
 
-    document.documentElement.scrollTop = 0;
-    document.documentElement.scrollLeft = 0;
+    this.resetScrollPosition();
 
     return this.storyRoot();
   }
@@ -86,8 +94,7 @@ export class WebView implements View<HTMLElement> {
     this.showDocs();
     this.applyLayout('fullscreen');
 
-    document.documentElement.scrollTop = 0;
-    document.documentElement.scrollLeft = 0;
+    this.resetScrollPosition();
 
     return this.docsRoot();
   }
@@ -204,5 +211,15 @@ export class WebView implements View<HTMLElement> {
     // See https://github.com/storybookjs/storybook/issues/16847 and
     //   http://localhost:9011/?path=/story/core-rendering--auto-focus (official SB)
     document.body.classList.add(classes.MAIN);
+  }
+
+  private resetScrollPosition() {
+    [
+      document.scrollingElement,
+      document.documentElement,
+      document.body,
+      this.storyRoot(),
+      this.docsRoot(),
+    ].forEach(resetScroll);
   }
 }


### PR DESCRIPTION
Fixes #12497

## Summary
- Reset the preview document/body scroll positions via the active scrolling element.
- Also reset the story and docs root scroll offsets so long docs do not preserve internal/root scroll between navigations.
- Added WebView coverage for docs and story scroll reset behavior.

## Validation
- `corepack yarn install --immutable`
- `corepack yarn oxfmt --check code/core/src/preview-api/modules/preview-web/WebView.ts code/core/src/preview-api/modules/preview-web/WebView.test.ts`
- Attempted `corepack yarn test --project core code/core/src/preview-api/modules/preview-web/WebView.test.ts` but this local clone cannot resolve existing Storybook internal package exports (`storybook/internal/client-logger`); the same resolver failure occurs with the pre-existing `PreviewWeb.test.ts`.
- Attempted changed-file eslint; local environment cannot resolve the workspace `eslint-plugin-storybook` plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite to verify scroll positions reset correctly and reliably when navigating between stories, documentation views, and various interactive elements throughout the application interface

* **Refactor**
  * Enhanced scroll position reset mechanism to ensure consistent and reliable behavior across all view containers and components, improving the overall navigation experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->