### PR TITLE
Docs: Deprecate ExternalDocs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,10 @@
 <h1>Migration</h1>
 
+- [From version 10.4.0 to 10.5.0](#from-version-1040-to-1050)
+  - [ExternalDocs and ExternalDocsContainer are deprecated](#externaldocs-and-externaldocscontainer-are-deprecated)
 - [From version 10.3.0 to 10.4.0](#from-version-1030-to-1040)
   - [React Native: on-device addons moved to `deviceAddons`](#react-native-on-device-addons-moved-to-deviceaddons)
-  - [TanStack React: migrate from `@storybook/react-vite` to `@storybook/tanstack-react`](#tanstack-router-projects-migrate-from-storybookreact-vite-to-storybooktanstack-react)
+  - [TanStack Router projects: migrate from `@storybook/react-vite` to `@storybook/tanstack-react`](#tanstack-router-projects-migrate-from-storybookreact-vite-to-storybooktanstack-react)
 - [From version 10.0.0 to 10.1.0](#from-version-1000-to-1010)
   - [API and Component Changes](#api-and-component-changes)
     - [Button Component API Changes](#button-component-api-changes)
@@ -522,6 +524,14 @@
   - [Webpack upgrade](#webpack-upgrade)
   - [Packages renaming](#packages-renaming)
   - [Deprecated embedded addons](#deprecated-embedded-addons)
+
+## From version 10.4.0 to 10.5.0
+
+### ExternalDocs and ExternalDocsContainer are deprecated
+
+The `ExternalDocs` and `ExternalDocsContainer` components from `@storybook/addon-docs` are deprecated and will be removed in Storybook 11. These components allowed rendering Storybook docs pages outside of the Storybook UI, but the approach was never stabilized and is redundant with other embedding options.
+
+If you are currently using `ExternalDocs` or `ExternalDocsContainer`, please open an issue describing your use case so the team can consider alternative solutions.
 
 ## From version 10.3.0 to 10.4.0
 

--- a/code/addons/docs/src/blocks/blocks/external/ExternalDocs.tsx
+++ b/code/addons/docs/src/blocks/blocks/external/ExternalDocs.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from 'react';
 import React, { useRef } from 'react';
 
+import { deprecate } from 'storybook/internal/client-logger';
 import type { ProjectAnnotations, Renderer } from 'storybook/internal/types';
 
 import { composeConfigs } from 'storybook/preview-api';
@@ -27,6 +28,7 @@ export function ExternalDocs<TRenderer extends Renderer = Renderer>({
   projectAnnotationsList,
   children,
 }: PropsWithChildren<ExternalDocsProps<TRenderer>>) {
+  deprecate(`ExternalDocs is deprecated and will be removed in Storybook 11.`);
   const projectAnnotations = composeConfigs<TRenderer>(projectAnnotationsList);
   const preview = usePreview<TRenderer>(projectAnnotations);
   const docsParameter = {

--- a/code/addons/docs/src/blocks/blocks/external/ExternalDocsContainer.tsx
+++ b/code/addons/docs/src/blocks/blocks/external/ExternalDocsContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { deprecate } from 'storybook/internal/client-logger';
 import type { Renderer } from 'storybook/internal/types';
 
 import { ThemeProvider, ensure, themes } from 'storybook/theming';
@@ -12,6 +13,7 @@ let preview: ExternalPreview<Renderer>;
 export const ExternalDocsContainer: React.FC<
   React.PropsWithChildren<{ projectAnnotations: any }>
 > = ({ projectAnnotations, children }) => {
+  deprecate(`ExternalDocsContainer is deprecated and will be removed in Storybook 11.`);
   if (!preview) {
     preview = new ExternalPreview(projectAnnotations);
   }


### PR DESCRIPTION
## What I did
Deprecated ExternalDocs, as per internal team discussions.

## Checklist for Contributors


#### Manual testing

* Try to render ExternalDocs in a side project
* Notice the deprecation warning
workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * ExternalDocs and ExternalDocsContainer components are now deprecated and scheduled for removal in Storybook 11.

* **Documentation**
  * Updated migration guide with new section documenting the transition path for version 10.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->