### PR TITLE
Preview: Stop mixed CSF3+4 stories getting core annotations injected twice

### DIFF
--- a/code/core/src/csf/core-annotations.test.ts
+++ b/code/core/src/csf/core-annotations.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getCoreAnnotations,
+  hasCoreAnnotations,
+  markAsComposedWithCoreAnnotations,
+} from './core-annotations.ts';
+
+describe('core annotations marker', () => {
+  it('marks an object as composed with core annotations', () => {
+    const annotations = { decorators: [] };
+    expect(hasCoreAnnotations(annotations)).toBe(false);
+
+    const marked = markAsComposedWithCoreAnnotations(annotations);
+    expect(marked).toBe(annotations);
+    expect(hasCoreAnnotations(annotations)).toBe(true);
+  });
+
+  it('uses a non-enumerable marker so it is not copied by object spread', () => {
+    const marked = markAsComposedWithCoreAnnotations({ decorators: [] });
+
+    // The marker must not leak into composed configs / spreads
+    expect(Object.keys(marked)).toEqual(['decorators']);
+    expect(hasCoreAnnotations({ ...marked })).toBe(false);
+  });
+
+  it('returns false for non-objects', () => {
+    expect(hasCoreAnnotations(undefined)).toBe(false);
+    expect(hasCoreAnnotations(null)).toBe(false);
+    expect(hasCoreAnnotations('preview')).toBe(false);
+    expect(hasCoreAnnotations(42)).toBe(false);
+  });
+
+  it('exposes the core annotations as an array', () => {
+    const core = getCoreAnnotations();
+    expect(Array.isArray(core)).toBe(true);
+    expect(core.length).toBeGreaterThan(0);
+  });
+});

--- a/code/core/src/csf/core-annotations.ts
+++ b/code/core/src/csf/core-annotations.ts
@@ -30,6 +30,42 @@ export type CoreTypes = StorybookTypes &
   TestTypes &
   ViewportTypes;
 
+/**
+ * Marker used to flag a project-annotations object that has *already* had the core annotations
+ * composed into it (e.g. the `composed` result of a CSF4 `definePreview`). Consumers that would
+ * otherwise prepend {@link getCoreAnnotations} (the `StoryStore` and the portable
+ * `setProjectAnnotations`) check for this marker so that core annotations are injected exactly once,
+ * avoiding doubled decorators/loaders/beforeEach/beforeAll.
+ *
+ * We use `Symbol.for` (the global symbol registry) rather than a unique `Symbol()` so that the same
+ * marker resolves across the duplicate ESM/CJS module instances that exist in dev — the annotation
+ * might be flagged by one instance and read by another. A plain `Symbol()` would be a different
+ * value per module instance and would not be detected. The symbol is also namespaced (no collision
+ * with user annotation fields) and hidden from enumeration/JSON/string-spread.
+ */
+const CORE_ANNOTATIONS_COMPOSED = Symbol.for('storybook.internal.composedWithCoreAnnotations');
+
+/** Flag a project-annotations object as already containing the core annotations. */
+export function markAsComposedWithCoreAnnotations<T extends object>(annotations: T): T {
+  // Keep the marker non-enumerable so it is not copied by object spread or composed configs.
+  Object.defineProperty(annotations, CORE_ANNOTATIONS_COMPOSED, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  return annotations;
+}
+
+/** Whether a project-annotations object already contains the core annotations. */
+export function hasCoreAnnotations(annotations: unknown): boolean {
+  return (
+    annotations != null &&
+    typeof annotations === 'object' &&
+    (annotations as Record<symbol, unknown>)[CORE_ANNOTATIONS_COMPOSED] === true
+  );
+}
+
 export function getCoreAnnotations() {
   return [
     // @ts-expect-error CJS fallback

--- a/code/core/src/csf/csf-factories.test.ts
+++ b/code/core/src/csf/csf-factories.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, expectTypeOf, test, vi } from 'vitest';
 import { testType } from 'type-plus';
 
+import { getCoreAnnotations, hasCoreAnnotations } from './core-annotations.ts';
 import { definePreview, definePreviewAddon, getStoryChildren } from './csf-factories.ts';
 import type { Tag } from './story.ts';
 
@@ -76,6 +77,22 @@ describe('test function', () => {
     // execute test
     await test.run();
     expect(testFn).toHaveBeenCalled();
+  });
+});
+
+describe('definePreview composed', () => {
+  test('composes the core annotations exactly once and marks the result', () => {
+    const previewFactory = definePreview({ renderToCanvas: () => {} });
+    const { composed } = previewFactory;
+
+    // The composed result must be flagged so that the StoryStore / portable setProjectAnnotations
+    // do not prepend the core annotations a second time (which would double decorators/loaders).
+    expect(hasCoreAnnotations(composed)).toBe(true);
+
+    // The core annotations are present (the actions/test addons contribute loaders unconditionally).
+    const coreLoaderCount = getCoreAnnotations().flatMap((it) => (it as any).loaders ?? []).length;
+    expect(coreLoaderCount).toBeGreaterThan(0);
+    expect(composed.loaders).toHaveLength(coreLoaderCount);
   });
 });
 

