### PR TITLE
Tanstack React: Preserve pathless layout routes

### DIFF
--- a/code/frameworks/tanstack-react/src/export-mocks/react-router.test.ts
+++ b/code/frameworks/tanstack-react/src/export-mocks/react-router.test.ts
@@ -44,6 +44,14 @@ describe('createFileRoute', () => {
     expect(Route.options.fullPath).toBe('/page');
   });
 
+  it('keeps pure pathless `_layout` routes id-only', () => {
+    const Route = build('/_layout');
+
+    expect(Route.options.id).toBe('/_layout');
+    expect(Route.options.path).toBeUndefined();
+    expect(Route.options.fullPath).toBeUndefined();
+  });
+
   it('normalizes a mix of `_layout` and `(group)` segments', () => {
     const Route = build('/_layout/(group)/page');
 

--- a/code/frameworks/tanstack-react/src/export-mocks/react-router.ts
+++ b/code/frameworks/tanstack-react/src/export-mocks/react-router.ts
@@ -85,7 +85,7 @@ export const Link = ({
 export function createFileRoute(path: string) {
   const normalizedPath = normalizeFileRoutePath(path);
   const segments = path.split('/').filter(Boolean);
-  const lastSegment = segments.at(-1);
+  const lastSegment = segments[segments.length - 1];
   const isPurePathlessLayoutRoute = (lastSegment?.startsWith('_') ?? false) && normalizedPath === '/';
 
   return (options: any) => {

--- a/code/frameworks/tanstack-react/src/export-mocks/react-router.ts
+++ b/code/frameworks/tanstack-react/src/export-mocks/react-router.ts
@@ -84,16 +84,23 @@ export const Link = ({
  */
 export function createFileRoute(path: string) {
   const normalizedPath = normalizeFileRoutePath(path);
+  const segments = path.split('/').filter(Boolean);
+  const lastSegment = segments.at(-1);
+  const isPurePathlessLayoutRoute = (lastSegment?.startsWith('_') ?? false) && normalizedPath === '/';
 
   return (options: any) => {
     return createRoute({
-      path: normalizedPath,
+      ...(isPurePathlessLayoutRoute ? { id: path } : { path: normalizedPath }),
       ...options,
       isRoot: false,
     }).update({
       id: path,
-      path: normalizedPath,
-      fullPath: normalizedPath,
+      ...(isPurePathlessLayoutRoute
+        ? {}
+        : {
+            path: normalizedPath,
+            fullPath: normalizedPath,
+          }),
       // any because tanstack router does that
     } as any);
   };

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { createMemoryHistory, createRootRoute, createRoute, createRouter } from '@tanstack/react-router';
+
+import { duplicateRouteTree } from './duplicate-tree.ts';
+
+describe('duplicateRouteTree', () => {
+  it('preserves pathless layout routes as id-only routes', async () => {
+    const root = createRootRoute();
+    const authed = createRoute({
+      id: '/_authed',
+      getParentRoute: () => root,
+      component: () => null,
+    });
+    const race = createRoute({
+      path: 'races/$racePublicId/$raceSlug',
+      getParentRoute: () => authed,
+      component: () => null,
+    });
+    const test = createRoute({
+      path: 'test',
+      getParentRoute: () => race,
+      component: () => null,
+    });
+
+    root.addChildren([authed.addChildren([race.addChildren([test])])]);
+
+    const { root: duplicatedRoot, byId } = duplicateRouteTree(root);
+    const clonedAuthed = byId.get(authed.id) as any;
+    const clonedRace = byId.get(race.id) as any;
+    const clonedTest = byId.get(test.id) as any;
+
+    expect(clonedAuthed.options.id).toBe('/_authed');
+    expect(clonedAuthed.options.path).toBeUndefined();
+
+    const router = createRouter({
+      routeTree: duplicatedRoot,
+      history: createMemoryHistory({
+        initialEntries: ['/races/dragonborn/dragonborn/test'],
+      }),
+    });
+    await router.load();
+
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      duplicatedRoot.id,
+      clonedAuthed.id,
+      clonedRace.id,
+      clonedTest.id,
+    ]);
+  });
+});

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
@@ -62,10 +62,10 @@ function cloneChild(
   byId: Map<string, AnyRoute>
 ): AnyRoute {
   const options = (oldRoute as any).options ?? {};
-  // Strip identity / parent-link options so the cloned route gets its identity
-  // derived from the new parent + path, and its parent linked to the cloned
-  // parent below. Keeping the original `id` would cause TanStack to register
-  // two routes with the same generated id (e.g. `__root__/about`).
+  // Strip parent-link options so the cloned route gets linked to the cloned
+  // parent below. Path routes derive identity from the new parent + path, then
+  // preserve the source file-route id after creation. Pathless layout routes
+  // are id-only, so giving them a path would turn the layout into a URL route.
   const { id: _id, getParentRoute: _g, ...rest } = options;
   const override = getOverrideFor(overrides, oldRoute.id);
 
@@ -73,11 +73,16 @@ function cloneChild(
   // registers the route in TanStack's global file-route registry by path, so
   // re-running the duplication on every story re-render registers a duplicate
   // and TanStack throws `Duplicate routeIds found: __root__`.
-  const cloned = createRoute({
+  let cloned = createRoute({
+    ...(options.id && options.path === undefined ? { id: options.id } : {}),
     ...rest,
     ...override,
     getParentRoute: () => parent as any,
   } as any);
+
+  if (options.id && options.path !== undefined) {
+    cloned = cloned.update({ id: options.id } as any);
+  }
 
   byId.set(oldRoute.id, cloned as unknown as AnyRoute);
 


### PR DESCRIPTION
## Summary
- Keep pure `_layout` file routes id-only in the TanStack React router mock instead of normalizing them to `path: '/'`.
- Preserve id-only pathless layout routes while duplicating route trees.
- Add regression coverage for mocked `createFileRoute('/_layout')` and matching through a duplicated pathless parent.

## What I did
`@storybook/tanstack-react` intercepts `@tanstack/react-router` imports in stories. Its `createFileRoute` mock normalized pure pathless layout routes like `/_authenticated` to a slash path. The duplicated story router then treated pathless layouts as real URL routes, which breaks nested route matching and APIs such as `getRouteApi('/_authenticated/...')`.

This keeps pure pathless layout routes id-only and preserves those routes while cloning the story route tree.

#### Manual testing
- Not run in this environment. The fork was edited through GitHub APIs because local Storybook monorepo checkout/install caused Codex Desktop instability, and the cloud worker could not clone GitHub due network 403.
- Locally verified the same fix in a consuming app by rendering a route-backed story through a pathless authenticated shell and reading params with `getRouteApi('/_authed/races/$racePublicId/$raceSlug/test')`.