### PR TITLE
Core: Fix Manifest Resolution For JS Imports Backed By TSX Files

### DIFF
--- a/code/core/src/common/utils/interpret-files.resolve.test.ts
+++ b/code/core/src/common/utils/interpret-files.resolve.test.ts
@@ -1,0 +1,28 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveImport } from './interpret-files.ts';
+
+describe('resolveImport', () => {
+  let fixtureDir: string | undefined;
+
+  afterEach(() => {
+    if (fixtureDir) {
+      rmSync(fixtureDir, { recursive: true, force: true });
+      fixtureDir = undefined;
+    }
+  });
+
+  it('resolves a .js import to a .tsx file when no .ts file exists', () => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'storybook-resolve-import-'));
+    mkdirSync(join(fixtureDir, 'src'));
+    writeFileSync(join(fixtureDir, 'src', 'Chip.tsx'), 'export const Chip = () => null;');
+
+    const resolved = resolveImport('./src/Chip.js', { basedir: fixtureDir });
+
+    expect(resolved).toBe(realpathSync(join(fixtureDir, 'src', 'Chip.tsx')));
+  });
+});

--- a/code/core/src/common/utils/interpret-files.ts
+++ b/code/core/src/common/utils/interpret-files.ts
@@ -32,16 +32,28 @@ export function resolveImport(id: string, options: ResolveImportOptions): string
     // a TypeScript file. This can happen in ES modules as TypeScript requires to import other
     // TypeScript files with .js extensions
     // https://www.typescriptlang.org/docs/handbook/esm-node.html#type-in-packagejson-and-new-extensions
-    const newId = ['.js', '.mjs', '.cjs'].includes(ext)
-      ? `${id.slice(0, -2)}ts`
+    const fallbackIds = ['.js', '.mjs', '.cjs'].includes(ext)
+      ? [
+          `${id.slice(0, -2)}ts`,
+          ...(ext === '.js' ? [`${id.slice(0, -2)}tsx`] : []),
+        ]
       : ext === '.jsx'
-        ? `${id.slice(0, -3)}tsx`
-        : null;
+        ? [`${id.slice(0, -3)}tsx`]
+        : [];
 
-    if (!newId) {
+    if (fallbackIds.length === 0) {
       throw error;
     }
-    return resolveSync(newId, options.basedir);
+
+    for (const fallbackId of fallbackIds) {
+      try {
+        return resolveSync(fallbackId, options.basedir);
+      } catch {
+        // Continue to the next TypeScript ESM fallback.
+      }
+    }
+
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #34812.

When `resolveImport()` falls back from an ESM-style `.js` import to TypeScript sources, it currently only checks the sibling `.ts` file. That misses common React component files such as `Chip.tsx`, so the component manifest can report `No component file found` even though the story renders correctly through the bundler.

This PR keeps the existing `.js -> .ts` behavior and adds a second `.js -> .tsx` fallback when no `.ts` file resolves. It also adds a regression test using a real temporary fixture directory so the resolver path matches production behavior.

## Testing

- `yarn install --immutable`
- `yarn vitest run --config code/core/vitest.config.ts code/core/src/common/utils/interpret-files.resolve.test.ts code/core/src/common/utils/__tests__/interpret-files.test.ts`

## Notes

I attempted the repository lint command locally, but this shallow fork checkout cannot resolve the workspace-built `eslint-plugin-storybook` package from `code/.eslintrc.js`. The focused Vitest regression passes locally; CI should run the full workspace pipeline with generated packages available.

#### Manual testing

Not run locally; this change is covered by the added automated regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for import resolution between JavaScript and TypeScript file formats.

* **Bug Fixes**
  * Enhanced import resolution error handling to attempt multiple file type conversion fallbacks, improving module resolution reliability in edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->