### PR TITLE
fix(core-server): prevent index.json from being overwritten by static…

### DIFF
--- a/code/core/src/core-server/utils/copy-all-static-files.ts
+++ b/code/core/src/core-server/utils/copy-all-static-files.ts
@@ -24,7 +24,9 @@ export async function copyAllStaticFiles(staticDirs: any[] | undefined, outputDi
           }
 
           // Storybook's own files should not be overwritten, so we skip such files if we find them
-          const skipPaths = ['index.html', 'iframe.html'].map((f) => join(outputDir, f));
+          const skipPaths = ['index.html', 'iframe.html', 'index.json'].map((f) =>
+            join(outputDir, f)
+          );
           await cp(staticPath, targetPath, {
             dereference: true,
             preserveTimestamps: true,
@@ -63,7 +65,7 @@ export async function copyAllStaticFilesRelativeToMain(
     );
 
     const targetPath = join(outputDir, to);
-    const skipPaths = ['index.html', 'iframe.html'].map((f) => join(outputDir, f));
+    const skipPaths = ['index.html', 'iframe.html', 'index.json'].map((f) => join(outputDir, f));
     if (!from.includes('node_modules')) {
       logger.info(
         `Copying static files: ${picocolors.cyan(print(from))} at ${picocolors.cyan(print(targetPath))}`


### PR DESCRIPTION
…Dirs

Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

## What I changed
Added `index.json` to the `skipPaths` array in both 
`copyAllStaticFiles` and `copyAllStaticFilesRelativeToMain` 
functions in `copy-all-static-files.ts`.

## Why
When `staticDirs` is configured to copy `../public` to a 
subdirectory (e.g. `{ from: "../public", to: "/foo" }`), 
Storybook was still copying `../public` to the build root 
AND overwriting its own generated `index.json`. This broke 
the build because stories could no longer be found.

## How to reproduce
1. Create a new app with Storybook
2. Create `public/index.json` with `{}`
3. Set `staticDirs: [{ from: "../public", to: "/foo" }]`
4. Run `build-storybook`
5. Before fix: `storybook-static/index.json` gets overwritten
6. After fix: Storybook's `index.json` is preserved correctly

Fixes #25070

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed static file copying to properly exclude index.json files from being copied, preventing unintended file overwrites during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->