### PR TITLE
Addon Docs: DocsContent not filling available width when TOC is enabled

### DIFF
--- a/code/addons/docs/src/blocks/components/DocsPage.tsx
+++ b/code/addons/docs/src/blocks/components/DocsPage.tsx
@@ -110,6 +110,7 @@ export const DocsContent = styled.div(({ theme }) => {
     maxWidth: 1000,
     width: '100%',
     minWidth: 0,
+    flex: 1,
     [toGlobalSelector('a')]: {
       ...reset,
       fontSize: 'inherit',


### PR DESCRIPTION
## What I did

Added `flex: 1` to `DocsContent` in `code/addons/docs/src/blocks/components/DocsPage.tsx`.

Before | After
-|-
<kbd> <img width="673" alt="toc-before" src="https://github.com/user-attachments/assets/7e5b42ac-a020-47e2-9e37-fec9e57037e8" /> | <kbd> <img width="673" alt="toc-after" src="https://github.com/user-attachments/assets/8dba2ff3-5047-45cc-bde2-5fad692eb76d" />

## Why

- `DocsWrapper` uses `display: flex; flex-direction: row-reverse`
- The TOC (`Nav`) is `position: fixed`, so it's removed from the flex flow
- `DocsContent` was the only in-flow flex item, but without `flex: 1` it shrank to its content width
- This caused the TOC to anchor at the viewport edge with no left padding

Adding `flex: 1` makes `DocsContent` fill the wrapper width, which corrects the TOC positioning.

_Reproduced with a fresh `create-next-app` + `storybook@10 init` project with `docs: { toc: true }` in preview config._

#### Manual testing

1. Create a new Storybook project (`npx storybook@latest init`)
2. Enable TOC in `.storybook/preview.ts`: `parameters: { docs: { toc: true } }`
3. Open any Docs page — the TOC should appear with proper spacing from the right edge

---

> AI assisted (Claude) in drafting this PR.