### PR TITLE
OpenService: Implement remote command execution

### DIFF
--- a/code/.storybook/background-service/definition.ts
+++ b/code/.storybook/background-service/definition.ts
@@ -4,10 +4,13 @@
  * Demonstrates the open-service multi-runtime sync pattern:
  *  - Manager registers and provides a toolbar tool to pick a color.
  *  - Preview registers and subscribes to update the document background.
- *  - Server registers and subscribes to log every color change.
+ *  - Server registers, implements the `setColor` command, and subscribes to log every change.
  *
- * All three runtimes share this one definition and stay in sync automatically via
- * the channel sync-start initialization and patch-broadcast protocol.
+ * `setColor` intentionally has NO handler here: it is implemented only at server registration (see
+ * `server.ts`). The manager has no local handler, so clicking a swatch requests *remote* command
+ * execution from the server, which runs it and broadcasts the new state back. This exercises the
+ * remote-command-execution path end to end. The resulting state still syncs to every runtime via the
+ * channel sync-start initialization and patch-broadcast protocol.
  *
  * Import from here in all three contexts; never import environment-specific bits
  * (hooks, addons, node-logger) from this file.
@@ -41,14 +44,9 @@ export const backgroundServiceDef = defineService({
   },
   commands: {
     setColor: {
-      description: 'Sets the background color.',
+      description: 'Sets the background color. Implemented at server registration (see server.ts).',
       input: v.object({ color: v.string() }),
       output: v.void(),
-      handler: async (input, ctx) => {
-        ctx.self.setState((state) => {
-          state.color = input.color;
-        });
-      },
     },
   },
 });

