### PR TITLE
Core: Fix play context types under Yarn PnP

### DIFF
--- a/code/core/src/csf/story-context.test-d.ts
+++ b/code/core/src/csf/story-context.test-d.ts
@@ -1,0 +1,10 @@
+import type { BoundFunctions } from '@testing-library/dom';
+import type { userEvent } from '@testing-library/user-event';
+import { expectTypeOf } from 'vitest';
+
+import type { PlayFunctionContext } from 'storybook/internal/csf';
+
+import type { queries } from '../test/testing-library.ts';
+
+expectTypeOf<PlayFunctionContext['canvas']>().toExtend<BoundFunctions<typeof queries>>();
+expectTypeOf<PlayFunctionContext['userEvent']>().toExtend<ReturnType<typeof userEvent.setup>>();

--- a/code/core/src/csf/story.ts
+++ b/code/core/src/csf/story.ts
@@ -1,5 +1,8 @@
+import type { BoundFunctions } from '@testing-library/dom';
+import type { userEvent } from '@testing-library/user-event';
 import type { OmitIndexSignature, Simplify, UnionToIntersection } from 'type-fest';
 
+import type { queries } from '../test/testing-library.ts';
 import type { ToolbarArgType } from '../toolbar/index.ts';
 import type { SBScalarType, SBType } from './SBType.ts';
 import type { CoreTypes } from './core-annotations.ts';
@@ -264,7 +267,7 @@ export type AfterEach<TRenderer extends Renderer = Renderer, TArgs = Args> = (
   context: StoryContext<TRenderer, TArgs>
 ) => Awaitable<void>;
 
-export interface Canvas {}
+export interface Canvas extends BoundFunctions<typeof queries> {}
 
 export interface StoryContext<TRenderer extends Renderer = Renderer, TArgs = Args>
   extends StoryContextForEnhancers<TRenderer, TArgs>, Required<StoryContextUpdate<TArgs>> {
@@ -277,6 +280,7 @@ export interface StoryContext<TRenderer extends Renderer = Renderer, TArgs = Arg
   step: StepFunction<TRenderer, TArgs>;
   context: this;
   canvas: Canvas;
+  userEvent: ReturnType<typeof userEvent.setup>;
   mount: TRenderer['mount'];
   reporting: ReportingAPI;
 }

--- a/code/core/src/test/index.ts
+++ b/code/core/src/test/index.ts
@@ -1,4 +1,3 @@
-import type { BoundFunctions } from '@testing-library/dom';
 import type { userEvent } from '@testing-library/user-event';
 
 import { instrument } from 'storybook/internal/instrumenter';
@@ -6,21 +5,11 @@ import { instrument } from 'storybook/internal/instrumenter';
 import { Assertion } from 'chai';
 
 import { expect as rawExpect } from './expect.ts';
-import { type queries } from './testing-library.ts';
 
 export * from './spy.ts';
 export type { Assertion, Expect } from './expect.ts';
 
-type Queries = BoundFunctions<typeof queries>;
-
 export type UserEventObject = ReturnType<typeof userEvent.setup>;
-
-declare module 'storybook/internal/csf' {
-  interface Canvas extends Queries {}
-  interface StoryContext {
-    userEvent: UserEventObject;
-  }
-}
 
 export const { expect } = instrument(
   { expect: rawExpect },


### PR DESCRIPTION
Fixes #30763

Moves the play context typing for `canvas` and `userEvent` into the CSF declarations instead of relying on a module augmentation that may not be loaded under Yarn PnP.

Adds a type regression test that checks both properties directly from `storybook/internal/csf`.

#### Manual testing
- Run the existing type tests covering `storybook/internal/csf`
- Verify the `play` context exposes both `canvas` and `userEvent` types when consuming Storybook under Yarn PnP