### PR TITLE
Themes: Apply theme to Autodocs in docs viewMode

### DIFF
--- a/code/addons/docs/src/blocks/components/DocsPage.tsx
+++ b/code/addons/docs/src/blocks/components/DocsPage.tsx
@@ -435,8 +435,7 @@ export const DocsContent = styled.div(({ theme }) => {
   };
 });
 
-export const DocsWrapper = styled.div(({ theme }) => ({
-  background: theme.background.content,
+export const DocsWrapper = styled.div({
   display: 'flex',
   flexDirection: 'row-reverse',
   justifyContent: 'center',
@@ -444,9 +443,8 @@ export const DocsWrapper = styled.div(({ theme }) => ({
   minHeight: '100vh',
   boxSizing: 'border-box',
   gap: '3rem',
-
   [`@media (min-width: ${breakpoint}px)`]: {},
-}));
+});
 
 interface DocsPageWrapperProps {
   children?: React.ReactNode;

--- a/code/addons/themes/src/decorators/class-name.decorator.tsx
+++ b/code/addons/themes/src/decorators/class-name.decorator.tsx
@@ -30,27 +30,28 @@ export const withThemeByClassName = <TRenderer extends Renderer = Renderer>({
     useEffect(() => {
       const selectedThemeName = themeOverride || selected || defaultTheme;
       const parentElement = document.querySelector(parentSelector);
+      const docsElement =
+        context.viewMode === 'docs' ? document.querySelector('#storybook-docs') : null;
 
-      if (!parentElement) {
-        return;
-      }
+      const elements = [parentElement, docsElement].filter(Boolean) as Element[];
 
-      Object.entries(themes)
-        .filter(([themeName]) => themeName !== selectedThemeName)
-        .forEach(([themeName, className]) => {
-          const classes = classStringToArray(className);
-          if (classes.length > 0) {
-            parentElement.classList.remove(...classes);
-          }
-        });
+      elements.forEach((element) => {
+        Object.entries(themes)
+          .filter(([themeName]) => themeName !== selectedThemeName)
+          .forEach(([, className]) => {
+            const classes = classStringToArray(className);
+            if (classes.length > 0) {
+              element.classList.remove(...classes);
+            }
+          });
 
-      const newThemeClasses = classStringToArray(themes[selectedThemeName]);
+        const newThemeClasses = classStringToArray(themes[selectedThemeName]);
 
-      if (newThemeClasses.length > 0) {
-        parentElement.classList.add(...newThemeClasses);
-      }
-    }, [themeOverride, selected]);
-
+        if (newThemeClasses.length > 0) {
+          element.classList.add(...newThemeClasses);
+        }
+      });
+    }, [themeOverride, selected, context.viewMode]);
     return storyFn();
   };
 };

--- a/code/addons/themes/src/decorators/data-attribute.decorator.tsx
+++ b/code/addons/themes/src/decorators/data-attribute.decorator.tsx
@@ -16,6 +16,7 @@ const DEFAULT_ELEMENT_SELECTOR = 'html';
 const DEFAULT_DATA_ATTRIBUTE = 'data-theme';
 
 // TODO check with @kasperpeulen: change the types so they can be correctly inferred from context e.g. <Story extends (...args: any[]) => any>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const withThemeByDataAttribute = <TRenderer extends Renderer = any>({
   themes,
   defaultTheme,
@@ -30,11 +31,15 @@ export const withThemeByDataAttribute = <TRenderer extends Renderer = any>({
     useEffect(() => {
       const parentElement = document.querySelector(parentSelector);
       const themeKey = themeOverride || selected || defaultTheme;
+      const docsElement =
+        context.viewMode === 'docs' ? document.querySelector('#storybook-docs') : null;
 
-      if (parentElement) {
-        parentElement.setAttribute(attributeName, themes[themeKey]);
-      }
-    }, [themeOverride, selected]);
+      [parentElement, docsElement].forEach((element) => {
+        if (element) {
+          element.setAttribute(attributeName, themes[themeKey]);
+        }
+      });
+    }, [themeOverride, selected, context.viewMode]);
 
     return storyFn();
   };


### PR DESCRIPTION
Closes #30928

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed `withThemeByClassName` and `withThemeByDataAttribute` decorators from `addon-themes` not applying the selected theme in the Autodocs (Docs) tab.

**Root cause:** Two problems combined to break theming in docs mode:

1. `DocsWrapper` in `addon-docs` applied `background: theme.background.content` as an inline styled-component style, which always used the Storybook UI theme (light by default) and overrode any user CSS class applied to `<html>`.
2. The decorators only applied the theme class/attribute to `document.querySelector(parentSelector)` (defaulting to `html`), but never to the `#storybook-docs` root element, so users could not target the docs container directly with their CSS.

**Fix:**

- Removed the hardcoded `background: theme.background.content` from `DocsWrapper` in `code/addons/docs/src/blocks/components/DocsPage.tsx`, allowing the user's theme CSS (e.g. a `.dark` class on `<html>`) to control the docs page background naturally.
- Updated `withThemeByClassName` and `withThemeByDataAttribute` to also apply the theme class/attribute to `#storybook-docs` when `context.viewMode === 'docs'`, so users can also target the docs root element directly in their CSS.
- Added `context.viewMode` to the `useEffect` dependency array in both decorators so the effect correctly re-runs when navigating between Canvas and Docs views.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Add `withThemeByClassName` to your `.storybook/preview.ts`:

```ts
import { withThemeByClassName } from '@storybook/addon-themes';
import type { Preview } from '@storybook/react';

const preview: Preview = {
  decorators: [
    withThemeByClassName({
      themes: { light: '', dark: 'dark' },
      defaultTheme: 'light',
    }),
  ],
  tags: ['autodocs'],
};

export default preview;
```

2. Add dark mode CSS to your `src/index.css`:

```css
html.dark,
#storybook-docs.dark {
  background-color: #1a1a1a;
  color: #ffffff;
}
```

3. Run Storybook and navigate to any component's **Docs** tab
4. Use the theme toggle in the toolbar to switch to **dark**
5. The docs page background now turns dark (was broken before, stayed white)
6. Switch back to **light**. Background returns to white
7. Navigate to the **Canvas** tab, confirm theme switching still works there too 

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme application in documentation view by ensuring theme classes and attributes are consistently applied across component previews and documentation layouts.

* **Style**
  * Removed theme-dependent background styling from documentation wrapper to support more flexible theming options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->