### PR TITLE
Controls: Infer select control when options property is present

### DIFF
--- a/code/core/src/preview-api/modules/store/inferControls.test.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.test.ts
@@ -133,4 +133,36 @@ describe('inferControls', () => {
     expect(Object.keys(excludeArray)).toEqual(['labelName', 'borderWidth']);
     expect(Object.keys(excludeRegex)).toEqual(['borderWidth']);
   });
+
+  it('should infer select control when options are present without explicit control type', () => {
+    const inferredControls = inferControls(
+      getStoryContext({
+        argTypes: {
+          size: {
+            type: { name: 'string' },
+            options: ['S', 'M', 'L'],
+          },
+        },
+      })
+    );
+
+    const control = inferredControls.size.control;
+    expect(typeof control === 'object' && control.type).toEqual('select');
+  });
+
+  it('should infer select control when options are present with number type', () => {
+    const inferredControls = inferControls(
+      getStoryContext({
+        argTypes: {
+          count: {
+            type: { name: 'number' },
+            options: [1, 2, 3],
+          },
+        },
+      })
+    );
+
+    const control = inferredControls.count.control;
+    expect(typeof control === 'object' && control.type).toEqual('select');
+  });
 });

--- a/code/core/src/preview-api/modules/store/inferControls.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.ts
@@ -42,6 +42,11 @@ const inferControl = (argType: StrictInputType, name: string, matchers: Controls
     return { control: { type: 'date' } };
   }
 
+  // If options are present, infer select control regardless of type name
+  if (options) {
+    return { control: { type: 'select' }, options };
+  }
+
   switch (type.name) {
     case 'array':
       return { control: { type: 'object' } };
@@ -59,7 +64,7 @@ const inferControl = (argType: StrictInputType, name: string, matchers: Controls
     case 'symbol':
       return null;
     default:
-      return { control: { type: options ? 'select' : 'object' } };
+      return { control: { type: 'object' } };
   }
 };
 


### PR DESCRIPTION
Fixes #20933

## Summary

When argTypes include an `options` property without an explicit `control: { type: 'select' }`, the control type should be automatically inferred as `select`. The docs state this should work, but it didn't.

## Root Cause

The `inferControl` function in `inferControls.ts` only checked for `options` in the `default` case of the type switch. Types like `string` or `number` would match earlier cases and return `text` or `number` controls, even when `options` were present.

## Fix

Added an early check for `options` before the switch statement. If `options` are present, the function returns a `select` control immediately, regardless of the type name.

## Testing

Added two test cases:
- `options` with `string` type → infers `select`
- `options` with `number` type → infers `select`

#### Manual testing

1. Create a story with an argType that has `options` but no explicit `control`:
```js
export default {
  argTypes: {
    color: { options: ['red', 'green', 'blue'] }
  }
}
```
2. Open the story in Storybook
3. Verify the control renders as a **select dropdown** (not a text input)
4. Select different options and verify the arg updates correctly