### PR TITLE
Core: Clean stale runtime instance records

### DIFF
--- a/code/core/src/core-server/utils/runtime-instance-registry.test.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.test.ts
@@ -1,17 +1,27 @@
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 
 import { join, resolve } from 'pathe';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createRuntimeInstanceRecord,
+  getRuntimeInstanceRegistryCleanupDecision,
   getMcpMetadataFromMainConfig,
   writeRuntimeInstanceRecord,
   writeStorybookRuntimeInstanceRecord,
 } from './runtime-instance-registry.ts';
 
 const tempDirs: string[] = [];
+const NOW = new Date('2026-06-02T12:00:00.000Z');
 
 function makeTempDir() {
   const dir = mkdtempSync(join(tmpdir(), 'storybook-runtime-registry-'));
@@ -19,7 +29,78 @@ function makeTempDir() {
   return dir;
 }
 
+function hoursAgo(hours: number) {
+  return new Date(NOW.getTime() - hours * 60 * 60 * 1000);
+}
+
+function daysAgo(days: number) {
+  return hoursAgo(days * 24);
+}
+
+function writeRecordFile({
+  instanceId,
+  mtime,
+  pid = 12345,
+  registryDir,
+  startedAt,
+  updatedAt,
+}: {
+  instanceId: string;
+  mtime?: Date;
+  pid?: number;
+  registryDir: string;
+  startedAt?: string;
+  updatedAt?: string;
+}) {
+  const record = createRuntimeInstanceRecord({
+    address: 'http://localhost:6006/',
+    instanceId,
+    now: NOW,
+    pid,
+    port: 6006,
+    storybookVersion: '10.5.0-alpha.0',
+  });
+  const recordPath = join(registryDir, `${instanceId}.json`);
+
+  writeFileSync(
+    recordPath,
+    `${JSON.stringify(
+      {
+        ...record,
+        ...(startedAt === undefined ? {} : { startedAt }),
+        ...(updatedAt === undefined ? {} : { updatedAt }),
+      },
+      null,
+      2
+    )}\n`,
+    'utf-8'
+  );
+
+  if (mtime) {
+    utimesSync(recordPath, mtime, mtime);
+  }
+
+  return recordPath;
+}
+
+async function writeCurrentRecord(registryDir: string) {
+  return writeRuntimeInstanceRecord(
+    createRuntimeInstanceRecord({
+      address: 'http://localhost:7007/',
+      instanceId: 'current-instance',
+      now: NOW,
+      pid: 7007,
+      port: 7007,
+      storybookVersion: '10.5.0-alpha.0',
+    }),
+    registryDir
+  );
+}
+
 afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+
   while (tempDirs.length > 0) {
     rmSync(tempDirs.pop()!, { force: true, recursive: true });
   }
@@ -111,6 +192,122 @@ describe('createRuntimeInstanceRecord', () => {
   });
 });
 
