### PR TITLE
Manager: Restore Docs canvas full height in Firefox ESR

### DIFF
--- a/code/core/src/manager/components/preview/utils/components.ts
+++ b/code/core/src/manager/components/preview/utils/components.ts
@@ -27,8 +27,10 @@ export const CanvasWrap = styled.div<{ show: boolean }>(
     gridTemplateColumns: '100%',
     gridTemplateRows: '100%',
     position: 'relative',
-    minWidth: '100%',
-    minHeight: '100%',
+    // Firefox ESR collapses `min-height: 100%` on `display: grid` to ~100px
+    // (issue #33743); use `height` to match the sibling `IframeWrapper`.
+    width: '100%',
+    height: '100%',
   },
   ({ show }) => ({ display: show ? 'grid' : 'none' })
 );


### PR DESCRIPTION
Closes #33743

## What I did

PR #33290 (Viewports tool redesign) changed `CanvasWrap` in `code/core/src/manager/components/preview/utils/components.ts` from `width/height: 100%` to `minWidth/minHeight: 100%`. Firefox ESR 140.7+ does not resolve `min-height: 100%` on a `display: grid` element the same way Chromium does, so since Storybook 10.2.x the Docs canvas collapses to ~100px in Firefox ESR and the preview becomes unusable.

This change replaces the two `min-*` values with explicit `width/height: 100%`, matching the sibling `IframeWrapper` in the same file (which has always used `width/height: 100%` for the same grid-container purpose). The reporter (@mihkeleidast) isolated the same lines in their bisect comment.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories — covered by the existing `Viewport.stories.tsx` added in #33290
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

No additional test was added because this is a CSS-only revert; the existing visual-regression pipeline (Chromatic) should catch any layout regression on other browsers.

#### Manual testing

> Note: I do not have Firefox ESR locally. I verified the root cause by reading the bisect in #33743 and the diff in #33290; visual confirmation in Firefox ESR will need to happen via Storybook's Chromatic pipeline or a maintainer with FF ESR access.

1. From `next`, run a Storybook sandbox:
   ```bash
   yarn task --task sandbox --start-from auto --template react-vite/default-ts
   ```
2. Open the running Storybook in **Firefox ESR 140.7+** (or any Firefox that reproduces the issue from #33743). With this PR applied, the Docs canvas should render at full height. Without it, the canvas collapses to ~100px and is vertically centered.
3. Open the same Storybook in Chromium and the latest Firefox. The canvas should render identically to current `next` (no visual regression on browsers that were not affected).

### Documentation

- [ ] Add or update documentation reflecting your changes — N/A, internal CSS fix
- [ ] If you are deprecating/removing a feature, make sure to update MIGRATION.MD — N/A

Suggested label: `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the documentation preview could collapse in Firefox, restoring correct preview layout and sizing so docs display reliably across browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->