### PR TITLE
Svelte: Skip Docgen for Svelte Story Files

### DIFF
--- a/code/frameworks/svelte-vite/src/plugins/svelte-docgen.test.ts
+++ b/code/frameworks/svelte-vite/src/plugins/svelte-docgen.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./generateDocgen.ts', { spy: true });
+
+import { createDocgenCache, generateDocgen } from './generateDocgen.ts';
+import { svelteDocgen } from './svelte-docgen.ts';
+
+describe('svelteDocgen', () => {
+  beforeEach(() => {
+    vi.mocked(createDocgenCache).mockReturnValue({
+      filenameToModifiedTime: {},
+      filenameToSourceFile: {},
+      fileCache: {},
+    });
+    vi.mocked(generateDocgen).mockReturnValue({ props: [] });
+  });
+
+  it('skips Svelte CSF story files', async () => {
+    const plugin = (await svelteDocgen()) as {
+      transform: {
+        handler: (src: string, id: string) => Promise<unknown>;
+      };
+    };
+
+    const result = await plugin.transform.handler(
+      'export default function Story() {}',
+      '/src/Button.stories.svelte'
+    );
+
+    expect(result).toBeUndefined();
+    expect(vi.mocked(generateDocgen)).not.toHaveBeenCalled();
+  });
+});

--- a/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
+++ b/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
@@ -108,7 +108,7 @@ function transformToSvelteDocParserDataItems(docgen: Docgen): SvelteDataItem[] {
 export async function svelteDocgen(): Promise<PluginOption> {
   const cwd = process.cwd();
   const include = /\.svelte$/;
-  const exclude = /node_modules\/.*/;
+  const exclude = [/node_modules\/.*/, /\.stories\.svelte$/];
   const { createFilter } = await import('vite');
 
   const filter = createFilter(include, exclude);


### PR DESCRIPTION
Refs #32233.

This skips Svelte docgen for `.stories.svelte` files. Those files are Svelte CSF story modules rather than component files, so running component docgen on them does unnecessary work and can add noise before the broader component-discovery optimization is tackled.

I kept this narrow: it does not try to solve the full issue yet, but removes one case that the issue already calls out as unnecessary.

#### Manual testing

Not run; this is plugin filter behavior covered by the focused unit test below.

Local checks:

- `yarn vitest run code/frameworks/svelte-vite/src/plugins/svelte-docgen.test.ts --config code/frameworks/svelte-vite/vitest.config.ts`
- `yarn nx compile svelte-vite`
- `yarn nx check svelte-vite`
- `yarn --cwd code lint:js:cmd frameworks/svelte-vite/src/plugins/svelte-docgen.ts frameworks/svelte-vite/src/plugins/svelte-docgen.test.ts`
- `git diff --check HEAD~1..HEAD`
- clean review-fix-loop pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for the Svelte docgen plugin to verify correct behavior when encountering Svelte story files during processing.

* **Bug Fixes**
  * Fixed the Svelte docgen plugin filter configuration to properly exclude Svelte story files from being processed by the transform handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->