+describe('getRuntimeInstanceRegistryCleanupDecision', () => {
+  const recentRecord = createRuntimeInstanceRecord({
+    address: 'http://localhost:6006/',
+    instanceId: 'recent-instance',
+    now: NOW,
+    pid: 12345,
+    port: 6006,
+    storybookVersion: '10.5.0-alpha.0',
+  });
+
+  it.each([
+    {
+      name: 'keeps temp files newer than a day',
+      entry: {
+        kind: 'temp-file' as const,
+        fileModifiedAtMs: hoursAgo(23).getTime(),
+        nowMs: NOW.getTime(),
+      },
+      expected: { action: 'keep' },
+    },
+    {
+      name: 'removes temp files older than a day',
+      entry: {
+        kind: 'temp-file' as const,
+        fileModifiedAtMs: daysAgo(2).getTime(),
+        nowMs: NOW.getTime(),
+      },
+      expected: { action: 'remove' },
+    },
+    {
+      name: 'keeps malformed JSON newer than seven days',
+      entry: {
+        kind: 'malformed-json' as const,
+        fileModifiedAtMs: daysAgo(6).getTime(),
+        nowMs: NOW.getTime(),
+      },
+      expected: { action: 'keep' },
+    },
+    {
+      name: 'removes malformed JSON older than seven days',
+      entry: {
+        kind: 'malformed-json' as const,
+        fileModifiedAtMs: daysAgo(8).getTime(),
+        nowMs: NOW.getTime(),
+      },
+      expected: { action: 'remove' },
+    },
+    {
+      name: 'keeps valid records newer than a day',
+      entry: {
+        kind: 'record' as const,
+        fileModifiedAtMs: daysAgo(8).getTime(),
+        nowMs: NOW.getTime(),
+        record: { ...recentRecord, updatedAt: hoursAgo(23).toISOString() },
+      },
+      expected: { action: 'keep' },
+    },
+    {
+      name: 'checks the PID for valid records from a day through seven days old',
+      entry: {
+        kind: 'record' as const,
+        fileModifiedAtMs: daysAgo(8).getTime(),
+        nowMs: NOW.getTime(),
+        record: { ...recentRecord, pid: 202, updatedAt: hoursAgo(24).toISOString() },
+      },
+      expected: { action: 'check-pid', pid: 202 },
+    },
+    {
+      name: 'keeps stale valid records without a usable PID',
+      entry: {
+        kind: 'record' as const,
+        fileModifiedAtMs: daysAgo(8).getTime(),
+        nowMs: NOW.getTime(),
+        record: { ...recentRecord, pid: 0, updatedAt: daysAgo(2).toISOString() },
+      },
+      expected: { action: 'keep' },
+    },
+    {
+      name: 'removes valid records older than seven days',
+      entry: {
+        kind: 'record' as const,
+        fileModifiedAtMs: hoursAgo(1).getTime(),
+        nowMs: NOW.getTime(),
+        record: { ...recentRecord, updatedAt: daysAgo(8).toISOString() },
+      },
+      expected: { action: 'remove' },
+    },
+    {
+      name: 'falls back from updatedAt to startedAt',
+      entry: {
+        kind: 'record' as const,
+        fileModifiedAtMs: hoursAgo(1).getTime(),
+        nowMs: NOW.getTime(),
+        record: {
+          ...recentRecord,
+          startedAt: daysAgo(8).toISOString(),
+          updatedAt: 'not-a-date',
+        },
+      },
+      expected: { action: 'remove' },
+    },
+    {
+      name: 'falls back to file mtime when record timestamps are invalid',
+      entry: {
+        kind: 'record' as const,
+        fileModifiedAtMs: daysAgo(8).getTime(),
+        nowMs: NOW.getTime(),
+        record: { ...recentRecord, startedAt: 'not-a-date', updatedAt: 'not-a-date' },
+      },
+      expected: { action: 'remove' },
+    },
+  ])('$name', ({ entry, expected }) => {
+    expect(getRuntimeInstanceRegistryCleanupDecision(entry)).toEqual(expected);
+  });
+});
+
 describe('writeRuntimeInstanceRecord', () => {
   it('writes via a temporary file in the registry directory and renames to the final JSON path', async () => {
     const registryDir = makeTempDir();
@@ -128,6 +325,175 @@ describe('writeRuntimeInstanceRecord', () => {
     expect(recordPath).toBe(join(registryDir, `${record.instanceId}.json`));
     expect(readdirSync(registryDir)).toEqual([`${record.instanceId}.json`]);
     expect(JSON.parse(readFileSync(recordPath, 'utf-8'))).toEqual(record);
+  });
+
+  it('sweeps stale registry entries before writing the current record', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const registryDir = makeTempDir();
+    writeRecordFile({
+      instanceId: 'recent-valid',
+      pid: 101,
+      registryDir,
+      updatedAt: hoursAgo(23).toISOString(),
+    });
+    writeRecordFile({
+      instanceId: 'stale-inactive',
+      pid: 202,
+      registryDir,
+      updatedAt: hoursAgo(24).toISOString(),
+    });
+    writeRecordFile({
+      instanceId: 'stale-active',
+      pid: 303,
+      registryDir,
+      updatedAt: daysAgo(2).toISOString(),
+    });
+    writeRecordFile({
+      instanceId: 'stale-ambiguous',
+      pid: 404,
+      registryDir,
+      updatedAt: daysAgo(2).toISOString(),
+    });
+    writeRecordFile({
+      instanceId: 'old-valid',
+      pid: 505,
+      registryDir,
+      updatedAt: daysAgo(8).toISOString(),
+    });
+    writeFileSync(join(registryDir, 'recent-malformed.json'), '{', 'utf-8');
+    writeFileSync(join(registryDir, 'old-malformed.json'), '{', 'utf-8');
+    writeFileSync(join(registryDir, 'recent.tmp'), '{}', 'utf-8');
+    writeFileSync(join(registryDir, 'old.tmp'), '{}', 'utf-8');
+    utimesSync(join(registryDir, 'recent-malformed.json'), daysAgo(6), daysAgo(6));
+    utimesSync(join(registryDir, 'old-malformed.json'), daysAgo(8), daysAgo(8));
+    utimesSync(join(registryDir, 'recent.tmp'), hoursAgo(23), hoursAgo(23));
+    utimesSync(join(registryDir, 'old.tmp'), daysAgo(2), daysAgo(2));
+
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid) => {
+      if (pid === 202) {
+        throw Object.assign(new Error('missing process'), { code: 'ESRCH' });
+      }
+
+      if (pid === 404) {
+        throw Object.assign(new Error('permission denied'), { code: 'EPERM' });
+      }
+
+      return true;
+    });
+
+    await writeCurrentRecord(registryDir);
+
+    expect(readdirSync(registryDir).sort()).toEqual([
+      'current-instance.json',
+      'recent-malformed.json',
+      'recent-valid.json',
+      'recent.tmp',
+      'stale-active.json',
+      'stale-ambiguous.json',
+    ]);
+    expect(killSpy.mock.calls.map(([pid]) => pid).sort()).toEqual([202, 303, 404]);
+  });
+
+  it('does not block writing the current record when one stale file cannot be removed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const registryDir = makeTempDir();
+    const lockedRecordPath = writeRecordFile({
+      instanceId: 'locked-instance',
+      registryDir,
+      updatedAt: daysAgo(8).toISOString(),
+    });
+    const actualFsPromises =
+      await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+
+    vi.resetModules();
+    vi.doMock('node:fs/promises', () => ({
+      ...actualFsPromises,
+      rm: vi.fn(async (path, options) => {
+        if (path === lockedRecordPath) {
+          throw Object.assign(new Error('locked'), { code: 'EBUSY' });
+        }
+
+        return actualFsPromises.rm(path, options);
+      }),
+    }));
+
+    try {
+      const {
+        createRuntimeInstanceRecord: createRuntimeInstanceRecordWithMockedFs,
+        writeRuntimeInstanceRecord: writeRuntimeInstanceRecordWithMockedFs,
+      } = await import('./runtime-instance-registry.ts');
+      const currentRecordPath = await writeRuntimeInstanceRecordWithMockedFs(
+        createRuntimeInstanceRecordWithMockedFs({
+          address: 'http://localhost:7007/',
+          instanceId: 'current-instance',
+          now: NOW,
+          pid: 7007,
+          port: 7007,
+          storybookVersion: '10.5.0-alpha.0',
+        }),
+        registryDir
+      );
+
+      expect(existsSync(lockedRecordPath)).toBe(true);
+      expect(existsSync(currentRecordPath)).toBe(true);
+    } finally {
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+    }
+  });
+
+  it('does not treat unreadable JSON files as malformed JSON', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const registryDir = makeTempDir();
+    const unreadableRecordPath = writeRecordFile({
+      instanceId: 'unreadable-instance',
+      registryDir,
+      updatedAt: daysAgo(8).toISOString(),
+    });
+    const actualFsPromises =
+      await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+
+    vi.resetModules();
+    vi.doMock('node:fs/promises', () => ({
+      ...actualFsPromises,
+      readFile: vi.fn(async (path, options) => {
+        if (path === unreadableRecordPath) {
+          throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+        }
+
+        return actualFsPromises.readFile(path, options);
+      }),
+    }));
+
+    try {
+      const {
+        createRuntimeInstanceRecord: createRuntimeInstanceRecordWithMockedFs,
+        writeRuntimeInstanceRecord: writeRuntimeInstanceRecordWithMockedFs,
+      } = await import('./runtime-instance-registry.ts');
+      const currentRecordPath = await writeRuntimeInstanceRecordWithMockedFs(
+        createRuntimeInstanceRecordWithMockedFs({
+          address: 'http://localhost:7007/',
+          instanceId: 'current-instance',
+          now: NOW,
+          pid: 7007,
+          port: 7007,
+          storybookVersion: '10.5.0-alpha.0',
+        }),
+        registryDir
+      );
+
+      expect(existsSync(unreadableRecordPath)).toBe(true);
+      expect(existsSync(currentRecordPath)).toBe(true);
+    } finally {
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+    }
   });
 });
 

