### PR TITLE
Interactions: Prevent debugger controls from stealing focus

### DIFF
--- a/code/core/src/component-testing/components/Interaction.stories.tsx
+++ b/code/core/src/component-testing/components/Interaction.stories.tsx
@@ -87,6 +87,32 @@ export const Done: Story = {
   },
 };
 
+export const PreventsFocusLossOnPointerDown: Story = {
+  tags: ['vitest'],
+  args: Done.args,
+  render: (args) => (
+    <>
+      <li style={{ listStyleType: 'none', padding: 8 }}>
+        <input data-testid="test-input" />
+      </li>
+      <Interaction {...args} />
+    </>
+  ),
+  play: async ({ canvas }) => {
+    const input = canvas.getByTestId('test-input');
+    input.focus();
+    await expect(input).toHaveFocus();
+
+    await userEvent.pointer({
+      target: canvas.getByRole('button', {
+        name: 'Go to interaction row: toHaveBeenCalled. Status: passed.',
+      }),
+      keys: '[MouseLeft]',
+    });
+    await expect(input).toHaveFocus();
+  },
+};
+
 export const WithParent: Story = {
   args: {
     call: { ...getCalls(CallStates.DONE, -1)[0], ancestors: ['parent-id'] },

--- a/code/core/src/component-testing/components/Interaction.tsx
+++ b/code/core/src/component-testing/components/Interaction.tsx
@@ -274,6 +274,7 @@ export const Interaction = ({
           })}
           call={call}
           onClick={() => controls.goto(call.id)}
+          onPointerDown={(e) => e.preventDefault()}
           disabled={isNavigationDisabled}
           onMouseEnter={() => controlStates.goto && setIsHovered(true)}
           onMouseLeave={() => controlStates.goto && setIsHovered(false)}

--- a/code/core/src/component-testing/components/Toolbar.stories.tsx
+++ b/code/core/src/component-testing/components/Toolbar.stories.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
 
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
 import { action } from 'storybook/actions';
+import type { API } from 'storybook/manager-api';
+import { expect, userEvent } from 'storybook/test';
 
 import { Toolbar } from './Toolbar.tsx';
 
-export default {
+const api = {
+  openInEditor: action('openInEditor'),
+} as unknown as API;
+
+const meta = {
   title: 'Toolbar',
   component: Toolbar,
   parameters: {
@@ -28,10 +36,13 @@ export default {
       end: false,
     },
     storyFileName: 'Toolbar.stories.tsx',
-    hasNext: true,
-    hasPrevious: true,
+    api,
   },
-};
+} satisfies Meta<typeof Toolbar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
 
 export const Wait = {
   args: {
@@ -147,5 +158,47 @@ export const WithOpenInEditorLink = {
       end: false,
     },
     canOpenInEditor: true,
+  },
+};
+
+export const PreventsFocusLossOnPointerDown: Story = {
+  tags: ['vitest'],
+  render: (args) => (
+    <>
+      <input data-testid="test-input" style={{ display: 'block', marginBottom: 8 }} />
+      <Toolbar {...args} />
+    </>
+  ),
+  args: {
+    status: 'playing',
+    onScrollToEnd: action('scrollToEnd'),
+    controlStates: {
+      detached: false,
+      start: true,
+      back: true,
+      goto: true,
+      next: true,
+      end: true,
+    },
+  },
+  play: async ({ canvas }) => {
+    const input = canvas.getByTestId('test-input');
+    input.focus();
+    await expect(input).toHaveFocus();
+
+    for (const name of [
+      'Scroll to end',
+      'Go to start',
+      'Go back',
+      'Go forward',
+      'Go to end',
+      'Rerun',
+    ]) {
+      await userEvent.pointer({
+        target: canvas.getByRole('button', { name }),
+        keys: '[MouseLeft]',
+      });
+      await expect(input).toHaveFocus();
+    }
   },
 };

--- a/code/core/src/component-testing/components/Toolbar.tsx
+++ b/code/core/src/component-testing/components/Toolbar.tsx
@@ -115,6 +115,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   const buttonText = status === 'errored' ? 'Scroll to error' : 'Scroll to end';
   const theme = useTheme();
 
+  const preventFocusLoss = (e: React.PointerEvent) => e.preventDefault();
+
   return (
     <ToolbarWrapper>
       <SharedToolbar
@@ -125,7 +127,12 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         <ControlsGroup>
           <StatusBadge status={status} />
 
-          <JumpToEndButton ariaLabel={false} onClick={onScrollToEnd} disabled={!onScrollToEnd}>
+          <JumpToEndButton
+            ariaLabel={false}
+            onClick={onScrollToEnd}
+            onPointerDown={preventFocusLoss}
+            disabled={!onScrollToEnd}
+          >
             {buttonText}
           </JumpToEndButton>
 
@@ -136,6 +143,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             variant="ghost"
             ariaLabel="Go to start"
             onClick={controls.start}
+            onPointerDown={preventFocusLoss}
             disabled={!controlStates.start}
           >
             <RewindIcon />
@@ -146,6 +154,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             variant="ghost"
             ariaLabel="Go back"
             onClick={controls.back}
+            onPointerDown={preventFocusLoss}
             disabled={!controlStates.back}
           >
             <PlayBackIcon />
@@ -156,6 +165,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             variant="ghost"
             ariaLabel="Go forward"
             onClick={controls.next}
+            onPointerDown={preventFocusLoss}
             disabled={!controlStates.next}
           >
             <PlayNextIcon />
@@ -166,12 +176,19 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             variant="ghost"
             ariaLabel="Go to end"
             onClick={controls.end}
+            onPointerDown={preventFocusLoss}
             disabled={!controlStates.end}
           >
             <FastForwardIcon />
           </StyledIconButton>
 
-          <RerunButton padding="small" variant="ghost" ariaLabel="Rerun" onClick={controls.rerun}>
+          <RerunButton
+            padding="small"
+            variant="ghost"
+            ariaLabel="Rerun"
+            onClick={controls.rerun}
+            onPointerDown={preventFocusLoss}
+          >
             <SyncIcon />
           </RerunButton>
         </ControlsGroup>


### PR DESCRIPTION
Closes #21259

## What I did

This PR prevents the interactions debugger controls from stealing focus from elements inside the story canvas.

When users debug interaction tests step by step, clicking the debugger controls currently moves focus away from the element under test. This makes it difficult to debug flows where focus is part of the expected behavior, such as keyboard navigation, focused inputs, or assertions written with Testing Library.

Implementation:

- Added `event.preventDefault()` on the `pointerdown` event for the interactions debugger toolbar controls.
- Applied the same focus-preserving behavior to the interaction row navigation button.
- Preserved the existing `click` behavior for all debugger controls, so the controls still start, step backward, step forward, jump, rerun, and navigate as before.
- Added Storybook Vitest-covered stories that verify focused elements keep focus after pointer interaction with:
  - toolbar debugger controls
  - interaction row navigation

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### CI status note

The TypeScript errors in `Toolbar.stories.tsx` were fixed and pushed.

At the time of the previous CI run, the remaining failures appeared unrelated to this PR:

- `lint:fmt` was missing from `code/package.json`.
- `nextjs-vite` failed in files outside this PR.
- The Svelte parser tests timed out.

This PR only changes files under `code/core/src/component-testing/components`.

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Run the internal Storybook UI:

   ```sh
   cd code
   yarn storybook:ui
   ```

2. Open Storybook in the browser.

3. Navigate to the `Toolbar / Prevents Focus Loss On Pointer Down` story.

4. Focus the input rendered above the interactions toolbar.

5. Click each debugger control: `Scroll to end`, `Go to start`, `Go back`, `Go forward`, `Go to end`, and `Rerun`.

6. Confirm that focus remains on the input after each click.

7. Navigate to the `Interaction / Prevents Focus Loss On Pointer Down` story.

8. Focus the input rendered above the interaction row.

9. Click the interaction row navigation button.

10. Confirm that focus remains on the input.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation updates were needed. This change only adjusts the runtime behavior of existing interactions debugger controls and adds regression coverage.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focus loss when interacting with row navigation and toolbar controls.

* **Tests**
  * Added test coverage for focus preservation during component interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->