### PR TITLE
feat(docgen): re-extract docgen on source change (server-side)

### DIFF
--- a/code/core/src/core-server/change-detection/ChangeDetectionService.test.ts
+++ b/code/core/src/core-server/change-detection/ChangeDetectionService.test.ts
@@ -1064,6 +1064,96 @@ describe('ChangeDetectionService', () => {
     await service.dispose();
   });
 
+  it('calls onInvalidate with the affected story files when a dependency changes', async () => {
+    // Button.tsx is imported by Button.stories.tsx (distance 1).
+    const reverseIndex = buildReverseIndex([
+      ['/repo/src/Button.tsx', '/repo/src/Button.stories.tsx', 1],
+      ['/repo/src/Button.stories.tsx', '/repo/src/Button.stories.tsx', 0],
+    ]);
+    const { buildSpy } = installDependencyGraphMocks(reverseIndex);
+    buildSpy.mockResolvedValue({ reverseIndex, graph: new Map() });
+
+    const storyIndex = createStoryIndex([
+      { storyId: 'button--primary', importPath: './src/Button.stories.tsx', title: 'Button' },
+    ]);
+    const { getStatusStoreByTypeId } = createStatusStore({
+      universalStatusStore: new MockUniversalStore(UNIVERSAL_STATUS_STORE_OPTIONS),
+      environment: 'server',
+    });
+    const onInvalidate = vi.fn();
+    const { adapter, emitFileChange } = createMockAdapter();
+    const service = new ChangeDetectionService({
+      storyIndexGeneratorPromise: Promise.resolve({
+        getIndex: vi.fn().mockResolvedValue(storyIndex),
+      } as never),
+      statusStore: getStatusStoreByTypeId(CHANGE_DETECTION_STATUS_TYPE_ID),
+      gitDiffProvider: createMockGitDiffProvider(),
+      indexBaselineService: createMockStoryIndexBaselineService(),
+      workingDir,
+      onInvalidate,
+    });
+
+    service.start(adapter, true);
+    await vi.runAllTimersAsync();
+
+    emitFileChange({ kind: 'change', path: '/repo/src/Button.tsx' });
+    await vi.runAllTimersAsync();
+
+    expect(onInvalidate).toHaveBeenCalledWith(['/repo/src/Button.stories.tsx']);
+
+    await service.dispose();
+  });
+
+  it('graph-only mode (publishStatuses:false) emits invalidations without publishing statuses or calling git', async () => {
+    const reverseIndex = buildReverseIndex([
+      ['/repo/src/Button.tsx', '/repo/src/Button.stories.tsx', 1],
+    ]);
+    const { buildSpy } = installDependencyGraphMocks(reverseIndex);
+    buildSpy.mockResolvedValue({ reverseIndex, graph: new Map() });
+
+    const storyIndex = createStoryIndex([
+      { storyId: 'button--primary', importPath: './src/Button.stories.tsx', title: 'Button' },
+    ]);
+    const { getStatusStoreByTypeId } = createStatusStore({
+      universalStatusStore: new MockUniversalStore(UNIVERSAL_STATUS_STORE_OPTIONS),
+      environment: 'server',
+    });
+    const gitDiffProvider = createMockGitDiffProvider((provider) => {
+      provider.getChangedFilesMock.mockResolvedValue({
+        changed: new Set(['src/Button.stories.tsx']),
+        new: new Set(),
+      });
+    });
+    const onInvalidate = vi.fn();
+    const { adapter, emitFileChange } = createMockAdapter();
+    const service = new ChangeDetectionService({
+      storyIndexGeneratorPromise: Promise.resolve({
+        getIndex: vi.fn().mockResolvedValue(storyIndex),
+      } as never),
+      statusStore: getStatusStoreByTypeId(CHANGE_DETECTION_STATUS_TYPE_ID),
+      gitDiffProvider,
+      indexBaselineService: createMockStoryIndexBaselineService(),
+      workingDir,
+      publishStatuses: false,
+      onInvalidate,
+    });
+
+    service.start(adapter, true);
+    await vi.runAllTimersAsync();
+
+    emitFileChange({ kind: 'change', path: '/repo/src/Button.tsx' });
+    await vi.runAllTimersAsync();
+
+    // Invalidations still fire, but no statuses are published and git is never consulted.
+    expect(onInvalidate).toHaveBeenCalledWith(['/repo/src/Button.stories.tsx']);
+    expect(getStatusStoreByTypeId(CHANGE_DETECTION_STATUS_TYPE_ID).getAll()).toEqual({});
+    expect(gitDiffProvider.getChangedFilesMock).not.toHaveBeenCalled();
+    expect(gitDiffProvider.onGitStateChangeMock).not.toHaveBeenCalled();
+    expect(await getChangeDetectionReadiness()).toEqual({ status: 'ready' });
+
+    await service.dispose();
+  });
+
   it('scan waits for the current patch to settle before reading reverseIndex', async () => {
     // Without the patchSnapshot await in scan(), a git-state-change that fires scheduleScan
     // while a patch is mid-rewalk (reverseIndex transiently empty) reads the empty index

--- a/code/core/src/core-server/change-detection/ChangeDetectionService.ts
+++ b/code/core/src/core-server/change-detection/ChangeDetectionService.ts
@@ -153,6 +153,8 @@ export class ChangeDetectionService {
   private indexBaselineService: IndexBaselineService | undefined;
   private readonly workingDir: string;
   private readonly debounceMs: number;
+  private readonly publishStatuses: boolean;
+  private readonly onInvalidate?: (affectedStoryFiles: string[]) => void;
   private adapter: ChangeDetectionAdapter | undefined;
   private dependencyGraphBuilder: DependencyGraphBuilder | undefined;
   private incrementalPatcher: IncrementalPatcher | undefined;
@@ -181,12 +183,27 @@ export class ChangeDetectionService {
       debounceMs?: number;
       /** Presets instance used to resolve `experimental_importParsers` contributions from framework/renderer plugins. */
       presets?: Presets;
+      /**
+       * When `false`, run the dependency graph + file watching + {@link onInvalidate} emit only,
+       * without computing or publishing git-diff statuses to the status store. Lets the graph power
+       * other consumers (e.g. the docgen service) without surfacing "review changes" sidebar
+       * statuses. Defaults to `true` (the existing full change-detection behavior).
+       */
+      publishStatuses?: boolean;
+      /**
+       * Called after each file-change batch with the absolute, normalized story files affected by
+       * the change (the changed file's reverse-index dependents, plus the file itself when it is a
+       * story). Independent of {@link publishStatuses}; fires in both modes.
+       */
+      onInvalidate?: (affectedStoryFiles: string[]) => void;
     }
   ) {
     this.gitDiffProvider = options.gitDiffProvider;
     this.indexBaselineService = options.indexBaselineService;
     this.workingDir = options.workingDir ?? process.cwd();
     this.debounceMs = options.debounceMs ?? CHANGE_DETECTION_DEBOUNCE_MS;
+    this.publishStatuses = options.publishStatuses ?? true;
+    this.onInvalidate = options.onInvalidate;
     resetChangeDetectionReadiness();
   }
 
@@ -345,20 +362,25 @@ export class ChangeDetectionService {
       });
     }
 
