### PR TITLE
Viewport: Fix toolbar button not highlighting when custom viewport is active

### DIFF
--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -66,6 +66,14 @@ export interface SelectProps extends Omit<
   /** IDs of the preselected options. */
   defaultOptions?: Value | Value[];
 
+  /**
+   * If true, the Select renders in a "has selection" visual state even if the
+   * current value does not match any of the options. Useful when a consumer has
+   * an active selection that is not part of the option list (e.g. a custom
+   * viewport in the viewport toolbar). Does not change selection behavior.
+   */
+  hasSelection?: boolean;
+
   /** Whether the Select should render open. */
   defaultOpen?: boolean;
 
@@ -206,6 +214,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       disabled = false,
       options: calleeOptions,
       defaultOptions,
+      hasSelection: hasSelectionOverride,
       multiSelect = false,
       onReset,
       padding = 'small',
@@ -509,7 +518,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
           ref={triggerRef}
           padding={padding}
           $isOpen={isOpen}
-          $hasSelection={!!selectedOptions.length}
+          $hasSelection={hasSelectionOverride ?? !!selectedOptions.length}
           // Can be removed once #32325 is fixed (Button will then provide aria-disabled)
           aria-disabled={disabled}
           disabled={disabled}

--- a/code/core/src/viewport/components/Tool.tsx
+++ b/code/core/src/viewport/components/Tool.tsx
@@ -20,7 +20,16 @@ const Dimensions = styled.div(({ theme }) => ({
 }));
 
 export const ViewportTool = () => {
-  const { name, value, isDefault, isLocked, options: viewportMap, reset, select } = useViewport();
+  const {
+    name,
+    value,
+    isDefault,
+    isCustom,
+    isLocked,
+    options: viewportMap,
+    reset,
+    select,
+  } = useViewport();
 
   const options = useMemo(
     () =>
@@ -48,7 +57,8 @@ export const ViewportTool = () => {
       ariaLabel={isLocked ? 'Viewport size set by story parameters' : 'Viewport size'}
       ariaDescription="Select a viewport among predefined options for the preview area, or reset to the default viewport."
       tooltip={isLocked ? 'Viewport set by story parameters' : 'Change viewport'}
-      defaultOptions={value}
+      defaultOptions={isCustom ? undefined : value}
+      hasSelection={isCustom || !isDefault}
       options={options}
       onSelect={(selected) => select(selected as string)}
       icon={<GrowIcon />}


### PR DESCRIPTION
## Summary

Fixes #35067.

When a custom viewport is selected (e.g. via the viewport panel's width/height inputs), the toolbar viewport Select button stays in its inactive/unhighlighted state. This happens because the custom viewport value (e.g. `440-355`) does not match any predefined option in the Select's options list, so `selectedOptions` is empty and `$hasSelection` is false on the styled button.

## Changes

- **`Select.tsx`**: Add an optional `hasSelection` override prop that lets consumers force the active visual state even when the current value doesn't match any option. Defaults to the existing internal calculation (`!!selectedOptions.length`), so behavior is unchanged for all other callers.
- **`Tool.tsx`**: 
  - Destructure `isCustom` from `useViewport()`.
  - Pass `hasSelection={isCustom || !isDefault}` so the button highlights whenever a non-default viewport is active.
  - Set `defaultOptions={isCustom ? undefined : value}` since the custom value string is not a valid option id.

#### Manual testing

1. Open any Storybook story in the **story** view mode.
2. Open the **Viewport** toolbar dropdown and select any preset (e.g. "iPhone 14"). Confirm the toolbar button is highlighted/active.
3. Now open the **Viewport** panel and manually enter a custom width and height (e.g. 440x355).
4. **Before this fix**: the toolbar button goes back to unhighlighted even though a non-default viewport is set.
5. **After this fix**: the toolbar button remains highlighted when a custom viewport is active.
6. Clicking "Reset viewport" should return the button to its inactive (default) state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the select component with improved visual state handling, allowing selection indicators to display independently from actual selections. This provides more flexible UI control and improved clarity in viewport configurations and other complex selection scenarios where visual state should reflect user intent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
