### PR TITLE
Build: Publish React Vite Source Files for Code Exports

### DIFF
--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -45,11 +45,11 @@
   },
   "files": [
     "dist/**/*",
+    "src/**/*",
     "template/**/*",
     "README.md",
     "*.js",
-    "*.d.ts",
-    "!src/**/*"
+    "*.d.ts"
   ],
   "dependencies": {
     "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -46,6 +46,11 @@
   "files": [
     "dist/**/*",
     "src/**/*",
+    "!src/**/*.test.*",
+    "!src/**/*.spec.*",
+    "!src/**/__tests__/**",
+    "!src/**/__mocks__/**",
+    "!src/**/__fixtures__/**",
     "template/**/*",
     "README.md",
     "*.js",


### PR DESCRIPTION
## What I changed

`@storybook/react-vite` exposes `code` export conditions that point at files under `src/`, but the package `files` list excluded `src/**/*`, so those targets were not included in published npm tarballs.

This updates the package file list to publish the source files alongside the existing dist/template entries, keeping the `code` export targets resolvable.

## Verification

From `code/frameworks/react-vite`:

```sh
npm pack --dry-run --json > /tmp/react-vite-pack.json
jq -r '.[0].files[].path' /tmp/react-vite-pack.json | sort | grep -E '^(src/index.ts|src/node/index.ts|src/preset.ts|package.json)$'
```

Confirmed that the package now includes:

- `src/index.ts`
- `src/node/index.ts`
- `src/preset.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package publishing to include source and template files in distributed packages while excluding test and internal helper files to ensure published bundles contain needed source but omit internal/tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

#### Manual testing

From `code/frameworks/react-vite`, run:

```sh
npm pack --dry-run --json > /tmp/react-vite-pack.json
jq -r '.[0].files[].path' /tmp/react-vite-pack.json | sort | grep -E '^(src/index.ts|src/node/index.ts|src/preset.ts|package.json)$'
```

This verifies the package tarball includes the `src` files referenced by the `code` export conditions while the `files` allowlist excludes source test/spec and fixture artifacts.