-    void this.getIndexBaselineService().start();
+    // Baseline + git-state subscriptions are status-only concerns. In graph-only mode (docgen)
+    // we skip them so the graph never depends on git and never publishes statuses.
+    if (this.publishStatuses) {
+      void this.getIndexBaselineService().start();
 
-    this.getGitDiffProvider().onGitStateChange(() => {
-      if (this.disposed) {
-        return;
-      }
+      this.getGitDiffProvider().onGitStateChange(() => {
+        if (this.disposed) {
+          return;
+        }
 
-      this.scheduleScan(this.debounceMs);
-      void this.getIndexBaselineService()
-        .handleGitStateChange()
-        .catch(() => undefined);
-    });
+        this.scheduleScan(this.debounceMs);
+        void this.getIndexBaselineService()
+          .handleGitStateChange()
+          .catch(() => undefined);
+      });
+    }
 
-    // Initial scan surfaces git-pending diffs immediately.
+    // Initial scan surfaces git-pending diffs immediately (and resolves readiness in graph-only
+    // mode).
     this.scheduleScan(0);
   }
 
@@ -514,6 +536,22 @@ export class ChangeDetectionService {
     if (this.disposed || !this.incrementalPatcher) {
       return;
     }
+
+    const path = normalize(event.path);
+    const affectedStoryFiles = new Set<string>();
+    const collectAffected = () => {
+      if (!this.reverseIndex) {
+        return;
+      }
+      for (const story of this.reverseIndex.lookup(path).keys()) {
+        affectedStoryFiles.add(story);
+      }
+    };
+    // Snapshot dependents before the patch so `unlink` (which prunes the reverse index) is still
+    // captured. The patcher may also early-return on a content-only edit with an unchanged import
+    // set, but the existing edges still resolve here.
+    collectAffected();
+
     try {
       await this.incrementalPatcher.patch(event);
     } catch (error) {
@@ -524,6 +562,17 @@ export class ChangeDetectionService {
     if (this.disposed) {
       return;
     }
+
+    // Snapshot again to capture dependents introduced by `add`/`change`, then include the file
+    // itself when it is a story root.
+    collectAffected();
+    if (this.storyFiles.has(path)) {
+      affectedStoryFiles.add(path);
+    }
+    if (this.onInvalidate && affectedStoryFiles.size > 0) {
+      this.onInvalidate([...affectedStoryFiles]);
+    }
+
     this.scheduleScan(this.debounceMs);
   }
 
@@ -561,6 +610,13 @@ export class ChangeDetectionService {
     this.scanInFlight = true;
 
     try {
+      // Graph-only mode: the dependency graph + invalidation emit are the only work; skip all
+      // git-diff status computation and publishing.
+      if (!this.publishStatuses) {
+        this.resolveReadiness({ status: 'ready' });
+        return;
+      }
+
       const nextStatuses = await this.buildStatuses(this.reverseIndex);
       if (this.disposed) {
         return;

--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -7,6 +7,9 @@ import type { Options } from 'storybook/internal/types';
 import compression from '@polka/compression';
 import polka from 'polka';
 
+import { getService } from '../shared/open-service/server.ts';
+import type { docgenServiceDef } from '../shared/open-service/services/docgen/definition.ts';
+import type { moduleGraphServiceDef } from '../shared/open-service/services/module-graph/definition.ts';
 import { isTelemetryModuleEnabled, telemetry } from '../telemetry/index.ts';
 import type { ChangeDetectionAdapter } from './change-detection/index.ts';
 import { ChangeDetectionService } from './change-detection/index.ts';
@@ -48,11 +51,51 @@ export async function storybookDevServer(
   const storyIndexGeneratorPromise =
     options.presets.apply<StoryIndexGenerator>('storyIndexGenerator');
 
+  // The docgen service (registered in the `services` preset) needs the change-detection dependency
+  // graph to know which components a file change affects, even when the change-detection *status*
+  // feature is off — so we run the graph (without publishing statuses) whenever docgen is enabled.
+  const experimentalDocgenServer = !!features?.experimentalDocgenServer && !options.ignorePreview;
+
+  /**
+   * Re-extracts docgen for components affected by a source change.
+   *
+   * Translates the change-detection graph's affected story files into component ids via the
+   * `core/module-graph` service, then asks `core/docgen` to re-extract the ones already in state
+   * (re-extract-if-present). Best-effort: failures are logged at debug and never break the watcher.
+   */
+  async function invalidateDocgenForStoryFiles(affectedStoryFiles: string[]): Promise<void> {
+    if (affectedStoryFiles.length === 0) {
+      return;
+    }
+    try {
+      const moduleGraph = getService<typeof moduleGraphServiceDef>('core/module-graph');
+      const docgen = getService<typeof docgenServiceDef>('core/docgen');
+      const { componentIds } = await moduleGraph.commands.resolveAffectedComponents({
+        storyFiles: affectedStoryFiles,
+      });
+      if (componentIds.length > 0) {
+        await docgen.commands.handleSourceChange({ componentIds });
+      }
+    } catch (error) {
+      logger.debug(
+        `Docgen invalidation skipped: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
   const changeDetectionService = new ChangeDetectionService({
     storyIndexGeneratorPromise,
     statusStore: getStatusStoreByTypeId(CHANGE_DETECTION_STATUS_TYPE_ID),
     workingDir,
     presets: options.presets,
+    // Only publish "review changes" sidebar statuses when the change-detection feature is on.
+    publishStatuses: !!features.changeDetection,
+    // When docgen is enabled, the graph drives docgen re-extraction on file changes.
+    onInvalidate: experimentalDocgenServer
+      ? (affectedStoryFiles) => {
+          void invalidateDocgenForStoryFiles(affectedStoryFiles);
+        }
+      : undefined,
   });
 
   app.use(compression({ level: 1 }));
@@ -124,7 +167,11 @@ export async function storybookDevServer(
     await Promise.resolve();
 
   if (!options.ignorePreview) {
-    if (!features.changeDetection) {
+    // Run the dependency graph when either the change-detection status feature or the docgen
+    // service needs it. `publishStatuses` (set above) decides whether statuses are surfaced.
+    const needsChangeDetectionGraph = !!features.changeDetection || experimentalDocgenServer;
+
+    if (!needsChangeDetectionGraph) {
       changeDetectionService.start(undefined, false);
     }
 
@@ -153,7 +200,7 @@ export async function storybookDevServer(
         throw e;
       });
 
-    if (features.changeDetection) {
+    if (needsChangeDetectionGraph) {
       let adapter: ChangeDetectionAdapter | undefined;
       try {
         adapter = previewBuilder.changeDetectionAdapter?.();

--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -8,7 +8,6 @@ import compression from '@polka/compression';
 import polka from 'polka';
 
 import { getService } from '../shared/open-service/server.ts';
-import type { docgenServiceDef } from '../shared/open-service/services/docgen/definition.ts';
 import type { moduleGraphServiceDef } from '../shared/open-service/services/module-graph/definition.ts';
 import { isTelemetryModuleEnabled, telemetry } from '../telemetry/index.ts';
 import type { ChangeDetectionAdapter } from './change-detection/index.ts';
@@ -57,28 +56,24 @@ export async function storybookDevServer(
   const experimentalDocgenServer = !!features?.experimentalDocgenServer && !options.ignorePreview;
 
   /**
-   * Re-extracts docgen for components affected by a source change.
+   * Feeds affected story files into the `core/module-graph` service.
    *
-   * Translates the change-detection graph's affected story files into component ids via the
-   * `core/module-graph` service, then asks `core/docgen` to re-extract the ones already in state
-   * (re-extract-if-present). Best-effort: failures are logged at debug and never break the watcher.
+   * This is the one imperative edge from the (non-open-service) change detector into the service
+   * world: it records which components changed into module-graph state. The docgen service reacts
+   * to that state change through an open-service subscription wired in the `services` preset — the
+   * dev server intentionally knows nothing about docgen here. Best-effort: failures are logged at
+   * debug and never break the watcher.
    */
-  async function invalidateDocgenForStoryFiles(affectedStoryFiles: string[]): Promise<void> {
+  async function recordAffectedStoryFiles(affectedStoryFiles: string[]): Promise<void> {
     if (affectedStoryFiles.length === 0) {
       return;
     }
     try {
       const moduleGraph = getService<typeof moduleGraphServiceDef>('core/module-graph');
-      const docgen = getService<typeof docgenServiceDef>('core/docgen');
-      const { componentIds } = await moduleGraph.commands.resolveAffectedComponents({
-        storyFiles: affectedStoryFiles,
-      });
-      if (componentIds.length > 0) {
-        await docgen.commands.handleSourceChange({ componentIds });
-      }
+      await moduleGraph.commands.resolveAffectedComponents({ storyFiles: affectedStoryFiles });
     } catch (error) {
       logger.debug(
-        `Docgen invalidation skipped: ${error instanceof Error ? error.message : String(error)}`
+        `Module-graph invalidation skipped: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }
@@ -90,10 +85,10 @@ export async function storybookDevServer(
     presets: options.presets,
     // Only publish "review changes" sidebar statuses when the change-detection feature is on.
     publishStatuses: !!features.changeDetection,
-    // When docgen is enabled, the graph drives docgen re-extraction on file changes.
+    // When docgen is enabled, feed file changes into the module-graph service; docgen reacts to it.
     onInvalidate: experimentalDocgenServer
       ? (affectedStoryFiles) => {
-          void invalidateDocgenForStoryFiles(affectedStoryFiles);
+          void recordAffectedStoryFiles(affectedStoryFiles);
         }
       : undefined,
   });

--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -26,7 +26,10 @@ import type {
   StorybookConfigRaw,
 } from 'storybook/internal/types';
 
-import { registerDocgenService } from '../../shared/open-service/services/docgen/server.ts';
+import {
+  connectDocgenToModuleGraph,
+  registerDocgenService,
+} from '../../shared/open-service/services/docgen/server.ts';
 import { registerModuleGraphService } from '../../shared/open-service/services/module-graph/server.ts';
 
 import { isAbsolute, join } from 'pathe';
@@ -347,17 +350,22 @@ export const services = async (_value: void, options: Options): Promise<void> =>
     );
 
     // The module-graph service translates change-detection's affected story files into component
-    // ids so the docgen service can re-extract only the components that actually changed. It owns
-    // no file watching itself; it is fed by the change-detection graph (wired in dev-server).
-    registerModuleGraphService({
+    // ids. It owns no file watching itself; it is fed by the change-detection graph (the dev server
+    // calls its `resolveAffectedComponents` command on file changes).
+    const moduleGraph = registerModuleGraphService({
       getIndex: () => generator.getIndex(),
       workingDir: process.cwd(),
     });
 
-    registerDocgenService({
+    const docgen = registerDocgenService({
       getIndex: () => generator.getIndex(),
       provider,
     });
+
+    // Connect the two services with an open-service subscription: docgen re-extracts whenever the
+    // module graph reports an invalidation. The dev server only feeds the module graph; it never
+    // talks to docgen directly.
+    connectDocgenToModuleGraph(docgen, moduleGraph);
   }
 };
 

--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -27,6 +27,7 @@ import type {
 } from 'storybook/internal/types';
 
 import { registerDocgenService } from '../../shared/open-service/services/docgen/server.ts';
+import { registerModuleGraphService } from '../../shared/open-service/services/module-graph/server.ts';
 
 import { isAbsolute, join } from 'pathe';
 import * as pathe from 'pathe';
@@ -344,6 +345,14 @@ export const services = async (_value: void, options: Options): Promise<void> =>
        */
       async () => undefined
     );
+
+    // The module-graph service translates change-detection's affected story files into component
+    // ids so the docgen service can re-extract only the components that actually changed. It owns
+    // no file watching itself; it is fed by the change-detection graph (wired in dev-server).
+    registerModuleGraphService({
+      getIndex: () => generator.getIndex(),
+      workingDir: process.cwd(),
+    });
 
     registerDocgenService({
       getIndex: () => generator.getIndex(),

--- a/code/core/src/shared/open-service/services/docgen/definition.ts
+++ b/code/core/src/shared/open-service/services/docgen/definition.ts
@@ -6,6 +6,9 @@ import type { DocgenPayload } from './types.ts';
 /** Caller-facing input to the `getDocgen` query and the `extractDocgen` command. */
 export const docgenInputSchema = v.object({ componentId: v.string() });
 
+/** Input to the `handleSourceChange` command: component ids whose source may have changed. */
+export const handleSourceChangeInputSchema = v.object({ componentIds: v.array(v.string()) });
+
 /**
  * Phase-1 docgen payload schema.
  *
@@ -72,6 +75,14 @@ export const docgenServiceDef = defineService({
       output: docgenOutputSchema,
       // Handler is supplied at registration time so it can close over the story index and the
       // composed experimental_docgenProvider chain.
+    },
+    handleSourceChange: {
+      description:
+        'Re-extracts docgen for the given componentIds that are already present in state (leaving absent ones for lazy load on next read). Used to keep docgen fresh when source files change.',
+      input: handleSourceChangeInputSchema,
+      output: v.void(),
+      // Handler is supplied at registration time so it can log keep-last-good extraction failures
+      // without pulling a node-only logger into the environment-agnostic definition.
     },
   },
 });

--- a/code/core/src/shared/open-service/services/docgen/invalidation.integration.test.ts
+++ b/code/core/src/shared/open-service/services/docgen/invalidation.integration.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { join, normalize } from 'pathe';
+
+import type { IndexEntry, StoryIndex } from '../../../../types/modules/indexer.ts';
+import { clearRegistry, getService } from '../../server.ts';
+import type { docgenServiceDef } from './definition.ts';
+import { registerDocgenService } from './server.ts';
+import type { DocgenProvider } from './types.ts';
+import type { moduleGraphServiceDef } from '../module-graph/definition.ts';
+import { registerModuleGraphService } from '../module-graph/server.ts';
+
+afterEach(() => {
+  clearRegistry();
+});
+
+const WORKING_DIR = '/repo';
+
+function makeStoryEntry(id: string, fileBase: string): IndexEntry {
+  return {
+    id,
+    name: id.split('--').slice(1).join('--') || 'Default',
+    title: fileBase,
+    type: 'story',
+    subtype: 'story',
+    importPath: `./${fileBase}.stories.tsx`,
+  };
+}
+
+function makeGetIndex(entries: IndexEntry[]) {
+  const index: StoryIndex = {
+    v: 5,
+    entries: Object.fromEntries(entries.map((entry) => [entry.id, entry])),
+  };
+  return () => Promise.resolve(index);
+}
+
+function absStoryFile(fileBase: string): string {
+  return normalize(join(WORKING_DIR, `./${fileBase}.stories.tsx`));
+}
+
+/**
+ * Mirrors the dev-server glue (`onInvalidate` -> module-graph -> docgen) against the real
+ * process-global registry, proving the cross-service composition works end-to-end on the server.
+ */
+async function invalidateDocgenForStoryFiles(affectedStoryFiles: string[]): Promise<void> {
+  const moduleGraph = getService<typeof moduleGraphServiceDef>('core/module-graph');
+  const docgen = getService<typeof docgenServiceDef>('core/docgen');
+  const { componentIds } = await moduleGraph.commands.resolveAffectedComponents({
+    storyFiles: affectedStoryFiles,
+  });
+  if (componentIds.length > 0) {
+    await docgen.commands.handleSourceChange({ componentIds });
+  }
+}
+
+describe('docgen invalidation (server-side end-to-end)', () => {
+  it('re-extracts and notifies subscribers when an affected story file changes', async () => {
+    // A content-sensitive provider whose output changes when the underlying source changes.
+    const descriptionByImportPath: Record<string, string> = {
+      './button.stories.tsx': 'v1',
+    };
+    const provider: DocgenProvider = async ({ importPath }) => ({
+      componentId: 'button',
+      name: 'Button',
+      description: descriptionByImportPath[importPath] ?? 'unknown',
+      props: [],
+    });
+
+    registerModuleGraphService({
+      getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
+      workingDir: WORKING_DIR,
+    });
+    const docgen = registerDocgenService({
+      getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
+      provider,
+    });
+
+    // User navigates to the component: docgen is extracted and cached.
+    await docgen.queries.getDocgen.loaded({ componentId: 'button' });
+    expect(docgen.queries.getDocgen({ componentId: 'button' })).toMatchObject({
+      description: 'v1',
+    });
+
+    const emitted: Array<{ description: string } | undefined> = [];
+    const unsubscribe = docgen.queries.getDocgen.subscribe({ componentId: 'button' }, (value) => {
+      emitted.push(value as { description: string } | undefined);
+    });
+    await vi.waitFor(() => expect(emitted.at(-1)).toMatchObject({ description: 'v1' }));
+
+    // The component's source changes on disk.
+    descriptionByImportPath['./button.stories.tsx'] = 'v2';
+    await invalidateDocgenForStoryFiles([absStoryFile('button')]);
+
+    // Future reads are fresh (no stale data) and the live subscriber was notified (no flash).
+    expect(docgen.queries.getDocgen({ componentId: 'button' })).toMatchObject({
+      description: 'v2',
+    });
+    await vi.waitFor(() => expect(emitted.at(-1)).toMatchObject({ description: 'v2' }));
+
+    unsubscribe();
+  });
+
+  it('does not extract components that were never viewed (re-extract-if-present)', async () => {
+    const provider = vi.fn<DocgenProvider>(async () => ({
+      componentId: 'button',
+      name: 'Button',
+      description: 'x',
+      props: [],
+    }));
+
+    registerModuleGraphService({
+      getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
+      workingDir: WORKING_DIR,
+    });
+    registerDocgenService({
+      getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
+      provider,
+    });
+
+    await invalidateDocgenForStoryFiles([absStoryFile('button')]);
+
+    expect(provider).not.toHaveBeenCalled();
+    expect(
+      getService<typeof docgenServiceDef>('core/docgen').queries.getDocgen({
+        componentId: 'button',
+      })
+    ).toBeUndefined();
+  });
+});

--- a/code/core/src/shared/open-service/services/docgen/invalidation.integration.test.ts
+++ b/code/core/src/shared/open-service/services/docgen/invalidation.integration.test.ts
@@ -3,11 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { join, normalize } from 'pathe';
 
 import type { IndexEntry, StoryIndex } from '../../../../types/modules/indexer.ts';
-import { clearRegistry, getService } from '../../server.ts';
-import type { docgenServiceDef } from './definition.ts';
-import { registerDocgenService } from './server.ts';
+import { clearRegistry } from '../../server.ts';
+import { connectDocgenToModuleGraph, registerDocgenService } from './server.ts';
 import type { DocgenProvider } from './types.ts';
-import type { moduleGraphServiceDef } from '../module-graph/definition.ts';
 import { registerModuleGraphService } from '../module-graph/server.ts';
 
 afterEach(() => {
@@ -40,22 +38,24 @@ function absStoryFile(fileBase: string): string {
 }
 
 /**
- * Mirrors the dev-server glue (`onInvalidate` -> module-graph -> docgen) against the real
- * process-global registry, proving the cross-service composition works end-to-end on the server.
+ * Sets up the same wiring the `services` preset does: register both services and connect docgen to
+ * the module graph via the open-service subscription. The change detector is simulated by calling
+ * the module graph's `resolveAffectedComponents` command directly (in production the dev server
+ * does this on file-change events).
  */
-async function invalidateDocgenForStoryFiles(affectedStoryFiles: string[]): Promise<void> {
-  const moduleGraph = getService<typeof moduleGraphServiceDef>('core/module-graph');
-  const docgen = getService<typeof docgenServiceDef>('core/docgen');
-  const { componentIds } = await moduleGraph.commands.resolveAffectedComponents({
-    storyFiles: affectedStoryFiles,
+function setup(provider: DocgenProvider) {
+  const entries = [makeStoryEntry('button--primary', 'button')];
+  const moduleGraph = registerModuleGraphService({
+    getIndex: makeGetIndex(entries),
+    workingDir: WORKING_DIR,
   });
-  if (componentIds.length > 0) {
-    await docgen.commands.handleSourceChange({ componentIds });
-  }
+  const docgen = registerDocgenService({ getIndex: makeGetIndex(entries), provider });
+  const unsubscribe = connectDocgenToModuleGraph(docgen, moduleGraph);
+  return { moduleGraph, docgen, unsubscribe };
 }
 
-describe('docgen invalidation (server-side end-to-end)', () => {
-  it('re-extracts and notifies subscribers when an affected story file changes', async () => {
+describe('docgen invalidation (server-side, open-service native wiring)', () => {
+  it('re-extracts and notifies subscribers when the module graph reports a change', async () => {
     // A content-sensitive provider whose output changes when the underlying source changes.
     const descriptionByImportPath: Record<string, string> = {
       './button.stories.tsx': 'v1',
@@ -67,37 +67,34 @@ describe('docgen invalidation (server-side end-to-end)', () => {
       props: [],
     });
 
-    registerModuleGraphService({
-      getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
-      workingDir: WORKING_DIR,
-    });
-    const docgen = registerDocgenService({
-      getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
-      provider,
-    });
+    const { moduleGraph, docgen, unsubscribe } = setup(provider);
 
-    // User navigates to the component: docgen is extracted and cached.
+    // User navigates to the component: docgen is extracted and cached ("present").
     await docgen.queries.getDocgen.loaded({ componentId: 'button' });
     expect(docgen.queries.getDocgen({ componentId: 'button' })).toMatchObject({
       description: 'v1',
     });
 
     const emitted: Array<{ description: string } | undefined> = [];
-    const unsubscribe = docgen.queries.getDocgen.subscribe({ componentId: 'button' }, (value) => {
+    const unsubDocgen = docgen.queries.getDocgen.subscribe({ componentId: 'button' }, (value) => {
       emitted.push(value as { description: string } | undefined);
     });
     await vi.waitFor(() => expect(emitted.at(-1)).toMatchObject({ description: 'v1' }));
 
-    // The component's source changes on disk.
+    // The component's source changes; the change detector feeds the module graph. No explicit
+    // docgen call here — docgen reacts through its subscription to the module graph.
     descriptionByImportPath['./button.stories.tsx'] = 'v2';
-    await invalidateDocgenForStoryFiles([absStoryFile('button')]);
+    await moduleGraph.commands.resolveAffectedComponents({ storyFiles: [absStoryFile('button')] });
 
     // Future reads are fresh (no stale data) and the live subscriber was notified (no flash).
-    expect(docgen.queries.getDocgen({ componentId: 'button' })).toMatchObject({
-      description: 'v2',
-    });
+    await vi.waitFor(() =>
+      expect(docgen.queries.getDocgen({ componentId: 'button' })).toMatchObject({
+        description: 'v2',
+      })
+    );
     await vi.waitFor(() => expect(emitted.at(-1)).toMatchObject({ description: 'v2' }));
 
+    unsubDocgen();
     unsubscribe();
   });
 
@@ -109,22 +106,49 @@ describe('docgen invalidation (server-side end-to-end)', () => {
       props: [],
     }));
 
-    registerModuleGraphService({
-      getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
-      workingDir: WORKING_DIR,
-    });
-    registerDocgenService({
-      getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
-      provider,
-    });
+    const { moduleGraph, unsubscribe } = setup(provider);
 
-    await invalidateDocgenForStoryFiles([absStoryFile('button')]);
+    await moduleGraph.commands.resolveAffectedComponents({ storyFiles: [absStoryFile('button')] });
+    // Let the docgen subscription run handleSourceChange.
+    await vi.waitFor(() =>
+      expect(moduleGraph.queries.getLastAffected({}).componentIds).toEqual(['button'])
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
+    // Never extracted -> absent -> provider must not have been invoked by the invalidation.
     expect(provider).not.toHaveBeenCalled();
-    expect(
-      getService<typeof docgenServiceDef>('core/docgen').queries.getDocgen({
-        componentId: 'button',
-      })
-    ).toBeUndefined();
+
+    unsubscribe();
+  });
+
+  it('re-emits on repeated changes to the same component (revision defeats value-dedup)', async () => {
+    let version = 1;
+    const provider: DocgenProvider = async () => ({
+      componentId: 'button',
+      name: 'Button',
+      description: `v${version}`,
+      props: [],
+    });
+
+    const { moduleGraph, docgen, unsubscribe } = setup(provider);
+
+    await docgen.queries.getDocgen.loaded({ componentId: 'button' });
+
+    const emitted: string[] = [];
+    const unsubDocgen = docgen.queries.getDocgen.subscribe({ componentId: 'button' }, (value) => {
+      emitted.push((value as { description: string }).description);
+    });
+    await vi.waitFor(() => expect(emitted.at(-1)).toBe('v1'));
+
+    version = 2;
+    await moduleGraph.commands.resolveAffectedComponents({ storyFiles: [absStoryFile('button')] });
+    await vi.waitFor(() => expect(emitted.at(-1)).toBe('v2'));
+
+    version = 3;
+    await moduleGraph.commands.resolveAffectedComponents({ storyFiles: [absStoryFile('button')] });
+    await vi.waitFor(() => expect(emitted.at(-1)).toBe('v3'));
+
+    unsubDocgen();
+    unsubscribe();
   });
 });

--- a/code/core/src/shared/open-service/services/docgen/server.test.ts
+++ b/code/core/src/shared/open-service/services/docgen/server.test.ts
@@ -139,6 +139,92 @@ describe('docgen open service', () => {
     });
   });
 
+  describe('handleSourceChange command', () => {
+    it('re-extracts components already in state and pushes the new value to subscribers', async () => {
+      let description = 'v1';
+      const service = registerDocgenService({
+        getIndex: makeGetIndex([makeStoryEntry('button--primary', 'Button')]),
+        provider: async () => ({
+          componentId: 'button',
+          name: 'Button',
+          description,
+          props: [],
+        }),
+      });
+
+      // Prime state so the component is "present".
+      await service.commands.extractDocgen({ componentId: 'button' });
+
+      const emitted: Array<{ description: string } | undefined> = [];
+      const unsubscribe = service.queries.getDocgen.subscribe(
+        { componentId: 'button' },
+        (value) => {
+          emitted.push(value as { description: string } | undefined);
+        }
+      );
+      await vi.waitFor(() => expect(emitted.length).toBeGreaterThan(0));
+
+      // The source "changes" so the provider now returns a different payload.
+      description = 'v2';
+      await service.commands.handleSourceChange({ componentIds: ['button'] });
+
+      expect(service.queries.getDocgen({ componentId: 'button' })).toMatchObject({
+        description: 'v2',
+      });
+      await vi.waitFor(() => expect(emitted.at(-1)).toMatchObject({ description: 'v2' }));
+
+      unsubscribe();
+    });
+
+    it('ignores components that are not already in state (re-extract-if-present)', async () => {
+      const provider = vi.fn<DocgenProvider>(async () => ({
+        componentId: 'button',
+        name: 'Button',
+        description: 'x',
+        props: [],
+      }));
+      const service = registerDocgenService({
+        getIndex: makeGetIndex([makeStoryEntry('button--primary', 'Button')]),
+        provider,
+      });
+
+      await service.commands.handleSourceChange({ componentIds: ['button'] });
+
+      // Never extracted -> absent -> provider must not have been invoked.
+      expect(provider).not.toHaveBeenCalled();
+      expect(service.queries.getDocgen({ componentId: 'button' })).toBeUndefined();
+    });
+
+    it('keeps the last-good payload when re-extraction throws', async () => {
+      let shouldThrow = false;
+      const service = registerDocgenService({
+        getIndex: makeGetIndex([makeStoryEntry('button--primary', 'Button')]),
+        provider: async () => {
+          if (shouldThrow) {
+            throw new Error('transient parse error');
+          }
+          return { componentId: 'button', name: 'Button', description: 'good', props: [] };
+        },
+      });
+
+      // Prime state with a good payload (command call, no fire-and-forget load involved).
+      await service.commands.extractDocgen({ componentId: 'button' });
+
+      shouldThrow = true;
+      await expect(
+        service.commands.handleSourceChange({ componentIds: ['button'] })
+      ).resolves.toBeUndefined();
+
+      // Re-enable success before reading via the query, whose `load` would otherwise re-run the
+      // throwing provider in the background. The assertion below confirms handleSourceChange kept
+      // the last-good payload despite the failed re-extraction.
+      shouldThrow = false;
+      expect(service.queries.getDocgen({ componentId: 'button' })).toMatchObject({
+        description: 'good',
+      });
+    });
+  });
+
   describe('static build', () => {
     it('writes one docgen JSON per componentId whose provider produced a payload', async () => {
       registerDocgenService({

--- a/code/core/src/shared/open-service/services/docgen/server.ts
+++ b/code/core/src/shared/open-service/services/docgen/server.ts
@@ -3,6 +3,8 @@ import { getComponentIdFromEntry } from '../../../../common/utils/component-id.t
 import { OpenServiceDocgenMissingComponentError } from '../../../../server-errors.ts';
 import type { StoryIndex } from '../../../../types/modules/indexer.ts';
 import { registerService } from '../../service-registration.ts';
+import type { ServiceInstanceOf } from '../../types.ts';
+import type { moduleGraphServiceDef } from '../module-graph/definition.ts';
 import { docgenServiceDef } from './definition.ts';
 import type { DocgenProvider } from './types.ts';
 
@@ -101,5 +103,34 @@ export function registerDocgenService(options: RegisterDocgenServiceOptions) {
         },
       },
     },
+  });
+}
+
+/**
+ * Connects `core/docgen` to `core/module-graph` so docgen re-extracts when source files change.
+ *
+ * This is the open-service-native link between the two services: docgen subscribes to the module
+ * graph's latest invalidation and re-extracts the affected components (re-extract-if-present, via
+ * `handleSourceChange`). Because the module graph bumps a monotonic `revision` on every change, two
+ * consecutive changes that affect the same components still emit distinct values, so value-dedup on
+ * the subscription never swallows a repeat change.
+ *
+ * Note: this is an explicit subscription rather than a pure reactive read because re-extraction is
+ * async/side-effecting and the open-service runtime fires a query's `load` only once (it does not
+ * re-run `load` when a tracked dependency changes). A future "reactive load" runtime primitive
+ * would let `getDocgen` depend on the revision directly and drop this wiring entirely.
+ *
+ * Returns an unsubscribe function; the caller (the `services` preset) keeps the subscription alive
+ * for the lifetime of the process.
+ */
+export function connectDocgenToModuleGraph(
+  docgen: ServiceInstanceOf<typeof docgenServiceDef>,
+  moduleGraph: ServiceInstanceOf<typeof moduleGraphServiceDef>
+): () => void {
+  return moduleGraph.queries.getLastAffected.subscribe({}, (affected) => {
+    if (affected.componentIds.length === 0) {
+      return;
+    }
+    void docgen.commands.handleSourceChange({ componentIds: affected.componentIds });
   });
 }

--- a/code/core/src/shared/open-service/services/docgen/server.ts
+++ b/code/core/src/shared/open-service/services/docgen/server.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../../node-logger/index.ts';
 import { getComponentIdFromEntry } from '../../../../common/utils/component-id.ts';
 import { OpenServiceDocgenMissingComponentError } from '../../../../server-errors.ts';
 import type { StoryIndex } from '../../../../types/modules/indexer.ts';
@@ -70,6 +71,33 @@ export function registerDocgenService(options: RegisterDocgenServiceOptions) {
             draft.components[input.componentId] = payload;
           });
           return payload;
+        },
+      },
+      handleSourceChange: {
+        handler: async (input, ctx) => {
+          // Re-extract only components that are already in state ("present"). Absent components are
+          // left untouched so the next read's `load` extracts them lazily. We never null out an
+          // entry: `extractDocgen` overwrites in place (or no-ops when the provider yields nothing),
+          // so a current reader never flashes empty and a future reader sees fresh data.
+          for (const componentId of input.componentIds) {
+            if (ctx.self.state.components[componentId] === undefined) {
+              continue;
+            }
+
+            try {
+              await ctx.self.commands.extractDocgen({ componentId });
+            } catch (error) {
+              // Keep the last-good payload rather than blanking it — e.g. when a file is mid-edit
+              // and the provider throws on a transient syntax error.
+              logger.warn(
+                `core/docgen: failed to re-extract docgen for "${componentId}" after a source change; keeping last-known value. ${
+                  error instanceof Error ? error.message : String(error)
+                }`
+              );
+            }
+          }
+
+          return undefined;
         },
       },
     },

--- a/code/core/src/shared/open-service/services/module-graph/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph/definition.ts
@@ -1,0 +1,58 @@
+import * as v from 'valibot';
+
+import { defineService } from '../../service-definition.ts';
+import type { ModuleGraphServiceState } from './types.ts';
+
+/** Input to the `resolveAffectedComponents` command: absolute, normalized story-file paths. */
+export const resolveAffectedComponentsInputSchema = v.object({
+  storyFiles: v.array(v.string()),
+});
+
+/** Output of `resolveAffectedComponents` and the shape stored in `lastAffected`. */
+export const moduleGraphInvalidationSchema = v.object({
+  revision: v.number(),
+  componentIds: v.array(v.string()),
+});
+
+/** Input to the `getLastAffected` query — no parameters. */
+export const getLastAffectedInputSchema = v.optional(v.object({}));
+
+/**
+ * Definition for the `core/module-graph` open service.
+ *
+ * A thin facade over the change-detection dependency graph. It does not own file watching or the
+ * reverse index (those stay in `code/core/src/core-server/change-detection/`); instead it is fed a
+ * batch of affected story files and translates them into the component ids that consumers like
+ * `core/docgen` (and, later, a story-snippet service) care about.
+ *
+ * The `resolveAffectedComponents` handler is supplied at registration time because it needs to
+ * close over the server-only story index and working directory. `getLastAffected` is a thin
+ * subscribable read of the last recorded invalidation — unused in the first slice, but the seam a
+ * future snippet service can subscribe to.
+ */
+export const moduleGraphServiceDef = defineService({
+  id: 'core/module-graph',
+  description:
+    'Maps changed source files to the component ids they affect, backed by the change-detection dependency graph.',
+  initialState: {
+    lastAffected: { revision: 0, componentIds: [] },
+  } as ModuleGraphServiceState,
+  queries: {
+    getLastAffected: {
+      description: 'Returns the most recent invalidation (revision + affected component ids).',
+      input: getLastAffectedInputSchema,
+      output: moduleGraphInvalidationSchema,
+      handler: (_input, ctx) => ctx.self.state.lastAffected,
+    },
+  },
+  commands: {
+    resolveAffectedComponents: {
+      description:
+        'Translates a batch of affected story files into affected component ids, records them as the latest invalidation, and returns them.',
+      input: resolveAffectedComponentsInputSchema,
+      output: moduleGraphInvalidationSchema,
+      // Handler is supplied at registration time so it can close over the story index and the
+      // working directory used to resolve absolute story-file paths back to index entries.
+    },
+  },
+});

--- a/code/core/src/shared/open-service/services/module-graph/server.test.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { join, normalize } from 'pathe';
+
+import type { IndexEntry, StoryIndex } from '../../../../types/modules/indexer.ts';
+import { clearRegistry } from '../../server.ts';
+import { registerModuleGraphService } from './server.ts';
+
+afterEach(() => {
+  clearRegistry();
+});
+
+const WORKING_DIR = '/repo';
+
+function makeStoryEntry(id: string, fileBase: string): IndexEntry {
+  return {
+    id,
+    name: id.split('--').slice(1).join('--') || 'Default',
+    title: fileBase,
+    type: 'story',
+    subtype: 'story',
+    importPath: `./${fileBase}.stories.tsx`,
+  };
+}
+
+function makeGetIndex(entries: IndexEntry[]) {
+  const index: StoryIndex = {
+    v: 5,
+    entries: Object.fromEntries(entries.map((entry) => [entry.id, entry])),
+  };
+  return () => Promise.resolve(index);
+}
+
+function abs(fileBase: string): string {
+  return normalize(join(WORKING_DIR, `./${fileBase}.stories.tsx`));
+}
+
+describe('module-graph open service', () => {
+  describe('resolveAffectedComponents command', () => {
+    it('maps absolute story files to distinct component ids', async () => {
+      const service = registerModuleGraphService({
+        getIndex: makeGetIndex([
+          makeStoryEntry('button--primary', 'button'),
+          makeStoryEntry('button--secondary', 'button'),
+          makeStoryEntry('card--default', 'card'),
+        ]),
+        workingDir: WORKING_DIR,
+      });
+
+      const result = await service.commands.resolveAffectedComponents({
+        storyFiles: [abs('button'), abs('card')],
+      });
+
+      expect(result.componentIds.sort()).toEqual(['button', 'card']);
+      expect(result.revision).toBe(1);
+    });
+
+    it('ignores story files that do not correspond to any index entry', async () => {
+      const service = registerModuleGraphService({
+        getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
+        workingDir: WORKING_DIR,
+      });
+
+      const result = await service.commands.resolveAffectedComponents({
+        storyFiles: [abs('does-not-exist')],
+      });
+
+      expect(result.componentIds).toEqual([]);
+    });
+
+    it('records the latest invalidation in state and bumps the revision', async () => {
+      const service = registerModuleGraphService({
+        getIndex: makeGetIndex([makeStoryEntry('button--primary', 'button')]),
+        workingDir: WORKING_DIR,
+      });
+
+      await service.commands.resolveAffectedComponents({ storyFiles: [abs('button')] });
+      const second = await service.commands.resolveAffectedComponents({ storyFiles: [] });
+
+      expect(second.revision).toBe(2);
+      expect(service.queries.getLastAffected({})).toEqual({
+        revision: 2,
+        componentIds: [],
+      });
+    });
+  });
+});

--- a/code/core/src/shared/open-service/services/module-graph/server.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.ts
@@ -1,0 +1,81 @@
+import { join, normalize } from 'pathe';
+
+import { getComponentIdFromEntry } from '../../../../common/utils/component-id.ts';
+import type { StoryIndex } from '../../../../types/modules/indexer.ts';
+import { registerService } from '../../service-registration.ts';
+import { moduleGraphServiceDef } from './definition.ts';
+
+export type RegisterModuleGraphServiceOptions = {
+  /**
+   * Returns the current story index when the service needs it. Callers should bind this to a
+   * pre-resolved generator so each call does not re-await generator initialization.
+   */
+  getIndex: () => Promise<StoryIndex>;
+  /**
+   * Working directory used to turn relative `IndexEntry.importPath` values into the absolute,
+   * normalized paths that the change-detection graph reports.
+   */
+  workingDir: string;
+};
+
+/**
+ * Builds an absolute-story-file -> component-ids lookup from a story index.
+ *
+ * Story index entries carry a relative `importPath`; the change-detection graph reports absolute,
+ * normalized paths. This resolves entries to absolute paths so the two can be matched.
+ */
+function buildStoryFileToComponentIds(
+  index: StoryIndex,
+  workingDir: string
+): Map<string, Set<string>> {
+  const byFile = new Map<string, Set<string>>();
+  for (const entry of Object.values(index.entries)) {
+    const absPath = normalize(join(workingDir, entry.importPath));
+    const componentId = getComponentIdFromEntry(entry);
+    const set = byFile.get(absPath) ?? new Set<string>();
+    set.add(componentId);
+    byFile.set(absPath, set);
+  }
+  return byFile;
+}
+
+/**
+ * Registers the `core/module-graph` open service against the process-global registry.
+ *
+ * The `resolveAffectedComponents` command maps a batch of affected story files (produced by the
+ * change-detection graph) to the distinct component ids they back, records them as the latest
+ * invalidation, and returns them so the composition root can forward them to `core/docgen`.
+ */
+export function registerModuleGraphService(options: RegisterModuleGraphServiceOptions) {
+  return registerService(moduleGraphServiceDef, {
+    commands: {
+      resolveAffectedComponents: {
+        handler: async (input, ctx) => {
+          const index = await options.getIndex();
+          const byFile = buildStoryFileToComponentIds(index, options.workingDir);
+
+          const componentIds = new Set<string>();
+          for (const storyFile of input.storyFiles) {
+            const ids = byFile.get(normalize(storyFile));
+            if (ids) {
+              for (const id of ids) {
+                componentIds.add(id);
+              }
+            }
+          }
+
+          const result = {
+            revision: ctx.self.state.lastAffected.revision + 1,
+            componentIds: Array.from(componentIds),
+          };
+
+          ctx.self.setState((draft) => {
+            draft.lastAffected = result;
+          });
+
+          return result;
+        },
+      },
+    },
+  });
+}

--- a/code/core/src/shared/open-service/services/module-graph/server.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.ts
@@ -69,8 +69,8 @@ export function registerModuleGraphService(options: RegisterModuleGraphServiceOp
             componentIds: Array.from(componentIds),
           };
 
-          ctx.self.setState((draft) => {
-            draft.lastAffected = result;
+          ctx.self.setState((state) => {
+            state.lastAffected = result;
           });
 
           return result;

--- a/code/core/src/shared/open-service/services/module-graph/types.ts
+++ b/code/core/src/shared/open-service/services/module-graph/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Latest invalidation recorded by `core/module-graph`.
+ *
+ * `revision` is a monotonically increasing counter that lets subscribers detect a new invalidation
+ * even when the affected component set is unchanged. `componentIds` is the set of component ids
+ * whose source (story file or a transitively-imported module) changed in the last reported batch.
+ */
+export interface ModuleGraphInvalidation {
+  revision: number;
+  componentIds: string[];
+}
+
+export type ModuleGraphServiceState = {
+  /** The most recent invalidation. `revision` starts at 0 with an empty component set. */
+  lastAffected: ModuleGraphInvalidation;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## What I did

Server-side **docgen invalidation (HMR)** for the experimental docgen server: when a watched source file changes, the already-extracted docgen for affected components is re-extracted so `core/docgen` never serves stale data — with **no flash to empty** for current readers and **no stale data** for later navigations.

This is the server-side slice only (no manager transport, which doesn't exist yet). Plan: [Server-side docgen invalidation (HMR) — plan](https://www.notion.so/3716e8162034818781dfedb0a861a82e) (subpage of *SB docgen server*).

### Design

Two halves:
- **Propagation** is already solved by the open-service runtime: once a command overwrites `state.components[componentId]`, deep-signal reactivity re-emits to subscribers (deduped by value), and future reads get fresh data via the normal sync-read + `load`. So we only have to update server state correctly.
- **Detection** is centralized. Providers stay pure (`(input) => Promise<DocgenPayload | undefined>`); they get no change-notification API. The existing oxc dependency graph in `change-detection/` maps a changed file to its affected story files.

Invalidation policy = **re-extract-if-present** (locked decision, "option b"): on invalidation for a component id, if it is already in state, re-run `extractDocgen` (atomic overwrite → reactive emit, deduped); if absent, do nothing (lazy on next read); on extraction error, **keep last-good**.

### Changes

- **New `core/module-graph` open service** — a thin facade that translates affected story files into component ids, backed by the change-detection dependency graph. Holds a monotonic `revision` + the latest affected component ids in state, exposed via the subscribable `getLastAffected` query.
- **`core/docgen` `handleSourceChange` command** — re-extract-if-present + keep-last-good.
- **Open-service-native wiring** — `core/docgen` subscribes to `core/module-graph`'s `getLastAffected` (`connectDocgenToModuleGraph`, wired in the `services` preset) and re-extracts affected components. The dev server only feeds the module graph; it has no knowledge of docgen. The `revision` bump ensures repeated changes to the same component still emit (value-dedup doesn't swallow them). This is an explicit subscription because re-extraction is async and the runtime fires a query's `load` only once — a future reactive-load primitive would let `getDocgen` depend on the revision directly and drop the subscription.
- **`ChangeDetectionService`** (see separated section in the plan; owned by another stakeholder) — two **additive, gated** changes:
  - `onInvalidate` callback emitting affected story files (fires on `add`/`change`/`unlink`, independent of git diff and of the "dep set unchanged" patch early-return).
  - `publishStatuses: false` **graph-only mode** so the dependency graph can power docgen without surfacing "review changes" sidebar statuses. Existing behavior is unchanged when `publishStatuses` is `true` (the default).
- **Composition root** (`dev-server.ts`, `common-preset.ts`) — run the graph when `features.changeDetection || features.experimentalDocgenServer`; the dev server's `onInvalidate` calls only `module-graph.resolveAffectedComponents` (best-effort).

### Non-regression

Builder-agnostic and **Webpack-supported**: both builder-vite (chokidar `server.watcher`) and builder-webpack5 (`compiler.hooks.watchRun`) ship change-detection adapters, so this does not regress Webpack docgen updates. The change is additive and behind `experimentalDocgenServer`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

The change is server-side only — there is no manager transport yet, so there is no UI to exercise, and the phase-1 mock provider is path-deterministic (its output doesn't change on edits). Validation is via automated tests plus a live dev-server smoke test confirming a file edit drives the reactive chain (`onInvalidate` → `module-graph` → docgen subscription → `handleSourceChange`):

- `core/docgen` `handleSourceChange`: re-extracts present components and pushes the new value to a subscriber (content-sensitive provider); ignores absent components; keeps last-good on provider error.
- `core/module-graph`: story files → component ids mapping; revision bump.
- Open-service-native integration test: register both services, `connectDocgenToModuleGraph`, feed the module graph, and assert docgen re-extracts + the subscriber is notified reactively (incl. repeated same-component changes via the revision).
- `ChangeDetectionService`: `onInvalidate` fires with affected story files; graph-only mode publishes no statuses and never calls git.

Commands run: `yarn test --run open-service change-detection` (237 passed), `yarn nx check core` (no type errors), lint + format.

### Documentation

- [ ] Add or update documentation reflecting your changes (experimental; deferred)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, add `ci:normal`, `ci:merged` or `ci:daily`.
- [ ] Make sure this PR contains **one** of the labels below: `feature request`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb59feab-75dd-4661-a7d0-feb22004fbe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb59feab-75dd-4661-a7d0-feb22004fbe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental docgen server: automatic, best-effort docgen re-extraction when related source/story files change.
  * Module-graph invalidation service: maps changed story files to affected component IDs and publishes revisioned invalidations.
  * Graph-only mode for change detection: emits invalidation notifications without publishing status entries or relying on git diffs.

* **Tests**
  * Added end-to-end and unit tests covering invalidation paths, re-extraction behavior, and graph-only semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->