### PR TITLE
Controls: Prevent the save bar from covering the last control

### DIFF
--- a/code/core/src/controls/components/ControlsPanel.stories.tsx
+++ b/code/core/src/controls/components/ControlsPanel.stories.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { global } from '@storybook/global';
+
 import { ManagerContext } from 'storybook/manager-api';
-import { expect, fn } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
 
 import { ControlsPanel } from './ControlsPanel.tsx';
 
@@ -126,5 +128,87 @@ export const ServiceDocgenControlsLoad: Story = {
   play: async ({ canvas }) => {
     await expect(await canvas.findByRole('radio', { name: 'primary' })).toBeInTheDocument();
     await expect(serviceGetDocgen).toHaveBeenCalledWith({ id: 'example-button' });
+  },
+};
+
+// A panel with more controls than fit, plus one edited arg so the "save from controls" bar
+// renders. The bar is absolutely positioned at the bottom of the panel, so the scrollable
+// content must reserve room for it — otherwise the last control sits under the bar (#34531).
+const PROP_COUNT = 12;
+const overlapArgTypes = Object.fromEntries(
+  Array.from({ length: PROP_COUNT }, (_, i) => [
+    `prop${i + 1}`,
+    { name: `prop${i + 1}`, control: { type: 'text' } },
+  ])
+);
+const overlapStoryData = {
+  type: 'story',
+  id: `${refId}_example-button--primary`,
+  refId,
+  argTypes: overlapArgTypes,
+  initialArgs: Object.fromEntries(
+    Array.from({ length: PROP_COUNT }, (_, i) => [`prop${i + 1}`, ''])
+  ),
+  // The first arg differs from its initial value, so the panel is in the "unsaved changes" state.
+  args: Object.fromEntries(
+    Array.from({ length: PROP_COUNT }, (_, i) => [`prop${i + 1}`, i === 0 ? 'edited' : ''])
+  ),
+};
+const overlapContext: any = {
+  state: {
+    path: overlapStoryData.id,
+    previewInitialized: false,
+    refs: { [refId]: { id: refId, previewInitialized: true } },
+  },
+  api: { ...managerContext.api, getCurrentStoryData: fn(() => overlapStoryData) },
+};
+
+/**
+ * Regression test for #34531: when the controls overflow the panel, the "save from controls"
+ * bar must not cover the last control. The save bar only renders in development, with unsaved
+ * arg changes — reproduced here inside a short, scrollable host that mimics the addon panel.
+ */
+export const SaveBarDoesNotCoverLastControl: Story = {
+  // The save bar only renders in development builds; set it for this story and restore after,
+  // so the mutation can't leak into other stories.
+  beforeEach: () => {
+    const original = global.CONFIG_TYPE;
+    global.CONFIG_TYPE = 'DEVELOPMENT';
+    return () => {
+      global.CONFIG_TYPE = original;
+    };
+  },
+  decorators: [
+    (storyFn) => (
+      <ManagerContext.Provider value={overlapContext}>
+        {/* relative parent = the bar's positioning context; inner div = the scroll container */}
+        <div style={{ position: 'relative', height: 200 }}>
+          <div data-testid="panel-scroll" style={{ height: '100%', overflowY: 'auto' }}>
+            {storyFn()}
+          </div>
+        </div>
+      </ManagerContext.Provider>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText(`prop${PROP_COUNT}`);
+
+    const scroller = canvasElement.querySelector<HTMLElement>('[data-testid="panel-scroll"]');
+    const saveBar = canvasElement.querySelector<HTMLElement>('#save-from-controls');
+    await expect(scroller).not.toBeNull();
+    await expect(saveBar).not.toBeNull();
+
+    // Scroll to the very bottom, where the last control would sit under the bar without the fix.
+    scroller!.scrollTop = scroller!.scrollHeight;
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+
+    const rows = canvasElement.querySelectorAll('.docblock-argstable tbody tr');
+    const lastRow = rows[rows.length - 1];
+    const lastRowRect = lastRow.getBoundingClientRect();
+    const barRect = saveBar!.getBoundingClientRect();
+
+    // The last control's bottom must clear the top of the save bar.
+    await expect(lastRowRect.bottom).toBeLessThanOrEqual(barRect.top + 1);
   },
 };

--- a/code/core/src/controls/components/ControlsPanel.tsx
+++ b/code/core/src/controls/components/ControlsPanel.tsx
@@ -34,8 +34,10 @@ const clean = (obj: { [key: string]: any }) =>
   );
 
 const AddonWrapper = styled.div<{ showSaveFromUI: boolean }>(({ showSaveFromUI, theme }) => ({
-  height: '100%',
-  maxHeight: '100vh',
+  // `minHeight` (not `height`) so the wrapper fills a short panel but grows with tall
+  // content; otherwise a fixed height clips the bottom padding into the middle of the
+  // scrolled content and the save bar overlaps the last control (#34531).
+  minHeight: '100%',
   paddingBottom: showSaveFromUI ? 41 : 0,
   backgroundColor: theme.background.content,
 


### PR DESCRIPTION
Closes #34531

## What I did

The "save from controls" bar (shown after you edit a story's args in development) is absolutely positioned at the bottom of the controls panel. The panel reserved room for it with `padding-bottom: 41px`, but that padding sat on a wrapper with a fixed `height: 100%`. Once the controls overflowed the panel and you scrolled to the bottom, the padding stayed pinned at the wrapper's fixed height — in the middle of the scrolled content — so the last control ended up underneath the bar.

Changing the wrapper from a fixed `height: 100%` (capped at `100vh`) to `min-height: 100%` keeps it filling a short panel as before, but lets it grow with tall content so the reserved bottom padding always falls after the last control. The last control now clears the save bar.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

A new `SaveBarDoesNotCoverLastControl` story in `ControlsPanel.stories.tsx` renders an overflowing controls panel with the save bar inside a short scroll container; its play function scrolls to the bottom and asserts the last control's bottom clears the top of the bar. It fails on the previous code and passes with this change.

#### Manual testing

1. Run a sandbox, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook and select a story whose component has enough args that the Controls panel scrolls (shrink the panel or window if needed).
3. Edit any control so the "You modified this story…" save bar appears at the bottom of the panel.
4. Scroll the Controls panel to the very bottom.
5. Expected: the last control row is fully visible above the save bar. Before this fix it was partially hidden behind the bar.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the save bar from overlapping or clipping the last control when the controls panel is scrolled with overflowing content.

* **Tests**
  * Added a Storybook regression story (`SaveBarDoesNotCoverLastControl`) that renders an overflow/unsaved-changes scenario in a scrollable container, scrolls to the bottom, and verifies the last control remains visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->