--- a/code/.storybook/background-service/server.ts
+++ b/code/.storybook/background-service/server.ts
@@ -1,8 +1,10 @@
 /**
  * Server-side registration for the example background-color service.
  *
- * Registers the service and subscribes to log every color change to the terminal,
- * including the previous and next value.
+ * This runtime is the sole implementer of the `setColor` command: the shared definition declares it
+ * without a handler, and the handler is supplied here at registration. When the manager toolbar calls
+ * `setColor`, the manager (which has no local handler) requests remote execution and this server runs
+ * it, mutates state, and broadcasts the new color back to every runtime.
  *
  * `registerService` joins the cross-peer sync protocol automatically as a relay hub when the dev
  * server has installed the channel (the `services` preset does this on a real websocket transport),
@@ -14,7 +16,17 @@ import { registerService } from 'storybook/internal/common';
 import { backgroundServiceDef } from './definition.ts';
 
 export function registerBackgroundService() {
-  const service = registerService(backgroundServiceDef);
+  const service = registerService(backgroundServiceDef, {
+    commands: {
+      setColor: {
+        handler: async (input, ctx) => {
+          ctx.self.setState((state) => {
+            state.color = input.color;
+          });
+        },
+      },
+    },
+  });
 
   let prevColor: string | undefined;
 

--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -265,6 +265,17 @@ export class OpenServiceMissingChannelError extends StorybookError {
   }
 }
 
+export class OpenServiceRemoteCommandDisconnectedError extends StorybookError {
+  constructor(public data: { serviceId: ServiceId }) {
+    super({
+      name: 'OpenServiceRemoteCommandDisconnectedError',
+      category: Category.CORE_COMMON,
+      code: 14,
+      message: `Service "${data.serviceId}" was unregistered before a remote command resolved.`,
+    });
+  }
+}
+
 export class WebpackMissingStatsError extends StorybookError {
   constructor() {
     super({

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -462,65 +462,127 @@ The dev server is a full peer, not a passive observer. `registerService` on the 
 
 ## Remote Command Execution
 
-Queries are local-only, but commands are not always implemented in every runtime. When a command's
-handler is supplied only in some runtimes (typically at server registration), the runtimes that lack
-it must still be able to invoke it. `registerService` decides this per command at registration: a
-command with a local handler runs locally and broadcasts state as usual; a command without one
-becomes a **remote invoker**. The protocol lives in
-[service-transport.ts](./service-transport.ts) (`connectCommandTransport`).
+Queries are local-only, but commands are not. A command's handler can be supplied in only **some**
+runtimes — the canonical case is a handler added at server registration that needs Node APIs or
+server context. The runtimes that lack the handler must still be able to invoke the command (from
+`useServiceCommand`, a test, or another service), so they ask a peer that can run it.
+
+`registerService` decides this **per command at registration time** by checking whether the resolved
+definition has a `handler`:
+
+- **Has a local handler** → the command runs locally and broadcasts its post-mutation state as usual
+  (the normal multi-master path), **and** the runtime listens for invoke requests so it can run the
+  command on behalf of peers that cannot.
+- **No local handler** → the command becomes a **remote invoker**: calling it sends a request over
+  the channel and returns a promise that settles when a peer answers.
+
+The protocol lives in [service-transport.ts](./service-transport.ts) (`connectCommandTransport`); the
+example background-color service (`code/.storybook/background-service/`) exercises it end to end —
+`setColor` is declared with no handler in the shared definition and implemented only at server
+registration, so the manager toolbar invokes it remotely.
 
 ### Roles
 
-Every registered runtime plays both roles simultaneously, per command:
+Every registered runtime plays **both** roles at once, decided per command:
 
-- **Requester** (no local handler): calling the command emits `services:command-invoke` with a unique
-  `callId` and returns a promise. The promise resolves with the first `services:command-result` for
-  that `callId`, or rejects with the deserialized error from the first `services:command-error`.
-- **Responder** (has a local handler): on a matching `services:command-invoke`, it emits
-  `services:command-ack` immediately, runs the command locally (which broadcasts the post-mutation
-  state through the normal command wrappers, so peers converge as usual), then emits
-  `services:command-result` or `services:command-error`.
+- **Requester** (no local handler): calling the command emits `services:command-invoke` carrying a
+  freshly generated `callId` and returns a promise. The promise resolves with the `result` of the
+  first `services:command-result` for that `callId`, or rejects with the reconstructed error from the
+  first `services:command-error`.
+- **Responder** (has a local handler): on a matching `services:command-invoke` it emits
+  `services:command-ack` **immediately** (before running), executes the command locally — which
+  validates input, mutates state, and broadcasts the post-mutation snapshot through the normal command
+  wrappers so every peer converges — then emits `services:command-result` or `services:command-error`.
 
-A runtime never requests a command it implements (it runs that locally), so it never answers its own
-invoke echo. The `services:command-ack` event is informational — it signals that a peer has picked the
-call up; the requester still settles only on the result/error reply.
+A runtime never requests a command it implements (it runs that locally), so a responder never answers
+its own invoke echo: `onInvoke` only acts on commands in its `implementedCommandNames` set.
 
 ### Events
 
-| Event | Direction | Payload |
-| ------------------------- | ----------------------- | ------------------------------------------------- |
-| `services:command-invoke` | requester → implementers | `{ serviceId, commandName, input, callId, clientId }` |
-| `services:command-ack`    | implementer → requester | `{ serviceId, callId, clientId }`                 |
-| `services:command-result` | implementer → requester | `{ serviceId, callId, result, clientId }`         |
-| `services:command-error`  | implementer → requester | `{ serviceId, callId, error, clientId }`          |
+All four events are namespaced under `services:` and carry the `serviceId` so a runtime that hosts
+several services routes them correctly.
 
-`error` is a transport-safe serialization of the thrown value, including its `cause` chain and
-Storybook fields like `code`/`fromStorybook` (see
-[service-error-serialization.ts](./service-error-serialization.ts)). The requester rethrows it as a
-reconstructed `Error`.
+| Event | Direction | Payload |
+| ------------------------- | ------------------------ | ----------------------------------------------------- |
+| `services:command-invoke` | requester → implementers | `{ serviceId, commandName, input, callId, clientId }` |
+| `services:command-ack`    | implementer → requester  | `{ serviceId, callId, clientId }`                     |
+| `services:command-result` | implementer → requester  | `{ serviceId, callId, result, clientId }`             |
+| `services:command-error`  | implementer → requester  | `{ serviceId, callId, error, clientId }`              |
+
+- `callId` is the per-invocation correlation id (see [Correlation and parallel calls](#correlation-and-parallel-calls)).
+- `clientId` is the id of the runtime that emitted the envelope — the requester on an invoke, the
+  responder on a reply.
+- `error` is a transport-safe serialization of the thrown value, including its full `cause` chain (and
+  arrays such as the `.loaded()` drain's `cause.aggregated`) plus Storybook fields like
+  `code`/`fromStorybook`. See [service-error-serialization.ts](./service-error-serialization.ts);
+  `Error` instances cannot cross a websocket (JSON) or postMessage (structured clone) boundary intact,
+  so they are flattened to a plain shape and rebuilt into a real `Error` on the requester.
+
+### Sequence
+
+Manager toolbar calls a command implemented only on the dev server:
+
+```text
+Manager (requester)              Channel               Server (responder)
+──────────────────────────────────────────────────────────────────────────
+service.commands.setColor(...)
+  └─ new callId
+  └─ emit command-invoke ───────────────────────────────────►
+                                                  └─ emit command-ack ──┐
+  ◄───────────────────────────────────────────────────────────────────┘
+                                                  └─ run setColor locally
+                                                       └─ mutate + emit patches ──►
+  ◄── apply patches (state converges) ───────────────────────────────────
+                                                  └─ emit command-result ──┐
+  ◄───────────────────────────────────────────────────────────────────────┘
+  └─ promise resolves with result
+```
+
+State still flows through the normal patch-broadcast path, so the requester gets the new state via
+`services:patches` and the resolved value via `services:command-result` — two independent channels of
+truth that both converge.
 
 ### Awaiting
 
 A command can be awaited from any runtime, even when it runs remotely: the returned promise resolves
-on success and rejects on failure exactly as if it had run locally. Callers do not need to know where
-the handler lives.
+on success and rejects on failure exactly as if the handler had been local. Callers never need to know
+where the handler lives.
 
-### Multiple implementers
+### Correlation and parallel calls
 
-If several peers implement the same command, each one runs it and replies. The requester keeps only
-the first reply per `callId` and ignores the rest, so a command can legitimately execute in more than
-one runtime. This is intentional for now — it is constrained by usage conventions and documentation
-rather than enforced in the protocol. Prefer implementing a command in exactly one runtime when its
-effects must not be duplicated.
+`callId` is generated fresh (`generateClientId()`) for **every** call, so it is effectively a unique
+execution id. This is what makes concurrent calls safe:
 
-### Topology limits
+- Two parallel calls — even with identical input — get two distinct `callId`s, two `pending` promise
+  entries, and two independent invoke envelopes. Replies are matched strictly by `callId`, so they can
+  never cross-wire and resolving one call never settles the other.
+- A reply whose `callId` is unknown (already settled, or for a different runtime's call) or whose
+  `serviceId` does not match is ignored.
+
+`callId` correlates **replies**; it does not make a command idempotent. Each invoke triggers a real
+execution on every responder that receives it.
+
+### Multiple implementers (at-most-once is not guaranteed)
+
+If several peers implement the same command, each one runs it (side effects and all) and replies. The
+requester keeps the **first** reply per `callId` and ignores the rest — so the *promise* is deduped,
+but the *execution* is not. A command can therefore legitimately run in more than one runtime.
+
+This is intentional for now and constrained by convention, not enforced by the protocol: **implement a
+command in exactly one runtime when its effects must not be duplicated.** Guaranteeing at-most-once
+across implementers would require electing a single executor per call, which this slice does not do.
+
+### Topology limits and timeouts
 
 Replies travel back over the same channel the invoke went out on, and command events are **not**
-relayed across a hub's other transports (unlike `services:patches`). The manager is connected to both
-the dev server and the preview, so it can invoke a command implemented in either. A preview cannot
-directly invoke a server-only command, and vice versa — route such calls through the manager, or
-implement the command on a directly-connected peer. There is no timeout: invoking a command no peer
-implements leaves the promise pending until the service is unregistered (which rejects it).
+relayed across a hub's other transports (unlike `services:patches`, which a relay hub re-broadcasts).
+The manager is connected to both the dev server and the preview, so it can invoke a command implemented
+in either; but a preview cannot directly invoke a server-only command, and vice versa — route such
+calls through the manager, or implement the command on a directly-connected peer.
+
+There is **no timeout**. Invoking a command that no reachable peer implements leaves the promise
+pending forever, until the service is unregistered — `disconnect` rejects every outstanding call with
+`OpenServiceRemoteCommandDisconnectedError`.
 
 ## React Hooks
 

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -66,8 +66,9 @@ Internal tests and implementation code may import from the individual modules di
 - [service-runtime.ts](./service-runtime.ts): signal-backed runtime construction, in-flight load registry, drain logic, and subscriptions
 - [service-registry.ts](./service-registry.ts): the single `registerService`, the realm-global registry, and the shared registry API passed into runtimes — used identically by server, manager, and preview
 - [service-channel.ts](./service-channel.ts): `ServiceChannel` interface, event name constants, and payload types
+- [service-error-serialization.ts](./service-error-serialization.ts): transport-safe (de)serialization of thrown errors and their `cause` chains, used by remote command replies
 - [channel-slot.ts](../../channels/channel-slot.ts): `getChannel` / `setChannel` — the shared channel install surface
-- [service-transport.ts](./service-transport.ts): shared channel transport — wraps commands to broadcast and wires the sync-start initialization + patch listeners (hub or leaf)
+- [service-transport.ts](./service-transport.ts): shared channel transport — wraps commands to broadcast, wires the sync-start initialization + patch listeners (hub or leaf), and runs the remote-command-execution protocol
 - [service-sync.ts](./service-sync.ts): last-write-wins ordering, the `deepReconcile` structural merge, and the per-service snapshot reconciler
 - [use-service-query.ts](./use-service-query.ts): `useServiceQuery` React hook backed by `useSyncExternalStore`
 - [use-service-command.ts](./use-service-command.ts): `useServiceCommand` React hook returning a stable command reference
@@ -144,6 +145,12 @@ A command is:
 - validated on both input and output
 
 Commands receive a `CommandCtx` whose `self` includes `state`, `queries`, `commands`, and `setState`.
+
+A command handler may be implemented in only **some** runtimes — most often a handler supplied at
+server registration that needs Node APIs or server context. A runtime that lacks a local handler does
+not throw when the command is called; it requests **remote command execution** from a peer that does
+implement it (see [Remote Command Execution](#remote-command-execution)). Queries stay local-only and
+still throw `OpenServiceUnimplementedOperationError` when no handler exists.
 
 ### Cross-service composition
 
@@ -453,6 +460,68 @@ service.commands.foo()
 
 The dev server is a full peer, not a passive observer. `registerService` on the server registers as a relay hub (`relay: true`): it wraps commands to broadcast their post-mutation snapshots, responds to sync-starts, applies incoming patches, and re-broadcasts every adopted snapshot so peers on its other transports (each connected manager tab) converge. This is wired automatically at registration once the `services` preset has installed the channel — there is no separate connect step.
 
+## Remote Command Execution
+
+Queries are local-only, but commands are not always implemented in every runtime. When a command's
+handler is supplied only in some runtimes (typically at server registration), the runtimes that lack
+it must still be able to invoke it. `registerService` decides this per command at registration: a
+command with a local handler runs locally and broadcasts state as usual; a command without one
+becomes a **remote invoker**. The protocol lives in
+[service-transport.ts](./service-transport.ts) (`connectCommandTransport`).
+
+### Roles
+
+Every registered runtime plays both roles simultaneously, per command:
+
+- **Requester** (no local handler): calling the command emits `services:command-invoke` with a unique
+  `callId` and returns a promise. The promise resolves with the first `services:command-result` for
+  that `callId`, or rejects with the deserialized error from the first `services:command-error`.
+- **Responder** (has a local handler): on a matching `services:command-invoke`, it emits
+  `services:command-ack` immediately, runs the command locally (which broadcasts the post-mutation
+  state through the normal command wrappers, so peers converge as usual), then emits
+  `services:command-result` or `services:command-error`.
+
+A runtime never requests a command it implements (it runs that locally), so it never answers its own
+invoke echo. The `services:command-ack` event is informational — it signals that a peer has picked the
+call up; the requester still settles only on the result/error reply.
+
+### Events
+
+| Event | Direction | Payload |
+| ------------------------- | ----------------------- | ------------------------------------------------- |
+| `services:command-invoke` | requester → implementers | `{ serviceId, commandName, input, callId, clientId }` |
+| `services:command-ack`    | implementer → requester | `{ serviceId, callId, clientId }`                 |
+| `services:command-result` | implementer → requester | `{ serviceId, callId, result, clientId }`         |
+| `services:command-error`  | implementer → requester | `{ serviceId, callId, error, clientId }`          |
+
+`error` is a transport-safe serialization of the thrown value, including its `cause` chain and
+Storybook fields like `code`/`fromStorybook` (see
+[service-error-serialization.ts](./service-error-serialization.ts)). The requester rethrows it as a
+reconstructed `Error`.
+
+### Awaiting
+
+A command can be awaited from any runtime, even when it runs remotely: the returned promise resolves
+on success and rejects on failure exactly as if it had run locally. Callers do not need to know where
+the handler lives.
+
+### Multiple implementers
+
+If several peers implement the same command, each one runs it and replies. The requester keeps only
+the first reply per `callId` and ignores the rest, so a command can legitimately execute in more than
+one runtime. This is intentional for now — it is constrained by usage conventions and documentation
+rather than enforced in the protocol. Prefer implementing a command in exactly one runtime when its
+effects must not be duplicated.
+
+### Topology limits
+
+Replies travel back over the same channel the invoke went out on, and command events are **not**
+relayed across a hub's other transports (unlike `services:patches`). The manager is connected to both
+the dev server and the preview, so it can invoke a command implemented in either. A preview cannot
+directly invoke a server-only command, and vice versa — route such calls through the manager, or
+implement the command on a directly-connected peer. There is no timeout: invoking a command no peer
+implements leaves the promise pending until the service is unregistered (which rejects it).
+
 ## React Hooks
 
 ### `useServiceQuery`
@@ -570,6 +639,7 @@ const ready = await exampleService.queries.getValue.loaded({ entryId: 'a' });
 - Validation behavior belongs in [service-validation.test.ts](./service-validation.test.ts)
 - Server registration and static snapshot behavior belong in [server.test.ts](./server.test.ts)
 - Leaf channel sync (`relay: false`, preview path) belongs in [service-transport-leaf.test.ts](./service-transport-leaf.test.ts); hub channel sync (dev server) in [service-registration-sync.test.ts](./service-registration-sync.test.ts)
+- Remote command execution (requester/responder protocol) belongs in [service-command-transport.test.ts](./service-command-transport.test.ts); error (de)serialization in [service-error-serialization.test.ts](./service-error-serialization.test.ts)
 - React hook behavior belongs in [use-service-query.test.tsx](./use-service-query.test.tsx) and [use-service-command.test.tsx](./use-service-command.test.tsx)
 - Reusable scenario definitions belong in [fixtures.ts](./fixtures.ts)
 
@@ -585,7 +655,8 @@ React hook tests must include `// @vitest-environment happy-dom` as the first li
 - If you need to change validation wording, start in [errors.ts](./errors.ts).
 - If you need to change schema handling, start in [service-validation.ts](./service-validation.ts).
 - If you need to change service authoring ergonomics, start in [service-definition.ts](./service-definition.ts) and [types.ts](./types.ts).
-- If you need to change channel transport or relay behavior, start in [service-transport.ts](./service-transport.ts).
+- If you need to change channel transport, relay behavior, or remote command execution, start in [service-transport.ts](./service-transport.ts).
+- If you need to change how thrown errors cross the channel for remote commands, start in [service-error-serialization.ts](./service-error-serialization.ts).
 - If you need to change last-write-wins ordering or the structural merge, start in [service-sync.ts](./service-sync.ts).
 - If you need to change the channel protocol (event names, payloads, channel reader), start in [service-channel.ts](./service-channel.ts).
 - If you need to change the React query hook, start in [use-service-query.ts](./use-service-query.ts).

--- a/code/core/src/shared/open-service/service-channel.ts
+++ b/code/core/src/shared/open-service/service-channel.ts
@@ -9,6 +9,7 @@
  * The live channel is read via {@link getChannel} from `storybook/internal/channels`.
  */
 import type { ChannelLike } from '../../channels/types.ts';
