### PR TITLE
Tools: Add agent skills and Claude skill pointers

### DIFF
--- a/.agents/skills/handle-pr-comments/SKILL.md
+++ b/.agents/skills/handle-pr-comments/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: handle-pr-comments
+description: Triage and resolve GitHub PR review comments one by one, interactively. Use when the user asks to handle, address, respond to, or resolve PR review comments, or mentions reviewer feedback on a pull request.
+---
+
+# Handle PR Comments
+
+Evaluate review comments on the PR (from the current branch, or a PR number/URL if given). For each unresolved comment: summarize the feedback, suggest a resolution, ask the user how to resolve it, apply their choice, commit if needed, and resolve the thread.
+
+1. **Find the PR.** Use the given number/URL, else derive it from the current branch (`gh pr view`). Stop if no PR exists.
+
+2. **Fetch unresolved review threads** via the GraphQL `reviewThreads` field on the pull request — request each thread's `id`, `isResolved`, `isOutdated`, `path`, `line`, and comments. Filter to `isResolved == false`. (Use GraphQL, not REST: only it exposes thread `id`s and resolution state.)
+
+3. **Loop one comment at a time.** For each: (a) summarize the feedback + file/line, reading surrounding code; (b) suggest a concrete fix; (c) ask via AskQuestion with options — apply suggested fix / apply a different fix / reply only / skip; (d) apply the choice; (e) if applicable, summarize what was changed and ask whether to commit; (f) resolve the thread via the GraphQL `resolveReviewThread` mutation. 
+
+4. **Report** an overview of what was changed, committed, replied to, skipped, and resolved. Include links.
+
+## Notes
+
+- Handle real-user comments before addressing AI agents' (Copilot, CodeRabbit).
+- Group duplicate comments; when the same/similar issue is mentioned multiple times, handle them all at once.
+- Make a separate commit for each change.

--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: open-pr
+description: Opens a pull request from the current branch using the PR template. Use when the user asks to open a PR, create a pull request, or invokes /open-pr.
+allowed-tools: Bash, Read, AskQuestion
+---
+
+# Open Pull Request
+
+Opens a draft PR from the current branch following Storybook conventions.
+
+## Workflow
+
+### 1. Gather context
+
+Run in parallel: `git status`, `git diff`, `git log --oneline <base>...HEAD` (after step 2), `git branch -vv`.
+
+Push first if needed: `git push -u origin HEAD`.
+
+### 2. Detect base branch
+
+```bash
+git fetch origin
+bash .agents/skills/open-pr/scripts/detect-base-branch.sh
+```
+
+Detects base in order: tracked upstream → reflog checkout source → closest `origin/*` ancestor (fewest commits from branch tip to HEAD). Supports telescoped/stacked PRs off feature branches, not only `next`/`main`. Skips branches at the same commit as HEAD. Tie-break: feature branch over trunk, then `next` over `main`. Falls back to `next`. Tell the user the result.
+
+### 3. Ask for labels
+
+Use **AskQuestion** for three questions. Options from `.github/PULL_REQUEST_TEMPLATE.md`:
+
+| Question | Options |
+| -------- | ------- |
+| CI label | `ci:normal`, `ci:merged`, `ci:daily` |
+| QA label | `qa:needed`, `qa:skip` |
+| Type label | `bug`, `maintenance`, `dependencies`, `build`, `cleanup`, `documentation`, `feature request`, `BREAKING CHANGE`, `other` |
+
+Verify the available labels with the PR template.
+
+### 4. Draft title and body
+
+**Title:** `[Area]: [Description]` — see the `pr` skill for format and examples.
+
+**Body:** Read `.github/PULL_REQUEST_TEMPLATE.md`. Copy it **exactly** (keep all HTML comments). Fill in:
+
+- `Closes #` when an issue is linked
+- **What I did**
+- Testing checkboxes and mandatory manual-testing steps (or state why none is needed)
+- Documentation checkboxes when applicable
+- Leave maintainer checklist items unchecked
+
+### 5. Create the PR
+
+```bash
+gh pr create \
+  --draft \
+  --base "<detected-base>" \
+  --title "<Area>: <Description>" \
+  --body "$(cat <<'EOF'
+<FILLED_TEMPLATE>
+EOF
+)" \
+  --assignee @me \
+  --label "<type>,<ci>,<qa>"
+```
+
+### 6. Report and offer canary
+
+Share the PR URL. Then **AskQuestion**: "Do you want to create a canary release for this PR?"
+
+- **Yes** — run `/canary <PR_NUMBER>` and report workflow status
+- **No** — stop
+
+## Notes
+
+- Always draft; always assign `@me`.
+- For canary details after publishing, see the `canary` skill.

