### PR TITLE
Build: Resolve svelte config paths against the sandbox cwd in sandbox-parts

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -1015,7 +1015,9 @@ async function getConfigFile(names: string[], cwd: string) {
     throw new Error(`No ${names.join(' or ')} found in sandbox: ${cwd}, cannot modify config.`);
   }
 
-  return firstPath;
+  // findFirstPath returns a path relative to `cwd`; resolve it so readConfig
+  // does not resolve it against the script's own working directory.
+  return join(cwd, firstPath);
 }
 
 async function prepareSvelteSandbox(cwd: string) {


### PR DESCRIPTION
## What I did

#35127 introduced `getConfigFile`, which passes the **relative** filename returned by `findFirstPath` straight to `readConfig` — so the path resolves against the script's own working directory instead of the sandbox. Since it merged, the `svelte-latest...create` and `sveltekit-latest...create` jobs fail on every PR with:

```
Error: ENOENT: no such file or directory, open 'svelte.config.js'   (prepareSvelteSandbox)
Error: ENOENT: no such file or directory, open 'vite.config.ts'     (prepareSvelteKitSandbox)
```

(e.g. on #35125: builds [1591247](https://circleci.com/gh/storybookjs/storybook/1591247), [1591177](https://circleci.com/gh/storybookjs/storybook/1591177))

The fix joins the sandbox cwd in `getConfigFile`, matching the existing `readFile(join(sandboxDir, configFile))` pattern elsewhere in the file.

## Manual testing

Ran `yarn task sandbox --template svelte-kit/skeleton-ts --start-from auto` with the fix: sandbox creation passes the previously failing prepare step, and the generated `vite.config.ts` contains the intended `compilerOptions.experimental.async` and `experimental.remoteFunctions` injections.

cc @sidnioulz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration file resolution in sandbox tooling. Previously, configuration files could be resolved from the script's directory instead of the intended location, which has now been fixed to properly resolve paths relative to the specified working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->