### PR TITLE
Core: Add missing sourceUrl and expanded options to StorybookConfig refs type

### DIFF
--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -336,7 +336,8 @@ export type Entry = string;
 
 type CoreCommon_StorybookRefs = Record<
   string,
-  { title: string; url: string } | { disable: boolean; expanded?: boolean }
+  | { title: string; url: string; sourceUrl?: string; expanded?: boolean }
+  | { disable: boolean; expanded?: boolean }
 >;
 
 export type DocsOptions = {


### PR DESCRIPTION
## Description
The refs configuration field of StorybookConfig was missing sourceUrl and expanded in its TypeScript definition, generating compilation errors when users configured references composition as documented.

This PR:
- Widens CoreCommon_StorybookRefs to accept sourceUrl?: string; and expanded?: boolean; on reference objects.

#### Manual testing
- Compiled a Storybook configuration file with refs containing sourceUrl and expanded fields and verified that TypeScript typechecking passes without errors.
