### PR TITLE
Preview: Use width/height instead of min-* in CanvasWrap

### DIFF
--- a/code/core/src/manager/components/preview/utils/components.ts
+++ b/code/core/src/manager/components/preview/utils/components.ts
@@ -27,8 +27,8 @@ export const CanvasWrap = styled.div<{ show: boolean }>(
     gridTemplateColumns: '100%',
     gridTemplateRows: '100%',
     position: 'relative',
-    minWidth: '100%',
-    minHeight: '100%',
+    width: '100%',
+    height: '100%',
   },
   ({ show }) => ({ display: show ? 'grid' : 'none' })
 );


### PR DESCRIPTION
Fix full-height layout in Firefox ESR for the story preview area.

PR #33290 changed the `CanvasWrap` styled component from using `width: 100%; height: 100%` to `min-width: 100%; min-height: 100%`. In Firefox ESR, `min-height: 100%` does not properly fill the available space when the parent has a defined height, causing the preview area to collapse vertically.

**Changes:**
- Reverted `minWidth: '100%'` → `width: '100%'` and `minHeight: '100%'` → `height: '100%'` in `CanvasWrap`

Fixes #33743

#### Manual testing

* Open chromatic deployed instance in Firefox ESR
* Check that viewport renders well
* Enable a custom viewport and check there is no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved preview canvas sizing behavior to ensure the component properly fills its container, delivering better layout consistency and responsive design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->