### PR TITLE
Tanstack: Remove Outlet mock

### DIFF
--- a/code/frameworks/tanstack-react/src/export-mocks/react-router.ts
+++ b/code/frameworks/tanstack-react/src/export-mocks/react-router.ts
@@ -45,8 +45,6 @@ export const useRouteContext = fn(_useRouteContext).mockName(
 export const useCanGoBack = fn(_useCanGoBack).mockName('@tanstack/react-router::useCanGoBack');
 export const useLinkProps = fn(_useLinkProps).mockName('@tanstack/react-router::useLinkProps');
 
-export const Outlet = () => null;
-
 export const Navigate: typeof _Navigate = ({ to, href }) => {
   useEffect(() => {
     onNavigate({ to: (to as string) || href });

--- a/code/frameworks/tanstack-react/template/stories/Outlet.stories.tsx
+++ b/code/frameworks/tanstack-react/template/stories/Outlet.stories.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+
+import { Outlet, createRootRoute, createRoute } from '@tanstack/react-router';
+import { expect, within } from 'storybook/test';
+
+// Regression coverage for https://github.com/storybookjs/storybook/issues/35007
+// `@tanstack/react-router`'s `Outlet` used to be mocked as `() => null`, which
+// silently swallowed any leaf content rendered inside a root layout. These
+// stories assert that both the root layout and the leaf content render.
+
+function LeafContent() {
+  return <p data-testid="tanstack-outlet-leaf">leaf rendered inside root outlet</p>;
+}
+
+const RootRoute = createRootRoute({
+  component: () => (
+    <div data-testid="tanstack-outlet-root">
+      <h1>root layout</h1>
+      <Outlet />
+    </div>
+  ),
+});
+
+const LeafRoute = createRoute({
+  getParentRoute: () => RootRoute,
+  path: '/',
+  component: LeafContent,
+});
+
+RootRoute.addChildren([LeafRoute]);
+
+const meta = {
+  component: LeafContent,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof LeafContent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Passing the leaf `Route` should render it inside the root layout's `<Outlet />`. */
+export const RendersLeafInsideRootOutlet: Story = {
+  parameters: {
+    tanstack: { router: { route: LeafRoute } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId('tanstack-outlet-root')).toBeInTheDocument();
+    await expect(canvas.getByTestId('tanstack-outlet-leaf')).toBeInTheDocument();
+  },
+};
+
+/** Passing the whole route tree plus an explicit `path` resolves through the same outlet. */
+export const RendersLeafViaRouteTreePath: Story = {
+  parameters: {
+    tanstack: {
+      router: { route: RootRoute, path: '/' },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId('tanstack-outlet-root')).toBeInTheDocument();
+    await expect(canvas.getByTestId('tanstack-outlet-leaf')).toBeInTheDocument();
+  },
+};

--- a/code/frameworks/tanstack-react/template/stories/Outlet.stories.tsx
+++ b/code/frameworks/tanstack-react/template/stories/Outlet.stories.tsx
@@ -48,6 +48,9 @@ export const RendersLeafInsideRootOutlet: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByTestId('tanstack-outlet-root')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('heading', { level: 1, name: 'root layout' })
+    ).toBeInTheDocument();
     await expect(canvas.getByTestId('tanstack-outlet-leaf')).toBeInTheDocument();
   },
 };
@@ -62,6 +65,9 @@ export const RendersLeafViaRouteTreePath: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByTestId('tanstack-outlet-root')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('heading', { level: 1, name: 'root layout' })
+    ).toBeInTheDocument();
     await expect(canvas.getByTestId('tanstack-outlet-leaf')).toBeInTheDocument();
   },
 };


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/35007

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR removes the outlet mock in the tanstack-react framework integration so users can also use it with root routes/nested routes 

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- verify a rootlayout would work with the reproduction provided in https://github.com/storybookjs/storybook/issues/35007

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Storybook stories providing regression coverage for the `Outlet` component, including scenarios for rendering content within root layouts and complete route tree configurations.

* **Chores**
  * Removed unused mock export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->