### PR TITLE
Vue: Switch to vue-component-meta by default

### DIFF
--- a/code/.storybook/preview.tsx
+++ b/code/.storybook/preview.tsx
@@ -30,6 +30,7 @@ import {
 } from 'storybook/theming';
 
 import { DocsPageWrapper } from '../addons/docs/src/blocks/components/index.ts';
+import { safeStringify } from '../addons/docs/src/blocks/controls/helpers.ts';
 import { toHaveLiveRegion } from '../core/src/shared/utils/toHaveLiveRegion.ts';
 import * as templatePreview from '../core/template/stories/preview.ts';
 import '../renderers/react/template/components/index.js';
@@ -348,7 +349,8 @@ const decorators = [
         />
         <div style={{ marginTop: '1rem' }}>
           Current <code>{parameters.withRawArg}</code>:{' '}
-          <pre>{JSON.stringify(args[parameters.withRawArg], null, 2) || 'undefined'}</pre>
+          {/* safeStringify so a non-serializable arg (e.g. a circular Vue VNode) doesn't crash the story. */}
+          <pre>{safeStringify(args[parameters.withRawArg], 2) || 'undefined'}</pre>
         </div>
       </>
     );

--- a/code/addons/docs/src/blocks/controls/Object.stories.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.stories.tsx
@@ -125,6 +125,34 @@ export const Function: Story = {
   },
 };
 
