### PR TITLE
Renderers: Automatically import type augmentation from storybook/test

### DIFF
--- a/code/frameworks/angular/src/client/public-types.ts
+++ b/code/frameworks/angular/src/client/public-types.ts
@@ -12,6 +12,7 @@ import type {
 } from 'storybook/internal/types';
 import type * as AngularCore from '@angular/core';
 import type { AngularRenderer } from './types.ts';
+import type {} from 'storybook/test';
 
 export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/types';
 export type { Parameters as AngularParameters } from './types.ts';

--- a/code/renderers/html/src/public-types.ts
+++ b/code/renderers/html/src/public-types.ts
@@ -11,6 +11,7 @@ import type {
 } from 'storybook/internal/types';
 
 import type { HtmlRenderer } from './types.ts';
+import type {} from 'storybook/test';
 
 export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/types';
 export type { HtmlRenderer };

--- a/code/renderers/preact/src/public-types.ts
+++ b/code/renderers/preact/src/public-types.ts
@@ -16,6 +16,7 @@ import type { ComponentProps, ComponentType } from 'preact';
 import type { SetOptional, Simplify } from 'type-fest';
 
 import type { PreactRenderer } from './types.ts';
+import type {} from 'storybook/test';
 
 export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/types';
 export type { PreactRenderer };

--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -17,6 +17,7 @@ import type {
 import type { SetOptional, Simplify } from 'type-fest';
 
 import type { ReactRenderer } from './types.ts';
+import type {} from 'storybook/test';
 
 export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/types';
 export type { ReactRenderer };

--- a/code/renderers/server/src/public-types.ts
+++ b/code/renderers/server/src/public-types.ts
@@ -11,6 +11,7 @@ import type {
 } from 'storybook/internal/types';
 
 import type { ServerRenderer } from './types.ts';
+import type {} from 'storybook/test';
 
 export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/types';
 

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -16,6 +16,7 @@ import type { Component, ComponentProps } from 'svelte';
 import type { SetOptional, Simplify } from 'type-fest';
 
 import type { SvelteRenderer } from './types.ts';
+import type {} from 'storybook/test';
 
 export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/types';
 

--- a/code/renderers/vue3/src/public-types.ts
+++ b/code/renderers/vue3/src/public-types.ts
@@ -17,6 +17,7 @@ import type { FunctionalComponent, VNodeChild } from 'vue';
 import type { ComponentProps, ComponentSlots } from 'vue-component-type-helpers';
 
 import type { VueRenderer } from './types.ts';
+import type {} from 'storybook/test';
 
 export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/types';
 export type { VueRenderer };

--- a/code/renderers/web-components/src/public-types.ts
+++ b/code/renderers/web-components/src/public-types.ts
@@ -11,6 +11,7 @@ import type {
 } from 'storybook/internal/types';
 
 import type { WebComponentsRenderer } from './types.ts';
+import type {} from 'storybook/test';
 
 export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/types';
 export type { WebComponentsRenderer };


### PR DESCRIPTION
## Description
In CSF play functions, users targeting the play canvas (e.g. canvas.getByRole) got type errors if @storybook/test was not explicitly imported in that story file, since type augmentations on canvas from testing-library queries are only loaded when @storybook/test is loaded.

This PR:
- Adds import type {} from 'storybook/test'; to the public type definitions of all renderers and frameworks (react, vue3, svelte, preact, web-components, html, server, and angular) so query types are automatically resolved when users import Storybook types.

#### Manual testing
- Wrote a play function in a typescript story file without importing @storybook/test directly, and verified that type definitions for canvas (e.g. canvas.getByRole) are resolved correctly.
