### PR TITLE
Pseudo States: Keep combinator broad pseudo selectors valid

### DIFF
--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -390,6 +390,22 @@ describe('rewriteStyleSheet', () => {
     );
   });
 
+  it('keeps child-combinator pseudo-state selectors valid', () => {
+    const sheet = new Sheet('.ds-card > :focus-visible { outline: none }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].cssText).toEqual(
+      '.ds-card > :focus-visible, .ds-card > .pseudo-focus-visible, .pseudo-focus-visible-all .ds-card > * { outline: none }'
+    );
+  });
+
+  it('keeps pseudo-state selectors valid inside ":has" child combinators', () => {
+    const sheet = new Sheet('.ds-card:has(> :focus-visible) { outline: 4px solid blue }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].cssText).toEqual(
+      '.ds-card:has(> :focus-visible), .ds-card:has(> .pseudo-focus-visible), .pseudo-focus-visible-all .ds-card:has(> *) { outline: 4px solid blue }'
+    );
+  });
+
   it('supports ":has" inside and outside of ":not"', () => {
     const sheet = new Sheet(':has(:not(:hover, :has(:focus), :has(:active))) { color: red }');
     rewriteStyleSheet(sheet as any);

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
@@ -69,6 +69,9 @@ const extractPseudoStates = (selector: string) => {
       // If removing pseudo-state selectors from inside a functional selector left it empty (thus invalid), must fix it by adding '*'.
       // The negative lookbehind ensures we don't replace :is() with :is(*).
       .replaceAll(/(?<!is)\(\)/g, '(*)')
+      // If removing pseudo-state selectors left a combinator without a right-hand selector,
+      // keep the selector valid by targeting any child/sibling.
+      .replace(/([>+~])\s*(?=$|[,)])/g, '$1 *')
       // If a selector list was left with blank items (e.g. ", foo, , bar, "), remove the extra commas/spaces.
       .replace(/(?<=[\s(]),\s+|(,\s+)+(?=\))/g, '') || '*';
 


### PR DESCRIPTION
## What I did

Fixes #34933.

When pseudo-state selectors are removed from the right-hand side of a child or sibling combinator, the pseudo-states addon could generate invalid CSS selectors such as `.ds-card > ` or `.ds-card:has(> )`. This keeps those rewritten selectors valid by inserting a universal selector for the emptied combinator target.

## How to test

```sh
yarn vitest run code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts --config code/addons/pseudo-states/vitest.config.ts
```

Result locally: 1 test file passed, 51 tests passed, no type errors.

Also checked:

```sh
yarn oxfmt --check code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
git diff --check origin/next -- code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
```

Both passed locally.

Note: the repository lint command currently fails locally before linting these files because ESLint cannot resolve `eslint-plugin-storybook` from the `code` workspace after a fresh immutable install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pseudo-state selector rewriting to correctly handle edge cases where selectors appear after child combinators (>, +, ~)
  * Improved selector validity preservation by automatically rewriting combinators to target any child/sibling element when pseudo-states are removed

* **Tests**
  * Added test coverage for pseudo-selector rewriting behavior with child combinators and `:has()` constructs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

#### Manual testing

Missing but unit tests cover issue repro case.