### PR TITLE
TanStack React: Only assign synthetic route id when no path is provided

### DIFF
--- a/code/frameworks/tanstack-react/src/routing/decorator.tsx
+++ b/code/frameworks/tanstack-react/src/routing/decorator.tsx
@@ -201,7 +201,11 @@ function resolveTree(Story: ComponentType, context: Parameters<Decorator>[1]): R
   );
   const syntheticChild = createRoute({
     component: () => <Story />,
-    id: 'storybook-story',
+    // A TanStack route may define an `id` or a `path`, never both. Only assign the
+    // synthetic id when the user's plain options don't already provide a path,
+    // otherwise `parameters.tanstack.router.route = { path: '...' }` throws
+    // "Route cannot have both an 'id' and a 'path' option."
+    ...('path' in plainOptions ? {} : { id: 'storybook-story' }),
     ...plainOptions,
     getParentRoute: () => syntheticRoot,
   } as any);


### PR DESCRIPTION
## What I did

Fixes the error thrown when writing a route-param story for a **plain component** via the documented `parameters.tanstack.router` API:

> `Route cannot have both an 'id' and a 'path' option.`

In `resolveTree()` (`code/frameworks/tanstack-react/src/routing/decorator.tsx`), the synthetic child route is built with a hardcoded `id: 'storybook-story'` and then the user's options are spread in:

```tsx
const syntheticChild = createRoute({
  component: () => <Story />,
  id: 'storybook-story',
  ...plainOptions,            // may contain { path }
  getParentRoute: () => syntheticRoot,
});
```

When `parameters.tanstack.router.route = { path: '/…' }` (the documented way to give a plain component a route + params), `plainOptions` includes a `path`, so the route ends up with **both** `id` and `path` — which TanStack Router rejects. Omitting `path` instead leaves the synthetic child pathless, so a param URL resolves to "Route not found". Either way it's impossible to render a plain component that reads `useParams`/`useSearch`.

The fix assigns the synthetic `id` only when the user hasn't supplied a `path`:

```tsx
...('path' in plainOptions ? {} : { id: 'storybook-story' }),
```

Pathless stories are unchanged (still get `id: 'storybook-story'`); path-based options now build a valid route so `useParams`/`useSearch` resolve.

## Related Issue

Fixes #35012

#### Manual testing

In a `@storybook/tanstack-react` project, write a story for a plain component that reads a route param:

```tsx
const meta = {
  component: MyComponent,
  parameters: {
    tanstack: { router: { route: { path: '/items/$id' }, params: { id: '42' } } },
  },
} satisfies Meta<typeof MyComponent>;

export const Default: StoryObj<typeof meta> = {};
```

- **Before this PR:** the story crashes with `Route cannot have both an 'id' and a 'path' option.`
- **After this PR:** the story renders and `useParams()` returns `{ id: '42' }`.
- A story with **no** `path` (relying on the default synthetic id) renders exactly as before.

I confirmed the root cause against the source and reproduced the runtime error in a downstream app on `@storybook/tanstack-react@10.4.1`. I couldn't run the framework's full test suite locally — happy to add a regression test wherever you'd prefer (there's no co-located test under `src/routing/`); a pointer to the right harness would help.