+import type { SerializedError } from './service-error-serialization.ts';
 
 /**
  * Minimal channel contract needed for service sync.
@@ -22,6 +23,7 @@ export const SERVICE_SYNC_START = 'services:sync-start' as const;
 export const SERVICE_SYNC_START_REPLY = 'services:sync-start-reply' as const;
 export const SERVICE_PATCHES = 'services:patches' as const;
 export const SERVICE_COMMAND_INVOKE = 'services:command-invoke' as const;
+export const SERVICE_COMMAND_ACK = 'services:command-ack' as const;
 export const SERVICE_COMMAND_RESULT = 'services:command-result' as const;
 export const SERVICE_COMMAND_ERROR = 'services:command-error' as const;
 
@@ -59,24 +61,54 @@ export interface PatchesPayload {
   clientId: string;
 }
 
-/** Payload for `services:command-invoke` (Option-A/hybrid reserved; unused in multi-master). */
+/**
+ * Sent by a runtime that wants a command executed but has no local handler for it.
+ *
+ * Any peer that *does* implement the command runs it and replies with an ack, then a result or
+ * error carrying the same `callId`. The requester awaits its promise until one of those arrives.
+ */
 export interface CommandInvokePayload {
   serviceId: string;
   commandName: string;
+  /** Raw (unvalidated) command input; the implementing peer validates it before running. */
   input: unknown;
+  /** Unique id correlating this invocation with its ack/result/error replies. */
   callId: string;
+  /** Id of the requesting runtime. */
+  clientId: string;
 }
 
