### PR TITLE
Core: Expose backgrounds types from public subpath

### DIFF
--- a/code/core/build-config.ts
+++ b/code/core/build-config.ts
@@ -119,6 +119,10 @@ const config: BuildEntries = {
         entryPoint: './src/actions/decorator.ts',
       },
       {
+        exportEntries: ['./backgrounds'],
+        entryPoint: './src/backgrounds/index.ts',
+      },
+      {
         exportEntries: ['./viewport'],
         entryPoint: './src/viewport/index.ts',
       },

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -56,6 +56,11 @@
       "code": "./src/actions/decorator.ts",
       "default": "./dist/actions/decorator.js"
     },
+    "./backgrounds": {
+      "types": "./dist/backgrounds/index.d.ts",
+      "code": "./src/backgrounds/index.ts",
+      "default": "./dist/backgrounds/index.js"
+    },
     "./highlight": {
       "types": "./dist/highlight/index.d.ts",
       "code": "./src/highlight/index.ts",

--- a/code/core/src/backgrounds/index.test-d.ts
+++ b/code/core/src/backgrounds/index.test-d.ts
@@ -1,0 +1,15 @@
+import { expectTypeOf } from 'vitest';
+
+import { DEFAULT_BACKGROUNDS } from 'storybook/backgrounds';
+import type { Background, BackgroundMap } from 'storybook/backgrounds';
+
+expectTypeOf<BackgroundMap>().toEqualTypeOf<Record<string, Background>>();
+
+expectTypeOf(DEFAULT_BACKGROUNDS).toEqualTypeOf<BackgroundMap>();
+
+const customBackgrounds = {
+  light: { name: 'Light', value: '#ffffff' },
+  dark: { name: 'Dark', value: '#1a1a1a' },
+} satisfies BackgroundMap;
+
+expectTypeOf(customBackgrounds.light).toExtend<Background>();

--- a/code/core/src/backgrounds/index.ts
+++ b/code/core/src/backgrounds/index.ts
@@ -1,0 +1,3 @@
+export * from './constants.ts';
+export * from './types.ts';
+export * from './defaults.ts';


### PR DESCRIPTION
Closes #34952

## What I did

Added a public storybook/backgrounds export so the backgrounds types and constants can be imported directly.

This includes:
- adding the storybook/backgrounds export
- exporting the relevant types and constants
- adding a type test to cover the public API

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Build the package.
2. Create a TypeScript file that imports from storybook/backgrounds.
3. Verify that Background, BackgroundMap, and DEFAULT_BACKGROUNDS can be imported without type errors.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update MIGRATION.MD

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35044-sha-4ef63dcf`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35044-sha-4ef63dcf sandbox` or in an existing project with `npx storybook@0.0.0-pr-35044-sha-4ef63dcf upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35044-sha-4ef63dcf`](https://npmjs.com/package/storybook/v/0.0.0-pr-35044-sha-4ef63dcf) |
| **Triggered by** | @Sidnioulz |
| **Repository** | [ShaharAviram1/storybook](https://github.com/ShaharAviram1/storybook) |
| **Branch** | [`expose-backgrounds-public-subpath`](https://github.com/ShaharAviram1/storybook/tree/expose-backgrounds-public-subpath) |
| **Commit** | [`4ef63dcf`](https://github.com/ShaharAviram1/storybook/commit/4ef63dcffe8d2124efce53dd05ca49deeeadeca8) |
| **Datetime** | Thu Jun  4 14:54:13 UTC 2026 (`1780584853`) |
| **Workflow run** | [26959698816](https://github.com/storybookjs/storybook/actions/runs/26959698816) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35044`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backgrounds module is now publicly exported and available for external integration.
  * Build configuration updated with new entry points for backgrounds module.
  * Export paths and type definitions configured in package manifest.

* **Tests**
  * Type safety tests added to validate backgrounds module type definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storybookjs/storybook/pull/35044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->