### PR TITLE
Agentic Review: Redesign screens according to updated designs

### DIFF
--- a/code/addons/review/src/ReviewPage.stories.tsx
+++ b/code/addons/review/src/ReviewPage.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
 
 import { ManagerContext, type API, type State } from 'storybook/manager-api';
 import { MemoryRouter } from 'storybook/internal/router';
@@ -118,25 +118,13 @@ export const Collections = meta.story({
     applyReviewState();
 
     await expect(await canvas.findByText('Manager settings polish')).toBeInTheDocument();
-    await expect(await canvas.findByRole('tab', { name: 'Collections' })).toBeInTheDocument();
-  },
-});
-
-export const Components = meta.story({
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    await expect(emitMock).toHaveBeenCalledWith(EVENTS.REQUEST_REVIEW);
-
-    applyReviewState();
-
-    const componentsTab = await canvas.findByRole('tab', { name: 'Components' });
-    await userEvent.click(componentsTab);
+    await expect(await canvas.findByText('Settings')).toBeInTheDocument();
   },
 });
 
 export const Details = meta.story({
   parameters: {
-    routerInitialEntries: ['/?path=/review/collections/0/manager-settings-guidepage--default'],
+    routerInitialEntries: ['/?path=/review/0/manager-settings-guidepage--default'],
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -145,6 +133,6 @@ export const Details = meta.story({
     applyReviewState();
 
     await expect(await canvas.findByRole('button', { name: '2/3' })).toBeInTheDocument();
-    await expect(await canvas.findByText('Latest on feat/review-page')).toBeInTheDocument();
+    await expect(await canvas.findByRole('heading', { name: 'Settings' })).toBeInTheDocument();
   },
 });

--- a/code/addons/review/src/ReviewPage.ts
+++ b/code/addons/review/src/ReviewPage.ts
@@ -5,14 +5,11 @@ import { Location, type RenderData, useNavigate } from 'storybook/internal/route
 
 import type { StoryInfo } from './components/CollectionGrid.tsx';
 import { EVENTS, RESTORE_NAV_SESSION_KEY, REVIEW_CHANGES_URL } from './constants.ts';
-import { groupStoriesByComponent, prettifyComponentId } from './review-grouping.ts';
 import {
   buildReviewChangesDetailHref,
   buildReviewChangesSummaryHref,
   normalizeReviewStoryId,
-  parseReviewChangesActiveTab,
   parseReviewChangesDetailLocation,
-  type ReviewTab,
 } from './review-navigation.ts';
 import type { ReviewState } from './review-state.ts';
 import { DetailsScreen } from './screens/DetailsScreen.tsx';
@@ -52,20 +49,7 @@ const ReviewPageContent: FC<{ search: string }> = ({ search }) => {
     emit(EVENTS.REQUEST_REVIEW);
   }, [emit]);
 
-  const activeTab = parseReviewChangesActiveTab(search);
   const detailLocation = parseReviewChangesDetailLocation(search);
-
-  // Keep the summary route canonical: `/review/` immediately becomes
-  // `/review/<tab>` so tab state is represented in the path.
-  useEffect(() => {
-    const params = new URLSearchParams(search);
-    const path = params.get('path');
-    const isLegacySummaryPath =
-      path === REVIEW_CHANGES_URL || path === REVIEW_CHANGES_URL.slice(0, -1);
-    if (isLegacySummaryPath && !detailLocation) {
-      navigate(buildReviewChangesSummaryHref(activeTab), { plain: true });
-    }
-  }, [activeTab, detailLocation, navigate, search]);
 
   // The review page is a focused, full-width surface — hide the manager
   // sidebar while it is open and restore it on the way out. The user's prior
@@ -89,8 +73,8 @@ const ReviewPageContent: FC<{ search: string }> = ({ search }) => {
   }, [api]);
 
   // Resolve each story's component title + name from the Storybook index.