--- a/code/core/src/csf/csf-factories.ts
+++ b/code/core/src/csf/csf-factories.ts
@@ -21,7 +21,7 @@ import {
 } from '../preview-api/index.ts';
 import { mountDestructured } from '../preview-api/modules/preview-web/render/mount-utils.ts';
 import { Tag } from '../shared/constants/tags.ts';
-import { getCoreAnnotations } from './core-annotations.ts';
+import { getCoreAnnotations, markAsComposedWithCoreAnnotations } from './core-annotations.ts';
 
 export interface Preview<TRenderer extends Renderer = Renderer> {
   readonly _tag: 'Preview';
@@ -54,8 +54,12 @@ export function definePreview<TRenderer extends Renderer, Addons extends Preview
         return composed;
       }
       const { addons, ...rest } = input;
-      composed = normalizeProjectAnnotations<TRenderer & InferTypes<Addons>>(
-        composeConfigs([...getCoreAnnotations(), ...(addons ?? []), rest])
+      // The composed result already includes the core annotations. Mark it so that downstream
+      // consumers (StoryStore / portable setProjectAnnotations) don't prepend them a second time.
+      composed = markAsComposedWithCoreAnnotations(
+        normalizeProjectAnnotations<TRenderer & InferTypes<Addons>>(
+          composeConfigs([...getCoreAnnotations(), ...(addons ?? []), rest])
+        )
       );
       return composed;
     },

