### PR TITLE
React: Resolve props for args-only CSF factory stories in component manifest

### DIFF
--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.metaFactory.test.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.metaFactory.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { dedent } from 'ts-dedent';
+
+import { extractFromStory } from './componentMetaExtractor.test-helpers.ts';
+
+const COMPONENT = dedent`
+  import React from 'react';
+  interface MyComponentProps {
+    /** The content to render */
+    children: React.ReactNode;
+    /** Visual emphasis */
+    emphasis?: 'low' | 'high';
+  }
+  export function MyComponent({ children, emphasis }: MyComponentProps) {
+    return <div data-emphasis={emphasis}>{children}</div>;
+  }
+`;
+
+const EXPECTED_META = {
+  displayName: 'MyComponent',
+  exportName: 'MyComponent',
+  props: {
+    children: {
+      required: true,
+      description: 'The content to render',
+      parent: { name: 'MyComponentProps' },
+    },
+    emphasis: {
+      type: { name: 'enum', value: [{ value: '"low"' }, { value: '"high"' }] },
+      required: false,
+      parent: { name: 'MyComponentProps' },
+    },
+  },
+};
+
+describe('prop extraction for CSF4 preview.meta() stories', () => {
+  // An args-only story has no JSX of the component anywhere in the file (Path 1 cannot resolve)
+  // and a CSF4 meta is a local `const`, not a default export (Path 2 cannot resolve). The component
+  // file + export name are still known from the story's imports, so props must resolve from there.
+  it('extracts props for an args-only story (no render, no JSX)', async () => {
+    const entry = await extractFromStory(
+      {
+        'csf4/MyComponent.tsx': COMPONENT,
+        'csf4/MyComponent.stories.tsx': dedent`
+          import preview from '#.storybook/preview';
+          import { MyComponent } from './MyComponent';
+          const meta = preview.meta({ component: MyComponent });
+          export const ArgsOnly = meta.story({ args: { children: 'Hello' } });
+        `,
+      },
+      'csf4/MyComponent.stories.tsx'
+    );
+
+    expect(entry.component?.reactComponentMeta).toMatchObject(EXPECTED_META);
+  });
+
+  // The existing JSX path must keep working for stories that do render the component.
+  it('extracts props for a story with an explicit render (JSX path)', async () => {
+    const entry = await extractFromStory(
+      {
+        'csf4/MyComponent.tsx': COMPONENT,
+        'csf4/MyComponent.stories.tsx': dedent`
+          import React from 'react';
+          import preview from '#.storybook/preview';
+          import { MyComponent } from './MyComponent';
+          const meta = preview.meta({ component: MyComponent });
+          export const WithRender = meta.story({
+            args: { children: 'Hello' },
+            render: (args) => <MyComponent {...args} />,
+          });
+        `,
+      },
+      'csf4/MyComponent.stories.tsx'
+    );
+
+    expect(entry.component?.reactComponentMeta).toMatchObject(EXPECTED_META);
+  });
+
+  // Mirrors the issue reproduction exactly: a declaration-merged component (function + namespace)
+  // whose props extend HTMLAttributes, in an args-only CSF4 story.
+  it('extracts props for a declaration-merged component (issue repro shape)', async () => {
+    const entry = await extractFromStory(
+      {
+        'csf4/MergedComponent.tsx': dedent`
+          import type { HTMLAttributes, ReactNode } from 'react';
+          export namespace MergedComponent {
+            export interface Props extends HTMLAttributes<HTMLDivElement> {
+              /** The content to render */
+              children: ReactNode;
+            }
+          }
+          export function MergedComponent({ children, ...rest }: MergedComponent.Props) {
+            return <div {...rest}>{children}</div>;
+          }
+        `,
+        'csf4/MergedComponent.stories.tsx': dedent`
+          import preview from '#.storybook/preview';
+          import { MergedComponent } from './MergedComponent';
+          const meta = preview.meta({ component: MergedComponent });
+          export const ArgsOnly = meta.story({ args: { children: 'Hello' } });
+        `,
+      },
+      'csf4/MergedComponent.stories.tsx'
+    );
+
+    expect(entry.component?.reactComponentMeta).toMatchObject({
+      displayName: 'MergedComponent',
+      exportName: 'MergedComponent',
+      props: {
+        children: {
+          required: true,
+          description: 'The content to render',
+        },
+      },
+    });
+  });
+});

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.metaFactory.test.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.metaFactory.test.ts
@@ -115,4 +115,45 @@ describe('prop extraction for CSF4 preview.meta() stories', () => {
       },
     });
   });
