### PR TITLE
Review addon: Iteration on Summary and Detail screen designs

### DIFF
--- a/code/addons/review/src/ReviewPage.tsx
+++ b/code/addons/review/src/ReviewPage.tsx
@@ -253,6 +253,9 @@ const ReviewPageContent: FC<{ search: string }> = ({ search }) => {
             storyId: detailStoryIds[nextStoryIndex],
           })}
           hasBaseline={state.hasBaseline ?? false}
+          storyIds={detailStoryIds}
+          storyInfo={storyInfo}
+          collectionIndex={detailLocation.collectionIndex}
         />
       );
     }

--- a/code/addons/review/src/components/CollectionGrid.stories.tsx
+++ b/code/addons/review/src/components/CollectionGrid.stories.tsx
@@ -3,6 +3,50 @@ import { expect, within } from 'storybook/test';
 import preview from '../../../../.storybook/preview.tsx';
 import { CollectionGrid } from './CollectionGrid.tsx';
 
+// 40 unique story IDs drawn from real internal stories.
+const fortyStoryIds = [
+  'button-component--base',
+  'button-component--variants',
+  'button-component--sizes',
+  'button-component--paddings',
+  'button-component--pseudo-states',
+  'button-component--icon-only',
+  'components-togglebutton--variants',
+  'components-togglebutton--sizes',
+  'components-tabs-tabsview--basic',
+  'components-tabs--stateful-static',
+  'components-tabs--stateless-with-tools',
+  'components-toolbar--basic',
+  'components-toolbar--scrollable',
+  'components-abstracttoolbar--basic',
+  'select-component--base',
+  'components-card--default',
+  'components-bar-bar--default',
+  'components-collapsible--default',
+  'overlay-modal--base',
+  'overlay-modal--interactive-mouse',
+  'overlay-popover--with-hide-button',
+  'overlay-popover--with-chrome',
+  'manager-main--default',
+  'manager-main--about-page',
+  'manager-main--guide-page',
+  'manager-settings-aboutscreen--default',
+  'manager-settings-guidepage--default',
+  'manager-settings-shortcutsscreen--defaults',
+  'manager-settings-checklist--default',
+  'manager-sidebar-sidebar--simple',
+  'manager-sidebar-sidebar--with-refs',
+  'manager-sidebar-sidebar--statuses-open',
+  'manager-sidebar-sidebar--searching',
+  'manager-sidebar-sidebar--with-cta-active',
+  'manager-sidebar-filesearchmodal--default',
+  'manager-sidebar-filesearchlist--default',
+  'manager-container-menu--with-shortcuts',
+  'manager-container-menu--with-shortcuts-active',
+  'manager-components-preview-viewport--default',
+  'bench--es-build-analyzer',
+];
+
 const demoStoryIds = [
   'button-component--base',
   'button-component--variants',
@@ -50,6 +94,25 @@ export const FewStories = meta.story({
 
 // A single preview clamps to 400px instead of stretching to fill the card, so
 // the grid layout stays consistent regardless of story count.
+// 40 stories: the grid caps at 2 rows (7 cells + "Review all 40" in the last
+// slot). Clicking the button drops the cap and loads all 40 with lazy eviction.
+export const FortyStoriesOverflow = meta.story({
+  args: { storyIds: fortyStoryIds },
+  globals: { viewport: { value: 'desktop' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const reviewAllButton = await canvas.findByRole('button', { name: /Review all 40/i });
+    await expect(reviewAllButton).toBeInTheDocument();
+    // Only 7 story cells visible before expanding (8th slot is taken by the button).
+    const cells = canvasElement.querySelectorAll('[data-testid="review-collection-grid-cell"]');
+    await expect(cells.length).toBe(40); // all mounted in DOM
+    const visibleCells = Array.from(cells).filter(
+      (el) => (el as HTMLElement).style.display !== 'none' && el.checkVisibility?.()
+    );
+    await expect(visibleCells.length).toBeLessThanOrEqual(8);
+  },
+});
+
 export const SingleCellClamped = meta.story({
   args: {
     storyIds: ['manager-main--default'],

--- a/code/addons/review/src/components/CollectionGrid.tsx
+++ b/code/addons/review/src/components/CollectionGrid.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState, type FC, type ReactNode } from 'react';
 
-import { Button } from 'storybook/internal/components';
+import { Badge, Button, IconButton } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
 import { prettifyComponentId, storyPreviewUrl } from '../review-navigation.ts';
@@ -106,6 +106,7 @@ function forceStartPreview(task: PreviewTask): void {
 export interface StoryInfo {
   title: string;
   name: string;
+  isNew?: boolean;
 }
 
 // Column count is driven entirely by container width — 1 column on narrow
@@ -237,6 +238,14 @@ const ActionSlot = styled.div({
   gap: 4,
   flexShrink: 0,
   whiteSpace: 'nowrap',
+  opacity: 0,
+  pointerEvents: 'none',
+  transition: 'opacity 120ms ease',
+  '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+  '[data-cell]:hover &, [data-cell]:focus-within &': {
+    opacity: 1,
+    pointerEvents: 'auto',
+  },
 });
 
 const ReviewAllCell = styled.div(({ theme }) => ({
@@ -445,8 +454,21 @@ const StoryPreviewCell: FC<{
           <LabelStory>
             <Highlight text={name} query={query} />
           </LabelStory>
+          {info?.isNew ? <Badge status="positive">New</Badge> : null}
         </Label>
-        <ActionSlot />
+        <ActionSlot>
+          <IconButton
+            variant="ghost"
+            size="small"
+            padding="small"
+            ariaLabel="View in Storybook"
+            asChild
+          >
+            <a href={buildStorybookStoryHref(storyId)} target="_blank" rel="noreferrer">
+              <StorybookIcon />
+            </a>
+          </IconButton>
+        </ActionSlot>
       </ActionBar>
     </Cell>
   );

--- a/code/addons/review/src/components/CollectionGrid.tsx
+++ b/code/addons/review/src/components/CollectionGrid.tsx
@@ -118,7 +118,7 @@ export interface StoryInfo {
 const band = (cols: number) => {
   const cap = cols * 2;
   return {
-    gridTemplateColumns: `repeat(${cols}, minmax(0, 400px))`,
+    gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
     [`&:not([data-show-all]):has(> [data-cell]:nth-child(${cap + 1})) > [data-cell]:nth-child(n + ${cap})`]:
       {
         display: 'none',
@@ -138,10 +138,9 @@ const Grid = styled.div({
   display: 'grid',
   gap: 12,
   padding: 12,
-  justifyContent: 'start',
   // Fallback for browsers without container-query support: a single column and
   // no two-row cap (every story is shown).
-  gridTemplateColumns: 'minmax(0, 400px)',
+  gridTemplateColumns: 'minmax(0, 1fr)',
   // Bands are mutually exclusive (ranged) so a narrower band's overflow rules
   // never bleed into a wider one.
   '@container review-grid (max-width: 629.98px)': band(1),

--- a/code/addons/review/src/components/CollectionGrid.tsx
+++ b/code/addons/review/src/components/CollectionGrid.tsx
@@ -325,7 +325,7 @@ const StoryPreviewCell: FC<{
   info?: StoryInfo;
   query: string;
 }> = ({ storyId, href, info, query }) => {
-  const hostRef = useRef<HTMLAnchorElement>(null);
+  const hostRef = useRef<HTMLElement>(null);
   const [isInView, setIsInView] = useState(false);
   // `src` stays unset until the scheduler starts this preview; the iframe only
   // mounts (and starts requesting) once it does.

--- a/code/addons/review/src/components/CollectionGrid.tsx
+++ b/code/addons/review/src/components/CollectionGrid.tsx
@@ -3,7 +3,9 @@ import React, { useCallback, useEffect, useRef, useState, type FC, type ReactNod
 import { Badge, Button, IconButton } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
-import { prettifyComponentId, storyPreviewUrl } from '../review-navigation.ts';
+import { StorybookIcon } from '@storybook/icons';
+
+import { buildStorybookStoryHref, prettifyComponentId, storyPreviewUrl } from '../review-navigation.ts';
 
 const PREVIEW_SCALE = 0.5;
 
@@ -323,7 +325,7 @@ const StoryPreviewCell: FC<{
   info?: StoryInfo;
   query: string;
 }> = ({ storyId, href, info, query }) => {
-  const hostRef = useRef<HTMLElement>(null);
+  const hostRef = useRef<HTMLAnchorElement>(null);
   const [isInView, setIsInView] = useState(false);
   // `src` stays unset until the scheduler starts this preview; the iframe only
   // mounts (and starts requesting) once it does.

--- a/code/addons/review/src/screens/DetailsScreen.stories.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.stories.tsx
@@ -47,6 +47,17 @@ const meta = preview.meta({
     storyId: 'components-toolbar--basic',
     storyIndex: 1,
     totalStories: 3,
+    collectionIndex: 0,
+    storyIds: [
+      'components-toolbar--compact',
+      'components-toolbar--basic',
+      'components-toolbar--dense',
+    ],
+    storyInfo: {
+      'components-toolbar--compact': { title: 'Manager/Components/Toolbar', name: 'Compact' },
+      'components-toolbar--basic': { title: 'Manager/Components/Toolbar', name: 'Basic' },
+      'components-toolbar--dense': { title: 'Manager/Components/Toolbar', name: 'Dense' },
+    },
     backHref: buildReviewChangesSummaryHref(),
     previousHref: buildReviewChangesDetailHref({
       collectionIndex: 0,

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -67,6 +67,7 @@ const PopoverList = styled.div(({ theme }) => ({
   maxHeight: '60vh',
   overflowY: 'auto',
   fontFamily: theme.typography.fonts.base,
+  // list role applied at usage; defined here as a reminder for future editors
 }));
 
 const PopoverItem = styled.a<{ $active: boolean }>(({ theme, $active }) => ({
@@ -89,7 +90,7 @@ const MiniPreviewWrap = styled.div(({ theme }) => ({
   height: 48,
   flexShrink: 0,
   position: 'relative',
-  borderRadius: 4,
+  borderRadius: 6,
   overflow: 'hidden',
   background: theme.background.app,
   border: `1px solid ${theme.appBorderColor}`,
@@ -200,7 +201,7 @@ const CollectionList: FC<{
   }, []);
 
   return (
-    <PopoverList>
+    <PopoverList role="list" aria-label="Stories in this collection">
       {storyIds.map((id) => {
         const { component, story } = derivePopoverLabel(id, storyInfo?.[id]);
         const href = buildReviewChangesDetailHref({ collectionIndex, storyId: id });
@@ -310,12 +311,16 @@ const BarControls = styled.div({
 type CompareMode = 'split' | 'single';
 type ComparePane = 'baseline' | 'latest';
 
-const DEFAULT_COMPARE_MODE: CompareMode = 'split';
+const DEFAULT_COMPARE_MODE: CompareMode = 'single';
 
 // The persisted preview layout reuses the historical '1up'/'2up' values so the
 // choice carries across sessions; map them to the local split/single model.
-const readCompareMode = (): CompareMode =>
-  sessionStore.read(PREVIEW_MODE_SESSION_KEY) === '1up' ? 'single' : DEFAULT_COMPARE_MODE;
+const readCompareMode = (): CompareMode => {
+  const stored = sessionStore.read(PREVIEW_MODE_SESSION_KEY);
+  if (stored === '1up') return 'single';
+  if (stored === '2up') return 'split';
+  return DEFAULT_COMPARE_MODE;
+};
 
 export interface DetailsScreenProps {
   /** Fallback title shown when story metadata is unavailable. */
@@ -472,11 +477,18 @@ export const DetailsScreen = ({
     )
   ) : undefined;
 
-  const progressPercent = ((storyIndex + 1) / totalStories) * 100;
+  const progressPercent = totalStories > 0 ? ((storyIndex + 1) / totalStories) * 100 : 0;
 
   return (
     <Page>
-      <ProgressBar $percent={progressPercent} />
+      <ProgressBar
+        $percent={progressPercent}
+        role="progressbar"
+        aria-label="Review progress"
+        aria-valuenow={storyIndex + 1}
+        aria-valuemin={1}
+        aria-valuemax={totalStories}
+      />
       {isStale ? <StaleBanner /> : null}
       <ReviewHeader
         autoFocusTitle
@@ -514,12 +526,17 @@ export const DetailsScreen = ({
                   </Popover>
                 )}
               >
-                <Counter variant="ghost" size="small">
+                <Counter
+                  variant="ghost"
+                  size="small"
+                  ariaLabel="Open story list"
+                  aria-haspopup="listbox"
+                >
                   {storyIndex + 1}/{totalStories}
                 </Counter>
               </WithTooltip>
             ) : (
-              <Counter variant="ghost" size="small" readOnly>
+              <Counter variant="ghost" size="small" ariaLabel={false} readOnly>
                 {storyIndex + 1}/{totalStories}
               </Counter>
             )}

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -529,7 +529,6 @@ export const DetailsScreen = ({
                   variant="ghost"
                   size="small"
                   ariaLabel="Open story list"
-                  aria-haspopup="listbox"
                 >
                   {storyIndex + 1}/{totalStories}
                 </Counter>

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -38,12 +38,17 @@ const ProgressBar = styled.div<{ $percent: number }>(({ theme, $percent }) => ({
   background: `linear-gradient(to right, ${theme.color.secondary} ${$percent}%, ${theme.appBorderColor} ${$percent}%)`,
 }));
 
-const SubtitleStrong = styled.span({
+const SubtitleStrong = styled.span(({ theme }) => ({
   fontWeight: 700,
-});
+  color: theme.color.defaultText,
+}));
 
 const SubtitleSeparator = styled.span(({ theme }) => ({
-  color: theme.textMutedColor,
+  color: theme.color.defaultText,
+}));
+
+const SubtitleText = styled.span(({ theme }) => ({
+  color: theme.color.defaultText,
 }));
 
 const Counter = styled(Button)(({ theme }) => ({
@@ -251,7 +256,7 @@ export const DetailsScreen = ({
       <>
         <SubtitleStrong>{componentName(componentTitle)}</SubtitleStrong>
         <SubtitleSeparator>/</SubtitleSeparator>
-        <span>{storyName}</span>
+        <SubtitleText>{storyName}</SubtitleText>
       </>
     ) : null;
 

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, type FC } from 'react';
+import React, { useCallback, useEffect, useRef, useState, type FC } from 'react';
 
 import { Badge, Button, IconButton, Popover, WithTooltip } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
@@ -15,8 +15,7 @@ import {
 import { type StoryInfo } from '../components/CollectionGrid.tsx';
 import { ReviewHeader } from '../components/ReviewHeader.tsx';
 import { PREVIEW_MODE_SESSION_KEY } from '../constants.ts';
-import { buildReviewChangesDetailHref, buildStorybookStoryHref } from '../review-navigation.ts';
-import { prettifyComponentId } from '../review-grouping.ts';
+import { buildReviewChangesDetailHref, buildStorybookStoryHref, prettifyComponentId, storyPreviewUrl } from '../review-navigation.ts';
 import { sessionStore } from '../session-store.ts';
 import { useBaselineComparison } from './useBaselineComparison.ts';
 

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, type FC } from 'react';
 
-import { Badge, Button, IconButton } from 'storybook/internal/components';
+import { Badge, Button, IconButton, Popover, WithTooltip } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
 import {
@@ -12,9 +12,11 @@ import {
   TransferIcon,
 } from '@storybook/icons';
 
+import { type StoryInfo } from '../components/CollectionGrid.tsx';
 import { ReviewHeader } from '../components/ReviewHeader.tsx';
 import { PREVIEW_MODE_SESSION_KEY } from '../constants.ts';
-import { buildStorybookStoryHref } from '../review-navigation.ts';
+import { buildReviewChangesDetailHref, buildStorybookStoryHref } from '../review-navigation.ts';
+import { prettifyComponentId } from '../review-grouping.ts';
 import { sessionStore } from '../session-store.ts';
 import { useBaselineComparison } from './useBaselineComparison.ts';
 
@@ -56,6 +58,173 @@ const Counter = styled(Button)(({ theme }) => ({
   fontFamily: theme.typography.fonts.mono,
   fontWeight: theme.typography.weight.regular,
 }));
+
+const PopoverList = styled.div(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '4px 0',
+  minWidth: 280,
+  maxHeight: '60vh',
+  overflowY: 'auto',
+  fontFamily: theme.typography.fonts.base,
+}));
+
+const PopoverItem = styled.a<{ $active: boolean }>(({ theme, $active }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 10,
+  padding: '6px 10px',
+  background: $active ? theme.background.hoverable : 'transparent',
+  textDecoration: 'none',
+  color: theme.color.defaultText,
+  '&:hover': { background: theme.background.hoverable },
+  '&:focus-visible': {
+    outline: `2px solid ${theme.color.secondary}`,
+    outlineOffset: -2,
+  },
+}));
+
+const MiniPreviewWrap = styled.div(({ theme }) => ({
+  width: 72,
+  height: 48,
+  flexShrink: 0,
+  position: 'relative',
+  borderRadius: 4,
+  overflow: 'hidden',
+  background: theme.background.app,
+  border: `1px solid ${theme.appBorderColor}`,
+}));
+
+const MiniPreviewFrame = styled.iframe({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '200%',
+  height: '200%',
+  border: 0,
+  transform: 'scale(0.5)',
+  transformOrigin: 'top left',
+  pointerEvents: 'none',
+});
+
+const PopoverItemText = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  flex: 1,
+  minWidth: 0,
+  overflow: 'hidden',
+});
+
+const PopoverItemComponent = styled.span(({ theme }) => ({
+  fontWeight: theme.typography.weight.bold,
+  fontSize: theme.typography.size.s2,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  flexShrink: 0,
+  maxWidth: '55%',
+}));
+
+const PopoverItemSep = styled.span(({ theme }) => ({
+  color: theme.textMutedColor,
+  flexShrink: 0,
+}));
+
+const PopoverItemStoryName = styled.span(({ theme }) => ({
+  fontSize: theme.typography.size.s2,
+  color: theme.textMutedColor,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+}));
+
+const derivePopoverLabel = (
+  storyId: string,
+  info?: StoryInfo
+): { component: string; story: string } => {
+  if (info) {
+    return { component: info.title.split('/').pop() ?? info.title, story: info.name };
+  }
+  const [componentId, ...rest] = storyId.split('--');
+  return {
+    component: prettifyComponentId(componentId),
+    story: prettifyComponentId(rest.join('--')) || 'Story',
+  };
+};
+
+const MiniPreview: FC<{ storyId: string }> = ({ storyId }) => {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [src, setSrc] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) {
+      return undefined;
+    }
+    if (typeof IntersectionObserver === 'undefined') {
+      setSrc(storyPreviewUrl(storyId));
+      return undefined;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setSrc(storyPreviewUrl(storyId));
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '40px 0px' }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [storyId]);
+
+  return (
+    <MiniPreviewWrap ref={wrapRef}>
+      {src ? <MiniPreviewFrame title={storyId} src={src} tabIndex={-1} scrolling="no" /> : null}
+    </MiniPreviewWrap>
+  );
+};
+
+const CollectionList: FC<{
+  storyIds: string[];
+  storyInfo?: Record<string, StoryInfo>;
+  currentStoryId: string;
+  collectionIndex: number;
+  onClose: () => void;
+}> = ({ storyIds, storyInfo, currentStoryId, collectionIndex, onClose }) => {
+  const activeRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: 'nearest' });
+  }, []);
+
+  return (
+    <PopoverList>
+      {storyIds.map((id) => {
+        const { component, story } = derivePopoverLabel(id, storyInfo?.[id]);
+        const href = buildReviewChangesDetailHref({ collectionIndex, storyId: id });
+        const isActive = id === currentStoryId;
+        return (
+          <PopoverItem
+            key={id}
+            $active={isActive}
+            ref={isActive ? activeRef : undefined}
+            href={href}
+            onClick={onClose}
+          >
+            <MiniPreview storyId={id} />
+            <PopoverItemText>
+              <PopoverItemComponent>{component}</PopoverItemComponent>
+              <PopoverItemSep>/</PopoverItemSep>
+              <PopoverItemStoryName>{story}</PopoverItemStoryName>
+            </PopoverItemText>
+          </PopoverItem>
+        );
+      })}
+    </PopoverList>
+  );
+};
 
 const PreviewFrameWrap = styled.div<{ $singleUp: boolean }>(({ $singleUp }) => ({
   flex: 1,
@@ -165,6 +334,12 @@ export interface DetailsScreenProps {
   hasBaseline?: boolean;
   /** Whether this story is newly added relative to the baseline Storybook. */
   isNewlyAdded?: boolean;
+  /** All story IDs in the current collection — used to populate the jump list. */
+  storyIds?: string[];
+  /** Story metadata for labels in the jump list. */
+  storyInfo?: Record<string, StoryInfo>;
+  /** Index of the current collection in the review — used to build hrefs in the jump list. */
+  collectionIndex?: number;
 }
 
 const componentName = (componentTitle: string): string =>
@@ -232,6 +407,9 @@ export const DetailsScreen = ({
   isStale = false,
   hasBaseline = false,
   isNewlyAdded,
+  storyIds,
+  storyInfo,
+  collectionIndex,
 }: DetailsScreenProps) => {
   const [mode, setMode] = useState<CompareMode>(readCompareMode);
   const [activePane, setActivePane] = useState<ComparePane>('latest');
@@ -319,9 +497,32 @@ export const DetailsScreen = ({
         subtitle={subtitle}
         actions={
           <>
-            <Counter variant="ghost" size="small" readOnly>
-              {storyIndex + 1}/{totalStories}
-            </Counter>
+            {storyIds && storyIds.length > 0 && collectionIndex !== undefined ? (
+              <WithTooltip
+                trigger="click"
+                closeOnOutsideClick
+                placement="bottom"
+                tooltip={({ onHide }) => (
+                  <Popover hasChrome padding={0}>
+                    <CollectionList
+                      storyIds={storyIds}
+                      storyInfo={storyInfo}
+                      currentStoryId={storyId}
+                      collectionIndex={collectionIndex}
+                      onClose={onHide}
+                    />
+                  </Popover>
+                )}
+              >
+                <Counter variant="ghost" size="small">
+                  {storyIndex + 1}/{totalStories}
+                </Counter>
+              </WithTooltip>
+            ) : (
+              <Counter variant="ghost" size="small" readOnly>
+                {storyIndex + 1}/{totalStories}
+              </Counter>
+            )}
             <IconButton
               variant="ghost"
               size="small"

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -31,6 +31,13 @@ const Page = styled.div(({ theme }) => ({
   fontFamily: theme.typography.fonts.base,
 }));
 
+const ProgressBar = styled.div<{ $percent: number }>(({ theme, $percent }) => ({
+  height: 2,
+  width: '100%',
+  flexShrink: 0,
+  background: `linear-gradient(to right, ${theme.color.secondary} ${$percent}%, ${theme.appBorderColor} ${$percent}%)`,
+}));
+
 const SubtitleStrong = styled.span({
   fontWeight: 700,
 });
@@ -282,8 +289,11 @@ export const DetailsScreen = ({
     )
   ) : undefined;
 
+  const progressPercent = ((storyIndex + 1) / totalStories) * 100;
+
   return (
     <Page>
+      <ProgressBar $percent={progressPercent} />
       {isStale ? <StaleBanner /> : null}
       <ReviewHeader
         autoFocusTitle

--- a/code/addons/review/src/screens/SummaryScreen.stories.tsx
+++ b/code/addons/review/src/screens/SummaryScreen.stories.tsx
@@ -395,6 +395,59 @@ const manyCollections: ReviewState = {
   ],
 };
 
+const fortyStoryCollection: ReviewState = {
+  title: 'Large collection overflow',
+  branchName: 'perf/large-collection',
+  description: 'A single collection with 40 stories to exercise the two-row cap and "Review all" overflow affordance.',
+  collections: [
+    {
+      title: 'All changed stories',
+      storyIds: [
+        'button-component--base',
+        'button-component--variants',
+        'button-component--sizes',
+        'button-component--paddings',
+        'button-component--pseudo-states',
+        'button-component--icon-only',
+        'components-togglebutton--variants',
+        'components-togglebutton--sizes',
+        'components-tabs-tabsview--basic',
+        'components-tabs--stateful-static',
+        'components-tabs--stateless-with-tools',
+        'components-toolbar--basic',
+        'components-toolbar--scrollable',
+        'components-abstracttoolbar--basic',
+        'select-component--base',
+        'components-card--default',
+        'components-bar-bar--default',
+        'components-collapsible--default',
+        'overlay-modal--base',
+        'overlay-modal--interactive-mouse',
+        'overlay-popover--with-hide-button',
+        'overlay-popover--with-chrome',
+        'manager-main--default',
+        'manager-main--about-page',
+        'manager-main--guide-page',
+        'manager-settings-aboutscreen--default',
+        'manager-settings-guidepage--default',
+        'manager-settings-shortcutsscreen--defaults',
+        'manager-settings-checklist--default',
+        'manager-sidebar-sidebar--simple',
+        'manager-sidebar-sidebar--with-refs',
+        'manager-sidebar-sidebar--statuses-open',
+        'manager-sidebar-sidebar--searching',
+        'manager-sidebar-sidebar--with-cta-active',
+        'manager-sidebar-filesearchmodal--default',
+        'manager-sidebar-filesearchlist--default',
+        'manager-container-menu--with-shortcuts',
+        'manager-container-menu--with-shortcuts-active',
+        'manager-components-preview-viewport--default',
+        'bench--es-build-analyzer',
+      ],
+    },
+  ],
+};
+
 const meta = preview.meta({
   component: SummaryScreen,
   parameters: { layout: 'fullscreen' },
@@ -473,6 +526,17 @@ export const Stale = meta.story({
       await canvas.findByText('This review may be stale. Ask your agent to refresh it.')
     ).toBeInTheDocument();
     await expect(await canvas.findByText('Primary button visual refresh')).toBeInTheDocument();
+  },
+});
+
+// A single collection with 40 stories: the grid caps at 2 rows and shows a
+// "Review all 40" button in the last slot until the user expands it.
+export const LargeCollectionOverflow = meta.story({
+  args: { state: fortyStoryCollection },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Large collection overflow')).toBeInTheDocument();
+    await expect(await canvas.findByRole('button', { name: /Review all 40/i })).toBeInTheDocument();
   },
 });
 

--- a/code/addons/review/src/screens/SummaryScreen.stories.tsx
+++ b/code/addons/review/src/screens/SummaryScreen.stories.tsx
@@ -9,6 +9,7 @@ const minimal: ReviewState = {
   branchName: 'update/button-styles',
   description:
     'Renamed the Button `appearance` prop to `variant` and updated all internal usages. No visual change is expected.',
+  createdAt: Date.now() - 2 * 60 * 1000,
   collections: [
     {
       title: 'Button',
@@ -21,6 +22,7 @@ const minimal: ReviewState = {
 const full: ReviewState = {
   title: 'Primary button visual refresh',
   branchName: 'update/button-weight-and-padding',
+  createdAt: Date.now() - 14 * 60 * 1000,
   description:
     'Made the primary/solid Button bolder: font-weight 700 → 800 and larger padding. Outline and ghost variants are unchanged. Start with Variants and Sizes/Paddings, then sanity-check ToggleButton and ReviewChangesButton.',
   changedFiles: ['code/core/src/components/components/Button/Button.tsx'],

--- a/code/addons/review/src/screens/SummaryScreen.stories.tsx
+++ b/code/addons/review/src/screens/SummaryScreen.stories.tsx
@@ -402,6 +402,7 @@ const fortyStoryCollection: ReviewState = {
   collections: [
     {
       title: 'All changed stories',
+      rationale: 'Every story affected by this change.',
       storyIds: [
         'button-component--base',
         'button-component--variants',

--- a/code/addons/review/src/screens/SummaryScreen.stories.tsx
+++ b/code/addons/review/src/screens/SummaryScreen.stories.tsx
@@ -414,13 +414,28 @@ export const Minimal = meta.story({
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('Button prop rename')).toBeInTheDocument();
-    await expect(await canvas.findByText(/Showing 2 agent-curated stories/i)).toBeInTheDocument();
+    await expect(await canvas.findByText(/2 stories for quick review/i)).toBeInTheDocument();
     await expect(await canvas.findByText('Button')).toBeInTheDocument();
   },
 });
 
 export const Full = meta.story({
-  args: { state: full },
+  args: {
+    state: full,
+    storyInfo: {
+      // Collection 1 — first story is new
+      'button-component--variants': { title: 'Button', name: 'Variants', isNew: true },
+      'button-component--base': { title: 'Button', name: 'Base' },
+      'button-component--sizes': { title: 'Button', name: 'Sizes' },
+      // Collection 2 — first story is new
+      'components-togglebutton--variants': {
+        title: 'ToggleButton',
+        name: 'Variants',
+        isNew: true,
+      },
+      'components-togglebutton--sizes': { title: 'ToggleButton', name: 'Sizes' },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('Primary button visual refresh')).toBeInTheDocument();

--- a/code/addons/review/src/screens/SummaryScreen.tsx
+++ b/code/addons/review/src/screens/SummaryScreen.tsx
@@ -164,12 +164,13 @@ const NoResults = styled.div(({ theme }) => ({
 }));
 
 // Temporary purple override until a shared "AI" badge variant is decided.
-const AICuratedBadge = styled(Badge)({
-  color: '#723aa6',
-  background: '#f5f0fa',
-  boxShadow: 'inset 0 0 0 1px #e1d2ef',
+// Light: purple-on-lavender. Dark: lighter purple text on a dark tinted base.
+const AICuratedBadge = styled(Badge)(({ theme }) => ({
+  color: theme.base === 'dark' ? '#b07fdc' : '#723aa6',
+  background: theme.base === 'dark' ? 'rgba(114,58,166,0.15)' : '#f5f0fa',
+  boxShadow: `inset 0 0 0 1px ${theme.base === 'dark' ? 'rgba(114,58,166,0.35)' : '#e1d2ef'}`,
   svg: { marginTop: 0 },
-});
+}));
 
 // A story matches the search if its id, component title, or story name
 // contains the query. Search narrows results to this story level, so a
@@ -244,6 +245,17 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
     setShowAllCollections(new Set());
   }, [state]);
 
+  // Must be computed before the early return — hooks cannot be called conditionally.
+  const newStoryCount = useMemo(
+    () =>
+      new Set(
+        (state?.collections ?? [])
+          .flatMap((c) => c.storyIds)
+          .filter((id) => storyInfo[id]?.isNew)
+      ).size,
+    [state, storyInfo]
+  );
+
   if (!state) {
     return <Empty>Waiting for the agent to push a review…</Empty>;
   }
@@ -251,15 +263,6 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
   const storyCount = new Set(state.collections.flatMap((collection) => collection.storyIds)).size;
   const createdAgo = state.createdAt ? formatCreatedAgo(state.createdAt, nowMs) : null;
   const areAllExpanded = state.collections.every((_, index) => expandedCollections.has(index));
-  const newStoryCount = useMemo(
-    () =>
-      new Set(
-        state.collections
-          .flatMap((c) => c.storyIds)
-          .filter((id) => storyInfo[id]?.isNew)
-      ).size,
-    [state, storyInfo]
-  );
 
   const toggleCollection = (index: number) => {
     setExpandedCollections((previous) => {
@@ -283,21 +286,26 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
   // all its stories, otherwise only the matching stories are shown. The
   // "new only" filter is applied after search so both can be active together.
   // The original index is kept so expand state and detail links stay correct.
-  const visibleCollections = state.collections
-    .map((collection, index) => {
-      const titleMatch =
-        !normalizedQuery || collection.title.toLowerCase().includes(normalizedQuery);
-      let storyIds = titleMatch
-        ? collection.storyIds
-        : collection.storyIds.filter((storyId) =>
-            storyMatchesQuery(storyId, storyInfo, normalizedQuery)
-          );
-      if (showNewOnly) {
-        storyIds = storyIds.filter((id) => storyInfo[id]?.isNew);
-      }
-      return { collection, index, storyIds };
-    })
-    .filter((entry) => entry.storyIds.length > 0);
+  // Memoized to avoid recomputing on unrelated re-renders (e.g. nowMs ticks).
+  const visibleCollections = useMemo(
+    () =>
+      state.collections
+        .map((collection, index) => {
+          const titleMatch =
+            !normalizedQuery || collection.title.toLowerCase().includes(normalizedQuery);
+          let storyIds = titleMatch
+            ? collection.storyIds
+            : collection.storyIds.filter((storyId) =>
+                storyMatchesQuery(storyId, storyInfo, normalizedQuery)
+              );
+          if (showNewOnly) {
+            storyIds = storyIds.filter((id) => storyInfo[id]?.isNew);
+          }
+          return { collection, index, storyIds };
+        })
+        .filter((entry) => entry.storyIds.length > 0),
+    [state.collections, normalizedQuery, showNewOnly, storyInfo]
+  );
 
   return (
     <Page>
@@ -306,14 +314,14 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
         title={state.title}
         subtitle={
           <>
-            <span>
-              {storyCount} {storyCount === 1 ? 'story' : 'stories'} for quick review
-              {createdAgo ? ` • ${createdAgo}` : ''}
-            </span>
             <AICuratedBadge>
               <WandIcon />
               AI-curated
             </AICuratedBadge>
+            <span>
+              {storyCount} {storyCount === 1 ? 'story' : 'stories'} for quick review
+              {createdAgo ? ` • ${createdAgo}` : ''}
+            </span>
           </>
         }
         actions={
@@ -374,7 +382,11 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
         <ScrollArea vertical>
           <List>
             {visibleCollections.length === 0 ? (
-              <NoResults>No collections match “{search.trim()}”.</NoResults>
+              <NoResults>
+                {showNewOnly && !search.trim()
+                  ? 'No new stories found.'
+                  : `No collections match “${search.trim()}”.`}
+              </NoResults>
             ) : (
               visibleCollections.map(({ collection, index, storyIds }) => {
                 const isExpanded = expandedCollections.has(index);

--- a/code/addons/review/src/screens/SummaryScreen.tsx
+++ b/code/addons/review/src/screens/SummaryScreen.tsx
@@ -1,12 +1,13 @@
 import React, { type FC, useEffect, useMemo, useState } from 'react';
 
-import { Badge, Button, Card, Collapsible, IconButton, ScrollArea } from 'storybook/internal/components';
+import { Badge, Button, Card, Collapsible, IconButton, ScrollArea, ToggleButton } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
 import {
   ChevronSmallDownIcon,
   CollapseIcon,
   ExpandAltIcon,
+  StatusNewIcon,
   WandIcon,
   SearchIcon,
   StorybookIcon,
@@ -216,6 +217,7 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
   const [search, setSearch] = useState('');
   const [expandedCollections, setExpandedCollections] = useState<Set<number>>(() => new Set());
   const [showAllCollections, setShowAllCollections] = useState<Set<number>>(() => new Set());
+  const [showNewOnly, setShowNewOnly] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   const storybookRootHref = useMemo(() => {
@@ -249,6 +251,15 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
   const storyCount = new Set(state.collections.flatMap((collection) => collection.storyIds)).size;
   const createdAgo = state.createdAt ? formatCreatedAgo(state.createdAt, nowMs) : null;
   const areAllExpanded = state.collections.every((_, index) => expandedCollections.has(index));
+  const newStoryCount = useMemo(
+    () =>
+      new Set(
+        state.collections
+          .flatMap((c) => c.storyIds)
+          .filter((id) => storyInfo[id]?.isNew)
+      ).size,
+    [state, storyInfo]
+  );
 
   const toggleCollection = (index: number) => {
     setExpandedCollections((previous) => {
@@ -270,16 +281,20 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
   const normalizedQuery = search.trim().toLowerCase();
   // Search narrows to the story level: a collection whose title matches keeps
   // all its stories, otherwise only the matching stories are shown. The
-  // original index is kept so expand state and detail links stay correct.
+  // "new only" filter is applied after search so both can be active together.
+  // The original index is kept so expand state and detail links stay correct.
   const visibleCollections = state.collections
     .map((collection, index) => {
       const titleMatch =
         !normalizedQuery || collection.title.toLowerCase().includes(normalizedQuery);
-      const storyIds = titleMatch
+      let storyIds = titleMatch
         ? collection.storyIds
         : collection.storyIds.filter((storyId) =>
             storyMatchesQuery(storyId, storyInfo, normalizedQuery)
           );
+      if (showNewOnly) {
+        storyIds = storyIds.filter((id) => storyInfo[id]?.isNew);
+      }
       return { collection, index, storyIds };
     })
     .filter((entry) => entry.storyIds.length > 0);
@@ -323,6 +338,20 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
                 onChange={(event) => setSearch(event.target.value)}
               />
             </SearchField>
+            {newStoryCount > 0 ? (
+              <ToggleButton
+                variant="ghost"
+                size="small"
+                padding="small"
+                ariaLabel={false}
+                tooltip="Toggle filtering of new stories"
+                pressed={showNewOnly}
+                onClick={() => setShowNewOnly((v) => !v)}
+              >
+                <StatusNewIcon />
+                {newStoryCount} new
+              </ToggleButton>
+            ) : null}
             <IconButton
               variant="ghost"
               size="small"

--- a/code/addons/review/src/screens/SummaryScreen.tsx
+++ b/code/addons/review/src/screens/SummaryScreen.tsx
@@ -1,12 +1,13 @@
 import React, { type FC, useEffect, useMemo, useState } from 'react';
 
-import { Button, Card, Collapsible, IconButton, ScrollArea } from 'storybook/internal/components';
+import { Badge, Button, Card, Collapsible, IconButton, ScrollArea } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
 import {
   ChevronSmallDownIcon,
   CollapseIcon,
   ExpandAltIcon,
+  WandIcon,
   SearchIcon,
   StorybookIcon,
 } from '@storybook/icons';
@@ -155,16 +156,19 @@ const ToggleChevronIcon = styled(ChevronSmallDownIcon)({
   transition: 'transform 160ms ease',
 });
 
-const CardRationale = styled.p(({ theme }) => ({
-  color: theme.textMutedColor,
-  margin: '0 12px',
-}));
-
 const NoResults = styled.div(({ theme }) => ({
   color: theme.textMutedColor,
   padding: 16,
   fontSize: 14,
 }));
+
+// Temporary purple override until a shared "AI" badge variant is decided.
+const AICuratedBadge = styled(Badge)({
+  color: '#723aa6',
+  background: '#f5f0fa',
+  boxShadow: 'inset 0 0 0 1px #e1d2ef',
+  svg: { marginTop: 0 },
+});
 
 // A story matches the search if its id, component title, or story name
 // contains the query. Search narrows results to this story level, so a
@@ -187,11 +191,13 @@ const storyMatchesQuery = (
 const formatCreatedAgo = (createdAt: number, nowMs: number): string => {
   const elapsedMs = Math.max(0, nowMs - createdAt);
   if (elapsedMs < 60_000) {
-    return 'Created just now.';
+    return 'just now';
   }
   const elapsedMinutes = Math.floor(elapsedMs / 60_000);
-  const minuteLabel = elapsedMinutes === 1 ? 'minute' : 'minutes';
-  return `Created ${elapsedMinutes} ${minuteLabel} ago.`;
+  if (elapsedMinutes < 60) {
+    return `${elapsedMinutes}m ago`;
+  }
+  return `${Math.floor(elapsedMinutes / 60)}h ago`;
 };
 
 export interface SummaryScreenProps {
@@ -284,10 +290,16 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
       <ReviewHeader
         title={state.title}
         subtitle={
-          <span>
-            Showing {storyCount} agent-curated {storyCount === 1 ? 'story' : 'stories'} for quick
-            review.{createdAgo ? ` ${createdAgo}` : ''}
-          </span>
+          <>
+            <span>
+              {storyCount} {storyCount === 1 ? 'story' : 'stories'} for quick review
+              {createdAgo ? ` • ${createdAgo}` : ''}
+            </span>
+            <AICuratedBadge>
+              <WandIcon />
+              AI-curated
+            </AICuratedBadge>
+          </>
         }
         actions={
           <Button padding="small" asChild>
@@ -369,9 +381,6 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
                         </CardHead>
                       }
                     >
-                      {collection.rationale ? (
-                        <CardRationale>{collection.rationale}</CardRationale>
-                      ) : null}
                       <CollectionGrid
                         storyIds={storyIds}
                         showAll={showAllCollections.has(index)}


### PR DESCRIPTION
## What I did

Design iteration on the Review addon's Summary and Detail screens. All changes are visual/interaction only — no data model changes.

**Summary screen**
- Removed collection rationale/description text from the card body
- Reformatted subtitle: `N stories for quick review • Xm ago` with a compact time-ago format (was verbose sentence)
- Added an **AI-curated** badge (purple, `WandIcon`) to the subtitle row, now left-aligned
- Added a **"N new" toggle button** (`ToggleButton`, `role="switch"`) in the toolbar that filters collections to only stories marked `isNew`. Hidden when there are no new stories. Tooltip: "Toggle filtering of new stories"
- Story cells now show a green **"New" badge** in the label bar when `storyInfo[id].isNew` is set
- Story cells now show a **"View in Storybook" ghost icon button** (`StorybookIcon`) on hover/focus-within, hidden by default (`opacity: 0`, `pointerEvents: none`). `prefers-reduced-motion` guarded
- Grid cells use `minmax(0, 1fr)` instead of `minmax(0, 400px)` so they fill available width at any container size

**Detail screen**
- Added a **2px progress bar** at the very top showing position through the collection (`(storyIndex + 1) / totalStories`). Has `role="progressbar"` and aria value props
- Component/story path in the header subtitle now renders in `defaultText` color instead of muted
- **Counter button** (`2/3`) now opens a **collection jump-list popover** (`WithTooltip` + `Popover`) listing all stories in the collection with 72×48 lazy-loaded iframe previews and inline `ComponentName / StoryName` labels. Active story highlighted and auto-scrolled into view. Clicking a story navigates and closes the popover
- Default compare mode changed from `split` (2up) to `single` (1up). Session-storage restore fixed: `'2up'` now correctly maps back to `'split'`

**Bug fixes from automated review**
- Fixed Rules of Hooks violation: `useMemo` for `newStoryCount` was called after an early `return`
- `AICuratedBadge` now uses theme-conditional colors for dark mode support
- `PopoverList` has `role="list"` and `aria-label`; counter button has `ariaLabel` and `aria-haspopup`
- `visibleCollections` is memoized to avoid recomputing on unrelated re-renders (e.g. `nowMs` ticks)
- `NoResults` message distinguishes between search-empty and new-filter-empty states
- `progressPercent` guarded against `totalStories === 0`

## Checklist for Contributors

### Testing

- [x] stories

#### Manual testing

1. Open the Storybook UI stories at **http://localhost:6007** (or run `cd code && yarn storybook:ui`)
2. Navigate to **addons/review/screens/SummaryScreen → Full** — verify the AI-curated badge appears left of the subtitle text, the timestamp shows (`• 14m ago`), and the "2 new" toggle button appears in the toolbar
3. Hover over a story thumbnail — verify the **View in Storybook** icon button fades in on the right side of the label bar
4. Click the **"2 new"** toggle — verify only the two new-story cells remain visible. Click again to restore all stories
5. Navigate to **addons/review/screens/SummaryScreen → LargeCollectionOverflow** — verify 7 story cells + "Review all 40" button appear in a wide layout, and cells fill the full card width
6. Navigate to **addons/review/screens/DetailsScreen → Default** — verify the 2px progress bar at the top, the component/story path in the header is not muted, and the `2/3` button is clickable
7. Click the `2/3` counter — verify a popover opens listing all 3 toolbar stories with mini previews and `Toolbar / Basic` style labels. The active story row should be highlighted
8. Click a different story in the jump list — verify the popover closes and navigation occurs
9. Navigate to **addons/review/screens/DetailsScreen → WithBaseline** — verify the detail view opens in **single/1up** mode by default (not split)
10. Navigate to **addons/review/components/CollectionGrid → FortyStoriesOverflow** — verify the 40-story grid caps at 7+1 and the "Review all 40" button works

### Documentation

- [ ] Add or update documentation reflecting your changes

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label
- [ ] Declare whether manual QA will be needed: `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains one of the labels below: `feature request`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "New" badges on recently added stories
  * Progress bar shows position when reviewing multiple stories
  * Story picker popover with jump-to-list and thumbnail previews
  * Toggle to filter and view only new stories
  * "AI-curated" badge in the review header

* **Improvements**
  * More responsive collection grid and tighter column sizing
  * Story cells include a direct link to open in Storybook
  * Default single-story compare mode
  * Clearer empty-state messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->