### PR TITLE
Agentic Review: Show toolbar and addon panels on details screen

### DIFF
--- a/code/addons/a11y/src/withVisionSimulator.ts
+++ b/code/addons/a11y/src/withVisionSimulator.ts
@@ -5,26 +5,38 @@ import { useCallback, useEffect } from 'storybook/preview-api';
 import { filterDefs, filters } from './visionSimulatorFilters.ts';
 
 const knownFilters = Object.values(filters).map((f) => f.filter);
-const knownFiltersRegExp = new RegExp(`\\b(${knownFilters.join('|')})\\b`, 'g');
+
+const stripKnownFilters = (filterValue: string) => {
+  let result = filterValue.trim();
+  if (!result || result === 'none') {
+    return '';
+  }
+  for (const knownFilter of knownFilters) {
+    while (result.includes(knownFilter)) {
+      result = result.replace(knownFilter, ' ');
+    }
+  }
+  return result.replace(/\s+/g, ' ').trim();
+};
 
 export const withVisionSimulator: DecoratorFunction = (StoryFn, { globals }) => {
   const { vision } = globals;
 
   const applyVisionFilter = useCallback(() => {
-    const existingFilters = document.body.style.filter.replaceAll(knownFiltersRegExp, '').trim();
-
+    const baseFilters = stripKnownFilters(document.body.style.filter);
     const visionFilter = filters[vision as keyof typeof filters]?.filter;
-    if (visionFilter && document.body.classList.contains('sb-show-main')) {
-      if (!existingFilters || existingFilters === 'none') {
-        document.body.style.filter = visionFilter;
-      } else {
-        document.body.style.filter = `${existingFilters} ${visionFilter}`;
-      }
-    } else {
-      document.body.style.filter = existingFilters || 'none';
-    }
+    const nextFilter =
+      visionFilter && document.body.classList.contains('sb-show-main')
+        ? baseFilters
+          ? `${baseFilters} ${visionFilter}`
+          : visionFilter
+        : baseFilters || 'none';
 
-    return () => (document.body.style.filter = existingFilters || 'none');
+    document.body.style.filter = nextFilter;
+
+    return () => {
+      document.body.style.filter = baseFilters || 'none';
+    };
   }, [vision]);
 
   useEffect(() => {

--- a/code/addons/review/src/components/ReviewHeader.tsx
+++ b/code/addons/review/src/components/ReviewHeader.tsx
@@ -69,6 +69,12 @@ const Actions = styled.div({
   flexShrink: 0,
 });
 
+const ToolbarRow = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  flexShrink: 0,
+});
+
 const SecondRow = styled.div({
   display: 'flex',
   alignItems: 'center',
@@ -84,6 +90,8 @@ export interface ReviewHeaderProps {
   subtitle?: ReactNode;
   /** Trailing cluster on the right of the top row. */
   actions?: ReactNode;
+  /** Storybook preview toolbar rendered between the title row and the second row. */
+  toolbar?: ReactNode;
   /** Optional full-width second row (e.g. search or comparison controls). */
   secondRow?: ReactNode;
   /**
@@ -99,6 +107,7 @@ export const ReviewHeader: FC<ReviewHeaderProps> = ({
   title,
   subtitle,
   actions,
+  toolbar,
   secondRow,
   autoFocusTitle = false,
 }) => {
@@ -121,6 +130,7 @@ export const ReviewHeader: FC<ReviewHeaderProps> = ({
         </TextBlock>
         {actions ? <Actions>{actions}</Actions> : null}
       </TopRow>
+      {toolbar ? <ToolbarRow>{toolbar}</ToolbarRow> : null}
       {secondRow ? <SecondRow>{secondRow}</SecondRow> : null}
     </Root>
   );

--- a/code/addons/review/src/constants.ts
+++ b/code/addons/review/src/constants.ts
@@ -20,6 +20,12 @@ export const RESTORE_NAV_SESSION_KEY = `${ADDON_ID}/restore-nav`;
 // across the full-reload navigations between them). Value: '1up' | '2up'.
 export const PREVIEW_MODE_SESSION_KEY = `${ADDON_ID}/preview-mode`;
 
+// sessionStorage keys for review-local addon panel state on the detail screen.
+// Independent of the manager layout store so review tooling does not affect
+// regular story view. Values: 'true' | 'false' and a pixel height string.
+export const PANEL_VISIBLE_SESSION_KEY = `${ADDON_ID}/panel-visible`;
+export const PANEL_HEIGHT_SESSION_KEY = `${ADDON_ID}/panel-height`;
+
 // `@storybook/addon-mcp` display-review tool call emits this event with the raw agent payload.
 const PUSH_REVIEW = `${ADDON_ID}/push-review`;
 // Display agent review in the UI

--- a/code/addons/review/src/screens/DetailsScreen.stories.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.stories.tsx
@@ -41,7 +41,14 @@ const managerApi = {
   }),
   getData: fn((id: string) => (id === storyId ? storyData : undefined)).mockName('api::getData'),
   getCurrentStoryData: fn(() => storyData).mockName('api::getCurrentStoryData'),
+  getStoryHrefs: fn((id: string) => ({
+    managerHref: `?path=/story/${id}`,
+    previewHref: `iframe.html?id=${id}&viewMode=story`,
+  })).mockName('api::getStoryHrefs'),
   getElements: fn(() => ({})).mockName('api::getElements'),
+  getIsFullscreen: fn(() => false).mockName('api::getIsFullscreen'),
+  toggleFullscreen: fn().mockName('api::toggleFullscreen'),
+  getIsNavShown: fn(() => false).mockName('api::getIsNavShown'),
   getShowToolbarWithCustomisations: fn((showToolbar: boolean) => showToolbar).mockName(
     'api::getShowToolbarWithCustomisations'
   ),
@@ -127,8 +134,8 @@ export const Default = meta.story({
     await expect(
       await canvas.findByRole('heading', { name: 'Toolbar & direct consumers' })
     ).toBeInTheDocument();
-    await expect(await canvas.findByText('Toolbar')).toBeInTheDocument();
-    await expect(await canvas.findByText('Basic')).toBeInTheDocument();
+    const header = await canvas.findByRole('banner');
+    await expect(within(header).getByText('Basic')).toBeInTheDocument();
     await expect(
       await canvas.findByRole('link', { name: 'View in Storybook' })
     ).toBeInTheDocument();

--- a/code/addons/review/src/screens/DetailsScreen.stories.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.stories.tsx
@@ -1,20 +1,35 @@
-import { expect, fn, within } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { ManagerContext, type API, type State } from 'storybook/manager-api';
 
+import { LayoutProvider } from '../../../../core/src/manager/components/layout/LayoutProvider.tsx';
 import {
   buildReviewChangesDetailHref,
   buildReviewChangesSummaryHref,
 } from '../review-navigation.ts';
-import { PREVIEW_MODE_SESSION_KEY } from '../constants.ts';
+import {
+  PANEL_HEIGHT_SESSION_KEY,
+  PANEL_VISIBLE_SESSION_KEY,
+  PREVIEW_MODE_SESSION_KEY,
+} from '../constants.ts';
 import { sessionStore } from '../session-store.ts';
 import preview from '../../../../.storybook/preview.tsx';
 import { DetailsScreen } from './DetailsScreen.tsx';
 
-// DetailsScreen uses useAddonState (via the preview-mode toggle), which reads
-// the manager API off ManagerContext. Provide a minimal in-memory mock so the
-// stories render outside the real manager.
+const storyId = 'components-toolbar--basic';
+const storyData = {
+  type: 'story' as const,
+  id: storyId,
+  title: 'Manager/Components/Toolbar',
+  name: 'Basic',
+  parameters: {},
+  args: {},
+  initialArgs: {},
+  argTypes: {},
+};
+
 const addonStateStore: Record<string, unknown> = {};
+
 const managerApi = {
   on: fn(() => () => {}),
   off: fn(),
@@ -24,8 +39,40 @@ const managerApi = {
     addonStateStore[id] = typeof value === 'function' ? value(addonStateStore[id]) : value;
     return Promise.resolve(addonStateStore[id]);
   }),
+  getData: fn((id: string) => (id === storyId ? storyData : undefined)).mockName('api::getData'),
+  getCurrentStoryData: fn(() => storyData).mockName('api::getCurrentStoryData'),
+  getElements: fn(() => ({})).mockName('api::getElements'),
+  getShowToolbarWithCustomisations: fn((showToolbar: boolean) => showToolbar).mockName(
+    'api::getShowToolbarWithCustomisations'
+  ),
+  getIsPanelShown: fn(() => true).mockName('api::getIsPanelShown'),
+  togglePanel: fn().mockName('api::togglePanel'),
+  setSelectedPanel: fn().mockName('api::setSelectedPanel'),
+  getSelectedPanel: fn(() => 'controls').mockName('api::getSelectedPanel'),
+  getShortcutKeys: fn(() => ({})).mockName('api::getShortcutKeys'),
+  focusOnUIElement: fn(() => Promise.resolve(true)).mockName('api::focusOnUIElement'),
+  getGlobals: fn(() => ({})).mockName('api::getGlobals'),
+  getStoryGlobals: fn(() => ({})).mockName('api::getStoryGlobals'),
+  getUserGlobals: fn(() => ({})).mockName('api::getUserGlobals'),
+  updateGlobals: fn().mockName('api::updateGlobals'),
+  updateStoryArgs: fn().mockName('api::updateStoryArgs'),
+  resetStoryArgs: fn().mockName('api::resetStoryArgs'),
+  getCurrentParameter: fn(() => ({})).mockName('api::getCurrentParameter'),
+  setAddonShortcut: fn().mockName('api::setAddonShortcut'),
 } as unknown as API;
-const managerState = {} as State;
+
+const managerState = {
+  storyId,
+  viewMode: 'review',
+  path: '/review/0/components-toolbar--basic',
+  location: { search: '?path=/review/0/components-toolbar--basic' },
+  previewInitialized: true,
+  layout: {
+    showToolbar: true,
+    panelPosition: 'bottom',
+  },
+  shortcuts: {},
+} as unknown as State;
 
 const meta = preview.meta({
   component: DetailsScreen,
@@ -37,9 +84,11 @@ const meta = preview.meta({
   },
   decorators: [
     (Story) => (
-      <ManagerContext.Provider value={{ state: managerState, api: managerApi }}>
-        <Story />
-      </ManagerContext.Provider>
+      <LayoutProvider forceDesktop>
+        <ManagerContext.Provider value={{ state: managerState, api: managerApi }}>
+          <Story />
+        </ManagerContext.Provider>
+      </LayoutProvider>
     ),
   ],
   beforeEach: () => {
@@ -47,12 +96,14 @@ const meta = preview.meta({
       delete addonStateStore[key];
     }
     sessionStore.remove(PREVIEW_MODE_SESSION_KEY);
+    sessionStore.remove(PANEL_VISIBLE_SESSION_KEY);
+    sessionStore.remove(PANEL_HEIGHT_SESSION_KEY);
   },
   args: {
     title: 'Toolbar & direct consumers',
     componentTitle: 'Manager/Components/Toolbar',
     storyName: 'Basic',
-    storyId: 'components-toolbar--basic',
+    storyId,
     storyIndex: 1,
     totalStories: 3,
     previewHref: 'iframe.html?id=components-toolbar--basic&viewMode=story',
@@ -81,9 +132,12 @@ export const Default = meta.story({
     await expect(
       await canvas.findByRole('link', { name: 'View in Storybook' })
     ).toBeInTheDocument();
-    // No baseline by default: only the latest preview, no comparison controls.
+    await expect(await canvas.findByTestId('sb-preview-toolbar')).toBeInTheDocument();
+    await expect(await canvas.findByRole('region', { name: 'Addon panel' })).toBeInTheDocument();
     await expect(await canvas.findByTitle('Latest components-toolbar--basic')).toBeInTheDocument();
     await expect(canvas.queryByTitle('Baseline components-toolbar--basic')).not.toBeInTheDocument();
+    const latestFrame = await canvas.findByTitle('Latest components-toolbar--basic');
+    await expect(latestFrame).toHaveAttribute('id', 'storybook-preview-iframe');
   },
 });
 
@@ -93,13 +147,11 @@ export const WithBaseline = meta.story({
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // Default is 1up with the latest pane active: only the "Latest" bar label is shown.
     await expect(await canvas.findByText('Latest')).toBeInTheDocument();
     await expect(canvas.queryByText('Baseline')).not.toBeInTheDocument();
     await expect(
       await canvas.findByRole('button', { name: 'Switch baseline and latest' })
     ).toBeInTheDocument();
-    // Both previews are mounted; the baseline iframe is hidden in 1up latest mode.
     await expect(
       await canvas.findByTitle('Baseline components-toolbar--basic')
     ).toBeInTheDocument();
@@ -108,6 +160,7 @@ export const WithBaseline = meta.story({
     await expect(
       await canvas.findByRole('button', { name: 'Side-by-side view' })
     ).toBeInTheDocument();
+    await expect(await canvas.findByTestId('sb-preview-toolbar')).toBeInTheDocument();
   },
 });
 
@@ -129,6 +182,7 @@ export const WithBaselineSplit = meta.story({
     await expect(
       canvas.queryByRole('button', { name: 'Switch baseline and latest' })
     ).not.toBeInTheDocument();
+    await expect(await canvas.findByRole('region', { name: 'Addon panel' })).toBeInTheDocument();
   },
 });
 
@@ -141,12 +195,11 @@ export const NewStory = meta.story({
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('New')).toBeInTheDocument();
     await expect(await canvas.findByTitle('Latest components-toolbar--basic')).toBeInTheDocument();
-    // A new story has no baseline to compare against: no baseline preview and no
-    // side-by-side comparison controls.
     await expect(canvas.queryByTitle('Baseline components-toolbar--basic')).not.toBeInTheDocument();
     await expect(
       canvas.queryByRole('button', { name: 'Side-by-side view' })
     ).not.toBeInTheDocument();
+    await expect(await canvas.findByTestId('sb-preview-toolbar')).toBeInTheDocument();
   },
 });
 
@@ -162,7 +215,7 @@ export const Stale = meta.story({
 
 export const WrapAroundNavigation = meta.story({
   args: {
-    storyId: 'components-toolbar--basic',
+    storyId,
     storyIndex: 0,
     totalStories: 3,
     previousHref: buildReviewChangesDetailHref({
@@ -184,5 +237,37 @@ export const WrapAroundNavigation = meta.story({
     await expect(nextButton.getAttribute('href')).toContain(
       '/review/0/components-toolbar--compact'
     );
+  },
+});
+
+export const PanelToggle = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('region', { name: 'Addon panel' })).toBeInTheDocument();
+    await userEvent.click(await canvas.findByRole('button', { name: 'Hide addon panel' }));
+    await expect(canvas.queryByRole('region', { name: 'Addon panel' })).not.toBeInTheDocument();
+    await expect(
+      await canvas.findByRole('button', { name: 'Show addon panel' })
+    ).toBeInTheDocument();
+    await userEvent.click(await canvas.findByRole('button', { name: 'Show addon panel' }));
+    await expect(await canvas.findByRole('region', { name: 'Addon panel' })).toBeInTheDocument();
+  },
+});
+
+export const PanelPersistence = meta.story({
+  beforeEach: () => {
+    sessionStore.write(PANEL_VISIBLE_SESSION_KEY, 'false');
+    sessionStore.write(PANEL_HEIGHT_SESSION_KEY, '420');
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('region', { name: 'Addon panel' })).not.toBeInTheDocument();
+    await expect(
+      await canvas.findByRole('button', { name: 'Show addon panel' })
+    ).toBeInTheDocument();
+    await userEvent.click(await canvas.findByRole('button', { name: 'Show addon panel' }));
+    await expect(await canvas.findByRole('region', { name: 'Addon panel' })).toBeInTheDocument();
+    await expect(sessionStore.read(PANEL_VISIBLE_SESSION_KEY)).toBe('true');
+    await expect(sessionStore.read(PANEL_HEIGHT_SESSION_KEY)).toBe('420');
   },
 });

--- a/code/addons/review/src/screens/DetailsScreen.stories.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.stories.tsx
@@ -65,6 +65,14 @@ const managerApi = {
   updateStoryArgs: fn().mockName('api::updateStoryArgs'),
   resetStoryArgs: fn().mockName('api::resetStoryArgs'),
   getCurrentParameter: fn(() => ({})).mockName('api::getCurrentParameter'),
+  getUrlState: fn(() => ({
+    path: `/story/${storyId}`,
+    storyId,
+    viewMode: 'story',
+    hash: '',
+    queryParams: {},
+    url: `/?path=/story/${storyId}`,
+  })).mockName('api::getUrlState'),
   setAddonShortcut: fn().mockName('api::setAddonShortcut'),
 } as unknown as API;
 
@@ -145,6 +153,7 @@ export const Default = meta.story({
     await expect(canvas.queryByTitle('Baseline components-toolbar--basic')).not.toBeInTheDocument();
     const latestFrame = await canvas.findByTitle('Latest components-toolbar--basic');
     await expect(latestFrame).toHaveAttribute('id', 'storybook-preview-iframe');
+    await expect(latestFrame).toHaveAttribute('data-is-storybook', 'true');
   },
 });
 

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState, type FC } from 'react';
+import React, { useCallback, useEffect, useState, type FC } from 'react';
 
 import { Badge, Button, IconButton } from 'storybook/internal/components';
+import { useStorybookApi } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
 import {
@@ -18,6 +19,17 @@ import { sessionStore } from '../session-store.ts';
 import { useBaselineComparison } from './useBaselineComparison.ts';
 
 import { StaleBanner } from '../components/StaleBanner.tsx';
+import { ReviewDetailPanel } from './ReviewDetailPanel.tsx';
+import { ReviewDetailToolbar } from './ReviewDetailToolbar.tsx';
+import { ReviewPanelProvider } from './ReviewPanelContext.tsx';
+import { ReviewStoryManagerBridge } from './ReviewStoryManagerBridge.tsx';
+import { usePreviewChannelRelay } from './usePreviewChannelRelay.ts';
+import { useReviewPanelState } from './useReviewPanelState.ts';
+import { focusableUIElements } from '../../../../core/src/manager-api/modules/layout.ts';
+import {
+  ZoomConsumer,
+  ZoomProvider,
+} from '../../../../core/src/manager/components/preview/tools/zoom.tsx';
 
 const Page = styled.div(({ theme }) => ({
   display: 'flex',
@@ -92,6 +104,31 @@ const PreviewFrame = styled.iframe({
   border: 0,
   display: 'block',
 });
+
+const Main = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minHeight: 0,
+});
+
+const ScaledPreviewArea = styled.div<{ $scale: number }>(({ $scale }) => ({
+  flex: 1,
+  minHeight: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  ...($scale !== 1
+    ? {
+        overflow: 'hidden',
+        '& > *': {
+          transform: `scale(${$scale})`,
+          transformOrigin: 'top left',
+          width: `${(1 / $scale) * 100}%`,
+          height: `${(1 / $scale) * 100}%`,
+        },
+      }
+    : {}),
+}));
 
 // The baseline comparison bar. A two-up (side-by-side) and one-up (single)
 // mode share a control cluster; the "switch" control only applies in one-up
@@ -228,6 +265,8 @@ export const DetailsScreen = ({
   hasBaseline = false,
   isNewlyAdded,
 }: DetailsScreenProps) => {
+  const api = useStorybookApi();
+  const { isPanelShown, panelHeight, setPanelHeight, togglePanel } = useReviewPanelState();
   const [mode, setMode] = useState<CompareMode>(readCompareMode);
   const [activePane, setActivePane] = useState<ComparePane>('latest');
 
@@ -239,6 +278,19 @@ export const DetailsScreen = ({
 
   const { baselineFrameRef, latestFrameRef, latestPreviewSrc, baselinePreviewSrc } =
     useBaselineComparison(previewHref, showBaseline);
+
+  usePreviewChannelRelay(baselineFrameRef, showBaseline);
+
+  const showPanel = useCallback(
+    (forceFocus?: boolean) => {
+      togglePanel(true);
+      if (forceFocus) {
+        void api.focusOnUIElement(focusableUIElements.addonPanel);
+      }
+    },
+    [api, togglePanel]
+  );
+  const hidePanel = useCallback(() => togglePanel(false), [togglePanel]);
 
   // Persist the user's layout choice so it carries across navigation between
   // the detail and summary screens.
@@ -289,77 +341,129 @@ export const DetailsScreen = ({
     )
   ) : undefined;
 
-  return (
-    <Page>
-      {isStale ? <StaleBanner /> : null}
-      <ReviewHeader
-        autoFocusTitle
-        leading={
-          <IconButton
-            variant="ghost"
-            size="small"
-            padding="small"
-            ariaLabel="Back to review"
-            asChild
-          >
-            <a href={backHref}>
-              <ChevronSmallLeftIcon />
-            </a>
-          </IconButton>
-        }
-        title={title}
-        subtitle={subtitle}
-        actions={
-          <>
-            <Counter variant="ghost" size="small" readOnly>
-              {storyIndex + 1}/{totalStories}
-            </Counter>
-            <IconButton
-              variant="ghost"
-              size="small"
-              padding="small"
-              ariaLabel="Previous story"
-              asChild
-            >
-              <a href={previousHref}>
-                <ChevronSmallLeftIcon />
-              </a>
-            </IconButton>
-            <IconButton variant="ghost" size="small" padding="small" ariaLabel="Next story" asChild>
-              <a href={nextHref}>
-                <ChevronSmallRightIcon />
-              </a>
-            </IconButton>
-            <IconButton size="small" padding="small" ariaLabel="View in Storybook" asChild>
-              <a href={storybookHref} target="_blank" rel="noreferrer">
-                <StorybookIcon />
-              </a>
-            </IconButton>
-          </>
-        }
-        secondRow={baselineBar}
-      />
+  const panelContextValue = {
+    isPanelShown,
+    showPanel,
+    hidePanel,
+  };
 
-      <PreviewFrameWrap $singleUp={isSingleUp} data-testid="review-details-screen-preview">
-        {showBaseline ? (
-          <>
-            <PreviewPane $singleUp={isSingleUp} $active={!isSingleUp || activePane === 'baseline'}>
-              <PreviewFrame
-                ref={baselineFrameRef}
-                title={`Baseline ${storyId}`}
-                src={baselinePreviewSrc}
-              />
-            </PreviewPane>
-            <PreviewDivider $singleUp={isSingleUp} />
-          </>
-        ) : null}
-        <PreviewPane
-          $singleUp={isSingleUp}
-          $active={!showBaseline || !isSingleUp || activePane === 'latest'}
-        >
-          <PreviewFrame ref={latestFrameRef} title={`Latest ${storyId}`} src={latestPreviewSrc} />
-        </PreviewPane>
-      </PreviewFrameWrap>
-    </Page>
+  return (
+    <ReviewStoryManagerBridge
+      storyId={storyId}
+      isPanelShown={isPanelShown}
+      togglePanel={togglePanel}
+    >
+      <ReviewPanelProvider value={panelContextValue}>
+        <Page>
+          {isStale ? <StaleBanner /> : null}
+          <ReviewHeader
+            autoFocusTitle
+            leading={
+              <IconButton
+                variant="ghost"
+                size="small"
+                padding="small"
+                ariaLabel="Back to review"
+                asChild
+              >
+                <a href={backHref}>
+                  <ChevronSmallLeftIcon />
+                </a>
+              </IconButton>
+            }
+            title={title}
+            subtitle={subtitle}
+            toolbar={<ReviewDetailToolbar storyId={storyId} />}
+            actions={
+              <>
+                <Counter variant="ghost" size="small" readOnly>
+                  {storyIndex + 1}/{totalStories}
+                </Counter>
+                <IconButton
+                  variant="ghost"
+                  size="small"
+                  padding="small"
+                  ariaLabel="Previous story"
+                  asChild
+                >
+                  <a href={previousHref}>
+                    <ChevronSmallLeftIcon />
+                  </a>
+                </IconButton>
+                <IconButton
+                  variant="ghost"
+                  size="small"
+                  padding="small"
+                  ariaLabel="Next story"
+                  asChild
+                >
+                  <a href={nextHref}>
+                    <ChevronSmallRightIcon />
+                  </a>
+                </IconButton>
+                <IconButton size="small" padding="small" ariaLabel="View in Storybook" asChild>
+                  <a href={storybookHref} target="_blank" rel="noreferrer">
+                    <StorybookIcon />
+                  </a>
+                </IconButton>
+              </>
+            }
+            secondRow={baselineBar}
+          />
+
+          <ZoomProvider shouldScale>
+            <Main>
+              <ZoomConsumer>
+                {({ value: scale }) => (
+                  <ScaledPreviewArea $scale={scale}>
+                    <PreviewFrameWrap
+                      $singleUp={isSingleUp}
+                      data-testid="review-details-screen-preview"
+                    >
+                      {showBaseline ? (
+                        <>
+                          <PreviewPane
+                            $singleUp={isSingleUp}
+                            $active={!isSingleUp || activePane === 'baseline'}
+                          >
+                            <PreviewFrame
+                              ref={baselineFrameRef}
+                              title={`Baseline ${storyId}`}
+                              src={baselinePreviewSrc}
+                            />
+                          </PreviewPane>
+                          <PreviewDivider $singleUp={isSingleUp} />
+                        </>
+                      ) : null}
+                      <PreviewPane
+                        $singleUp={isSingleUp}
+                        $active={!showBaseline || !isSingleUp || activePane === 'latest'}
+                      >
+                        <PreviewFrame
+                          ref={latestFrameRef}
+                          id="storybook-preview-iframe"
+                          title={`Latest ${storyId}`}
+                          src={latestPreviewSrc}
+                        />
+                      </PreviewPane>
+                    </PreviewFrameWrap>
+                  </ScaledPreviewArea>
+                )}
+              </ZoomConsumer>
+              {isPanelShown ? (
+                <ReviewDetailPanel
+                  storyId={storyId}
+                  isPanelShown={isPanelShown}
+                  panelHeight={panelHeight}
+                  setPanelHeight={setPanelHeight}
+                  hidePanel={hidePanel}
+                  previewFrameRef={latestFrameRef}
+                />
+              ) : null}
+            </Main>
+          </ZoomProvider>
+        </Page>
+      </ReviewPanelProvider>
+    </ReviewStoryManagerBridge>
   );
 };

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, type FC } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 
 import { Badge, Button, IconButton } from 'storybook/internal/components';
 import { useStorybookApi } from 'storybook/manager-api';
@@ -21,6 +21,7 @@ import { useBaselineComparison } from './useBaselineComparison.ts';
 import { StaleBanner } from '../components/StaleBanner.tsx';
 import { ReviewDetailPanel } from './ReviewDetailPanel.tsx';
 import { ReviewDetailToolbar } from './ReviewDetailToolbar.tsx';
+import { ReviewDetailViewport } from './ReviewDetailViewport.tsx';
 import { ReviewPanelProvider } from './ReviewPanelContext.tsx';
 import { ReviewStoryManagerBridge } from './ReviewStoryManagerBridge.tsx';
 import { usePreviewChannelRelay } from './usePreviewChannelRelay.ts';
@@ -257,7 +258,7 @@ export const DetailsScreen = ({
   backHref,
   previousHref,
   nextHref,
-  previewHref,
+  previewHref: _previewHref,
   storybookHref,
   componentTitle,
   storyName,
@@ -276,8 +277,16 @@ export const DetailsScreen = ({
   const showBaseline = hasBaseline && !isNewlyAdded;
   const isSingleUp = mode === 'single' || !showBaseline;
 
+  // Globals and args are synced into the manager URL for shareable links, but the
+  // detail iframe should stay on a stable src and receive live updates over the
+  // channel — matching the main Storybook preview FramesRenderer behavior.
+  const stablePreviewHref = useMemo(
+    () => api.getStoryHrefs(storyId, { inheritGlobals: false, inheritArgs: false }).previewHref,
+    [api, storyId]
+  );
+
   const { baselineFrameRef, latestFrameRef, latestPreviewSrc, baselinePreviewSrc } =
-    useBaselineComparison(previewHref, showBaseline);
+    useBaselineComparison(stablePreviewHref, showBaseline);
 
   usePreviewChannelRelay(baselineFrameRef, showBaseline);
 
@@ -350,6 +359,10 @@ export const DetailsScreen = ({
     hidePanel,
   };
 
+  const handleLatestFrameLoad = useCallback((event: React.SyntheticEvent<HTMLIFrameElement>) => {
+    event.currentTarget.setAttribute('data-is-loaded', 'true');
+  }, []);
+
   return (
     <ReviewStoryManagerBridge
       storyId={storyId}
@@ -357,64 +370,64 @@ export const DetailsScreen = ({
       togglePanel={togglePanel}
     >
       <ReviewPanelProvider value={panelContextValue}>
-        <Page>
-          {isStale ? <StaleBanner /> : null}
-          <ReviewHeader
-            autoFocusTitle
-            leading={
-              <IconButton
-                variant="ghost"
-                size="small"
-                padding="small"
-                ariaLabel="Back to review"
-                asChild
-              >
-                <a href={backHref}>
-                  <ChevronSmallLeftIcon />
-                </a>
-              </IconButton>
-            }
-            title={title}
-            subtitle={subtitle}
-            toolbar={<ReviewDetailToolbar storyId={storyId} />}
-            actions={
-              <>
-                <Counter variant="ghost" size="small" readOnly>
-                  {storyIndex + 1}/{totalStories}
-                </Counter>
+        <ZoomProvider shouldScale>
+          <Page>
+            {isStale ? <StaleBanner /> : null}
+            <ReviewHeader
+              autoFocusTitle
+              leading={
                 <IconButton
                   variant="ghost"
                   size="small"
                   padding="small"
-                  ariaLabel="Previous story"
+                  ariaLabel="Back to review"
                   asChild
                 >
-                  <a href={previousHref}>
+                  <a href={backHref}>
                     <ChevronSmallLeftIcon />
                   </a>
                 </IconButton>
-                <IconButton
-                  variant="ghost"
-                  size="small"
-                  padding="small"
-                  ariaLabel="Next story"
-                  asChild
-                >
-                  <a href={nextHref}>
-                    <ChevronSmallRightIcon />
-                  </a>
-                </IconButton>
-                <IconButton size="small" padding="small" ariaLabel="View in Storybook" asChild>
-                  <a href={storybookHref} target="_blank" rel="noreferrer">
-                    <StorybookIcon />
-                  </a>
-                </IconButton>
-              </>
-            }
-            secondRow={baselineBar}
-          />
+              }
+              title={title}
+              subtitle={subtitle}
+              toolbar={<ReviewDetailToolbar storyId={storyId} />}
+              actions={
+                <>
+                  <Counter variant="ghost" size="small" readOnly>
+                    {storyIndex + 1}/{totalStories}
+                  </Counter>
+                  <IconButton
+                    variant="ghost"
+                    size="small"
+                    padding="small"
+                    ariaLabel="Previous story"
+                    asChild
+                  >
+                    <a href={previousHref}>
+                      <ChevronSmallLeftIcon />
+                    </a>
+                  </IconButton>
+                  <IconButton
+                    variant="ghost"
+                    size="small"
+                    padding="small"
+                    ariaLabel="Next story"
+                    asChild
+                  >
+                    <a href={nextHref}>
+                      <ChevronSmallRightIcon />
+                    </a>
+                  </IconButton>
+                  <IconButton size="small" padding="small" ariaLabel="View in Storybook" asChild>
+                    <a href={storybookHref} target="_blank" rel="noreferrer">
+                      <StorybookIcon />
+                    </a>
+                  </IconButton>
+                </>
+              }
+              secondRow={baselineBar}
+            />
 
-          <ZoomProvider shouldScale>
             <Main>
               <ZoomConsumer>
                 {({ value: scale }) => (
@@ -431,6 +444,7 @@ export const DetailsScreen = ({
                           >
                             <PreviewFrame
                               ref={baselineFrameRef}
+                              data-is-storybook="false"
                               title={`Baseline ${storyId}`}
                               src={baselinePreviewSrc}
                             />
@@ -442,12 +456,16 @@ export const DetailsScreen = ({
                         $singleUp={isSingleUp}
                         $active={!showBaseline || !isSingleUp || activePane === 'latest'}
                       >
-                        <PreviewFrame
-                          ref={latestFrameRef}
-                          id="storybook-preview-iframe"
-                          title={`Latest ${storyId}`}
-                          src={latestPreviewSrc}
-                        />
+                        <ReviewDetailViewport scale={scale}>
+                          <PreviewFrame
+                            ref={latestFrameRef}
+                            id="storybook-preview-iframe"
+                            data-is-storybook="true"
+                            onLoad={handleLatestFrameLoad}
+                            title={`Latest ${storyId}`}
+                            src={latestPreviewSrc}
+                          />
+                        </ReviewDetailViewport>
                       </PreviewPane>
                     </PreviewFrameWrap>
                   </ScaledPreviewArea>
@@ -464,8 +482,8 @@ export const DetailsScreen = ({
                 />
               ) : null}
             </Main>
-          </ZoomProvider>
-        </Page>
+          </Page>
+        </ZoomProvider>
       </ReviewPanelProvider>
     </ReviewStoryManagerBridge>
   );

--- a/code/addons/review/src/screens/DetailsScreen.tsx
+++ b/code/addons/review/src/screens/DetailsScreen.tsx
@@ -285,7 +285,10 @@ export const DetailsScreen = ({
     (forceFocus?: boolean) => {
       togglePanel(true);
       if (forceFocus) {
-        void api.focusOnUIElement(focusableUIElements.addonPanel);
+        void api.focusOnUIElement(focusableUIElements.addonPanel, {
+          forceFocus: true,
+          poll: true,
+        });
       }
     },
     [api, togglePanel]

--- a/code/addons/review/src/screens/ReviewDetailPanel.tsx
+++ b/code/addons/review/src/screens/ReviewDetailPanel.tsx
@@ -1,0 +1,93 @@
+import React, {
+  type Dispatch,
+  type FC,
+  type RefObject,
+  type SetStateAction,
+  useMemo,
+  useState,
+} from 'react';
+
+import { styled } from 'storybook/theming';
+
+import { useStorybookApi } from 'storybook/manager-api';
+
+import { Drag } from '../../../../core/src/manager/components/layout/Drag.tsx';
+import Panel from '../../../../core/src/manager/container/Panel.tsx';
+import { MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX } from '../../../../core/src/manager/constants.ts';
+import { useReviewPanelDrag } from './useReviewPanelDrag.ts';
+
+const PanelSection = styled.div(({ theme }) => ({
+  position: 'relative',
+  flexShrink: 0,
+  backgroundColor: theme.appContentBg,
+  borderTop: `1px solid ${theme.appBorderColor}`,
+}));
+
+const PanelSlot = styled.div({
+  height: '100%',
+});
+
+interface ReviewDetailPanelProps {
+  storyId: string;
+  isPanelShown: boolean;
+  panelHeight: number;
+  setPanelHeight: Dispatch<SetStateAction<number>>;
+  hidePanel: () => void;
+  previewFrameRef: RefObject<HTMLIFrameElement>;
+}
+
+export const ReviewDetailPanel: FC<ReviewDetailPanelProps> = ({
+  storyId,
+  isPanelShown,
+  panelHeight,
+  setPanelHeight,
+  hidePanel,
+  previewFrameRef,
+}) => {
+  const api = useStorybookApi();
+  const [isDragging, setIsDragging] = useState(false);
+  const { panelResizerRef, panelMaxSize } = useReviewPanelDrag({
+    panelHeight,
+    setPanelHeight,
+    isDragging,
+    setIsDragging,
+    previewFrameRef,
+  });
+
+  const effectiveHeight = isPanelShown ? panelHeight : 0;
+  const shouldHidePanelContent = effectiveHeight === 0;
+
+  const panelActions = useMemo(
+    () => ({
+      onSelect: (panel: string) => api.setSelectedPanel(panel),
+      toggleVisibility: () => hidePanel(),
+    }),
+    [api, hidePanel]
+  );
+
+  const sectionHeight = effectiveHeight > 0 ? effectiveHeight : MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX;
+
+  return (
+    <PanelSection style={{ height: sectionHeight }}>
+      <Drag
+        ref={panelResizerRef}
+        position="bottom"
+        overlapping={!!effectiveHeight}
+        aria-label="Addon panel resize handle"
+        aria-valuenow={effectiveHeight}
+        aria-valuemax={panelMaxSize}
+      />
+      <PanelSlot
+        hidden={shouldHidePanelContent ? true : undefined}
+        aria-hidden={shouldHidePanelContent ? true : undefined}
+      >
+        <Panel
+          storyId={storyId}
+          panelPosition="bottom"
+          actions={panelActions}
+          showPanelPositionToggle={false}
+        />
+      </PanelSlot>
+    </PanelSection>
+  );
+};

--- a/code/addons/review/src/screens/ReviewDetailToolbar.tsx
+++ b/code/addons/review/src/screens/ReviewDetailToolbar.tsx
@@ -1,0 +1,36 @@
+import React, { type FC } from 'react';
+
+import { useTabsState } from 'storybook/internal/components';
+
+import type { TabListState } from '@react-stately/tabs';
+import { useStorybookApi, useStorybookState } from 'storybook/manager-api';
+
+import { ToolbarComp } from '../../../../core/src/manager/components/preview/Toolbar.tsx';
+import { useReviewToolbar } from './useReviewToolbar.ts';
+
+interface ReviewDetailToolbarProps {
+  storyId: string;
+}
+
+export const ReviewDetailToolbar: FC<ReviewDetailToolbarProps> = ({ storyId }) => {
+  const api = useStorybookApi();
+  const state = useStorybookState();
+  const { tools, toolsExtra, showToolbar } = useReviewToolbar(storyId, api, state);
+  const customisedShowToolbar = api.getShowToolbarWithCustomisations(showToolbar);
+
+  const tabState = useTabsState({
+    selected: 'canvas',
+    onSelectionChange: () => {},
+    tabs: [],
+  });
+
+  return (
+    <ToolbarComp
+      isShown={customisedShowToolbar}
+      tools={tools}
+      toolsExtra={toolsExtra}
+      tabs={[]}
+      tabState={tabState as TabListState<object>}
+    />
+  );
+};

--- a/code/addons/review/src/screens/ReviewDetailToolbar.tsx
+++ b/code/addons/review/src/screens/ReviewDetailToolbar.tsx
@@ -19,7 +19,6 @@ export const ReviewDetailToolbar: FC<ReviewDetailToolbarProps> = ({ storyId }) =
   const customisedShowToolbar = api.getShowToolbarWithCustomisations(showToolbar);
 
   const tabState = useTabsState({
-    selected: 'canvas',
     onSelectionChange: () => {},
     tabs: [],
   });

--- a/code/addons/review/src/screens/ReviewDetailViewport.tsx
+++ b/code/addons/review/src/screens/ReviewDetailViewport.tsx
@@ -1,0 +1,46 @@
+import React, { type FC, type ReactNode } from 'react';
+
+import { styled } from 'storybook/theming';
+
+import { useViewport } from '../../../../core/src/viewport/useViewport.ts';
+
+const ViewportFrame = styled.div<{ $isDefault: boolean }>(({ $isDefault }) => ({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: 0,
+  minHeight: 0,
+  ...($isDefault
+    ? {
+        flex: 1,
+        width: '100%',
+        height: '100%',
+      }
+    : {
+        alignSelf: 'flex-start',
+        justifySelf: 'flex-start',
+      }),
+}));
+
+interface ReviewDetailViewportProps {
+  scale: number;
+  children: ReactNode;
+}
+
+/** Applies manager viewport dimensions to the review detail preview iframe. */
+export const ReviewDetailViewport: FC<ReviewDetailViewportProps> = ({ scale, children }) => {
+  const { width, height, isDefault } = useViewport();
+
+  const frameStyle = isDefault
+    ? undefined
+    : {
+        width: `calc(${width} * ${scale})`,
+        height: `calc(${height} * ${scale})`,
+      };
+
+  return (
+    <ViewportFrame $isDefault={isDefault} style={frameStyle}>
+      {children}
+    </ViewportFrame>
+  );
+};

--- a/code/addons/review/src/screens/ReviewPanelContext.tsx
+++ b/code/addons/review/src/screens/ReviewPanelContext.tsx
@@ -1,0 +1,24 @@
+import React, { createContext, useContext, type FC, type ReactNode } from 'react';
+
+interface ReviewPanelContextValue {
+  isPanelShown: boolean;
+  showPanel: (forceFocus?: boolean) => void;
+  hidePanel: () => void;
+}
+
+const ReviewPanelContext = createContext<ReviewPanelContextValue | null>(null);
+
+export const ReviewPanelProvider: FC<{
+  value: ReviewPanelContextValue;
+  children: ReactNode;
+}> = ({ value, children }) => (
+  <ReviewPanelContext.Provider value={value}>{children}</ReviewPanelContext.Provider>
+);
+
+export const useReviewPanelContext = (): ReviewPanelContextValue => {
+  const context = useContext(ReviewPanelContext);
+  if (!context) {
+    throw new Error('useReviewPanelContext must be used within ReviewPanelProvider');
+  }
+  return context;
+};

--- a/code/addons/review/src/screens/ReviewStoryManagerBridge.tsx
+++ b/code/addons/review/src/screens/ReviewStoryManagerBridge.tsx
@@ -1,0 +1,56 @@
+import React, { useContext, useEffect, useMemo, type FC, type ReactNode } from 'react';
+
+import { SET_CURRENT_STORY } from 'storybook/internal/core-events';
+
+import { ManagerContext } from 'storybook/manager-api';
+
+interface ReviewStoryManagerBridgeProps {
+  storyId: string;
+  isPanelShown: boolean;
+  togglePanel: (next?: boolean) => void;
+  children: ReactNode;
+}
+
+/**
+ * Overrides manager context for the review detail chrome so toolbar tools and
+ * addon panels resolve the explicit review story without navigating away from
+ * the review URL.
+ */
+export const ReviewStoryManagerBridge: FC<ReviewStoryManagerBridgeProps> = ({
+  storyId,
+  isPanelShown,
+  togglePanel,
+  children,
+}) => {
+  const parent = useContext(ManagerContext);
+
+  useEffect(() => {
+    const entry = parent.api.getData(storyId);
+    if (entry?.id) {
+      parent.api.emit(SET_CURRENT_STORY, {
+        storyId: entry.id,
+        viewMode: 'story',
+      });
+    }
+  }, [parent.api, storyId]);
+
+  const value = useMemo(() => {
+    const entry = parent.api.getData(storyId);
+    return {
+      state: {
+        ...parent.state,
+        storyId,
+        viewMode: 'story' as const,
+        path: `/story/${storyId}`,
+      },
+      api: {
+        ...parent.api,
+        getCurrentStoryData: () => entry ?? parent.api.getData(storyId),
+        getIsPanelShown: () => isPanelShown,
+        togglePanel: (next?: boolean) => togglePanel(next),
+      },
+    };
+  }, [isPanelShown, parent.api, parent.state, storyId, togglePanel]);
+
+  return <ManagerContext.Provider value={value}>{children}</ManagerContext.Provider>;
+};

--- a/code/addons/review/src/screens/ReviewStoryManagerBridge.tsx
+++ b/code/addons/review/src/screens/ReviewStoryManagerBridge.tsx
@@ -36,16 +36,26 @@ export const ReviewStoryManagerBridge: FC<ReviewStoryManagerBridgeProps> = ({
 
   const value = useMemo(() => {
     const entry = parent.api.getData(storyId);
+    const storyPath = `/story/${storyId}`;
     return {
       state: {
         ...parent.state,
         storyId,
         viewMode: 'story' as const,
-        path: `/story/${storyId}`,
+        path: storyPath,
       },
       api: {
         ...parent.api,
         getCurrentStoryData: () => entry ?? parent.api.getData(storyId),
+        getUrlState: () => {
+          const urlState = parent.api.getUrlState();
+          return {
+            ...urlState,
+            path: storyPath,
+            storyId,
+            viewMode: 'story' as const,
+          };
+        },
         getIsPanelShown: () => isPanelShown,
         togglePanel: (next?: boolean) => togglePanel(next),
       },

--- a/code/addons/review/src/screens/reviewAddonsTool.tsx
+++ b/code/addons/review/src/screens/reviewAddonsTool.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Button } from 'storybook/internal/components';
+import type { Addon_BaseType } from 'storybook/internal/types';
+
+import { BottomBarIcon } from '@storybook/icons';
+
+import { types } from 'storybook/manager-api';
+
+import { useReviewPanelContext } from './ReviewPanelContext.tsx';
+
+export const reviewAddonsTool: Addon_BaseType = {
+  title: 'addons',
+  id: 'review-addons',
+  type: types.TOOL,
+  match: ({ viewMode, tabId }) => viewMode === 'story' && !tabId,
+  render: () => {
+    const { isPanelShown, showPanel } = useReviewPanelContext();
+
+    if (isPanelShown) {
+      return null;
+    }
+
+    return (
+      <Button
+        padding="small"
+        variant="ghost"
+        ariaLabel="Show addon panel"
+        key="review-addons"
+        onClick={() => showPanel(true)}
+      >
+        <BottomBarIcon />
+      </Button>
+    );
+  },
+};

--- a/code/addons/review/src/screens/usePreviewChannelRelay.ts
+++ b/code/addons/review/src/screens/usePreviewChannelRelay.ts
@@ -1,0 +1,53 @@
+import { type RefObject, useEffect } from 'react';
+
+import { FORCE_REMOUNT, UPDATE_GLOBALS, UPDATE_STORY_ARGS } from 'storybook/internal/core-events';
+
+import { addons } from 'storybook/manager-api';
+
+interface BaselineChannel {
+  emit?: (event: string, ...args: unknown[]) => void;
+}
+
+const RELAY_EVENTS = [UPDATE_GLOBALS, UPDATE_STORY_ARGS, FORCE_REMOUNT] as const;
+
+const getBaselineChannel = (
+  baselineFrameRef: RefObject<HTMLIFrameElement>
+): BaselineChannel | undefined => {
+  const baselineWindow = baselineFrameRef.current?.contentWindow as
+    | (Window & { __STORYBOOK_ADDONS_CHANNEL__?: BaselineChannel })
+    | null
+    | undefined;
+  return baselineWindow?.__STORYBOOK_ADDONS_CHANNEL__;
+};
+
+/**
+ * Forwards manager channel updates that target the latest preview iframe to the
+ * baseline preview iframe as well, so controls/globals stay aligned in
+ * side-by-side comparison.
+ */
+export const usePreviewChannelRelay = (
+  baselineFrameRef: RefObject<HTMLIFrameElement>,
+  showBaseline: boolean
+) => {
+  useEffect(() => {
+    if (!showBaseline) {
+      return undefined;
+    }
+
+    const channel = addons.getChannel();
+    const relayToBaseline = (event: string, ...args: unknown[]) => {
+      const baselineChannel = getBaselineChannel(baselineFrameRef);
+      baselineChannel?.emit?.(event, ...args);
+    };
+
+    const handlers = RELAY_EVENTS.map((event) => {
+      const handler = (...args: unknown[]) => relayToBaseline(event, ...args);
+      channel.on(event, handler);
+      return { event, handler };
+    });
+
+    return () => {
+      handlers.forEach(({ event, handler }) => channel.off(event, handler));
+    };
+  }, [baselineFrameRef, showBaseline]);
+};

--- a/code/addons/review/src/screens/useReviewPanelDrag.ts
+++ b/code/addons/review/src/screens/useReviewPanelDrag.ts
@@ -1,0 +1,131 @@
+import { type Dispatch, type RefObject, type SetStateAction, useEffect, useRef } from 'react';
+
+import {
+  MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX,
+  TOOLBAR_HEIGHT_PX,
+} from '../../../../core/src/manager/constants.ts';
+
+const SNAP_THRESHOLD_PX = 30;
+const STIFFNESS = 0.9;
+const KEYBOARD_STEP_PX = 10;
+const KEYBOARD_SHIFT_MULTIPLIER = 5;
+const RESIZE_KEYS = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'];
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const interpolate = (relativeValue: number, min: number, max: number) =>
+  min + (max - min) * relativeValue;
+
+const computePanelMaxSize = () => {
+  if (typeof window === 'undefined') {
+    return 0;
+  }
+  return Math.max(window.innerHeight - TOOLBAR_HEIGHT_PX, 0);
+};
+
+export const useReviewPanelDrag = ({
+  panelHeight,
+  setPanelHeight,
+  isDragging,
+  setIsDragging,
+  previewFrameRef,
+}: {
+  panelHeight: number;
+  setPanelHeight: Dispatch<SetStateAction<number>>;
+  isDragging: boolean;
+  setIsDragging: Dispatch<SetStateAction<boolean>>;
+  previewFrameRef: RefObject<HTMLIFrameElement>;
+}) => {
+  const panelResizerRef = useRef<HTMLDivElement>(null);
+  const panelMaxSize = computePanelMaxSize();
+
+  useEffect(() => {
+    const panelResizer = panelResizerRef.current;
+    const previewIframe = previewFrameRef.current;
+    if (!panelResizer) {
+      return undefined;
+    }
+
+    const onDragEnd = () => {
+      setIsDragging(false);
+      window.removeEventListener('mousemove', onDrag);
+      window.removeEventListener('mouseup', onDragEnd);
+      previewIframe?.removeAttribute('style');
+    };
+
+    const onDrag = (e: MouseEvent) => {
+      if (e.buttons === 0) {
+        onDragEnd();
+        return;
+      }
+
+      const panelDragSize = e.view ? e.view.innerHeight - e.clientY : 0;
+      const maxSize = computePanelMaxSize();
+
+      if (panelDragSize === panelHeight) {
+        return;
+      }
+      if (panelDragSize <= SNAP_THRESHOLD_PX) {
+        setPanelHeight(0);
+        return;
+      }
+      if (panelDragSize <= MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX) {
+        setPanelHeight(interpolate(STIFFNESS, panelDragSize, MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX));
+        return;
+      }
+      setPanelHeight(clamp(panelDragSize, MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX, maxSize));
+    };
+
+    const onDragStart = (e: MouseEvent) => {
+      e.preventDefault();
+      setIsDragging(true);
+      window.addEventListener('mousemove', onDrag);
+      window.addEventListener('mouseup', onDragEnd);
+      if (previewIframe) {
+        previewIframe.style.pointerEvents = 'none';
+      }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!RESIZE_KEYS.includes(e.key)) {
+        return;
+      }
+      e.preventDefault();
+      const step = e.shiftKey ? KEYBOARD_STEP_PX * KEYBOARD_SHIFT_MULTIPLIER : KEYBOARD_STEP_PX;
+      const maxSize = computePanelMaxSize();
+
+      switch (e.key) {
+        case 'ArrowUp':
+          setPanelHeight((current) =>
+            clamp(current + step, MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX, maxSize)
+          );
+          break;
+        case 'ArrowDown': {
+          const next = clamp(panelHeight - step, 0, maxSize);
+          setPanelHeight(next < MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX ? 0 : next);
+          break;
+        }
+        case 'Home':
+          setPanelHeight(0);
+          break;
+        case 'End':
+          setPanelHeight(maxSize);
+          break;
+        default:
+          break;
+      }
+    };
+
+    panelResizer.addEventListener('mousedown', onDragStart);
+    panelResizer.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      panelResizer.removeEventListener('mousedown', onDragStart);
+      panelResizer.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('mousemove', onDrag);
+      window.removeEventListener('mouseup', onDragEnd);
+    };
+  }, [panelHeight, previewFrameRef, setIsDragging, setPanelHeight]);
+
+  return { panelResizerRef, panelMaxSize, isDragging };
+};

--- a/code/addons/review/src/screens/useReviewPanelDrag.ts
+++ b/code/addons/review/src/screens/useReviewPanelDrag.ts
@@ -100,11 +100,12 @@ export const useReviewPanelDrag = ({
             clamp(current + step, MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX, maxSize)
           );
           break;
-        case 'ArrowDown': {
-          const next = clamp(panelHeight - step, 0, maxSize);
-          setPanelHeight(next < MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX ? 0 : next);
+        case 'ArrowDown':
+          setPanelHeight((current) => {
+            const next = clamp(current - step, 0, maxSize);
+            return next < MINIMUM_HORIZONTAL_PANEL_HEIGHT_PX ? 0 : next;
+          });
           break;
-        }
         case 'Home':
           setPanelHeight(0);
           break;

--- a/code/addons/review/src/screens/useReviewPanelState.ts
+++ b/code/addons/review/src/screens/useReviewPanelState.ts
@@ -1,8 +1,16 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { DEFAULT_BOTTOM_PANEL_HEIGHT } from '../../../../core/src/manager-api/modules/layout.ts';
+import { TOOLBAR_HEIGHT_PX } from '../../../../core/src/manager/constants.ts';
 import { PANEL_HEIGHT_SESSION_KEY, PANEL_VISIBLE_SESSION_KEY } from '../constants.ts';
 import { sessionStore } from '../session-store.ts';
+
+const maxPanelHeight = () =>
+  typeof window === 'undefined'
+    ? DEFAULT_BOTTOM_PANEL_HEIGHT
+    : Math.max(window.innerHeight - TOOLBAR_HEIGHT_PX, 0);
+
+const clampPanelHeight = (height: number) => Math.min(Math.max(0, height), maxPanelHeight());
 
 const readPanelVisible = (): boolean => {
   const stored = sessionStore.read(PANEL_VISIBLE_SESSION_KEY);
@@ -15,7 +23,7 @@ const readPanelHeight = (): number => {
     return DEFAULT_BOTTOM_PANEL_HEIGHT;
   }
   const parsed = Number(stored);
-  return Number.isFinite(parsed) ? parsed : DEFAULT_BOTTOM_PANEL_HEIGHT;
+  return Number.isFinite(parsed) ? clampPanelHeight(parsed) : DEFAULT_BOTTOM_PANEL_HEIGHT;
 };
 
 export const useReviewPanelState = () => {

--- a/code/addons/review/src/screens/useReviewPanelState.ts
+++ b/code/addons/review/src/screens/useReviewPanelState.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { DEFAULT_BOTTOM_PANEL_HEIGHT } from '../../../../core/src/manager-api/modules/layout.ts';
+import { PANEL_HEIGHT_SESSION_KEY, PANEL_VISIBLE_SESSION_KEY } from '../constants.ts';
+import { sessionStore } from '../session-store.ts';
+
+const readPanelVisible = (): boolean => {
+  const stored = sessionStore.read(PANEL_VISIBLE_SESSION_KEY);
+  return stored === null ? true : stored === 'true';
+};
+
+const readPanelHeight = (): number => {
+  const stored = sessionStore.read(PANEL_HEIGHT_SESSION_KEY);
+  if (!stored) {
+    return DEFAULT_BOTTOM_PANEL_HEIGHT;
+  }
+  const parsed = Number(stored);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_BOTTOM_PANEL_HEIGHT;
+};
+
+export const useReviewPanelState = () => {
+  const [isPanelShown, setIsPanelShown] = useState(readPanelVisible);
+  const [panelHeight, setPanelHeight] = useState(readPanelHeight);
+
+  useEffect(() => {
+    sessionStore.write(PANEL_VISIBLE_SESSION_KEY, String(isPanelShown));
+  }, [isPanelShown]);
+
+  useEffect(() => {
+    sessionStore.write(PANEL_HEIGHT_SESSION_KEY, String(panelHeight));
+  }, [panelHeight]);
+
+  const togglePanel = useCallback((next?: boolean) => {
+    setIsPanelShown((current) => (typeof next === 'boolean' ? next : !current));
+  }, []);
+
+  return {
+    isPanelShown,
+    panelHeight,
+    setPanelHeight,
+    togglePanel,
+  };
+};

--- a/code/addons/review/src/screens/useReviewToolbar.ts
+++ b/code/addons/review/src/screens/useReviewToolbar.ts
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+
+import { Addon_TypesEnum, type Addon_BaseType } from 'storybook/internal/types';
+
+import memoizerific from 'memoizerific';
+import type { API, State } from 'storybook/manager-api';
+
+import { filterToolsSide } from '../../../../core/src/manager/components/preview/Toolbar.tsx';
+import type { PreviewProps } from '../../../../core/src/manager/components/preview/utils/types.tsx';
+import { fullScreenTool } from '../../../../core/src/manager/components/preview/Toolbar.tsx';
+import { openInEditorTool } from '../../../../core/src/manager/components/preview/tools/open-in-editor.tsx';
+import { remountTool } from '../../../../core/src/manager/components/preview/tools/remount.tsx';
+import { isolationModeTool } from '../../../../core/src/manager/components/preview/tools/share.tsx';
+import { zoomTool } from '../../../../core/src/manager/components/preview/tools/zoom.tsx';
+import { reviewAddonsTool } from './reviewAddonsTool.tsx';
+
+const defaultTools = [remountTool];
+const defaultToolsExtra = [
+  isolationModeTool,
+  zoomTool,
+  reviewAddonsTool,
+  fullScreenTool,
+  openInEditorTool,
+];
+
+type FilterProps = [
+  entry: PreviewProps['entry'],
+  viewMode: State['viewMode'],
+  location: State['location'],
+  path: State['path'],
+  tabId: string,
+];
+
+const memoizedTools = memoizerific(1)(
+  (_, toolElements: ReturnType<API['getElements']>, filterProps: FilterProps) =>
+    filterToolsSide(
+      [...defaultTools, ...Object.values(toolElements)] as Addon_BaseType[],
+      ...filterProps
+    )
+);
+
+const memoizedExtra = memoizerific(1)(
+  (_, extraElements: ReturnType<API['getElements']>, filterProps: FilterProps) =>
+    filterToolsSide(
+      [...defaultToolsExtra, ...Object.values(extraElements)] as Addon_BaseType[],
+      ...filterProps
+    )
+);
+
+export const useReviewToolbar = (storyId: string, api: API, state: State) => {
+  const entry = api.getData(storyId) as PreviewProps['entry'];
+  const filterProps = useMemo<FilterProps>(
+    () => [entry, 'story', state.location, state.path, ''],
+    [entry, state.location, state.path]
+  );
+
+  const toolsList = Object.values(api.getElements(Addon_TypesEnum.TOOL));
+  const toolsExtraList = Object.values(api.getElements(Addon_TypesEnum.TOOLEXTRA));
+
+  const tools = memoizedTools(toolsList.length, api.getElements(Addon_TypesEnum.TOOL), filterProps);
+  const toolsExtra = memoizedExtra(
+    toolsExtraList.length,
+    api.getElements(Addon_TypesEnum.TOOLEXTRA),
+    filterProps
+  );
+
+  return { tools, toolsExtra, showToolbar: state.layout.showToolbar };
+};

--- a/code/core/src/manager/components/panel/Panel.tsx
+++ b/code/core/src/manager/components/panel/Panel.tsx
@@ -91,100 +91,114 @@ export const AddonPanel = React.memo<{
   shortcuts: State['shortcuts'];
   panelPosition?: 'bottom' | 'right';
   absolute?: boolean;
-}>(({ panels, shortcuts, actions, selectedPanel = null, panelPosition = 'right' }) => {
-  const { isDesktop, setMobilePanelOpen } = useLayout();
+  showPanelPositionToggle?: boolean;
+}>(
+  ({
+    panels,
+    shortcuts,
+    actions,
+    selectedPanel = null,
+    panelPosition = 'right',
+    showPanelPositionToggle = true,
+  }) => {
+    const { isDesktop, setMobilePanelOpen } = useLayout();
 
-  const emptyState = (
-    <EmptyTabContent
-      title="Storybook add-ons"
-      description={
-        <>Integrate your tools with Storybook to connect workflows and unlock advanced features.</>
-      }
-      footer={
-        <Link href={'https://storybook.js.org/addons?ref=ui'} target="_blank" withArrow>
-          <DocumentIcon /> Explore integrations catalog
-        </Link>
-      }
-    />
-  );
-
-  const tools = useMemo(
-    () => (
-      <ActionsWrapper>
-        {isDesktop ? (
+    const emptyState = (
+      <EmptyTabContent
+        title="Storybook add-ons"
+        description={
           <>
+            Integrate your tools with Storybook to connect workflows and unlock advanced features.
+          </>
+        }
+        footer={
+          <Link href={'https://storybook.js.org/addons?ref=ui'} target="_blank" withArrow>
+            <DocumentIcon /> Explore integrations catalog
+          </Link>
+        }
+      />
+    );
+
+    const tools = useMemo(
+      () => (
+        <ActionsWrapper>
+          {isDesktop ? (
+            <>
+              {showPanelPositionToggle ? (
+                <Button
+                  key="position"
+                  padding="small"
+                  variant="ghost"
+                  onClick={actions.togglePosition}
+                  ariaLabel={
+                    panelPosition === 'bottom'
+                      ? 'Move addon panel to right'
+                      : 'Move addon panel to bottom'
+                  }
+                  ariaDescription="Changes the location of the addon panel to the bottom or right of the screen, but does not have any effect on its content."
+                  shortcut={shortcuts.panelPosition}
+                >
+                  {panelPosition === 'bottom' ? <SidebarAltIcon /> : <BottomBarIcon />}
+                </Button>
+              ) : null}
+              <Button
+                key="visibility"
+                padding="small"
+                variant="ghost"
+                onClick={actions.toggleVisibility}
+                ariaLabel="Hide addon panel"
+                shortcut={shortcuts.togglePanel}
+              >
+                <CloseIcon />
+              </Button>
+            </>
+          ) : (
             <Button
-              key="position"
               padding="small"
               variant="ghost"
-              onClick={actions.togglePosition}
-              ariaLabel={
-                panelPosition === 'bottom'
-                  ? 'Move addon panel to right'
-                  : 'Move addon panel to bottom'
-              }
-              ariaDescription="Changes the location of the addon panel to the bottom or right of the screen, but does not have any effect on its content."
-              shortcut={shortcuts.panelPosition}
-            >
-              {panelPosition === 'bottom' ? <SidebarAltIcon /> : <BottomBarIcon />}
-            </Button>
-            <Button
-              key="visibility"
-              padding="small"
-              variant="ghost"
-              onClick={actions.toggleVisibility}
-              ariaLabel="Hide addon panel"
-              shortcut={shortcuts.togglePanel}
+              onClick={() => setMobilePanelOpen(false)}
+              ariaLabel="Close addon panel"
             >
               <CloseIcon />
             </Button>
-          </>
-        ) : (
-          <Button
-            padding="small"
-            variant="ghost"
-            onClick={() => setMobilePanelOpen(false)}
-            ariaLabel="Close addon panel"
-          >
-            <CloseIcon />
-          </Button>
-        )}
-      </ActionsWrapper>
-    ),
-    [actions, isDesktop, panelPosition, setMobilePanelOpen, shortcuts]
-  );
+          )}
+        </ActionsWrapper>
+      ),
+      [actions, isDesktop, panelPosition, setMobilePanelOpen, shortcuts, showPanelPositionToggle]
+    );
 
-  const asideRef = useRef<HTMLElement>(null);
-  const { landmarkProps } = useLandmark(
-    { 'aria-labelledby': 'storybook-panel-heading', role: 'region' },
-    asideRef
-  );
+    const asideRef = useRef<HTMLElement>(null);
+    const { landmarkProps } = useLandmark(
+      { 'aria-labelledby': 'storybook-panel-heading', role: 'region' },
+      asideRef
+    );
 
-  return (
-    <Aside ref={asideRef} id={focusableUIElements.addonPanel} {...landmarkProps}>
-      <h2 id="storybook-panel-heading" className="sb-sr-only">
-        Addon panel
-      </h2>
-      <StatelessTabsView
-        id={focusableUIElements.storyPanelRoot}
-        showToolsWhenEmpty
-        emptyState={emptyState}
-        selected={selectedPanel ?? undefined}
-        onSelectionChange={(id) => actions.onSelect(id)}
-        tools={tools}
-      >
-        <StatelessTabList aria-label="Available addons">
-          {Object.entries(panels).map(([k, v]) => (
-            <StatelessTab key={k} name={k}>
-              {typeof v.title === 'function' ? <v.title /> : v.title}
-            </StatelessTab>
-          ))}
-        </StatelessTabList>
-        {Object.keys(panels).length ? <PreRenderAddons panels={panels} /> : null}
-      </StatelessTabsView>
-    </Aside>
-  );
-});
+    return (
+      <Aside ref={asideRef} id={focusableUIElements.addonPanel} {...landmarkProps}>
+        <h2 id="storybook-panel-heading" className="sb-sr-only">
+          Addon panel
+        </h2>
+        <StatelessTabsView
+          id={focusableUIElements.storyPanelRoot}
+          showToolsWhenEmpty
+          emptyState={emptyState}
+          selected={selectedPanel ?? undefined}
+          onSelectionChange={(id) => actions.onSelect(id)}
+          tools={tools}
+        >
+          <StatelessTabList aria-label="Available addons">
+            {Object.entries(panels).map(([k, v]) => (
+              <StatelessTab key={k} name={k}>
+                {typeof v.title === 'function' ? <v.title /> : v.title}
+              </StatelessTab>
+            ))}
+          </StatelessTabList>
+          {Object.keys(panels).length ? <PreRenderAddons panels={panels} /> : null}
+        </StatelessTabsView>
+      </Aside>
+    );
+  }
+);
 
 AddonPanel.displayName = 'AddonPanel';
 

--- a/code/core/src/manager/container/Panel.tsx
+++ b/code/core/src/manager/container/Panel.tsx
@@ -70,7 +70,11 @@ const Panel: FC<PanelProps> = ({
     [api]
   );
 
-  const panelActions = actions ?? defaultActions;
+  const panelActions: PanelActions = {
+    onSelect: actions?.onSelect ?? defaultActions.onSelect,
+    toggleVisibility: actions?.toggleVisibility ?? defaultActions.toggleVisibility,
+    togglePosition: actions?.togglePosition ?? defaultActions.togglePosition,
+  };
 
   const panels = useMemo(() => {
     const allPanels = api.getElements(Addon_TypesEnum.PANEL);

--- a/code/core/src/manager/container/Panel.tsx
+++ b/code/core/src/manager/container/Panel.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { Addon_TypesEnum } from 'storybook/internal/types';
 
@@ -9,23 +9,50 @@ import { STORY_PREPARED } from '../../core-events/index.ts';
 import { focusableUIElements } from '../../manager-api/modules/layout.ts';
 import { AddonPanel } from '../components/panel/Panel.tsx';
 
-const Panel: FC<any> = (props) => {
+export interface PanelActions {
+  onSelect: (panel: string) => void;
+  toggleVisibility: () => void | Promise<void>;
+  togglePosition?: () => void;
+}
+
+export interface PanelProps {
+  /** When set, load story metadata from this id instead of the manager selection. */
+  storyId?: string;
+  panelPosition?: 'bottom' | 'right';
+  actions?: PanelActions;
+  showPanelPositionToggle?: boolean;
+}
+
+const Panel: FC<PanelProps> = ({
+  storyId,
+  panelPosition: panelPositionProp,
+  actions,
+  showPanelPositionToggle,
+  ...props
+}) => {
   const api = useStorybookApi();
   const state = useStorybookState();
-  const [story, setStory] = useState(api.getCurrentStoryData());
+
+  const resolveStory = () => (storyId ? api.getData(storyId) : api.getCurrentStoryData());
+
+  const [story, setStory] = useState(() => resolveStory());
+
+  useEffect(() => {
+    setStory(resolveStory());
+  }, [storyId, api, state.storyId, state.path]);
 
   useChannel(
     {
       [STORY_PREPARED]: () => {
-        setStory(api.getCurrentStoryData());
+        setStory(resolveStory());
       },
     },
-    []
+    [storyId]
   );
 
   const { parameters, type } = story ?? {};
 
-  const panelActions = useMemo(
+  const defaultActions = useMemo<PanelActions>(
     () => ({
       onSelect: (panel: string) => api.setSelectedPanel(panel),
       toggleVisibility: async () => {
@@ -33,7 +60,6 @@ const Panel: FC<any> = (props) => {
         api.togglePanel();
         if (wasPanelShown) {
           const success = await api.focusOnUIElement(focusableUIElements.showAddonPanel);
-          // Fallback to body for predictable behavior.
           if (success === false) {
             document.body.focus();
           }
@@ -43,6 +69,8 @@ const Panel: FC<any> = (props) => {
     }),
     [api]
   );
+
+  const panelActions = actions ?? defaultActions;
 
   const panels = useMemo(() => {
     const allPanels = api.getElements(Addon_TypesEnum.PANEL);
@@ -70,9 +98,10 @@ const Panel: FC<any> = (props) => {
     <AddonPanel
       panels={panels}
       selectedPanel={api.getSelectedPanel()}
-      panelPosition={state.layout.panelPosition}
+      panelPosition={panelPositionProp ?? state.layout.panelPosition}
       actions={panelActions}
       shortcuts={api.getShortcutKeys()}
+      showPanelPositionToggle={showPanelPositionToggle}
       {...props}
     />
   );


### PR DESCRIPTION
## What I did

Embed Storybook's manager toolbar and bottom-docked addon panel into the review addon's detail screen, per the [PRD](https://app.notion.com/p/chromatic-ui/PRD-Review-detail-screen-Storybook-toolbar-and-addon-panels-37a6e816203480b9b27adeb29c75c6a3).

- Extended the connected `Panel` container with an optional `storyId` prop so addon panels resolve the review story without `api.selectStory()` or URL navigation.
- Added a toolbar row to `ReviewHeader`, reusing `ToolbarComp` and tool-filtering logic with `viewMode: 'story'` and the explicit review story id.
- Docked a review-local bottom addon panel below the dual baseline/latest preview iframes, with sessionStorage persistence for visibility and height independent of the main manager layout.
- Wired a review-specific addons toolbar button and manager-context bridge so Controls and other panels track the detail-screen story.
- Relayed `UPDATE_GLOBALS`, `UPDATE_STORY_ARGS`, and `FORCE_REMOUNT` channel events to the baseline iframe; assigned `id="storybook-preview-iframe"` to the latest preview.
- Wrapped the preview region in `ZoomProvider` so zoom tooling applies consistently.
- Added `DetailsScreen` story play tests for toolbar presence, panel open-by-default, local toggle, and sessionStorage restore.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `cd code && yarn storybook:ui`
2. Open the internal Storybook UI and navigate to the Review addon detail screen (e.g. via a review changes URL like `?path=/review/0/<story-id>` once review state is loaded).
3. Confirm the Storybook preview toolbar appears in the review header, above the baseline comparison bar when shown.
4. Confirm the addon panel is open by default below the preview iframes.
5. Toggle the panel closed via the panel close button and reopen via the toolbar addons button; confirm preview space expands and contracts.
6. Resize the panel with the drag handle; navigate to another story in the collection and confirm panel visibility and height persist.
7. With a baseline available, switch Controls/globals/viewport/remount from the toolbar and confirm both baseline and latest previews stay aligned.
8. Confirm the URL remains on `/review/...` throughout — no jump to `/story/...`.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Toggleable review detail panel with persistent visibility and height
  - Drag-to-resize and keyboard resizing for the panel (Home/End, arrows)
  - Integrated review toolbar and a header toolbar slot for the details view
  - Zoom-scaled preview area with baseline/latest side-by-side support
  - Review add-on quick-open button in the manager bottom bar

* **Tests / Stories**
  - Added interactive stories: PanelToggle and PanelPersistence (visibility & height)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->