### PR TITLE
UI: Prevent docs page scroll reset on HMR re-render

### DIFF
--- a/code/addons/docs/template/stories/docs2/UtfSymbolScroll.mdx
+++ b/code/addons/docs/template/stories/docs2/UtfSymbolScroll.mdx
@@ -6,7 +6,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 > Instruction below works only in iframe.html. Unknown code in normal mode (with manager) removes hash from url.
 
-Click on [link](#anchor-with-utf-symbols-абвг). T hat will jump scroll to anchor after green block below. Then reload page and
+Click on [link](#anchor-with-utf-symbols-абвг). That will jump scroll to anchor after green block below. Then reload page and
 it should smooth-scroll to that anchor.
 
 <div style={{ height: "1500px", background: "green", color: "white" }}>

--- a/code/addons/docs/template/stories/docs2/UtfSymbolScroll.mdx
+++ b/code/addons/docs/template/stories/docs2/UtfSymbolScroll.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta } from "@storybook/addon-docs/blocks";
 
 <Meta title="UtfSymbolsScroll" />
 
@@ -6,9 +6,11 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 > Instruction below works only in iframe.html. Unknown code in normal mode (with manager) removes hash from url.
 
-Click on [link](#anchor-with-utf-symbols-абвг). That will jump scroll to anchor after green block below. Then reload page and 
-it should smooth-scroll to that anchor. 
+Click on [link](#anchor-with-utf-symbols-абвг). T hat will jump scroll to anchor after green block below. Then reload page and
+it should smooth-scroll to that anchor.
 
-<div style={{ height: "1500px", background: "green", color: "white" }}>Space for scroll test</div>
+<div style={{ height: "1500px", background: "green", color: "white" }}>
+  Space for scroll test
+</div>
 
 ## Anchor with utf symbols (абвг)

--- a/code/addons/docs/template/stories/docs2/UtfSymbolScroll.mdx
+++ b/code/addons/docs/template/stories/docs2/UtfSymbolScroll.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="UtfSymbolsScroll" />
 

--- a/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
@@ -458,7 +458,7 @@ export class PreviewWithSelection<TRenderer extends Renderer> extends Preview<TR
       );
     } else {
       this.currentRender.renderToElement(
-        this.view.prepareForDocs(),
+        this.view.prepareForDocs({ scrollReset: storyIdChanged || viewModeChanged }),
         // This argument is used for docs, which is currently only compatible with HTMLElements
         this.renderStoryToElement.bind(this) as any
       );

--- a/code/core/src/preview-api/modules/preview-web/View.ts
+++ b/code/core/src/preview-api/modules/preview-web/View.ts
@@ -4,7 +4,7 @@ export interface View<TStorybookRoot> {
   // Get ready to render a story, returning the element to render to
   prepareForStory(story: PreparedStory<any>): TStorybookRoot;
 
-  prepareForDocs(): TStorybookRoot;
+  prepareForDocs(options?: { scrollReset?: boolean }): TStorybookRoot;
 
   showErrorDisplay(err: { message?: string; stack?: string }): void;
 

--- a/code/core/src/preview-api/modules/preview-web/WebView.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.ts
@@ -81,13 +81,19 @@ export class WebView implements View<HTMLElement> {
     return document.getElementById('storybook-root')!;
   }
 
-  prepareForDocs() {
+  prepareForDocs({ scrollReset = true }: { scrollReset?: boolean } = {}) {
     this.showMain();
     this.showDocs();
     this.applyLayout('fullscreen');
 
-    document.documentElement.scrollTop = 0;
-    document.documentElement.scrollLeft = 0;
+    // Only reset scroll when navigating to a new docs page, not on HMR re-renders.
+    // Without this guard, hot-reloading a story file while scrolled down on a docs page
+    // causes the page to jump back to the top.
+
+    if (scrollReset) {
+      document.documentElement.scrollTop = 0;
+      document.documentElement.scrollLeft = 0;
+    }
 
     return this.docsRoot();
   }


### PR DESCRIPTION
Closes #26060

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed a bug where hot-reloading a story or MDX file while scrolled down on a docs page 
causes the page to jump back to the top.

`WebView.prepareForDocs()` was unconditionally resetting `scrollTop`/`scrollLeft` to 0 on every docs render, including HMR re-renders. The scroll reset is only appropriate when navigating to a new docs page (story or view mode changed), not when the same page reloads due to HMR.

**Fix:** 
- Added a `scrollReset` option to `prepareForDocs()` (defaulting to `true` for backwards compatibility). 
- `PreviewWithSelection` now passes `scrollReset: storyIdChanged || viewModeChanged`, so scroll only resets on actual navigation, not HMR.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->
  1. Compile, clear cache, and start Storybook:
     ```bash
     yarn nx compile core --skip-nx-cache
     rm -rf code/node_modules/.cache/storybook
     cd code && yarn storybook:ui
  2. In Chrome, navigate to Addons → Docs → Utf Symbols Scroll
  3. Scroll all the way down in the preview
  4. Open code/addons/docs/template/stories/docs2/UtfSymbolScroll.mdx in your editor and make
  a trivial change (add a space or letter), then save
  5. Before fix: page jumps back to the top on hot reload
  6. After fix: page stays at your scroll position after hot reload

  Also verify normal navigation still resets scroll correctly:
  - Click a different story in the sidebar → scroll resets to top 
  - Switch from story view to docs view → scroll resets to top 
  
  **Video Demo**

**Before Fix**

https://github.com/user-attachments/assets/232e030a-916f-40de-8682-0feef9ac2e38

https://github.com/user-attachments/assets/b7ac6238-5c27-4a95-9f60-69b156a386c4

**After Fix**

https://github.com/user-attachments/assets/9924f179-f79b-48a4-a887-336a6dfe1ab1

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated a docs story’s instruction text and reformatted its example markup for clearer layout and consistent styling.

* **Bug Fixes**
  * Improved docs preview scroll behavior so the page scroll is reset only when the displayed story or view mode changes, avoiding unnecessary scroll resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->