### PR TITLE
fix(addon-a11y): announce tab selection state to screen readers

### DIFF
--- a/code/core/src/components/components/Tabs/TabList.tsx
+++ b/code/core/src/components/components/Tabs/TabList.tsx
@@ -132,6 +132,8 @@ const TabButton: FC<TabButtonProps> = ({ item, state }) => {
   return (
     <StyledTabButton
       {...tabProps}
+      role="tab"
+      aria-selected={isSelected}
       isDisabled={isDisabled}
       isPressed={isPressed}
       isSelected={isSelected}


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

## What I changed
Added `role="tab"` and `aria-selected` to the `StyledTabButton` 
component in `TabList.tsx` so screen readers correctly announce 
which tab is currently selected when navigating the 
Violations/Passes/Incomplete tabs in the a11y addon panel.

## Why
Screen readers were not announcing the selection state when 
switching between tabs — users had no way to know which tab 
was active. As a Deaf developer who uses assistive technology 
daily, I experienced this gap directly and wanted to fix it 
for the broader accessibility community.

## How to test
1. Open Storybook with the a11y addon enabled
2. Navigate to the Accessibility panel
3. Use a screen reader (VoiceOver, NVDA, or JAWS)
4. Tab between Violations/Passes/Incomplete — selection state 
   is now announced correctly

Fixes #24191

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab component accessibility with explicit role and selection state attributes for assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->