### PR TITLE
Docs: Add optional isTemplate property to MetaProps type

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Meta.tsx
+++ b/code/addons/docs/src/blocks/blocks/Meta.tsx
@@ -6,7 +6,7 @@ import type { BaseAnnotations, ModuleExports } from 'storybook/internal/types';
 import { Anchor } from './Anchor';
 import { DocsContext } from './DocsContext';
 
-type MetaProps = BaseAnnotations & { of?: ModuleExports; title?: string };
+type MetaProps = BaseAnnotations & { of?: ModuleExports; title?: string; isTemplate?: boolean };
 
 /**
  * This component is used to declare component metadata in docs and gets transformed into a default


### PR DESCRIPTION
## Description
In Docs blocks, users who specify <Meta isTemplate /> get a type error because isTemplate is omitted from MetaProps type definition.

This PR:
- Adds isTemplate?: boolean to the MetaProps type.

#### Manual testing
- Rendered <Meta isTemplate /> in a Docs block file and verified that no TypeScript compilation errors occur.
