### PR TITLE
Vue: Extract default values from defineProps output

### DIFF
--- a/code/frameworks/vue3-vite/package.json
+++ b/code/frameworks/vue3-vite/package.json
@@ -52,11 +52,13 @@
     "@storybook/builder-vite": "workspace:*",
     "@storybook/vue3": "workspace:*",
     "magic-string": "^0.30.0",
+    "recast": "^0.23.11",
     "typescript": "^5.9.3",
     "vue-component-meta": "^2.0.0",
     "vue-docgen-api": "^4.75.1"
   },
   "devDependencies": {
+    "@babel/types": "^7.28.5",
     "@types/node": "^22.19.1",
     "typescript": "^5.9.3",
     "vite": "^7.0.4"

--- a/code/frameworks/vue3-vite/src/plugins/vue-docgen-props-destructure.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-docgen-props-destructure.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSource } from 'vue-docgen-api';
+
+import { setupPropsDestructureHandler } from './vue-docgen-props-destructure.ts';
+
+const parse = (source: string) =>
+  parseSource(source, 'Component.vue', { addScriptHandlers: [setupPropsDestructureHandler] });
+
+const propDefault = (doc: Awaited<ReturnType<typeof parse>>, name: string) =>
+  doc.props?.find((prop) => prop.name === name)?.defaultValue;
+
+describe('setupPropsDestructureHandler', () => {
+  it('resolves defaults from reactive props destructure, preserving unicode', async () => {
+    const doc = await parse(`
+      <script setup lang="ts">
+      const { label = '你好', size = '大きい', icon = '✨' } = defineProps<{
+        label?: string;
+        size?: string;
+        icon?: string;
+      }>();
+      </script>
+    `);
+
+    expect(propDefault(doc, 'label')).toEqual({ func: false, value: "'你好'" });
+    expect(propDefault(doc, 'size')).toEqual({ func: false, value: "'大きい'" });
+    expect(propDefault(doc, 'icon')).toEqual({ func: false, value: "'✨'" });
+  });
+
+  it('flags function defaults so they are not treated as string literals', async () => {
+    const doc = await parse(`
+      <script setup lang="ts">
+      const { items = () => [] } = defineProps<{ items?: string[] }>();
+      </script>
+    `);
+
+    expect(propDefault(doc, 'items')).toEqual({ func: true, value: '() => []' });
+  });
+
+  it('leaves props without a destructured default untouched', async () => {
+    const doc = await parse(`
+      <script setup lang="ts">
+      const { label = 'hi', size } = defineProps<{ label?: string; size?: string }>();
+      </script>
+    `);
+
+    expect(propDefault(doc, 'label')).toEqual({ func: false, value: "'hi'" });
+    expect(propDefault(doc, 'size')).toBeUndefined();
+  });
+
+  it('does not clobber defaults already resolved by withDefaults', async () => {
+    const doc = await parse(`
+      <script setup lang="ts">
+      const props = withDefaults(defineProps<{ label?: string }>(), { label: 'from-withDefaults' });
+      </script>
+    `);
+
+    expect(propDefault(doc, 'label')).toEqual({ func: false, value: "'from-withDefaults'" });
+  });
+});

