### PR TITLE
Viewport: Fix toolbar button not highlighting when custom viewport is active

### DIFF
--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -66,6 +66,14 @@ export interface SelectProps extends Omit<
   /** IDs of the preselected options. */
   defaultOptions?: Value | Value[];
 
+  /**
+   * If true, the Select renders in a "has selection" visual state even if the
+   * current value does not match any of the options. Useful when a consumer has
+   * an active selection that is not part of the option list (e.g. a custom
+   * viewport in the viewport toolbar). Does not change selection behavior.
+   */
+  hasSelection?: boolean;
+
   /** Whether the Select should render open. */
   defaultOpen?: boolean;
 
@@ -206,6 +214,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       disabled = false,
       options: calleeOptions,
       defaultOptions,
+      hasSelection: hasSelectionOverride,
       multiSelect = false,
       onReset,
       padding = 'small',
@@ -509,7 +518,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
           ref={triggerRef}
           padding={padding}
           $isOpen={isOpen}
-          $hasSelection={!!selectedOptions.length}
+          $hasSelection={hasSelectionOverride ?? !!selectedOptions.length}
           // Can be removed once #32325 is fixed (Button will then provide aria-disabled)
           aria-disabled={disabled}
           disabled={disabled}

--- a/code/core/src/viewport/components/Tool.tsx
+++ b/code/core/src/viewport/components/Tool.tsx
@@ -20,7 +20,16 @@ const Dimensions = styled.div(({ theme }) => ({
 }));
 
 export const ViewportTool = () => {
-  const { name, value, isDefault, isLocked, options: viewportMap, reset, select } = useViewport();
+  const {
+    name,
+    value,
+    isDefault,
+    isCustom,
+    isLocked,
+    options: viewportMap,
+    reset,
+    select,
+  } = useViewport();
 
   const options = useMemo(
     () =>
@@ -48,7 +57,8 @@ export const ViewportTool = () => {
       ariaLabel={isLocked ? 'Viewport size set by story parameters' : 'Viewport size'}
       ariaDescription="Select a viewport among predefined options for the preview area, or reset to the default viewport."
       tooltip={isLocked ? 'Viewport set by story parameters' : 'Change viewport'}
-      defaultOptions={value}
+      defaultOptions={isCustom ? undefined : value}
+      hasSelection={isCustom || !isDefault}
       options={options}
       onSelect={(selected) => select(selected as string)}
       icon={<GrowIcon />}


### PR DESCRIPTION
## Summary

Fixes #35067.

The Viewport Select button only rendered the active highlight when the current viewport value matched one of the predefined options. When a user customized the viewport (e.g. via `440-355`), the button stayed in its inactive state because the custom value is not in the options list, so `selectedOptions` was empty and `$hasSelection` was false on the styled button.

## Changes

- Add an optional `hasSelection` override prop on `Select` (in `code/core/src/components/components/Select/Select.tsx`) that lets consumers force the active visual state even when the current value is not in the option list. The prop defaults to the existing internal calculation, so behavior is unchanged for callers that do not pass it.
- In `ViewportTool`, pass `hasSelection={isCustom || !isDefault}` so the button is highlighted whenever the viewport is not the default `Responsive` state.
- Switch `defaultOptions` to `undefined` when the value is custom, since the custom string (e.g. `440-355`) is not a valid option id and `setSelectedFromDefault` would have filtered it out anyway.

### Manual testing

1. Open any Storybook story in the `story` view mode.
2. Open the **Viewport** toolbar dropdown and select any preset (e.g. "iPhone 14").
3. Confirm the toolbar button is highlighted/active (blue tint background).
4. Now open the **Viewport** panel and manually enter a custom width and height (e.g. 440×355).
5. Before this fix: the toolbar button goes back to unhighlighted even though a non-default viewport is set.
6. After this fix: the toolbar button remains highlighted when a custom viewport is active.
7. Clicking "Reset viewport" should return the button to its inactive (default) state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Select component now correctly displays selection indicators for custom configurations
  * Viewport tool provides improved visual feedback for custom or non-default viewport selections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
