### PR TITLE
Core: Respect !dev tag on MDX docs in sidebar

### DIFF
--- a/code/addons/docs/template/stories/docs2/no-dev-attached.mdx
+++ b/code/addons/docs/template/stories/docs2/no-dev-attached.mdx
@@ -1,0 +1,10 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as ButtonStories from './button.stories.ts';
+
+<Meta of={ButtonStories} tags={['!dev', 'manifest']} />
+
+# Attached docs with `!dev`
+
+Attached MDX (`Meta of={…}`) with `tags={['!dev', 'manifest']}`.
+
+Should be hidden from the sidebar, same as `no-dev-unattached.mdx`.

--- a/code/addons/docs/template/stories/docs2/no-dev-unattached.mdx
+++ b/code/addons/docs/template/stories/docs2/no-dev-unattached.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta tags={['!dev', 'manifest']} />
+
+Unattached docs with the tags `!dev` and `manifest`
+
+Should be hidden from the sidebar (unattached MDX; compare with `no-dev-attached.mdx`).

--- a/code/core/src/manager-api/modules/tags.ts
+++ b/code/core/src/manager-api/modules/tags.ts
@@ -70,8 +70,18 @@ export const computeStaticFilterFn = (tagPresets: TagsOptions) => {
 
   return (item: API_PreparedIndexEntry) => {
     const tags = item.tags ?? [];
+    // Docs entry kinds are distinguished by system tags at index time:
+    // - autodocs: type `docs`, no `attached-mdx` / `unattached-mdx` (importPath is the CSF file)
+    // - attached MDX: `attached-mdx`
+    // - unattached MDX: `unattached-mdx`
+    // Autodocs inherit CSF meta tags (e.g. `!dev`) and must stay in the sidebar; MDX should
+    // respect `!dev` like stories. See 15d7ef9149d.
+    const isCsfAutodocsEntry =
+      item.type === 'docs' &&
+      !tags.includes(TagEnum.ATTACHED_MDX) &&
+      !tags.includes(TagEnum.UNATTACHED_MDX);
     return (
-      (tags.includes(TagEnum.DEV) || item.type === 'docs') &&
+      (tags.includes(TagEnum.DEV) || isCsfAutodocsEntry) &&
       tags.filter((tag) => staticExcludeTags[tag]).length === 0
     );
   };

--- a/code/core/src/manager-api/tests/tags.test.js
+++ b/code/core/src/manager-api/tests/tags.test.js
@@ -1,6 +1,63 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseTagsParam, serializeTagsParam } from '../modules/tags';
+import { computeStaticFilterFn, parseTagsParam, serializeTagsParam } from '../modules/tags';
+
+describe('computeStaticFilterFn', () => {
+  const filter = computeStaticFilterFn({});
+
+  it('shows stories with dev tag and hides stories without dev', () => {
+    expect(filter({ id: 's1', type: 'story', tags: ['dev'] })).toBe(true);
+    expect(filter({ id: 's2', type: 'story', tags: ['test'] })).toBe(false);
+  });
+
+  it('hides MDX docs without dev tag (respects !dev on Meta)', () => {
+    expect(
+      filter({
+        id: 'd1',
+        type: 'docs',
+        tags: ['unattached-mdx', 'manifest'],
+      })
+    ).toBe(false);
+    expect(
+      filter({
+        id: 'd2',
+        type: 'docs',
+        tags: ['attached-mdx', 'manifest'],
+      })
+    ).toBe(false);
+    expect(
+      filter({
+        id: 'd3',
+        type: 'docs',
+        tags: ['unattached-mdx', 'dev', 'manifest'],
+      })
+    ).toBe(true);
+    expect(
+      filter({
+        id: 'd4',
+        type: 'docs',
+        tags: ['attached-mdx', 'dev', 'manifest'],
+      })
+    ).toBe(true);
+  });
+
+  it('shows CSF autodocs docs without dev tag (meta !dev regression from 15d7ef9)', () => {
+    expect(
+      filter({
+        id: 'core-tags-add--docs',
+        type: 'docs',
+        tags: ['manifest', 'story-one', 'play-fn'],
+      })
+    ).toBe(true);
+  });
+
+  it('hides entries that carry a tag marked excludeFromSidebar', () => {
+    const filterWithExclude = computeStaticFilterFn({
+      dev: { excludeFromSidebar: true },
+    });
+    expect(filterWithExclude({ id: 's1', type: 'story', tags: ['dev'] })).toBe(false);
+  });
+});
 
 describe('parseTagsParam', () => {
   it('returns empty arrays for falsy input', () => {

--- a/code/e2e-tests/tags.spec.ts
+++ b/code/e2e-tests/tags.spec.ts
@@ -46,6 +46,10 @@ test.describe('tags', () => {
     await expect(preview.locator('#anchor--core-tags-remove--no-dev')).toHaveCount(1);
     await expect(preview.locator('#anchor--core-tags-remove--no-autodocs')).toHaveCount(0);
     await expect(preview.locator('#anchor--core-tags-remove--no-test')).toHaveCount(1);
+
+    // Static sidebar filter: entries tagged !dev must not appear (see no-dev-*.mdx in addons/docs)
+    await expect(page.locator('#addons-docs-docs2-no-dev-unattached--docs')).toHaveCount(0);
+    await expect(page.locator('#addons-docs-docs2-button--no-dev-attached')).toHaveCount(0);
   });
 
   test.describe('Tag filters tooltip', () => {


### PR DESCRIPTION
Closes #35029

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The static sidebar filter treated every `type === 'docs'` entry as visible, which bypassed `!dev` on unattached and attached MDX. That behavior was introduced in 15d7ef9 to keep CSF autodocs pages visible when meta uses `!dev`.

Narrowed the exception to CSF autodocs entries only (docs without `attached-mdx` or `unattached-mdx` system tags). MDX docs now require the `dev` tag to appear in the sidebar, same as stories.

Added `no-dev-unattached.mdx` and `no-dev-attached.mdx` fixtures under `addons/docs` docs2, unit tests for `computeStaticFilterFn`, and e2e assertions in `tags.spec.ts`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Run `cd code && yarn storybook:ui` (or a React sandbox with docs: `yarn task sandbox --template react-vite/default-ts --start-from auto`)
2. Open the sidebar under **addons/docs → docs2**
3. Confirm **no-dev-unattached** and **no-dev-attached** (under button) are not listed
4. Open **core → tags-add → Docs** and confirm the autodocs page still appears in the sidebar when meta uses `!dev`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar filtering now correctly hides docs marked with the `!dev` tag, including autodocs and attached/unattached MDX docs.

* **Documentation**
  * Added MDX docs demonstrating `!dev` behavior for attached and unattached examples.

* **Tests**
  * Expanded unit and end-to-end tests to cover doc visibility, `!dev` handling, and sidebar exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->