### PR TITLE
Controls: Preserve Null Enum Options

### DIFF
--- a/code/core/src/csf/SBType.ts
+++ b/code/core/src/csf/SBType.ts
@@ -22,7 +22,7 @@ export type SBObjectType = SBBaseType & {
 };
 export type SBEnumType = SBBaseType & {
   name: 'enum';
-  value: (string | number)[];
+  value: (string | number | null)[];
 };
 export type SBIntersectionType = SBBaseType & {
   name: 'intersection';

--- a/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/unions.tsx
+++ b/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/unions.tsx
@@ -16,6 +16,8 @@ type EnumUnion = DefaultEnum | NumericEnum;
 interface Props {
   kind?: Kind;
   inlinedNumericLiteralUnion: 0 | 1;
+  nullableUnion: string | number | null;
+  nullableLiteralUnion: 'default' | 1 | null;
   enumUnion: EnumUnion;
 }
 export const Component: FC<Props> = (props: Props) => <>JSON.stringify(props)</>;

--- a/code/core/src/docs-tools/argTypes/convert/convert.test.ts
+++ b/code/core/src/docs-tools/argTypes/convert/convert.test.ts
@@ -174,6 +174,8 @@ describe('storybook type system', () => {
         interface Props {
           kind?: Kind;
           inlinedNumericLiteralUnion: 0 | 1;
+          nullableUnion: string | number | null;
+          nullableLiteralUnion: 'default' | 1 | null;
           enumUnion: EnumUnion;
         }
         export const Component: FC<Props> = (props: Props) => <>JSON.stringify(props)</>;
@@ -195,6 +197,31 @@ describe('storybook type system', () => {
             "value": [
               0,
               1
+            ]
+          },
+          "nullableUnion": {
+            "raw": "string | number | null",
+            "name": "union",
+            "value": [
+              {
+                "name": "string"
+              },
+              {
+                "name": "number"
+              },
+              {
+                "name": "other",
+                "value": "null"
+              }
+            ]
+          },
+          "nullableLiteralUnion": {
+            "raw": "'default' | 1 | null",
+            "name": "enum",
+            "value": [
+              "default",
+              1,
+              null
             ]
           },
           "enumUnion": {

--- a/code/core/src/docs-tools/argTypes/convert/typescript/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/typescript/convert.ts
@@ -6,10 +6,17 @@ import type { TSSigType, TSType } from './types.ts';
 
 // Type guards for narrowing TSType discriminant unions
 type TSLiteralType = Extract<TSType, { name: 'literal' }>;
+type TSNullType = Extract<TSType, { name: 'null' }>;
 type TSUndefinedType = Extract<TSType, { name: 'undefined' }>;
 
 const isLiteral = (type: TSType): type is TSLiteralType => type.name === 'literal';
+const isNull = (type: TSType): type is TSNullType => type.name === 'null';
 const isUndefined = (type: TSType): type is TSUndefinedType => type.name === 'undefined';
+const isEnumValue = (type: TSType): type is TSLiteralType | TSNullType =>
+  isLiteral(type) || isNull(type);
+
+const convertEnumValue = (type: TSLiteralType | TSNullType) =>
+  isNull(type) ? null : parseLiteral(type.value);
 
 const convertSig = (type: TSSigType) => {
   switch (type.type) {
@@ -43,6 +50,9 @@ export const convert = (type: TSType): SBType | void => {
     case 'boolean': {
       return { ...base, name };
     }
+    case 'null': {
+      return { ...base, name: 'other', value: name };
+    }
     case 'Array': {
       return { ...base, name: 'array', value: type.elements.map(convert) };
     }
@@ -50,15 +60,15 @@ export const convert = (type: TSType): SBType | void => {
       return { ...base, ...convertSig(type) };
     case 'union': {
       const nonUndefinedElements = type.elements.filter((element) => !isUndefined(element));
-      const allLiterals = nonUndefinedElements.length > 0 && nonUndefinedElements.every(isLiteral);
+      const allEnumValues = nonUndefinedElements.length > 0 && nonUndefinedElements.every(isEnumValue);
 
-      if (allLiterals) {
+      if (allEnumValues) {
         // TypeScript can't infer from .every(), so we filter again with the type guard
-        const literalElements = nonUndefinedElements.filter(isLiteral);
+        const enumElements = nonUndefinedElements.filter(isEnumValue);
         return {
           ...base,
           name: 'enum',
-          value: literalElements.map((element) => parseLiteral(element.value)),
+          value: enumElements.map(convertEnumValue),
         };
       }
       return { ...base, name, value: type.elements.map(convert) };

--- a/code/core/src/docs-tools/argTypes/convert/typescript/types.ts
+++ b/code/core/src/docs-tools/argTypes/convert/typescript/types.ts
@@ -33,7 +33,7 @@ type TSObjectSigType = TSBaseType & {
 };
 
 type TSScalarType = TSBaseType & {
-  name: 'any' | 'boolean' | 'number' | 'void' | 'string' | 'symbol' | 'undefined';
+  name: 'any' | 'boolean' | 'number' | 'void' | 'string' | 'symbol' | 'undefined' | 'null';
 };
 
 type TSLiteralType = TSBaseType & {

--- a/code/core/src/preview-api/modules/store/inferControls.test.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.test.ts
@@ -110,6 +110,24 @@ describe('inferControls', () => {
     expect(Object.keys(controls)).toEqual(['label', 'labelName', 'borderWidth']);
   });
 
+  it('should keep null as an enum option', () => {
+    const controls = inferControls(
+      getStoryContext({
+        argTypes: {
+          variant: {
+            type: { name: 'enum', value: ['primary', null, 1] },
+            name: 'variant',
+          },
+        },
+      })
+    );
+
+    expect(controls.variant).toMatchObject({
+      control: { type: 'radio' },
+      options: ['primary', null, 1],
+    });
+  });
+
   it('should return filtered argTypes when include is passed', () => {
     const [includeString, includeArray, includeRegex] = [
       inferControls(getStoryContext({ parameters: { controls: { include: 'label' } } })),


### PR DESCRIPTION
## Summary

Fixes #32106.

This keeps `null` when TypeScript nullable literal unions are converted into Storybook enum arg types, so inferred Controls options can include `null` instead of degrading the union away from enum handling. It also widens `SBEnumType` to reflect the primitive values Storybook already accepts as arg options.

## What changed

- Treat TypeScript `null` union members as enum-compatible values alongside literals.
- Preserve `null` in inferred enum control options.
- Add coverage for nullable TS unions and Controls inference.

## Testing

- `corepack yarn install --immutable`
- `corepack yarn build storybook` from `code/`
- `corepack yarn vitest run --config code/core/vitest.config.ts code/core/src/docs-tools/argTypes/convert/convert.test.ts code/core/src/preview-api/modules/store/inferControls.test.ts`

#### Manual testing

Not run. This change is covered by focused unit tests for TypeScript argTypes conversion and Controls inference.

Note: the local pre-commit hook could not run `yarn --cwd code lint:js:cmd --fix` because this fresh clone could not resolve `eslint-plugin-storybook` from `code/.eslintrc.js`; the focused Vitest coverage above passes with no type errors.