### PR TITLE
Core: Implement component to stories lookup

### DIFF
--- a/code/core/src/core-server/change-detection/ChangeDetectionService.ts
+++ b/code/core/src/core-server/change-detection/ChangeDetectionService.ts
@@ -17,6 +17,7 @@ import { CHANGE_DETECTION_STATUS_TYPE_ID } from 'storybook/internal/types';
 
 import type { StoryIndexGenerator } from '../utils/StoryIndexGenerator.ts';
 import type { ChangeDetectionAdapter, FileChangeEvent } from './adapters/index.ts';
+import { setActiveChangeDetectionService } from './active-service-registry.ts';
 import {
   ChangeDetectionResolverFactory,
   DependencyGraphBuilder,
@@ -489,9 +490,47 @@ export class ChangeDetectionService {
     }
   }
 
+  /**
+   * Returns the live reverse-dependency index, or `undefined` if the graph
+   * hasn't finished its cold-start build yet (or change detection is unavailable).
+   *
+   * The returned instance is the same reference patched by `IncrementalPatcher`
+   * on file changes — callers read it lazily at query time, not snapshotted.
+   *
+   * @experimental
+   */
+  getReverseIndex(): ReverseIndexImpl | undefined {
+    return this.reverseIndex;
+  }
+
+  /**
+   * Returns a map from absolute story file path → set of story IDs declared in
+   * that file, derived from the current story index.
+   *
+   * Useful for callers (e.g. addons) that consume {@link getReverseIndex} output:
+   * the reverse-index entries are keyed by absolute file path, but consumers
+   * typically need story IDs.
+   *
+   * @experimental
+   */
+  async getStoryIdsByFile(): Promise<Map<string, Set<string>>> {
+    const generator = await this.options.storyIndexGeneratorPromise;
+    const storyIndex = await generator.getIndex();
+    return getStoryIdsByAbsolutePath(this.storyIdsByFileCache, storyIndex, this.workingDir);
+  }
+
+  /** @experimental Working directory used to resolve relative paths. */
+  getWorkingDir(): string {
+    return this.workingDir;
+  }
+
   async dispose(): Promise<void> {
     this.disposed = true;
     this.rerunAfterCurrentScan = false;
+
+    // Clear the active-service registry so in-process consumers stop seeing
+    // a disposed instance after dev-server shutdown.
+    setActiveChangeDetectionService(undefined);
 
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);

--- a/code/core/src/core-server/change-detection/active-service-registry.ts
+++ b/code/core/src/core-server/change-detection/active-service-registry.ts
@@ -1,0 +1,27 @@
+import type { ChangeDetectionService } from './ChangeDetectionService.ts';
+
+let activeService: ChangeDetectionService | undefined;
+
+/**
+ * Records the change-detection service started by the current Storybook dev server
+ * so that in-process consumers (addon presets) can reach it without going through a
+ * preset hook. Dev server is single-instance, so only one service is ever active.
+ *
+ * @internal
+ */
+export function setActiveChangeDetectionService(service: ChangeDetectionService | undefined): void {
+  activeService = service;
+}
+
+/**
+ * Returns the change-detection service for the current dev-server process, or
+ * `undefined` when change detection is disabled / not yet started / disposed.
+ *
+ * Read at request time, not at preset load time — the service is constructed
+ * after presets register.
+ *
+ * @experimental
+ */
+export function getActiveChangeDetectionService(): ChangeDetectionService | undefined {
+  return activeService;
+}

--- a/code/core/src/core-server/change-detection/index.ts
+++ b/code/core/src/core-server/change-detection/index.ts
@@ -6,6 +6,10 @@ export {
   type ChangeDetectionReadiness,
 } from './readiness.ts';
 export { ChangeDetectionService } from './ChangeDetectionService.ts';
+export {
+  getActiveChangeDetectionService,
+  setActiveChangeDetectionService,
+} from './active-service-registry.ts';
 export type {
   ChangeDetectionAdapter,
   FileChangeEvent,

--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -9,7 +9,10 @@ import polka from 'polka';
 
 import { isTelemetryModuleEnabled, telemetry } from '../telemetry/index.ts';
 import type { ChangeDetectionAdapter } from './change-detection/index.ts';
-import { ChangeDetectionService } from './change-detection/index.ts';
+import {
+  ChangeDetectionService,
+  setActiveChangeDetectionService,
+} from './change-detection/index.ts';
 import { getStatusStoreByTypeId } from './stores/status.ts';
 import type { StoryIndexGenerator } from './utils/StoryIndexGenerator.ts';
 import { doTelemetry } from './utils/doTelemetry.ts';
@@ -54,6 +57,9 @@ export async function storybookDevServer(
     workingDir,
     presets: options.presets,
   });
+  // Expose to in-process consumers (addon presets) via the active-service registry.
+  // Dev server is single-instance, so only one service is ever active.
+  setActiveChangeDetectionService(changeDetectionService);
 
   app.use(compression({ level: 1 }));
 

--- a/code/core/src/core-server/index.ts
+++ b/code/core/src/core-server/index.ts
@@ -67,6 +67,7 @@ export type {
   ParseFileArgs,
 } from './change-detection/index.ts';
 export { ChangeDetectionService } from './change-detection/ChangeDetectionService.ts';
+export { getActiveChangeDetectionService as experimental_getActiveChangeDetectionService } from './change-detection/active-service-registry.ts';
 export {
   getTestProviderStoreById as experimental_getTestProviderStore,
   fullTestProviderStore as internal_fullTestProviderStore,


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR opens the change-detection module's reverse-dependency index to external consumers (e.g. @storybook/addon-mcp) so they can answer "which stories relate to this file?" for any arbitrary list of paths.

The MCP addon needs this for its `get-stories-by-component` and `get-changed-stories` tools, so that it won't need to reinvent the wheel in order to detect the correlation of a change to stories. This is needed because the change detection is not always accurate (e.g. if you make a change in preview file, it won't detect any change), and with access to the reverse index the agent can decide on what to drill in.

This is done through a new preset `experimental_getActiveChangeDetectionService` and three accessor methods on ChangeDetectionService:
`getReverseIndex(): ReverseIndexImpl | undefined` — live reverse-dep map; same reference patched by IncrementalPatcher.
`getStoryIdsByFile(): Promise<Map<string, Set<string>>>` — join helper, absolute story-file path → declared story IDs.
`getWorkingDir(): string` — for resolving relative paths.

Usage from an addon side:
```
const service = experimental_getActiveChangeDetectionService();
if (!service) return; // change detection disabled / not yet started
const index = service.getReverseIndex();
if (!index) return; // graph still cold-starting
const hits = index.lookup(absolutePath); // → Map<storyFile, depth>
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed experimental inspection APIs on the change detection service for in-process consumers
  * Added methods to retrieve reverse dependencies, story-to-file mappings, and working directory information
  * Made change detection service accessible via active-service registry during development

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->