### PR TITLE
fix(viewport): highlight toolbar button for custom viewports

### DIFF
--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -85,6 +85,7 @@ export interface SelectProps extends Omit<
    * @default true
    */
   showSelectedOptionTitle?: boolean;
+  active?: boolean;
 }
 
 function valueToId(parentId: string, { value }: InternalOption | ResetOption): string {
@@ -216,6 +217,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       tooltip,
       ariaLabel,
       showSelectedOptionTitle = true,
+      active = false,
       ...props
     },
     ref
@@ -253,6 +255,10 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
     const [selectedOptions, setSelectedOptions] = useState<InternalOption[]>(
       setSelectedFromDefault(calleeOptions, defaultOptions)
     );
+
+    useEffect(() => {
+      setSelectedOptions(setSelectedFromDefault(calleeOptions, defaultOptions));
+    }, [defaultOptions, calleeOptions]);
 
     // Selects an option (updating the selection state based on multiSelect).
     const handleSelectOption = useCallback(
@@ -318,11 +324,6 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
     // For instance, when a URL query param is passed for the theme addon, the
     // addon receives, undefined, then the default theme value (incorrectly),
     // then the actual URL query param as a selected theme.
-    useEffect(() => {
-      if (defaultOptions) {
-        setSelectedOptions(setSelectedFromDefault(calleeOptions, defaultOptions));
-      }
-    }, [defaultOptions, calleeOptions]);
 
     // The active option in the listbox, which will receive focus when the listbox is open.
     const [activeOption, setActiveOptionState] = useState<InternalOption | ResetOption | undefined>(
@@ -509,7 +510,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
           ref={triggerRef}
           padding={padding}
           $isOpen={isOpen}
-          $hasSelection={!!selectedOptions.length}
+          $hasSelection={!!selectedOptions.length || active}
           // Can be removed once #32325 is fixed (Button will then provide aria-disabled)
           aria-disabled={disabled}
           disabled={disabled}

--- a/code/core/src/viewport/components/Tool.tsx
+++ b/code/core/src/viewport/components/Tool.tsx
@@ -20,7 +20,7 @@ const Dimensions = styled.div(({ theme }) => ({
 }));
 
 export const ViewportTool = () => {
-  const { name, value, isDefault, isLocked, options: viewportMap, reset, select } = useViewport();
+  const { name, value, isDefault, isLocked, options: viewportMap, reset, select, isCustom } = useViewport();
 
   const options = useMemo(
     () =>
@@ -48,10 +48,11 @@ export const ViewportTool = () => {
       ariaLabel={isLocked ? 'Viewport size set by story parameters' : 'Viewport size'}
       ariaDescription="Select a viewport among predefined options for the preview area, or reset to the default viewport."
       tooltip={isLocked ? 'Viewport set by story parameters' : 'Change viewport'}
-      defaultOptions={value}
+      defaultOptions={isCustom ? undefined : value}
       options={options}
       onSelect={(selected) => select(selected as string)}
       icon={<GrowIcon />}
+      active={!isDefault}
     >
       {isDefault ? null : name}
     </Select>


### PR DESCRIPTION
## What does this PR do?
Fixes the Viewport toolbar button not highlighting when a 
custom viewport is selected.

## Steps to reproduce
1. Open any story
2. Click viewport tool in toolbar
3. Select a preset viewport
4. Customize the viewport size manually
5. Observe toolbar button loses highlight (bug)

## Changes made
- Tool.tsx: destructure isCustom, pass active={!isDefault} to Select
- Select.tsx: add active prop, sync selectedOptions on defaultOptions change

Fixes #35067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Select component state synchronization to better track available options
  * Enhanced handling of custom viewport selections for more reliable state management

* **New Features**
  * Added optional active state support for Select component to improve UI feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->