### PR TITLE
Telemetry: Add timeout to event-log POST to prevent build hang

### DIFF
--- a/code/core/src/telemetry/telemetry.test.ts
+++ b/code/core/src/telemetry/telemetry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
 import { fetch } from './fetch.ts';
 import { sendTelemetry } from './telemetry.ts';
@@ -22,6 +22,10 @@ beforeEach(() => {
   fetchMock.mockResolvedValue({ status: 200 } as any);
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 it('makes a fetch request with name and data', async () => {
   await sendTelemetry({ eventType: 'dev', payload: { foo: 'bar' } });
 
@@ -31,6 +35,45 @@ it('makes a fetch request with name and data', async () => {
     eventType: 'dev',
     payload: { foo: 'bar' },
   });
+});
+
+it('abandons a request that never responds, instead of hanging the process', async () => {
+  const controller = new AbortController();
+  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+
+  // fetch that never settles on its own - it only rejects once its signal aborts, which we control via the timeoutSpy above.
+  fetchMock.mockImplementation(
+    (_url, init) =>
+      new Promise((_resolve, reject) => {
+        const signal = (init as RequestInit | undefined)?.signal;
+        if (signal?.aborted) {
+          reject(signal.reason);
+        } else {
+          signal?.addEventListener('abort', () => reject(signal.reason));
+        }
+      })
+  );
+
+  let settled = false;
+  const promise = sendTelemetry({ eventType: 'dev', payload: { foo: 'bar' } }).finally(() => {
+    settled = true;
+  });
+
+  // Let the request reach its in-flight state.
+  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+  expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+  expect(settled).toBe(false);
+
+  // Abort the request, simulating the timeout expiring. This should cause the promise to reject and the sendTelemetry
+  // call to settle, instead of hanging indefinitely.
+  controller.abort();
+
+  await promise;
+
+  expect(settled).toBe(true);
+
+  // Ensure the aborted request is not retried
+  expect(fetchMock).toHaveBeenCalledTimes(1);
 });
 
 it('retries if fetch fails with a 503', async () => {

--- a/code/core/src/telemetry/telemetry.ts
+++ b/code/core/src/telemetry/telemetry.ts
@@ -66,18 +66,28 @@ const prepareRequest = async (data: TelemetryData, context: Record<string, any>,
   const sessionId = await getSessionId();
   const eventId = nanoid();
   const body = { ...rest, eventType, eventId, sessionId, metadata, payload, context };
+  const signal = AbortSignal.timeout(30_000);
+  const maxRetries = 3;
 
   return retryingFetch(URL, {
     method: 'post',
     body: JSON.stringify(body),
     headers: { 'Content-Type': 'application/json' },
-    retries: 3,
-    retryOn: [503, 504],
     retryDelay: (attempt: number) =>
       2 ** attempt *
       (typeof options?.retryDelay === 'number' && !Number.isNaN(options?.retryDelay)
         ? options.retryDelay
         : 1000),
+    retryOn: (attempt, error, response) => {
+      // If explicitly aborted (e.g. by the timeout above), or if we've exhausted our retries, give up.
+      if (signal.aborted || attempt >= maxRetries) {
+        return false;
+      }
+
+      // Retry transient network errors and server-overload responses.
+      return Boolean(error) || response?.status === 503 || response?.status === 504;
+    },
+    signal,
   });
 };
 


### PR DESCRIPTION
Closes #35084 (and likely the root cause of #29828).

## What I did

`storybook build` can hang after compiling: the post-build telemetry POST is a `fetch` with no timeout, so a stalled connection to the event-log endpoint never settles, the awaited call never returns, and the open socket keeps the event loop alive — the CLI never exits. (`try/catch` can't catch a non-rejection; `fetch-retry` only retries a *settled* attempt.)

Time-box the request in `prepareRequest` (`core/src/telemetry/telemetry.ts`):

1. **Timeout** — `signal: AbortSignal.timeout(30_000)`, created once so it bounds the whole request.
2. **Stop retrying on abort** — `retryOn` becomes a function returning `false` once `signal.aborted`. Otherwise `fetch-retry` treats the `AbortError` as retryable and burns the 1s/2s/4s backoff on instant-aborting attempts (~37s, not 30s). The function also bounds attempts explicitly (`attempt >= maxRetries`), which the array form did implicitly.

```ts
const signal = AbortSignal.timeout(30_000);
const maxRetries = 3;

return retryingFetch(URL, {
  method: 'post',
  body: JSON.stringify(body),
  headers: { 'Content-Type': 'application/json' },
  retryDelay: (attempt) => 2 ** attempt * (options?.retryDelay ?? 1000),
  retryOn: (attempt, error, response) => {
    if (signal.aborted || attempt >= maxRetries) return false;
    return Boolean(error) || response?.status === 503 || response?.status === 504;
  },
  signal,
});
```

503/504 and transient errors still retry; `sendTelemetry` already swallows errors, so a timed-out event is just dropped — no user-visible change.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`core/src/telemetry/telemetry.test.ts` adds a regression test: a fetch that only settles once aborted is abandoned after the timeout and **not retried** (exactly one attempt). Existing 503/give-up tests still pass.

#### Manual testing

The repro ships this exact change as a patch, so you can see before/after on the released build:

```bash
git clone https://github.com/badams/storybook-telemetry-hang-repro
cd storybook-telemetry-hang-repro && npm install   # unpatched storybook 10.4.1

# blackhole endpoint: accepts the connection, never replies
node -e 'require("net").createServer(s => s.on("data", () => {})).listen(9999)' &

# 1. Before — reproduce the hang
STORYBOOK_TELEMETRY_URL=http://localhost:9999/event-log npx storybook build
#    → compiles, then stalls instead of exiting (ctrl-C to stop)

# 2. Apply this fix (patches/storybook+10.4.1.patch == the change in this PR)
npx patch-package

# 3. After — same command now exits
STORYBOOK_TELEMETRY_URL=http://localhost:9999/event-log npx storybook build
#    → aborts the telemetry POST at 30s and exits cleanly
```

### Documentation

- [ ] No documentation change needed (internal bugfix).

## Notes

- `AbortSignal.timeout()` needs Node ≥17.3; Storybook requires Node ≥20.
- Scope: time-boxes the event-log POST only; other telemetry fetches (version-check / notify) are a follow-up.
- Suggested label: `bug`.

---

*Disclosure (per CONTRIBUTING.md): I used Claude heavily for the investigation, reproduction, and fix — all under my direction and review. Happy to go deeper on any of it.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry requests now include a 30-second timeout to prevent indefinite hangs and improve application responsiveness.
  * Improved retry behavior to handle transient network errors and temporary server issues more effectively.

* **Tests**
  * Added comprehensive test coverage to verify telemetry requests complete properly without hanging or unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->