### PR TITLE
React: Fix subcomponent prop extraction without JSX usage

### DIFF
--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -74,6 +74,7 @@
     "escodegen": "^2.1.0",
     "expect-type": "^0.15.0",
     "html-tags": "^3.1.0",
+    "memfs": "^4.11.1",
     "prop-types": "^15.7.2",
     "react-element-to-jsx-string": "patch:react-element-to-jsx-string@npm%3A@7rulnik/react-element-to-jsx-string@15.0.1#~/.yarn/patches/@7rulnik-react-element-to-jsx-string-npm-15.0.1-e53b67c4b3.patch",
     "require-from-string": "^2.0.2",

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.test.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.test.ts
@@ -385,6 +385,147 @@ describe('compound component extraction', () => {
     );
   });
 
+  it('extracts declared compound subcomponent without JSX when meta.component is the base export', async () => {
+    await withProject(
+      {
+        'button.tsx': dedent`
+          import React from 'react';
+
+          interface ButtonProps {
+            variant?: 'solid' | 'outline';
+          }
+          const Button = (props: ButtonProps) => <button />;
+
+          interface AlignerProps {
+            side?: 'start' | 'end';
+          }
+          const Aligner = (props: AlignerProps) => <div />;
+
+          const ButtonRoot = Button as typeof Button & {
+            Aligner: typeof Aligner;
+          };
+          ButtonRoot.Aligner = Aligner;
+
+          export default ButtonRoot;
+        `,
+        'button.stories.tsx': dedent`
+          import type { Meta } from '@storybook/react';
+          import Button from './button';
+
+          const meta = {
+            title: 'Example/Button',
+            component: Button,
+            subcomponents: { Aligner: Button.Aligner },
+          } satisfies Meta<typeof Button>;
+
+          export default meta;
+        `,
+      },
+      async (project, filePaths) => {
+        const storyPath = filePaths['button.stories.tsx'];
+        const storyFile = fs.readFileSync(storyPath, 'utf-8');
+        const csf = loadCsf(storyFile, { makeTitle: () => 'Example/Button' }).parse();
+        const declaredSubcomponents = extractDeclaredSubcomponents(csf);
+        const components = await getComponents({
+          csf,
+          storyFilePath: storyPath,
+          docgenEngine: 'react-component-meta',
+          additionalComponentNames: declaredSubcomponents.map(
+            (subcomponent) => subcomponent.componentName
+          ),
+        });
+
+        const mainComponent = findMatchingComponent(components, csf._meta?.component, 'Button');
+        const alignerEntry = {
+          storyPath,
+          component: findExactComponentMatch(components, 'Button.Aligner'),
+        };
+
+        project.extractPropsFromStories([{ storyPath, component: mainComponent }, alignerEntry]);
+
+        expect(mainComponent?.reactComponentMeta?.props?.variant).toBeDefined();
+        expect(mainComponent?.reactComponentMeta?.props?.side).toBeUndefined();
+
+        expect(alignerEntry.component?.reactComponentMeta?.props?.side).toBeDefined();
+        expect(alignerEntry.component?.reactComponentMeta?.props?.variant).toBeUndefined();
+      }
+    );
+  });
+
+  it('extracts declared subcomponents from namespace import without JSX', async () => {
+    await withProject(
+      {
+        'controls-parameters.tsx': dedent`
+          import React from 'react';
+
+          type MainProps = { a?: string; b: string };
+          export const ControlsParameters = ({ a = 'a', b }: MainProps) => <div>{a}{b}</div>;
+
+          type SubcomponentAProps = { e: boolean; c: boolean; d?: boolean };
+          export const SubcomponentA = ({ d = false }: SubcomponentAProps) => <div />;
+
+          type SubcomponentBProps = { g: number; h: number; f?: number };
+          export const SubcomponentB = ({ f = 42 }: SubcomponentBProps) => <div />;
+        `,
+        'controls-parameters.stories.tsx': dedent`
+          import type { Meta } from '@storybook/react';
+          import * as UI from './controls-parameters';
+
+          const meta = {
+            title: 'Example/ControlsParameters',
+            component: UI.ControlsParameters,
+            subcomponents: { SubcomponentA: UI.SubcomponentA, SubcomponentB: UI.SubcomponentB },
+          } satisfies Meta<typeof UI.ControlsParameters>;
+
+          export default meta;
+        `,
+      },
+      async (project, filePaths) => {
+        const storyPath = filePaths['controls-parameters.stories.tsx'];
+        const storyFile = fs.readFileSync(storyPath, 'utf-8');
+        const csf = loadCsf(storyFile, { makeTitle: () => 'Example/ControlsParameters' }).parse();
+        const declaredSubcomponents = extractDeclaredSubcomponents(csf);
+        const components = await getComponents({
+          csf,
+          storyFilePath: storyPath,
+          docgenEngine: 'react-component-meta',
+          additionalComponentNames: declaredSubcomponents.map(
+            (subcomponent) => subcomponent.componentName
+          ),
+        });
+
+        const mainComponent = findMatchingComponent(
+          components,
+          csf._meta?.component,
+          'ControlsParameters'
+        );
+        const subcomponentEntries = declaredSubcomponents.map((declared) => ({
+          storyPath,
+          component: findExactComponentMatch(components, declared.componentName),
+        }));
+
+        project.extractPropsFromStories([
+          { storyPath, component: mainComponent },
+          ...subcomponentEntries,
+        ]);
+
+        expect(mainComponent?.reactComponentMeta?.props?.a).toBeDefined();
+        expect(mainComponent?.reactComponentMeta?.props?.b).toBeDefined();
+
+        const subcomponentA = subcomponentEntries[0].component;
+        const subcomponentB = subcomponentEntries[1].component;
+
+        expect(subcomponentA?.reactComponentMeta?.props?.e).toBeDefined();
+        expect(subcomponentA?.reactComponentMeta?.props?.c).toBeDefined();
+        expect(subcomponentA?.reactComponentMeta?.props?.a).toBeUndefined();
+
+        expect(subcomponentB?.reactComponentMeta?.props?.g).toBeDefined();
+        expect(subcomponentB?.reactComponentMeta?.props?.h).toBeDefined();
+        expect(subcomponentB?.reactComponentMeta?.props?.b).toBeUndefined();
+      }
+    );
+  });
+
   it('extracts declared subcomponents from meta without JSX', async () => {
     await withProject(
       {

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.test.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.test.ts
@@ -1,8 +1,15 @@
+import * as fs from 'node:fs';
+
+import { loadCsf } from 'storybook/internal/csf-tools';
+
 import { describe, expect, it } from 'vitest';
 
 import { dedent } from 'ts-dedent';
 
 import type { StoryRef } from '../getComponentImports.ts';
+import { getComponents } from '../getComponentImports.ts';
+import { findMatchingComponent } from '../resolveComponents.ts';
+import { extractDeclaredSubcomponents, findExactComponentMatch } from '../subcomponents.ts';
 import { extractFromStory, withProject } from './componentMetaExtractor.test-helpers.ts';
 
 describe('compound component extraction', () => {
@@ -374,6 +381,83 @@ describe('compound component extraction', () => {
         expect(entries[1]?.component?.reactComponentMeta).toMatchObject({
           props: { label: expect.anything(), variant: expect.anything() },
         });
+      }
+    );
+  });
+
+  it('extracts declared subcomponents from meta without JSX', async () => {
+    await withProject(
+      {
+        'controls-parameters.tsx': dedent`
+          import React from 'react';
+
+          type MainProps = { a?: string; b: string };
+          export const ControlsParameters = ({ a = 'a', b }: MainProps) => <div>{a}{b}</div>;
+
+          type SubcomponentAProps = { e: boolean; c: boolean; d?: boolean };
+          export const SubcomponentA = ({ d = false }: SubcomponentAProps) => <div />;
+
+          type SubcomponentBProps = { g: number; h: number; f?: number };
+          export const SubcomponentB = ({ f = 42 }: SubcomponentBProps) => <div />;
+        `,
+        'controls-parameters.stories.tsx': dedent`
+          import type { Meta } from '@storybook/react';
+          import { ControlsParameters, SubcomponentA, SubcomponentB } from './controls-parameters';
+
+          const meta = {
+            title: 'Example/ControlsParameters',
+            component: ControlsParameters,
+            subcomponents: { SubcomponentA, SubcomponentB },
+          } satisfies Meta<typeof ControlsParameters>;
+
+          export default meta;
+        `,
+      },
+      async (project, filePaths) => {
+        const storyPath = filePaths['controls-parameters.stories.tsx'];
+        const storyFile = fs.readFileSync(storyPath, 'utf-8');
+        const csf = loadCsf(storyFile, { makeTitle: () => 'Example/ControlsParameters' }).parse();
+        const declaredSubcomponents = extractDeclaredSubcomponents(csf);
+        const components = await getComponents({
+          csf,
+          storyFilePath: storyPath,
+          docgenEngine: 'react-component-meta',
+          additionalComponentNames: declaredSubcomponents.map(
+            (subcomponent) => subcomponent.componentName
+          ),
+        });
+
+        const mainComponent = findMatchingComponent(
+          components,
+          csf._meta?.component,
+          'ControlsParameters'
+        );
+        const subcomponentEntries = declaredSubcomponents.map((declared) => ({
+          storyPath,
+          component: findExactComponentMatch(components, declared.componentName),
+        }));
+
+        project.extractPropsFromStories([
+          { storyPath, component: mainComponent },
+          ...subcomponentEntries,
+        ]);
+
+        expect(mainComponent?.reactComponentMeta?.props?.a).toBeDefined();
+        expect(mainComponent?.reactComponentMeta?.props?.b).toBeDefined();
+        expect(mainComponent?.reactComponentMeta?.props?.e).toBeUndefined();
+
+        const subcomponentA = subcomponentEntries[0].component;
+        const subcomponentB = subcomponentEntries[1].component;
+
+        expect(subcomponentA?.reactComponentMeta?.props?.e).toBeDefined();
+        expect(subcomponentA?.reactComponentMeta?.props?.c).toBeDefined();
+        expect(subcomponentA?.reactComponentMeta?.props?.d).toBeDefined();
+        expect(subcomponentA?.reactComponentMeta?.props?.a).toBeUndefined();
+
+        expect(subcomponentB?.reactComponentMeta?.props?.g).toBeDefined();
+        expect(subcomponentB?.reactComponentMeta?.props?.h).toBeDefined();
+        expect(subcomponentB?.reactComponentMeta?.props?.f).toBeDefined();
+        expect(subcomponentB?.reactComponentMeta?.props?.b).toBeUndefined();
       }
     );
   });

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.test.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.test.ts
@@ -1,16 +1,20 @@
-import * as fs from 'node:fs';
-
-import { loadCsf } from 'storybook/internal/csf-tools';
-
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { dedent } from 'ts-dedent';
 
 import type { StoryRef } from '../getComponentImports.ts';
-import { getComponents } from '../getComponentImports.ts';
 import { findMatchingComponent } from '../resolveComponents.ts';
-import { extractDeclaredSubcomponents, findExactComponentMatch } from '../subcomponents.ts';
-import { extractFromStory, withProject } from './componentMetaExtractor.test-helpers.ts';
+import { findExactComponentMatch } from '../subcomponents.ts';
+import {
+  extractFromStory,
+  loadDeclaredSubcomponentComponents,
+  resetProjectVolume,
+  withProject,
+} from './componentMetaExtractor.test-helpers.ts';
+
+afterEach(() => {
+  resetProjectVolume();
+});
 
 describe('compound component extraction', () => {
   it('extracts props for Accordion.Root, not Item or Trigger', async () => {
@@ -422,17 +426,10 @@ describe('compound component extraction', () => {
         `,
       },
       async (project, filePaths) => {
-        const storyPath = filePaths['button.stories.tsx'];
-        const storyFile = fs.readFileSync(storyPath, 'utf-8');
-        const csf = loadCsf(storyFile, { makeTitle: () => 'Example/Button' }).parse();
-        const declaredSubcomponents = extractDeclaredSubcomponents(csf);
-        const components = await getComponents({
-          csf,
-          storyFilePath: storyPath,
-          docgenEngine: 'react-component-meta',
-          additionalComponentNames: declaredSubcomponents.map(
-            (subcomponent) => subcomponent.componentName
-          ),
+        const { storyPath, csf, components } = await loadDeclaredSubcomponentComponents({
+          filePaths,
+          storyFileName: 'button.stories.tsx',
+          title: 'Example/Button',
         });
 
         const mainComponent = findMatchingComponent(components, csf._meta?.component, 'Button');
@@ -481,18 +478,12 @@ describe('compound component extraction', () => {
         `,
       },
       async (project, filePaths) => {
-        const storyPath = filePaths['controls-parameters.stories.tsx'];
-        const storyFile = fs.readFileSync(storyPath, 'utf-8');
-        const csf = loadCsf(storyFile, { makeTitle: () => 'Example/ControlsParameters' }).parse();
-        const declaredSubcomponents = extractDeclaredSubcomponents(csf);
-        const components = await getComponents({
-          csf,
-          storyFilePath: storyPath,
-          docgenEngine: 'react-component-meta',
-          additionalComponentNames: declaredSubcomponents.map(
-            (subcomponent) => subcomponent.componentName
-          ),
-        });
+        const { storyPath, csf, declaredSubcomponents, components } =
+          await loadDeclaredSubcomponentComponents({
+            filePaths,
+            storyFileName: 'controls-parameters.stories.tsx',
+            title: 'Example/ControlsParameters',
+          });
 
         const mainComponent = findMatchingComponent(
           components,
@@ -555,18 +546,12 @@ describe('compound component extraction', () => {
         `,
       },
       async (project, filePaths) => {
-        const storyPath = filePaths['controls-parameters.stories.tsx'];
-        const storyFile = fs.readFileSync(storyPath, 'utf-8');
-        const csf = loadCsf(storyFile, { makeTitle: () => 'Example/ControlsParameters' }).parse();
-        const declaredSubcomponents = extractDeclaredSubcomponents(csf);
-        const components = await getComponents({
-          csf,
-          storyFilePath: storyPath,
-          docgenEngine: 'react-component-meta',
-          additionalComponentNames: declaredSubcomponents.map(
-            (subcomponent) => subcomponent.componentName
-          ),
-        });
+        const { storyPath, csf, declaredSubcomponents, components } =
+          await loadDeclaredSubcomponentComponents({
+            filePaths,
+            storyFileName: 'controls-parameters.stories.tsx',
+            title: 'Example/ControlsParameters',
+          });
 
         const mainComponent = findMatchingComponent(
           components,

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -316,6 +316,7 @@ export class ComponentMetaProject {
         }
 
         // Path 2: Fallback — resolve from meta.component in the story file.
+        // Only fires when the user explicitly set `component:` in the meta object.
         // Only applies to the meta component itself, not declared subcomponents.
         if (!resolvedComponent) {
           resolvedComponent = this.resolveFromMetaComponent(

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -30,6 +30,8 @@ import type ts from 'typescript';
 import type { StoryRef } from '../getComponentImports.ts';
 import type { ComponentRef, ResolvedComponentTarget } from '../types.ts';
 import {
+  metaComponentMatchesRef,
+  resolvePropsFromComponentExport,
   resolvePropsFromComponentType,
   resolvePropsFromStoryFile,
   serializeComponentDoc,
@@ -314,11 +316,21 @@ export class ComponentMetaProject {
         }
 
         // Path 2: Fallback — resolve from meta.component in the story file.
-        // Only fires when the user explicitly set `component:` in the meta object.
+        // Only applies to the meta component itself, not declared subcomponents.
         if (!resolvedComponent) {
           resolvedComponent = this.resolveFromMetaComponent(
             checker,
             storySourceFile,
+            entryComponent
+          );
+        }
+
+        // Path 3: Resolve directly from the component module export (declared subcomponents).
+        if (!resolvedComponent) {
+          resolvedComponent = resolvePropsFromComponentExport(
+            this.typescript,
+            checker,
+            componentSourceFile,
             entryComponent
           );
         }
@@ -415,7 +427,24 @@ export class ComponentMetaProject {
 
     const metaType = checker.getTypeOfSymbol(defaultExport);
     const componentProp = metaType.getProperty('component');
-    if (!componentProp) {
+    if (
+      !componentProp?.valueDeclaration ||
+      !this.typescript.isPropertyAssignment(componentProp.valueDeclaration)
+    ) {
+      return undefined;
+    }
+
+    const metaComponentInitializer = componentProp.valueDeclaration.initializer;
+    if (
+      !metaComponentInitializer ||
+      !metaComponentMatchesRef(
+        this.typescript,
+        checker,
+        storySourceFile,
+        componentRef,
+        metaComponentInitializer
+      )
+    ) {
       return undefined;
     }
 

--- a/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.test-helpers.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.test-helpers.ts
@@ -1,12 +1,13 @@
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { loadCsf } from 'storybook/internal/csf-tools';
 
+import { vol } from 'memfs';
 import ts from 'typescript';
 
 import { type StoryRef, getComponents } from '../getComponentImports.ts';
 import { findMatchingComponent } from '../resolveComponents.ts';
+import { extractDeclaredSubcomponents } from '../subcomponents.ts';
 import { ComponentMetaProject } from './ComponentMetaProject.ts';
 import { createTempProject, writeFiles } from './test-helpers.ts';
 
@@ -29,17 +30,56 @@ const sharedProject = new ComponentMetaProject(
   fsFileSnapshots
 );
 
+/** Reads a project file from the in-memory mirror populated by {@link withProject}. */
+export function readProjectFile(filePath: string): string {
+  return vol.readFileSync(filePath, 'utf-8') as string;
+}
+
+/** Resets the memfs mirror between tests. */
+export function resetProjectVolume(): void {
+  vol.reset();
+}
+
 /** Write files into the shared project, invalidate caches, and run a callback. */
 export async function withProject<T>(
   files: Record<string, string>,
   fn: (project: ComponentMetaProject, filePaths: Record<string, string>) => T | Promise<T>
 ): Promise<T> {
+  vol.reset();
   const filePaths = writeFiles(projectDir, files);
+  vol.fromNestedJSON(
+    Object.fromEntries(Object.entries(filePaths).map(([name, filePath]) => [filePath, files[name]]))
+  );
   for (const fp of Object.values(filePaths)) {
     fsFileSnapshots.delete(fp);
   }
   (sharedProject as any).projectVersion++;
   return fn(sharedProject, filePaths);
+}
+
+/** Parses a story file and resolves declared subcomponents for extraction tests. */
+export async function loadDeclaredSubcomponentComponents({
+  filePaths,
+  storyFileName,
+  title,
+}: {
+  filePaths: Record<string, string>;
+  storyFileName: string;
+  title: string;
+}) {
+  const storyPath = filePaths[storyFileName];
+  const csf = loadCsf(readProjectFile(storyPath), { makeTitle: () => title }).parse();
+  const declaredSubcomponents = extractDeclaredSubcomponents(csf);
+  const components = await getComponents({
+    csf,
+    storyFilePath: storyPath,
+    docgenEngine: 'react-component-meta',
+    additionalComponentNames: declaredSubcomponents.map(
+      (subcomponent) => subcomponent.componentName
+    ),
+  });
+
+  return { storyPath, csf, declaredSubcomponents, components };
 }
 
 /**
@@ -54,7 +94,7 @@ export async function extractFromStory(
   return withProject(files, async (project, filePaths) => {
     const storyPath = filePaths[storyFileName];
     const title = path.basename(storyFileName).replace(/\.stories\.\w+$/, '');
-    const csf = loadCsf(fs.readFileSync(storyPath, 'utf-8'), {
+    const csf = loadCsf(readProjectFile(storyPath), {
       makeTitle: () => title,
     }).parse();
 

--- a/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
@@ -251,22 +251,19 @@ function resolveComponentSymbol(
  * @param importName - The export name of the component (e.g., 'Button', 'default')
  * @param memberAccess - For compound components (e.g., 'Root' in `<Accordion.Root />`)
  */
-export function resolvePropsFromStoryFile(
+/** Finds the story-local import binding for a {@link ComponentRef}. */
+export function findImportSymbolInStoryFile(
   typescript: typeof ts,
   checker: ts.TypeChecker,
   storySourceFile: ts.SourceFile,
   componentRef: ComponentRef
-): ResolvedComponentTarget | undefined {
+): ts.Symbol | undefined {
   const importSpecifier = componentRef.importId;
   const importName = componentRef.importName;
   const memberAccess = componentRef.member;
   if (!importSpecifier) {
     return undefined;
   }
-
-  // Step 1: Find the import binding symbol in the story file.
-  // This is the local symbol that the story uses in JSX (e.g., `Button` from `import { Button } from './Button'`).
-  let importSymbol: ts.Symbol | undefined;
 
   for (const stmt of storySourceFile.statements) {
     if (!typescript.isImportDeclaration(stmt)) {
@@ -285,12 +282,12 @@ export function resolvePropsFromStoryFile(
       continue;
     }
 
+    let importSymbol: ts.Symbol | undefined;
+
     if (importName === 'default') {
-      // Default import: import Button from '...'
       if (clause.name) {
         importSymbol = checker.getSymbolAtLocation(clause.name);
       }
-      // Also check named imports for `{ default as Button }` pattern
       if (
         !importSymbol &&
         clause.namedBindings &&
@@ -304,22 +301,16 @@ export function resolvePropsFromStoryFile(
           }
         }
       }
-    } else {
-      // Named import: import { Button } from '...' or import { Button as Btn } from '...'
-      if (clause.namedBindings && typescript.isNamedImports(clause.namedBindings)) {
-        for (const spec of clause.namedBindings.elements) {
-          const originalName = (spec.propertyName ?? spec.name).text;
-          if (originalName === importName) {
-            importSymbol = checker.getSymbolAtLocation(spec.name);
-            break;
-          }
+    } else if (clause.namedBindings && typescript.isNamedImports(clause.namedBindings)) {
+      for (const spec of clause.namedBindings.elements) {
+        const originalName = (spec.propertyName ?? spec.name).text;
+        if (originalName === importName) {
+          importSymbol = checker.getSymbolAtLocation(spec.name);
+          break;
         }
       }
     }
-    // Namespace import: import * as Ns from '...'
-    // Only applies when memberAccess is set (compound components accessed as <Ns.Member />).
-    // Without this guard, a namespace import from the same module could shadow a named
-    // import we're actually looking for (e.g. `import * as X from './m'; import { Y } from './m'`).
+
     if (
       !importSymbol &&
       memberAccess &&
@@ -330,9 +321,59 @@ export function resolvePropsFromStoryFile(
     }
 
     if (importSymbol) {
-      break;
+      return importSymbol;
     }
   }
+
+  return undefined;
+}
+
+/** Returns whether `componentRef` is the story meta's `component`, not a declared subcomponent. */
+export function metaComponentMatchesRef(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  storySourceFile: ts.SourceFile,
+  componentRef: ComponentRef,
+  metaComponentInitializer: ts.Expression
+): boolean {
+  const refSymbol = findImportSymbolInStoryFile(typescript, checker, storySourceFile, componentRef);
+  const metaSymbol = resolveComponentSymbolFromNode(typescript, checker, metaComponentInitializer);
+
+  if (refSymbol && metaSymbol) {
+    return (
+      resolveAliasedSymbol(typescript, checker, refSymbol) ===
+      resolveAliasedSymbol(typescript, checker, metaSymbol)
+    );
+  }
+
+  if (typescript.isIdentifier(metaComponentInitializer)) {
+    return componentRef.componentName === metaComponentInitializer.text;
+  }
+
+  if (
+    typescript.isPropertyAccessExpression(metaComponentInitializer) &&
+    typescript.isIdentifier(metaComponentInitializer.expression)
+  ) {
+    const metaName = `${metaComponentInitializer.expression.text}.${metaComponentInitializer.name.text}`;
+    return componentRef.componentName === metaName;
+  }
+
+  return false;
+}
+
+export function resolvePropsFromStoryFile(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  storySourceFile: ts.SourceFile,
+  componentRef: ComponentRef
+): ResolvedComponentTarget | undefined {
+  const memberAccess = componentRef.member;
+  const importSymbol = findImportSymbolInStoryFile(
+    typescript,
+    checker,
+    storySourceFile,
+    componentRef
+  );
 
   if (!importSymbol) {
     return undefined;
@@ -458,6 +499,80 @@ export function resolvePropsFromComponentType(
   }
 
   return undefined;
+}
+
+/**
+ * Path 3 fallback: resolve props from the component module export directly.
+ *
+ * Used for declared subcomponents that only appear in `meta.subcomponents` and have no JSX in the
+ * story file. Without this, Path 2 would incorrectly reuse `meta.component`'s props for every
+ * batch entry.
+ */
+export function resolvePropsFromComponentExport(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  componentSourceFile: ts.SourceFile,
+  componentRef: ComponentRef
+): ResolvedComponentTarget | undefined {
+  const moduleSymbol = checker.getSymbolAtLocation(componentSourceFile);
+  if (!moduleSymbol) {
+    return undefined;
+  }
+
+  const exports = checker.getExportsOfModule(checker.getMergedSymbol(moduleSymbol));
+  const exportName = componentRef.importName ?? componentRef.componentName.split('.').at(-1);
+  if (!exportName) {
+    return undefined;
+  }
+
+  let exportSymbol: ts.Symbol | undefined;
+  let componentType: ts.Type | undefined;
+
+  if (componentRef.namespace && componentRef.member) {
+    const namespaceSymbol = exports.find((symbol) => symbol.getName() === componentRef.namespace);
+    if (!namespaceSymbol) {
+      return undefined;
+    }
+    const namespaceType = checker.getTypeOfSymbol(namespaceSymbol);
+    const memberSymbol = namespaceType.getProperty(componentRef.member);
+    if (!memberSymbol) {
+      return undefined;
+    }
+    exportSymbol = memberSymbol;
+    componentType = checker.getTypeOfSymbol(memberSymbol);
+  } else {
+    exportSymbol =
+      exportName === 'default'
+        ? exports.find((symbol) => symbol.getName() === 'default')
+        : exports.find((symbol) => symbol.getName() === exportName);
+
+    if (!exportSymbol) {
+      return undefined;
+    }
+
+    componentType = checker.getTypeOfSymbol(exportSymbol);
+
+    if (componentRef.member) {
+      const memberSymbol = componentType.getProperty(componentRef.member);
+      if (!memberSymbol) {
+        return undefined;
+      }
+      exportSymbol = memberSymbol;
+      componentType = checker.getTypeOfSymbol(memberSymbol);
+    }
+  }
+
+  const propsType = resolvePropsFromComponentType(typescript, checker, componentType);
+  const contextNode = exportSymbol ? getSymbolContextNode(exportSymbol) : undefined;
+  if (!propsType || !exportSymbol || !contextNode) {
+    return undefined;
+  }
+
+  return {
+    componentRef,
+    propsType,
+    symbol: resolveComponentSymbol(typescript, checker, exportSymbol, contextNode),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
@@ -334,7 +334,9 @@ export function metaComponentMatchesRef(
   const refSymbol = findImportSymbolInStoryFile(typescript, checker, storySourceFile, componentRef);
   const metaSymbol = resolveComponentSymbolFromNode(typescript, checker, metaComponentInitializer);
 
-  if (refSymbol && metaSymbol) {
+  // Plain symbol equality only when the ref is not a member expression — otherwise
+  // `Button.Aligner` would match `meta.component: Button` because both resolve to the Button import.
+  if (refSymbol && metaSymbol && !componentRef.member) {
     return (
       resolveAliasedSymbol(typescript, checker, refSymbol) ===
       resolveAliasedSymbol(typescript, checker, metaSymbol)
@@ -538,17 +540,18 @@ export function resolvePropsFromComponentExport(
   let componentType: ts.Type | undefined;
 
   if (componentRef.namespace && componentRef.member) {
-    const namespaceSymbol = exports.find((symbol) => symbol.getName() === componentRef.namespace);
-    if (!namespaceSymbol) {
+    // `import * as UI` — importName is the module export, not the local namespace alias.
+    const namespaceExportName = componentRef.importName ?? componentRef.member;
+    exportSymbol =
+      namespaceExportName === 'default'
+        ? exports.find((symbol) => symbol.getName() === 'default')
+        : exports.find((symbol) => symbol.getName() === namespaceExportName);
+
+    if (!exportSymbol) {
       return undefined;
     }
-    const namespaceType = checker.getTypeOfSymbol(namespaceSymbol);
-    const memberSymbol = namespaceType.getProperty(componentRef.member);
-    if (!memberSymbol) {
-      return undefined;
-    }
-    exportSymbol = memberSymbol;
-    componentType = checker.getTypeOfSymbol(memberSymbol);
+
+    componentType = checker.getTypeOfSymbol(exportSymbol);
   } else {
     exportSymbol =
       exportName === 'default'

--- a/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
@@ -237,20 +237,6 @@ function resolveComponentSymbol(
 // Story-based prop extraction (probe-free)
 // ---------------------------------------------------------------------------
 
-/**
- * Resolves the selected component symbol and props type by finding JSX usage of the target
- * component in a story file.
- *
- * Story files already contain JSX like `<Button />` that TypeScript has resolved. This function
- * walks the story AST to find a JSX element matching the target component and extracts the props
- * type via `getResolvedSignature()` — the same mechanism as autocomplete and the former probe
- * approach.
- *
- * @param importSpecifier - The import specifier as written in the story file (e.g., './Button',
- *   '@mantine/core')
- * @param importName - The export name of the component (e.g., 'Button', 'default')
- * @param memberAccess - For compound components (e.g., 'Root' in `<Accordion.Root />`)
- */
 /** Finds the story-local import binding for a {@link ComponentRef}. */
 export function findImportSymbolInStoryFile(
   typescript: typeof ts,
@@ -264,6 +250,9 @@ export function findImportSymbolInStoryFile(
   if (!importSpecifier) {
     return undefined;
   }
+
+  // Step 1: Find the import binding symbol in the story file.
+  // This is the local symbol that the story uses in JSX (e.g., `Button` from `import { Button } from './Button'`).
 
   for (const stmt of storySourceFile.statements) {
     if (!typescript.isImportDeclaration(stmt)) {
@@ -285,9 +274,11 @@ export function findImportSymbolInStoryFile(
     let importSymbol: ts.Symbol | undefined;
 
     if (importName === 'default') {
+      // Default import: import Button from '...'
       if (clause.name) {
         importSymbol = checker.getSymbolAtLocation(clause.name);
       }
+      // Also check named imports for `{ default as Button }` pattern
       if (
         !importSymbol &&
         clause.namedBindings &&
@@ -302,6 +293,7 @@ export function findImportSymbolInStoryFile(
         }
       }
     } else if (clause.namedBindings && typescript.isNamedImports(clause.namedBindings)) {
+      // Named import: import { Button } from '...' or import { Button as Btn } from '...'
       for (const spec of clause.namedBindings.elements) {
         const originalName = (spec.propertyName ?? spec.name).text;
         if (originalName === importName) {
@@ -310,7 +302,10 @@ export function findImportSymbolInStoryFile(
         }
       }
     }
-
+    // Namespace import: import * as Ns from '...'
+    // Only applies when memberAccess is set (compound components accessed as <Ns.Member />).
+    // Without this guard, a namespace import from the same module could shadow a named
+    // import we're actually looking for (e.g. `import * as X from './m'; import { Y } from './m'`).
     if (
       !importSymbol &&
       memberAccess &&
@@ -361,6 +356,20 @@ export function metaComponentMatchesRef(
   return false;
 }
 
+/**
+ * Resolves the selected component symbol and props type by finding JSX usage of the target
+ * component in a story file.
+ *
+ * Story files already contain JSX like `<Button />` that TypeScript has resolved. This function
+ * walks the story AST to find a JSX element matching the target component and extracts the props
+ * type via `getResolvedSignature()` — the same mechanism as autocomplete and the former probe
+ * approach.
+ *
+ * @param importSpecifier - The import specifier as written in the story file (e.g., './Button',
+ *   '@mantine/core')
+ * @param importName - The export name of the component (e.g., 'Button', 'default')
+ * @param memberAccess - For compound components (e.g., 'Root' in `<Accordion.Root />`)
+ */
 export function resolvePropsFromStoryFile(
   typescript: typeof ts,
   checker: ts.TypeChecker,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9072,6 +9072,7 @@ __metadata:
     escodegen: "npm:^2.1.0"
     expect-type: "npm:^0.15.0"
     html-tags: "npm:^3.1.0"
+    memfs: "npm:^4.11.1"
     prop-types: "npm:^15.7.2"
     react-docgen: "npm:^8.0.2"
     react-docgen-typescript: "npm:^2.2.2"


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixes React Component Meta (RCM) resolving the wrong props for subcomponents when they are not used in JSX. Path 2 (`resolveFromMetaComponent`) now only applies when the ref matches `meta.component`; subcomponents resolve through Path 3 (`resolvePropsFromComponentExport`).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual testing required beyond the new `ComponentMetaProject` regression test for subcomponents without JSX.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prop extraction now reliably resolves props for declared subcomponents referenced in Storybook metadata.

* **Improvements**
  * Better matching of meta-declared components with stronger fallbacks when story JSX is absent.
  * Test infrastructure switched to an in-memory project mirror for faster, isolated runs.

* **Tests**
  * Added coverage for multiple meta/subcomponent declaration patterns and extraction behaviors.

* **Chores**
  * Added a dev dependency to support the in-memory test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->