### PR TITLE
Docs: Fix Controls losing focus when subcomponents are defined

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Controls.stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Controls.stories.tsx
@@ -4,7 +4,7 @@ import type { PlayFunctionContext } from 'storybook/internal/csf';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { expect, within } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 
 import * as ExampleStories from '../examples/ControlsParameters.stories';
 import * as SubcomponentsExampleStories from '../examples/ControlsWithSubcomponentsParameters.stories';
@@ -117,6 +117,24 @@ export const SubcomponentsOfStory: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     await findSubcomponentTabs(canvas, step);
+  },
+};
+
+/**
+ * When a component declares subcomponents, editing a control on the main component tab should not
+ * remount the input and drop focus. This verifies the fix for
+ * https://github.com/storybookjs/storybook/issues/29028
+ */
+export const SubcomponentsRetainControlFocus: Story = {
+  args: {
+    of: SubcomponentsExampleStories.NoParameters,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = await canvas.findByDisplayValue('b');
+    await userEvent.click(input);
+    await userEvent.type(input, 'x');
+    await expect(document.activeElement).toBe(input);
   },
 };
 

--- a/code/addons/docs/src/blocks/components/ArgsTable/TabbedArgsTable.stories.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/TabbedArgsTable.stories.tsx
@@ -1,10 +1,17 @@
+import React, { useState } from 'react';
+
 import { TabsView } from 'storybook/internal/components';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { expect, userEvent, within } from 'storybook/test';
+
+import * as ArgRow from './ArgRow.stories';
 import { ArgsTable } from './ArgsTable';
 import { Compact, Normal, Sections } from './ArgsTable.stories';
+import type { TabbedArgsTableProps } from './TabbedArgsTable';
 import { TabbedArgsTable } from './TabbedArgsTable';
+import type { Args } from './types';
 
 const meta = {
   component: TabbedArgsTable,
@@ -56,4 +63,43 @@ export const WithContentAround: StoryObj<typeof meta> = {
       <p>This is some content below the TabbedArgsTable.</p>
     </>
   ),
+};
+
+/**
+ * When multiple tabs are shown, editing a control on the first tab should not remount the input and
+ * drop focus. This verifies the fix for https://github.com/storybookjs/storybook/issues/29028
+ */
+export const RetainControlFocusWithTabs: StoryObj<typeof meta> = {
+  args: {
+    tabs: {
+      Main: {
+        rows: {
+          someString: ArgRow.String.args.row,
+        },
+      },
+      Other: {
+        rows: {
+          numberType: ArgRow.Number.args.row,
+        },
+      },
+    },
+    args: { someString: 'hello' },
+  },
+  render: function Render(props) {
+    const [storyArgs, setStoryArgs] = useState<Args>({ someString: 'hello' });
+    return (
+      <TabbedArgsTable
+        {...(props as TabbedArgsTableProps)}
+        args={storyArgs}
+        updateArgs={(updated) => setStoryArgs((prev) => ({ ...prev, ...updated }))}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = await canvas.findByDisplayValue('hello');
+    await userEvent.click(input);
+    await userEvent.type(input, 'x');
+    await expect(document.activeElement).toBe(input);
+  },
 };

--- a/code/addons/docs/src/blocks/components/ArgsTable/TabbedArgsTable.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/TabbedArgsTable.tsx
@@ -25,20 +25,19 @@ export const TabbedArgsTable: FC<TabbedArgsTableProps> = ({ tabs, ...props }) =>
     return <ArgsTable {...entries[0][1]} {...props} />;
   }
 
-  const tabsFromEntries = entries.map(([label, table], index) => ({
-    id: `prop_table_div_${label}`,
-    title: label,
-    children: () => {
-      /**
-       * The first tab is the main component, controllable if in the Controls block All other tabs
-       * are subcomponents, never controllable, so we filter out the props indicating
-       * controllability Essentially all subcomponents always behave like ArgTypes, never Controls
-       */
-      const argsTableProps = index === 0 ? props : { sort: props.sort };
+  const tabsFromEntries = entries.map(([label, table], index) => {
+    // The first tab is the main component, controllable if in the Controls block. All other tabs
+    // are subcomponents, never controllable, so we filter out the props indicating
+    // controllability. Pass a stable element (not an inline function component) so React
+    // reconciles the tab panel instead of remounting it on every args update.
+    const argsTableProps = index === 0 ? props : { sort: props.sort };
 
-      return <ArgsTable inTabPanel key={`prop_table_${label}`} {...table} {...argsTableProps} />;
-    },
-  }));
+    return {
+      id: `prop_table_div_${label}`,
+      title: label,
+      children: <ArgsTable inTabPanel {...table} {...argsTableProps} />,
+    };
+  });
 
   return <StyledTabsView tabs={tabsFromEntries} />;
 };


### PR DESCRIPTION
Closes #29028

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed docs Controls losing focus on every keystroke when a component defines `subcomponents`.

When subcomponents are present, the Controls block renders a tabbed args table via `TabbedArgsTable`. Each tab's content was passed to `TabsView` as a new inline arrow function on every render. React treated that as a new component type on each args update, remounting the args table and dropping input focus.

The fix passes a stable `<ArgsTable />` element as tab content instead, so React reconciles the existing tree across args updates and focus is preserved.

Added regression stories:
- `RetainControlFocusWithTabs` in `TabbedArgsTable.stories.tsx`
- `SubcomponentsRetainControlFocus` in `Controls.stories.tsx`

AI assistance (Cursor) was used to investigate, implement, and test this change.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Run a sandbox, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. In the sandbox, add `subcomponents` to a component meta and open its **Docs** page
3. In the Controls table on the main component tab, type into a text control (e.g. `label`)
4. Confirm the input keeps focus and you can type continuously without re-clicking after each character

Reproduction reference: https://stackblitz.com/edit/github-ygdrxf

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus retention when interacting with component controls, ensuring the focused input remains active when updating control values.

* **Tests**
  * Added verification tests for focus behavior with subcomponents and tabbed interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->