+
+  // A default-exported component reaches Path 3 with `importName === 'default'`; the module-export
+  // lookup must resolve it the same as a named export.
+  it('extracts props for an args-only story whose component is a default export', async () => {
+    const entry = await extractFromStory(
+      {
+        'csf4/DefaultComponent.tsx': dedent`
+          import React from 'react';
+          interface MyComponentProps {
+            /** The content to render */
+            children: React.ReactNode;
+            /** Visual emphasis */
+            emphasis?: 'low' | 'high';
+          }
+          function MyComponent({ children, emphasis }: MyComponentProps) {
+            return <div data-emphasis={emphasis}>{children}</div>;
+          }
+          export default MyComponent;
+        `,
+        'csf4/DefaultComponent.stories.tsx': dedent`
+          import preview from '#.storybook/preview';
+          import MyComponent from './DefaultComponent';
+          const meta = preview.meta({ component: MyComponent });
+          export const ArgsOnly = meta.story({ args: { children: 'Hello' } });
+        `,
+      },
+      'csf4/DefaultComponent.stories.tsx'
+    );
+
+    expect(entry.component?.reactComponentMeta).toMatchObject({
+      displayName: 'MyComponent',
+      exportName: 'default',
+      props: {
+        children: { required: true, description: 'The content to render' },
+        emphasis: {
+          type: { name: 'enum', value: [{ value: '"low"' }, { value: '"high"' }] },
+          required: false,
+        },
+      },
+    });
+  });
 });

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -323,6 +323,18 @@ export class ComponentMetaProject {
           );
         }
 
+        // Path 3: Fallback — resolve directly from the component's own source file export.
+        // Handles args-only CSF4 `preview.meta()` stories: no story-file JSX (Path 1) and a meta
+        // that is a local/imported binding rather than a default export (Path 2). The component
+        // file and export name are already known from the story's imports.
+        if (!resolvedComponent) {
+          resolvedComponent = this.resolveFromComponentExport(
+            checker,
+            componentSourceFile,
+            entryComponent
+          );
+        }
+
         if (!resolvedComponent) {
           continue;
         }
@@ -445,6 +457,52 @@ export class ComponentMetaProject {
       componentRef,
       propsType,
       symbol: selectedSymbol,
+    };
+  }
+
+  /**
+   * Path 3 fallback: resolve the component type from its own source file export.
+   *
+   * Activates for args-only stories where Path 1 (story-file JSX) found nothing and Path 2 found no
+   * default-export meta — most notably CSF4 `preview.meta()` + `meta.story({ args })`, whose meta is
+   * a local `const`/imported binding. The component path and export name are already resolved from
+   * the story's imports, so the props type is read straight from the component module.
+   *
+   * Member/compound components (`Accordion.Root`) are written with explicit JSX and resolve via
+   * Path 1, so they are intentionally left to that path.
+   */
+  private resolveFromComponentExport(
+    checker: ts.TypeChecker,
+    componentSourceFile: ts.SourceFile,
+    componentRef: ComponentRef
+  ): ResolvedComponentTarget | undefined {
+    const { importName, member: memberAccess } = componentRef;
+    if (!importName || memberAccess) {
+      return undefined;
+    }
+
+    const moduleSymbol = checker.getSymbolAtLocation(componentSourceFile);
+    if (!moduleSymbol) {
+      return undefined;
+    }
+
+    const exportSymbol = checker
+      .getExportsOfModule(moduleSymbol)
+      .find((e) => e.getName() === importName);
+    if (!exportSymbol) {
+      return undefined;
+    }
+
+    const componentType = checker.getTypeOfSymbol(exportSymbol);
+    const propsType = resolvePropsFromComponentType(this.typescript, checker, componentType);
+    if (!propsType) {
+      return undefined;
+    }
+
+    return {
+      componentRef,
+      propsType,
+      symbol: exportSymbol,
     };
   }
 }