-  // Drives the Components tab headers and the floating thumbnail labels;
-  // falls back gracefully (per-consumer) when the index has not loaded.
+  // Drives the cell labels and the detail subtitle; falls back gracefully
+  // (per-consumer) when the index has not loaded.
   const storyInfo = useMemo(() => {
     const info: Record<string, StoryInfo> = {};
     if (!state) {
@@ -151,28 +135,9 @@ const ReviewPageContent: FC<{ search: string }> = ({ search }) => {
 
   let detailScreen: ReactNode = null;
   if (state && detailLocation) {
-    let detailTitle: string | undefined;
-    let detailStoryIds: string[] | undefined;
-
-    if (detailLocation.kind === 'collection') {
-      const collection = state.collections[detailLocation.collectionIndex];
-      if (collection) {
-        detailTitle = collection.title;
-        detailStoryIds = collection.storyIds;
-      }
-    } else {
-      const grouped = groupStoriesByComponent(state.collections);
-      const targetStoryId = detailLocation.storyId;
-      const group = grouped.find(
-        (candidate) => targetStoryId !== undefined && candidate.storyIds.includes(targetStoryId)
-      );
-      if (group) {
-        detailStoryIds = group.storyIds;
-        detailTitle = storyInfo[group.storyIds[0]]?.title ?? prettifyComponentId(group.componentId);
-      }
-    }
-
-    if (detailTitle !== undefined && detailStoryIds && detailStoryIds.length > 0) {
+    const collection = state.collections[detailLocation.collectionIndex];
+    if (collection && collection.storyIds.length > 0) {
+      const detailStoryIds = collection.storyIds;
       const totalStories = detailStoryIds.length;
       const resolvedIndexFromStoryId =
         detailLocation.storyId !== undefined
@@ -182,45 +147,25 @@ const ReviewPageContent: FC<{ search: string }> = ({ search }) => {
       const previousStoryIndex = (currentStoryIndex - 1 + totalStories) % totalStories;
       const nextStoryIndex = (currentStoryIndex + 1) % totalStories;
 
-      const previousStoryId = detailStoryIds[previousStoryIndex];
-      const nextStoryId = detailStoryIds[nextStoryIndex];
       const currentStoryId = detailStoryIds[currentStoryIndex];
       const currentStoryInfo = storyInfo[currentStoryId];
       detailScreen = React.createElement(DetailsScreen, {
-        title: detailTitle,
+        title: collection.title,
         storyId: currentStoryId,
         storyIndex: currentStoryIndex,
         totalStories,
         componentTitle: currentStoryInfo?.title,
         storyName: currentStoryInfo?.name,
-        backHref: buildReviewChangesSummaryHref(activeTab),
-        previousHref: buildReviewChangesDetailHref(
-          detailLocation.kind === 'collection'
-            ? {
-                kind: 'collection',
-                collectionIndex: detailLocation.collectionIndex,
-                storyId: previousStoryId,
-              }
-            : {
-                kind: 'component',
-                storyId: previousStoryId,
-              },
-          activeTab
-        ),
-        nextHref: buildReviewChangesDetailHref(
-          detailLocation.kind === 'collection'
-            ? {
-                kind: 'collection',
-                collectionIndex: detailLocation.collectionIndex,
-                storyId: nextStoryId,
-              }
-            : {
-                kind: 'component',
-                storyId: nextStoryId,
-              },
-          activeTab
-        ),
-        branchName: state.branchName,
+        backHref: buildReviewChangesSummaryHref(),
+        previousHref: buildReviewChangesDetailHref({
+          collectionIndex: detailLocation.collectionIndex,
+          storyId: detailStoryIds[previousStoryIndex],
+        }),
+        nextHref: buildReviewChangesDetailHref({
+          collectionIndex: detailLocation.collectionIndex,
+          storyId: detailStoryIds[nextStoryIndex],
+        }),
+        hasBaseline: state.hasBaseline ?? false,
       });
     }
   }
@@ -242,10 +187,6 @@ const ReviewPageContent: FC<{ search: string }> = ({ search }) => {
         },
         React.createElement(SummaryScreen, {
           state,
-          initialTab: activeTab,
-          onTabChange: (nextTab: ReviewTab) => {
-            navigate(buildReviewChangesSummaryHref(nextTab), { plain: true });
-          },
           storyInfo,
         })
       ),

--- a/code/addons/review/src/components/CollectionGrid.stories.tsx
+++ b/code/addons/review/src/components/CollectionGrid.stories.tsx
@@ -24,21 +24,17 @@ const meta = preview.meta({
 
 export const Default = meta.story({});
 
-export const ManyStoriesAutoFit = meta.story({
+// On a narrow (mobile) container the grid drops to a single column and caps at
+// two rows, so eight stories overflow into the "Review all" affordance.
+export const ManyStoriesOverflow = meta.story({
   globals: { viewport: { value: 'mobile1' } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByRole('button', { name: /Review all/i })).toBeInTheDocument();
-
-    const cells = Array.from(
-      canvasElement.querySelectorAll('[data-testid="review-collection-grid-cell"]')
-    ) as HTMLElement[];
-    const rows = new Set(cells.map((cell) => Math.round(cell.getBoundingClientRect().top)));
-    await expect(rows.size).toBeGreaterThan(1);
   },
 });
 
-export const FewStoriesStretch = meta.story({
+export const FewStories = meta.story({
   args: {
     storyIds: ['manager-main--default', 'manager-settings-aboutscreen--default'],
   },
@@ -46,10 +42,15 @@ export const FewStoriesStretch = meta.story({
   play: async ({ canvasElement }) => {
     const cells = canvasElement.querySelectorAll('[data-testid="review-collection-grid-cell"]');
     await expect(cells.length).toBe(2);
+    await expect(
+      canvasElement.querySelector<HTMLButtonElement>('[data-review-all] button')
+    ).not.toBeVisible();
   },
 });
 
-export const HeightIsCapped = meta.story({
+// A single preview clamps to 400px instead of stretching to fill the card, so
+// the grid layout stays consistent regardless of story count.
+export const SingleCellClamped = meta.story({
   args: {
     storyIds: ['manager-main--default'],
   },
@@ -57,6 +58,6 @@ export const HeightIsCapped = meta.story({
   play: async ({ canvasElement }) => {
     const cell = canvasElement.querySelector('[data-testid="review-collection-grid-cell"]');
     await expect(cell).toBeTruthy();
-    await expect((cell as HTMLElement).getBoundingClientRect().height).toBeLessThanOrEqual(400);
+    await expect((cell as HTMLElement).getBoundingClientRect().width).toBeLessThanOrEqual(401);
   },
 });

--- a/code/addons/review/src/components/CollectionGrid.tsx
+++ b/code/addons/review/src/components/CollectionGrid.tsx
@@ -1,15 +1,14 @@
 import React, { type FC, type ReactNode, useEffect, useRef, useState } from 'react';
 
-import { Button } from 'storybook/internal/components';
+import { Button, IconButton } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
+import { StorybookIcon } from '@storybook/icons';
+
 import { prettifyComponentId } from '../review-grouping.ts';
+import { buildStorybookStoryHref } from '../review-navigation.ts';
 
 const PREVIEW_SCALE = 0.5;
-const GRID_MIN_CELL_WIDTH = 300;
-const GRID_GAP = 12;
-const GRID_HORIZONTAL_PADDING = 24;
-const MAX_ROWS = 2;
 
 /** Component title + story name for a story, resolved from the Storybook index. */
 export interface StoryInfo {
@@ -17,48 +16,80 @@ export interface StoryInfo {
   name: string;
 }
 
-const Grid = styled.div({
-  display: 'grid',
-  // Keep the CSS min track width in sync with the JS column-count math so
-  // overflow / "Review all" behavior can't drift from the rendered layout.
-  gridTemplateColumns: `repeat(auto-fit, minmax(min(100%, ${GRID_MIN_CELL_WIDTH}px), 1fr))`,
-  gap: 12,
-  // 6px top padding leaves clearance for the cell's focus outline (2px
-  // offset + 2px width = 4px outside the border box) — the parent
-  // Collapsible clips with `overflow: hidden` for its open/close animation,
-  // so without this the top edge of the outline gets cut off.
-  padding: '6px 12px 12px',
+// Column count is driven entirely by container width — 1 column on narrow
+// (mobile) widths up to 4 on wide screens — with each cell clamped to 400px so
+// a lone preview never stretches across the card. Each band also caps the grid
+// to two rows: once more stories exist than fit, the overflow cells are hidden
+// and a "Review all" cell takes the last visible slot. Both behaviors are pure
+// CSS (`:has()` + `:nth-child`), so no layout measurement runs in JS.
+const band = (cols: number) => {
+  const cap = cols * 2;
+  return {
+    gridTemplateColumns: `repeat(${cols}, minmax(0, 400px))`,
+    [`&:not([data-show-all]):has(> [data-cell]:nth-child(${cap + 1})) > [data-cell]:nth-child(n + ${cap})`]:
+      {
+        display: 'none',
+      },
+    [`&:not([data-show-all]):has(> [data-cell]:nth-child(${cap + 1})) > [data-review-all]`]: {
+      display: 'grid',
+    },
+  };
+};
+
+const GridContainer = styled.div({
+  containerType: 'inline-size',
+  containerName: 'review-grid',
 });
 
-const GridCell = styled.div(({ theme }) => ({
+const Grid = styled.div({
+  display: 'grid',
+  gap: 12,
+  padding: 12,
+  justifyContent: 'start',
+  // Fallback for browsers without container-query support: a single column and
+  // no two-row cap (every story is shown).
+  gridTemplateColumns: 'minmax(0, 400px)',
+  // Bands are mutually exclusive (ranged) so a narrower band's overflow rules
+  // never bleed into a wider one.
+  '@container review-grid (max-width: 629.98px)': band(1),
+  '@container review-grid (min-width: 630px) and (max-width: 844.98px)': band(2),
+  '@container review-grid (min-width: 845px) and (max-width: 1259.98px)': band(3),
+  '@container review-grid (min-width: 1260px)': band(4),
+});
+
+const Cell = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: 0,
+});
+
+// The bordered, clickable preview frame. Rendered as an <a> when a detail href
+// is provided, otherwise a plain <div>. Hover and keyboard focus are indicated
+// here (not on the surrounding cell) since the frame is the interactive target.
+const Frame = styled.a(({ theme }) => ({
   position: 'relative',
+  display: 'block',
   width: '100%',
-  justifySelf: 'stretch',
   aspectRatio: '3 / 2',
-  maxHeight: 400,
   borderRadius: 6,
   overflow: 'hidden',
   background: theme.background.app,
   border: `1px solid ${theme.appBorderColor}`,
   transition: 'border-color 120ms ease',
-  // Reveal the floating story-info banner on hover or while any focusable
-  // descendant (the GridLink itself, or the "Review all" button) is focused.
-  '&:hover [data-story-info], &:focus-within [data-story-info]': {
-    opacity: 1,
-    transform: 'translateY(0)',
-  },
-  '&:hover': {
+  textDecoration: 'none',
+  outline: 'none',
+  '&[href]:hover': {
     borderColor: theme.color.secondary,
   },
-  // Keyboard focus ring lives on the cell so it isn't clipped by the cell's
-  // own `overflow: hidden`. Tabbing into the GridLink triggers `:focus-within`.
-  '&:focus-within': {
+  '&:focus-visible': {
     outline: `${theme.barSelectedColor} solid 2px`,
     outlineOffset: 2,
   },
 }));
 
-const StoryPreview = styled.iframe({
+const Preview = styled.iframe({
+  position: 'absolute',
+  inset: 0,
   width: `${(1 / PREVIEW_SCALE) * 100}%`,
   height: `${(1 / PREVIEW_SCALE) * 100}%`,
   border: 0,
@@ -68,59 +99,27 @@ const StoryPreview = styled.iframe({
   pointerEvents: 'none',
 });
 
-const CellAction = styled.div({
-  width: '100%',
-  height: '100%',
-  display: 'grid',
-  placeItems: 'center',
+// The info/action bar below the preview: the component/story label stretches
+// and ellipsizes on the left; the action slot on the right never wraps.
+const ActionBar = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
+  minHeight: 36,
 });
 
-const GridLink = styled.a({
-  display: 'block',
-  width: '100%',
-  height: '100%',
-  textDecoration: 'none',
-  // Focus indicator is consolidated onto the parent GridCell so it isn't
-  // clipped by the cell's overflow and matches the cell's rounded corners.
-  outline: 'none',
-});
-
-// Floating story-info footer. Hidden by default — fades in on hover or
-// keyboard focus of the parent cell (selectors live on GridCell). Flush
-// full-width and clipped by the cell's rounded corners.
-const InfoBar = styled.div(({ theme }) => ({
-  position: 'absolute',
-  left: 0,
-  right: 0,
-  bottom: 0,
-  height: 41,
+const Label = styled.div({
   display: 'flex',
   alignItems: 'center',
   gap: 4,
-  padding: '10px 16px',
-  // Frosted overlay tuned per theme base so it stays a light scrim in light
-  // mode and a dark scrim in dark mode instead of always translucent white.
-  background: theme.base === 'dark' ? 'rgba(22, 23, 24, 0.85)' : 'rgba(255, 255, 255, 0.9)',
-  color: theme.color.defaultText,
-  backdropFilter: 'blur(24px)',
-  WebkitBackdropFilter: 'blur(24px)',
-  fontFamily: theme.typography.fonts.base,
-  fontSize: 14,
-  lineHeight: '21px',
-  opacity: 0,
-  // Hidden state sits flush below the cell and slides up into view on reveal.
-  transform: 'translateY(100%)',
-  transition: 'opacity 120ms ease, transform 120ms ease',
-  pointerEvents: 'none',
-  // While the search field is focused, reveal every thumbnail's label at once
-  // (the summary marks an ancestor with data-search-active).
-  '[data-search-active] &': {
-    opacity: 1,
-    transform: 'translateY(0)',
-  },
-}));
+  flex: 1,
+  minWidth: 0,
+  marginLeft: 10,
+  overflow: 'hidden',
+});
 
-const InfoComponent = styled.span({
+const LabelComponent = styled.span({
   fontWeight: 700,
   whiteSpace: 'nowrap',
   flexShrink: 0,
@@ -129,20 +128,37 @@ const InfoComponent = styled.span({
   textOverflow: 'ellipsis',
 });
 
-const InfoSeparator = styled.span(({ theme }) => ({
+const LabelSeparator = styled.span(({ theme }) => ({
   color: theme.textMutedColor,
   flexShrink: 0,
 }));
 
-const InfoStory = styled.span({
-  fontWeight: 400,
+const LabelStory = styled.span({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
 });
 
-// Search matches are tinted with the accent colour; their weight is inherited
-// so a match keeps the bold component / normal story styling.
+const ActionSlot = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  flexShrink: 0,
+  whiteSpace: 'nowrap',
+});
+
+const ReviewAllCell = styled.div(({ theme }) => ({
+  display: 'none',
+  placeItems: 'center',
+  width: '100%',
+  aspectRatio: '3 / 2',
+  borderRadius: 6,
+  background: theme.background.app,
+  border: `1px dashed ${theme.appBorderColor}`,
+}));
+
+// Search matches are tinted with the accent colour; weight is inherited so a
+// match keeps the bold component / normal story styling.
 const Mark = styled.mark(({ theme }) => ({
   background: 'transparent',
   color: theme.color.secondary,
@@ -150,13 +166,6 @@ const Mark = styled.mark(({ theme }) => ({
 }));
 
 const storyPreviewUrl = (id: string) => `iframe.html?id=${encodeURIComponent(id)}&viewMode=story`;
-
-const isWithinPreloadRange = (element: HTMLElement, margin: number): boolean => {
-  const rect = element.getBoundingClientRect();
-  const viewportHeight =
-    typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerHeight || 0;
-  return rect.bottom >= -margin && rect.top <= viewportHeight + margin;
-};
 
 // Render `text`, wrapping every case-insensitive occurrence of `query` in a
 // <Mark>. With no query the text renders untouched.
@@ -204,18 +213,12 @@ const StoryPreviewCell: FC<{
   info?: StoryInfo;
   query: string;
 }> = ({ storyId, href, info, query }) => {
-  const hostRef = useRef<HTMLDivElement>(null);
+  const hostRef = useRef<HTMLAnchorElement>(null);
   const [hasMounted, setHasMounted] = useState(false);
 
   useEffect(() => {
     const host = hostRef.current;
     if (!host || hasMounted) {
-      return undefined;
-    }
-    // Ensure above-the-fold previews mount on first paint even if the initial
-    // IntersectionObserver callback is deferred until the next scroll.
-    if (isWithinPreloadRange(host, 200)) {
-      setHasMounted(true);
       return undefined;
     }
     if (typeof IntersectionObserver === 'undefined') {
@@ -237,39 +240,49 @@ const StoryPreviewCell: FC<{
 
   const { component, name } = deriveStoryInfo(storyId, info);
 
-  const content = (
-    <>
-      {hasMounted ? (
-        <StoryPreview
-          title={storyId}
-          src={storyPreviewUrl(storyId)}
-          loading="lazy"
-          tabIndex={-1}
-          scrolling="no"
-        />
-      ) : null}
-      <InfoBar data-story-info>
-        <InfoComponent>
-          <Highlight text={component} query={query} />
-        </InfoComponent>
-        <InfoSeparator>/</InfoSeparator>
-        <InfoStory>
-          <Highlight text={name} query={query} />
-        </InfoStory>
-      </InfoBar>
-    </>
-  );
-
   return (
-    <GridCell ref={hostRef} data-testid="review-collection-grid-cell">
-      {href ? (
-        <GridLink href={href} aria-label={`Review story ${storyId}`}>
-          {content}
-        </GridLink>
-      ) : (
-        content
-      )}
-    </GridCell>
+    <Cell data-cell data-testid="review-collection-grid-cell">
+      <Frame
+        as={href ? 'a' : 'div'}
+        href={href}
+        ref={hostRef}
+        aria-label={href ? `Review story ${storyId}` : undefined}
+      >
+        {hasMounted ? (
+          <Preview
+            title={storyId}
+            src={storyPreviewUrl(storyId)}
+            loading="lazy"
+            tabIndex={-1}
+            scrolling="no"
+          />
+        ) : null}
+      </Frame>
+      <ActionBar>
+        <Label>
+          <LabelComponent>
+            <Highlight text={component} query={query} />
+          </LabelComponent>
+          <LabelSeparator>/</LabelSeparator>
+          <LabelStory>
+            <Highlight text={name} query={query} />
+          </LabelStory>
+        </Label>
+        <ActionSlot>
+          {/* <IconButton
+            variant="ghost"
+            size="small"
+            padding="small"
+            ariaLabel="View in Storybook"
+            asChild
+          >
+            <a href={buildStorybookStoryHref(storyId)} target="_blank" rel="noreferrer">
+              <StorybookIcon />
+            </a>
+          </IconButton> */}
+        </ActionSlot>
+      </ActionBar>
+    </Cell>
   );
 };
 
@@ -280,9 +293,9 @@ export interface CollectionGridProps {
   showAll?: boolean;
   /** Called when the user expands to "Review all". */
   onShowAll?: () => void;
-  /** Story id → component title + story name, for the floating thumbnail label. */
+  /** Story id → component title + story name, for the cell label. */
   storyInfo?: Record<string, StoryInfo>;
-  /** Active search query — matches in the thumbnail label are highlighted. */
+  /** Active search query — matches in the cell label are highlighted. */
   query?: string;
 }
 
@@ -293,45 +306,10 @@ export const CollectionGrid: FC<CollectionGridProps> = ({
   onShowAll,
   storyInfo,
   query = '',
-}) => {
-  const gridRef = useRef<HTMLDivElement>(null);
-  const [columnsPerRow, setColumnsPerRow] = useState(1);
-
-  useEffect(() => {
-    const grid = gridRef.current;
-    if (!grid) {
-      return undefined;
-    }
-
-    const updateColumns = () => {
-      const contentWidth = Math.max(0, grid.clientWidth - GRID_HORIZONTAL_PADDING);
-      const nextColumns = Math.max(
-        1,
-        Math.floor((contentWidth + GRID_GAP) / (GRID_MIN_CELL_WIDTH + GRID_GAP))
-      );
-      setColumnsPerRow(nextColumns);
-    };
-
-    updateColumns();
-
-    if (typeof ResizeObserver === 'undefined') {
-      return undefined;
-    }
-
-    const observer = new ResizeObserver(updateColumns);
-    observer.observe(grid);
-    return () => observer.disconnect();
-  }, []);
-
-  const maxCells = columnsPerRow * MAX_ROWS;
-  const hasOverflow = !showAll && storyIds.length > maxCells;
-  // Reserve the last cell for the "Review all" button only while collapsed.
-  const visibleStoryCount = hasOverflow ? Math.max(0, maxCells - 1) : storyIds.length;
-  const previewStoryIds = storyIds.slice(0, visibleStoryCount);
-
-  return (
-    <Grid ref={gridRef} data-testid="review-collection-grid">
-      {previewStoryIds.map((storyId, storyIndex) => (
+}) => (
+  <GridContainer>
+    <Grid data-show-all={showAll || undefined} data-testid="review-collection-grid">
+      {storyIds.map((storyId, storyIndex) => (
         <StoryPreviewCell
           key={storyId}
           storyId={storyId}
@@ -340,20 +318,11 @@ export const CollectionGrid: FC<CollectionGridProps> = ({
           query={query}
         />
       ))}
-      {hasOverflow && (
-        <GridCell data-testid="review-collection-grid-cell">
-          <CellAction>
-            <Button
-              size="medium"
-              onClick={() => {
-                onShowAll?.();
-              }}
-            >
-              Review all {storyIds.length}
-            </Button>
-          </CellAction>
-        </GridCell>
-      )}
+      <ReviewAllCell data-review-all>
+        <Button size="medium" onClick={() => onShowAll?.()}>
+          Review all {storyIds.length}
+        </Button>
+      </ReviewAllCell>
     </Grid>
-  );
-};
+  </GridContainer>
+);

--- a/code/addons/review/src/components/ReviewHeader.tsx
+++ b/code/addons/review/src/components/ReviewHeader.tsx
@@ -1,0 +1,135 @@
+import React, { type FC, type ReactNode, useEffect, useRef } from 'react';
+
+import { styled } from 'storybook/theming';
+
+// A fixed, white (content-background) heading shared by the summary and detail
+// screens so the two surfaces stay visually coherent. The first row carries an
+// optional leading control (e.g. a back button), the title + subtitle, and a
+// trailing actions cluster. An optional second row spans the full width for
+// controls like search or the baseline comparison bar.
+const Root = styled.header(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  flexShrink: 0,
+  background: theme.background.content,
+  color: theme.color.defaultText,
+  borderBottom: `1px solid ${theme.appBorderColor}`,
+}));
+
+const TopRow = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  // Top-align the leading control and actions with the title's first line
+  // (rather than centering against the taller title + subtitle block).
+  alignItems: 'flex-start',
+  gap: 8,
+  padding: '16px 16px 8px 16px',
+  minHeight: 40,
+  '&:last-of-type': {
+    paddingBottom: 16,
+  },
+});
+
+const Leading = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  flexShrink: 0,
+});
+
+const TextBlock = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  flexGrow: 1,
+  minWidth: 0,
+});
+
+const Title = styled.h1(({ theme }) => ({
+  margin: 0,
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontSize: theme.typography.size.m1,
+  fontWeight: theme.typography.weight.bold,
+  lineHeight: '24px',
+  // The heading is only focused programmatically on route change (see
+  // autoFocusTitle); it is not an interactive control, so suppress the ring.
+  '&:focus': {
+    outline: 'none',
+  },
+}));
+
+const Subtitle = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 5,
+  minWidth: 0,
+  color: theme.textMutedColor,
+  fontSize: theme.typography.size.s2,
+  lineHeight: '20px',
+}));
+
+const Actions = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  flexShrink: 0,
+});
+
+const SecondRow = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 12px 8px 16px',
+  minHeight: 40,
+});
+
+export interface ReviewHeaderProps {
+  /** Optional control rendered before the title (e.g. a back button). */
+  leading?: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  /** Trailing cluster on the right of the top row. */
+  actions?: ReactNode;
+  /** Optional full-width second row (e.g. search or comparison controls). */
+  secondRow?: ReactNode;
+  /**
+   * Move keyboard focus to the title heading on mount. Used on route changes
+   * (e.g. opening the detail screen) so assistive tech lands on the new view's
+   * heading instead of being left on the now-unmounted trigger.
+   */
+  autoFocusTitle?: boolean;
+}
+
+export const ReviewHeader: FC<ReviewHeaderProps> = ({
+  leading,
+  title,
+  subtitle,
+  actions,
+  secondRow,
+  autoFocusTitle = false,
+}) => {
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    if (autoFocusTitle) {
+      titleRef.current?.focus();
+    }
+  }, [autoFocusTitle]);
+
+  return (
+    <Root>
+      <TopRow>
+        {leading ? <Leading>{leading}</Leading> : null}
+        <TextBlock>
+          <Title ref={titleRef} tabIndex={autoFocusTitle ? -1 : undefined}>
+            {title}
+          </Title>
+          {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
+        </TextBlock>
+        {actions ? <Actions>{actions}</Actions> : null}
+      </TopRow>
+      {secondRow ? <SecondRow>{secondRow}</SecondRow> : null}
+    </Root>
+  );
+};

--- a/code/addons/review/src/prototype/ReviewFlowDemo.stories.tsx
+++ b/code/addons/review/src/prototype/ReviewFlowDemo.stories.tsx
@@ -5,11 +5,9 @@ import { expect, userEvent, within } from 'storybook/test';
 import preview from '../../../../.storybook/preview.tsx';
 import type { StoryInfo } from '../components/CollectionGrid.tsx';
 import { REVIEW_CHANGES_URL } from '../constants.ts';
-import { groupStoriesByComponent, prettifyComponentId } from '../review-grouping.ts';
 import {
   buildReviewChangesDetailHref,
   buildReviewChangesSummaryHref,
-  parseReviewChangesActiveTab,
   parseReviewChangesDetailLocation,
 } from '../review-navigation.ts';
 import type { ReviewState } from '../review-state.ts';
@@ -61,33 +59,13 @@ const ReviewFlowPrototype: FC<{
     return () => container.removeEventListener('click', onClick);
   }, []);
 
-  const activeTab = parseReviewChangesActiveTab(search);
   const detailLocation = parseReviewChangesDetailLocation(search);
 
   let detailScreen: ReactNode = null;
   if (detailLocation) {
-    let detailTitle: string | undefined;
-    let detailStoryIds: string[] | undefined;
-
-    if (detailLocation.kind === 'collection') {
-      const collection = state.collections[detailLocation.collectionIndex];
-      if (collection) {
-        detailTitle = collection.title;
-        detailStoryIds = collection.storyIds;
-      }
-    } else {
-      const grouped = groupStoriesByComponent(state.collections);
-      const targetStoryId = detailLocation.storyId;
-      const group = grouped.find(
-        (candidate) => targetStoryId !== undefined && candidate.storyIds.includes(targetStoryId)
-      );
-      if (group) {
-        detailStoryIds = group.storyIds;
-        detailTitle = storyInfo[group.storyIds[0]]?.title ?? prettifyComponentId(group.componentId);
-      }
-    }
-
-    if (detailTitle !== undefined && detailStoryIds && detailStoryIds.length > 0) {
+    const collection = state.collections[detailLocation.collectionIndex];
+    if (collection && collection.storyIds.length > 0) {
+      const detailStoryIds = collection.storyIds;
       const totalStories = detailStoryIds.length;
       const resolvedIndexFromStoryId =
         detailLocation.storyId !== undefined
@@ -96,47 +74,27 @@ const ReviewFlowPrototype: FC<{
       const currentStoryIndex = resolvedIndexFromStoryId >= 0 ? resolvedIndexFromStoryId : 0;
       const previousStoryIndex = (currentStoryIndex - 1 + totalStories) % totalStories;
       const nextStoryIndex = (currentStoryIndex + 1) % totalStories;
-      const previousStoryId = detailStoryIds[previousStoryIndex];
-      const nextStoryId = detailStoryIds[nextStoryIndex];
       const currentStoryId = detailStoryIds[currentStoryIndex];
       const currentStoryInfo = storyInfo[currentStoryId];
 
       detailScreen = (
         <DetailsScreen
-          title={detailTitle}
+          title={collection.title}
           storyId={currentStoryId}
           storyIndex={currentStoryIndex}
           totalStories={totalStories}
           componentTitle={currentStoryInfo?.title}
           storyName={currentStoryInfo?.name}
-          backHref={buildReviewChangesSummaryHref(activeTab)}
-          previousHref={buildReviewChangesDetailHref(
-            detailLocation.kind === 'collection'
-              ? {
-                  kind: 'collection',
-                  collectionIndex: detailLocation.collectionIndex,
-                  storyId: previousStoryId,
-                }
-              : {
-                  kind: 'component',
-                  storyId: previousStoryId,
-                },
-            activeTab
-          )}
-          nextHref={buildReviewChangesDetailHref(
-            detailLocation.kind === 'collection'
-              ? {
-                  kind: 'collection',
-                  collectionIndex: detailLocation.collectionIndex,
-                  storyId: nextStoryId,
-                }
-              : {
-                  kind: 'component',
-                  storyId: nextStoryId,
-                },
-            activeTab
-          )}
-          branchName={state.branchName}
+          backHref={buildReviewChangesSummaryHref()}
+          previousHref={buildReviewChangesDetailHref({
+            collectionIndex: detailLocation.collectionIndex,
+            storyId: detailStoryIds[previousStoryIndex],
+          })}
+          nextHref={buildReviewChangesDetailHref({
+            collectionIndex: detailLocation.collectionIndex,
+            storyId: detailStoryIds[nextStoryIndex],
+          })}
+          hasBaseline={state.hasBaseline ?? false}
         />
       );
     }
@@ -144,7 +102,7 @@ const ReviewFlowPrototype: FC<{
 
   return (
     <div ref={containerRef} style={{ display: 'contents' }}>
-      {detailScreen ?? <SummaryScreen state={state} initialTab={activeTab} storyInfo={storyInfo} />}
+      {detailScreen ?? <SummaryScreen state={state} storyInfo={storyInfo} />}
     </div>
   );
 };
@@ -230,34 +188,11 @@ export const Default = meta.story({
 // deep link. Verifies the URL→view derivation in isolation.
 export const StartingOnDetail = meta.story({
   args: {
-    initialSearch: '?path=/review/collections/0/button-component--sizes',
+    initialSearch: '?path=/review/0/button-component--sizes',
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByRole('button', { name: '2/5' })).toBeInTheDocument();
-  },
-});
-
-// Switch tabs first, then drill from the Components grouping into a detail
-// page. The back link should carry the components subpath so we land back on the
-// Components tab.
-export const ComponentDetailFlow = meta.story({
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    await userEvent.click(await canvas.findByRole('tab', { name: 'Components' }));
-
-    const [firstThumb] = await canvas.findAllByRole('link', { name: /Review story/ });
-    await userEvent.click(firstThumb);
-
-    await expect(await canvas.findByRole('link', { name: 'Back to review' })).toBeInTheDocument();
-
-    await userEvent.click(await canvas.findByRole('link', { name: 'Back to review' }));
-
-    // Back on the summary — the Components tab should still be active.
-    await expect(
-      await canvas.findByRole('tab', { name: 'Components', selected: true })
-    ).toBeInTheDocument();
   },
 });
 

--- a/code/addons/review/src/review-grouping.ts
+++ b/code/addons/review/src/review-grouping.ts
@@ -1,39 +1,3 @@
-import type { ReviewCollection } from './review-state.ts';
-
-export interface ComponentGroup {
-  componentId: string;
-  storyIds: string[];
-}
-
-// Every story referenced by the review, grouped by component. The component
-// id is the story id prefix (everything before `--`) — exactly how Storybook
-// itself groups stories under a component. A story that appears in multiple
-// collections is listed once; component order follows first appearance.
-export const groupStoriesByComponent = (collections: ReviewCollection[]): ComponentGroup[] => {
-  const order: string[] = [];
-  const storiesByComponent = new Map<string, string[]>();
-
-  for (const collection of collections) {
-    for (const storyId of collection.storyIds) {
-      const componentId = storyId.split('--')[0];
-      let stories = storiesByComponent.get(componentId);
-      if (!stories) {
-        stories = [];
-        storiesByComponent.set(componentId, stories);
-        order.push(componentId);
-      }
-      if (!stories.includes(storyId)) {
-        stories.push(storyId);
-      }
-    }
-  }
-
-  return order.map((componentId) => ({
-    componentId,
-    storyIds: storiesByComponent.get(componentId) ?? [],
-  }));
-};
-
 // Fallback display name when the Storybook index has not resolved a title.
 export const prettifyComponentId = (componentId: string) =>
   componentId

--- a/code/addons/review/src/review-navigation.ts
+++ b/code/addons/review/src/review-navigation.ts
@@ -1,14 +1,11 @@
 import { REVIEW_CHANGES_URL } from './constants.ts';
 
-export type ReviewTab = 'collections' | 'components';
-
-// A detail-screen target: either a collection (indexed into state.collections)
-// or a component grouping selected by a unique storyId.
-export type ReviewDetailLocation =
-  | { kind: 'collection'; collectionIndex: number; storyId?: string }
-  | { kind: 'component'; storyId: string };
-
-const tabPath = (tab: ReviewTab = 'collections') => `${REVIEW_CHANGES_URL}${tab}`;
+// A detail-screen target: a collection (indexed into state.collections) and,
+// optionally, the specific story within it that is being reviewed.
+export interface ReviewDetailLocation {
+  collectionIndex: number;
+  storyId?: string;
+}
 
 const tryDecodeURIComponent = (value: string): string => {
   try {
@@ -55,78 +52,49 @@ export const normalizeReviewStoryId = (value: string): string => {
 
 // Storybook's manager router keeps the active route in the `path` query param
 // (see core/src/router) — `Route`/`api.navigate` read `?path=…`, not
-// window.location.pathname. Hrefs therefore wrap the route in `?path=…` and
-// keep collection/component/story as sibling params.
-export const buildReviewChangesSummaryHref = (tab: ReviewTab = 'collections') =>
-  `?path=${tabPath(tab)}`;
+// window.location.pathname. Hrefs therefore wrap the route in `?path=…`.
+export const buildReviewChangesSummaryHref = () => `?path=${REVIEW_CHANGES_URL}`;
 
-export const buildReviewChangesDetailHref = (
-  location: ReviewDetailLocation,
-  tab: ReviewTab = 'collections'
-): string => {
-  if (location.kind === 'collection') {
-    const base = `${tabPath(tab)}/${location.collectionIndex}`;
-    const target = location.storyId
-      ? `${base}/${encodeURIComponent(normalizeReviewStoryId(location.storyId))}`
-      : base;
-    return `?path=${target}`;
-  }
-  const base = tabPath(tab);
-  const target = `${base}/${encodeURIComponent(normalizeReviewStoryId(location.storyId))}`;
+export const buildReviewChangesDetailHref = (location: ReviewDetailLocation): string => {
+  const base = `${REVIEW_CHANGES_URL}${location.collectionIndex}`;
+  const target = location.storyId
+    ? `${base}/${encodeURIComponent(normalizeReviewStoryId(location.storyId))}`
+    : base;
   return `?path=${target}`;
 };
 
-// The summary tab the user last had open, carried through detail-page links
-// so the back button returns them to the tab they came from.
-export const parseReviewChangesActiveTab = (search: string): ReviewTab => {
-  const params = new URLSearchParams(search);
-  const path = params.get('path') ?? '';
-  if (path.startsWith(`${REVIEW_CHANGES_URL}components`)) {
-    return 'components';
-  }
-  return 'collections';
-};
+// Link to a story in the regular Storybook manager. Kept under `/story/` so the
+// review page's SPA click handler (which only captures `/review/` links) lets it
+// through as a normal navigation.
+export const buildStorybookStoryHref = (storyId: string): string =>
+  `?path=/story/${encodeURIComponent(normalizeReviewStoryId(storyId))}`;
 
 // Parse a detail-screen target out of the URL. Returns null for the summary.
 export const parseReviewChangesDetailLocation = (search: string): ReviewDetailLocation | null => {
   const params = new URLSearchParams(search);
   const path = params.get('path') ?? '';
 
-  if (path.startsWith(`${REVIEW_CHANGES_URL}collections/`)) {
-    const segments = path.slice(`${REVIEW_CHANGES_URL}collections/`.length).split('/');
-    const collectionParam = segments[0];
-    const collectionIndex = Number(collectionParam);
-    if (!Number.isInteger(collectionIndex) || collectionIndex < 0) {
-      return null;
-    }
-    // Reject trailing junk (e.g. `collections/0/story/extra`) so the route is
-    // parsed as strictly as the components route below.
-    if (segments.length > 2 && segments[2]) {
-      return null;
-    }
-    const storySegment = segments[1];
-    return {
-      kind: 'collection',
-      collectionIndex,
-      storyId: storySegment
-        ? normalizeReviewStoryId(tryDecodeURIComponent(storySegment))
-        : undefined,
-    };
+  if (!path.startsWith(REVIEW_CHANGES_URL)) {
+    return null;
   }
 
-  if (path.startsWith(`${REVIEW_CHANGES_URL}components/`)) {
-    const segments = path.slice(`${REVIEW_CHANGES_URL}components/`.length).split('/');
-    const firstSegment = segments[0];
-    if (!firstSegment) {
-      return null;
-    }
-    if (segments.length > 1 && segments[1]) {
-      return null;
-    }
-    return {
-      kind: 'component',
-      storyId: normalizeReviewStoryId(tryDecodeURIComponent(firstSegment)),
-    };
+  const segments = path.slice(REVIEW_CHANGES_URL.length).split('/').filter(Boolean);
+  if (segments.length === 0) {
+    return null;
   }
-  return null;
+
+  const collectionIndex = Number(segments[0]);
+  if (!Number.isInteger(collectionIndex) || collectionIndex < 0) {
+    return null;
+  }
+  // Reject trailing junk (e.g. `0/story/extra`) so the route parses strictly.
+  if (segments.length > 2) {
+    return null;
+  }
+
+  const storySegment = segments[1];
+  return {
+    collectionIndex,
+    storyId: storySegment ? normalizeReviewStoryId(tryDecodeURIComponent(storySegment)) : undefined,
+  };
 };

--- a/code/addons/review/src/review-state.ts
+++ b/code/addons/review/src/review-state.ts
@@ -36,4 +36,11 @@ export interface ReviewState {
    * received; used for live "Created x minutes ago" UI in the summary.
    */
   createdAt?: number;
+  /**
+   * Whether a baseline is available to compare against. Enables the
+   * baseline/latest comparison controls on the detail screen. The baseline
+   * source itself is provided on a separate branch; until then this stays
+   * unset and the controls are hidden.
+   */
+  hasBaseline?: boolean;
 }

--- a/code/addons/review/src/screens/DetailsScreen.stories.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.stories.tsx
@@ -11,7 +11,7 @@ const meta = preview.meta({
   component: DetailsScreen,
   parameters: { layout: 'fullscreen' },
   args: {
-    title: 'Toolbar',
+    title: 'Toolbar & direct consumers',
     componentTitle: 'Manager/Components/Toolbar',
     storyName: 'Basic',
     storyId: 'components-toolbar--basic',
@@ -19,16 +19,13 @@ const meta = preview.meta({
     totalStories: 3,
     backHref: buildReviewChangesSummaryHref(),
     previousHref: buildReviewChangesDetailHref({
-      kind: 'collection',
       collectionIndex: 0,
       storyId: 'components-toolbar--compact',
     }),
     nextHref: buildReviewChangesDetailHref({
-      kind: 'collection',
       collectionIndex: 0,
       storyId: 'components-toolbar--dense',
     }),
-    branchName: 'update/button-weight-and-padding',
   },
 });
 
@@ -36,10 +33,27 @@ export const Default = meta.story({
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByRole('button', { name: '2/3' })).toBeInTheDocument();
+    await expect(
+      await canvas.findByRole('heading', { name: 'Toolbar & direct consumers' })
+    ).toBeInTheDocument();
     await expect(await canvas.findByText('Toolbar')).toBeInTheDocument();
     await expect(await canvas.findByText('Basic')).toBeInTheDocument();
     await expect(
-      await canvas.findByText('Latest on update/button-weight-and-padding')
+      await canvas.findByRole('link', { name: 'View in Storybook' })
+    ).toBeInTheDocument();
+  },
+});
+
+export const WithBaseline = meta.story({
+  args: {
+    hasBaseline: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Baseline')).toBeInTheDocument();
+    await expect(await canvas.findByText('Latest')).toBeInTheDocument();
+    await expect(
+      await canvas.findByRole('button', { name: 'Side-by-side view' })
     ).toBeInTheDocument();
   },
 });
@@ -50,12 +64,10 @@ export const WrapAroundNavigation = meta.story({
     storyIndex: 0,
     totalStories: 3,
     previousHref: buildReviewChangesDetailHref({
-      kind: 'collection',
       collectionIndex: 0,
       storyId: 'components-toolbar--dense',
     }),
     nextHref: buildReviewChangesDetailHref({
-      kind: 'collection',
       collectionIndex: 0,
       storyId: 'components-toolbar--basic',
     }),
@@ -65,10 +77,8 @@ export const WrapAroundNavigation = meta.story({
     const previousButton = await canvas.findByRole('link', { name: 'Previous story' });
     const nextButton = await canvas.findByRole('link', { name: 'Next story' });
     await expect(previousButton.getAttribute('href')).toContain(
-      '/review/collections/0/components-toolbar--dense'
+      '/review/0/components-toolbar--dense'
     );
-    await expect(nextButton.getAttribute('href')).toContain(
-      '/review/collections/0/components-toolbar--basic'
-    );
+    await expect(nextButton.getAttribute('href')).toContain('/review/0/components-toolbar--basic');
   },
 });

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -1,61 +1,44 @@
-import React, { type FC } from 'react';
+import React, { type FC, useState } from 'react';
 
-import { Button } from 'storybook/internal/components';
+import { Button, IconButton } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
-import { ChevronSmallLeftIcon, ChevronSmallRightIcon } from '@storybook/icons';
+import {
+  ChevronSmallLeftIcon,
+  ChevronSmallRightIcon,
+  SideBySideIcon,
+  StopAltHollowIcon,
+  StorybookIcon,
+  TransferIcon,
+} from '@storybook/icons';
+
+import { ReviewHeader } from '../components/ReviewHeader.tsx';
+import { buildStorybookStoryHref } from '../review-navigation.ts';
 
 const Page = styled.div(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   height: '100dvh',
-  minHeight: '100dvh',
+  minHeight: 0,
   overflow: 'hidden',
   background: theme.background.content,
   color: theme.color.defaultText,
   fontFamily: theme.typography.fonts.base,
 }));
 
-const Toolbar = styled.div(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: 6,
-  minHeight: 40,
-  padding: '0 10px',
-  borderBottom: `1px solid ${theme.appBorderColor}`,
-}));
-
-const ToolbarSide = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  gap: 6,
-  minWidth: 0,
-});
-
-const DetailTitle = styled.h2({
-  margin: 0,
-  minWidth: 0,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-  fontSize: 14,
+const SubtitleStrong = styled.span({
   fontWeight: 700,
-  lineHeight: '20px',
 });
 
-const DetailTitleMuted = styled.span(({ theme }) => ({
+const SubtitleSeparator = styled.span(({ theme }) => ({
   color: theme.textMutedColor,
-  fontWeight: 400,
 }));
 
-const DetailTitleStrong = styled.span({
-  fontWeight: 700,
-});
-
-const DetailTitleRegular = styled.span({
-  fontWeight: 400,
-});
+const Counter = styled(Button)(({ theme }) => ({
+  fontVariantNumeric: 'tabular-nums',
+  fontFamily: theme.typography.fonts.mono,
+  fontWeight: theme.typography.weight.regular,
+}));
 
 const PreviewFrameWrap = styled.div({
   flex: 1,
@@ -72,28 +55,42 @@ const PreviewFrame = styled.iframe({
   display: 'block',
 });
 
-const BottomToolbar = styled.div(({ theme }) => ({
+// The baseline comparison bar. A two-up (side-by-side) and one-up (single)
+// mode share a control cluster; the "switch" control only applies in one-up
+// mode, where it flips which pane (baseline or latest) is shown.
+const BaselineBar = styled.div({
   display: 'flex',
+  width: '100%',
   alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: 6,
-  minHeight: 40,
-  padding: '0 10px 0 16px',
-  borderTop: `1px solid ${theme.appBorderColor}`,
-}));
-
-const BranchText = styled.div({
-  fontSize: 13,
-  lineHeight: '20px',
-  fontWeight: 600,
 });
 
-const BottomRightPlaceholder = styled.div({
-  width: 24,
-  height: 24,
+const BarHalf = styled.div({
+  display: 'flex',
+  flex: 1,
+  minWidth: 0,
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
+});
+
+const BarLabel = styled.strong(({ theme }) => ({
+  fontWeight: theme.typography.weight.bold,
+  fontSize: 14,
+  lineHeight: '20px',
+  whiteSpace: 'nowrap',
+}));
+
+const BarControls = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  flexShrink: 0,
 });
 
 const storyPreviewUrl = (id: string) => `iframe.html?id=${encodeURIComponent(id)}&viewMode=story`;
+
+type CompareMode = 'split' | 'single';
+type ComparePane = 'baseline' | 'latest';
 
 export interface DetailsScreenProps {
   /** Fallback title shown when story metadata is unavailable. */
@@ -106,33 +103,56 @@ export interface DetailsScreenProps {
   nextHref: string;
   componentTitle?: string;
   storyName?: string;
-  branchName?: string;
+  /** Enables the baseline/latest comparison controls when a baseline exists. */
+  hasBaseline?: boolean;
 }
 
-const renderDetailTitle = ({
-  title,
-  componentTitle,
-  storyName,
-}: Pick<DetailsScreenProps, 'title' | 'componentTitle' | 'storyName'>) => {
-  if (!componentTitle || !storyName) {
-    return title;
-  }
+const componentName = (componentTitle: string): string =>
+  componentTitle
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .pop() ?? componentTitle;
 
-  const componentName =
-    componentTitle
-      .split('/')
-      .map((part) => part.trim())
-      .filter(Boolean)
-      .pop() ?? componentTitle;
-
-  return (
-    <>
-      <DetailTitleStrong>{componentName}</DetailTitleStrong>
-      <DetailTitleMuted>{' / '}</DetailTitleMuted>
-      <DetailTitleRegular>{storyName}</DetailTitleRegular>
-    </>
-  );
-};
+const CompareControls: FC<{
+  mode: CompareMode;
+  onModeChange: (mode: CompareMode) => void;
+  onSwitch: () => void;
+}> = ({ mode, onModeChange, onSwitch }) => (
+  <BarControls>
+    {mode === 'single' ? (
+      <IconButton
+        variant="ghost"
+        size="small"
+        padding="small"
+        ariaLabel="Switch baseline and latest"
+        onClick={onSwitch}
+      >
+        <TransferIcon />
+      </IconButton>
+    ) : null}
+    <IconButton
+      variant="ghost"
+      size="small"
+      padding="small"
+      active={mode === 'single'}
+      ariaLabel="Single view"
+      onClick={() => onModeChange('single')}
+    >
+      <StopAltHollowIcon />
+    </IconButton>
+    <IconButton
+      variant="ghost"
+      size="small"
+      padding="small"
+      active={mode === 'split'}
+      ariaLabel="Side-by-side view"
+      onClick={() => onModeChange('split')}
+    >
+      <SideBySideIcon />
+    </IconButton>
+  </BarControls>
+);
 
 // The preview <iframe> is intentionally a stable element: when the story
 // changes the parent only updates `src`, so the iframe navigates in place
@@ -147,43 +167,99 @@ export const DetailsScreen: FC<DetailsScreenProps> = ({
   nextHref,
   componentTitle,
   storyName,
-  branchName,
-}) => (
-  <Page>
-    <Toolbar>
-      <ToolbarSide>
-        <Button variant="ghost" size="small" padding="small" ariaLabel="Back to review" asChild>
-          <a href={backHref}>
-            <ChevronSmallLeftIcon />
-          </a>
-        </Button>
-        <DetailTitle>{renderDetailTitle({ title, componentTitle, storyName })}</DetailTitle>
-      </ToolbarSide>
+  hasBaseline = false,
+}) => {
+  const [mode, setMode] = useState<CompareMode>('split');
+  const [activePane, setActivePane] = useState<ComparePane>('latest');
 
-      <ToolbarSide>
-        <Button variant="ghost" size="small" readOnly>
-          {storyIndex + 1}/{totalStories}
-        </Button>
-        <Button variant="ghost" size="small" padding="small" ariaLabel="Previous story" asChild>
-          <a href={previousHref}>
-            <ChevronSmallLeftIcon />
-          </a>
-        </Button>
-        <Button variant="ghost" size="small" padding="small" ariaLabel="Next story" asChild>
-          <a href={nextHref}>
-            <ChevronSmallRightIcon />
-          </a>
-        </Button>
-      </ToolbarSide>
-    </Toolbar>
+  const subtitle =
+    componentTitle && storyName ? (
+      <>
+        <SubtitleStrong>{componentName(componentTitle)}</SubtitleStrong>
+        <SubtitleSeparator>/</SubtitleSeparator>
+        <span>{storyName}</span>
+      </>
+    ) : undefined;
 
-    <PreviewFrameWrap>
-      <PreviewFrame title={storyId} src={storyPreviewUrl(storyId)} />
-    </PreviewFrameWrap>
+  const baselineBar = hasBaseline ? (
+    mode === 'split' ? (
+      <BaselineBar>
+        <BarHalf>
+          <BarLabel>Baseline</BarLabel>
+          <span />
+        </BarHalf>
+        <BarHalf>
+          <BarLabel>Latest</BarLabel>
+          <CompareControls mode={mode} onModeChange={setMode} onSwitch={() => {}} />
+        </BarHalf>
+      </BaselineBar>
+    ) : (
+      <BaselineBar>
+        <BarHalf>
+          <BarLabel>{activePane === 'baseline' ? 'Baseline' : 'Latest'}</BarLabel>
+          <CompareControls
+            mode={mode}
+            onModeChange={setMode}
+            onSwitch={() => setActivePane((pane) => (pane === 'baseline' ? 'latest' : 'baseline'))}
+          />
+        </BarHalf>
+      </BaselineBar>
+    )
+  ) : undefined;
 
-    <BottomToolbar>
-      <BranchText>Latest on {branchName ?? 'this branch'}</BranchText>
-      <BottomRightPlaceholder />
-    </BottomToolbar>
-  </Page>
-);
+  return (
+    <Page>
+      <ReviewHeader
+        autoFocusTitle
+        leading={
+          <IconButton
+            variant="ghost"
+            size="small"
+            padding="small"
+            ariaLabel="Back to review"
+            asChild
+          >
+            <a href={backHref}>
+              <ChevronSmallLeftIcon />
+            </a>
+          </IconButton>
+        }
+        title={title}
+        subtitle={subtitle}
+        actions={
+          <>
+            <Counter variant="ghost" size="small" readOnly>
+              {storyIndex + 1}/{totalStories}
+            </Counter>
+            <IconButton
+              variant="ghost"
+              size="small"
+              padding="small"
+              ariaLabel="Previous story"
+              asChild
+            >
+              <a href={previousHref}>
+                <ChevronSmallLeftIcon />
+              </a>
+            </IconButton>
+            <IconButton variant="ghost" size="small" padding="small" ariaLabel="Next story" asChild>
+              <a href={nextHref}>
+                <ChevronSmallRightIcon />
+              </a>
+            </IconButton>
+            <IconButton size="small" padding="small" ariaLabel="View in Storybook" asChild>
+              <a href={buildStorybookStoryHref(storyId)} target="_blank" rel="noreferrer">
+                <StorybookIcon />
+              </a>
+            </IconButton>
+          </>
+        }
+        secondRow={baselineBar}
+      />
+
+      <PreviewFrameWrap>
+        <PreviewFrame title={storyId} src={storyPreviewUrl(storyId)} />
+      </PreviewFrameWrap>
+    </Page>
+  );
+};

--- a/code/addons/review/src/screens/SummaryScreen.stories.tsx
+++ b/code/addons/review/src/screens/SummaryScreen.stories.tsx
@@ -213,7 +213,7 @@ export const Minimal = meta.story({
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('Button prop rename')).toBeInTheDocument();
     await expect(await canvas.findByText(/Showing 2 agent-curated stories/i)).toBeInTheDocument();
-    await expect(await canvas.findByRole('tab', { name: 'Collections' })).toBeInTheDocument();
+    await expect(await canvas.findByText('Button')).toBeInTheDocument();
   },
 });
 
@@ -222,7 +222,7 @@ export const Full = meta.story({
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('Primary button visual refresh')).toBeInTheDocument();
-    await expect(await canvas.findByRole('link', { name: 'Storybook' })).toBeInTheDocument();
+    await expect(await canvas.findByRole('link', { name: 'View Storybook' })).toBeInTheDocument();
   },
 });
 

--- a/code/addons/review/src/screens/SummaryScreen.tsx
+++ b/code/addons/review/src/screens/SummaryScreen.tsx
@@ -1,6 +1,6 @@
-import React, { type FC, type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type FC, useEffect, useMemo, useState } from 'react';
 
-import { Button, Collapsible } from 'storybook/internal/components';
+import { Button, Card, Collapsible, IconButton, ScrollArea } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
 import {
@@ -12,24 +12,20 @@ import {
 } from '@storybook/icons';
 
 import { CollectionGrid, type StoryInfo } from '../components/CollectionGrid.tsx';
-import { groupStoriesByComponent, prettifyComponentId } from '../review-grouping.ts';
-import { buildReviewChangesDetailHref, type ReviewTab } from '../review-navigation.ts';
-import type { ReviewCollection, ReviewState } from '../review-state.ts';
+import { ReviewHeader } from '../components/ReviewHeader.tsx';
+import { buildReviewChangesDetailHref } from '../review-navigation.ts';
+import type { ReviewState } from '../review-state.ts';
 
-// A definite height (not `minHeight`) is what makes the page scrollable:
-// the inner flex chain — Body → TabPanels → TabPanelBody — needs a bounded
-// height to resolve against so the panel content can take over
-// scrolling. `minHeight: 100vh` left the page free to grow taller than its
-// container with nothing scrollable — hence the "can't scroll" bug. `100dvh`
-// (matching DetailsScreen) fills the manager's page cell and also works in
-// the addon's own fullscreen stories, where #storybook-root has no height.
+// `100dvh` fills the manager's page cell and also works in the addon's own
+// fullscreen stories, where #storybook-root has no height. The card list below
+// the fixed header is the single scroll container.
 const Page = styled.div(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   height: '100dvh',
   minHeight: 0,
   overflow: 'hidden',
-  background: theme.background.content,
+  background: theme.background.app,
   color: theme.color.defaultText,
   fontFamily: theme.typography.fonts.base,
   fontSize: theme.typography.size.s2,
@@ -42,102 +38,6 @@ const Empty = styled.div(({ theme }) => ({
   height: '100dvh',
   color: theme.color.mediumdark,
 }));
-
-const Header = styled.header({
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'flex-start',
-  justifyContent: 'space-between',
-  gap: 20,
-  padding: '16px 16px 8px',
-  minHeight: 72,
-});
-
-const HeaderText = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-start',
-  gap: 4,
-  flexGrow: 1,
-  minWidth: 0,
-});
-
-const Heading = styled.h1(({ theme }) => ({
-  margin: 0,
-  alignSelf: 'stretch',
-  fontSize: theme.typography.size.m1,
-  fontWeight: theme.typography.weight.bold,
-}));
-
-const HeaderMeta = styled.div(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  gap: 5,
-  color: theme.textMutedColor,
-}));
-
-const Body = styled.div({
-  flex: 1,
-  minHeight: 0,
-  display: 'flex',
-  flexDirection: 'column',
-});
-
-const TabHeader = styled.div(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  borderBottom: `1px solid ${theme.appBorderColor}`,
-  minHeight: 40,
-}));
-const TabButton = styled.button<{ $selected: boolean }>(({ theme, $selected }) => ({
-  appearance: 'none',
-  border: 0,
-  borderBottom: `3px solid ${$selected ? theme.barSelectedColor : 'transparent'}`,
-  background: 'transparent',
-  color: $selected ? theme.barSelectedColor : theme.barTextColor,
-  cursor: 'pointer',
-  fontSize: 13,
-  fontWeight: 700,
-  height: 40,
-  padding: '0 15px',
-  '&:hover': {
-    color: $selected ? theme.barSelectedColor : theme.barHoverColor,
-  },
-  '&:focus-visible': {
-    outline: '0 none',
-    boxShadow: `inset 0 0 0 2px ${theme.barSelectedColor}`,
-  },
-}));
-const TabPanels = styled.div(({ theme }) => ({
-  flex: 1,
-  minHeight: 0,
-  background: theme.background.app,
-  overflow: 'hidden',
-}));
-
-const TabPanelBody = styled.div({
-  height: '100%',
-  minHeight: 0,
-  overflow: 'auto',
-});
-
-// Compact search row — the search field shares the row with optional
-// trailing controls (e.g. the Components tab change-filter toggle).
-const SearchRow = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'flex-start',
-  gap: 8,
-  margin: '10px 12px',
-});
-
-const SearchActions = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  gap: 8,
-  marginLeft: 'auto',
-});
 
 const SearchField = styled.div(({ theme }) => ({
   display: 'flex',
@@ -183,66 +83,50 @@ const SearchIconWrap = styled.span(({ theme }) => ({
   width: 22,
 }));
 
-const CollectionList = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
+// Wrapper that gives the overlay ScrollArea a bounded height to scroll within.
+const ListScroll = styled.div({
+  flex: 1,
+  minHeight: 0,
 });
 
-const CollectionBlock = styled.section(({ theme }) => ({
-  borderBottom: `1px solid ${theme.appBorderColor}`,
-}));
+const List = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+  padding: 12,
+  // Cards must keep their intrinsic height so the list scrolls; without this
+  // the default flex-shrink collapses them to fit the viewport and Card's
+  // overflow:hidden clips the content at the bottom.
+  '& > *': {
+    flexShrink: 0,
+  },
+});
 
 // A plain clickable row, not a semantic control: making the whole header
 // toggle is just a convenience affordance for pointer users. The real
-// accessible control is the chevron <Button> inside, which carries the
+// accessible control is the chevron <IconButton> inside, which carries the
 // aria-label and aria-expanded state for assistive technologies.
-const CollectionHead = styled.div(({ theme }) => ({
+const CardHead = styled.div({
   display: 'flex',
-  width: '100%',
-  cursor: 'pointer',
-  position: 'sticky',
-  top: 0,
-  zIndex: 1,
-  background: theme.background.app,
-  containerType: 'scroll-state',
-  containerName: 'sticky-heading',
-}));
-
-const CollectionHeadInner = styled.div(({ theme }) => ({
-  display: 'flex',
-  width: '100%',
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: 8,
-  padding: '6px 12px',
+  padding: '6px 10px 6px 12px',
   minHeight: 40,
-  boxShadow: 'inset 0 -1px 0 transparent',
-  '@container sticky-heading scroll-state(stuck: top)': {
-    boxShadow: `0 1px 0 ${theme.appBorderColor}`,
-  },
-  '&:hover [data-collapsible-title], &:hover [data-collapsible-title] *': {
-    color: theme.color.secondary,
-  },
-}));
+  cursor: 'pointer',
+});
 
-const CollectionLabel = styled.strong(({ theme }) => ({
+const CardTitle = styled.strong(({ theme }) => ({
   minWidth: 0,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  fontWeight: 700,
+  fontWeight: theme.typography.weight.bold,
   lineHeight: '20px',
   color: theme.color.defaultText,
 }));
 
-// The leading group segments of a component title ("Components /"), kept
-// lighter so the component name itself stands out.
-const ComponentPathPrefix = styled.span(({ theme }) => ({
-  fontWeight: 400,
-  color: theme.textMutedColor,
-}));
-
-const CollectionControls = styled.div({
+const CardControls = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'flex-end',
@@ -250,33 +134,22 @@ const CollectionControls = styled.div({
   flexShrink: 0,
 });
 
+const CardCount = styled.span(({ theme }) => ({
+  minWidth: 28,
+  fontFamily: theme.typography.fonts.mono,
+  fontSize: theme.typography.size.s2 - 1,
+  lineHeight: '20px',
+  textAlign: 'center',
+  color: theme.textMutedColor,
+}));
+
 const ToggleChevronIcon = styled(ChevronSmallDownIcon)({
   transition: 'transform 160ms ease',
 });
 
-const CollectionHeadText = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 2,
-  flex: 1,
-  minWidth: 0,
-});
-
-const CollectionRationale = styled.p(({ theme }) => ({
+const CardRationale = styled.p(({ theme }) => ({
   color: theme.textMutedColor,
-  margin: '0 12px 6px 12px',
-}));
-
-const CollectionCount = styled.span(({ theme }) => ({
-  minWidth: 28,
-  height: 20,
-  fontFamily: '"SF Mono", SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-  fontStyle: 'normal',
-  fontWeight: 400,
-  fontSize: 13,
-  lineHeight: '20px',
-  textAlign: 'center',
-  color: theme.textMutedColor,
+  margin: '0 12px',
 }));
 
 const NoResults = styled.div(({ theme }) => ({
@@ -285,25 +158,9 @@ const NoResults = styled.div(({ theme }) => ({
   fontSize: 14,
 }));
 
-// Renders a component title ("Components/Button") as a path with the leading
-// group segments dimmed and the component name emphasised.
-const renderComponentTitle = (title: string): ReactNode => {
-  const parts = title
-    .split('/')
-    .map((part) => part.trim())
-    .filter(Boolean);
-  const last = parts.pop() ?? title;
-  return (
-    <CollectionLabel>
-      {parts.length > 0 ? <ComponentPathPrefix>{parts.join(' / ')} / </ComponentPathPrefix> : null}
-      {last}
-    </CollectionLabel>
-  );
-};
-
 // A story matches the search if its id, component title, or story name
-// contains the query. Search narrows results down to this story level, so a
-// collection/component is shown with only its matching stories.
+// contains the query. Search narrows results to this story level, so a
+// collection is shown with only its matching stories.
 const storyMatchesQuery = (
   storyId: string,
   storyInfo: Record<string, StoryInfo>,
@@ -319,241 +176,6 @@ const storyMatchesQuery = (
   return meta.title.toLowerCase().includes(query) || meta.name.toLowerCase().includes(query);
 };
 
-const CollectionsTab: FC<{
-  collections: ReviewCollection[];
-  query: string;
-  storyInfo: Record<string, StoryInfo>;
-  expandedCollections: ReadonlySet<number>;
-  showAllCollections: ReadonlySet<number>;
-  onToggleCollection: (index: number) => void;
-  onMarkCollectionShowAll: (index: number) => void;
-}> = ({
-  collections,
-  query,
-  storyInfo,
-  expandedCollections,
-  showAllCollections,
-  onToggleCollection,
-  onMarkCollectionShowAll,
-}) => {
-  const normalizedQuery = query.trim().toLowerCase();
-  // Search narrows to the story level: a collection whose title matches keeps
-  // all its stories, otherwise only the matching stories are shown. The
-  // original collection index is kept so expand state and detail links stay
-  // correct after filtering.
-  const visibleCollections = collections
-    .map((collection, index) => {
-      const titleMatch =
-        !normalizedQuery || collection.title.toLowerCase().includes(normalizedQuery);
-      const storyIds = titleMatch
-        ? collection.storyIds
-        : collection.storyIds.filter((storyId) =>
-            storyMatchesQuery(storyId, storyInfo, normalizedQuery)
-          );
-      return { collection, index, storyIds };
-    })
-    .filter((entry) => entry.storyIds.length > 0);
-
-  if (visibleCollections.length === 0) {
-    return <NoResults>No collections match “{query.trim()}”.</NoResults>;
-  }
-
-  return (
-    <CollectionList>
-      {visibleCollections.map(({ collection, index, storyIds }) => {
-        const isExpanded = expandedCollections.has(index);
-
-        return (
-          <CollectionBlock key={`${collection.title}-${index}`}>
-            <Collapsible
-              collapsed={!isExpanded}
-              summary={() => (
-                <CollectionHead onClick={() => onToggleCollection(index)}>
-                  <CollectionHeadInner>
-                    <CollectionHeadText data-collapsible-title>
-                      <CollectionLabel>{collection.title}</CollectionLabel>
-                    </CollectionHeadText>
-                    <CollectionControls>
-                      <CollectionCount>{storyIds.length}</CollectionCount>
-                      <Button
-                        variant="ghost"
-                        size="small"
-                        padding="small"
-                        ariaLabel={isExpanded ? 'Collapse cluster' : 'Expand cluster'}
-                        aria-expanded={isExpanded}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onToggleCollection(index);
-                        }}
-                      >
-                        <ToggleChevronIcon
-                          style={{ transform: `rotate(${isExpanded ? -180 : 0}deg)` }}
-                        />
-                      </Button>
-                    </CollectionControls>
-                  </CollectionHeadInner>
-                </CollectionHead>
-              )}
-            >
-              {collection.rationale ? (
-                <CollectionRationale>{collection.rationale}</CollectionRationale>
-              ) : null}
-              <CollectionGrid
-                storyIds={storyIds}
-                showAll={showAllCollections.has(index)}
-                onShowAll={() => onMarkCollectionShowAll(index)}
-                storyInfo={storyInfo}
-                query={query}
-                getStoryHref={(storyId) =>
-                  // The detail-route prefix encodes the detail *kind*, not the
-                  // active tab: a collection detail must always be
-                  // `collections/<index>/<story>` so it parses back with an
-                  // index (using the active tab here would drop the index for
-                  // the inactive panel and break navigation).
-                  buildReviewChangesDetailHref(
-                    {
-                      kind: 'collection',
-                      collectionIndex: index,
-                      storyId,
-                    },
-                    'collections'
-                  )
-                }
-              />
-            </Collapsible>
-          </CollectionBlock>
-        );
-      })}
-    </CollectionList>
-  );
-};
-
-const ComponentsTab: FC<{
-  collections: ReviewCollection[];
-  storyInfo: Record<string, StoryInfo>;
-  query: string;
-  expandedComponents: ReadonlySet<string>;
-  showAllComponents: ReadonlySet<string>;
-  onToggleComponent: (componentId: string) => void;
-  onMarkComponentShowAll: (componentId: string) => void;
-}> = ({
-  collections,
-  storyInfo,
-  query,
-  expandedComponents,
-  showAllComponents,
-  onToggleComponent,
-  onMarkComponentShowAll,
-}) => {
-  const normalizedQuery = query.trim().toLowerCase();
-  // Search narrows to the story level here too: a component whose name
-  // matches keeps all its stories, otherwise only matching stories show.
-  const visibleGroups = groupStoriesByComponent(collections)
-    .map((group) => {
-      const name = storyInfo[group.storyIds[0]]?.title ?? prettifyComponentId(group.componentId);
-      const nameMatch =
-        !normalizedQuery ||
-        name.toLowerCase().includes(normalizedQuery) ||
-        group.componentId.toLowerCase().includes(normalizedQuery);
-      const storyIds = nameMatch
-        ? group.storyIds
-        : group.storyIds.filter((storyId) =>
-            storyMatchesQuery(storyId, storyInfo, normalizedQuery)
-          );
-      return { group, name, storyIds };
-    })
-    .filter((entry) => entry.storyIds.length > 0);
-
-  if (visibleGroups.length === 0) {
-    return <NoResults>No components match “{query.trim()}”.</NoResults>;
-  }
-
-  return (
-    <CollectionList>
-      {visibleGroups.map(({ group, name, storyIds }) => {
-        const isExpanded = expandedComponents.has(group.componentId);
-
-        return (
-          <CollectionBlock key={group.componentId}>
-            <Collapsible
-              collapsed={!isExpanded}
-              summary={() => (
-                <CollectionHead onClick={() => onToggleComponent(group.componentId)}>
-                  <CollectionHeadInner>
-                    <CollectionHeadText data-collapsible-title>
-                      {renderComponentTitle(name)}
-                    </CollectionHeadText>
-                    <CollectionControls>
-                      <CollectionCount>{storyIds.length}</CollectionCount>
-                      <Button
-                        variant="ghost"
-                        size="small"
-                        padding="small"
-                        ariaLabel={isExpanded ? 'Collapse component' : 'Expand component'}
-                        aria-expanded={isExpanded}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onToggleComponent(group.componentId);
-                        }}
-                      >
-                        <ToggleChevronIcon
-                          style={{ transform: `rotate(${isExpanded ? -180 : 0}deg)` }}
-                        />
-                      </Button>
-                    </CollectionControls>
-                  </CollectionHeadInner>
-                </CollectionHead>
-              )}
-            >
-              <CollectionGrid
-                storyIds={storyIds}
-                showAll={showAllComponents.has(group.componentId)}
-                onShowAll={() => onMarkComponentShowAll(group.componentId)}
-                storyInfo={storyInfo}
-                query={query}
-                getStoryHref={(storyId) =>
-                  // Component details always live under the `components/`
-                  // prefix regardless of which tab is currently active, so the
-                  // inactive panel's links stay valid.
-                  buildReviewChangesDetailHref(
-                    {
-                      kind: 'component',
-                      storyId,
-                    },
-                    'components'
-                  )
-                }
-              />
-            </Collapsible>
-          </CollectionBlock>
-        );
-      })}
-    </CollectionList>
-  );
-};
-
-const SearchBox: FC<{
-  value: string;
-  onChange: (value: string) => void;
-  onFocus?: () => void;
-  onBlur?: () => void;
-}> = ({ value, onChange, onFocus, onBlur }) => (
-  <SearchField>
-    <SearchIconWrap>
-      <SearchIcon />
-    </SearchIconWrap>
-    <SearchInput
-      type="search"
-      aria-label="Find stories"
-      placeholder="Find stories"
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-      onFocus={onFocus}
-      onBlur={onBlur}
-    />
-  </SearchField>
-);
-
 const formatCreatedAgo = (createdAt: number, nowMs: number): string => {
   const elapsedMs = Math.max(0, nowMs - createdAt);
   if (elapsedMs < 60_000) {
@@ -566,49 +188,22 @@ const formatCreatedAgo = (createdAt: number, nowMs: number): string => {
 
 export interface SummaryScreenProps {
   state: ReviewState | null;
-  /** Tab to open initially — carried in the URL so the back button restores it. */
-  initialTab?: ReviewTab;
-  /** Optional callback to keep summary-tab URL in sync with tab switches. */
-  onTabChange?: (tab: ReviewTab) => void;
   /** Story id → component title + name, resolved from the Storybook index. */
   storyInfo?: Record<string, StoryInfo>;
 }
 
-export const SummaryScreen: FC<SummaryScreenProps> = ({
-  state,
-  initialTab = 'collections',
-  onTabChange,
-  storyInfo = {},
-}) => {
-  const [tab, setTab] = useState<ReviewTab>(initialTab);
+export const SummaryScreen: FC<SummaryScreenProps> = ({ state, storyInfo = {} }) => {
   const [search, setSearch] = useState('');
   const [expandedCollections, setExpandedCollections] = useState<Set<number>>(() => new Set());
-  const [expandedComponents, setExpandedComponents] = useState<Set<string>>(() => new Set());
   const [showAllCollections, setShowAllCollections] = useState<Set<number>>(() => new Set());
-  const [showAllComponents, setShowAllComponents] = useState<Set<string>>(() => new Set());
   const [nowMs, setNowMs] = useState(() => Date.now());
-  // Focusing the search field reveals every thumbnail's info bar at once, so
-  // labels are scannable while filtering (they otherwise only show on hover).
-  const [isSearchFocused, setIsSearchFocused] = useState(false);
-  const tabOrder: [ReviewTab, ReviewTab] = ['collections', 'components'];
-  const tabRefs = useRef<Record<ReviewTab, HTMLButtonElement | null>>({
-    collections: null,
-    components: null,
-  });
-  const collectionsTabId = 'review-tab-collections';
-  const componentsTabId = 'review-tab-components';
-  const collectionsPanelId = 'review-tabpanel-collections';
-  const componentsPanelId = 'review-tabpanel-components';
+
   const storybookRootHref = useMemo(() => {
     const rootUrl = new URL(window.location.href);
     rootUrl.searchParams.delete('path');
     rootUrl.searchParams.set('statuses', 'modified;new;related');
     return rootUrl.toString();
   }, []);
-
-  useEffect(() => {
-    setTab(initialTab);
-  }, [initialTab]);
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
@@ -620,17 +215,11 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
   useEffect(() => {
     if (!state) {
       setExpandedCollections(new Set());
-      setExpandedComponents(new Set());
       setShowAllCollections(new Set());
-      setShowAllComponents(new Set());
       return;
     }
     setExpandedCollections(new Set(state.collections.map((_, index) => index)));
-    setExpandedComponents(
-      new Set(groupStoriesByComponent(state.collections).map((g) => g.componentId))
-    );
     setShowAllCollections(new Set());
-    setShowAllComponents(new Set());
   }, [state]);
 
   if (!state) {
@@ -639,13 +228,8 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
 
   const storyCount = new Set(state.collections.flatMap((collection) => collection.storyIds)).size;
   const createdAgo = state.createdAt ? formatCreatedAgo(state.createdAt, nowMs) : null;
-  const componentIds = groupStoriesByComponent(state.collections).map((group) => group.componentId);
-  const areAllCollectionsExpanded = state.collections.every((_, index) =>
-    expandedCollections.has(index)
-  );
-  const areAllComponentsExpanded = componentIds.every((componentId) =>
-    expandedComponents.has(componentId)
-  );
+  const areAllExpanded = state.collections.every((_, index) => expandedCollections.has(index));
+
   const toggleCollection = (index: number) => {
     setExpandedCollections((previous) => {
       const next = new Set(previous);
@@ -657,209 +241,136 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
       return next;
     });
   };
-  const toggleComponent = (componentId: string) => {
-    setExpandedComponents((previous) => {
-      const next = new Set(previous);
-      if (next.has(componentId)) {
-        next.delete(componentId);
-      } else {
-        next.add(componentId);
-      }
-      return next;
-    });
-  };
   const markCollectionShowAll = (index: number) => {
     setShowAllCollections((previous) =>
       previous.has(index) ? previous : new Set(previous).add(index)
     );
   };
-  const markComponentShowAll = (componentId: string) => {
-    setShowAllComponents((previous) =>
-      previous.has(componentId) ? previous : new Set(previous).add(componentId)
-    );
-  };
-  const setActiveTab = (nextTab: ReviewTab) => {
-    setTab(nextTab);
-    onTabChange?.(nextTab);
-  };
-  const moveTabFocus = (nextTab: ReviewTab) => {
-    setActiveTab(nextTab);
-    tabRefs.current[nextTab]?.focus();
-  };
-  const handleTabKeyDown = (
-    event: React.KeyboardEvent<HTMLButtonElement>,
-    currentTab: ReviewTab
-  ) => {
-    const currentIndex = tabOrder.indexOf(currentTab);
-    let nextTab: ReviewTab | null = null;
 
-    switch (event.key) {
-      case 'ArrowLeft':
-        nextTab = tabOrder[(currentIndex - 1 + tabOrder.length) % tabOrder.length];
-        break;
-      case 'ArrowRight':
-        nextTab = tabOrder[(currentIndex + 1) % tabOrder.length];
-        break;
-      case 'Home':
-        nextTab = tabOrder[0];
-        break;
-      case 'End':
-        nextTab = tabOrder[tabOrder.length - 1];
-        break;
-      default:
-        break;
-    }
-
-    if (nextTab) {
-      event.preventDefault();
-      moveTabFocus(nextTab);
-    }
-  };
+  const normalizedQuery = search.trim().toLowerCase();
+  // Search narrows to the story level: a collection whose title matches keeps
+  // all its stories, otherwise only the matching stories are shown. The
+  // original index is kept so expand state and detail links stay correct.
+  const visibleCollections = state.collections
+    .map((collection, index) => {
+      const titleMatch =
+        !normalizedQuery || collection.title.toLowerCase().includes(normalizedQuery);
+      const storyIds = titleMatch
+        ? collection.storyIds
+        : collection.storyIds.filter((storyId) =>
+            storyMatchesQuery(storyId, storyInfo, normalizedQuery)
+          );
+      return { collection, index, storyIds };
+    })
+    .filter((entry) => entry.storyIds.length > 0);
 
   return (
-    <Page data-search-active={isSearchFocused || undefined}>
-      <Header>
-        <HeaderText>
-          <Heading>{state.title}</Heading>
-          <HeaderMeta>
-            <span>
-              Showing {storyCount} agent-curated {storyCount === 1 ? 'story' : 'stories'} for quick
-              review.{createdAgo ? ` ${createdAgo}` : ''}
-            </span>
-          </HeaderMeta>
-        </HeaderText>
-        <Button padding="small" asChild>
-          <a href={storybookRootHref} target="_blank" rel="noreferrer">
-            <StorybookIcon />
-            Storybook
-          </a>
-        </Button>
-      </Header>
-
-      <Body>
-        <TabHeader role="tablist" aria-label="Review tabs">
-          <TabButton
-            id={collectionsTabId}
-            type="button"
-            role="tab"
-            ref={(element) => {
-              tabRefs.current.collections = element;
-            }}
-            $selected={tab === 'collections'}
-            aria-selected={tab === 'collections'}
-            aria-controls={collectionsPanelId}
-            tabIndex={tab === 'collections' ? 0 : -1}
-            onClick={() => setActiveTab('collections')}
-            onKeyDown={(event) => handleTabKeyDown(event, 'collections')}
-          >
-            Collections
-          </TabButton>
-          <TabButton
-            id={componentsTabId}
-            type="button"
-            role="tab"
-            ref={(element) => {
-              tabRefs.current.components = element;
-            }}
-            $selected={tab === 'components'}
-            aria-selected={tab === 'components'}
-            aria-controls={componentsPanelId}
-            tabIndex={tab === 'components' ? 0 : -1}
-            onClick={() => setActiveTab('components')}
-            onKeyDown={(event) => handleTabKeyDown(event, 'components')}
-          >
-            Components
-          </TabButton>
-        </TabHeader>
-
-        <TabPanels>
-          <TabPanelBody
-            id={collectionsPanelId}
-            role="tabpanel"
-            aria-labelledby={collectionsTabId}
-            hidden={tab !== 'collections'}
-          >
-            <SearchRow>
-              <SearchBox
+    <Page>
+      <ReviewHeader
+        title={state.title}
+        subtitle={
+          <span>
+            Showing {storyCount} agent-curated {storyCount === 1 ? 'story' : 'stories'} for quick
+            review.{createdAgo ? ` ${createdAgo}` : ''}
+          </span>
+        }
+        actions={
+          <Button padding="small" asChild>
+            <a href={storybookRootHref} target="_blank" rel="noreferrer">
+              <StorybookIcon />
+              View Storybook
+            </a>
+          </Button>
+        }
+        secondRow={
+          <>
+            <SearchField>
+              <SearchIconWrap>
+                <SearchIcon />
+              </SearchIconWrap>
+              <SearchInput
+                type="search"
+                aria-label="Find stories"
+                placeholder="Find stories"
                 value={search}
-                onChange={setSearch}
-                onFocus={() => setIsSearchFocused(true)}
-                onBlur={() => setIsSearchFocused(false)}
+                onChange={(event) => setSearch(event.target.value)}
               />
-              <SearchActions>
-                <Button
-                  variant="ghost"
-                  size="small"
-                  padding="small"
-                  ariaLabel={
-                    areAllCollectionsExpanded
-                      ? 'Collapse all collections'
-                      : 'Expand all collections'
-                  }
-                  onClick={() => {
-                    setExpandedCollections(
-                      new Set(
-                        areAllCollectionsExpanded ? [] : state.collections.map((_, index) => index)
-                      )
-                    );
-                  }}
-                >
-                  {areAllCollectionsExpanded ? <CollapseIcon /> : <ExpandAltIcon />}
-                </Button>
-              </SearchActions>
-            </SearchRow>
-            <CollectionsTab
-              collections={state.collections}
-              query={search}
-              storyInfo={storyInfo}
-              expandedCollections={expandedCollections}
-              showAllCollections={showAllCollections}
-              onToggleCollection={toggleCollection}
-              onMarkCollectionShowAll={markCollectionShowAll}
-            />
-          </TabPanelBody>
+            </SearchField>
+            <IconButton
+              variant="ghost"
+              size="small"
+              padding="small"
+              ariaLabel={areAllExpanded ? 'Collapse all collections' : 'Expand all collections'}
+              style={{ marginLeft: 'auto' }}
+              onClick={() => {
+                setExpandedCollections(
+                  new Set(areAllExpanded ? [] : state.collections.map((_, index) => index))
+                );
+              }}
+            >
+              {areAllExpanded ? <CollapseIcon /> : <ExpandAltIcon />}
+            </IconButton>
+          </>
+        }
+      />
 
-          <TabPanelBody
-            id={componentsPanelId}
-            role="tabpanel"
-            aria-labelledby={componentsTabId}
-            hidden={tab !== 'components'}
-          >
-            <SearchRow>
-              <SearchBox
-                value={search}
-                onChange={setSearch}
-                onFocus={() => setIsSearchFocused(true)}
-                onBlur={() => setIsSearchFocused(false)}
-              />
-              <SearchActions>
-                <Button
-                  variant="ghost"
-                  size="small"
-                  padding="small"
-                  ariaLabel={
-                    areAllComponentsExpanded ? 'Collapse all components' : 'Expand all components'
-                  }
-                  onClick={() => {
-                    setExpandedComponents(new Set(areAllComponentsExpanded ? [] : componentIds));
-                  }}
-                >
-                  {areAllComponentsExpanded ? <CollapseIcon /> : <ExpandAltIcon />}
-                </Button>
-              </SearchActions>
-            </SearchRow>
-            <ComponentsTab
-              collections={state.collections}
-              storyInfo={storyInfo}
-              query={search}
-              expandedComponents={expandedComponents}
-              showAllComponents={showAllComponents}
-              onToggleComponent={toggleComponent}
-              onMarkComponentShowAll={markComponentShowAll}
-            />
-          </TabPanelBody>
-        </TabPanels>
-      </Body>
+      <ListScroll>
+        <ScrollArea vertical>
+          <List>
+            {visibleCollections.length === 0 ? (
+              <NoResults>No collections match “{search.trim()}”.</NoResults>
+            ) : (
+              visibleCollections.map(({ collection, index, storyIds }) => {
+                const isExpanded = expandedCollections.has(index);
+                return (
+                  <Card key={`${collection.title}-${index}`}>
+                    <Collapsible
+                      collapsed={!isExpanded}
+                      summary={
+                        <CardHead onClick={() => toggleCollection(index)}>
+                          <CardTitle>{collection.title}</CardTitle>
+                          <CardControls>
+                            <CardCount>{storyIds.length}</CardCount>
+                            <IconButton
+                              variant="ghost"
+                              size="small"
+                              padding="small"
+                              ariaLabel={isExpanded ? 'Collapse collection' : 'Expand collection'}
+                              aria-expanded={isExpanded}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                toggleCollection(index);
+                              }}
+                            >
+                              <ToggleChevronIcon
+                                style={{ transform: `rotate(${isExpanded ? -180 : 0}deg)` }}
+                              />
+                            </IconButton>
+                          </CardControls>
+                        </CardHead>
+                      }
+                    >
+                      {collection.rationale ? (
+                        <CardRationale>{collection.rationale}</CardRationale>
+                      ) : null}
+                      <CollectionGrid
+                        storyIds={storyIds}
+                        showAll={showAllCollections.has(index)}
+                        onShowAll={() => markCollectionShowAll(index)}
+                        storyInfo={storyInfo}
+                        query={search}
+                        getStoryHref={(storyId) =>
+                          buildReviewChangesDetailHref({ collectionIndex: index, storyId })
+                        }
+                      />
+                    </Collapsible>
+                  </Card>
+                );
+              })
+            )}
+          </List>
+        </ScrollArea>
+      </ListScroll>
     </Page>
   );
 };


### PR DESCRIPTION
## What I did

Redesign of the agent review addon screens (`code/addons/review`):

- **Summary screen**: removed the tab interface (no more "Components" view). Collections are the single view, each rendered as a collapsible `Card`. The search box and collapse-all toggle moved into a fixed header. Story labels now sit below each preview frame (frame keeps the border/hover/focus), in a split label/actions bar.
- **Responsive grid**: grid column count and the two-row cap are now driven entirely by CSS container queries + `:has()`/`nth-child` (removed the JS `ResizeObserver`/column-count logic). Cells clamp to a 300–400px range; a single cell no longer stretches.
- **Shared `ReviewHeader`**: a new component used by both summary and detail screens for visual coherence. The detail screen's baseline/latest comparison controls are merged into this header (only shown when a baseline exists).
- **Simplification**: collapsed the navigation routes, trimmed `review-grouping` (dropped `groupStoriesByComponent`), and added `hasBaseline` to review state. Net ~1250 lines removed.
- **Overlay scrollbar**: summary list uses the Radix `ScrollArea` so the scrollbar overlays content instead of shifting layout.
- **Bug fix**: cards were being clipped at the bottom because the flex column let them shrink below their content height (`Card` has `overflow: hidden`); fixed by keeping their intrinsic height.
- **A11y**: focus moves to the detail screen's heading on open, and the summary behind it is `inert`/`aria-hidden`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Play functions for `SummaryScreen`, `DetailsScreen`, `CollectionGrid`, and `ReviewPage` were updated to cover the new layout (tabless summary, label-below grid + "Review all" overflow, baseline bar, simplified routes).

#### Manual testing

1. Run the internal Storybook UI: `cd code && yarn storybook:ui`
2. With the review MCP/addon, push a review (or open `?path=/review/`) so the summary screen renders with several collections.
3. Verify the summary screen:
   - No tabs; each collection is a collapsible card; search + collapse-all live in the fixed header.
   - Resize the window — the preview grid reflows between 1/2/3/4 columns, capped at two rows, with a "Review all" affordance on overflow.
   - The scrollbar overlays content (no horizontal content shift when it appears).
   - Scroll a tall collection — card content is not clipped at the bottom.
4. Click a preview to open the detail screen and confirm keyboard focus lands on the heading; the baseline comparison bar appears only when a baseline is present, with working 1-up/2-up + switch controls.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

This is an in-progress, unreleased addon, so no user docs/migration changes are needed.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35051-sha-92d9e51a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35051-sha-92d9e51a sandbox` or in an existing project with `npx storybook@0.0.0-pr-35051-sha-92d9e51a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35051-sha-92d9e51a`](https://npmjs.com/package/storybook/v/0.0.0-pr-35051-sha-92d9e51a) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`review-layout-updates`](https://github.com/storybookjs/storybook/tree/review-layout-updates) |
| **Commit** | [`92d9e51a`](https://github.com/storybookjs/storybook/commit/92d9e51accbfbdb15c3d62b899da18827e895274) |
| **Datetime** | Thu Jun  4 09:16:37 UTC 2026 (`1780564597`) |
| **Workflow run** | [26942649776](https://github.com/storybookjs/storybook/actions/runs/26942649776) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35051`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Baseline/latest comparison in detail view with single vs split modes and pane controls.
  * CSS-driven responsive grid with a persistent "Review all" cell.
  * New two-row header for review screens with optional subtitle/actions and autofocusable title.

* **Bug Fixes & Improvements**
  * Collections-focused summary view (removed tabs) for simpler browsing.
  * Simplified review detail navigation/URLs and clearer "View in Storybook" links.
  * Accessibility improvements (title autofocus, improved focus targets).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->