-/** Payload for `services:command-result`. */
+/**
+ * Emitted by an implementing peer the moment it accepts a `services:command-invoke`.
+ *
+ * Purely informational: it tells observers (and the requester) that at least one peer has picked
+ * the call up. The requester still resolves/rejects only on the result/error reply.
+ */
+export interface CommandAckPayload {
+  serviceId: string;
+  callId: string;
+  /** Id of the runtime that accepted the invocation. */
+  clientId: string;
+}
+
+/** Sent by an implementing peer after a remote command resolves successfully. */
 export interface CommandResultPayload {
+  serviceId: string;
   callId: string;
+  /** Validated command output. */
   result: unknown;
+  /** Id of the runtime that executed the command. */
+  clientId: string;
 }
 
-/** Payload for `services:command-error`. */
+/** Sent by an implementing peer after a remote command throws. */
 export interface CommandErrorPayload {
+  serviceId: string;
   callId: string;
-  error: unknown;
+  /** Serialized error (including its `cause` chain) so the requester can rethrow a real Error. */
+  error: SerializedError;
+  /** Id of the runtime that executed the command. */
+  clientId: string;
 }
 
 /**

--- a/code/core/src/shared/open-service/service-command-transport.test.ts
+++ b/code/core/src/shared/open-service/service-command-transport.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for remote command execution: a runtime without a local handler requests execution from a
+ * peer, and a runtime that has one responds. The protocol (`service-transport.ts`) is documented on
+ * {@link connectCommandTransport}.
+ *
+ * Peers are simulated with the test channel's `emitExternal`, the same approach the sync tests use.
+ */
+import * as v from 'valibot';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mutableRecordLookupServiceDef } from './fixtures.ts';
+import { defineService } from './service-definition.ts';
+import {
+  SERVICE_COMMAND_ACK,
+  SERVICE_COMMAND_ERROR,
+  SERVICE_COMMAND_INVOKE,
+  SERVICE_COMMAND_RESULT,
+  SERVICE_PATCHES,
+  type CommandErrorPayload,
+  type CommandInvokePayload,
+} from './service-channel.ts';
+import { deserializeError } from './service-error-serialization.ts';
+import { clearRegistry, registerService, unregisterService } from './service-registry.ts';
+import { createTestChannel, installTestChannel } from '../../channels/test-channel.ts';
+
+const remoteOnlyServiceDef = defineService({
+  id: 'internal-fixture/remote-only-command',
+  description: 'Declares a command with no local handler so it must run remotely.',
+  initialState: {} as Record<string, never>,
+  queries: {},
+  commands: {
+    doThing: {
+      description: 'Has no local handler in this runtime.',
+      input: v.object({ value: v.string() }),
+      output: v.string(),
+    },
+  },
+});
+
+const throwingCommandServiceDef = defineService({
+  id: 'internal-fixture/throwing-command',
+  description: 'Implements a command that always throws, to exercise error replies.',
+  initialState: {} as Record<string, never>,
+  queries: {},
+  commands: {
+    boom: {
+      description: 'Throws an error with a cause.',
+      input: v.object({}),
+      output: v.void(),
+      handler: async () => {
+        throw new Error('kaboom', { cause: new Error('root cause') });
+      },
+    },
+  },
+});
+
+function emittedCalls(channel: ReturnType<typeof createTestChannel>, event: string) {
+  return channel.emit.mock.calls.filter(([name]) => name === event);
+}
+
+afterEach(() => {
+  clearRegistry();
+  installTestChannel(null);
+});
+
+describe('remote command requester (no local handler)', () => {
+  it('emits a command-invoke envelope when the command is called', () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    const service = registerService(remoteOnlyServiceDef);
+    // Never settled in this test; swallow the unregister rejection clearRegistry triggers in afterEach.
+    service.commands.doThing({ value: 'hi' }).catch(() => {});
+
+    const invokes = emittedCalls(channel, SERVICE_COMMAND_INVOKE);
+    expect(invokes).toHaveLength(1);
+    expect(invokes[0][1]).toMatchObject({
+      serviceId: remoteOnlyServiceDef.id,
+      commandName: 'doThing',
+      input: { value: 'hi' },
+      callId: expect.any(String),
+      clientId: expect.any(String),
+    });
+  });
+
+  it('resolves with the result of the matching command-result reply', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    const service = registerService(remoteOnlyServiceDef);
+    const promise = service.commands.doThing({ value: 'hi' });
+
+    const { callId } = emittedCalls(channel, SERVICE_COMMAND_INVOKE)[0][1] as CommandInvokePayload;
+    channel.emitExternal(SERVICE_COMMAND_RESULT, {
+      serviceId: remoteOnlyServiceDef.id,
+      callId,
+      result: 'done',
+      clientId: 'peer',
+    });
+
+    await expect(promise).resolves.toBe('done');
+  });
+
+  it('rejects with the reconstructed error from a command-error reply', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    const service = registerService(remoteOnlyServiceDef);
+    const promise = service.commands.doThing({ value: 'hi' });
+
+    const { callId } = emittedCalls(channel, SERVICE_COMMAND_INVOKE)[0][1] as CommandInvokePayload;
+    channel.emitExternal(SERVICE_COMMAND_ERROR, {
+      serviceId: remoteOnlyServiceDef.id,
+      callId,
+      clientId: 'peer',
+      error: {
+        __openServiceError__: true,
+        name: 'OpenServiceValidationError',
+        message: 'invalid input',
+        properties: { fromStorybook: true, code: 5 },
+      },
+    });
+
+    await expect(promise).rejects.toMatchObject({
+      message: 'invalid input',
+      fromStorybook: true,
+      code: 5,
+    });
+  });
+
+  it('keeps only the first reply when several peers answer one call', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    const service = registerService(remoteOnlyServiceDef);
+    const promise = service.commands.doThing({ value: 'hi' });
+
+    const { callId } = emittedCalls(channel, SERVICE_COMMAND_INVOKE)[0][1] as CommandInvokePayload;
+    channel.emitExternal(SERVICE_COMMAND_RESULT, {
+      serviceId: remoteOnlyServiceDef.id,
+      callId,
+      result: 'first',
+      clientId: 'peer-1',
+    });
+    // A later reply for the same call (a second implementer) must be ignored, not throw.
+    expect(() =>
+      channel.emitExternal(SERVICE_COMMAND_RESULT, {
+        serviceId: remoteOnlyServiceDef.id,
+        callId,
+        result: 'second',
+        clientId: 'peer-2',
+      })
+    ).not.toThrow();
+
+    await expect(promise).resolves.toBe('first');
+  });
+
+  it('ignores replies addressed to a different service or an unknown call', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    const service = registerService(remoteOnlyServiceDef);
+    const promise = service.commands.doThing({ value: 'hi' });
+
+    const { callId } = emittedCalls(channel, SERVICE_COMMAND_INVOKE)[0][1] as CommandInvokePayload;
+    channel.emitExternal(SERVICE_COMMAND_RESULT, {
+      serviceId: 'some/other-service',
+      callId,
+      result: 'wrong-service',
+      clientId: 'peer',
+    });
+    channel.emitExternal(SERVICE_COMMAND_RESULT, {
+      serviceId: remoteOnlyServiceDef.id,
+      callId: 'unknown-call',
+      result: 'wrong-call',
+      clientId: 'peer',
+    });
+    channel.emitExternal(SERVICE_COMMAND_RESULT, {
+      serviceId: remoteOnlyServiceDef.id,
+      callId,
+      result: 'correct',
+      clientId: 'peer',
+    });
+
+    await expect(promise).resolves.toBe('correct');
+  });
+
+  it('rejects in-flight remote calls when the service is unregistered', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    const service = registerService(remoteOnlyServiceDef);
+    const promise = service.commands.doThing({ value: 'hi' });
+
+    unregisterService(remoteOnlyServiceDef.id);
+
+    await expect(promise).rejects.toThrow(/unregistered before a remote command resolved/);
+  });
+});
+
+describe('remote command responder (has local handler)', () => {
+  it('acknowledges, runs the command, broadcasts state, and replies with the result', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    const service = registerService(mutableRecordLookupServiceDef);
+
+    channel.emitExternal(SERVICE_COMMAND_INVOKE, {
+      serviceId: mutableRecordLookupServiceDef.id,
+      commandName: 'assignRecordField',
+      input: { entryId: 'a', fieldKey: 'k', fieldValue: 'v' },
+      callId: 'call-1',
+      clientId: 'requester',
+    });
+
+    // The ack is emitted synchronously on receipt, before the command runs.
+    expect(channel.emit).toHaveBeenCalledWith(
+      SERVICE_COMMAND_ACK,
+      expect.objectContaining({
+        serviceId: mutableRecordLookupServiceDef.id,
+        callId: 'call-1',
+        clientId: expect.any(String),
+      })
+    );
+
+    await vi.waitFor(() =>
+      expect(channel.emit).toHaveBeenCalledWith(
+        SERVICE_COMMAND_RESULT,
+        expect.objectContaining({ callId: 'call-1', serviceId: mutableRecordLookupServiceDef.id })
+      )
+    );
+
+    expect(service.queries.getRecordFields({ entryId: 'a' })).toEqual({ k: 'v' });
+    expect(emittedCalls(channel, SERVICE_PATCHES).length).toBeGreaterThan(0);
+  });
+
+  it('replies with a serialized error (including the cause) when the handler throws', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    registerService(throwingCommandServiceDef);
+
+    channel.emitExternal(SERVICE_COMMAND_INVOKE, {
+      serviceId: throwingCommandServiceDef.id,
+      commandName: 'boom',
+      input: {},
+      callId: 'call-err',
+      clientId: 'requester',
+    });
+
+    await vi.waitFor(() => expect(emittedCalls(channel, SERVICE_COMMAND_ERROR)).toHaveLength(1));
+
+    const payload = emittedCalls(channel, SERVICE_COMMAND_ERROR)[0][1] as CommandErrorPayload;
+    expect(payload).toMatchObject({ serviceId: throwingCommandServiceDef.id, callId: 'call-err' });
+
+    const restored = deserializeError(payload.error);
+    expect(restored.message).toBe('kaboom');
+    expect((restored.cause as Error).message).toBe('root cause');
+  });
+
+  it('ignores invokes for commands it does not implement', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    // This runtime has no local handler for `doThing`, so it must not answer the invoke.
+    registerService(remoteOnlyServiceDef);
+
+    channel.emitExternal(SERVICE_COMMAND_INVOKE, {
+      serviceId: remoteOnlyServiceDef.id,
+      commandName: 'doThing',
+      input: { value: 'hi' },
+      callId: 'call-unhandled',
+      clientId: 'requester',
+    });
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+    expect(emittedCalls(channel, SERVICE_COMMAND_ACK)).toHaveLength(0);
+    expect(emittedCalls(channel, SERVICE_COMMAND_RESULT)).toHaveLength(0);
+  });
+});