--- a/code/core/src/preview-api/modules/store/StoryStore.test.ts
+++ b/code/core/src/preview-api/modules/store/StoryStore.test.ts
@@ -112,8 +112,8 @@ describe('StoryStore', () => {
 
     // The number of loaders contributed by the core annotations (actions + test addons).
     // We use loaders as a deterministic, FEATURES-independent signal for "core was injected".
-    const coreLoaderCount = normalizeProjectAnnotations(composeConfigs(getCoreAnnotations())).loaders!
-      .length;
+    const coreLoaderCount = normalizeProjectAnnotations(composeConfigs(getCoreAnnotations()))
+      .loaders!.length;
 
     it('injects the core annotations exactly once for a plain (CSF1/2/3) preview', () => {
       // `projectAnnotations` here is what the Vite/Webpack codegen produces for a CSF3 preview:
@@ -127,7 +127,7 @@ describe('StoryStore', () => {
     it('does NOT double the core annotations for a CSF4 (definePreview) composed preview', () => {
       // `definePreview().composed` is what the codegen returns for a CSF4 preview. It already
       // contains the core annotations and is flagged as such.
-      const composed = definePreview({ render: () => {} }).composed;
+      const composed = definePreview({ renderToCanvas: () => {} }).composed;
       const store = new StoryStore(storyIndex, importFn, composed);
 
       // Core is present exactly once, matching the already-composed preview.
@@ -136,7 +136,7 @@ describe('StoryStore', () => {
     });
 
     it('regression guard: an un-flagged composed preview would double the core annotations', () => {
-      const composed = definePreview({ render: () => {} }).composed;
+      const composed = definePreview({ renderToCanvas: () => {} }).composed;
       // Strip the (non-enumerable) marker to simulate the pre-fix behavior.
       const unflagged = { ...composed };
       const store = new StoryStore(storyIndex, importFn, unflagged);
@@ -147,11 +147,11 @@ describe('StoryStore', () => {
 
     it('does NOT double the core annotations via setProjectAnnotations for a CSF4 preview (HMR)', () => {
       const store = new StoryStore(storyIndex, importFn, projectAnnotations);
-      const composed = definePreview({ render: () => {} }).composed;
+      const composed = definePreview({ renderToCanvas: () => {} }).composed;
 
       // The HMR path (setProjectAnnotations) only re-normalizes the incoming project annotations,
       // it never prepends core, so an already-core-composed CSF4 preview stays at core x1.
-      store.setProjectAnnotations(composed);
+      store.setProjectAnnotations(composed as unknown as ProjectAnnotations<any>);
 
       expect(store.projectAnnotations.loaders).toEqual(composed.loaders);
       expect(store.projectAnnotations.loaders).toHaveLength(coreLoaderCount);

--- a/code/core/src/preview-api/modules/store/StoryStore.test.ts
+++ b/code/core/src/preview-api/modules/store/StoryStore.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { ProjectAnnotations, Renderer, StoryIndex } from 'storybook/internal/types';
 
+import { definePreview } from '../../../csf/csf-factories.ts';
+import { getCoreAnnotations } from '../../../csf/core-annotations.ts';
 import { StoryStore } from './StoryStore.ts';
 import { composeConfigs } from './csf/composeConfigs.ts';
+import { normalizeProjectAnnotations } from './csf/normalizeProjectAnnotations.ts';
 import { prepareStory } from './csf/prepareStory.ts';
 import { processCSFFile } from './csf/processCSFFile.ts';
 import type { HooksContext } from './hooks.ts';
@@ -105,6 +108,53 @@ describe('StoryStore', () => {
       expect(store.projectAnnotations!.argTypes).toEqual({
         a: { name: 'a', type: { name: 'string' } },
       });
+    });
+
+    // The number of loaders contributed by the core annotations (actions + test addons).
+    // We use loaders as a deterministic, FEATURES-independent signal for "core was injected".
+    const coreLoaderCount = normalizeProjectAnnotations(composeConfigs(getCoreAnnotations())).loaders!
+      .length;
+
+    it('injects the core annotations exactly once for a plain (CSF1/2/3) preview', () => {
+      // `projectAnnotations` here is what the Vite/Webpack codegen produces for a CSF3 preview:
+      // a `composeConfigs(rawModules)` WITHOUT the core annotations.
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
+
+      expect(coreLoaderCount).toBeGreaterThan(0);
+      expect(store.projectAnnotations.loaders).toHaveLength(coreLoaderCount);
+    });
+
+    it('does NOT double the core annotations for a CSF4 (definePreview) composed preview', () => {
+      // `definePreview().composed` is what the codegen returns for a CSF4 preview. It already
+      // contains the core annotations and is flagged as such.
+      const composed = definePreview({ render: () => {} }).composed;
+      const store = new StoryStore(storyIndex, importFn, composed);
+
+      // Core is present exactly once, matching the already-composed preview.
+      expect(store.projectAnnotations.loaders).toEqual(composed.loaders);
+      expect(store.projectAnnotations.loaders).toHaveLength(coreLoaderCount);
+    });
+
+    it('regression guard: an un-flagged composed preview would double the core annotations', () => {
+      const composed = definePreview({ render: () => {} }).composed;
+      // Strip the (non-enumerable) marker to simulate the pre-fix behavior.
+      const unflagged = { ...composed };
+      const store = new StoryStore(storyIndex, importFn, unflagged);
+
+      // Without the marker, the store prepends core again -> loaders are doubled.
+      expect(store.projectAnnotations.loaders!.length).toBe(coreLoaderCount * 2);
+    });
+
+    it('does NOT double the core annotations via setProjectAnnotations for a CSF4 preview (HMR)', () => {
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
+      const composed = definePreview({ render: () => {} }).composed;
+
+      // The HMR path (setProjectAnnotations) only re-normalizes the incoming project annotations,
+      // it never prepends core, so an already-core-composed CSF4 preview stays at core x1.
+      store.setProjectAnnotations(composed);
+
+      expect(store.projectAnnotations.loaders).toEqual(composed.loaders);
+      expect(store.projectAnnotations.loaders).toHaveLength(coreLoaderCount);
     });
   });
 

--- a/code/core/src/preview-api/modules/store/StoryStore.ts
+++ b/code/core/src/preview-api/modules/store/StoryStore.ts
@@ -1,5 +1,5 @@
 import type { CleanupCallback } from 'storybook/internal/csf';
-import { getCoreAnnotations } from 'storybook/internal/csf';
+import { getCoreAnnotations, hasCoreAnnotations } from 'storybook/internal/csf';
 import {
   CalledExtractOnStoreError,
   MissingStoryFromCsfFileError,
@@ -44,6 +44,23 @@ export function picky<T extends Record<string, any>, K extends keyof T>(
   return omitBy(pick(obj, keys), (v) => v === undefined);
 }
 
+/**
+ * Compose and normalize the project annotations for the store, prepending the core annotations.
+ *
+ * CSF4 previews (created with `definePreview`) already compose the core annotations into their
+ * `composed` result and flag it via {@link hasCoreAnnotations}. In that case we must NOT prepend
+ * core annotations again, otherwise every core decorator/loader/beforeEach/beforeAll would run
+ * twice for non-factory (CSF1/2/3) stories that fall back to `store.projectAnnotations`.
+ */
+function composeProjectAnnotations<TRenderer extends Renderer>(
+  projectAnnotations: ProjectAnnotations<TRenderer>
+): NormalizedProjectAnnotations<TRenderer> {
+  if (hasCoreAnnotations(projectAnnotations)) {
+    return normalizeProjectAnnotations(projectAnnotations);
+  }
+  return normalizeProjectAnnotations(composeConfigs([...getCoreAnnotations(), projectAnnotations]));
+}
+
 // TODO -- what are reasonable values for these?
 const CSF_CACHE_SIZE = 1000;
 const STORY_CACHE_SIZE = 10000;
@@ -78,9 +95,7 @@ export class StoryStore<TRenderer extends Renderer> {
   ) {
     this.storyIndex = new StoryIndexStore(storyIndex);
 
-    this.projectAnnotations = normalizeProjectAnnotations(
-      composeConfigs([...getCoreAnnotations(), projectAnnotations])
-    );
+    this.projectAnnotations = composeProjectAnnotations(projectAnnotations);
     const { initialGlobals, globalTypes } = this.projectAnnotations;
 
     this.args = new ArgsStore();
@@ -98,6 +113,9 @@ export class StoryStore<TRenderer extends Renderer> {
 
   setProjectAnnotations(projectAnnotations: ProjectAnnotations<TRenderer>) {
     // By changing `this.projectAnnotations, we implicitly invalidate the `prepareStoryWithCache`
+    // NOTE: unlike the constructor, this does not prepend the core annotations: the project
+    // annotations passed here (from `getProjectAnnotations()`) are only ever re-normalized, never
+    // re-composed with core, so there's no risk of doubling them on HMR updates.
     this.projectAnnotations = normalizeProjectAnnotations(projectAnnotations);
     const { initialGlobals, globalTypes } = projectAnnotations;
     this.userGlobals.set({ globals: initialGlobals, globalTypes });

--- a/code/core/src/preview-api/modules/store/csf/portable-stories.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.test.ts
@@ -8,6 +8,8 @@ import type {
   StoryAnnotationsOrFn as Story,
 } from 'storybook/internal/types';
 
+import { getCoreAnnotations } from '../../../../csf/core-annotations.ts';
+import { definePreview } from '../../../../csf/csf-factories.ts';
 import { Tag } from '../../../../shared/constants/tags.ts';
 import * as defaultExportAnnotations from './__mocks__/defaultExportAnnotations.mockfile.ts';
 import * as namedExportAnnotations from './__mocks__/namedExportAnnotations.mockfile.ts';
@@ -64,6 +66,25 @@ describe('composeStory', () => {
         tags: [Tag.AUTODOCS],
       })
     );
+  });
+
+  it('injects the core annotations once for plain (CSF3) project annotations', () => {
+    const coreLoaderCount = getCoreAnnotations().flatMap((it) => (it as any).loaders ?? []).length;
+    const finalAnnotations = setProjectAnnotations([{ render: () => {} }]);
+
+    expect(coreLoaderCount).toBeGreaterThan(0);
+    expect(finalAnnotations.loaders).toHaveLength(coreLoaderCount);
+  });
+
+  it('does NOT double the core annotations for a CSF4 composed preview (addon-vitest path)', () => {
+    // addon-vitest's setup file calls setProjectAnnotations(getProjectAnnotations()), where the
+    // CSF4 codegen returns the already-core-composed `definePreview().composed`.
+    const composed = definePreview({ render: () => {} }).composed;
+    const coreLoaderCount = getCoreAnnotations().flatMap((it) => (it as any).loaders ?? []).length;
+
+    const finalAnnotations = setProjectAnnotations(composed);
+
+    expect(finalAnnotations.loaders).toHaveLength(coreLoaderCount);
   });
 
   it('should compose project annotations in all module formats', () => {

--- a/code/core/src/preview-api/modules/store/csf/portable-stories.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.test.ts
@@ -79,7 +79,7 @@ describe('composeStory', () => {
   it('does NOT double the core annotations for a CSF4 composed preview (addon-vitest path)', () => {
     // addon-vitest's setup file calls setProjectAnnotations(getProjectAnnotations()), where the
     // CSF4 codegen returns the already-core-composed `definePreview().composed`.
-    const composed = definePreview({ render: () => {} }).composed;
+    const composed = definePreview({ renderToCanvas: () => {} }).composed;
     const coreLoaderCount = getCoreAnnotations().flatMap((it) => (it as any).loaders ?? []).length;
 
     const finalAnnotations = setProjectAnnotations(composed);

--- a/code/core/src/preview-api/modules/store/csf/portable-stories.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.ts
@@ -1,5 +1,5 @@
 import { type CleanupCallback, isExportStory } from 'storybook/internal/csf';
-import { getCoreAnnotations } from 'storybook/internal/csf';
+import { getCoreAnnotations, hasCoreAnnotations } from 'storybook/internal/csf';
 import { MountMustBeDestructuredError } from 'storybook/internal/preview-errors';
 import type {
   Args,
@@ -76,8 +76,12 @@ export function setProjectAnnotations<TRenderer extends Renderer = Renderer>(
     | NamedOrDefaultProjectAnnotations<TRenderer>[]
 ): NormalizedProjectAnnotations<TRenderer> {
   const annotations = Array.isArray(projectAnnotations) ? projectAnnotations : [projectAnnotations];
+  // CSF4 previews (definePreview) already compose the core annotations into their `composed`
+  // result, which is what e.g. addon-vitest passes here via `getProjectAnnotations()`. Detect that
+  // marker and skip prepending core annotations so they are not applied twice.
+  const alreadyComposedWithCore = annotations.some((annotation) => hasCoreAnnotations(annotation));
   globalThis.globalProjectAnnotations = composeConfigs([
-    ...getCoreAnnotations(),
+    ...(alreadyComposedWithCore ? [] : getCoreAnnotations()),
     globalThis.defaultProjectAnnotations ?? {},
     composeConfigs(annotations.map(extractAnnotation)),
   ]);

--- a/code/core/src/preview-api/modules/store/csf/processCSFFile.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/processCSFFile.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { hasCoreAnnotations } from '../../../../csf/core-annotations.ts';
+import { definePreview } from '../../../../csf/csf-factories.ts';
 import { processCSFFile } from './processCSFFile.ts';
 
 it('returns a CSFFile object with meta and stories', () => {
@@ -133,6 +135,26 @@ it('filters exports using excludeStories regex', () => {
   );
 
   expect(Object.keys(stories)).toEqual(['component--y', 'component--w']);
+});
+
+describe('CSF4 factory files', () => {
+  it('sets projectAnnotations to the core-composed preview exactly once', () => {
+    const preview = definePreview({ render: () => {} });
+    const meta = preview.meta({ title: 'Component' });
+    const Primary = meta.story({});
+
+    const csfFile = processCSFFile(
+      { default: meta, Primary },
+      './path/to/component.js',
+      'Component'
+    );
+
+    // Factory stories carry their own project annotations (the preview's composed result), which
+    // already contain the core annotations exactly once and are flagged as such. This is what lets
+    // them bypass the (potentially doubled) store-level projectAnnotations.
+    expect(csfFile.projectAnnotations).toBe(preview.composed);
+    expect(hasCoreAnnotations(csfFile.projectAnnotations)).toBe(true);
+  });
 });
 
 describe('moduleExports', () => {

--- a/code/core/src/preview-api/modules/store/csf/processCSFFile.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/processCSFFile.test.ts
@@ -139,9 +139,9 @@ it('filters exports using excludeStories regex', () => {
 
 describe('CSF4 factory files', () => {
   it('sets projectAnnotations to the core-composed preview exactly once', () => {
-    const preview = definePreview({ render: () => {} });
+    const preview = definePreview({ renderToCanvas: () => {} });
     const meta = preview.meta({ title: 'Component' });
-    const Primary = meta.story({});
+    const Primary = meta.story();
 
     const csfFile = processCSFFile(
       { default: meta, Primary },


### PR DESCRIPTION
Closes #

## What I did

Core preview annotations (decorators, and by the same mechanism `beforeEach`/`beforeAll`/`loaders`) were applied **twice** for a single render of a non-factory (CSF1/2/3) story when the project's `.storybook/preview` is a CSF4 (`definePreview`) factory preview.

Root cause — core annotations were injected at multiple sites that stacked for a CSF4 preview:

1. `definePreview(...).composed` composes the core annotations in (`csf-factories.ts`).
2. Both the Vite and Webpack codegens return that `composed` object for CSF4 previews — so it already contains core.
3. `StoryStore`'s constructor (and the portable `setProjectAnnotations` used by `addon-vitest`) then prepended core **again**.

So `store.projectAnnotations` held core twice under a CSF4 preview. CSF4 stories bypass it (they use `csfFile.projectAnnotations = preview.composed`, core ×1), but non-factory stories fall back to `store.projectAnnotations` → doubled decorators/loaders/etc. `defaultDecorateStory` does not dedupe, so the duplicated entries execute twice.

### Fix (mark-and-skip)

- `core-annotations.ts`: add `markAsComposedWithCoreAnnotations()` / `hasCoreAnnotations()`. The marker is a **non-enumerable `Symbol.for`** key, so it resolves across the duplicate ESM/CJS `core` module instances that exist in dev (a plain `Symbol()` would differ per instance), is collision-proof against user annotation fields, and is hidden from enumeration/JSON/string-spread.
- `csf-factories.ts`: flag `definePreview().composed` with the marker.
- `StoryStore.ts`: skip prepending core when the incoming project annotations are already flagged.
- `portable-stories.ts`: `setProjectAnnotations` skips prepending core when any incoming annotation is flagged (fixes the `addon-vitest` setup path).

This makes core inject **exactly once** for every (preview × story) combination, with no builder changes — both Vite and Webpack hand the store the same flagged `.composed` object.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

The doubling is **not visible by default**: the affected core annotations are either feature-gated or pass-through, so a duplicated decorator produces no extra DOM on its own. To observe it you need a temporary, always-on, framework-agnostic probe in core. Apply the patch below, which adds a pass-through core decorator and a core `beforeEach` that each `console.log` when they run.

Save as `core-probe.patch` at the repo root and apply with `git apply core-probe.patch`:

```diff
diff --git a/code/core/src/measure/preview.ts b/code/core/src/measure/preview.ts
index caf0f3bf541..db52cca8127 100644
--- a/code/core/src/measure/preview.ts
+++ b/code/core/src/measure/preview.ts
@@ -4,7 +4,15 @@ import { PARAM_KEY } from './constants.ts';
 import type { MeasureTypes } from './types.ts';
 import { withMeasure } from './withMeasure.ts';
 
-export const decorators = globalThis.FEATURES?.measure ? [withMeasure] : [];
+// TEMP QA PROBE — framework-agnostic, pass-through. DELETE before merging.
+const coreProbe = (storyFn: any, context: any) => {
+  const g = globalThis as any;
+  g.__CORE_PROBE__ = (g.__CORE_PROBE__ ?? 0) + 1;
+  console.log(`[core-probe] decorator #${g.__CORE_PROBE__} for "${context?.id}"`);
+  return storyFn();
+};
+
+export const decorators = [coreProbe, ...(globalThis.FEATURES?.measure ? [withMeasure] : [])];
 
 export const initialGlobals = {
   [PARAM_KEY]: false,
@@ -16,4 +24,10 @@ export default () =>
   definePreviewAddon<MeasureTypes>({
     decorators,
     initialGlobals,
+    // TEMP QA PROBE — DELETE before merging.
+    beforeEach: (context: any) => {
+      const g = globalThis as any;
+      g.__CORE_PROBE_BE__ = (g.__CORE_PROBE_BE__ ?? 0) + 1;
+      console.log(`[core-probe] beforeEach #${g.__CORE_PROBE_BE__} for "${context?.id}"`);
+    },
   });
```

Then:

1. Generate a sandbox — its `.storybook/preview.ts` already ships a CSF4 `definePreview` preview, so **no preview edits are needed**:
   `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. Apply the probe patch and rebuild core: `yarn nx compile core`.
3. In the sandbox's `.storybook/main.ts`, point the `stories` glob at the renderer fixtures so you have a non-factory and a factory story side by side:
   - non-factory (CSF1): `code/renderers/react/template/stories/csf1.stories.tsx` (e.g. the `Hello1` story)
   - factory (CSF4): `code/renderers/react/template/stories/csf4.stories.tsx`
4. Start the sandbox Storybook and **open the browser devtools console**. (If you rebuild core again, stop the dev server and clear its `node_modules/.cache` before restarting, otherwise Vite serves the stale pre-bundled `core`.)
5. Open the **non-factory** story and watch the console — this is the key check:
   - **Before this PR (on `next`):** the probe fires **twice** for a single render — two `[core-probe] decorator #…` lines and two `[core-probe] beforeEach #…` lines per navigation.
   - **With this PR:** exactly **one** `decorator` line and **one** `beforeEach` line per render.
6. Open the **factory (CSF4)** story: the probe fires **once** in both cases — confirming factory stories were never affected (they read `csfFile.projectAnnotations`), and that the fix didn't regress them.
7. Optional no-rebuild cross-check, in the console: `__STORYBOOK_STORY_STORE__.projectAnnotations.decorators.filter(d => d.name === 'coreProbe').length` returns `2` on `next` and `1` with this PR. (Reference-based dedupe would not catch this — the two copies are distinct function instances from two `getCoreAnnotations()` calls — which is why the count, not identity, is the signal.)
8. **Revert the probe before merging:** `git apply -R core-probe.patch` and rebuild core.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented core Storybook annotations from being applied multiple times for composed previews and portable stories, eliminating duplicate loaders and related duplication regressions.

* **Tests**
  * Added tests to verify core annotations are injected exactly once across plain and composed preview scenarios, covering preview factories, story store behavior, HMR path, and CSF4 processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->