### PR TITLE
Docs: Document Conditional Controls Workaround

### DIFF
--- a/docs/essentials/controls.mdx
+++ b/docs/essentials/controls.mdx
@@ -364,6 +364,42 @@ It may also contain at most one of the following operators:
 
 If no operator is provided, that is equivalent to `{ truthy: true }`.
 
+Conditional controls accept a single query object. To show similar controls for multiple conditions, define separate argTypes with unique arg keys and the same display `name` in your story meta or story definition:
+
+```ts
+argTypes: {
+  'loading.hasOverlineWhenLabel': {
+    name: 'loading.hasOverline',
+    control: 'boolean',
+    if: { arg: 'loading.hasLabel', eq: true },
+  },
+  'loading.hasOverlineWhenValue': {
+    name: 'loading.hasOverline',
+    control: 'boolean',
+    if: { arg: 'loading.hasValue', eq: true },
+  },
+},
+```
+
+Then combine their values inside the story's `render` function before passing them to your component:
+
+```tsx
+export const Example: Story = {
+  render: (args) => {
+    const loading = {
+      hasOverline:
+        args['loading.hasOverlineWhenLabel'] || args['loading.hasOverlineWhenValue'],
+      hasLabel: args['loading.hasLabel'],
+      hasValue: args['loading.hasValue'],
+    };
+
+    return <MyComponent loading={loading} />;
+  },
+};
+```
+
+Each control keeps its own independent arg value. Switching the active condition shows the value for the newly visible control, but does not change or synchronize values set for other conditions.
+
 ## Troubleshooting
 
 <If renderer={['angular', 'ember', 'web-components']}>


### PR DESCRIPTION
Closes #34507

## What I did

Added documentation that conditional controls accept a single query object, plus a duplicate argType key workaround for showing similar controls under multiple conditions.

AI assisted by Codex.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Documentation-only change. Verified the MDX diff and ran `git diff --check`.

`yarn docs:check` did not run because this fresh clone has no installed node_modules state, and I avoided installing the full monorepo dependencies for this docs-only change.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how conditional controls accept a single query object and provided examples showing how to create multiple independent conditional controls that share display names but use distinct keys. Demonstrates combining their boolean values in a story render to control visibility, and notes behavior when switching active conditions (values remain unsynchronized).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->