### PR TITLE
Build: Rewrite config overrides in SvelteKit sandbox

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -1016,9 +1016,7 @@ async function getConfigFile(names: string[], cwd: string) {
     }
   }
 
-  throw new Error(
-    `No ${names.join(' or ')} found in sandbox: ${cwd}, cannot modify config.`
-  );
+  throw new Error(`No ${names.join(' or ')} found in sandbox: ${cwd}, cannot modify config.`);
 }
 
 async function prepareSvelteSandbox(cwd: string) {

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -288,7 +288,11 @@ export const init: Task['run'] = async (
       extra = { type: 'server' };
       break;
     case '@storybook/svelte':
-      await prepareSvelteSandbox(cwd);
+      if (template.expected.framework === '@storybook/sveltekit') {
+        await prepareSvelteKitSandbox(cwd);
+      } else {
+        await prepareSvelteSandbox(cwd);
+      }
       break;
   }
 
@@ -1004,23 +1008,36 @@ async function prepareReactNativeWebSandbox(cwd: string) {
   }
 }
 
-async function prepareSvelteSandbox(cwd: string) {
-  const svelteConfigJsPath = join(cwd, 'vite.config.js');
-  const svelteConfigTsPath = join(cwd, 'vite.config.ts');
-
-  // Check which config file exists
-  const configPath = (await pathExists(svelteConfigTsPath))
-    ? svelteConfigTsPath
-    : (await pathExists(svelteConfigJsPath))
-      ? svelteConfigJsPath
-      : null;
-
-  if (!configPath) {
-    throw new Error(
-      `No vite.config.js or vite.config.ts found in sandbox: ${cwd}, cannot modify config.`
-    );
+async function getConfigFile(names: string[], cwd: string) {
+  for (const name of names) {
+    const configPath = join(cwd, name);
+    if (await pathExists(configPath)) {
+      return configPath;
+    }
   }
 
+  throw new Error(
+    `No ${names.join(' or ')} found in sandbox: ${cwd}, cannot modify config.`
+  );
+}
+
+async function prepareSvelteSandbox(cwd: string) {
+  const configPath = await getConfigFile(['svelte.config.ts', 'svelte.config.js'], cwd);
+  const svelteConfig = await csfReadConfig(configPath);
+
+  // Enable async components
+  // see https://svelte.dev/docs/svelte/await-expressions
+  svelteConfig.setFieldValue(['compilerOptions', 'experimental', 'async'], true);
+
+  // Enable remote functions
+  // see https://svelte.dev/docs/kit/remote-functions
+  svelteConfig.setFieldValue(['kit', 'experimental', 'remoteFunctions'], true);
+
+  await writeConfig(svelteConfig);
+}
+
+async function prepareSvelteKitSandbox(cwd: string) {
+  const configPath = await getConfigFile(['vite.config.ts', 'vite.config.js'], cwd);
   const viteConfig = await csfReadConfig(configPath);
 
   // Enable async components

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -11,7 +11,7 @@ import { join, relative, resolve, sep } from 'path';
 // eslint-disable-next-line depend/ban-dependencies
 import slash from 'slash';
 
-import { babelParse, types as t } from '../../code/core/src/babel/index.ts';
+import { babelParse, traverse, types as t } from '../../code/core/src/babel/index.ts';
 import { JsPackageManagerFactory } from '../../code/core/src/common/js-package-manager/index.ts';
 import storybookPackages from '../../code/core/src/common/versions.ts';
 import type { ConfigFile } from '../../code/core/src/csf-tools/index.ts';
@@ -90,6 +90,114 @@ async function pathExists(path: string) {
   } catch {
     return false;
   }
+}
+
+const propKey = (p: t.ObjectProperty) => {
+  if (t.isIdentifier(p.key)) {
+    return p.key.name;
+  }
+
+  if (t.isStringLiteral(p.key)) {
+    return p.key.value;
+  }
+
+  return null;
+};
+
+const makeObjectExpression = (path: string[], value: t.Expression): t.Expression => {
+  if (path.length === 0) {
+    return value;
+  }
+
+  const [first, ...rest] = path;
+  return t.objectExpression([
+    t.objectProperty(t.identifier(first), makeObjectExpression(rest, value)),
+  ]);
+};
+
+const updateObjectExpression = (
+  path: string[],
+  expr: t.Expression,
+  existing: t.ObjectExpression
+) => {
+  const [first, ...rest] = path;
+  const existingField = (existing.properties as t.ObjectProperty[]).find(
+    (p) => propKey(p) === first
+  ) as t.ObjectProperty;
+
+  if (!existingField) {
+    existing.properties.push(
+      t.objectProperty(t.identifier(first), makeObjectExpression(rest, expr))
+    );
+  } else if (t.isObjectExpression(existingField.value) && rest.length > 0) {
+    updateObjectExpression(rest, expr, existingField.value);
+  } else {
+    existingField.value = makeObjectExpression(rest, expr);
+  }
+};
+
+const findPluginCall = (name: string, ast: t.File): t.CallExpression | undefined => {
+  let call: t.CallExpression | undefined;
+  traverse(ast, {
+    CallExpression: {
+      enter(path) {
+        if (call) {
+          return;
+        }
+
+        const { callee } = path.node;
+        if (t.isIdentifier(callee) && callee.name === name) {
+          call = path.node;
+          path.stop();
+        }
+      },
+    },
+  });
+  return call;
+};
+
+function setPluginParam(
+  config: ConfigFile,
+  {
+    pluginName,
+    paramPos,
+    paramPath,
+    paramValue,
+  }: {
+    pluginName: string;
+    paramPos: number;
+    paramPath: string[];
+    paramValue: unknown;
+  }
+) {
+  const call = findPluginCall(pluginName, config._ast);
+  if (!call) {
+    throw new Error(`Could not find a call to the "${pluginName}" plugin in this file.`);
+  }
+
+  if (paramPos > call.arguments.length) {
+    throw new Error(
+      `Cannot set argument ${paramPos} of "${pluginName}" as the call only has ${call.arguments.length} argument(s).`
+    );
+  }
+
+  if (paramPos === call.arguments.length) {
+    call.arguments.push(t.objectExpression([]));
+  }
+
+  const param = call.arguments[paramPos];
+  if (!t.isObjectExpression(param)) {
+    throw new Error(
+      `Expected argument ${paramPos} of "${pluginName}" to be an object, got '${param.type}'.`
+    );
+  }
+
+  const valueNode = config.valueToNode(paramValue);
+  if (!valueNode) {
+    throw new Error(`Unexpected value ${JSON.stringify(paramValue)}`);
+  }
+
+  updateObjectExpression(paramPath, valueNode, param);
 }
 
 const logger = console;
@@ -897,8 +1005,8 @@ async function prepareReactNativeWebSandbox(cwd: string) {
 }
 
 async function prepareSvelteSandbox(cwd: string) {
-  const svelteConfigJsPath = join(cwd, 'svelte.config.js');
-  const svelteConfigTsPath = join(cwd, 'svelte.config.ts');
+  const svelteConfigJsPath = join(cwd, 'vite.config.js');
+  const svelteConfigTsPath = join(cwd, 'vite.config.ts');
 
   // Check which config file exists
   const configPath = (await pathExists(svelteConfigTsPath))
@@ -909,21 +1017,31 @@ async function prepareSvelteSandbox(cwd: string) {
 
   if (!configPath) {
     throw new Error(
-      `No svelte.config.js or svelte.config.ts found in sandbox: ${cwd}, cannot modify config.`
+      `No vite.config.js or vite.config.ts found in sandbox: ${cwd}, cannot modify config.`
     );
   }
 
-  const svelteConfig = await csfReadConfig(configPath);
+  const viteConfig = await csfReadConfig(configPath);
 
   // Enable async components
   // see https://svelte.dev/docs/svelte/await-expressions
-  svelteConfig.setFieldValue(['compilerOptions', 'experimental', 'async'], true);
+  setPluginParam(viteConfig, {
+    pluginName: 'sveltekit',
+    paramPos: 0,
+    paramPath: ['compilerOptions', 'experimental', 'async'],
+    paramValue: true,
+  });
 
   // Enable remote functions
   // see https://svelte.dev/docs/kit/remote-functions
-  svelteConfig.setFieldValue(['kit', 'experimental', 'remoteFunctions'], true);
+  setPluginParam(viteConfig, {
+    pluginName: 'sveltekit',
+    paramPos: 0,
+    paramPath: ['experimental', 'remoteFunctions'],
+    paramValue: true,
+  });
 
-  await writeConfig(svelteConfig);
+  await writeConfig(viteConfig);
 }
 
 /**

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -1027,10 +1027,6 @@ async function prepareSvelteSandbox(cwd: string) {
   // see https://svelte.dev/docs/svelte/await-expressions
   svelteConfig.setFieldValue(['compilerOptions', 'experimental', 'async'], true);
 
-  // Enable remote functions
-  // see https://svelte.dev/docs/kit/remote-functions
-  svelteConfig.setFieldValue(['kit', 'experimental', 'remoteFunctions'], true);
-
   await writeConfig(svelteConfig);
 }
 

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -1009,14 +1009,13 @@ async function prepareReactNativeWebSandbox(cwd: string) {
 }
 
 async function getConfigFile(names: string[], cwd: string) {
-  for (const name of names) {
-    const configPath = join(cwd, name);
-    if (await pathExists(configPath)) {
-      return configPath;
-    }
+  const firstPath = await findFirstPath(names, { cwd })
+
+  if (!firstPath) {
+    throw new Error(`No ${names.join(' or ')} found in sandbox: ${cwd}, cannot modify config.`);
   }
 
-  throw new Error(`No ${names.join(' or ')} found in sandbox: ${cwd}, cannot modify config.`);
+  return firstPath;
 }
 
 async function prepareSvelteSandbox(cwd: string) {


### PR DESCRIPTION


## What I did
Rewrote SvelteKit sandbox config overrides to modify vite.config.ts now that SvelteKit 2.62 ships without a dedicated svelte config file.

## Checklist for Contributors

### Testing


#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

CI should be green. That's the test here.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandboxes now detect SvelteKit vs non-SvelteKit: SvelteKit sandboxes enable async components and remote functions; non-Svelte sandboxes enable async components only.

* **Chores**
  * Improved sandbox configuration detection, updates, and persistence for more reliable feature enabling and clearer errors when required config files are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->