### PR TITLE
Vue: Ensure vue-component-meta runs in post

### DIFF
--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -35,6 +35,7 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
   return {
     name: 'storybook:vue-component-meta-plugin',
     transform: {
+      order: 'post',
       filter: { id: { include, exclude } },
       async handler(src, id) {
         if (!filter(id)) {

--- a/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
@@ -11,6 +11,7 @@ export async function vueDocgen(): Promise<Plugin> {
   return {
     name: 'storybook:vue-docgen-plugin',
     transform: {
+      order: 'post',
       filter: { id: include },
       async handler(src, id) {
         if (!filter(id)) {


### PR DESCRIPTION
Closes #29494

#### Manual testing

* Create vue SB project
* Ensure vue plugin is loaded after vue-component-meta
  * Remove it from `vite.config.ts`
  * And re-add it in `viteFinal` in your main
* Run SB
* Notice most docgen data does not get shown
* Then install SB canary `0.0.0-pr-34976-sha-bf5dde0e`
* Run SB again and notice docgen is back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted plugin execution order in the Vue 3 Vite build to run later in the transform phase, yielding more consistent plugin sequencing across builds.
  * No changes to public interfaces or exported declarations.
  * Internal build change only — no end-user UI or behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->