### PR TITLE
React: Render boolean props set to false in source snippets

### DIFF
--- a/.yarn/patches/@7rulnik-react-element-to-jsx-string-npm-15.0.1-e53b67c4b3.patch
+++ b/.yarn/patches/@7rulnik-react-element-to-jsx-string-npm-15.0.1-e53b67c4b3.patch
@@ -1,0 +1,34 @@
+diff --git a/dist/cjs/index.js b/dist/cjs/index.js
+index 6d1961830f978c0f3d90cc864003b0c50eb98f0d..9d48f1990ef440431e0e12ebf7560912893cd725 100644
+--- a/dist/cjs/index.js
++++ b/dist/cjs/index.js
+@@ -373,11 +373,7 @@ var formatProp = (function (name, hasValue, value, hasDefaultValue, defaultValue
+   var attributeFormattedInline = ' ';
+   var attributeFormattedMultiline = "\n".concat(spacer(lvl + 1, tabStop));
+   var isMultilineAttribute = formattedPropValue.includes('\n');
+-  if (useBooleanShorthandSyntax && formattedPropValue === '{false}' && !hasDefaultValue) {
+-    // If a boolean is false and not different from it's default, we do not render the attribute
+-    attributeFormattedInline = '';
+-    attributeFormattedMultiline = '';
+-  } else if (useBooleanShorthandSyntax && formattedPropValue === '{true}') {
++  if (useBooleanShorthandSyntax && formattedPropValue === '{true}') {
+     attributeFormattedInline += "".concat(name);
+     attributeFormattedMultiline += "".concat(name);
+   } else {
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index 1c23d38bc15c76c6f9277c39b362f01e99e561ae..4e2de641a3ddb5851f7afa18c74d5a0f22d1c364 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -347,11 +347,7 @@ var formatProp = (function (name, hasValue, value, hasDefaultValue, defaultValue
+   var attributeFormattedInline = ' ';
+   var attributeFormattedMultiline = "\n".concat(spacer(lvl + 1, tabStop));
+   var isMultilineAttribute = formattedPropValue.includes('\n');
+-  if (useBooleanShorthandSyntax && formattedPropValue === '{false}' && !hasDefaultValue) {
+-    // If a boolean is false and not different from it's default, we do not render the attribute
+-    attributeFormattedInline = '';
+-    attributeFormattedMultiline = '';
+-  } else if (useBooleanShorthandSyntax && formattedPropValue === '{true}') {
++  if (useBooleanShorthandSyntax && formattedPropValue === '{true}') {
+     attributeFormattedInline += "".concat(name);
+     attributeFormattedMultiline += "".concat(name);
+   } else {

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -75,7 +75,7 @@
     "expect-type": "^0.15.0",
     "html-tags": "^3.1.0",
     "prop-types": "^15.7.2",
-    "react-element-to-jsx-string": "npm:@7rulnik/react-element-to-jsx-string@15.0.1",
+    "react-element-to-jsx-string": "patch:react-element-to-jsx-string@npm%3A@7rulnik/react-element-to-jsx-string@15.0.1#~/.yarn/patches/@7rulnik-react-element-to-jsx-string-npm-15.0.1-e53b67c4b3.patch",
     "require-from-string": "^2.0.2",
     "ts-dedent": "^2.0.0",
     "type-fest": "^5.6.0"

--- a/code/renderers/react/src/docs/jsxDecorator.test.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.test.tsx
@@ -297,6 +297,18 @@ describe('renderJsx', () => {
       </Container>
     `);
   });
+
+  // Regression for #27127: react-element-to-jsx-string used to omit boolean
+  // props explicitly set to `false`. Patched via algolia/react-element-to-jsx-string#733
+  // so a `false` prop is rendered while a `true` prop keeps the shorthand syntax.
+  it('should render boolean props set to false', () => {
+    expect(renderJsx(<div hidden={false} draggable={true} />, {})).toMatchInlineSnapshot(`
+      <div
+        draggable
+        hidden={false}
+      />
+    `);
+  });
 });
 
 // @ts-expect-error (Converted from ts-ignore)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9067,7 +9067,7 @@ __metadata:
     prop-types: "npm:^15.7.2"
     react-docgen: "npm:^8.0.2"
     react-docgen-typescript: "npm:^2.2.2"
-    react-element-to-jsx-string: "npm:@7rulnik/react-element-to-jsx-string@15.0.1"
+    react-element-to-jsx-string: "patch:react-element-to-jsx-string@npm%3A@7rulnik/react-element-to-jsx-string@15.0.1#~/.yarn/patches/@7rulnik-react-element-to-jsx-string-npm-15.0.1-e53b67c4b3.patch"
     require-from-string: "npm:^2.0.2"
     ts-dedent: "npm:^2.0.0"
     type-fest: "npm:^5.6.0"
@@ -26990,6 +26990,20 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: 10c0/e52439d2dd4b25e073ab3928c484a6470a7094f4e77c4844cb86248016c7b34a3d5efddfc6e2ae30cf715c1cb53498d08d7211a505e67c56c7ab6607c5d0fbfe
+  languageName: node
+  linkType: hard
+
+"react-element-to-jsx-string@patch:react-element-to-jsx-string@npm%3A@7rulnik/react-element-to-jsx-string@15.0.1#~/.yarn/patches/@7rulnik-react-element-to-jsx-string-npm-15.0.1-e53b67c4b3.patch":
+  version: 15.0.1
+  resolution: "react-element-to-jsx-string@patch:@7rulnik/react-element-to-jsx-string@npm%3A15.0.1#~/.yarn/patches/@7rulnik-react-element-to-jsx-string-npm-15.0.1-e53b67c4b3.patch::version=15.0.1&hash=a50fcc"
+  dependencies:
+    "@base2/pretty-print-object": "npm:1.0.1"
+    is-plain-object: "npm:5.0.0"
+    react-is: "npm:18.1.0"
+  peerDependencies:
+    react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
+    react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
+  checksum: 10c0/33f06a86ad7f8ea81bcdc0dc1111f42a7030910b9c8d5deba0adbc79eaaa38618976211d928ee664142286108b7c2955a5ab7709288c86778d1077f21a8177c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #27127

## What I did

Patched [`react-element-to-jsx-string`](https://github.com/algolia/react-element-to-jsx-string) (the `@7rulnik` fork we consume) with [algolia/react-element-to-jsx-string#733](https://github.com/algolia/react-element-to-jsx-string/pull/733).

That PR removes the branch in `formatProp` that silently **omitted boolean props explicitly set to `false`** when `useBooleanShorthandSyntax` is enabled (the default). As a result, React auto-generated source snippets dropped `false` props entirely — e.g. `<Component disabled={false} />` rendered as `<Component />`.

After this patch:
- A prop set to `false` renders as `disabled={false}`.
- A prop set to `true` keeps the shorthand syntax (`disabled`), as before.

This is one of the long-standing source-snippet bugs tracked in #33628.

### Implementation notes

- The fork ships pre-bundled (`dist/esm/index.js` + `dist/cjs/index.js`) with no separate `src/formatProp.js`, so the Yarn patch applies the equivalent change to **both** bundles.
- Wired via the dependency locator in `code/renderers/react/package.json` (mirroring the existing `react-aria-components` patch), since `yarn patch-commit` doesn't auto-rewire npm-aliased dependencies.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Added a regression test in `jsxDecorator.test.tsx` (`should render boolean props set to false`) that locks the new output. The full `@storybook/react` renderer suite (617 passed / 8 skipped) was re-run to confirm no existing source snapshot relied on the old false-omission behavior.

#### Manual testing

1. Run a sandbox: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser.
3. Add (or open) a story for a component that receives a boolean prop set to `false`, e.g. `args: { disabled: false }`.
4. Open the **Docs** tab / **Show code** for that story.
5. Confirm the generated snippet now shows `disabled={false}` instead of omitting the prop. A prop set to `true` should still render as the shorthand `disabled`.

> [!NOTE]
> This intentionally changes source-snippet output for any React story that passes an explicit `false` boolean prop, so docs/Chromatic snapshots for those stories will shift — that's the desired fix, not a regression.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation changes needed — this restores expected behavior for an existing feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test for boolean prop rendering in JSX decorator to ensure props explicitly set to `false` render correctly.

* **Chores**
  * Updated dependency specification format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->