--- a/code/core/src/shared/open-service/service-error-serialization.test.ts
+++ b/code/core/src/shared/open-service/service-error-serialization.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { OpenServiceValidationError } from '../../server-errors.ts';
+import { deserializeError, serializeError } from './service-error-serialization.ts';
+
+describe('serializeError / deserializeError', () => {
+  it('round-trips name, message, and stack', () => {
+    const original = new TypeError('boom');
+    const restored = deserializeError(serializeError(original));
+
+    expect(restored).toBeInstanceOf(Error);
+    expect(restored.name).toBe('TypeError');
+    expect(restored.message).toBe('boom');
+    expect(restored.stack).toBe(original.stack);
+  });
+
+  it('preserves the nested cause chain as real Errors', () => {
+    const root = new Error('root');
+    const middle = new Error('middle', { cause: root });
+    const top = new Error('top', { cause: middle });
+
+    const restored = deserializeError(serializeError(top));
+
+    expect(restored.message).toBe('top');
+    expect((restored.cause as Error).message).toBe('middle');
+    expect((restored.cause as Error).cause).toBeInstanceOf(Error);
+    expect(((restored.cause as Error).cause as Error).message).toBe('root');
+  });
+
+  it('preserves an aggregated array of causes (as produced by the .loaded() drain)', () => {
+    const primary = new Error('primary');
+    primary.cause = { aggregated: [new Error('a'), new Error('b')] };
+
+    const restored = deserializeError(serializeError(primary));
+    const aggregated = (restored.cause as { aggregated: Error[] }).aggregated;
+
+    expect(aggregated).toHaveLength(2);
+    expect(aggregated[0]).toBeInstanceOf(Error);
+    expect(aggregated[0].message).toBe('a');
+    expect(aggregated[1].message).toBe('b');
+  });
+
+  it('retains Storybook error fields like code and fromStorybook', () => {
+    const original = new OpenServiceValidationError({
+      kind: 'command',
+      serviceId: 'svc',
+      name: 'run',
+      phase: 'input',
+      issues: [{ message: 'nope' }],
+    });
+
+    const restored = deserializeError(serializeError(original)) as Error & {
+      code?: number;
+      fromStorybook?: boolean;
+    };
+
+    expect(restored.message).toBe(original.message);
+    expect(restored.fromStorybook).toBe(true);
+    expect(restored.code).toBe(5);
+  });
+
+  it('produces a transport-safe (structured-cloneable) payload', () => {
+    const error = new Error('with fn');
+    (error as unknown as Record<string, unknown>).callback = () => 'dropped';
+    (error as unknown as Record<string, unknown>).count = 3;
+
+    const serialized = serializeError(error);
+
+    expect(() => structuredClone(serialized)).not.toThrow();
+    expect(serialized.properties).toMatchObject({ count: 3 });
+    expect(serialized.properties?.callback).toBeUndefined();
+  });
+
+  it('wraps non-Error throws in a real Error', () => {
+    const restored = deserializeError(serializeError('just a string'));
+
+    expect(restored).toBeInstanceOf(Error);
+    expect(restored.message).toBe('just a string');
+  });
+});

