### PR TITLE
Docs: Clarify Storybook Initializer Packages

### DIFF
--- a/docs/get-started/install.mdx
+++ b/docs/get-started/install.mdx
@@ -128,6 +128,12 @@ After completing the prompts, the command above will make the following changes 
 - 📝 Add some boilerplate stories to get you started.
 - 📡 Set up telemetry to help us improve Storybook. Read more about it [here](../configure/telemetry.mdx).
 
+<Callout variant="info">
+
+The initializer updates your `package.json` with Storybook's `storybook` package, the framework package for your project (for example, `@storybook/react-vite` or `@storybook/nextjs`), any selected addons, and scripts for running and building Storybook. In a typical project, you do not need to manually add `@storybook/cli`; use the generated package scripts instead.
+
+</Callout>
+
 <If renderer="react">
 
 ## Run the Setup Wizard


### PR DESCRIPTION
## Summary

- Clarify that the Storybook initializer updates `package.json` with the `storybook` package, the project framework package, selected addons, and run/build scripts.
- Note that typical projects do not need to manually add `@storybook/cli`.

Fixes #20030.

## Validation

- `git diff --check`

#### Manual testing

Documentation-only change. I reviewed the rendered MDX source and confirmed the new callout appears in the install flow after the initializer change list.