### PR TITLE
Controls: Prevent AbortError on rapid Reset button clicks

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgsTable.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 
 import { once } from 'storybook/internal/client-logger';
 import { Button, Link, ResetWrapper } from 'storybook/internal/components';
@@ -344,6 +344,23 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
     controlsId,
   } = props;
 
+  const [isResetting, setIsResetting] = useState(false);
+  const isResettingRef = useRef(false);
+
+  const handleResetArgs = useCallback(() => {
+    if (isResettingRef.current || !resetArgs) {
+      return;
+    }
+    isResettingRef.current = true;
+    setIsResetting(true);
+    resetArgs();
+    // Allow re-enabling after a short debounce so the channel event completes
+    setTimeout(() => {
+      isResettingRef.current = false;
+      setIsResetting(false);
+    }, 300);
+  }, [resetArgs]);
+
   if ('error' in props) {
     const { error } = props;
     return (
@@ -412,7 +429,8 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
             <StyledButton
               variant="ghost"
               padding="small"
-              onClick={() => resetArgs()}
+              disabled={isResetting}
+              onClick={handleResetArgs}
               ariaLabel="Reset controls"
             >
               <UndoIcon />


### PR DESCRIPTION
## Description
When clicking the 'Reset controls' button rapidly, concurrent resetArgs() calls fired, causing a race condition resulting in an unhandled AbortError.

This PR introduces a useRef guard to block concurrent resets and a useState state to immediately disable the button visually during the reset action.

#### Manual testing
- Double-clicked the reset button repeatedly in the Storybook controls panel to confirm that only a single request is fired and no AbortError is thrown in the console.