### PR TITLE
Csf-tools: Prevent false positive ObjectExpression warning on valid default exports

### DIFF
--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { babelPrint } from 'storybook/internal/babel';
+import { babelPrint, types as t } from 'storybook/internal/babel';
+import { logger } from 'storybook/internal/node-logger';
 
 import { dedent } from 'ts-dedent';
 
@@ -251,6 +252,30 @@ describe('ConfigFile', () => {
             `
           )
         ).toEqual('bar');
+      });
+
+      it('should not log warning when default export is Identifier, CallExpression, or MemberExpression', () => {
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+        // Identifier
+        loadConfig(dedent`
+          import config from './config';
+          export default config;
+        `).parse();
+
+        // CallExpression
+        loadConfig(dedent`
+          export default createConfig({ foo: 'bar' });
+        `).parse();
+
+        // MemberExpression
+        loadConfig(dedent`
+          const myConfig = { val: {} };
+          export default myConfig.val;
+        `).parse();
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
       });
     });
 

--- a/code/core/src/csf-tools/ConfigFile.ts
+++ b/code/core/src/csf-tools/ConfigFile.ts
@@ -221,7 +221,12 @@ export class ConfigFile {
 
           if (t.isObjectExpression(decl)) {
             self._parseExportsObject(decl);
-          } else {
+          } else if (
+            decl &&
+            !t.isIdentifier(decl) &&
+            !t.isCallExpression(decl) &&
+            !t.isMemberExpression(decl)
+          ) {
             logger.warn(
               getCsfParsingErrorMessage({
                 expectedType: 'ObjectExpression',
@@ -304,7 +309,12 @@ export class ConfigFile {
                     self._exports[exportName] = exportVal as t.Expression;
                   }
                 });
-              } else {
+              } else if (
+                exportObject &&
+                !t.isIdentifier(exportObject) &&
+                !t.isCallExpression(exportObject) &&
+                !t.isMemberExpression(exportObject)
+              ) {
                 logger.warn(
                   getCsfParsingErrorMessage({
                     expectedType: 'ObjectExpression',


### PR DESCRIPTION
## Description
Storybook logged a warning CSF Parsing error: Expected 'ObjectExpression' when the default export of a preview/story configuration was an imported reference or expression (e.g. an Identifier, CallExpression, or MemberExpression) that cannot be parsed statically. These exports are valid at runtime but could not be parsed to an ObjectExpression by the static parser.

This PR:
- Guards default export and module.exports checks in ConfigFile to skip warnings on Identifier, CallExpression, and MemberExpression nodes.
- Adds unit tests to cover the warning exclusion logic.

#### Manual testing
- Created a preview config with `export default config;` (imported reference) and verified that the CSF Parsing error console warning is no longer logged.
