### PR TITLE
CI: Restrict trusted CircleCI PR authors to specific teams

### DIFF
--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -145,11 +145,13 @@ jobs:
           WORKFLOW: ${{ needs.get-parameters.outputs.workflow }}
           GH_BASE_BRANCH: ${{ needs.get-parameters.outputs.ghBaseBranch }}
           GH_PR_NUMBER: ${{ needs.get-parameters.outputs.ghPrNumber }}
+          GH_TRUSTED_AUTHOR: ${{ needs.get-parameters.outputs.ghTrustedAuthor }}
         run: |
           PARAMETERS=$(jq -nc \
             --arg workflow "$WORKFLOW" \
             --arg ghBaseBranch "$GH_BASE_BRANCH" \
             --arg ghPrNumber "$GH_PR_NUMBER" \
+            --arg ghTrustedAuthor "$GH_TRUSTED_AUTHOR" \
             '{workflow: $workflow, ghBaseBranch: $ghBaseBranch, ghPrNumber: $ghPrNumber}')
           PAYLOAD=$(jq -nc --arg branch "$BRANCH" --argjson parameters "$PARAMETERS" \
             '{branch: $branch, parameters: $parameters}')

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -94,9 +94,9 @@ jobs:
       - id: trusted-author
         env:
           EVENT_NAME: ${{ github.event_name }}
-          ASSOCIATION: ${{ github.event.pull_request.author_association }}
           USER_TYPE: ${{ github.event.pull_request.user.type }}
           USER_LOGIN: ${{ github.event.pull_request.user.login }}
+          GITHUB_API_TOKEN: ${{ github.token }}
         run: |
           # You can only push to `main` and `next` as a core team member, so the content is trustworthy.
           if [ "$EVENT_NAME" = "push" ]; then
@@ -104,11 +104,27 @@ jobs:
           # These commits are made by the release actions, which are gated to core team members.
           elif [ "$USER_LOGIN" = "github-actions[bot]" ] && [ "$USER_TYPE" = "Bot" ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
-          # Trusted members of the organization can also write to cache (core team, DX, and a few maintainers)
-          elif { [ "$ASSOCIATION" = "OWNER" ] || [ "$ASSOCIATION" = "MEMBER" ]; } && [ "$USER_TYPE" != "Bot" ]; then
-            echo "result=true" >> "$GITHUB_OUTPUT"
           else
-            echo "result=false" >> "$GITHUB_OUTPUT"
+            # Explicitly trust only members of specific Storybook teams.
+            # Team slugs for: Maintainers, Core, Developer Experience.
+            TRUSTED_TEAMS="maintainers core developer-experience"
+            IS_TRUSTED=false
+
+            for TEAM in $TRUSTED_TEAMS; do
+              STATE=$(curl -fsSL \
+                -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/orgs/storybookjs/teams/$TEAM/memberships/$USER_LOGIN" \
+                | jq -r '.state' 2>/dev/null || true)
+
+              if [ "$STATE" = "active" ]; then
+                IS_TRUSTED=true
+                break
+              fi
+            done
+
+            echo "result=$IS_TRUSTED" >> "$GITHUB_OUTPUT"
           fi
     outputs:
       workflow: ${{ steps.normal.outputs.workflow || steps.docs.outputs.workflow || steps.merged.outputs.workflow || steps.daily.outputs.workflow }}

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -77,8 +77,7 @@ jobs:
   get-parameters:
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
-    permissions:
-      members: read
+    permissions: {}
     steps:
       - id: normal
         if: github.event_name == 'pull_request_target' && (contains(github.event.pull_request.labels.*.name, 'ci:normal'))
@@ -97,7 +96,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           USER_TYPE: ${{ github.event.pull_request.user.type }}
           USER_LOGIN: ${{ github.event.pull_request.user.login }}
-          GITHUB_API_TOKEN: ${{ github.token }}
+          GITHUB_API_TOKEN: ${{ secrets.STORYBOOKJS_ORG_MEMBERSHIP_TOKEN }}
         run: |
           # You can only push to `main` and `next` as a core team member, so the content is trustworthy.
           if [ "$EVENT_NAME" = "push" ]; then

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -77,7 +77,8 @@ jobs:
   get-parameters:
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      members: read
     steps:
       - id: normal
         if: github.event_name == 'pull_request_target' && (contains(github.event.pull_request.labels.*.name, 'ci:normal'))
@@ -152,7 +153,7 @@ jobs:
             --arg ghBaseBranch "$GH_BASE_BRANCH" \
             --arg ghPrNumber "$GH_PR_NUMBER" \
             --arg ghTrustedAuthor "$GH_TRUSTED_AUTHOR" \
-            '{workflow: $workflow, ghBaseBranch: $ghBaseBranch, ghPrNumber: $ghPrNumber}')
+            '{workflow: $workflow, ghBaseBranch: $ghBaseBranch, ghPrNumber: $ghPrNumber, ghTrustedAuthor: $ghTrustedAuthor}')
           PAYLOAD=$(jq -nc --arg branch "$BRANCH" --argjson parameters "$PARAMETERS" \
             '{branch: $branch, parameters: $parameters}')
           curl -sS --fail-with-body -X POST \


### PR DESCRIPTION
## What I did

Tightened security by only allowing Core team and trusted maintainers to write to the shared CircleCI cache.

## Checklist for Contributors

### Testing

ø

#### Manual testing

* Add debug commit to this branch allowing to trigger the workflows when opening a PR that targets it
* Create a dummy PR targeting it
* Verify flag passed based on author identity
* Clean up debug commit   

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by strengthening pull-request author verification to check active membership across project teams and by passing the resulting trust flag into the pipeline trigger—reducing false positives/negatives and making automated pipeline runs more accurate and secure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->