### PR TITLE
fix: restore generic type propagation in `useArgs`

### DIFF
--- a/code/core/src/preview-api/modules/addons/hooks.ts
+++ b/code/core/src/preview-api/modules/addons/hooks.ts
@@ -560,7 +560,7 @@ export function useChannel(eventMap: EventMap, deps: any[] = []) {
 export function useStoryContext<
   TRenderer extends Renderer,
   TArgs extends Args = Args,
->(): StoryContext<TRenderer> {
+>(): StoryContext<TRenderer, TArgs> {
   const { currentContext } = getHooksContextOrThrow<TRenderer, TArgs>();
   if (currentContext == null) {
     throw invalidHooksError();


### PR DESCRIPTION
## What this does

Fixes #25070 — Broken types for `useArgs<generic>`.

## Problem

`useArgs<MyArgs>()` was not returning properly typed args. The return type was plain `Args` instead of `MyArgs`.

## Root cause

`useStoryContext` was dropping the `TArgs` generic parameter from its return type:

```diff
- >(): StoryContext<TRenderer> {
+ >(): StoryContext<TRenderer, TArgs> {
```

Since `useArgs` calls `useStoryContext<Renderer, TArgs>()` to get the args, the dropped generic meant `args` was always typed as plain `Args` regardless of what generic was passed.

## Changes

1 character changed — adding `, TArgs` to `useStoryContext`s return type to preserve the generic through the call chain.

## How it works

- `StoryContext<TRenderer, TArgs>` already supports TArgs (defined in `code/core/src/csf/story.ts`)
- `getHooksContextOrThrow<TRenderer, TArgs>()` already passes TArgs correctly
- The fix just types the function signature to match whats already happening at runtime

## Testing

TypeScript compilation of Storybook itself succeeds with the change. Users calling `useArgs<{ name: string }>()` will now correctly get `[{ name: string }, ...]` instead of `[Args, ...]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type parameters for the story context hook to include story arguments type parameterization, enabling more precise type inference and better developer experience when working with story contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->