### PR TITLE
Controls: Load controls for stories from a composed ref

### DIFF
--- a/code/core/src/controls/components/ControlsPanel.stories.tsx
+++ b/code/core/src/controls/components/ControlsPanel.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ManagerContext } from 'storybook/manager-api';
+import { expect, fn } from 'storybook/test';
+
+import { ControlsPanel } from './ControlsPanel.tsx';
+
+const refId = 'my-ref';
+const storyData = {
+  type: 'story',
+  id: `${refId}_example-button--primary`,
+  refId,
+  args: { label: 'Submit' },
+  initialArgs: { label: 'Submit' },
+  argTypes: { label: { name: 'label', control: { type: 'text' } } },
+};
+
+// Reproduces the #34553 condition: the story comes from a composed ref, so the host's
+// global `previewInitialized` stays false while the ref's own flag is true.
+const managerContext: any = {
+  state: {
+    path: storyData.id,
+    previewInitialized: false,
+    refs: { [refId]: { id: refId, previewInitialized: true } },
+  },
+  api: {
+    getCurrentStoryData: fn(() => storyData).mockName('api::getCurrentStoryData'),
+    getCurrentParameter: fn(() => ({})).mockName('api::getCurrentParameter'),
+    getGlobals: fn(() => ({})).mockName('api::getGlobals'),
+    getStoryGlobals: fn(() => ({})).mockName('api::getStoryGlobals'),
+    getUserGlobals: fn(() => ({})).mockName('api::getUserGlobals'),
+    updateGlobals: fn().mockName('api::updateGlobals'),
+    updateStoryArgs: fn().mockName('api::updateStoryArgs'),
+    resetStoryArgs: fn().mockName('api::resetStoryArgs'),
+    on: fn().mockName('api::on'),
+    off: fn().mockName('api::off'),
+    emit: fn().mockName('api::emit'),
+  },
+};
+
+const meta = {
+  component: ControlsPanel,
+  args: { saveStory: fn(), createStory: fn() },
+  decorators: [
+    (storyFn) => (
+      <ManagerContext.Provider value={managerContext}>{storyFn()}</ManagerContext.Provider>
+    ),
+  ],
+} satisfies Meta<typeof ControlsPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Regression test for #34553: controls for a story from a composed ref must render even
+ * though the host's global `previewInitialized` flag never flips. Before the fix the panel
+ * read only that global flag, so it stayed in its loading state and showed skeletons forever.
+ */
+export const RefStoryControlsLoad: Story = {
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByText('label')).toBeInTheDocument();
+  },
+};

--- a/code/core/src/controls/components/ControlsPanel.tsx
+++ b/code/core/src/controls/components/ControlsPanel.tsx
@@ -65,16 +65,21 @@ export const ControlsPanel = ({ saveStory, createStory }: ControlsPanelProps) =>
     presetColors,
     disableSaveFromUI = false,
   } = useParameter<ControlsParameters>(PARAM_KEY, {});
-  const { path, previewInitialized } = useStorybookState();
+  const { path, refs, previewInitialized } = useStorybookState();
   const storyData = api.getCurrentStoryData();
 
-  // If the story is prepared, then show the args table
-  // and reset the loading states
+  // Stories from a composed ref track their own `previewInitialized` flag; the host's
+  // global flag stays false for them, so read the ref's flag when on a ref story (#34553).
+  const isPreviewInitialized = storyData?.refId
+    ? !!refs[storyData.refId]?.previewInitialized
+    : previewInitialized;
+
+  // If the story is prepared, then show the args table and reset the loading state
   useEffect(() => {
-    if (previewInitialized) {
+    if (isPreviewInitialized) {
       setIsLoading(false);
     }
-  }, [previewInitialized]);
+  }, [isPreviewInitialized]);
 
   const hasControls = Object.values(rows).some((arg) => arg?.control);
 


### PR DESCRIPTION
## What I did

Fixes #34553 — controls never load for a story served from a composed Storybook ref (`refs` / `extends: true`). `ControlsPanel` only watched the host's global `previewInitialized` flag, which stays `false` for ref stories — their readiness is tracked per-ref in `state.refs[refId].previewInitialized`. So `isLoading` never cleared and the args table showed loading skeletons forever.

The fix reads the ref's `previewInitialized` when the current story belongs to a ref, and falls back to the global flag otherwise.

#### Manual testing

- Repro: compose a second Storybook via `refs` and open one of its stories — its Controls now load instead of showing skeletons.
- Added a regression story `ControlsPanel.stories.tsx` (`RefStoryControlsLoad`): it mocks `ManagerContext` for a ref story while the host's global `previewInitialized` is still `false`, and asserts the controls render. Verified it fails on the pre-fix behaviour and passes with the fix:

```
yarn vitest run --config code/vitest.config.storybook.ts core/src/controls/components/ControlsPanel.stories.tsx
```

Closes #34553


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `ControlsPanel` to correctly determine preview initialization status for stories in composed refs, ensuring controls load properly when referencing stories from other Storybook instances (resolves issue `#34553`).

* **Tests**
  * Added regression test for composed ref story control rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->