### PR TITLE
Manager: Keep local preview iframe on host URL when a ref story loads first

### DIFF
--- a/code/core/src/manager/components/preview/FramesRenderer.stories.tsx
+++ b/code/core/src/manager/components/preview/FramesRenderer.stories.tsx
@@ -4,16 +4,19 @@ import { expect, fn } from 'storybook/test';
 import preview from '../../../../../.storybook/preview.tsx';
 import { FramesRenderer } from './FramesRenderer.tsx';
 
-const refId = 'composed-ref';
-const refUrl = 'https://composed-ref.example';
+// Use the `Icons` composed ref that this Storybook already references, so the active ref frame
+// renders a real story instead of a non-existent URL.
+const refId = 'icons';
+const refUrl = 'https://main--64b56e737c0aeefed9d5e675.chromatic.com';
+const storyId = 'icons-accessibilityicon--default';
 
 // getStoryHrefs returns the composed ref's iframe URL whenever a refId is passed, so we can
 // assert the local preview frame is requested without one (mirrors manager-api/url.ts).
-const getStoryHrefs = fn((storyId: string, opts?: { refId?: string }) => ({
+const getStoryHrefs = fn((id: string, opts?: { refId?: string }) => ({
   managerHref: '',
   previewHref: opts?.refId
-    ? `${refUrl}/iframe.html?id=${storyId}&refId=${opts.refId}`
-    : `iframe.html?id=${storyId}`,
+    ? `${refUrl}/iframe.html?id=${id}&refId=${opts.refId}`
+    : `iframe.html?id=${id}`,
 })).mockName('api::getStoryHrefs');
 
 const api: any = {
@@ -33,7 +36,7 @@ const api: any = {
 };
 
 const managerContext: any = {
-  state: { storyId: 'button--primary' },
+  state: { storyId },
   api,
 };
 
@@ -42,14 +45,14 @@ const meta = preview.meta({
   args: {
     api,
     refId,
-    storyId: 'button--primary',
+    storyId,
     viewMode: 'story',
     scale: 1,
     baseUrl: 'iframe.html',
     queryParams: {},
-    entry: { type: 'story', id: 'button--primary' } as any,
+    entry: { type: 'story', id: storyId } as any,
     refs: {
-      [refId]: { id: refId, url: refUrl, type: 'lazy', title: 'Composed ref' },
+      [refId]: { id: refId, url: refUrl, type: 'lazy', title: 'Icons' },
     } as any,
   },
   decorators: [
@@ -74,6 +77,6 @@ export const RefStoryKeepsLocalPreviewOnHost = meta.story({
 
     const src = localFrame?.getAttribute('src') ?? '';
     await expect(src).not.toContain(refUrl);
-    await expect(src).toContain('iframe.html?id=button--primary');
+    await expect(src).toContain(`iframe.html?id=${storyId}`);
   },
 });

--- a/code/core/src/manager/components/preview/FramesRenderer.stories.tsx
+++ b/code/core/src/manager/components/preview/FramesRenderer.stories.tsx
@@ -1,0 +1,79 @@
+import { ManagerContext } from 'storybook/manager-api';
+import { expect, fn } from 'storybook/test';
+
+import preview from '../../../../../.storybook/preview.tsx';
+import { FramesRenderer } from './FramesRenderer.tsx';
+
+const refId = 'composed-ref';
+const refUrl = 'https://composed-ref.example';
+
+// getStoryHrefs returns the composed ref's iframe URL whenever a refId is passed, so we can
+// assert the local preview frame is requested without one (mirrors manager-api/url.ts).
+const getStoryHrefs = fn((storyId: string, opts?: { refId?: string }) => ({
+  managerHref: '',
+  previewHref: opts?.refId
+    ? `${refUrl}/iframe.html?id=${storyId}&refId=${opts.refId}`
+    : `iframe.html?id=${storyId}`,
+})).mockName('api::getStoryHrefs');
+
+const api: any = {
+  getStoryHrefs,
+  getIsFullscreen: fn(() => false),
+  getIsNavShown: fn(() => true),
+  getCurrentParameter: fn(() => undefined),
+  getGlobals: fn(() => ({})),
+  getStoryGlobals: fn(() => ({})),
+  getUserGlobals: fn(() => ({})),
+  getUrlState: fn(() => ({ viewMode: 'story' })),
+  updateGlobals: fn(),
+  setAddonShortcut: fn(),
+  on: fn(),
+  off: fn(),
+  emit: fn(),
+};
+
+const managerContext: any = {
+  state: { storyId: 'button--primary' },
+  api,
+};
+
+const meta = preview.meta({
+  component: FramesRenderer,
+  args: {
+    api,
+    refId,
+    storyId: 'button--primary',
+    viewMode: 'story',
+    scale: 1,
+    baseUrl: 'iframe.html',
+    queryParams: {},
+    entry: { type: 'story', id: 'button--primary' } as any,
+    refs: {
+      [refId]: { id: refId, url: refUrl, type: 'lazy', title: 'Composed ref' },
+    } as any,
+  },
+  decorators: [
+    (Story) => (
+      <ManagerContext.Provider value={managerContext}>
+        <Story />
+      </ManagerContext.Provider>
+    ),
+  ],
+  parameters: { layout: 'fullscreen' },
+});
+
+/**
+ * Regression test for #34553: when a composed-ref story is the initial selection, the local
+ * preview frame must still point at the host's own iframe URL. Otherwise the local frame
+ * stays stuck on the ref's Storybook (it is only set once) and host stories never render.
+ */
+export const RefStoryKeepsLocalPreviewOnHost = meta.story({
+  play: async ({ canvasElement }) => {
+    const localFrame = canvasElement.querySelector<HTMLIFrameElement>('#storybook-preview-iframe');
+    await expect(localFrame).not.toBeNull();
+
+    const src = localFrame?.getAttribute('src') ?? '';
+    await expect(src).not.toContain(refUrl);
+    await expect(src).toContain('iframe.html?id=button--primary');
+  },
+});

--- a/code/core/src/manager/components/preview/FramesRenderer.tsx
+++ b/code/core/src/manager/components/preview/FramesRenderer.tsx
@@ -69,9 +69,12 @@ export const FramesRenderer: FC<FramesRendererProps> = ({
   }, {});
 
   if (!frames['storybook-preview-iframe']) {
+    // Always build the local preview iframe from the host's own URL. Passing `refId` here
+    // makes getStoryHrefs return the composed ref's iframe URL, and since this is only set
+    // once, the local frame would stay stuck on the ref's Storybook when a ref story is
+    // loaded first — so host stories could never render afterwards (#34553).
     frames['storybook-preview-iframe'] = api.getStoryHrefs(storyId, {
       queryParams: { ...queryParams, ...(version && { version }) },
-      refId,
       viewMode,
     }).previewHref;
   }

--- a/code/core/src/manager/components/preview/FramesRenderer.tsx
+++ b/code/core/src/manager/components/preview/FramesRenderer.tsx
@@ -69,12 +69,13 @@ export const FramesRenderer: FC<FramesRendererProps> = ({
   }, {});
 
   if (!frames['storybook-preview-iframe']) {
-    // Always build the local preview iframe from the host's own URL. Passing `refId` here
-    // makes getStoryHrefs return the composed ref's iframe URL, and since this is only set
-    // once, the local frame would stay stuck on the ref's Storybook when a ref story is
-    // loaded first — so host stories could never render afterwards (#34553).
+    // The local preview iframe must always use the host's own URL, so pass `refId: undefined`
+    // explicitly. Passing the current story's `refId` makes getStoryHrefs return the composed
+    // ref's iframe URL, and since this is only set once, the local frame would stay stuck on
+    // the ref's Storybook when a ref story is loaded first (#34553).
     frames['storybook-preview-iframe'] = api.getStoryHrefs(storyId, {
       queryParams: { ...queryParams, ...(version && { version }) },
+      refId: undefined,
       viewMode,
     }).previewHref;
   }


### PR DESCRIPTION
Closes #34553

## What I did

Follow-up to #35050. That PR fixed Controls for stories from a composed ref, but surfaced a separate, pre-existing bug: after loading a composed-ref story first, navigating to a host story left the host preview stuck (`Couldn't find story matching id …` → spinner), so host stories never rendered and their Controls stayed in the loading state.

The root cause is in `FramesRenderer`. The local preview frame is initialized once, and since v10.3.0 (the `getStoryHrefs` refactor, `2a864fdb`) that init passes the current story's `refId`:

```ts
frames['storybook-preview-iframe'] = api.getStoryHrefs(storyId, { queryParams, refId, viewMode }).previewHref;
```

For a non-empty `refId`, `getStoryHrefs` returns the ref's iframe URL, so on a ref-first load the local frame is pointed at the composed ref's Storybook and — because it is only set once (the `if (!frames[...])` guard) — never re-pointed. Host stories can then never load. Host-first avoids it because the first call has no `refId`.

This drops `refId` from that one call so the local preview frame always uses the host's own iframe URL (the behavior before v10.3.0), and adds a story covering it. Verified on the repro that ref-first → host renders correctly, with host-first still working.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Request a canary for this PR (see below) and point a composed-ref repro at it — e.g. https://github.com/Sidnioulz/storybook-35050-repro, or the `storybook-refs-issue.zip` from #34553.
2. Build and serve it, then open the host Storybook.
3. Deep-link/refresh directly on a composed-ref story (e.g. `?path=/story/react_my-button--default`). Its Controls should load.
4. Navigate to a host story. It should render and its Controls should load (before this fix the canvas stayed on a spinner / `Couldn't find story matching id …`).
5. Reload on a host story first, then navigate to a ref story — both keep working (this path was already fine; it confirms no regression).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35078-sha-e5f7408f`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35078-sha-e5f7408f sandbox` or in an existing project with `npx storybook@0.0.0-pr-35078-sha-e5f7408f upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35078-sha-e5f7408f`](https://npmjs.com/package/storybook/v/0.0.0-pr-35078-sha-e5f7408f) |
| **Triggered by** | @Sidnioulz |
| **Repository** | [TheSeydiCharyyev/storybook](https://github.com/TheSeydiCharyyev/storybook) |
| **Branch** | [`fix/framesrenderer-ref-first-host-preview`](https://github.com/TheSeydiCharyyev/storybook/tree/fix/framesrenderer-ref-first-host-preview) |
| **Commit** | [`e5f7408f`](https://github.com/TheSeydiCharyyev/storybook/commit/e5f7408fb770d91fabf019833bbb7a524f2b283e) |
| **Datetime** | Sat Jun  6 12:05:25 UTC 2026 (`1780747525`) |
| **Workflow run** | [27061821162](https://github.com/storybookjs/storybook/actions/runs/27061821162) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35078`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preview frame no longer navigates to a referenced Storybook instance when selecting composed-reference stories; it stays on the host preview URL and preserves expected local iframe parameters.

* **Tests**
  * Added a Storybook regression interaction test that verifies the preview remains on the host environment for composed-reference stories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->