--- a/code/renderers/react/src/componentManifest/generator.componentMetaFactory.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.componentMetaFactory.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { dedent } from 'ts-dedent';
+
+import { cleanup, createTempProject } from './componentMeta/test-helpers.ts';
+import { manifests } from './generator.ts';
+
+// End-to-end through the real manifest generator (the layer that emits the user-visible
+// "No component file found" error) with the React Component Meta engine. Uses a real on-disk
+// project because the engine resolves types via a real TypeScript LanguageService.
+
+type ManifestOptions = Parameters<typeof manifests>[1];
+
+interface ManifestComponent {
+  name?: string;
+  error?: { name: string; message: string };
+  reactComponentMeta?: {
+    props?: Record<
+      string,
+      { required?: boolean; type?: { name: string; value?: Array<{ value: string }> } }
+    >;
+  };
+}
+
+const presets = {
+  apply: async (key: string, fallback: unknown) =>
+    key === 'features'
+      ? { experimentalReactComponentMeta: true }
+      : key === 'typescript'
+        ? {}
+        : fallback,
+};
+
+describe('manifests() with experimentalReactComponentMeta', () => {
+  let projectDir: string | undefined;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (projectDir) {
+      cleanup(projectDir);
+      projectDir = undefined;
+    }
+  });
+
+  it('resolves an args-only CSF factory story instead of erroring', async () => {
+    const { projectDir: dir } = createTempProject({
+      'MyComponent.tsx': dedent`
+        import React from 'react';
+        interface MyComponentProps {
+          /** The content to render */
+          children: React.ReactNode;
+          /** Visual emphasis */
+          emphasis?: 'low' | 'high';
+        }
+        export function MyComponent({ children, emphasis }: MyComponentProps) {
+          return <div data-emphasis={emphasis}>{children}</div>;
+        }
+      `,
+      'MyComponent.stories.tsx': dedent`
+        import preview from '#.storybook/preview';
+        import { MyComponent } from './MyComponent';
+        const meta = preview.meta({ title: 'MyComponent', component: MyComponent });
+        export const ArgsOnly = meta.story({ args: { children: 'Hello' } });
+      `,
+    });
+    projectDir = dir;
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    const manifestEntries = [
+      {
+        type: 'story',
+        subtype: 'story',
+        id: 'mycomponent--args-only',
+        name: 'Args Only',
+        title: 'MyComponent',
+        importPath: 'MyComponent.stories.tsx',
+        tags: [],
+      },
+    ];
+
+    const result = await manifests(undefined, {
+      manifestEntries,
+      watch: false,
+      presets,
+    } as unknown as ManifestOptions);
+
+    const components = Object.values(result?.components?.components ?? {}) as ManifestComponent[];
+    const component = components.find((c) => c?.name === 'MyComponent');
+
+    expect(component).toBeDefined();
+    // The reported symptom: no "No component file found" error is surfaced.
+    expect(component?.error).toBeUndefined();
+    expect(component?.reactComponentMeta?.props?.children?.required).toBe(true);
+    expect(component?.reactComponentMeta?.props?.emphasis).toMatchObject({
+      type: { name: 'enum', value: [{ value: '"low"' }, { value: '"high"' }] },
+    });
+  }, 30000);
+});


### PR DESCRIPTION
Closes #34877

## What I did

`experimentalReactComponentMeta` failed args-only CSF factory stories (`preview.meta()` + `meta.story({ args })` with no `render`) with `No component file found for the "X" component.` — no props were extracted for the component.

The extractor had two resolution paths: Path 1 (component JSX in the story file) and Path 2 (a `default`-export meta object). A CSF factory story has neither — its `meta` is a local `const`/imported binding, and an args-only story renders no JSX. Both paths bail, and the component-level error surfaces.

This adds a Path 3 fallback that resolves the component type directly from its own source file export, reusing the component path and export name already resolved from the story's imports. It runs only after Paths 1 and 2 return nothing, so existing behavior is unchanged.

The root cause was traced by @spokodev in the issue; this PR resolves it from the component's source file rather than walking the imported `meta` binding.

As with Path 2, generic/polymorphic components resolve with unbound type parameters (only the JSX path infers concrete types) — the broader limitation noted in #33914. That is left as a separate follow-up.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

Two layers of automated coverage, both on real TypeScript programs (the engine resolves types via a real `LanguageService`):

- **Unit** (`ComponentMetaProject.metaFactory.test.ts`) — extracts props for args-only `preview.meta()` stories, including the declaration-merged component shape from the repro.
- **Integration** (`generator.componentMetaFactory.test.ts`) — runs the real manifest generator with `experimentalReactComponentMeta` on the repro's story shape and asserts the component-level error is gone and props are present. With the fix reverted, this test reproduces the exact reported error: `No component file found for the "MyComponent" component.`

To verify in a full app: clone [`kurtdoherty/supreme-octo-succotash`](https://github.com/kurtdoherty/supreme-octo-succotash), run `yarn install && yarn storybook`, and open the components manifest — the `ArgsOnly` error is gone.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for React component metadata extraction from Storybook stories across multiple configurations
  * Added end-to-end integration tests for the component meta manifest generator

* **Improvements**
  * Enhanced component props resolution with an additional fallback mechanism for improved metadata extraction reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->