### PR TITLE
Pseudo-states: Wrap -all ancestor selector in :where() to preserve specificity

### DIFF
--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -190,6 +190,18 @@ describe('rewriteStyleSheet', () => {
     expect(sheet.cssRules[0].getSelectors()).toContain('.pseudo-hover-all :is()');
   });
 
+  it('preserves specificity when original selector uses :where()', () => {
+    const sheet = new Sheet('.textLink:where(:focus-visible) { outline: 1px solid red; }');
+    rewriteStyleSheet(sheet as any);
+    const selectors = sheet.cssRules[0].getSelectors();
+    // Per-element class variant should stay zero-specificity
+    expect(selectors).toContain('.textLink:where(.pseudo-focus-visible)');
+    // Ancestor (-all) variant must also be zero-specificity: wrapped in :where()
+    expect(selectors).toContain(':where(.pseudo-focus-visible-all) .textLink');
+    // The broken old form must NOT appear
+    expect(selectors).not.toContain('.pseudo-focus-visible-all .textLink:where(*)');
+  });
+
   it('adds alternative selector for each pseudo selector', () => {
     const sheet = new Sheet('a:hover, a:focus { color: red }');
     rewriteStyleSheet(sheet as any);

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
@@ -43,7 +43,7 @@ const replacePseudoStatesWithAncestorSelector = (
     return selector;
   }
 
-  const selectors = `${additionalHostSelectors ?? ''}${extracted.states.map((s) => `.pseudo-${s}-all`).join('')}`;
+  const selectors = `${additionalHostSelectors ?? ''}:where(${extracted.states.map((s) => `.pseudo-${s}-all`).join('')})`;
 
   // If there was a :host-context() containing only pseudo-states, we will later add a :host selector that replaces it.
   let { withoutPseudoStates } = extracted;
@@ -67,8 +67,11 @@ const extractPseudoStates = (selector: string) => {
         return '';
       })
       // If removing pseudo-state selectors from inside a functional selector left it empty (thus invalid), must fix it by adding '*'.
-      // The negative lookbehind ensures we don't replace :is() with :is(*).
-      .replaceAll(/(?<!is)\(\)/g, '(*)')
+      // The negative lookbehind ensures we don't replace :is() or :where() with :is(*) / :where(*).
+      .replaceAll(/(?<!is|here)\(\)/g, '(*)')
+      // :where() left empty after pseudo-state removal has no effect — strip it entirely so the
+      // ancestor rewrite doesn't produce ".textLink:where()" as the base selector.
+      .replaceAll(/:where\(\)/g, '')
       // If a selector list was left with blank items (e.g. ", foo, , bar, "), remove the extra commas/spaces.
       .replace(/(?<=[\s(]),\s+|(,\s+)+(?=\))/g, '') || '*';
 


### PR DESCRIPTION
Closes #31411 

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed the `addon-pseudo-states` CSS selector rewriter to preserve specificity when a selector uses `:where()` to wrap a pseudo-class.

**Root cause:** 
- When a CSS rule uses `:where()` to keep specificity at zero (e.g. `.textLink:where(:focus-visible)`), the addon correctly rewrites the per-element variant as `.textLink:where(.pseudo-focus-visible)` — zero added specificity.
- However, for the `-all` ancestor variant, it was generating `.pseudo-focus-visible-all .textLink:where(*)`, which adds an extra class to the specificity (0-2-0 instead of 0-1-0).
- This caused the forced pseudo-state style to incorrectly override rules that should have won by source order.

**Fix:** 
- Wrap the generated ancestor class list in `:where()` so it contributes zero specificity:

Before:
```css
.pseudo-focus-visible-all .textLink:where(*) { ... } /* specificity 0-2-0 ❌ */
```

After:
```css
:where(.pseudo-focus-visible-all) .textLink { ... } /* specificity 0-1-0 ✅ */
```

## Checklist for Contributors

### Testing

### Automated tests

The fix is covered by a new unit test in `rewriteStyleSheet.test.ts` that:
- Asserts the per-element variant `.textLink:where(.pseudo-focus-visible)` is generated correctly
- Asserts the ancestor variant is `:where(.pseudo-focus-visible-all) .textLink` (not `.pseudo-focus-visible-all .textLink:where(*)`)

Run with:
```bash
yarn vitest run --config code/addons/pseudo-states/vitest.config.ts code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
```

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

No manual testing video is included as this is a pure CSS selector string transformation with no visible UI change in isolation. The fix only manifests when two rules of equal intended specificity compete, which is covered by the unit test.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CSS specificity handling in pseudo-state extraction to correctly preserve zero-specificity selectors using `:where()` during ancestor rewriting.
  * Improved empty selector cleanup to prevent invalid selector fragments.

* **Tests**
  * Added test coverage to verify CSS specificity semantics are maintained when using `:where()` in pseudo-state selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->