--- a/.agents/skills/open-pr/scripts/detect-base-branch.sh
+++ b/.agents/skills/open-pr/scripts/detect-base-branch.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Pick the remote branch the current branch most likely forked from.
+# Supports telescoped/stacked PRs by scanning all origin/* ancestors.
+set -euo pipefail
+
+current_branch=$(git branch --show-current)
+head_tip=$(git rev-parse HEAD)
+best=""
+min_commits=999999
+best_is_feature=0
+
+is_trunk() {
+  case "$1" in
+    main | next) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+normalize_branch_name() {
+  local name=$1
+  name=${name#origin/}
+  name=${name#remotes/origin/}
+  echo "${name}"
+}
+
+branch_exists_on_origin() {
+  git rev-parse --verify "origin/$1" >/dev/null 2>&1
+}
+
+is_valid_base() {
+  local branch=$1
+  local ref="origin/${branch}"
+
+  [ "${branch}" != "${current_branch}" ] || return 1
+  branch_exists_on_origin "${branch}" || return 1
+
+  local branch_tip
+  branch_tip=$(git rev-parse "${ref}")
+  [ "${branch_tip}" != "${head_tip}" ] || return 1
+  git merge-base --is-ancestor "${ref}" HEAD 2>/dev/null
+}
+
+commit_count_since() {
+  git rev-list --count "origin/$1..HEAD"
+}
+
+consider() {
+  local branch=$1
+  local commit_count=$2
+
+  if ! is_valid_base "${branch}"; then
+    return
+  fi
+
+  local is_feature=0
+  is_trunk "${branch}" || is_feature=1
+
+  if [ -z "${best}" ]; then
+    best=${branch}
+    min_commits=${commit_count}
+    best_is_feature=${is_feature}
+    return
+  fi
+
+  if [ "${commit_count}" -lt "${min_commits}" ]; then
+    best=${branch}
+    min_commits=${commit_count}
+    best_is_feature=${is_feature}
+    return
+  fi
+
+  if [ "${commit_count}" -gt "${min_commits}" ]; then
+    return
+  fi
+
+  # Tie: prefer telescoped parent over trunk, then next over main.
+  if [ "${best_is_feature}" -eq 0 ] && [ "${is_feature}" -eq 1 ]; then
+    best=${branch}
+    best_is_feature=${is_feature}
+    return
+  fi
+
+  if [ "${best_is_feature}" -eq 1 ] && [ "${is_feature}" -eq 0 ]; then
+    return
+  fi
+
+  if [ "${branch}" = "next" ]; then
+    best=${branch}
+    best_is_feature=${is_feature}
+  fi
+}
+
+try_explicit_base() {
+  local branch=$1
+  branch=$(normalize_branch_name "${branch}")
+  consider "${branch}" "$(commit_count_since "${branch}")"
+}
+
+# 1. Tracked upstream (set when branching with -u or --track)
+if upstream=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null); then
+  try_explicit_base "${upstream}"
+fi
+
+# 2. Reflog: most recent branch we checked out from
+if [ -z "${best}" ]; then
+  while IFS= read -r line; do
+    if [[ ${line} =~ checkout:\ moving\ from\ (.+)\ to\ ${current_branch} ]]; then
+      try_explicit_base "${BASH_REMATCH[1]}"
+      break
+    fi
+    if [[ ${line} =~ branch:\ Created\ from\ (.+) ]]; then
+      try_explicit_base "${BASH_REMATCH[1]}"
+      break
+    fi
+  done < <(git reflog show --format='%gs' "${current_branch}" 2>/dev/null || true)
+fi
+
+# 3. Scan all origin/* branches — closest strict ancestor wins
+while IFS= read -r ref; do
+  branch=${ref#origin/}
+
+  if [ "${branch}" = "HEAD" ] || [ "${branch}" = "${current_branch}" ]; then
+    continue
+  fi
+
+  if ! is_valid_base "${branch}"; then
+    continue
+  fi
+
+  consider "${branch}" "$(commit_count_since "${branch}")"
+done < <(git for-each-ref --format='%(refname:short)' refs/remotes/origin/)
+
+if [ -z "${best}" ]; then
+  best="next"
+fi
+
+echo "${best}"

--- a/.agents/skills/rebuild-restart-storybook/SKILL.md
+++ b/.agents/skills/rebuild-restart-storybook/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: rebuild-restart-storybook
+description: Rebuild and restart the internal Storybook UI after changes to internal Storybook code (core, addons, frameworks, renderers, libs, etc.), then optionally display a UI review. Use after editing any package in the Storybook monorepo's code/ directory, or when the user asks to rebuild and/or restart Storybook.
+allowed-tools: Bash, Read
+---
+
+# Rebuild and Restart Storybook
+
+After making changes to internal Storybook code (core, addons or otherwise), follow this workflow.
+
+## Step 1: Ask whether to rebuild and restart (in case of model invocation)
+
+Unless the user explicitly ran `/rebuild-restart-storybook`, ask the user whether they want to rebuild and restart Storybook. If they decline, stop here.
+
+## Step 2: Determine modified packages
+
+Build a space-separated list of the monorepo packages that were modified in the conversation. For each modified package, find its Nx project name in the `project.json` file in that package's directory (the `name` field), not the `package.json` name.
+
+For example, if `code/addons/review` and `code/addons/vitest` were modified, the list is `addon-review addon-vitest`.
+
+## Step 3: Run the build and start commands in sequence
+
+Run these in the `code` directory, in order. Substitute `<extra packages>` with the list from Step 2.
+
+```bash
+rm -rf node_modules/.cache
+yarn
+yarn build storybook <extra packages>
+```
+
+Then, run in the background:
+
+```bash
+NODE_OPTIONS="--preserve-symlinks" yarn storybook:ui --no-open
+```
+
+### Handle an occupied port
+
+A Storybook may already be running. If the port is occupied, cancel the start, kill the old process to free the port, then start Storybook again.
+
+## Step 4: Provide the URL and ask about a review
+
+Once Storybook has started, give the user the URL. Then ask whether they want to display a review.
+
+## Step 5: Display the review
+
+If the user wants a review, use Storybook's `display-review` MCP tool to create a UI review of relevant stories. Pick a set of stories related to the entirety of the conversation so far.
+
+If there are no relevant stories because no UI elements were touched, ask the user what they would like to see a review for.

--- a/.agents/skills/storybook-startup-benchmark/SKILL.md
+++ b/.agents/skills/storybook-startup-benchmark/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: storybook-startup-benchmark
+description: Measure Storybook startup time from spawning `storybook dev` until the first story renders in the browser. Use when the user asks about Storybook boot time, server-ready timing, first story render timing, startup regressions, benchmarking with repeat runs, or comparing Storybook versions or feature flags.
+allowed-tools: Bash, Read
+---
+
+# Storybook Startup Benchmark
+
+## Purpose
+
+Use this skill to build or explain a repeatable benchmark for Storybook startup:
+
+- `server`: process spawn -> Storybook server responds
+- `browser`: server responds -> first story rendered
+- `total`: process spawn -> first story rendered
+
+## Quick Start
+
+When asked to benchmark Storybook startup:
+
+1. Confirm the boundary:
+   - Start timing immediately before spawning `storybook dev`
+   - Open Storybook at `/`, not `iframe.html`
+   - Stop timing on first story mount plus one `requestAnimationFrame()`
+2. Check whether the repo already has a benchmark script. Reuse it if possible.
+3. If not, create a Node script that:
+   - starts Storybook with `--no-open`
+   - waits for the server to respond
+   - launches a browser it controls
+   - waits for a preview-side render signal
+   - prints JSON results
+4. Add `--repeat <count>` support with grouped summary stats.
+
+## Measurement Rules
+
+Use these defaults unless the user asks otherwise:
+
+- Start URL: `/`
+- Browser path: normal manager page, let Storybook load the preview iframe itself
+- Render signal: first preview story mount + one `requestAnimationFrame()`
+- Browser launch: external harness launches the browser, not Storybook
+- Auto-open: disable Storybook browser auto-open with `storybook dev --no-open`
+
+Do not measure only CLI output. Server listening is not the same as first story rendered.
+
+## Recommended Implementation
+
+### 1. Preview-side signal
+
+Add a small global preview decorator or component that runs once on the first story mount:
+
+- wait one `requestAnimationFrame()`
+- set a global value like `window.__sbStartupBenchmark`
+- also mirror that value to `window.top` when same-origin
+- optionally call `performance.mark('sb:first-story-rendered')`
+
+Preferred payload:
+
+```ts
+{
+  firstStoryRenderedAt: performance.now(),
+  storyId: id
+}
+```
+
+### 2. Harness behavior
+
+The benchmark script should:
+
+1. Fail fast if the target Storybook port is already in use
+2. Spawn Storybook with `--no-open`
+3. Start timing immediately before spawn
+4. Wait for HTTP readiness on the Storybook URL
+5. Launch a controlled browser to `/`
+6. Wait for the preview-side signal
+7. Print JSON results
+8. Kill the full spawned process group during cleanup
+
+### 3. Repeated runs
+
+For `--repeat N`, print:
+
+- per-run results
+- summary stats grouped by `server`, `browser`, and `total`
+- human-readable durations like `5.2s` or `2m15s`, not raw millisecond field names
+
+Recommended summary fields:
+
+```json
+{
+  "server": {
+    "average": "5.2s",
+    "min": "4.8s",
+    "max": "6.1s",
+    "p95": "6.0s"
+  },
+  "browser": {
+    "average": "1.9s",
+    "min": "1.6s",
+    "max": "2.4s",
+    "p95": "2.3s"
+  },
+  "total": {
+    "average": "7.1s",
+    "min": "6.6s",
+    "max": "8.2s",
+    "p95": "8.1s"
+  }
+}
+```
+
+## Interpretation Guidance
+
+Use these heuristics when explaining results:
+
+- If `server` grows, the regression is likely on the server/build side.
+- If `browser` grows, the regression is likely in manager boot, preview boot, or first-story render.
+- If averages are close but `p95` grows a lot, the feature likely increases variability or tail latency.
+- If newer Storybook without a feature is much faster than older Storybook, but enabling the feature returns timings to older levels, the feature likely erases the newer startup gains.
+
+## Common Pitfalls
+
+- Existing Storybook already running on the benchmark port
+- Storybook auto-opening a separate browser window
+- Measuring direct `iframe.html` loads instead of normal `/`
+- Leaving child Storybook processes alive between runs
+- Treating warm repeated runs as cold-start data
+
+If a repeated benchmark reports unrealistically low `server.average`, first check for a stale Storybook server on the same port.
+
+## Tooling Notes
+
+- Prefer a plain Node script for portability.
+- For Chrome-family browsers, remote debugging is a practical control path.
+- If Storybook CLI flags or behavior are in question, fetch current Storybook docs first.
+
+## Output Style
+
+When reporting results:
+
+- clearly separate `server`, `browser`, and `total`
+- call out averages and p95 first, with min/max as supporting bounds
+- highlight whether the regression affects common-case latency, tail latency, or both
+- avoid claiming root cause unless the benchmark isolates server vs render behavior
+
+## Example Triggers
+
+Use this skill when the user says things like:
+
+- "How can I test Storybook startup time?"
+- "Measure from `storybook dev` to first story render"
+- "Compare Storybook startup with and without this feature flag"
+- "Run 20 startup measurements and summarize averages"
+- "Is this startup regression server-side or render-side?"

--- a/.agents/skills/update-pr-description/SKILL.md
+++ b/.agents/skills/update-pr-description/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: update-pr-description
+description: Evaluate a PR's title and description against its actual implementation, then iteratively suggest and apply updates. Use when the user asks to check, fix, or update a PR title or description.
+---
+
+# Update PR Description
+
+## Workflow
+
+1. **Resolve the PR.** Use the number/URL the user provided. If none, look up the PR for the current branch with `gh pr view`.
+2. **Gather evidence:**
+   - `gh pr view <pr> --json title,body`
+   - `gh pr view <pr> --json commits` (commit messages)
+   - `gh pr diff <pr>` (full diff against base)
+3. **Evaluate divergence.** Compare the stated title/description against what the commits and diff actually do. Only flag *meaningful* divergence (wrong scope, missing major changes, stale claims, inaccurate summary). Ignore trivial wording.
+4. **Report.** Tell the user whether the title and/or description meaningfully diverges. If not, stop here.
+5. **Suggest iteratively.** Propose concrete updated title/description. Ask the user one change at a time whether to apply, accept edits, and refine.
+6. **Apply.** Once agreed, update on the user's behalf with `gh pr edit <pr> --title ... --body ...`.
+
+## Notes
+
+- Match the repository's existing PR template/style if the body uses one.
+- Don't rewrite a description that's already accurate.
+- Update the state of checkboxes where appropriate.
+- Remove section placeholders/reminders when filling out a section.

--- a/.agents/skills/update-pr-description/SKILL.md
+++ b/.agents/skills/update-pr-description/SKILL.md
@@ -23,3 +23,4 @@ description: Evaluate a PR's title and description against its actual implementa
 - Don't rewrite a description that's already accurate.
 - Update the state of checkboxes where appropriate.
 - Remove section placeholders/reminders when filling out a section.
+- Do not remove the canary release section.

--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/docs-review/SKILL.md

--- a/.claude/skills/fix-linting-types-on-pr/SKILL.md
+++ b/.claude/skills/fix-linting-types-on-pr/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/fix-linting-types-on-pr/SKILL.md

--- a/.claude/skills/handle-pr-comments/SKILL.md
+++ b/.claude/skills/handle-pr-comments/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/handle-pr-comments/SKILL.md

--- a/.claude/skills/minor-release/SKILL.md
+++ b/.claude/skills/minor-release/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/minor-release/SKILL.md

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/open-pr/SKILL.md

--- a/.claude/skills/rebuild-restart-storybook/SKILL.md
+++ b/.claude/skills/rebuild-restart-storybook/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/rebuild-restart-storybook/SKILL.md

--- a/.claude/skills/storybook-startup-benchmark/SKILL.md
+++ b/.claude/skills/storybook-startup-benchmark/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/storybook-startup-benchmark/SKILL.md

--- a/.claude/skills/update-pr-description/SKILL.md
+++ b/.claude/skills/update-pr-description/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/update-pr-description/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,9 @@ code/core/report
 
 .junie
 CLAUDE.local.md
-.claude
+.claude/*
+!.claude/skills/
+!.claude/skills/**
 .cursor/mcp.json
 .vscode/mcp.json
 .mcp.json


### PR DESCRIPTION
## Summary

- Add four new agent skills: `handle-pr-comments`, `rebuild-restart-storybook`, `storybook-startup-benchmark`, and `update-pr-description`
- Add matching `.claude/skills` pointer files for those skills and for existing skills that were missing pointers (`docs-review`, `fix-linting-types-on-pr`, `minor-release`)
- Update `.gitignore` so `.claude/skills` remains trackable while the rest of `.claude` stays ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-assisted workflows to open draft pull requests, triage and resolve PR review comments, update PR descriptions using collected evidence, rebuild/restart the Storybook UI, and benchmark Storybook startup performance.
* **Chores**
  * Consolidated skill documentation by linking Claude skill entries to the shared shared skill definitions.
  * Updated ignore rules so Claude metadata is ignored except for published skill documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->