### PR TITLE
Angular: Infer controls from single-quoted literal union types

### DIFF
--- a/code/frameworks/angular/src/client/compodoc.test.ts
+++ b/code/frameworks/angular/src/client/compodoc.test.ts
@@ -111,6 +111,10 @@ describe('extractType', () => {
       // ['T[]', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       ['[]', { name: 'other', value: 'empty-enum' }],
       ['"primary" | "secondary"', { name: 'enum', value: ['primary', 'secondary'] }],
+      // Single-quoted string-literal unions (e.g. from Angular `input<'S' | 'M' | 'L'>()`)
+      // are how compodoc emits literal types; they must infer a select control too.
+      ["'primary' | 'secondary'", { name: 'enum', value: ['primary', 'secondary'] }],
+      ["'S' | 'M' | 'L'", { name: 'enum', value: ['S', 'M', 'L'] }],
       ['TypeAlias', { name: 'enum', value: ['Type Alias 1', 'Type Alias 2', 'Type Alias 3'] }],
       // ['EnumNumeric', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       // ['EnumNumericInitial', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT

--- a/code/frameworks/angular/src/client/compodoc.ts
+++ b/code/frameworks/angular/src/client/compodoc.ts
@@ -131,7 +131,21 @@ const extractEnumValues = (compodocType: any) => {
   }
 
   try {
-    return compodocType.split('|').map((value) => JSON.parse(value));
+    return compodocType.split('|').map((value) => {
+      const trimmed = value.trim();
+      try {
+        return JSON.parse(trimmed);
+      } catch {
+        // Compodoc emits string-literal union members using single quotes
+        // (e.g. `'S' | 'M' | 'L'`), which are not valid JSON and throw above.
+        // Strip the matching single quotes and return the inner string literal.
+        const singleQuoted = trimmed.match(/^'(.*)'$/);
+        if (singleQuoted) {
+          return singleQuoted[1];
+        }
+        throw new Error(`Cannot parse union member: ${trimmed}`);
+      }
+    });
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
Closes #33779

## What I did

Angular components that type an input as a literal union written with **single quotes** — e.g. `@Input() size: 'S' | 'M' | 'L'` or `size = input<'S' | 'M' | 'L'>()` — stopped inferring a `select`/`radio` control in Storybook 10 and fell back to a free-text box (regression from v9).

Root cause is in `extractEnumValues` (`code/frameworks/angular/src/client/compodoc.ts`). Union members were parsed with `JSON.parse`, which is only valid for **double-quoted** strings. Compodoc emits literal-union members using **single** quotes, so `JSON.parse("'S'")` throws; the `catch` swallowed it and returned `null`, leaving the property with no enum and therefore no control.

The fix tries `JSON.parse` first (unchanged behavior for double-quoted strings, numbers, booleans), and on failure falls back to stripping matching single quotes and returning the inner string literal. Members that are neither valid JSON nor single-quoted literals still cause the whole type to resolve to `null` (unchanged), so non-enum unions are unaffected.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests

Added two cases to `compodoc.test.ts` covering single-quoted unions (`'primary' | 'secondary'` and `'S' | 'M' | 'L'`). Existing double-quoted, numeric, and type-alias cases continue to pass, confirming no regression.

#### Manual testing

1. Run an Angular sandbox: `yarn task --task sandbox --start-from auto --template angular-cli/default-ts`
2. Add an input typed with a single-quoted literal union to a component, e.g. `size = input<'S' | 'M' | 'L'>()`, and write a story for it.
3. Open Storybook → the component's story → **Controls** panel.
4. **Expected:** the `size` control renders as a `select` with options `S`, `M`, `L`.
   **Before this fix:** `size` renders as a plain text input.

## Checklist for Maintainers

- Suggested label: **`bug`** (fixes incorrect behavior).

---

> Disclosure: this fix was authored with AI assistance (Claude). The root cause, fix, and tests were reviewed against the existing test fixtures, and the parsing logic was verified in isolation (single-quoted unions now resolve to enums; double-quoted/numeric/mixed unions are unchanged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of string-literal union types in component inputs, ensuring they are properly recognized and documented.

* **Tests**
  * Added test coverage for string-literal union type parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->