### PR TITLE
UI: Fix Chrome iframe scroll lost after resizing sidebar/panel divider

### DIFF
--- a/code/core/src/manager/components/layout/useDragging.ts
+++ b/code/core/src/manager/components/layout/useDragging.ts
@@ -203,6 +203,16 @@ export function useDragging({
       window.removeEventListener('mouseup', onDragEnd);
       // make iframe capture pointer events again
       previewIframe?.removeAttribute('style');
+
+      // In Chrome, scrolling inside the preview iframe breaks after dragging
+      // a resize divider because Chrome doesn't restore scroll hit-testing
+      // when pointer-events is removed from an iframe. Blurring and immediately
+      // refocusing the iframe resets Chrome's internal scroll context so the
+      // user can scroll again without having to click inside first.
+      if (previewIframe) {
+        previewIframe.blur();
+        previewIframe.focus({ preventScroll: true });
+      }
       draggedElement = null;
     };
 


### PR DESCRIPTION
Closes #29221 

## What I did

In Chrome, scrolling inside the preview iframe stops working after dragging a sidebar or panel resize divider. This happens because Chrome doesn't restore scroll hit-testing when `pointer-events` is removed from an iframe.

Fix: after drag ends, blur and immediately refocus the iframe with `preventScroll: true`. This resets Chrome's internal scroll context so the user can scroll again without having to click inside the preview first.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run `cd code && yarn storybook:ui`
2. Open Storybook in Chrome
3. Scroll down inside the preview iframe
4. Drag the sidebar or panel resize divider
5. Try scrolling inside the preview iframe — should work without needing to click first

**Before fix:** Scroll stops working after drag until you click inside the preview.
**After fix:** Scroll works immediately after drag.

**Demo**


https://github.com/user-attachments/assets/88dab96b-b09a-49bc-a7de-af37a3c28c2f


### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes.
- [ ] Make sure this PR contains **one** of the labels below: `bug`