### PR TITLE
Core: Clean up JSDoc

### DIFF
--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -573,8 +573,7 @@ export interface StorybookConfigRaw {
 
     /**
      * Enable change detection
-     * TODO: Turn to true before 10.4 release
-     * @default false
+     * @default true
      */
     changeDetection?: boolean;
   };


### PR DESCRIPTION
ø

#### Manual testing

Go wherever you found this screenshot and check it now says default true.

<img width="932" height="362" alt="image" src="https://github.com/user-attachments/assets/870c9799-657d-4f37-8f9b-f3d0503bf077" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature flag documentation to reflect the current default behavior configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->