### PR TITLE
Danger: Add QA labeling requirement to all PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,6 +49,7 @@ Thank you for contributing to Storybook! Please submit all PRs to the `next` bra
 ## Checklist for Maintainers
 
 - [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
+- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
 - [ ] Make sure this PR contains **one** of the labels below:
    <details>
      <summary>Available labels</summary>

--- a/scripts/dangerfile.js
+++ b/scripts/dangerfile.js
@@ -36,6 +36,7 @@ const Versions = {
 };
 
 const ciLabels = ['ci:normal', 'ci:merged', 'ci:daily', 'ci:docs'];
+const qaLabels = ['qa:needed', 'qa:skip', 'qa:success'];
 
 const { labels } = danger.github.issue;
 
@@ -92,6 +93,13 @@ const checkRequiredLabels = (labels) => {
       fail(`PR is not labeled with one of: ${JSON.stringify(ciLabels)}`);
     } else if (foundCILabels.length > 1) {
       fail(`Please choose only one of these labels: ${JSON.stringify(foundCILabels)}`);
+    }
+
+    const foundQALabels = intersection(qaLabels, labels);
+    if (foundQALabels.length === 0) {
+      fail(`PR is not labeled with one of: ${JSON.stringify(qaLabels)}`);
+    } else if (foundQALabels.length > 1) {
+      fail(`Please choose only one of these labels: ${JSON.stringify(foundQALabels)}`);
     }
   }
 };


### PR DESCRIPTION
## What I did

Modified team process for QA requirements. Instead of labeling all QA worthy PRs at the end of a cycle, and then removed the QA label post QA, we'll now indicate on each PR whether it is QA worthy or not at the time of authoring. Then, the release team will go through all QA worthy PRs and label them as successful post-QA. This should help:
* Limit the risk of missing a QA-worthy PR
* Save time for project team members as they no longer need to recheck all their PRs at the end of a cycle
* Better track when QA was done and by whom, to help with postmortem in case of release incidents


## Checklist for Contributors


#### Manual testing
N/A

### Documentation
N/A

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PR validation now requires exactly one QA label for non-release PRs; validation fails with clear instructions if none or multiple are present.
  * Pull request template updated with a checklist item asking maintainers to declare manual QA for the next release via qa:needed or qa:skip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->