### PR TITLE
Vitest: Forward skipTags to CSF factory child tests

### DIFF
--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -1133,6 +1133,55 @@ describe('transformer', () => {
     });
 
     describe('tags filtering mechanism', () => {
+      it('should pass skip tags to testStory call of child tests using tags.skip', async () => {
+        const code = `
+          import { config } from '#.storybook/preview';
+          const meta = config.meta({});
+          export const Primary = meta.story({});
+          Primary.test("foo", () => {});
+        `;
+
+        const result = await transform({
+          code,
+          tagsFilter: {
+            include: [],
+            exclude: [],
+            skip: ['skip', 'custom-skip'],
+          },
+        });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, expect as _expect, describe as _describe } from "vitest";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          import { config } from '#.storybook/preview';
+          const meta = config.meta({
+            title: "automatic/calculated/title"
+          });
+          export const Primary = meta.story({});
+          Primary.test("foo", () => {});
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            _describe("Primary  ", () => {
+              _test("base story", _testStory({
+                exportName: "Primary",
+                story: Primary,
+                meta: meta,
+                skipTags: ["skip","custom-skip"],
+                storyId: "automatic-calculated-title--primary"
+              }));
+              _test("foo", _testStory({
+                exportName: "Primary",
+                story: Primary,
+                meta: meta,
+                skipTags: ["skip","custom-skip"],
+                storyId: "automatic-calculated-title--primary:foo",
+                testName: "foo"
+              }));
+            });
+          }
+        `);
+      });
+
       it('should only include stories from tags.include', async () => {
         const code = `
         import { config } from '#.storybook/preview';

--- a/code/frameworks/nextjs-vite/src/index.ts
+++ b/code/frameworks/nextjs-vite/src/index.ts
@@ -5,8 +5,6 @@ import type { ReactPreview } from '@storybook/react';
 import { __definePreview } from '@storybook/react';
 import type { ReactTypes } from '@storybook/react';
 
-import type vitePluginStorybookNextJs from 'vite-plugin-storybook-nextjs';
-
 import * as nextPreview from './preview.tsx';
 import type { NextJsTypes } from './types.ts';
 
@@ -14,12 +12,6 @@ export * from '@storybook/react';
 // @ts-expect-error (double exports)
 export * from './portable-stories.ts';
 export * from './types.ts';
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-declare module '@storybook/nextjs-vite/vite-plugin' {
-  export const storybookNextJsPlugin: typeof vitePluginStorybookNextJs;
-}
 
 export function definePreview<Addons extends PreviewAddon<never>[]>(
   preview: { addons?: Addons } & ProjectAnnotations<ReactTypes & NextJsTypes & InferTypes<Addons>>

--- a/code/frameworks/nextjs-vite/src/vite-plugin/index.ts
+++ b/code/frameworks/nextjs-vite/src/vite-plugin/index.ts
@@ -1,7 +1,8 @@
+import type vitePluginStorybookNextJs from 'vite-plugin-storybook-nextjs';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
 const vitePluginStorybookNextjs = require('vite-plugin-storybook-nextjs');
 
-export const storybookNextJsPlugin = vitePluginStorybookNextjs;
+export const storybookNextJsPlugin = vitePluginStorybookNextjs as typeof vitePluginStorybookNextJs;


### PR DESCRIPTION
Relates to #30119

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->
CSF factory child tests (created via `.test()`) were hardcoding `skipTags` to an empty array literal (`[]`) in the Vitest AST transformer. This caused stories with `skip` tags or global skip filters to be executed anyway during the test suite execution.

I updated the AST transformer to correctly forward the calculated `skipTagsId` to the child tests' `testStory` call arguments.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Clone the reproduction repository: `https://github.com/kwonoj/csf-test-skip`
2. Run `yarn test-storybook` (uses `@storybook/addon-vitest`)
3. Verify that 2 tests are marked as skipped (the story with the `skip` tag and the `.test()` child with the `skip` tag). Currently, without this fix, only the base story is skipped while the child test fails.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for CSF Factories tags filtering to ensure skip tags are propagated to child test cases and generated story/test IDs remain consistent.
* **Chores**
  * Cleaned up TypeScript typing around the Next.js + Vite integration and plugin exports; no runtime or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->