--- a/code/core/src/shared/open-service/service-error-serialization.ts
+++ b/code/core/src/shared/open-service/service-error-serialization.ts
@@ -1,0 +1,157 @@
+/**
+ * Error (de)serialization for remote command execution.
+ *
+ * A command invoked from a runtime that has no local handler runs on a peer; when it throws, the
+ * thrown value has to cross the channel and be rethrown on the requester. `Error` instances are not
+ * structured-cloneable in a way that survives a websocket (JSON) or postMessage transport with their
+ * `name`, `stack`, `cause`, and Storybook-specific fields (`code`, `fromStorybook`, …) intact, so we
+ * convert to and from a plain, transport-safe shape here.
+ *
+ * The conversion is recursive: an error's `cause` (and any nested arrays/objects, e.g. the
+ * `cause.aggregated` array used by the `.loaded()` drain) is walked so a multi-cause failure arrives
+ * on the requester with its chain reconstructed rather than flattened to a single message.
+ */
+
+/** Marks a serialized object as a reconstructable `Error` rather than a plain payload object. */
+const ERROR_MARKER = '__openServiceError__' as const;
+
+/** Keys handled explicitly so they are not duplicated into the extra-properties bag. */
+const RESERVED_KEYS = new Set<string>([ERROR_MARKER, 'name', 'message', 'stack', 'cause']);
+
+/** Transport-safe representation of a thrown `Error`, including its recursive `cause` chain. */
+export interface SerializedError {
+  [ERROR_MARKER]: true;
+  name: string;
+  message: string;
+  stack?: string;
+  /** The error's `cause`, itself serialized (another error, a plain object, an array, …). */
+  cause?: unknown;
+  /** Extra own enumerable fields (e.g. Storybook's `code`, `fromStorybook`), serialized. */
+  properties?: Record<string, unknown>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSerializedError(value: unknown): value is SerializedError {
+  return isPlainObject(value) && value[ERROR_MARKER] === true;
+}
+
+/**
+ * Reduces any value to one a channel transport can clone.
+ *
+ * Functions, symbols, and `undefined` are dropped (structuredClone throws on functions/symbols);
+ * `bigint` is stringified; plain objects and arrays are walked; `Error`s become {@link SerializedError}.
+ */
+function toTransportSafe(value: unknown): unknown {
+  if (value instanceof Error) {
+    return serializeError(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => toTransportSafe(entry));
+  }
+
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      result[key] = toTransportSafe(entry);
+    }
+    return result;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const kind = typeof value;
+  if (kind === 'string' || kind === 'number' || kind === 'boolean') {
+    return value;
+  }
+  if (kind === 'bigint') {
+    return (value as bigint).toString();
+  }
+
+  // function / symbol / undefined: not cloneable and not meaningful on the wire.
+  return undefined;
+}
+
+/**
+ * Converts a thrown value into a transport-safe {@link SerializedError}.
+ *
+ * Non-`Error` throws (a string, an object, …) are wrapped in a synthetic error whose message is the
+ * stringified value, so the requester always receives a real `Error` to reject with.
+ */
+export function serializeError(value: unknown): SerializedError {
+  if (!(value instanceof Error)) {
+    return { [ERROR_MARKER]: true, name: 'Error', message: String(value) };
+  }
+
+  const properties: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    if (!RESERVED_KEYS.has(key)) {
+      properties[key] = toTransportSafe((value as unknown as Record<string, unknown>)[key]);
+    }
+  }
+
+  return {
+    [ERROR_MARKER]: true,
+    name: value.name,
+    message: value.message,
+    ...(value.stack !== undefined ? { stack: value.stack } : {}),
+    ...(value.cause !== undefined ? { cause: toTransportSafe(value.cause) } : {}),
+    ...(Object.keys(properties).length > 0 ? { properties } : {}),
+  };
+}
+
+/** Inverse of {@link toTransportSafe}: rebuilds nested errors while passing other values through. */
+function fromTransportSafe(value: unknown): unknown {
+  if (isSerializedError(value)) {
+    return deserializeError(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => fromTransportSafe(entry));
+  }
+
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      result[key] = fromTransportSafe(entry);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Rebuilds an `Error` from a {@link SerializedError}, restoring its `name`, `stack`, `cause` chain,
+ * and any extra fields (so a Storybook error arrives with `code`/`fromStorybook` intact).
+ *
+ * The result is a plain `Error`, not the original subclass — reconstructing arbitrary classes across
+ * a realm boundary is neither possible nor needed; callers branch on the restored fields instead.
+ */
+export function deserializeError(serialized: SerializedError): Error {
+  // A generic Error is intentional: this reconstructs an arbitrary error thrown in another runtime
+  // (its original class cannot cross the realm boundary). Storybook-specific fields like `code` and
+  // `fromStorybook` are restored from `properties`, so callers can still branch on them.
+  // eslint-disable-next-line local-rules/no-uncategorized-errors
+  const error = new Error(serialized.message);
+  error.name = serialized.name;
+
+  if (serialized.stack !== undefined) {
+    error.stack = serialized.stack;
+  }
+  if ('cause' in serialized) {
+    error.cause = fromTransportSafe(serialized.cause);
+  }
+  if (serialized.properties) {
+    for (const [key, value] of Object.entries(serialized.properties)) {
+      (error as unknown as Record<string, unknown>)[key] = fromTransportSafe(value);
+    }
+  }
+
+  return error;
+}

--- a/code/core/src/shared/open-service/service-registration.test.ts
+++ b/code/core/src/shared/open-service/service-registration.test.ts
@@ -87,11 +87,13 @@ describe('service registration', () => {
     );
   });
 
