### PR TITLE
Build: Anchor vite config injection on the plugins key in sandbox-parts

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -587,17 +587,20 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
 
   let fileContent = await readFile(join(sandboxDir, configFile), 'utf-8');
 
-  // Insert resolve: { preserveSymlinks: true } and optionally server.fs.allow as siblings to plugins
-  // Handles both defineConfig({ ... }) and defineWorkspace([ ... , { ... }])
-  fileContent = fileContent.replace(/(plugins\s*:\s*\[[^\]]*\],?)/, (match) => {
-    let replacement = `${match}\n  resolve: {\n    preserveSymlinks: true\n  },`;
+  // Insert resolve: { preserveSymlinks: true } and optionally server.fs.allow as siblings to
+  // plugins. Handles both defineConfig({ ... }) and defineWorkspace([ ... , { ... }]). Anchored
+  // on the `plugins:` key (injecting before it) instead of matching the whole array: plugin code
+  // may contain `]` (e.g. the regex literal in the sveltekit template), which a bracket-counting
+  // regex like `\[[^\]]*\]` would cut short, splicing the injection into the middle of it.
+  fileContent = fileContent.replace(/^([ \t]*)plugins\s*:/m, (match, indent) => {
+    let injected = `${indent}resolve: {\n${indent}  preserveSymlinks: true\n${indent}},\n`;
 
     // In linked mode, also add server.fs.allow to allow Vite to serve files from the monorepo root
     if (options.link) {
-      replacement += `\n  server: {\n    fs: {\n      allow: ['../../..']\n    }\n  },`;
+      injected += `${indent}server: {\n${indent}  fs: {\n${indent}    allow: ['../../..']\n${indent}  }\n${indent}},\n`;
     }
 
-    return replacement;
+    return `${injected}${match}`;
   });
 
   // search for storybookTest({...}) and place `tags: 'vitest'` into it but tags option doesn't exist yet in the config. Also consider multi line


### PR DESCRIPTION
## What I did

Follow-up to #35130. With the config path fixed, the sveltekit build/dev jobs surfaced the next latent bug: the `resolve: { preserveSymlinks }` / `server.fs.allow` injection matches the whole plugins array with `plugins\s*:\s*\[[^\]]*\],?`, which stops at the **first** `]`. The sveltekit template's runes option contains `filename.split(/[/\\]/)` — a `]` inside a regex character class — so the injection was spliced into the middle of the regex literal, producing an unparseable `vite.config.ts`:

```
[PARSE_ERROR] Unterminated regular expression
18 │     }) => filename.split(/[/\\]
```

(builds [1591391](https://circleci.com/gh/storybookjs/storybook/1591391), [1591394](https://circleci.com/gh/storybookjs/storybook/1591394) on #35130)

The fix injects the sibling keys **before** `plugins:` instead of after the array, so the array contents are never parsed at all.

## Manual testing

Ran `yarn task build --template svelte-kit/skeleton-ts --start-from auto`: the generated `vite.config.ts` is now valid — `resolve`/`server` as proper siblings, runes regex intact.

cc @sidnioulz — this should be the missing piece after #35127/#35130.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal test and build configuration patching logic for more reliable configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->