### PR TITLE
Angular: Fix @angular/forms version to 21 in sandbox

### DIFF
--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -720,7 +720,7 @@ export const baseTemplates = {
     script:
       'npx -p @angular/cli ng new angular-latest --directory {{beforeDir}} --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn --ssr',
     modifications: {
-      extraDependencies: ['@angular/forms@latest'],
+      extraDependencies: ['@angular/forms@21.2.16'], // Move this to latest or 22 once ng new creates v22 projects
       useCsfFactory: true,
     },
     extraCiSteps: {


### PR DESCRIPTION
## What I did

Forced `@angular/forms` to stay on v21 to match other deps instead of going to v22.

Avoids [this kind of CI failure](https://app.circleci.com/jobs/github/storybookjs/storybook/1580445).

Might need to be adjusted again in the near future once `ng new` starts releasing Angular 22, time will tell.

## Checklist for Contributors

ø

#### Manual testing

* Create angular sandbox
* Go to sandbox and run build-storybook

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Angular CLI sandbox template dependency versioning to use a pinned version for stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->