### PR TITLE
Docs: Add test proving scroll is reset across nav

### DIFF
--- a/code/e2e-sandbox/addon-docs.spec.ts
+++ b/code/e2e-sandbox/addon-docs.spec.ts
@@ -288,4 +288,27 @@ test.describe('addon-docs', () => {
     const root = sbPage.previewRoot();
     await expect(root.getByText('children').first()).toBeVisible();
   });
+
+  test('should reset scroll position between pages', async ({ page }) => {
+    await page.goto(storybookUrl);
+    const sbPage = new SbPage(page, expect);
+    await sbPage.waitUntilLoaded();
+
+    // Open a long docs page and scroll it down. The preview is rendered inside the iframe, so the
+    // scroll lives on the iframe's documentElement (see WebView.prepareForDocs).
+    await sbPage.navigateToStory('addons/docs/docspage/basic', 'docs');
+
+    const documentElement = sbPage.previewIframe().locator('html');
+    await documentElement.evaluate((el) => {
+      el.scrollTop = 100000;
+    });
+
+    // Confirm the page actually scrolled, otherwise the reset assertion below would be meaningless.
+    await expect.poll(() => documentElement.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+
+    // Navigate to a different docs page by clicking its link in the sidebar.
+    await sbPage.navigateToStory('example/button', 'docs');
+
+    await expect.poll(() => documentElement.evaluate((el) => el.scrollTop)).toBe(0);
+  });
 });

--- a/code/e2e-sandbox/addon-docs.spec.ts
+++ b/code/e2e-sandbox/addon-docs.spec.ts
@@ -290,9 +290,7 @@ test.describe('addon-docs', () => {
   });
 
   test('should reset scroll position between pages', async ({ page }) => {
-    await page.goto(storybookUrl);
     const sbPage = new SbPage(page, expect);
-    await sbPage.waitUntilLoaded();
 
     // Open a long docs page and scroll it down. The preview is rendered inside the iframe, so the
     // scroll lives on the iframe's documentElement (see WebView.prepareForDocs).


### PR DESCRIPTION
Confirms #12497 is fixed

## What I did

Added e2e test proving that when you navigate to a new docs page, scroll position gets reset.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

Run e2e test suite or wait for CI.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that verifies the documentation preview resets its scroll position when navigating between docs pages via the sidebar. This ensures consistent behavior and prevents unexpected scroll carryover when switching pages, improving reliability of docs navigation and the user experience when browsing different documentation entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->