### PR TITLE
UI: Allow hiding tags from sidebar filters

### DIFF
--- a/code/core/src/manager/components/sidebar/Filter.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Filter.stories.tsx
@@ -215,6 +215,51 @@ export const ClosedWithSelection: Story = {
   },
 };
 
+export const HiddenTagSelection: Story = {
+  ...ClosedWithSelection,
+  beforeEach: () => {
+    const originalTagsOptions = global.TAGS_OPTIONS;
+    global.TAGS_OPTIONS = {
+      ...originalTagsOptions,
+      hidden: {
+        showFilter: false,
+      },
+    };
+
+    return () => {
+      global.TAGS_OPTIONS = originalTagsOptions;
+    };
+  },
+  parameters: {
+    initialStoryState: {
+      internal_index: {
+        v: 6,
+        entries: {
+          'c1-s1': { tags: ['hidden', 'visible', 'dev', 'play-fn'], type: 'story' } as StoryIndexEntry,
+          'c1-test': { tags: ['test-fn'], type: 'story', subtype: 'test' } as StoryIndexEntry,
+          'c1-doc': { tags: [], type: 'docs' } as unknown as DocsIndexEntry,
+        },
+      } as StoryIndex,
+      includedTagFilters: ['hidden'],
+    },
+  },
+  play: async ({ canvas }) => {
+    const button = await canvas.findByRole('button', {}, { timeout: 3000 });
+    expect(button).toHaveAccessibleName('1 active tag filter');
+
+    button.click();
+
+    const visibleTag = await screen.findByText('visible');
+    expect(visibleTag).toBeInTheDocument();
+    expect(screen.queryByText('hidden')).not.toBeInTheDocument();
+
+    const clearButton = await screen.findByRole('button', { name: 'Clear filters' });
+    clearButton.click();
+
+    await screen.findByRole('button', { name: 'Tag filters' });
+  },
+} satisfies Story;
+
 export const Clear = {
   ...ClosedWithSelection,
   beforeEach: () => {

--- a/code/core/src/manager/components/sidebar/FilterPanel.tsx
+++ b/code/core/src/manager/components/sidebar/FilterPanel.tsx
@@ -159,14 +159,15 @@ export const FilterPanel = ({
     includedStatusFilters.length === 0 &&
     excludedStatusFilters.length === 0;
 
-  const hasItems = builtInItems.length > 0 || tagItems.length > 0;
+  const hasTagItems = builtInItems.length > 0 || tagItems.length > 0;
+  const showActions = hasTagItems || !isNothingSelectedYet;
 
   return (
     <Wrapper>
-      {hasItems && (
+      {showActions && (
         <ActionList as="div">
           <ActionList.Item as="div">
-            {isNothingSelectedYet ? (
+            {isNothingSelectedYet && hasTagItems ? (
               <ActionList.Button
                 ariaLabel={false}
                 id="select-all"

--- a/code/core/src/manager/components/sidebar/useFilterData.tsx
+++ b/code/core/src/manager/components/sidebar/useFilterData.tsx
@@ -9,6 +9,7 @@ import type {
 } from 'storybook/internal/types';
 
 import { BeakerIcon, DocumentIcon, PlayHollowIcon } from '@storybook/icons';
+import { global } from '@storybook/global';
 
 import { color } from 'storybook/theming';
 
@@ -50,10 +51,11 @@ const BUILT_IN_FILTER_DEFS: Array<{
 export function useTagFilterEntries(indexJson: StoryIndex) {
   return useMemo(() => {
     const entries = Object.values(indexJson.entries);
+    const tagOptions = global.TAGS_OPTIONS ?? {};
 
     const userTagsCounts = entries.reduce<Record<Tag, number>>((acc, entry) => {
       entry.tags?.forEach((tag: Tag) => {
-        if (!BUILT_IN_TAGS.has(tag)) {
+        if (!BUILT_IN_TAGS.has(tag) && tagOptions[tag]?.showFilter !== false) {
           acc[tag] = (acc[tag] || 0) + 1;
         }
       });
@@ -71,7 +73,9 @@ export function useTagFilterEntries(indexJson: StoryIndex) {
     const getBuiltInCount = (filterFn: FilterFunction | null) =>
       entries.filter((entry) => filterFn?.(entry)).length;
 
-    const builtInEntries: TagFilterEntry[] = BUILT_IN_FILTER_DEFS.map((def) => ({
+    const builtInEntries: TagFilterEntry[] = BUILT_IN_FILTER_DEFS.filter(
+      (def) => tagOptions[def.tag]?.showFilter !== false
+    ).map((def) => ({
       id: def.id,
       type: 'built-in',
       title: def.title,

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -394,6 +394,8 @@ type Tag = string;
 export interface TagOptions {
   /** Visually include or exclude stories with this tag in the sidebar by default */
   defaultFilterSelection?: 'include' | 'exclude' | undefined;
+  /** Hide this tag from the sidebar filter UI. */
+  showFilter?: boolean;
   excludeFromSidebar: boolean;
   excludeFromDocsStories: boolean;
 }

--- a/docs/_snippets/main-config-tags.md
+++ b/docs/_snippets/main-config-tags.md
@@ -7,6 +7,7 @@ export default {
     // 👇 Define a custom tag named "experimental"
     experimental: {
       defaultFilterSelection: 'exclude', // Or 'include'
+      showFilter: false, // Hide from the sidebar tag filter UI
     },
   },
 };
@@ -23,6 +24,7 @@ const config: StorybookConfig = {
     // 👇 Define a custom tag named "experimental"
     experimental: {
       defaultFilterSelection: 'exclude', // Or 'include'
+      showFilter: false, // Hide from the sidebar tag filter UI
     },
   },
 };
@@ -41,6 +43,7 @@ export default defineMain({
     // 👇 Define a custom tag named "experimental"
     experimental: {
       defaultFilterSelection: 'exclude', // Or 'include'
+      showFilter: false, // Hide from the sidebar tag filter UI
     },
   },
 });
@@ -60,6 +63,7 @@ export default defineMain({
     // 👇 Define a custom tag named "experimental"
     experimental: {
       defaultFilterSelection: 'exclude', // Or 'include'
+      showFilter: false, // Hide from the sidebar tag filter UI
     },
   },
 });
@@ -75,6 +79,7 @@ export default defineMain({
     // 👇 Define a custom tag named "experimental"
     experimental: {
       defaultFilterSelection: 'exclude', // Or 'include'
+      showFilter: false, // Hide from the sidebar tag filter UI
     },
   },
 });
@@ -92,6 +97,7 @@ export default defineMain({
     // 👇 Define a custom tag named "experimental"
     experimental: {
       defaultFilterSelection: 'exclude', // Or 'include'
+      showFilter: false, // Hide from the sidebar tag filter UI
     },
   },
 });
@@ -107,6 +113,7 @@ export default defineMain({
     // 👇 Define a custom tag named "experimental"
     experimental: {
       defaultFilterSelection: 'exclude', // Or 'include'
+      showFilter: false, // Hide from the sidebar tag filter UI
     },
   },
 });
@@ -122,6 +129,7 @@ export default defineMain({
     // 👇 Define a custom tag named "experimental"
     experimental: {
       defaultFilterSelection: 'exclude', // Or 'include'
+      showFilter: false, // Hide from the sidebar tag filter UI
     },
   },
 });
@@ -139,6 +147,7 @@ export default defineMain({
     // 👇 Define a custom tag named "experimental"
     experimental: {
       defaultFilterSelection: 'exclude', // Or 'include'
+      showFilter: false, // Hide from the sidebar tag filter UI
     },
   },
 });

--- a/docs/api/main-config/main-config-tags.mdx
+++ b/docs/api/main-config/main-config-tags.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 Parent: [main.js|ts configuration](./main-config.mdx)
 
-Type: `{ [tagName: string]: { defaultFilterSelection?: 'include' | 'exclude' } }`
+Type: `{ [tagName: string]: { defaultFilterSelection?: 'include' | 'exclude'; showFilter?: boolean } }`
 
 Define custom [tags](../../writing-stories/tags.mdx) for your stories, or alter the default configuration of built-in tags.
 
@@ -23,5 +23,11 @@ The name of the tag. This can be any static (i.e. not created dynamically) strin
 Type: `'include' | 'exclude'`
 
 Set the default filter selection state for a tag in the Storybook sidebar. If set to `include`, stories with this tag are selected as included. If set to `exclude`, stories with this tag are selected as excluded, and must be explicitly included by selecting the tag in the sidebar filter menu. If not set, the tag has no default selection.
+
+### `[tagName].showFilter`
+
+Type: `boolean`
+
+Hide a tag from the sidebar filter UI by setting this to `false`. The tag can still be used for defaults, URL filters, and other internal logic.
 
 ![Filtering by tags](../../_assets/writing-stories/tag-filter.png)

--- a/docs/writing-stories/tags.mdx
+++ b/docs/writing-stories/tags.mdx
@@ -40,6 +40,8 @@ For example, to define an "experimental" tag that is excluded by default in the 
 
 If `defaultFilterSelection` is set to `include`, stories with this tag are selected as included in the filter menu. If set to `exclude`, stories with this tag are selected as excluded, and must be explicitly included by selecting the tag in the sidebar filter menu. If not set, the tag has no default selection.
 
+If `showFilter` is set to `false`, the tag stays available for Storybook logic but is hidden from the sidebar tag filter UI.
+
 You can also use the [`tags` configuration](../api/main-config/main-config-tags.mdx) to alter the configuration of built-in tags.
 
 ## Applying tags


### PR DESCRIPTION
Closes #34186 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tags can now be hidden from the sidebar filter UI using the `showFilter` configuration option while remaining available for internal logic.
  * Filter panel now displays actions appropriately when filters are selected.

* **Documentation**
  * Added documentation for the `showFilter` tag configuration option.
  * Updated configuration examples demonstrating the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->