### PR TITLE
Docs: Add TOC Duplicate Subheading Coverage

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Heading.test.tsx
+++ b/code/addons/docs/src/blocks/blocks/Heading.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import React from 'react';
+
+import { ThemeProvider, convert, themes } from 'storybook/theming';
+
+import { createDocsSlugger, DocsSluggerContext } from './DocsSluggerContext';
+import { Heading } from './Heading';
+import { Subheading } from './Subheading';
+
+const renderWithSlugger = (children: React.ReactNode) => {
+  return render(
+    <ThemeProvider theme={convert(themes.light)}>
+      <DocsSluggerContext.Provider value={createDocsSlugger()}>
+        {children}
+      </DocsSluggerContext.Provider>
+    </ThemeProvider>
+  );
+};
+
+describe('Heading and Subheading', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('deduplicates repeated subheading IDs across heading groups', () => {
+    const { container } = renderWithSlugger(
+      <>
+        {['Button', 'Input', 'Tooltip'].map((section) => (
+          <React.Fragment key={section}>
+            <Heading>{section}</Heading>
+            <Subheading>Properties</Subheading>
+            <Subheading>Slots</Subheading>
+            <Subheading>Events</Subheading>
+          </React.Fragment>
+        ))}
+      </>
+    );
+
+    expect(Array.from(container.querySelectorAll('h2, h3')).map((heading) => heading.id)).toEqual([
+      'button',
+      'properties',
+      'slots',
+      'events',
+      'input',
+      'properties-1',
+      'slots-1',
+      'events-1',
+      'tooltip',
+      'properties-2',
+      'slots-2',
+      'events-2',
+    ]);
+  });
+});

--- a/code/addons/docs/src/blocks/components/TableOfContents.stories.tsx
+++ b/code/addons/docs/src/blocks/components/TableOfContents.stories.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 
+import type { Channel } from 'storybook/internal/channels';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { expect, within } from 'storybook/test';
+import { expect, waitFor, within } from 'storybook/test';
 import { styled } from 'storybook/theming';
 
+import { createDocsSlugger, DocsSluggerContext } from '../blocks/DocsSluggerContext';
 import { Heading } from '../blocks/Heading';
+import { Subheading } from '../blocks/Subheading';
 import { TableOfContents } from './TableOfContents';
 
 const MockPage = styled.div`
@@ -17,6 +20,31 @@ const MockContent = styled.div`
   width: 75%;
   border: 1px solid #ccc;
 `;
+
+const mockChannel = {
+  emit: () => {},
+} as unknown as Channel;
+
+const DuplicateHeadingDocs = () => {
+  const slugger = React.useMemo(() => createDocsSlugger(), []);
+
+  return (
+    <DocsSluggerContext.Provider value={slugger}>
+      <h1>Page title</h1>
+      {['Button', 'Input', 'Tooltip'].map((section) => (
+        <React.Fragment key={section}>
+          <Heading>{section}</Heading>
+          <Subheading>Properties</Subheading>
+          Lorem ipsum.
+          <Subheading>Slots</Subheading>
+          Lorem ipsum.
+          <Subheading>Events</Subheading>
+          Lorem ipsum.
+        </React.Fragment>
+      ))}
+    </DocsSluggerContext.Provider>
+  );
+};
 
 const meta = {
   component: TableOfContents,
@@ -50,7 +78,7 @@ export default meta;
 export const Default: StoryObj<typeof meta> = {
   args: {
     // Not used here yet. Would need to be mocked to test navigation.
-    channel: {} as any,
+    channel: mockChannel,
     headingSelector: 'h1, h2, h3',
     contentsSelector: '.local-story-docs',
   },
@@ -84,7 +112,7 @@ export const Default: StoryObj<typeof meta> = {
 
 export const WithTitle: StoryObj<typeof meta> = {
   args: {
-    channel: {} as any,
+    channel: mockChannel,
     headingSelector: 'h1, h2, h3',
     contentsSelector: '.local-story-docs',
     title: 'In this page',
@@ -111,7 +139,7 @@ export const WithTitle: StoryObj<typeof meta> = {
 
 export const WithReactTitle: StoryObj<typeof meta> = {
   args: {
-    channel: {} as any,
+    channel: mockChannel,
     headingSelector: 'h1, h2, h3',
     contentsSelector: '.local-story-docs',
     title: (
@@ -137,6 +165,50 @@ export const WithReactTitle: StoryObj<typeof meta> = {
 
     await step('Verify nav aria-labelledby', async () => {
       expect(toc).toHaveAttribute('aria-labelledby', title.id);
+    });
+  },
+};
+
+export const WithDuplicateSubheadings: StoryObj<typeof meta> = {
+  args: {
+    channel: mockChannel,
+    headingSelector: 'h2, h3',
+    contentsSelector: '.local-story-docs',
+  },
+  render: (args) => {
+    return (
+      <MockPage>
+        <MockContent className="local-story-docs">
+          <DuplicateHeadingDocs />
+        </MockContent>
+        <TableOfContents {...args} />
+      </MockPage>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    const links = await waitFor(() => {
+      const tocLinks = canvas.getAllByRole('link');
+      expect(tocLinks).toHaveLength(12);
+      return tocLinks;
+    });
+
+    await step('Verify repeated subheadings get distinct TOC links', async () => {
+      expect(links.map((link) => link.getAttribute('href'))).toEqual([
+        '#button',
+        '#properties',
+        '#slots',
+        '#events',
+        '#input',
+        '#properties-1',
+        '#slots-1',
+        '#events-1',
+        '#tooltip',
+        '#properties-2',
+        '#slots-2',
+        '#events-2',
+      ]);
     });
   },
 };


### PR DESCRIPTION
## What changed

Adds regression coverage for repeated docs subheadings such as the layout from #23584:

- `Heading.test.tsx` verifies `Heading` and `Subheading` share a docs slugger and dedupe repeated H3 labels across H2 groups.
- `TableOfContents.stories.tsx` adds a visual/play story that renders repeated `Properties`, `Slots`, and `Events` subheadings and asserts the generated TOC links target the deduped IDs.

## Why

The original TOC bug depended on duplicate H3 names under different H2 sections. Current `next` already dedupes those IDs, so this PR locks in the behavior and gives the TOC story a focused reproduction fixture.

Fixes #23584.

## Validation

- `yarn vitest run code/addons/docs/src/blocks/blocks/Heading.test.tsx`
- `yarn --cwd code lint:js:cmd addons/docs/src/blocks/components/TableOfContents.stories.tsx addons/docs/src/blocks/blocks/Heading.test.tsx`

#### Manual testing

Not run locally; this change is covered by the added automated regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for heading and subheading ID deduplication in documentation blocks.
  * Added Storybook story demonstrating proper handling of duplicate subheadings with distinct link targets in table of contents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/34984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->