-  it('throws a Storybook error when a registered query or command is missing its handler', async () => {
+  it('throws a Storybook error when a registered query is missing its handler', () => {
+    // A command without a local handler does NOT throw here — it requests remote execution from a
+    // peer that implements it (see service-command-transport.test.ts). Queries stay local-only.
     const service = registerService(
       defineService({
         id: 'internal-fixture/unimplemented-operations',
-        description: 'Leaves command handlers undefined so registration can supply them later.',
+        description: 'Leaves the query handler undefined so registration can supply it later.',
         initialState: {} as Record<string, never>,
         queries: {
           getValue: {
@@ -100,25 +102,13 @@ describe('service registration', () => {
             output: v.string(),
           },
         },
-        commands: {
-          run: {
-            description: 'Runs a command that is not implemented in this environment.',
-            input: v.undefined(),
-            output: voidOutputSchema,
-          },
-        },
+        commands: {},
       })
     );
 
     expect(() => service.queries.getValue(undefined)).toThrow(
       'Query "internal-fixture/unimplemented-operations.getValue" is not implemented for this environment.'
     );
-    await expect(service.commands.run(undefined)).rejects.toMatchObject({
-      fromStorybook: true,
-      code: 8,
-      message:
-        'Command "internal-fixture/unimplemented-operations.run" is not implemented for this environment.',
-    });
   });
 
   it('lets handlers resolve another registered service by id through ctx.getService', async () => {

--- a/code/core/src/shared/open-service/service-registry.ts
+++ b/code/core/src/shared/open-service/service-registry.ts
@@ -24,7 +24,11 @@ import { getChannel } from '../../channels/channel-slot.ts';
 import { generateClientId } from './service-channel.ts';
 import { createServiceRuntime } from './service-runtime.ts';
 import { createSnapshotReconciler } from './service-sync.ts';
-import { connectRuntimeToChannel, wrapCommandsForBroadcast } from './service-transport.ts';
+import {
+  connectCommandTransport,
+  connectRuntimeToChannel,
+  wrapCommandsForBroadcast,
+} from './service-transport.ts';
 import type {
   AnyServiceDefinition,
   Commands,
@@ -233,25 +237,6 @@ export function registerService<
   const getSnapshot = (): Record<string, unknown> =>
     runtime.getStateSnapshot() as Record<string, unknown>;
 
-  // Wrap commands so a local mutation broadcasts its post-mutation snapshot to peers. The wrapper
-  // re-reads the channel at call time, so without a channel it is a no-op and static builds are
-  // unaffected. State adopted from peers flows through the reconciler's `setState`, never these
-  // wrappers, so an adopted snapshot never loops back out as a broadcast.
-  const instance = {
-    queries: runtime.queries,
-    commands: wrapCommandsForBroadcast(
-      runtime.commands as Record<string, (input: unknown) => Promise<unknown>>,
-      {
-        serviceId: definition.id,
-        ownClientId,
-        reconciler,
-        getSnapshot,
-        getChannel,
-      }
-    ) as ServiceInstance<TState, TQueries, TCommands>['commands'],
-    ...serviceRegistryApi,
-  } as ServiceInstance<TState, TQueries, TCommands> & ServiceRegistryApi;
-
   const descriptor = describeDefinition(resolvedDefinition as AnyServiceDefinition);
 
   const channel = getChannel();
@@ -259,19 +244,62 @@ export function registerService<
     throw new OpenServiceMissingChannelError({ serviceId: definition.id });
   }
 
+  // Wrap commands so a local mutation broadcasts its post-mutation snapshot to peers. The wrapper
+  // re-reads the channel at call time, so without a channel it is a no-op and static builds are
+  // unaffected. State adopted from peers flows through the reconciler's `setState`, never these
+  // wrappers, so an adopted snapshot never loops back out as a broadcast.
+  const broadcastCommands = wrapCommandsForBroadcast(
+    runtime.commands as Record<string, (input: unknown) => Promise<unknown>>,
+    {
+      serviceId: definition.id,
+      ownClientId,
+      reconciler,
+      getSnapshot,
+      getChannel,
+    }
+  );
+
+  // A command may only have a handler in some runtimes (e.g. supplied at server registration). Where
+  // a local handler exists, callers run it here and broadcast; where it does not, the command map
+  // routes calls to a peer that implements it and awaits the reply. See `connectCommandTransport`.
+  const implementedCommandNames = new Set<string>(
+    Object.entries(resolvedDefinition.commands)
+      .filter(([, command]) => typeof command.handler === 'function')
+      .map(([name]) => name)
+  );
+  const commandTransport = connectCommandTransport({
+    serviceId: definition.id,
+    ownClientId,
+    channel,
+    localCommands: broadcastCommands,
+    implementedCommandNames,
+    commandNames: Object.keys(resolvedDefinition.commands),
+  });
+
+  const instance = {
+    queries: runtime.queries,
+    commands: commandTransport.commands as ServiceInstance<TState, TQueries, TCommands>['commands'],
+    ...serviceRegistryApi,
+  } as ServiceInstance<TState, TQueries, TCommands> & ServiceRegistryApi;
+
+  const disconnectSync = connectRuntimeToChannel({
+    serviceId: definition.id,
+    channel,
+    ownClientId,
+    reconciler,
+    getSnapshot,
+    relay,
+  });
+
   registry.set(definition.id, {
     definition: resolvedDefinition as AnyServiceDefinition,
     instance: instance as unknown as RuntimeService,
     descriptor,
     summary: summarizeDescriptor(descriptor),
-    disconnect: connectRuntimeToChannel({
-      serviceId: definition.id,
-      channel,
-      ownClientId,
-      reconciler,
-      getSnapshot,
-      relay,
-    }),
+    disconnect: (): void => {
+      disconnectSync();
+      commandTransport.disconnect();
+    },
   });
 
   return instance;

--- a/code/core/src/shared/open-service/service-transport.ts
+++ b/code/core/src/shared/open-service/service-transport.ts
@@ -15,20 +15,39 @@
  * - {@link connectRuntimeToChannel} attaches the sync-start initialization and patch listeners, emits
  *   the bootstrap sync-start, and returns a teardown. A `relay` hub re-broadcasts every snapshot it
  *   adopts so peers on its *other* transports converge; leaves keep `relay: false`.
+ * - {@link connectCommandTransport} bridges the gap where a command is only implemented in *some*
+ *   runtimes (e.g. a handler supplied at server registration). A runtime without a local handler
+ *   requests remote execution; a runtime that has one listens for those requests, runs the command,
+ *   and replies. See its docs for the request/ack/result/error protocol.
  *
  * The merge and ordering rules themselves live in `service-sync.ts`; this module only moves snapshots
  * on and off the channel.
  */
 
+import { OpenServiceRemoteCommandDisconnectedError } from '../../server-errors.ts';
 import {
+  SERVICE_COMMAND_ACK,
+  SERVICE_COMMAND_ERROR,
+  SERVICE_COMMAND_INVOKE,
+  SERVICE_COMMAND_RESULT,
   SERVICE_PATCHES,
   SERVICE_SYNC_START,
   SERVICE_SYNC_START_REPLY,
+  type CommandAckPayload,
+  type CommandErrorPayload,
+  type CommandInvokePayload,
+  type CommandResultPayload,
   type PatchesPayload,
   type ServiceChannel,
   type SyncStartPayload,
   type SyncStartReplyPayload,
+  generateClientId,
 } from './service-channel.ts';
+import {
+  type SerializedError,
+  deserializeError,
+  serializeError,
+} from './service-error-serialization.ts';
 import { parseStampedSnapshot, parseSyncStart, type SnapshotReconciler } from './service-sync.ts';
 import type { ServiceId } from './types.ts';
 
@@ -198,5 +217,237 @@ export function connectRuntimeToChannel(
     channel.off(SERVICE_SYNC_START, onSyncStart);
     channel.off(SERVICE_SYNC_START_REPLY, onSyncStartReply);
     channel.off(SERVICE_PATCHES, onPatches);
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Narrows an untrusted `services:command-invoke` payload, returning `null` when malformed. */
+function parseCommandInvoke(payload: unknown): CommandInvokePayload | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const { serviceId, commandName, callId, clientId } = payload;
+  if (
+    typeof serviceId !== 'string' ||
+    typeof commandName !== 'string' ||
+    typeof callId !== 'string' ||
+    typeof clientId !== 'string'
+  ) {
+    return null;
+  }
+
+  return { serviceId, commandName, callId, clientId, input: payload.input };
+}
+
+/** Narrows an untrusted `services:command-result` payload, returning `null` when malformed. */
+function parseCommandResult(payload: unknown): CommandResultPayload | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const { serviceId, callId, clientId } = payload;
+  if (typeof serviceId !== 'string' || typeof callId !== 'string' || typeof clientId !== 'string') {
+    return null;
+  }
+
+  return { serviceId, callId, clientId, result: payload.result };
+}
+
+/** Narrows an untrusted `services:command-error` payload, returning `null` when malformed. */
+function parseCommandError(payload: unknown): CommandErrorPayload | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const { serviceId, callId, clientId, error } = payload;
+  if (
+    typeof serviceId !== 'string' ||
+    typeof callId !== 'string' ||
+    typeof clientId !== 'string' ||
+    !isRecord(error)
+  ) {
+    return null;
+  }
+
+  return { serviceId, callId, clientId, error: error as unknown as SerializedError };
+}
+
+/**
+ * Wires the remote-command-execution protocol for one service runtime, returning the command map
+ * callers should use plus a teardown.
+ *
+ * ## Why this exists
+ *
+ * A command handler can be supplied at registration in only *some* runtimes — the canonical case is
+ * a server-only handler that needs Node APIs or server context. Runtimes without a local handler
+ * still expose the command (so `useServiceCommand`, tests, and other services can call it), but they
+ * cannot run it themselves; they must ask a peer that can.
+ *
+ * ## Protocol
+ *
+ * - **Requester** (no local handler): the returned command emits `services:command-invoke` with a
+ *   unique `callId` and returns a promise. The promise resolves with the first
+ *   `services:command-result` for that `callId`, or rejects with the (deserialized) error from the
+ *   first `services:command-error`.
+ * - **Responder** (has a local handler): on a matching `services:command-invoke` it emits
+ *   `services:command-ack` immediately, runs the command locally (which also broadcasts the
+ *   post-mutation state via the broadcast wrappers, so peers converge as usual), then emits
+ *   `services:command-result` or `services:command-error`.
+ *
+ * Both roles coexist on one runtime: it responds for the commands it implements and requests the
+ * ones it does not. A runtime never requests a command it implements (it runs that locally), so it
+ * never answers its own invoke echo.
+ *
+ * ## Multiple implementers
+ *
+ * If several peers implement the same command they will each run it and reply. The requester keeps
+ * only the first reply per `callId` and ignores the rest. Running a command in more than one runtime
+ * is therefore possible by construction; it is constrained by usage conventions and documentation
+ * rather than enforced here.
+ *
+ * ## Topology
+ *
+ * Replies travel back over the same channel the invoke went out on. A request reaches every peer on
+ * the requester's transports; the manager is connected to both the dev server and the preview, so it
+ * can invoke a command implemented in either. Command events are *not* relayed across a hub's other
+ * transports, so a preview cannot directly invoke a server-only command (and vice versa) — route such
+ * calls through the manager or implement the command on a directly-connected peer.
+ */
+export function connectCommandTransport(context: {
+  /** Id of the service these commands belong to; stamped on every emitted envelope. */
+  serviceId: ServiceId;
+  /** This runtime's stable id, stamped on replies so peers know who answered. */
+  ownClientId: string;
+  channel: ServiceChannel;
+  /**
+   * Broadcast-wrapped local commands keyed by name. Only entries in {@link implementedCommandNames}
+   * are runnable; the rest are present only so the map is complete.
+   */
+  localCommands: Record<string, RuntimeCommand>;
+  /** Command names that have a local handler in this runtime. */
+  implementedCommandNames: ReadonlySet<string>;
+  /** Every command name declared by the service definition. */
+  commandNames: readonly string[];
+}): { commands: Record<string, RuntimeCommand>; disconnect: () => void } {
+  const { serviceId, ownClientId, channel, localCommands, implementedCommandNames, commandNames } =
+    context;
+
+  // Requester bookkeeping: in-flight remote calls keyed by callId, settled by the first reply.
+  const pending = new Map<
+    string,
+    { resolve: (value: unknown) => void; reject: (error: unknown) => void }
+  >();
+
+  const settle = (
+    callId: string,
+    apply: (entry: { resolve: (v: unknown) => void; reject: (e: unknown) => void }) => void
+  ): void => {
+    const entry = pending.get(callId);
+    if (!entry) {
+      return;
+    }
+    pending.delete(callId);
+    apply(entry);
+  };
+
+  // Responder: run a locally-implemented command on a peer's request and reply with the outcome.
+  const onInvoke = (payload: unknown): void => {
+    const invoke = parseCommandInvoke(payload);
+    if (
+      !invoke ||
+      invoke.serviceId !== serviceId ||
+      !implementedCommandNames.has(invoke.commandName)
+    ) {
+      return;
+    }
+
+    channel.emit(SERVICE_COMMAND_ACK, {
+      serviceId,
+      callId: invoke.callId,
+      clientId: ownClientId,
+    } satisfies CommandAckPayload);
+
+    void Promise.resolve()
+      .then(() => localCommands[invoke.commandName](invoke.input))
+      .then(
+        (result) => {
+          channel.emit(SERVICE_COMMAND_RESULT, {
+            serviceId,
+            callId: invoke.callId,
+            result,
+            clientId: ownClientId,
+          } satisfies CommandResultPayload);
+        },
+        (error: unknown) => {
+          channel.emit(SERVICE_COMMAND_ERROR, {
+            serviceId,
+            callId: invoke.callId,
+            error: serializeError(error),
+            clientId: ownClientId,
+          } satisfies CommandErrorPayload);
+        }
+      );
+  };
+
+  // Requester: resolve/reject the pending promise for a reply addressed to one of our calls.
+  const onResult = (payload: unknown): void => {
+    const result = parseCommandResult(payload);
+    if (!result || result.serviceId !== serviceId) {
+      return;
+    }
+    settle(result.callId, (entry) => entry.resolve(result.result));
+  };
+
+  const onError = (payload: unknown): void => {
+    const failure = parseCommandError(payload);
+    if (!failure || failure.serviceId !== serviceId) {
+      return;
+    }
+    settle(failure.callId, (entry) => entry.reject(deserializeError(failure.error)));
+  };
+
+  channel.on(SERVICE_COMMAND_INVOKE, onInvoke);
+  channel.on(SERVICE_COMMAND_RESULT, onResult);
+  channel.on(SERVICE_COMMAND_ERROR, onError);
+
+  const requestRemote = (commandName: string, input: unknown): Promise<unknown> => {
+    const callId = generateClientId();
+
+    return new Promise<unknown>((resolve, reject) => {
+      pending.set(callId, { resolve, reject });
+      channel.emit(SERVICE_COMMAND_INVOKE, {
+        serviceId,
+        commandName,
+        input,
+        callId,
+        clientId: ownClientId,
+      } satisfies CommandInvokePayload);
+    });
+  };
+
+  const commands: Record<string, RuntimeCommand> = {};
+  for (const name of commandNames) {
+    commands[name] = implementedCommandNames.has(name)
+      ? localCommands[name]
+      : (input: unknown) => requestRemote(name, input);
+  }
+
+  return {
+    commands,
+    disconnect: (): void => {
+      channel.off(SERVICE_COMMAND_INVOKE, onInvoke);
+      channel.off(SERVICE_COMMAND_RESULT, onResult);
+      channel.off(SERVICE_COMMAND_ERROR, onError);
+
+      // Fail any still-pending remote calls so awaiters don't hang forever past teardown.
+      for (const [, entry] of pending) {
+        entry.reject(new OpenServiceRemoteCommandDisconnectedError({ serviceId }));
+      }
+      pending.clear();
+    },
   };
 }


### PR DESCRIPTION
Tracked by: https://github.com/storybookjs/storybook/issues/34824

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled remote command execution with error serialization for improved service reliability
  * Enhanced error handling for service commands with detailed error recovery

* **Documentation**
  * Updated service documentation to describe remote command execution, error handling, and multi-runtime topologies

* **Tests**
  * Added comprehensive test coverage for remote command transport and error serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->