--- a/code/frameworks/vue3-vite/src/plugins/vue-docgen-props-destructure.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-docgen-props-destructure.ts
@@ -1,0 +1,76 @@
+import type { ScriptHandler } from 'vue-docgen-api';
+
+import type * as bt from '@babel/types';
+import * as recast from 'recast';
+
+/**
+ * `vue-docgen-api` only resolves prop defaults declared with `withDefaults(defineProps<…>(), {…})`.
+ * Vue 3.5's reactive props destructure declares them via destructuring instead:
+ *
+ * ```ts
+ * const { label = '你好' } = defineProps<{ label?: string }>();
+ * ```
+ *
+ * `vue-docgen-api` ignores those destructured defaults, so the docs table shows no default. This
+ * handler reads the destructured defaults and assigns them to the matching prop descriptors,
+ * producing the same `defaultValue` shape `withDefaults` does.
+ *
+ * Remove this handler once `vue-docgen-api` extracts destructured defaults natively.
+ */
+export const setupPropsDestructureHandler: ScriptHandler = async (
+  documentation,
+  _component,
+  ast
+) => {
+  for (const statement of ast.program.body) {
+    if (statement.type !== 'VariableDeclaration') {
+      continue;
+    }
+
+    for (const declarator of statement.declarations) {
+      if (declarator.id.type !== 'ObjectPattern' || !isDefinePropsCall(declarator.init)) {
+        continue;
+      }
+
+      for (const property of declarator.id.properties) {
+        // skip rest elements (`...rest`), computed and shorthand keys without a default
+        if (
+          property.type !== 'ObjectProperty' ||
+          property.key.type !== 'Identifier' ||
+          property.value.type !== 'AssignmentPattern'
+        ) {
+          continue;
+        }
+
+        const descriptor = documentation.getPropDescriptor(property.key.name);
+
+        // don't clobber a default that was already resolved (e.g. via `withDefaults`)
+        if (descriptor.defaultValue) {
+          continue;
+        }
+
+        const defaultExpression = property.value.right;
+        descriptor.defaultValue = {
+          func:
+            defaultExpression.type === 'ArrowFunctionExpression' ||
+            defaultExpression.type === 'FunctionExpression',
+          value: recast.print(defaultExpression).code,
+        };
+      }
+    }
+  }
+};
+
+/** Whether the node is a `defineProps(…)` call, including the `withDefaults(defineProps(…), …)` form. */
+function isDefinePropsCall(node: bt.Expression | null | undefined): boolean {
+  if (!node || node.type !== 'CallExpression' || node.callee.type !== 'Identifier') {
+    return false;
+  }
+  if (node.callee.name === 'defineProps') {
+    return true;
+  }
+  if (node.callee.name === 'withDefaults') {
+    return isDefinePropsCall(node.arguments[0] as bt.Expression | undefined);
+  }
+  return false;
+}

--- a/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
@@ -2,6 +2,8 @@ import MagicString from 'magic-string';
 import type { Plugin } from 'vite';
 import { parse } from 'vue-docgen-api';
 
+import { setupPropsDestructureHandler } from './vue-docgen-props-destructure.ts';
+
 export async function vueDocgen(): Promise<Plugin> {
   const { createFilter } = await import('vite');
 
@@ -18,7 +20,9 @@ export async function vueDocgen(): Promise<Plugin> {
           return undefined;
         }
 
-        const metaData = await parse(id);
+        const metaData = await parse(id, {
+          addScriptHandlers: [setupPropsDestructureHandler],
+        });
 
         const s = new MagicString(src);
 

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/unicode-defaults/destructured-define-props.vue
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/unicode-defaults/destructured-define-props.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+const {
+  label = '你好',
+  size = '大きい',
+  icon = '✨',
+} = defineProps<{
+  /**
+   * Greeting label.
+   */
+  label?: string;
+  /**
+   * Size label.
+   */
+  size?: string;
+  /**
+   * Decorative icon.
+   */
+  icon?: string;
+}>();
+</script>
+
+<template>
+  <p>{{ label }} - {{ size }} - {{ icon }}</p>
+</template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9366,10 +9366,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/vue3-vite@workspace:code/frameworks/vue3-vite"
   dependencies:
+    "@babel/types": "npm:^7.28.5"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/vue3": "workspace:*"
     "@types/node": "npm:^22.19.1"
     magic-string: "npm:^0.30.0"
+    recast: "npm:^0.23.11"
     typescript: "npm:^5.9.3"
     vite: "npm:^7.0.4"
     vue-component-meta: "npm:^2.0.0"


### PR DESCRIPTION

## What I did

We don't actually have an issue for this. This PR addresses the Vue 3 Options API syntax:
```ts
const { foo: 1, bar: 2 } = defineProps();
```

Where `foo`'s default value should be 1, for instance.

The PR addresses this by extracting destructured values and passing them as defaults in vue-docgen-api, via an existing hook. We need to discuss whether this mechanism, and the framework deps that come with it, are acceptable; and whether other docgen methods need handling.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

* Merge this PR's content on top of a local copy of the branch used for https://github.com/storybookjs/storybook/pull/34909
* Build a Vue3 TS sandbox and run it
* Go to http://localhost:6006/?path=/docs/stories-renderers-vue3-vue3-vite-default-ts-component-meta-unicode-define-props--docs and see that the defaults are well defined

### Documentation



## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Vue 3.5 prop documentation to correctly capture default values from destructured `defineProps` syntax, including support for unicode/non-ASCII defaults.

* **Tests**
  * Added test coverage for destructured prop defaults handling with various scenarios including function expressions and reactive props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->