+/**
+ * Some renderers (e.g. Vue) pass non-serializable, circular values as args — a VNode's `el`
+ * references back to the VNode via `__vnode`. Such values cannot be edited as JSON, so the control
+ * shows a read-only best-effort view instead of crashing the panel with "Converting circular
+ * structure to JSON".
+ */
+export const CircularReference: Story = {
+  args: {
+    value: (() => {
+      const el: any = {};
+      const vnode: any = { __v_isVNode: true, type: 'p', props: null, children: 'Footer', el };
+      el.__vnode = vnode;
+      return vnode;
+    })(),
+  },
+  play: async ({ canvas }) => {
+    // Rendered read-only (no editable JSON tree, no crash); circular refs shown as [Circular].
+    const textbox = await canvas.findByRole('textbox', { name: 'Edit object as JSON' });
+    await expect(textbox).toHaveAttribute('readonly');
+    await expect((textbox as HTMLTextAreaElement).value).toContain('[Circular]');
+    // The edit-as-JSON toggle is disabled and explains why the value can't be edited.
+    const editButton = await canvas.findByLabelText(
+      'Args with circular references cannot be edited.'
+    );
+    await expect(editButton).toHaveAttribute('aria-disabled', 'true');
+  },
+};
+
 export const Readonly: Story = {
   args: {
     value: {

--- a/code/addons/docs/src/blocks/controls/Object.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.tsx
@@ -8,7 +8,12 @@ import { AddIcon, EditIcon, SubtractIcon } from '@storybook/icons';
 import { cloneDeep } from 'es-toolkit/object';
 import { styled } from 'storybook/theming';
 
-import { getControlId, getControlSetterButtonId } from './helpers';
+import {
+  getControlId,
+  getControlSetterButtonId,
+  isJsonSerializable,
+  safeStringify,
+} from './helpers';
 import { JsonTree } from './react-editable-json-tree';
 import type { ControlProps, ObjectConfig, ObjectValue } from './types';
 
@@ -172,6 +177,10 @@ export const ObjectControl: FC<ObjectProps> = ({
   argType,
   required,
 }) => {
+  // A non-serializable value (e.g. a Vue VNode with a circular `el`/`__vnode`) cannot be edited as
+  // JSON, so it is shown read-only. Checked on the raw value before cloneDeep.
+  const serializable = useMemo(() => isJsonSerializable(value), [value]);
+
   const data = useMemo(() => value && cloneDeep(value), [value]);
   const hasData = data !== null && data !== undefined;
   const [showRaw, setShowRaw] = useState(!hasData);
@@ -213,15 +222,16 @@ export const ObjectControl: FC<ObjectProps> = ({
     }
   }, [forceVisible]);
 
-  // Use string value as key to force re-render on Arg value reset.
+  // Use string value as key to force re-render on Arg value reset. `safeStringify` keeps a
+  // non-serializable arg (e.g. a circular Vue VNode) from crashing the whole controls panel.
   const jsonString = useMemo(() => {
-    return JSON.stringify(data ?? '', null, 2);
+    return safeStringify(data ?? '', 2);
   }, [data]);
 
   if (!hasData) {
     return (
       <Button
-        ariaLabel={false}
+        ariaLabel={readonly ? `This arg is configured to be read-only.` : false}
         disabled={readonly}
         id={getControlSetterButtonId(name, storyId, controlsId)}
         onClick={onForceVisible}
@@ -244,11 +254,15 @@ export const ObjectControl: FC<ObjectProps> = ({
         name={name}
         key={jsonString}
         defaultValue={jsonString}
-        onBlur={(event: FocusEvent<HTMLTextAreaElement>) => updateRaw(event.target.value)}
+        onBlur={
+          readonly || !serializable
+            ? undefined
+            : (event: FocusEvent<HTMLTextAreaElement>) => updateRaw(event.target.value)
+        }
         placeholder="Edit JSON string..."
         autoFocus={forceVisible}
         valid={parseError ? 'error' : undefined}
-        readOnly={readonly}
+        readOnly={readonly || !serializable}
         aria-required={required || undefined}
       />
     </>
@@ -261,9 +275,15 @@ export const ObjectControl: FC<ObjectProps> = ({
     <Wrapper>
       {isObjectOrArray && (
         <RawButton
-          disabled={readonly}
+          disabled={readonly || !serializable}
           pressed={showRaw}
-          ariaLabel={`Edit ${name} as JSON`}
+          ariaLabel={
+            !serializable
+              ? 'Args with circular references cannot be edited.'
+              : readonly
+                ? `This arg is configured to be read-only.`
+                : `Edit ${name} as JSON`
+          }
           onClick={(e: SyntheticEvent) => {
             e.preventDefault();
             setShowRaw((isRaw) => !isRaw);
@@ -275,9 +295,9 @@ export const ObjectControl: FC<ObjectProps> = ({
           <EditIcon />
         </RawButton>
       )}
-      {!showRaw ? (
+      {!showRaw && serializable ? (
         <JsonTree
-          readOnly={readonly || !isObjectOrArray}
+          readOnly={readonly || !serializable || !isObjectOrArray}
           isCollapsed={isObjectOrArray ? /* default value */ undefined : () => true}
           data={data}
           rootName={name}

--- a/code/addons/docs/src/blocks/controls/helpers.test.ts
+++ b/code/addons/docs/src/blocks/controls/helpers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { getControlId, getControlSetterButtonId } from './helpers';
+import {
+  getControlId,
+  getControlSetterButtonId,
+  isJsonSerializable,
+  safeStringify,
+} from './helpers';
 
 describe('getControlId', () => {
   it.each([
@@ -47,5 +52,49 @@ describe('getControlSetterButtonId', () => {
     expect(getControlSetterButtonId('some-id', 'story--name', 'r1')).toBe(
       'set-r1-story--name-some-id'
     );
+  });
+});
+
+describe('safeStringify', () => {
+  it('matches JSON.stringify for plain serializable values', () => {
+    const value = { a: 1, b: [2, 3], c: { d: 'e' } };
+    expect(safeStringify(value, 2)).toBe(JSON.stringify(value, null, 2));
+  });
+
+  it('preserves shared (non-circular) references on the fast path', () => {
+    const shared = { id: 1 };
+    expect(safeStringify({ x: shared, y: shared })).toBe('{"x":{"id":1},"y":{"id":1}}');
+  });
+
+  it('does not throw on a circular structure (e.g. a Vue VNode: el -> __vnode -> el)', () => {
+    const el: any = {};
+    const vnode: any = { type: 'p', el };
+    el.__vnode = vnode;
+
+    expect(() => safeStringify(vnode, 2)).not.toThrow();
+    const result = safeStringify(vnode, 2);
+    expect(result).toContain('"type": "p"');
+    expect(result).toContain('[Circular]');
+  });
+
+  it('does not throw on BigInt values', () => {
+    expect(() => safeStringify({ big: 10n })).not.toThrow();
+    expect(safeStringify({ big: 10n })).toBe('{"big":"10n"}');
+  });
+});
+
+describe('isJsonSerializable', () => {
+  it('returns true for plain JSON values', () => {
+    expect(isJsonSerializable({ a: 1, b: [2, { c: 'd' }] })).toBe(true);
+    expect(isJsonSerializable('string')).toBe(true);
+    expect(isJsonSerializable(null)).toBe(true);
+  });
+
+  it('returns false for circular structures (e.g. a Vue VNode: el -> __vnode -> el)', () => {
+    const el: any = {};
+    const vnode: any = { type: 'p', el };
+    el.__vnode = vnode;
+
+    expect(isJsonSerializable(vnode)).toBe(false);
   });
 });

--- a/code/addons/docs/src/blocks/controls/helpers.ts
+++ b/code/addons/docs/src/blocks/controls/helpers.ts
@@ -49,3 +49,55 @@ export const getControlSetterButtonId = (value: string, storyId?: string, contro
   parts.push(base);
   return parts.join('-');
 };
+
+/**
+ * `JSON.stringify` that won't throw on values an object control can receive but that aren't plain
+ * serializable data — most importantly circular structures (e.g. Vue VNodes, whose `el` references
+ * back via `__vnode`), but also `BigInt`s. A single such arg must not crash the whole controls
+ * panel, so circular references are rendered as `'[Circular]'` for a best-effort view.
+ *
+ * Plain values take the fast path and stringify identically to `JSON.stringify`, preserving shared
+ * (non-circular) references; only already-unserializable values fall back to the lossy replacer.
+ */
+export const safeStringify = (value: unknown, space?: string | number): string => {
+  try {
+    return JSON.stringify(value, null, space);
+  } catch {
+    const seen = new WeakSet<object>();
+    try {
+      return JSON.stringify(
+        value,
+        (_key, val) => {
+          if (typeof val === 'bigint') {
+            return `${val}n`;
+          }
+          if (val !== null && typeof val === 'object') {
+            if (seen.has(val)) {
+              return '[Circular]';
+            }
+            seen.add(val);
+          }
+          return val;
+        },
+        space
+      );
+    } catch {
+      return '';
+    }
+  }
+};
+
+/**
+ * Whether a value round-trips through plain JSON. Object controls let users edit the value as JSON,
+ * which is meaningless (and previously crash-prone) for non-serializable values — most notably Vue
+ * VNodes, whose `el → __vnode → el` cycle makes `JSON.stringify` throw. Such values are shown
+ * read-only instead of as an editable control.
+ */
+export const isJsonSerializable = (value: unknown): boolean => {
+  try {
+    JSON.stringify(value);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/code/core/src/common/utils/paths.ts
+++ b/code/core/src/common/utils/paths.ts
@@ -1,5 +1,7 @@
 import { join, relative, resolve, sep } from 'node:path';
 
+import { logger } from 'storybook/internal/node-logger';
+
 import * as find from 'empathic/find';
 import * as walk from 'empathic/walk';
 import { globSync } from 'tinyglobby';
@@ -8,11 +10,7 @@ import { LOCK_FILES } from '../js-package-manager/constants.ts';
 
 let projectRoot: string | undefined;
 
-export const getProjectRoot = () => {
-  if (projectRoot) {
-    return projectRoot;
-  }
-
+const computeProjectRoot = (): string => {
   // Allow manual override in cases where auto-detect doesn't work
   if (process.env.STORYBOOK_PROJECT_ROOT) {
     return process.env.STORYBOOK_PROJECT_ROOT;
@@ -21,8 +19,7 @@ export const getProjectRoot = () => {
   try {
     const found = find.up('.git') || find.up('.svn') || find.up('.hg');
     if (found) {
-      projectRoot = join(found, '..');
-      return projectRoot;
+      return join(found, '..');
     }
   } catch (e) {
     process.stdout.write(`\nerror searching for repository root: ${e}\n`);
@@ -31,8 +28,7 @@ export const getProjectRoot = () => {
   try {
     const found = find.any(LOCK_FILES);
     if (found) {
-      projectRoot = join(found, '..');
-      return projectRoot;
+      return join(found, '..');
     }
   } catch (e) {
     process.stdout.write(`\nerror searching for lock file: ${e}\n`);
@@ -45,14 +41,27 @@ export const getProjectRoot = () => {
       !basePath.includes(`${sep}npm-cache${sep}`) &&
       !relative(basePath, process.cwd()).startsWith('..')
     ) {
-      projectRoot = basePath;
-      return projectRoot;
+      return basePath;
     }
   } catch (e) {
     process.stdout.write(`\nerror searching for splitDirname: ${e}\n`);
   }
 
-  projectRoot = process.cwd();
+  return process.cwd();
+};
+
+export const getProjectRoot = () => {
+  if (projectRoot) {
+    return projectRoot;
+  }
+
+  projectRoot = computeProjectRoot();
+
+  // Resolving too high (e.g. when there is no `.git` folder and detection falls back to a parent
+  // directory) can make tooling scan too many files. Surfacing the computed root directory helps
+  // us diagnose such situations.
+  logger.debug(`Computed project root directory: ${projectRoot}`);
+
   return projectRoot;
 };
 

--- a/code/core/src/controls/stringifyArgs.test.ts
+++ b/code/core/src/controls/stringifyArgs.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { stringifyArgs } from './stringifyArgs.tsx';
+
+describe('stringifyArgs', () => {
+  it('serializes plain args', () => {
+    expect(stringifyArgs({ a: 1, b: 'two', c: { d: true } })).toBe(
+      JSON.stringify({ a: 1, b: 'two', c: { d: true } })
+    );
+  });
+
+  it('replaces functions with a marker', () => {
+    expect(stringifyArgs({ onClick: () => {} })).toBe('{"onClick":"__sb_empty_function_arg__"}');
+  });
+
+  it('does not throw on a circular arg (e.g. a Vue VNode: el -> __vnode -> el)', () => {
+    const el: { __vnode?: { type: string; el: typeof el } } = {};
+    const vnode = { type: 'p', el };
+    el.__vnode = vnode;
+
+    expect(() => stringifyArgs({ footer: vnode })).not.toThrow();
+    expect(stringifyArgs({ footer: vnode })).toContain('[Circular]');
+  });
+});

--- a/code/core/src/controls/stringifyArgs.tsx
+++ b/code/core/src/controls/stringifyArgs.tsx
@@ -1,7 +1,18 @@
-export const stringifyArgs = (args: Record<string, any>) =>
-  JSON.stringify(args, (_, value) => {
+// Args can hold non-serializable values (e.g. Vue VNodes, whose `el` references back via `__vnode`).
+// `JSON.stringify` throws "Converting circular structure to JSON" on those, which would crash the
+// save-story flow — so circular references are dropped to a marker, like functions are.
+export const stringifyArgs = (args: Record<string, unknown>) => {
+  const seen = new WeakSet<object>();
+  return JSON.stringify(args, (_, value) => {
     if (typeof value === 'function') {
       return '__sb_empty_function_arg__';
     }
+    if (value !== null && typeof value === 'object') {
+      if (seen.has(value)) {
+        return '[Circular]';
+      }
+      seen.add(value);
+    }
     return value;
   });
+};

--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -670,7 +670,6 @@ export default {
   ],
   'storybook/internal/router': [
     'BaseLocationProvider',
-    'DEEPLY_EQUAL',
     'Link',
     'Location',
     'LocationProvider',
@@ -678,7 +677,6 @@ export default {
     'MemoryRouter',
     'Route',
     'buildArgsParam',
-    'deepDiff',
     'getMatch',
     'parsePath',
     'queryFromLocation',

--- a/code/core/src/preview-api/modules/store/ArgsStore.ts
+++ b/code/core/src/preview-api/modules/store/ArgsStore.ts
@@ -1,7 +1,7 @@
-import type { PreparedStory } from 'storybook/internal/types';
-import type { Args, StoryId } from 'storybook/internal/types';
+import type { Args, PreparedStory, StoryId } from 'storybook/internal/types';
 
-import { DEEPLY_EQUAL, combineArgs, deepDiff, mapArgsToTypes, validateOptions } from './args.ts';
+import { deepDiff, DEEPLY_EQUAL } from '../../../shared/utils/deep-diff.ts';
+import { combineArgs, mapArgsToTypes, validateOptions } from './args.ts';
 
 function deleteUndefined(obj: Record<string, any>) {
   Object.keys(obj).forEach((key) => obj[key] === undefined && delete obj[key]);

--- a/code/core/src/preview-api/modules/store/GlobalsStore.ts
+++ b/code/core/src/preview-api/modules/store/GlobalsStore.ts
@@ -1,7 +1,7 @@
 import { logger } from 'storybook/internal/client-logger';
-import type { GlobalTypes, Globals } from 'storybook/internal/types';
+import type { Globals, GlobalTypes } from 'storybook/internal/types';
 
-import { DEEPLY_EQUAL, deepDiff } from './args.ts';
+import { deepDiff, DEEPLY_EQUAL } from '../../../shared/utils/deep-diff.ts';
 import { getValuesFromGlobalTypes } from './csf/getValuesFromGlobalTypes.ts';
 
 export class GlobalsStore {

--- a/code/core/src/preview-api/modules/store/args.ts
+++ b/code/core/src/preview-api/modules/store/args.ts
@@ -8,7 +8,7 @@ import type {
   StoryContext,
 } from 'storybook/internal/types';
 
-import { isEqual as deepEqual, isPlainObject } from 'es-toolkit/predicate';
+import { isPlainObject } from 'es-toolkit/predicate';
 import { dedent } from 'ts-dedent';
 
 const INCOMPATIBLE = Symbol('incompatible');
@@ -163,40 +163,6 @@ export const validateOptions = (args: Args, argTypes: ArgTypes): Args => {
 
     return acc;
   }, {} as Args);
-};
-
-// TODO -- copied from router, needs to be in a shared location
-export const DEEPLY_EQUAL = Symbol('Deeply equal');
-export const deepDiff = (value: any, update: any): any => {
-  if (typeof value !== typeof update) {
-    return update;
-  }
-
-  if (deepEqual(value, update)) {
-    return DEEPLY_EQUAL;
-  }
-  if (Array.isArray(value) && Array.isArray(update)) {
-    const res = update.reduce((acc, upd, index) => {
-      const diff = deepDiff(value[index], upd);
-
-      if (diff !== DEEPLY_EQUAL) {
-        acc[index] = diff;
-      }
-      return acc;
-    }, new Array(update.length));
-
-    if (update.length >= value.length) {
-      return res;
-    }
-    return res.concat(new Array(value.length - update.length).fill(undefined));
-  }
-  if (isPlainObject(value) && isPlainObject(update)) {
-    return Object.keys({ ...value, ...update }).reduce((acc, key) => {
-      const diff = deepDiff(value?.[key], update?.[key]);
-      return diff === DEEPLY_EQUAL ? acc : Object.assign(acc, { [key]: diff });
-    }, {});
-  }
-  return update;
 };
 
 export const UNTARGETED = 'UNTARGETED';

--- a/code/core/src/router/utils.test.ts
+++ b/code/core/src/router/utils.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DEEPLY_EQUAL, buildArgsParam, deepDiff, getMatch, parsePath } from './utils.ts';
+import { logger } from 'storybook/internal/client-logger';
+
+import { buildArgsParam, getMatch, parsePath } from './utils.ts';
 
 vi.mock('storybook/internal/client-logger', () => ({
   once: { warn: vi.fn() },
+  logger: { warn: vi.fn() },
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('getMatch', () => {
   it('gets startsWithTarget match', () => {
@@ -84,46 +91,25 @@ describe('parsePath', () => {
   });
 });
 
-describe('deepDiff', () => {
-  it('returns DEEPLY_EQUAL when the values are deeply equal', () => {
-    expect(deepDiff({ foo: [{ bar: 1 }] }, { foo: [{ bar: 1 }] })).toBe(DEEPLY_EQUAL);
-  });
-
-  it('returns the update when the types are different', () => {
-    expect(deepDiff(true, 1)).toBe(1);
-  });
-
-  it('returns a sparse array when updating an array', () => {
-    expect(deepDiff([1, 2], [1, 3])).toStrictEqual([, 3]);
-  });
-
-  it('returns undefined for removed array values', () => {
-    expect(deepDiff([1, 2], [1])).toStrictEqual([, undefined]);
-  });
-
-  it('returns a longer array when adding to an array', () => {
-    expect(deepDiff([1, 2], [1, 2, 3])).toStrictEqual([, , 3]);
-  });
-
-  it('returns a partial when updating an object', () => {
-    expect(deepDiff({ foo: 1, bar: 2 }, { foo: 1, bar: 3 })).toStrictEqual({ bar: 3 });
-  });
-
-  it('returns undefined for omitted object properties', () => {
-    expect(deepDiff({ foo: 1, bar: 2 }, { foo: 1 })).toStrictEqual({ bar: undefined });
-  });
-
-  it('traverses into objects', () => {
-    expect(deepDiff({ foo: { bar: [1, 2], baz: [3, 4] } }, { foo: { bar: [3] } })).toStrictEqual({
-      foo: { bar: [3, undefined], baz: undefined },
-    });
-  });
-});
-
 describe('buildArgsParam', () => {
   it('builds a simple key-value pair', () => {
     const param = buildArgsParam({}, { key: 'val' });
     expect(param).toEqual('key:val');
+  });
+
+  it('does not overflow the stack while validating a pathologically deep arg', () => {
+    // validateArgs recurses through nested arrays/objects; without a depth guard a deeply nested
+    // arg (e.g. a Vue VNode graph) overflows the stack. The arg is unsafe to serialize, so it's
+    // simply omitted.
+    const buildDeep = (depth: number) => {
+      let node: any = { leaf: 1 };
+      for (let i = 0; i < depth; i += 1) {
+        node = { child: node };
+      }
+      return node;
+    };
+
+    expect(() => buildArgsParam({}, { deep: buildDeep(50_000) })).not.toThrow();
   });
 
   it('builds multiple values', () => {
@@ -243,6 +229,68 @@ describe('buildArgsParam', () => {
         { obj: { nested: [{ one: 1 }, { two: 2, three: 3 }] } }
       );
       expect(param).toEqual('obj.nested[1].three:3');
+    });
+  });
+
+  describe('non-plain value diagnostics', () => {
+    it('does not warn for plain serializable args', () => {
+      buildArgsParam({}, { str: 'a', num: 1, nested: { arr: [1, 2] }, when: new Date(0) });
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('flags a Vue reactive proxy by its reactivity flag', () => {
+      const reactive = { __v_isReactive: true, label: 'hello' };
+      buildArgsParam({}, { component: reactive });
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      const [, suspects] = (logger.warn as Mock).mock.calls[0];
+      expect(suspects).toContainEqual({ source: 'args', path: 'component', kind: 'vue-reactive' });
+    });
+
+    it('flags a React element by its $$typeof symbol', () => {
+      const reactElement = { $$typeof: Symbol.for('react.element'), type: 'div', props: {} };
+      buildArgsParam({}, { node: reactElement });
+
+      const [, suspects] = (logger.warn as Mock).mock.calls[0];
+      expect(suspects).toContainEqual({
+        source: 'args',
+        path: 'node',
+        kind: 'react-element (react.element)',
+      });
+    });
+
+    it('flags a class instance with a custom prototype', () => {
+      class Widget {
+        x = 1;
+      }
+      buildArgsParam({}, { widget: new Widget() });
+
+      const [, suspects] = (logger.warn as Mock).mock.calls[0];
+      expect(suspects).toContainEqual({
+        source: 'args',
+        path: 'widget',
+        kind: 'class-instance (Widget)',
+      });
+    });
+
+    it('flags a functions value', () => {
+      buildArgsParam({}, { onClick: () => {} });
+
+      const [, suspects] = (logger.warn as Mock).mock.calls[0];
+      expect(suspects).toContainEqual({ source: 'args', path: 'onClick', kind: 'function' });
+    });
+
+    it('flags a circular reference reachable through plain objects', () => {
+      const args: any = { a: { b: {} } };
+      args.a.b.loop = args.a;
+      buildArgsParam({}, args);
+
+      const [, suspects] = (logger.warn as Mock).mock.calls[0];
+      expect(suspects).toContainEqual({
+        source: 'args',
+        path: 'a.b.loop',
+        kind: 'circular-reference',
+      });
     });
   });
 });

--- a/code/core/src/router/utils.ts
+++ b/code/core/src/router/utils.ts
@@ -1,10 +1,16 @@
-import { once } from 'storybook/internal/client-logger';
+import { logger, once } from 'storybook/internal/client-logger';
 
-import { isEqual as deepEqual, isPlainObject } from 'es-toolkit/predicate';
+import { isPlainObject } from 'es-toolkit/predicate';
+
 import memoize from 'memoizerific';
-import type { Options as QueryOptions } from 'picoquery';
 import { parse, stringify } from 'picoquery';
 import { dedent } from 'ts-dedent';
+import {
+  DEEPLY_EQUAL,
+  DEEP_DIFF_MAX_DEPTH,
+  deepDiff,
+  isObject,
+} from '../shared/utils/deep-diff.ts';
 
 export interface StoryData {
   viewMode?: string;
@@ -40,46 +46,18 @@ interface Args {
   [key: string]: any;
 }
 
-export const DEEPLY_EQUAL = Symbol('Deeply equal');
-export const deepDiff = (value: any, update: any): any => {
-  if (typeof value !== typeof update) {
-    return update;
-  }
-
-  if (deepEqual(value, update)) {
-    return DEEPLY_EQUAL;
-  }
-  if (Array.isArray(value) && Array.isArray(update)) {
-    const res = update.reduce((acc, upd, index) => {
-      const diff = deepDiff(value[index], upd);
-
-      if (diff !== DEEPLY_EQUAL) {
-        acc[index] = diff;
-      }
-      return acc;
-    }, new Array(update.length));
-
-    if (update.length >= value.length) {
-      return res;
-    }
-    return res.concat(new Array(value.length - update.length).fill(undefined));
-  }
-  if (isPlainObject(value) && isPlainObject(update)) {
-    return Object.keys({ ...value, ...update }).reduce((acc, key) => {
-      const diff = deepDiff(value?.[key], update?.[key]);
-      return diff === DEEPLY_EQUAL ? acc : Object.assign(acc, { [key]: diff });
-    }, {});
-  }
-  return update;
-};
-
 // Keep this in sync with validateArgs in core-client/src/preview/parseArgsParam.ts
 const VALIDATION_REGEXP = /^[a-zA-Z0-9 _-]*$/;
 const NUMBER_REGEXP = /^-?[0-9]+(\.[0-9]+)?$/;
 const HEX_REGEXP = /^#([a-f0-9]{3,4}|[a-f0-9]{6}|[a-f0-9]{8})$/i;
 const COLOR_REGEXP =
   /^(rgba?|hsla?)\(([0-9]{1,3}),\s?([0-9]{1,3})%?,\s?([0-9]{1,3})%?,?\s?([0-9](\.[0-9]{1,2})?)?\)$/i;
-const validateArgs = (key = '', value: unknown): boolean => {
+const validateArgs = (
+  key = '',
+  value: unknown,
+  stack: Set<object> = new Set(),
+  depth = 0
+): boolean => {
   if (key === null) {
     return false;
   }
@@ -109,20 +87,41 @@ const validateArgs = (key = '', value: unknown): boolean => {
       COLOR_REGEXP.test(value)
     );
   }
-  if (Array.isArray(value)) {
-    return value.every((v) => validateArgs(key, v));
+
+  // A circular value cannot be serialized into the URL, so reject it instead of recursing forever.
+  if (isObject(value) && stack.has(value)) {
+    return false;
   }
 
-  if (isPlainObject(value)) {
-    return Object.entries(value as Record<string, any>).every(([k, v]) => validateArgs(k, v));
+  // The depth guard also catches reactive proxies that return a fresh reference per access and so
+  // slip past the identity cycle guard.
+  if (depth >= DEEP_DIFF_MAX_DEPTH) {
+    return false;
   }
-  return false;
+
+  if (isObject(value)) {
+    stack.add(value);
+  }
+  try {
+    if (Array.isArray(value)) {
+      return value.every((v) => validateArgs(key, v, stack, depth + 1));
+    }
+
+    if (isPlainObject(value)) {
+      return Object.entries(value).every(([k, v]) => validateArgs(k, v, stack, depth + 1));
+    }
+    return false;
+  } finally {
+    if (isObject(value)) {
+      stack.delete(value);
+    }
+  }
 };
 
 // Note this isn't a picoquery serializer because pq will turn any object
 // into a nested key internally. So we need to deal witth things like `Date`
 // up front.
-const encodeSpecialValues = (value: unknown): any => {
+const encodeSpecialValues = (value: unknown): unknown => {
   if (value === undefined) {
     return '!undefined';
   }
@@ -154,7 +153,7 @@ const encodeSpecialValues = (value: unknown): any => {
   }
 
   if (isPlainObject(value)) {
-    return Object.entries(value as Record<string, any>).reduce(
+    return Object.entries(value).reduce(
       (acc, [key, val]) => Object.assign(acc, { [key]: encodeSpecialValues(val) }),
       {}
     );
@@ -183,7 +182,159 @@ const decodeKnownQueryChar = (chr: string) => {
 };
 const knownQueryChar = /%[0-9A-F]{2}/g;
 
+/**
+ * Best-effort classification of a value that is *not* a plain object/array/primitive. These
+ * framework/host objects (Vue reactive proxies, React elements, DOM nodes, class instances, ...)
+ * carry densely cross-linked internal graphs — often with cycles — that make `deepDiff` and
+ * es-toolkit's `isEqual` recurse without bound. Returns a short label for logging, or `null` when
+ * the value is safe to diff structurally.
+ *
+ * Property reads are wrapped in try/catch because reactive proxies and exotic objects can throw
+ * from getters or traps.
+ */
+const getNonPlainKind = (value: unknown): string | null => {
+  if (typeof value === 'function') {
+    return 'function';
+  }
+  if (!isObject(value)) {
+    return null;
+  }
+  // Dates are explicitly supported as args and round-trip safely, so don't flag them.
+  if (value instanceof Date) {
+    return null;
+  }
+
+  try {
+    const obj = value;
+
+    // Vue 3 reactivity flags (reactive/ref/readonly proxies and vnodes).
+    if (obj.__v_isVNode === true) {
+      return 'vue-vnode';
+    }
+    if (obj.__v_isRef === true) {
+      return 'vue-ref';
+    }
+    if (obj.__v_isReactive === true || obj.__v_isReadonly === true || obj.__v_raw !== undefined) {
+      return 'vue-reactive';
+    }
+    if (obj.$ !== undefined && obj.$el !== undefined && obj.$options !== undefined) {
+      return 'vue-component-instance';
+    }
+
+    // React elements/portals/fragments, and fiber nodes.
+    if (typeof obj.$$typeof === 'symbol') {
+      const tag = (obj.$$typeof as symbol).description ?? '';
+      return tag.startsWith('react.') ? `react-element (${tag})` : `exotic ($$typeof: ${tag})`;
+    }
+    if (obj.stateNode !== undefined && obj.elementType !== undefined && obj.return !== undefined) {
+      return 'react-fiber';
+    }
+
+    // DOM / host objects.
+    if (typeof Node !== 'undefined' && value instanceof Node) {
+      return `dom-node (${(value as unknown as Node).nodeName})`;
+    }
+    if (typeof Window !== 'undefined' && value instanceof Window) {
+      return 'window';
+    }
+    if (typeof Event !== 'undefined' && value instanceof Event) {
+      return `dom-event (${(value as unknown as Event).type})`;
+    }
+    if (typeof obj.nodeType === 'number' && typeof obj.nodeName === 'string') {
+      return `dom-like (${obj.nodeName})`;
+    }
+
+    // Built-ins that aren't plain objects.
+    if (value instanceof Promise) {
+      return 'promise';
+    }
+    if (value instanceof Map || value instanceof WeakMap) {
+      return 'map';
+    }
+    if (value instanceof Set || value instanceof WeakSet) {
+      return 'set';
+    }
+    if (value instanceof RegExp) {
+      return 'regexp';
+    }
+    if (value instanceof Error) {
+      return `error (${obj.name ?? 'Error'})`;
+    }
+
+    // Anything left that is neither a plain object nor an array is a class instance with a custom
+    // prototype — also unsafe to diff blindly.
+    if (!Array.isArray(value) && !isPlainObject(value)) {
+      return `class-instance (${obj.constructor?.name || 'anonymous'})`;
+    }
+  } catch {
+    return 'unreadable (threw while inspecting)';
+  }
+
+  return null;
+};
+
+interface NonPlainFinding {
+  source: string;
+  path: string;
+  kind: string;
+}
+
+/**
+ * Walks a value (args/globals) and reports any non-plain or circular sub-values that could make
+ * `deepDiff` recurse unsafely. The walk is itself bounded by a cycle guard and a depth limit so the
+ * diagnostic can never reproduce the very crash it's meant to surface.
+ */
+const scanForNonPlain = (root: unknown, source: string): NonPlainFinding[] => {
+  const findings: NonPlainFinding[] = [];
+  const seen = new WeakSet<object>();
+
+  const walk = (value: unknown, path: string, depth: number): void => {
+    const kind = getNonPlainKind(value);
+    if (kind) {
+      // Don't descend into a flagged value — that interlinked graph is exactly what we avoid.
+      findings.push({ source, path: path || '<root>', kind });
+      return;
+    }
+    if (!isObject(value)) {
+      return;
+    }
+    if (seen.has(value)) {
+      findings.push({ source, path: path || '<root>', kind: 'circular-reference' });
+      return;
+    }
+    seen.add(value);
+    if (depth >= DEEP_DIFF_MAX_DEPTH) {
+      return;
+    }
+    try {
+      if (Array.isArray(value)) {
+        value.forEach((item, index) => walk(item, `${path}[${index}]`, depth + 1));
+      } else {
+        for (const key of Object.keys(value)) {
+          walk(value[key], path ? `${path}.${key}` : key, depth + 1);
+        }
+      }
+    } catch {
+      findings.push({ source, path: path || '<root>', kind: 'unreadable (threw while walking)' });
+    }
+  };
+
+  walk(root, '', 0);
+  return findings;
+};
+
 export const buildArgsParam = (initialArgs: Args | undefined, args: Args): string => {
+  const suspects = [
+    ...scanForNonPlain(initialArgs, 'initialArgs'),
+    ...scanForNonPlain(args, 'args'),
+  ];
+  if (suspects.length > 0) {
+    logger.warn(
+      `[deepDiff] buildArgsParam received ${suspects.length} non-plain/circular value(s) that can make deepDiff/deepEqual recurse unbounded:`,
+      suspects
+    );
+  }
+
   const update = deepDiff(initialArgs, args);
 
   if (!update || update === DEEPLY_EQUAL) {

--- a/code/core/src/shared/utils/deep-diff.test.ts
+++ b/code/core/src/shared/utils/deep-diff.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { once } from 'storybook/internal/client-logger';
+
+import { DEEP_DIFF_MAX_DEPTH, deepDiff, DEEPLY_EQUAL, isObject } from './deep-diff.ts';
+
+vi.mock('storybook/internal/client-logger', () => ({
+  once: { warn: vi.fn() },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('isObject', () => {
+  it('returns true for plain objects and arrays', () => {
+    expect(isObject({})).toBe(true);
+    expect(isObject([])).toBe(true);
+    expect(isObject(new Date())).toBe(true);
+  });
+
+  it('returns false for null and primitives', () => {
+    expect(isObject(null)).toBe(false);
+    expect(isObject(undefined)).toBe(false);
+    expect(isObject(1)).toBe(false);
+    expect(isObject('a')).toBe(false);
+    expect(isObject(true)).toBe(false);
+  });
+});
+
+describe('deepDiff', () => {
+  describe('equality', () => {
+    it('returns DEEPLY_EQUAL for equal primitives', () => {
+      expect(deepDiff(1, 1)).toBe(DEEPLY_EQUAL);
+      expect(deepDiff('a', 'a')).toBe(DEEPLY_EQUAL);
+      expect(deepDiff(true, true)).toBe(DEEPLY_EQUAL);
+      expect(deepDiff(null, null)).toBe(DEEPLY_EQUAL);
+      expect(deepDiff(undefined, undefined)).toBe(DEEPLY_EQUAL);
+    });
+
+    it('returns DEEPLY_EQUAL for deeply equal objects and arrays', () => {
+      expect(deepDiff({ foo: [{ bar: 1 }] }, { foo: [{ bar: 1 }] })).toBe(DEEPLY_EQUAL);
+      expect(deepDiff([1, [2, 3]], [1, [2, 3]])).toBe(DEEPLY_EQUAL);
+      expect(deepDiff({}, {})).toBe(DEEPLY_EQUAL);
+      expect(deepDiff([], [])).toBe(DEEPLY_EQUAL);
+    });
+
+    it('prunes equal subtrees rather than returning empty objects', () => {
+      // The nested `bar` object is unchanged, so it must not appear in the diff at all.
+      expect(deepDiff({ foo: 1, bar: { baz: 2 } }, { foo: 2, bar: { baz: 2 } })).toStrictEqual({
+        foo: 2,
+      });
+    });
+  });
+
+  describe('primitives and type changes', () => {
+    it('returns the update when types differ', () => {
+      expect(deepDiff(true, 1)).toBe(1);
+      expect(deepDiff(1, 'a')).toBe('a');
+      expect(deepDiff({}, 1)).toBe(1);
+      expect(deepDiff([], {})).toStrictEqual({});
+    });
+
+    it('returns the update for changed primitives', () => {
+      expect(deepDiff(1, 2)).toBe(2);
+      expect(deepDiff('a', 'b')).toBe('b');
+    });
+  });
+
+  describe('arrays', () => {
+    it('returns a sparse array when updating an array', () => {
+      expect(deepDiff([1, 2], [1, 3])).toStrictEqual([, 3]);
+    });
+
+    it('returns undefined for removed array values', () => {
+      expect(deepDiff([1, 2], [1])).toStrictEqual([, undefined]);
+    });
+
+    it('returns a longer array when adding to an array', () => {
+      expect(deepDiff([1, 2], [1, 2, 3])).toStrictEqual([, , 3]);
+    });
+  });
+
+  describe('objects', () => {
+    it('returns a partial when updating an object', () => {
+      expect(deepDiff({ foo: 1, bar: 2 }, { foo: 1, bar: 3 })).toStrictEqual({ bar: 3 });
+    });
+
+    it('returns undefined for omitted object properties', () => {
+      expect(deepDiff({ foo: 1, bar: 2 }, { foo: 1 })).toStrictEqual({ bar: undefined });
+    });
+
+    it('traverses into nested objects and arrays', () => {
+      expect(deepDiff({ foo: { bar: [1, 2], baz: [3, 4] } }, { foo: { bar: [3] } })).toStrictEqual({
+        foo: { bar: [3, undefined], baz: undefined },
+      });
+    });
+  });
+
+  describe('built-in objects', () => {
+    it('compares Dates by value', () => {
+      expect(deepDiff(new Date('2020-01-01'), new Date('2020-01-01'))).toBe(DEEPLY_EQUAL);
+      const changed = deepDiff(new Date('2020-01-01'), new Date('2021-01-01'));
+      expect(changed).toBeInstanceOf(Date);
+      expect((changed as Date).getFullYear()).toBe(2021);
+    });
+
+    it('compares RegExps by value', () => {
+      expect(deepDiff(/a/g, /a/g)).toBe(DEEPLY_EQUAL);
+      expect(deepDiff(/a/g, /b/g)).toStrictEqual(/b/g);
+    });
+  });
+
+  describe('non-plain objects', () => {
+    class Point {
+      constructor(
+        public x: number,
+        public y: number
+      ) {}
+    }
+
+    it('treats the same reference as equal', () => {
+      const point = new Point(1, 2);
+      expect(deepDiff({ point }, { point })).toBe(DEEPLY_EQUAL);
+    });
+
+    it('treats a different reference as changed without recursing into it', () => {
+      const next = new Point(1, 2);
+      const diff = deepDiff({ point: new Point(1, 2) }, { point: next });
+      expect(diff).toStrictEqual({ point: next });
+      expect((diff as { point: Point }).point).toBe(next);
+    });
+  });
+
+  describe('cycle and depth guards', () => {
+    it('does not overflow on a circular update value', () => {
+      const initial = { a: 1 };
+      const update: Record<string, unknown> = { a: 2 };
+      update.self = update;
+
+      expect(() => deepDiff(initial, update)).not.toThrow();
+      expect(deepDiff(initial, update)).toMatchObject({ a: 2 });
+    });
+
+    it('does not overflow when both sides share a cycle', () => {
+      const a: Record<string, unknown> = { tag: 'a' };
+      a.self = a;
+      const b: Record<string, unknown> = { tag: 'b' };
+      b.self = b;
+
+      expect(() => deepDiff(a, b)).not.toThrow();
+      expect(deepDiff(a, b)).toMatchObject({ tag: 'b' });
+    });
+
+    it('does not overflow on pathologically deep structures and warns once', () => {
+      const makeDeep = (leaf: number) => {
+        const root: Record<string, unknown> = {};
+        let node: Record<string, unknown> & { child?: Record<string, unknown> } = root;
+        for (let i = 0; i < 5000; i += 1) {
+          node.child = {};
+          node = node.child;
+        }
+        node.value = leaf;
+        return root;
+      };
+
+      expect(() => deepDiff(makeDeep(1), makeDeep(2))).not.toThrow();
+      expect(once.warn).toHaveBeenCalled();
+    });
+
+    it('does not overflow on a reactive-like proxy that yields fresh references per access', () => {
+      // Vue's reactive()/VNode graphs can return a *new* reference on each access, defeating
+      // identity-based cycle guards — only the depth guard prevents overflow here.
+      const makeInfinite = (tag: string): unknown =>
+        new Proxy(
+          {},
+          {
+            get: (_t, prop) =>
+              prop === 'tag' ? tag : prop === 'child' ? makeInfinite(tag) : undefined,
+            ownKeys: () => ['tag', 'child'],
+            getOwnPropertyDescriptor: () => ({ enumerable: true, configurable: true }),
+          }
+        );
+
+      expect(() => deepDiff(makeInfinite('a'), makeInfinite('b'))).not.toThrow();
+    });
+
+    it('does not warn for shallow structures within the depth limit', () => {
+      deepDiff({ a: { b: { c: 1 } } }, { a: { b: { c: 2 } } });
+      expect(once.warn).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('DEEP_DIFF_MAX_DEPTH', () => {
+  it('is a positive backstop limit', () => {
+    expect(DEEP_DIFF_MAX_DEPTH).toBeGreaterThan(0);
+  });
+});

--- a/code/core/src/shared/utils/deep-diff.ts
+++ b/code/core/src/shared/utils/deep-diff.ts
@@ -1,0 +1,108 @@
+import { once } from 'storybook/internal/client-logger';
+
+import { isEqual as deepEqual, isPlainObject } from 'es-toolkit/predicate';
+
+export const DEEPLY_EQUAL = Symbol('Deeply equal');
+
+// Acyclic args/globals are shallow in practice; this only backstops pathologically deep (or
+// reactive, fresh-reference-per-access) structures such as Vue VNodes/proxies that would otherwise
+// overflow the call stack.
+export const DEEP_DIFF_MAX_DEPTH = 100;
+
+export const isObject = (value: unknown): value is Record<PropertyKey, unknown> =>
+  value !== null && typeof value === 'object';
+
+/**
+ * Structural diff between two values, used to derive the minimal `args`/`globals` delta from their
+ * initial state (e.g. to serialize into the URL or to emit arg updates). Because it runs against
+ * arbitrary user-supplied values, it can receive circular or pathologically deep graphs (Vue
+ * reactive proxies, VNodes, DOM nodes, class instances, ...).
+ *
+ * es-toolkit's `isEqual` has no cycle or depth protection, so we must never hand it a whole object
+ * graph — doing so overflows the stack. Instead `isEqual` is only used to compare primitive leaves;
+ * equality of objects and arrays is decided structurally here, bounded by both a cycle guard
+ * (`stack`, the references currently on this recursion path) and a depth guard (`depth`), which also
+ * catches reactive proxies that hand out a fresh reference on every access and so defeat
+ * identity-based cycle detection.
+ */
+const diffInternal = (
+  value: unknown,
+  update: unknown,
+  stack: Set<object>,
+  depth: number
+): unknown => {
+  if (typeof value !== typeof update) {
+    return update;
+  }
+
+  // Primitive (or null) leaves: a direct comparison is cheap and cannot recurse.
+  if (!isObject(value) || !isObject(update)) {
+    return deepEqual(value, update) ? DEEPLY_EQUAL : update;
+  }
+
+  // Cycle guard: we're re-entering an object already being diffed further up the stack.
+  if (stack.has(value) || stack.has(update)) {
+    return DEEPLY_EQUAL;
+  }
+
+  if (depth >= DEEP_DIFF_MAX_DEPTH) {
+    once.warn(
+      `deepDiff: reached max depth (${DEEP_DIFF_MAX_DEPTH}); treating deeper values as changed.`
+    );
+    return update;
+  }
+
+  stack.add(value);
+  stack.add(update);
+
+  try {
+    if (Array.isArray(value) && Array.isArray(update)) {
+      const res = new Array(update.length);
+      let changed = value.length !== update.length;
+      for (let index = 0; index < update.length; index += 1) {
+        const diff = diffInternal(value[index], update[index], stack, depth + 1);
+        if (diff !== DEEPLY_EQUAL) {
+          res[index] = diff;
+          changed = true;
+        }
+      }
+      if (!changed) {
+        return DEEPLY_EQUAL;
+      }
+      if (update.length >= value.length) {
+        return res;
+      }
+      return res.concat(new Array(value.length - update.length).fill(undefined));
+    }
+
+    if (isPlainObject(value) && isPlainObject(update)) {
+      const acc: Record<string, unknown> = {};
+      let changed = false;
+      for (const key of Object.keys({ ...value, ...update })) {
+        const diff = diffInternal(value?.[key], update?.[key], stack, depth + 1);
+        if (diff !== DEEPLY_EQUAL) {
+          acc[key] = diff;
+          changed = true;
+        }
+      }
+      return changed ? acc : DEEPLY_EQUAL;
+    }
+
+    // Non-plain objects (Vue VNode/proxy, DOM node, class instance, ...): recursing into them is
+    // unsafe. Compare known shallow built-ins by value; treat everything else as changed unless it
+    // is the very same reference.
+    if (value instanceof Date && update instanceof Date) {
+      return value.getTime() === update.getTime() ? DEEPLY_EQUAL : update;
+    }
+    if (value instanceof RegExp && update instanceof RegExp) {
+      return value.toString() === update.toString() ? DEEPLY_EQUAL : update;
+    }
+    return value === update ? DEEPLY_EQUAL : update;
+  } finally {
+    stack.delete(value);
+    stack.delete(update);
+  }
+};
+
+export const deepDiff = (value: unknown, update: unknown): unknown =>
+  diffInternal(value, update, new Set(), 0);

--- a/code/core/src/shared/utils/deep-diff.ts
+++ b/code/core/src/shared/utils/deep-diff.ts
@@ -104,5 +104,8 @@ const diffInternal = (
   }
 };
 
-export const deepDiff = (value: unknown, update: unknown): unknown =>
-  diffInternal(value, update, new Set(), 0);
+export function deepDiff<T>(value: T, update: T): T | typeof DEEPLY_EQUAL;
+export function deepDiff(value: unknown, update: unknown): unknown;
+export function deepDiff(value: unknown, update: unknown): unknown {
+  return diffInternal(value, update, new Set(), 0);
+}

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -2,9 +2,11 @@ import { readFile, stat } from 'node:fs/promises';
 import { join, parse } from 'node:path';
 
 import { getProjectRoot } from 'storybook/internal/common';
+import { logger } from 'storybook/internal/node-logger';
 import { parseLocalBindings } from 'storybook/internal/oxc-parser';
 
 import MagicString from 'magic-string';
+import picocolors from 'picocolors';
 import type { ModuleNode, Plugin } from 'vite';
 import {
   type ComponentMeta,
@@ -183,7 +185,18 @@ async function createVueComponentMetaChecker(tsconfigPath = 'tsconfig.json') {
 
   const projectTsConfigPath = join(projectRoot, tsconfigPath);
 
-  const defaultChecker = createCheckerByJson(projectRoot, { include: ['**/*'] }, checkerOptions);
+  // If the project root resolves too high, it can make vue-component-meta scan a huge tree and
+  // exhaust memory, freezing the Storybook UI and crashing the dev server. Surface computed
+  // directory to help users understand what to do in case of crashes.
+  logger.info(
+    `vue-component-meta: extracting docgen using project root: \n\t${picocolors.cyan(projectRoot)}`
+  );
+
+  const defaultChecker = createCheckerByJson(
+    projectRoot,
+    { include: ['**/*.{vue,ts,tsx,js,jsx,cjs,mjs}'] },
+    checkerOptions
+  );
 
   // prefer the tsconfig.json file of the project to support alias resolution etc.
   if (await fileExists(projectTsConfigPath)) {

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -189,7 +189,7 @@ async function createVueComponentMetaChecker(tsconfigPath = 'tsconfig.json') {
   // exhaust memory, freezing the Storybook UI and crashing the dev server. Surface computed
   // directory to help users understand what to do in case of crashes.
   logger.info(
-    `vue-component-meta: extracting docgen using project root: \n\t${picocolors.cyan(projectRoot)}`
+    `vue-component-meta: extracting docgen using project root: ${picocolors.cyan(projectRoot)}`
   );
 
   const defaultChecker = createCheckerByJson(

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -149,6 +149,10 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
             map: s.generateMap({ hires: true, source: id }),
           };
         } catch (e) {
+          // Docgen extraction is best-effort: a failure for one file must not break the build.
+          // We still log it at debug level so silent extraction failures (e.g. checker setup
+          // issues) can be diagnosed instead of disappearing.
+          logger.debug(`vue-component-meta: failed to extract docgen for ${id}: ${String(e)}`);
           return undefined;
         }
       },
@@ -194,7 +198,10 @@ async function createVueComponentMetaChecker(tsconfigPath = 'tsconfig.json') {
 
   const defaultChecker = createCheckerByJson(
     projectRoot,
-    { include: ['**/*.{vue,ts,tsx,js,jsx,cjs,mjs}'] },
+    // tsconfig "include" globbing does not support brace expansion, extensions must be listed separately.
+    {
+      include: ['**/*.vue', '**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
+    },
     checkerOptions
   );
 

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -22,11 +22,12 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
   const docgen = resolveDocgenOptions(frameworkOptions.docgen);
 
   // add docgen plugin depending on framework option
+  // from 10.5 on, vue-component-meta is default.
   if (docgen !== false) {
-    if (docgen.plugin === 'vue-component-meta') {
-      plugins.push(await vueComponentMeta(docgen.tsconfig));
-    } else {
+    if (docgen.plugin === 'vue-docgen-api') {
       plugins.push(await vueDocgen());
+    } else {
+      plugins.push(await vueComponentMeta(docgen.tsconfig));
     }
   }
 
@@ -45,7 +46,7 @@ const resolveDocgenOptions = (
   }
 
   if (docgen === undefined || docgen === true) {
-    return { plugin: 'vue-docgen-api' };
+    return { plugin: 'vue-component-meta' };
   }
 
   if (typeof docgen === 'string') {

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -99,6 +99,13 @@ export type Template = {
     resolutions?: Record<string, string>;
     editAddons?: (addons: string[]) => string[];
     useCsfFactory?: boolean;
+    /**
+     * Pin `STORYBOOK_PROJECT_ROOT` to the sandbox directory when running the sandbox's Storybook.
+     * Some docgen tools (e.g. `vue-component-meta`) build a TypeScript program rooted at the
+     * detected project root. Sandboxes have no `.git` marker, so detection can resolve too high and
+     * make the program scan a huge tree, exhausting memory. Setting this keeps it scoped.
+     */
+    setProjectRoot?: boolean;
   };
   /** Additional CI steps in case this template has special needs during CI. */
   extraCiSteps?: {
@@ -587,6 +594,14 @@ export const baseTemplates = {
     },
     modifications: {
       useCsfFactory: true,
+      mainConfig: {
+        framework: {
+          name: '@storybook/vue3-vite',
+          options: {
+            docgen: 'vue-docgen-api',
+          },
+        },
+      },
     },
     skipTasks: ['e2e-tests', 'bench'],
   },
@@ -600,6 +615,9 @@ export const baseTemplates = {
     },
     modifications: {
       useCsfFactory: true,
+      // vue-component-meta scans the TypeScript project from the detected project root; pin it to
+      // the sandbox dir so the absence of a `.git` marker doesn't make it scan a huge tree.
+      setProjectRoot: true,
     },
     skipTasks: ['bench'],
   },

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/DefineProps.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/DefineProps.stories.ts
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import Component from './define-props/component.vue';
+
+const meta = {
+  component: Component,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Component>;
+
+type Story = StoryObj<typeof meta>;
+export default meta;
+
+export const RuntimeProps: Story = {
+  args: {
+    name: 'Ada Lovelace',
+  },
+};
+
+export const RuntimePropsWithCategory: Story = {
+  args: {
+    name: 'Ada Lovelace',
+    category: 'Content',
+  },
+};

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/DefinePropsDestructured.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/DefinePropsDestructured.stories.ts
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import Component from './define-props-destructured/component.vue';
+
+const meta = {
+  component: Component,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Component>;
+
+type Story = StoryObj<typeof meta>;
+export default meta;
+
+export const PropsWithDefaults: Story = {
+  args: {
+    name: 'Ada Lovelace',
+  },
+};
+
+export const PropsWithDefaultsOverridden: Story = {
+  args: {
+    name: 'Ada Lovelace',
+    category: 'Content',
+  },
+};

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/DefinePropsWithDefaults.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/DefinePropsWithDefaults.stories.ts
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import Component from './define-props-with-defaults/component.vue';
+
+const meta = {
+  component: Component,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Component>;
+
+type Story = StoryObj<typeof meta>;
+export default meta;
+
+export const PropsWithDefaults: Story = {
+  args: {
+    name: 'Ada Lovelace',
+  },
+};
+
+export const PropsWithDefaultsOverridden: Story = {
+  args: {
+    name: 'Ada Lovelace',
+    category: 'Content',
+  },
+};

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/define-props-destructured/component.vue
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/define-props-destructured/component.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <p>Name: {{ name }}</p>
+    <p>Category: {{ category }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface MyComponentProps {
+  /** The name of the user */
+  name: string;
+  /**
+   * The category of the component
+   *
+   * @since 8.0.0
+   */
+  category?: string;
+}
+
+const { name, category = 'Uncategorized' } = defineProps<MyComponentProps>();
+</script>

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/define-props-with-defaults/component.vue
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/define-props-with-defaults/component.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <p>Name: {{ name }}</p>
+    <p>Category: {{ category }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface MyComponentProps {
+  /** The name of the user */
+  name: string;
+  /**
+   * The category of the component
+   *
+   * @since 8.0.0
+   */
+  category?: string;
+}
+
+withDefaults(defineProps<MyComponentProps>(), {
+  category: 'Uncategorized',
+});
+</script>

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/define-props/component.vue
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/define-props/component.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <p>Name: {{ name }}</p>
+    <p>Category: {{ category }}</p>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  /** The name of the user */
+  name: { type: String, required: true },
+  /**
+   * The category of the component
+   *
+   * @since 8.0.0
+   */
+  category: { type: String, default: 'Uncategorized' },
+});
+</script>

--- a/docs/_snippets/vue-vite-framework-options.md
+++ b/docs/_snippets/vue-vite-framework-options.md
@@ -3,7 +3,7 @@ export default {
   framework: {
     name: '@storybook/vue3-vite',
     options: {
-      docgen: 'vue-component-meta',
+      docgen: 'vue-docgen-api',
     },
   },
 };
@@ -16,7 +16,7 @@ const config: StorybookConfig = {
   framework: {
     name: '@storybook/vue3-vite',
     options: {
-      docgen: 'vue-component-meta',
+      docgen: 'vue-docgen-api',
     },
   },
 };
@@ -31,7 +31,7 @@ export default defineMain({
   framework: {
     name: '@storybook/vue3-vite',
     options: {
-      docgen: 'vue-component-meta',
+      docgen: 'vue-docgen-api',
     },
   },
 });
@@ -46,7 +46,7 @@ export default defineMain({
   framework: {
     name: '@storybook/vue3-vite',
     options: {
-      docgen: 'vue-component-meta',
+      docgen: 'vue-docgen-api',
     },
   },
 });

--- a/docs/_snippets/vue3-vite-docgen-example.md
+++ b/docs/_snippets/vue3-vite-docgen-example.md
@@ -1,0 +1,50 @@
+```html filename="YourComponent.vue" language="ts" renderer="vue" tabTitle="Reactive Props Destructure"
+<script setup lang="ts">
+  interface MyComponentProps {
+    /** The name of the user */
+    name: string;
+    /**
+     * The category of the component
+     *
+     * @since 8.0.0
+     */
+    category?: string;
+  }
+
+  const { name, category = 'Uncategorized' } = defineProps<MyComponentProps>();
+</script>
+```
+
+```html filename="YourComponent.vue" language="ts" renderer="vue" tabTitle="withDefaults"
+<script setup lang="ts">
+  interface MyComponentProps {
+    /** The name of the user */
+    name: string;
+    /**
+     * The category of the component
+     *
+     * @since 8.0.0
+     */
+    category?: string;
+  }
+
+  withDefaults(defineProps<MyComponentProps>(), {
+    category: 'Uncategorized',
+  });
+</script>
+```
+
+```html filename="YourComponent.vue" language="js" renderer="vue" tabTitle="Runtime Prop Declaration"
+<script setup>
+  const props = defineProps({
+    /** The name of the user */
+    name: { type: String, required: true },
+    /**
+     * The category of the component
+     *
+     * @since 8.0.0
+     */
+    category: { type: String, default: 'Uncategorized' },
+  });
+</script>
+```

--- a/docs/_snippets/vue3-vite-vue-component-meta.md
+++ b/docs/_snippets/vue3-vite-vue-component-meta.md
@@ -1,0 +1,38 @@
+```js filename=".storybook/main.js" renderer="vue" language="js" tabTitle="CSF 3 JS"
+export default {
+  framework: {
+    name: '@storybook/vue3-vite',
+    options: {
+      docgen: 'vue-component-meta',
+    },
+  },
+};
+```
+
+```ts filename=".storybook/main.ts" renderer="vue" language="ts" tabTitle="CSF 3 TS"
+import type { StorybookConfig } from '@storybook/vue3-vite';
+
+const config: StorybookConfig = {
+  framework: {
+    name: '@storybook/vue3-vite',
+    options: {
+      docgen: 'vue-component-meta',
+    },
+  },
+};
+
+export default config;
+```
+
+```ts filename=".storybook/main.ts" renderer="vue" language="ts" tabTitle="CSF Next 🧪"
+import { defineMain } from '@storybook/vue3-vite/node';
+
+export default defineMain({
+  framework: {
+    name: '@storybook/vue3-vite',
+    options: {
+      docgen: 'vue-component-meta',
+    },
+  },
+});
+```

--- a/docs/get-started/frameworks/vue3-vite.mdx
+++ b/docs/get-started/frameworks/vue3-vite.mdx
@@ -71,28 +71,15 @@ setup((app) => {
 
 <Callout variant="info">
 
-`vue-component-meta` is only available in Storybook ≥ 8. It is currently an opt-in, but it will become the default in a future version of Storybook.
+`vue-component-meta` is enabled by default as of Storybook 10.5. In older versions, `vue-docgen-api` was the default.
 
 </Callout>
 
 [`vue-component-meta`](https://github.com/vuejs/language-tools/tree/master/packages/component-meta) is a tool maintained by the Vue team that extracts metadata from Vue components. Storybook can use it to generate the [controls](../../essentials/controls.mdx) for your stories and documentation. It's a more full-featured alternative to `vue-docgen-api` and is recommended for most projects.
 
-If you want to use `vue-component-meta`, you can configure it in your `.storybook/main.js|ts` file:
+If you want to use `vue-component-meta` in Storybook 10.4 or older, you can configure it in your `.storybook/main.js|ts` file:
 
-```ts title=".storybook/main.ts"
-import type { StorybookConfig } from '@storybook/vue3-vite';
-
-const config: StorybookConfig = {
-  framework: {
-    name: '@storybook/vue3-vite',
-    options: {
-      docgen: 'vue-component-meta',
-    },
-  },
-};
-
-export default config;
-```
+<CodeSnippets path="vue3-vite-vue-component-meta.md" />
 
 `vue-component-meta` comes with many benefits and enables more documentation features, such as:
 
@@ -106,24 +93,7 @@ It also supports both default and named component exports.
 
 To describe a prop, including tags, you can use JSDoc comments in your component's props definition:
 
-```html title="YourComponent.vue"
-<script setup lang="ts">
-  interface MyComponentProps {
-    /** The name of the user */
-    name: string;
-    /**
-     * The category of the component
-     *
-     * @since 8.0.0
-     */
-    category?: string;
-  }
-
-  withDefaults(defineProps<MyComponentProps>(), {
-    category: 'Uncategorized',
-  });
-</script>
-```
+<CodeSnippets path="vue3-vite-docgen-example.md" />
 
 The props definition above will generate the following controls:
 
@@ -244,6 +214,28 @@ This is not a limitation of Storybook, but how `vue-component-meta` works. For m
 </Callout>
 
 Otherwise, you might face missing component types/descriptions or unresolvable import aliases like `@/some/import`.
+
+### Using `vue-docgen-api`
+
+If you want to keep using `vue-docgen-api`, you can set it as your docgen tool in your `.storybook/main.js|ts` file:
+
+<CodeSnippets path="vue-vite-framework-options.md" />
+
+#### Troubleshooting
+
+##### The Storybook UI freezes and the dev server crashes
+
+If your Storybook UI freezes and the dev server crashes (often with a `JavaScript heap out of memory` error) when using `vue-component-meta`, the cause is likely a miscomputed project root. To extract component metadata, `vue-component-meta` builds a TypeScript program rooted at the directory Storybook detects as your project root. When that directory is correct, only your project's files are scanned and everything works as expected. When it resolves to a location higher up your file system, such as a parent folder or your home directory, the program scans far more files than intended and runs out of memory.
+
+Storybook detects the project root by first looking for a `.git` (or `.svn`/`.hg`) folder, then a lockfile (e.g. `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`), and finally falling back to the current working directory. When none of these markers sit at your project root, detection can land on the wrong directory.
+
+To confirm this is happening, start your Storybook and look at the dev server console output. When `vue-component-meta` is in use, Storybook logs the resolved project root and `tsconfig` path. If the reported project root doesn't point at your actual project, the detection is at fault, and you can fix it in one of the following ways:
+
+- Initialize a Git repository (run `git init`) or make sure a lockfile exists at your project root, so detection succeeds.
+- Set the `STORYBOOK_PROJECT_ROOT` environment variable to your project's absolute path to override auto-detection.
+- Point docgen at the correct configuration with the [`docgen.tsconfig` option](#override-the-default-configuration), so the TypeScript program is scoped to your project's `include`/`exclude`.
+
+If the reported project root is already correct but the program is still too large, [disable docgen](#when-to-disable-docgen) or increase Node's memory limit with `NODE_OPTIONS=--max-old-space-size=8192`.
 
 ## FAQ
 

--- a/docs/get-started/frameworks/vue3-vite.mdx
+++ b/docs/get-started/frameworks/vue3-vite.mdx
@@ -215,12 +215,6 @@ This is not a limitation of Storybook, but how `vue-component-meta` works. For m
 
 Otherwise, you might face missing component types/descriptions or unresolvable import aliases like `@/some/import`.
 
-### Using `vue-docgen-api`
-
-If you want to keep using `vue-docgen-api`, you can set it as your docgen tool in your `.storybook/main.js|ts` file:
-
-<CodeSnippets path="vue-vite-framework-options.md" />
-
 #### Troubleshooting
 
 ##### The Storybook UI freezes and the dev server crashes
@@ -236,6 +230,12 @@ To confirm this is happening, start your Storybook and look at the dev server co
 - Point docgen at the correct configuration with the [`docgen.tsconfig` option](#override-the-default-configuration), so the TypeScript program is scoped to your project's `include`/`exclude`.
 
 If the reported project root is already correct but the program is still too large, [disable docgen](#when-to-disable-docgen) or increase Node's memory limit with `NODE_OPTIONS=--max-old-space-size=8192`.
+
+### Using `vue-docgen-api`
+
+If you want to keep using `vue-docgen-api`, you can set it as your docgen tool in your `.storybook/main.js|ts` file:
+
+<CodeSnippets path="vue-vite-framework-options.md" />
 
 ## FAQ
 
@@ -273,7 +273,7 @@ Configure options for the [framework's builder](../../api/main-config/main-confi
 
 Type: `'vue-docgen-api' | 'vue-component-meta' | boolean`
 
-Default: `'vue-docgen-api'`
+Default: `'vue-component-meta'`
 
 Since: `8.0`
 

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -334,7 +334,13 @@ export const init: Task['run'] = async (
   }
 
   const nodeOptionsString = nodeOptions.join(' ');
-  const prefix = `NODE_OPTIONS='${nodeOptionsString}' STORYBOOK_TELEMETRY_URL="http://localhost:6007/event-log"`;
+  const prefix = [
+    `NODE_OPTIONS='${nodeOptionsString}'`,
+    `STORYBOOK_TELEMETRY_URL="http://localhost:6007/event-log"`,
+    // Pin the project root to the sandbox dir for templates that need it (e.g. vue-component-meta),
+    // since sandboxes have no `.git` marker and auto-detection could otherwise resolve too high.
+    ...(template.modifications?.setProjectRoot ? [`STORYBOOK_PROJECT_ROOT="${cwd}"`] : []),
+  ].join(' ');
 
   await updatePackageScripts({
     cwd,


### PR DESCRIPTION
## What I did

- Now using vue-component-meta as default docgen
- Added stories to prove we get the same docgen output for all 3 Vue prop syntaxes
- Switched the `vue3-vite/default-ts sandbox` to use vue-component-meta too
- Added `modifications.setProjectRoot` to the sandbox templates if you need to ensure the project root is well computed, for sandboxes with tooling that does a lot of file watching
- Updated framework docs accordingly :)

## Checklist for Contributors

### Testing


#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

No E2E tests added because this was all prompted by a need to give a contributor a working docgen algorithm so their existing, already written E2E tests on https://github.com/storybookjs/storybook/pull/34909 could work

Also I'm not sure how CI is gonna go considering I modified a sandbox. :face_with_spiral_eyes: 

#### Manual testing

* Build the Vue3 TS sandbox
* Visit the new stories
* Read the docs to spot any discrepancies

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

@shilman @jonniebigodes please LMK if you think switching a default deserves a mention in MIGRATION.md!

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `vue-component-meta` is now the default Vue 3 + Vite docgen option (enabled in v10.5+); `vue-docgen-api` remains available.
  * Sandbox templates can pin the detected project root to reduce large-tree docgen scanning.
* **Bug Fixes**
  * Improved robustness when building story args/globals URL parameters, preventing crashes or excessive processing with circular or extremely deep values.
* **Templates / Examples**
  * Added Vue 3 “component meta” example stories covering `defineProps`, destructured props, and default prop values.
* **Documentation**
  * Updated Vue 3 + Vite docgen snippets and the getting-started guide, including troubleshooting and guidance for opting into `vue-docgen-api`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->