### PR TITLE
Builder-vite: Disable Vite's default publicDir copy task

### DIFF
--- a/code/builders/builder-vite/src/vite-config.test.ts
+++ b/code/builders/builder-vite/src/vite-config.test.ts
@@ -47,6 +47,7 @@ describe('commonConfig', () => {
     );
     const config = await commonConfig(dummyOptions, 'development');
     expect(config.configFile).toBe(false);
+    expect(config.publicDir).toBe(false);
     expect(config.plugins).toBeDefined();
   });
 

--- a/code/builders/builder-vite/src/vite-config.ts
+++ b/code/builders/builder-vite/src/vite-config.ts
@@ -66,6 +66,7 @@ export async function commonConfig(
   // shared between @storybook/builder-vite and @storybook/addon-vitest.
   const sbConfig: InlineConfig = {
     configFile: false,
+    publicDir: false,
     plugins: await pluginConfig(options),
     root: projectRoot,
     // Allow storybook deployed as subfolder. See https://github.com/storybookjs/builder-vite/issues/238


### PR DESCRIPTION
## Description
Vite automatically copies the public/ directory to the build root by default. This duplicates the assets already copied by Storybook's staticDirs and can overwrite Storybook's generated assets.

This PR:
- Sets publicDir: false in the default Storybook Vite config.
- Adds unit tests to verify the config.

#### Manual testing
- Ran Vite build and verified that public assets are copied only once via Storybook's static directories copying task and not duplicated by Vite's build task.