### PR TITLE
Docs: Preserve null option in TypeScript union types

### DIFF
--- a/code/core/src/csf/SBType.ts
+++ b/code/core/src/csf/SBType.ts
@@ -22,7 +22,7 @@ export type SBObjectType = SBBaseType & {
 };
 export type SBEnumType = SBBaseType & {
   name: 'enum';
-  value: (string | number)[];
+  value: (string | number | null)[];
 };
 export type SBIntersectionType = SBBaseType & {
   name: 'intersection';

--- a/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/unions.tsx
+++ b/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/unions.tsx
@@ -17,5 +17,6 @@ interface Props {
   kind?: Kind;
   inlinedNumericLiteralUnion: 0 | 1;
   enumUnion: EnumUnion;
+  unionWithNull: 'primary' | null | 1;
 }
 export const Component: FC<Props> = (props: Props) => <>JSON.stringify(props)</>;

--- a/code/core/src/docs-tools/argTypes/convert/convert.test.ts
+++ b/code/core/src/docs-tools/argTypes/convert/convert.test.ts
@@ -175,6 +175,7 @@ describe('storybook type system', () => {
           kind?: Kind;
           inlinedNumericLiteralUnion: 0 | 1;
           enumUnion: EnumUnion;
+          unionWithNull: 'primary' | null | 1;
         }
         export const Component: FC<Props> = (props: Props) => <>JSON.stringify(props)</>;
         "
@@ -209,6 +210,15 @@ describe('storybook type system', () => {
                 "name": "other",
                 "value": "NumericEnum"
               }
+            ]
+          },
+          "unionWithNull": {
+            "raw": "'primary' | null | 1",
+            "name": "enum",
+            "value": [
+              "primary",
+              null,
+              1
             ]
           }
         }

--- a/code/core/src/docs-tools/argTypes/convert/typescript/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/typescript/convert.ts
@@ -7,9 +7,11 @@ import type { TSSigType, TSType } from './types.ts';
 // Type guards for narrowing TSType discriminant unions
 type TSLiteralType = Extract<TSType, { name: 'literal' }>;
 type TSUndefinedType = Extract<TSType, { name: 'undefined' }>;
+type TSNullType = Extract<TSType, { name: 'null' }>;
 
 const isLiteral = (type: TSType): type is TSLiteralType => type.name === 'literal';
 const isUndefined = (type: TSType): type is TSUndefinedType => type.name === 'undefined';
+const isNull = (type: TSType): type is TSNullType => type.name === 'null';
 
 const convertSig = (type: TSSigType) => {
   switch (type.type) {
@@ -50,15 +52,23 @@ export const convert = (type: TSType): SBType | void => {
       return { ...base, ...convertSig(type) };
     case 'union': {
       const nonUndefinedElements = type.elements.filter((element) => !isUndefined(element));
-      const allLiterals = nonUndefinedElements.length > 0 && nonUndefinedElements.every(isLiteral);
+      const allLiterals =
+        nonUndefinedElements.length > 0 &&
+        nonUndefinedElements.every((element) => isLiteral(element) || isNull(element));
 
       if (allLiterals) {
-        // TypeScript can't infer from .every(), so we filter again with the type guard
-        const literalElements = nonUndefinedElements.filter(isLiteral);
         return {
           ...base,
           name: 'enum',
-          value: literalElements.map((element) => parseLiteral(element.value)),
+          value: nonUndefinedElements.map((element) => {
+            if (isNull(element)) {
+              return null;
+            }
+            if (isLiteral(element)) {
+              return parseLiteral(element.value);
+            }
+            return (element as any).value;
+          }),
         };
       }
       return { ...base, name, value: type.elements.map(convert) };

--- a/code/core/src/docs-tools/argTypes/convert/typescript/types.ts
+++ b/code/core/src/docs-tools/argTypes/convert/typescript/types.ts
@@ -33,7 +33,7 @@ type TSObjectSigType = TSBaseType & {
 };
 
 type TSScalarType = TSBaseType & {
-  name: 'any' | 'boolean' | 'number' | 'void' | 'string' | 'symbol' | 'undefined';
+  name: 'any' | 'boolean' | 'number' | 'void' | 'string' | 'symbol' | 'undefined' | 'null';
 };
 
 type TSLiteralType = TSBaseType & {

--- a/code/core/src/preview-api/modules/store/inferControls.test.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.test.ts
@@ -110,6 +110,25 @@ describe('inferControls', () => {
     expect(Object.keys(controls)).toEqual(['label', 'labelName', 'borderWidth']);
   });
 
+  it('should infer radio control and preserve options including null for enum type with <= 5 values', () => {
+    const inferredControls = inferControls(
+      getStoryContext({
+        argTypes: {
+          choice: {
+            type: {
+              name: 'enum',
+              value: ['primary', null, 1],
+            },
+            name: 'choice',
+          },
+        },
+      })
+    );
+
+    expect(inferredControls.choice.control).toEqual({ type: 'radio' });
+    expect(inferredControls.choice.options).toEqual(['primary', null, 1]);
+  });
+
   it('should return filtered argTypes when include is passed', () => {
     const [includeString, includeArray, includeRegex] = [
       inferControls(getStoryContext({ parameters: { controls: { include: 'label' } } })),


### PR DESCRIPTION
## Description
Unions containing null (e.g. 'primary' | null | 1) were previously ignored during allLiterals enum conversion because null was classified as name: 'null' instead of name: 'literal'. This caused null options to be removed from inferred Controls.

This PR:
- Widens SBEnumType value type to accept null.
- Widens TSScalarType name to accept 'null'.
- Adds isNull type guard to the TypeScript union converter to convert AST null element into a javascript null value in the enum option array.
- Adds corresponding tests to cover enum inference preserving null values.

#### Manual testing
- Verified with a component prop typed as a union containing null, and ensured that the control is inferred as a Radio/Select containing all options including null.