### PR TITLE
Viewport: Warn when legacy `defaultViewport` parameter is used

### DIFF
--- a/code/core/src/viewport/useViewport.ts
+++ b/code/core/src/viewport/useViewport.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
+import { deprecate } from 'storybook/internal/client-logger';
 import type { Globals } from 'storybook/internal/csf';
 
 import { useGlobals, useParameter, useStorybookApi } from 'storybook/manager-api';
@@ -156,6 +157,17 @@ export const useViewport = () => {
 
   const parameter = useParameter<ViewportParameters['viewport']>(PARAM_KEY);
   const [globals, updateGlobals, storyGlobals, userGlobals] = useGlobals();
+
+  useEffect(() => {
+    if (parameter && 'defaultViewport' in parameter) {
+      const value = (parameter as { defaultViewport?: unknown }).defaultViewport;
+      deprecate(
+        `The \`viewport.defaultViewport\` parameter was removed in Storybook 10. ` +
+          `Use \`globals: { viewport: ${JSON.stringify(value)} }\` instead, ` +
+          `or run \`npx storybook automigrate\` to update your code automatically.`
+      );
+    }
+  }, [parameter]);
 
   const { options = MINIMAL_VIEWPORTS, disable = false } = parameter || {};
   const { name, type, width, height, value, option, isCustom, isDefault, isLocked, isRotated } =


### PR DESCRIPTION

Closes #15923

## What I did

When the viewport addon was rewritten for Storybook 10, `parameters.viewport.defaultViewport` was replaced by `globals.viewport`. The old parameter is no longer read anywhere in `code/core/src/viewport/`, so existing user code that still sets it silently does nothing — no warning, no error. This produces the exact symptom described in #15923 (and in the comments from people on v7/v8/v9), even though the original `useEffect` state-sync bug is long gone.

This PR adds a one-time deprecation warning in `useViewport` when the legacy parameter is detected. The warning quotes the value that was set and tells the user to either switch to `globals.viewport` or run `npx storybook automigrate`, which already knows how to perform the migration.

Behavior is otherwise unchanged: no runtime fallback, no extra side effects.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

> The change is a single `deprecate()` call wired to a `useEffect` that reads a parameter; happy to add a unit test for `useViewport` if a maintainer prefers — let me know which test file fits best.

#### Manual testing

1. In any Storybook 10 project, create a story that uses the legacy parameter:
   ```ts
   export const Mobile = {
     parameters: { viewport: { defaultViewport: 'mobile1' } },
   };
   ```
2. Start the dev server (`yarn storybook` / `npm run storybook`).
3. Open that story and open the browser DevTools console.
4. **Expected:** a single warning appears, e.g.
   > The `viewport.defaultViewport` parameter was removed in Storybook 10. Use `globals: { viewport: "mobile1" }` instead, or run `npx storybook automigrate` to update your code automatically.
5. Change the story to use the new API:
   ```ts
   export const Mobile = {
     globals: { viewport: 'mobile1' },
   };
   ```
6. **Expected:** no warning, and the preview now shrinks to the mobile viewport.

The warning uses Storybook's existing `deprecate()` helper, so it is de-duplicated per unique message string.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

> The parameter itself was removed in an earlier PR; this only surfaces a runtime warning, so docs and MIGRATION.md should already cover the rename. Happy to add a note if maintainers prefer.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

> Suggested label: `bug` (turns a silent failure into a clear, actionable warning).

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a deprecation warning for the `viewport.defaultViewport` configuration option in Storybook 10. Users are advised to migrate to `globals: { viewport: ... }` or run the `storybook automigrate` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->