--- a/code/core/src/core-server/utils/runtime-instance-registry.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.ts
@@ -1,5 +1,5 @@
 import { existsSync, rmSync } from 'node:fs';
-import { mkdir, rename, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
@@ -9,6 +9,8 @@ import { join, resolve } from 'pathe';
 
 const STORYBOOK_MCP_ADDON = '@storybook/addon-mcp';
 const DEFAULT_MCP_ENDPOINT = '/mcp';
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * ONE_DAY_MS;
 
 export type RuntimeInstanceRecord = {
   schemaVersion: 1;
@@ -29,6 +31,16 @@ export type RuntimeInstanceRegistration = {
   cleanup: () => Promise<void>;
   unregisterProcessCleanup: () => void;
 };
+
+export type RuntimeInstanceRegistryCleanupEntry =
+  | { kind: 'temp-file'; fileModifiedAtMs: number; nowMs: number }
+  | { kind: 'malformed-json'; fileModifiedAtMs: number; nowMs: number }
+  | { kind: 'record'; fileModifiedAtMs: number; nowMs: number; record: unknown };
+
+export type RuntimeInstanceRegistryCleanupDecision =
+  | { action: 'keep' }
+  | { action: 'remove' }
+  | { action: 'check-pid'; pid: number };
 
 export function getDefaultRuntimeInstanceRegistryDir() {
   return join(homedir(), '.storybook', 'instances');
@@ -100,6 +112,7 @@ export async function writeRuntimeInstanceRecord(
   registryDir = getDefaultRuntimeInstanceRegistryDir()
 ) {
   await mkdir(registryDir, { recursive: true });
+  await cleanupRuntimeInstanceRegistry(registryDir);
 
   const recordPath = join(registryDir, `${record.instanceId}.json`);
   const tempPath = join(
@@ -116,6 +129,157 @@ export async function writeRuntimeInstanceRecord(
   }
 
   return recordPath;
+}
+
+function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getTimestampMs(record: Record<string, unknown>, key: 'updatedAt' | 'startedAt') {
+  const value = record[key];
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const timestamp = Date.parse(value);
+
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function getRecordAgeMs(record: unknown, fileModifiedAtMs: number, nowMs: number) {
+  const recordTimestampMs = isRecordObject(record)
+    ? (getTimestampMs(record, 'updatedAt') ?? getTimestampMs(record, 'startedAt'))
+    : undefined;
+
+  return nowMs - (recordTimestampMs ?? fileModifiedAtMs);
+}
+
+function getRecordPid(record: unknown) {
+  if (!isRecordObject(record) || typeof record.pid !== 'number') {
+    return undefined;
+  }
+
+  return Number.isInteger(record.pid) && record.pid > 0 ? record.pid : undefined;
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === 'object' && error !== null && 'code' in error;
+}
+
+export function getRuntimeInstanceRegistryCleanupDecision(
+  entry: RuntimeInstanceRegistryCleanupEntry
+): RuntimeInstanceRegistryCleanupDecision {
+  if (entry.kind === 'temp-file') {
+    return entry.nowMs - entry.fileModifiedAtMs > ONE_DAY_MS
+      ? { action: 'remove' }
+      : { action: 'keep' };
+  }
+
+  if (entry.kind === 'malformed-json') {
+    return entry.nowMs - entry.fileModifiedAtMs > SEVEN_DAYS_MS
+      ? { action: 'remove' }
+      : { action: 'keep' };
+  }
+
+  const recordAgeMs = getRecordAgeMs(entry.record, entry.fileModifiedAtMs, entry.nowMs);
+
+  if (recordAgeMs > SEVEN_DAYS_MS) {
+    return { action: 'remove' };
+  }
+
+  if (recordAgeMs < ONE_DAY_MS) {
+    return { action: 'keep' };
+  }
+
+  const recordPid = getRecordPid(entry.record);
+
+  return recordPid === undefined ? { action: 'keep' } : { action: 'check-pid', pid: recordPid };
+}
+
+function isPidInactive(pid: number) {
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error) {
+    return isErrnoException(error) && error.code === 'ESRCH';
+  }
+}
+
+async function applyCleanupDecision(
+  recordPath: string,
+  decision: RuntimeInstanceRegistryCleanupDecision
+) {
+  if (
+    decision.action === 'remove' ||
+    (decision.action === 'check-pid' && isPidInactive(decision.pid))
+  ) {
+    await rm(recordPath, { force: true });
+  }
+}
+
+async function cleanupRuntimeInstanceRegistry(registryDir: string) {
+  const nowMs = Date.now();
+  const entries = await readdir(registryDir, { withFileTypes: true }).catch(() => []);
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isFile()) {
+        return;
+      }
+
+      const recordPath = join(registryDir, entry.name);
+
+      try {
+        const { mtimeMs } = await stat(recordPath);
+
+        if (entry.name.endsWith('.tmp')) {
+          await applyCleanupDecision(
+            recordPath,
+            getRuntimeInstanceRegistryCleanupDecision({
+              kind: 'temp-file',
+              fileModifiedAtMs: mtimeMs,
+              nowMs,
+            })
+          );
+          return;
+        }
+
+        if (!entry.name.endsWith('.json')) {
+          return;
+        }
+
+        const content = await readFile(recordPath, 'utf-8');
+        let record: unknown;
+
+        try {
+          record = JSON.parse(content) as unknown;
+        } catch {
+          await applyCleanupDecision(
+            recordPath,
+            getRuntimeInstanceRegistryCleanupDecision({
+              kind: 'malformed-json',
+              fileModifiedAtMs: mtimeMs,
+              nowMs,
+            })
+          );
+          return;
+        }
+
+        await applyCleanupDecision(
+          recordPath,
+          getRuntimeInstanceRegistryCleanupDecision({
+            kind: 'record',
+            fileModifiedAtMs: mtimeMs,
+            nowMs,
+            record,
+          })
+        );
+      } catch {
+        // Registry cleanup is opportunistic; one bad file should not block the current record.
+      }
+    })
+  );
 }
 
 function registerProcessCleanup(recordPath: string) {


### PR DESCRIPTION
Closes #35022

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

- Added a best-effort runtime instance registry sweep before writing the current process record.
- Implemented the cleanup policy from #35022:
  - keep records younger than 24h without PID checks
  - for records from 24h through 7d, remove only when `process.kill(pid, 0)` definitely reports `ESRCH`
  - keep active or ambiguous PID checks
  - remove valid records older than 7d unconditionally
  - remove malformed JSON only when file mtime is older than 7d
  - remove `.tmp` files only when file mtime is older than 24h
- Kept the existing temp-file-and-rename write path intact.
- Split the policy into a pure decision helper and a small IO shell so the retention rules are easy to review and test.
- Completed an independent `cursor-team-kit:thermo-nuclear-code-quality-review` subagent review. The review findings were addressed by extracting the pure cleanup decision helper, converting the policy coverage to compact table tests, and fixing the unreadable-file vs malformed-JSON boundary. The final re-review found no remaining actionable maintainability issues.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

Automated verification run locally:

```sh
yarn nx compile core
yarn fmt:write
yarn --cwd code lint:js:cmd core/src/core-server/utils/runtime-instance-registry.ts core/src/core-server/utils/runtime-instance-registry.test.ts --fix
yarn vitest run --config code/core/vitest.config.ts code/core/src/core-server/utils/runtime-instance-registry.test.ts
git diff --check
```

Manual QA was performed by running real Storybook dev servers with temporary `HOME` directories so the runtime registry was isolated at `$HOME/.storybook/instances`.

Commands used:

```sh
HOME=/tmp/storybook-dev-registry-qa-p0FLgA STORYBOOK_DISABLE_TELEMETRY=1 NODE_OPTIONS="--max_old_space_size=4096 --trace-deprecation" node code/core/dist/bin/dispatcher.js dev --port 61234 --config-dir code/.storybook --ci --no-open --exact-port
HOME=/tmp/storybook-dev-registry-qa-active-FTSbc7 STORYBOOK_DISABLE_TELEMETRY=1 NODE_OPTIONS="--max_old_space_size=4096 --trace-deprecation" node code/core/dist/bin/dispatcher.js dev --port 61235 --config-dir code/.storybook --ci --no-open --exact-port
```

Observed:

- Storybook dev reached `Storybook ready!` on `http://localhost:61234/` and `http://localhost:61235/`.
- `curl -I` returned `HTTP/1.1 200 OK` for both ports while Storybook was running.
- A current runtime instance record was written with the live Storybook PID, URL, port, cwd, and version.
- Sending `SIGTERM` to Storybook removed its current runtime instance record.
- The seeded cleanup matrix behaved as expected:
  - recent valid record stayed
  - recent `.tmp` stayed
  - stale inactive PID record was removed
  - stale active PID record stayed
  - valid record older than 7 days was removed even with an active PID
  - old `.tmp` was removed
  - old malformed JSON was removed
  - recent malformed JSON stayed

```json
{
  "registry": "/tmp/storybook-dev-registry-qa-active-FTSbc7/.storybook/instances",
  "remaining": [
    "368519e1-baca-4248-ba5b-e1d9ba7c74e2.json",
    "recent-valid.json",
    "recent.tmp",
    "stale-active.json"
  ],
  "expectedPresent": [
    "recent-valid.json",
    "recent.tmp",
    "stale-active.json"
  ],
  "expectedAbsent": [
    "stale-inactive.json",
    "old-valid-active-pid.json",
    "old.tmp"
  ],
  "pass": true
}
```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No docs update: this is internal runtime registry maintenance behavior.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cleanup of stale and temporary registry files before writing new records to enhance system stability.
  * Enhanced system robustness when file cleanup encounters errors, ensuring record operations succeed despite cleanup failures.

* **Tests**
  * Expanded test coverage for registry cleanup behavior with deterministic time-based assertions and new cleanup decision validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->