### PR TITLE
CLI: Add telemetry for the `storybook ai <command>` passthrough

### DIFF
--- a/code/core/src/core-server/withTelemetry.test.ts
+++ b/code/core/src/core-server/withTelemetry.test.ts
@@ -161,6 +161,41 @@ describe('withTelemetry', () => {
     exitSpy.mockRestore();
   });
 
+  it('treats ai-command interruption errors as canceled telemetry', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const run = vi.fn(async () => {
+      const error = new Error('The operation was aborted');
+      Object.assign(error, { name: 'AbortError', code: 'ABORT_ERR' });
+      throw error;
+    });
+
+    await expect(withTelemetry('ai-command', { cliOptions }, run)).resolves.toBeUndefined();
+
+    expect(telemetry).toHaveBeenNthCalledWith(
+      2,
+      'canceled',
+      { eventType: 'ai-command' },
+      { stripMetadata: true, immediate: true }
+    );
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    exitSpy.mockRestore();
+  });
+
+  it('does not treat dev interruption errors as canceled telemetry', async () => {
+    const run = vi.fn(async () => {
+      const error = new Error('The operation was aborted');
+      Object.assign(error, { name: 'AbortError', code: 'ABORT_ERR' });
+      throw error;
+    });
+
+    await expect(withTelemetry('dev', { cliOptions, printError: vi.fn() }, run)).rejects.toThrow(
+      'The operation was aborted'
+    );
+
+    expect(telemetry).not.toHaveBeenCalledWith('canceled', expect.anything(), expect.anything());
+  });
+
   it('treats wrapped init interruption failures as canceled telemetry', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
     const run = vi.fn(async () => {

--- a/code/core/src/core-server/withTelemetry.ts
+++ b/code/core/src/core-server/withTelemetry.ts
@@ -212,6 +212,12 @@ function isInterruptionError(error: unknown): boolean {
   );
 }
 
+/**
+ * Commands that report a `canceled` event when the user interrupts them with Ctrl+C. Other
+ * commands simply die on SIGINT without telemetry.
+ */
+const CANCELLATION_TRACKED_EVENTS: EventType[] = ['init', 'ai-command'];
+
 export async function withTelemetry<T>(
   eventType: EventType,
   options: TelemetryOptions,
@@ -230,7 +236,8 @@ export async function withTelemetry<T>(
     process.exit(0);
   }
 
-  if (eventType === 'init') {
+  const trackCancellation = CANCELLATION_TRACKED_EVENTS.includes(eventType);
+  if (trackCancellation) {
     // We catch Ctrl+C user interactions to be able to detect a cancel event
     process.on('SIGINT', cancelTelemetry);
   }
@@ -251,7 +258,7 @@ export async function withTelemetry<T>(
       return undefined;
     }
 
-    if (eventType === 'init' && isInterruptionError(error)) {
+    if (trackCancellation && isInterruptionError(error)) {
       await cancelTelemetry();
       return undefined;
     }

--- a/code/core/src/telemetry/types.ts
+++ b/code/core/src/telemetry/types.ts
@@ -46,6 +46,7 @@ export type EventType =
   | 'share'
   | 'ghost-stories'
   | 'sidebar-filter'
+  | 'ai-command'
   | 'ai-init-opt-in'
   | 'ai-prompt-nudge'
   | 'ai-setup'

--- a/code/lib/cli-storybook/src/ai/mcp/client.test.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/client.test.ts
@@ -1,6 +1,8 @@
+import { versions } from 'storybook/internal/common';
+
 import { describe, expect, it, vi } from 'vitest';
 
-import { McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
+import { MCP_CLIENT_INFO, McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
 import type { StorybookInstanceRecord } from './types.ts';
 
 const record: StorybookInstanceRecord = {
@@ -13,10 +15,10 @@ const record: StorybookInstanceRecord = {
   mcp: { status: 'ready', endpoint: '/mcp' },
 };
 
-const jsonResponse = (body: unknown, status = 200) =>
+const jsonResponse = (body: unknown, status = 200, headers: Record<string, string> = {}) =>
   new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
   });
 
 const sseResponse = (body: string, status = 200) =>
@@ -24,6 +26,12 @@ const sseResponse = (body: string, status = 200) =>
     status,
     headers: { 'Content-Type': 'text/event-stream' },
   });
+
+/**
+ * Every JSON-RPC request is preceded by a best-effort `initialize` handshake POST, so the actual
+ * request under test is always the last fetch call.
+ */
+const lastCall = (fetchImpl: typeof fetch) => vi.mocked(fetchImpl).mock.calls.at(-1)!;
 
 describe('callMcpTool', () => {
   it('POSTs a JSON-RPC tools/call request to the endpoint (application/json)', async () => {
@@ -43,7 +51,7 @@ describe('callMcpTool', () => {
 
     expect(result.content).toEqual([{ type: 'text', text: 'hello' }]);
 
-    const call = vi.mocked(fetchImpl).mock.calls[0];
+    const call = lastCall(fetchImpl);
     expect(call[0]).toBe('http://localhost:6006/mcp');
     const init = call[1] as RequestInit;
     const headers = init.headers as Record<string, string>;
@@ -73,7 +81,7 @@ describe('callMcpTool', () => {
       fetchImpl
     );
 
-    expect(vi.mocked(fetchImpl).mock.calls[0][0]).toBe('http://127.0.0.1:6007/mcp');
+    expect(lastCall(fetchImpl)[0]).toBe('http://127.0.0.1:6007/mcp');
   });
 
   it('parses a single-event SSE response (text/event-stream)', async () => {
@@ -192,7 +200,7 @@ describe('listMcpTools', () => {
 
     await expect(listMcpTools(record, fetchImpl)).resolves.toEqual(tools);
 
-    const body = JSON.parse(vi.mocked(fetchImpl).mock.calls[0][1]?.body as string);
+    const body = JSON.parse(lastCall(fetchImpl)[1]?.body as string);
     expect(body).toMatchObject({ method: 'tools/list', params: {} });
   });
 
@@ -210,5 +218,146 @@ describe('listMcpTools', () => {
         result: { tools: [{ description: 'nameless' }] },
       })) as typeof fetch;
     await expect(listMcpTools(record, fetchImpl)).rejects.toThrow(/unexpected response shape/);
+  });
+});
+
+describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
+  const initializeResponse = (sessionId?: string) =>
+    jsonResponse(
+      { jsonrpc: '2.0', id: 'init', result: { protocolVersion: '2025-06-18', serverInfo: {} } },
+      200,
+      sessionId ? { 'mcp-session-id': sessionId } : {}
+    );
+
+  const toolResult = () =>
+    jsonResponse({
+      jsonrpc: '2.0',
+      id: 'call',
+      result: { content: [{ type: 'text', text: 'hi' }] },
+    });
+
+  it('sends initialize with the storybook-cli clientInfo before the actual request', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(initializeResponse('session-1'))
+      .mockResolvedValueOnce(toolResult()) as unknown as typeof fetch;
+
+    await callMcpTool(record, { name: 'list-all-documentation' }, fetchImpl);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const [initTarget, initInit] = vi.mocked(fetchImpl).mock.calls[0];
+    expect(initTarget).toBe('http://localhost:6006/mcp');
+    const initBody = JSON.parse((initInit as RequestInit).body as string);
+    expect(initBody).toMatchObject({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        capabilities: {},
+        clientInfo: { name: 'storybook-cli', version: versions.storybook },
+      },
+    });
+    expect(MCP_CLIENT_INFO).toEqual({ name: 'storybook-cli', version: versions.storybook });
+  });
+
+  it('threads the session id from the handshake into the actual request', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(initializeResponse('session-42'))
+      .mockResolvedValueOnce(toolResult()) as unknown as typeof fetch;
+
+    await callMcpTool(record, { name: 'list-all-documentation' }, fetchImpl);
+
+    const headers = (lastCall(fetchImpl)[1] as RequestInit).headers as Record<string, string>;
+    expect(headers['Mcp-Session-Id']).toBe('session-42');
+  });
+
+  it('proceeds without a session header when the handshake response has no session id', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(initializeResponse(undefined))
+      .mockResolvedValueOnce(toolResult()) as unknown as typeof fetch;
+
+    const result = await callMcpTool(record, { name: 'list-all-documentation' }, fetchImpl);
+
+    expect(result.content).toEqual([{ type: 'text', text: 'hi' }]);
+    const headers = (lastCall(fetchImpl)[1] as RequestInit).headers as Record<string, string>;
+    expect(headers).not.toHaveProperty('Mcp-Session-Id');
+  });
+
+  it('proceeds without a session header when the handshake request rejects', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValueOnce(toolResult()) as unknown as typeof fetch;
+
+    const result = await callMcpTool(record, { name: 'list-all-documentation' }, fetchImpl);
+
+    expect(result.content).toEqual([{ type: 'text', text: 'hi' }]);
+    const headers = (lastCall(fetchImpl)[1] as RequestInit).headers as Record<string, string>;
+    expect(headers).not.toHaveProperty('Mcp-Session-Id');
+  });
+
+  it('ignores the session id of a non-ok handshake response', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('boom', { status: 500, headers: { 'mcp-session-id': 'session-broken' } })
+      )
+      .mockResolvedValueOnce(toolResult()) as unknown as typeof fetch;
+
+    await callMcpTool(record, { name: 'list-all-documentation' }, fetchImpl);
+
+    const headers = (lastCall(fetchImpl)[1] as RequestInit).headers as Record<string, string>;
+    expect(headers).not.toHaveProperty('Mcp-Session-Id');
+  });
+
+  it('drains the handshake response body before sending the actual request', async () => {
+    // The server stores the clientInfo while producing the handshake response body, so the
+    // follow-up request may only be sent after that body has been consumed.
+    let drained = false;
+    const initBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        drained = true;
+        controller.enqueue(new TextEncoder().encode('{}'));
+        controller.close();
+      },
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(initBody, {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', 'mcp-session-id': 'session-1' },
+        })
+      )
+      .mockImplementationOnce(async () => {
+        expect(drained).toBe(true);
+        return toolResult();
+      }) as unknown as typeof fetch;
+
+    await callMcpTool(record, { name: 'list-all-documentation' }, fetchImpl);
+    expect(drained).toBe(true);
+  });
+
+  it('also performs the handshake for tools/list requests', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(initializeResponse('session-7'))
+      .mockResolvedValueOnce(
+        jsonResponse({ jsonrpc: '2.0', id: 'x', result: { tools: [] } })
+      ) as unknown as typeof fetch;
+
+    await listMcpTools(record, fetchImpl);
+
+    const initBody = JSON.parse(
+      (vi.mocked(fetchImpl).mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(initBody.method).toBe('initialize');
+    const headers = (vi.mocked(fetchImpl).mock.calls[1][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(headers['Mcp-Session-Id']).toBe('session-7');
   });
 });

--- a/code/lib/cli-storybook/src/ai/mcp/client.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/client.ts
@@ -103,6 +103,11 @@ const REQUEST_HEADERS = {
  * The handshake is strictly best-effort — when it fails, the actual command request proceeds
  * without a session and keeps working, so error reporting stays anchored on the real call.
  *
+ * Sessions are deliberately one-shot: each JSON-RPC request gets its own handshake and the session
+ * is never reused or closed. A CLI invocation makes one request on the happy path (two on error
+ * paths that fetch the tool list), so against a localhost server the extra round-trip is
+ * negligible — not worth threading session state through the call sites.
+ *
  * The response body is drained before returning because the transport produces it only after the
  * server has processed the initialize message (and stored the clientInfo); returning on headers
  * alone would race the follow-up request against that processing.

--- a/code/lib/cli-storybook/src/ai/mcp/client.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/client.ts
@@ -1,3 +1,5 @@
+import { versions } from 'storybook/internal/common';
+
 import * as v from 'valibot';
 
 import {
@@ -20,6 +22,22 @@ const STORYBOOK_MCP_PROXY_HEADER_VALUE = 'true';
  * `run-story-tests` on a full suite legitimately runs for minutes.
  */
 const REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Identifies the CLI on the MCP connection, so `@storybook/addon-mcp`'s server-side `tool:*`
+ * telemetry can segment CLI-originated calls from agents connected over MCP directly
+ * (storybookjs/storybook#35131).
+ */
+export const MCP_CLIENT_INFO = { name: 'storybook-cli', version: versions.storybook };
+
+/** Protocol version sent on `initialize`; tmcp (the addon-mcp server library) supports it. */
+const MCP_PROTOCOL_VERSION = '2025-06-18';
+
+/**
+ * The handshake is telemetry garnish: it must never delay or fail the actual command, so it gets
+ * a short timeout instead of {@link REQUEST_TIMEOUT_MS}.
+ */
+const INITIALIZE_TIMEOUT_MS = 10 * 1000;
 
 export type ToolCallParams = {
   name: string;
@@ -70,14 +88,66 @@ export async function listMcpTools(
   return result.tools ?? [];
 }
 
+const REQUEST_HEADERS = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json, text/event-stream',
+  [STORYBOOK_MCP_PROXY_HEADER]: STORYBOOK_MCP_PROXY_HEADER_VALUE,
+};
+
+/**
+ * Send a minimal MCP `initialize` request carrying {@link MCP_CLIENT_INFO} and return the session
+ * id the transport assigned, or null when the handshake fails in any way.
+ *
+ * Its only purpose is telemetry segmentation: tmcp's HttpTransport stores the clientInfo keyed by
+ * session id, and attaches it to later requests carrying that id in the `Mcp-Session-Id` header.
+ * The handshake is strictly best-effort — when it fails, the actual command request proceeds
+ * without a session and keeps working, so error reporting stays anchored on the real call.
+ *
+ * The response body is drained before returning because the transport produces it only after the
+ * server has processed the initialize message (and stored the clientInfo); returning on headers
+ * alone would race the follow-up request against that processing.
+ */
+async function initializeMcpSession(
+  target: string,
+  fetchImpl: typeof fetch
+): Promise<string | null> {
+  try {
+    const response = await fetchImpl(target, {
+      method: 'POST',
+      headers: REQUEST_HEADERS,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: crypto.randomUUID(),
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: MCP_CLIENT_INFO,
+        },
+      }),
+      signal: AbortSignal.timeout(INITIALIZE_TIMEOUT_MS),
+    });
+    const sessionId = response.headers.get('mcp-session-id');
+    if (!response.ok || !sessionId) {
+      return null;
+    }
+    await response.text();
+    return sessionId;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Send a single JSON-RPC request to the instance's MCP endpoint over HTTP.
  *
- * This is deliberately NOT a full MCP client: there is no `initialize` handshake, session, or
- * protocol-version negotiation. The downstream is always `@storybook/addon-mcp`, whose tmcp
- * HttpTransport is stateless and serves `tools/*` per-request — the same local shortcut
- * `@storybook/mcp-proxy` takes in its proxy-client. If the CLI ever needs to talk to arbitrary
- * MCP servers, replace this with a real client instead of extending it.
+ * This is deliberately NOT a full MCP client: the `initialize` request exists solely to convey
+ * `clientInfo` for telemetry (see {@link initializeMcpSession}) — there is no protocol-version
+ * negotiation, capability handling, or session lifecycle beyond this one follow-up request. The
+ * downstream is always `@storybook/addon-mcp`, whose tmcp HttpTransport serves `tools/*`
+ * per-request — the same local shortcut `@storybook/mcp-proxy` takes in its proxy-client. If the
+ * CLI ever needs to talk to arbitrary MCP servers, replace this with a real client instead of
+ * extending it.
  *
  * tmcp hardcodes `text/event-stream` for any request with an id, so we accept both content-types
  * and parse the SSE envelope when needed.
@@ -96,12 +166,13 @@ async function sendJsonRpcRequest<TResult>(
 
   const target = new URL(endpoint, record.url).href;
 
+  const sessionId = await initializeMcpSession(target, fetchImpl);
+
   const response = await fetchImpl(target, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json, text/event-stream',
-      [STORYBOOK_MCP_PROXY_HEADER]: STORYBOOK_MCP_PROXY_HEADER_VALUE,
+      ...REQUEST_HEADERS,
+      ...(sessionId ? { 'Mcp-Session-Id': sessionId } : {}),
     },
     body: JSON.stringify({
       jsonrpc: '2.0',

--- a/code/lib/cli-storybook/src/ai/mcp/client.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/client.ts
@@ -100,10 +100,14 @@ const REQUEST_HEADERS = {
  * Send a minimal MCP `initialize` request carrying {@link MCP_CLIENT_INFO} and return the session
  * id the transport assigned, or null when the handshake fails in any way.
  *
- * Its only purpose is telemetry segmentation: tmcp's HttpTransport stores the clientInfo keyed by
- * session id, and attaches it to later requests carrying that id in the `Mcp-Session-Id` header.
- * The handshake is strictly best-effort — when it fails, the actual command request proceeds
- * without a session and keeps working, so error reporting stays anchored on the real call.
+ * Its only purpose is telemetry segmentation, and the flow is MCP Streamable HTTP spec behavior,
+ * not a tmcp implementation detail: the server assigns a session id during initialization,
+ * returns it in the `Mcp-Session-Id` response header, and associates the session's clientInfo
+ * with later requests echoing that header. Any spec-compliant server (e.g. the official MCP SDK
+ * transports) behaves the same, so addon-mcp can move off tmcp without breaking this client.
+ * The handshake is strictly best-effort — when it fails (or a future server ignores sessions),
+ * the actual command request proceeds without a session and keeps working; only the telemetry
+ * segmentation is lost, and error reporting stays anchored on the real call.
  *
  * Sessions are deliberately one-shot: each JSON-RPC request gets its own handshake and the session
  * is never reused or closed. A CLI invocation makes one request on the happy path (two on error

--- a/code/lib/cli-storybook/src/ai/mcp/client.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/client.ts
@@ -34,10 +34,12 @@ export const MCP_CLIENT_INFO = { name: 'storybook-cli', version: versions.storyb
 const MCP_PROTOCOL_VERSION = '2025-06-18';
 
 /**
- * The handshake is telemetry garnish: it must never delay or fail the actual command, so it gets
- * a short timeout instead of {@link REQUEST_TIMEOUT_MS}.
+ * The handshake is telemetry garnish sitting on the critical path of every command, so its budget
+ * must stay small: a local tmcp `initialize` answers in milliseconds, and a few seconds is already
+ * generous headroom for a busy dev server. On timeout (or any other failure) the command simply
+ * proceeds without clientInfo.
  */
-const INITIALIZE_TIMEOUT_MS = 10 * 1000;
+const INITIALIZE_TIMEOUT_MS = 3 * 1000;
 
 export type ToolCallParams = {
   name: string;

--- a/code/lib/cli-storybook/src/ai/mcp/register.test.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/register.test.ts
@@ -283,7 +283,11 @@ describe('ai-command telemetry', () => {
     await parse(program, ['ai', 'tool-x']);
     expect(withTelemetry).toHaveBeenCalledWith(
       'ai-command',
-      { cliOptions: { disableTelemetry: undefined, logfile: undefined } },
+      {
+        cliOptions: { disableTelemetry: undefined, logfile: undefined },
+        // Keeps the no-instance intercept reportable from a cwd without a loadable main config.
+        fallbackTelemetryState: true,
+      },
       expect.any(Function)
     );
   });
@@ -392,7 +396,7 @@ describe('ai-command telemetry', () => {
     await parse(program, ['ai', '--disable-telemetry', 'tool-x']);
     expect(withTelemetry).toHaveBeenCalledWith(
       'ai-command',
-      { cliOptions: expect.objectContaining({ disableTelemetry: true }) },
+      expect.objectContaining({ cliOptions: expect.objectContaining({ disableTelemetry: true }) }),
       expect.any(Function)
     );
   });
@@ -403,7 +407,7 @@ describe('ai-command telemetry', () => {
     await parse(program, ['ai', 'tool-x']);
     expect(withTelemetry).toHaveBeenCalledWith(
       'ai-command',
-      { cliOptions: expect.objectContaining({ disableTelemetry: true }) },
+      expect.objectContaining({ cliOptions: expect.objectContaining({ disableTelemetry: true }) }),
       expect.any(Function)
     );
   });

--- a/code/lib/cli-storybook/src/ai/mcp/register.test.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/register.test.ts
@@ -15,14 +15,9 @@ vi.mock('./run-tool.ts', { spy: true });
 
 vi.mock('node:fs/promises', { spy: true });
 
-vi.mock('storybook/internal/core-server', () => ({
-  withTelemetry: vi.fn(),
-  sendTelemetryError: vi.fn(),
-}));
+vi.mock('storybook/internal/core-server', { spy: true });
 
-vi.mock('storybook/internal/telemetry', () => ({
-  telemetry: vi.fn(),
-}));
+vi.mock('storybook/internal/telemetry', { spy: true });
 
 describe('isAiCliFeatureEnabled', () => {
   it.each([

--- a/code/lib/cli-storybook/src/ai/mcp/register.test.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/register.test.ts
@@ -1,5 +1,9 @@
 import { writeFile } from 'node:fs/promises';
 
+import { optionalEnvToBoolean } from 'storybook/internal/common';
+import { sendTelemetryError, withTelemetry } from 'storybook/internal/core-server';
+import { telemetry } from 'storybook/internal/telemetry';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Command } from 'commander';
@@ -10,6 +14,15 @@ import { buildStorybookCommandsHelp, runAiTool, runAiToolHelp } from './run-tool
 vi.mock('./run-tool.ts', { spy: true });
 
 vi.mock('node:fs/promises', { spy: true });
+
+vi.mock('storybook/internal/core-server', () => ({
+  withTelemetry: vi.fn(),
+  sendTelemetryError: vi.fn(),
+}));
+
+vi.mock('storybook/internal/telemetry', () => ({
+  telemetry: vi.fn(),
+}));
 
 describe('isAiCliFeatureEnabled', () => {
   it.each([
@@ -24,16 +37,34 @@ describe('isAiCliFeatureEnabled', () => {
   });
 });
 
-/** Replicate the `ai` command tree from `bin/run.ts`: a `setup` subcommand plus a help action. */
+/**
+ * Replicate the `ai` command tree from `bin/run.ts`: a `setup` subcommand plus a help action. The
+ * `--disable-telemetry` and `--logfile` options mirror the shared options that the `command()`
+ * factory in `bin/run.ts` registers on every command, including the env-var default.
+ */
 function buildProgram({ withPassthrough }: { withPassthrough: boolean }) {
   const program = new Command();
   program.exitOverride();
   const setupAction = vi.fn();
   const helpAction = vi.fn();
+  const failures: unknown[] = [];
+  const handleCommandFailure = vi.fn(
+    (_logFilePath: string | boolean | undefined) =>
+      async (error: unknown): Promise<never> => {
+        failures.push(error);
+        return undefined as never;
+      }
+  );
 
   const aiCommand = program
     .command('ai')
     .description('AI agent helpers for Storybook')
+    .option(
+      '--disable-telemetry',
+      'Disable sending telemetry data',
+      optionalEnvToBoolean(process.env.STORYBOOK_DISABLE_TELEMETRY)
+    )
+    .option('--logfile [path]', 'Write all debug logs to the specified file')
     .option('-o, --output <path>', 'Write the prompt output to a file')
     .exitOverride();
   aiCommand.configureOutput({ writeOut: () => {}, writeErr: () => {} });
@@ -41,10 +72,10 @@ function buildProgram({ withPassthrough }: { withPassthrough: boolean }) {
   aiCommand.action(helpAction);
 
   if (withPassthrough) {
-    registerAiMcpPassthrough(program, aiCommand);
+    registerAiMcpPassthrough(program, aiCommand, handleCommandFailure);
   }
 
-  return { program, aiCommand, setupAction, helpAction };
+  return { program, aiCommand, setupAction, helpAction, handleCommandFailure, failures };
 }
 
 function parse(program: Command, argv: string[]) {
@@ -58,13 +89,35 @@ function stdoutText(): string {
     .join('');
 }
 
+/** The payloads of all `ai-command` events fired through the mocked telemetry module. */
+function aiCommandPayloads(): unknown[] {
+  return vi
+    .mocked(telemetry)
+    .mock.calls.filter(([eventType]) => eventType === 'ai-command')
+    .map(([, payload]) => payload);
+}
+
 beforeEach(() => {
-  vi.mocked(runAiTool).mockResolvedValue({ exitCode: 0, output: 'ok' });
-  vi.mocked(runAiToolHelp).mockResolvedValue({ exitCode: 0, output: 'tool help' });
+  // The CI/dev shell may have the opt-out set; tests control it explicitly via vi.stubEnv.
+  vi.stubEnv('STORYBOOK_DISABLE_TELEMETRY', undefined);
+  vi.mocked(runAiTool).mockResolvedValue({
+    exitCode: 0,
+    output: 'ok',
+    outcome: { kind: 'success' },
+  });
+  vi.mocked(runAiToolHelp).mockResolvedValue({
+    exitCode: 0,
+    output: 'tool help',
+    outcome: { kind: 'help' },
+  });
   vi.mocked(buildStorybookCommandsHelp).mockResolvedValue(
     'Storybook commands (from the running Storybook):'
   );
   vi.mocked(writeFile).mockResolvedValue(undefined);
+  // Pass-through that mirrors the real contract: run the callback, propagate its rejection.
+  vi.mocked(withTelemetry).mockImplementation(async (_eventType, _options, run) => run());
+  vi.mocked(telemetry).mockResolvedValue(undefined);
+  vi.mocked(sendTelemetryError).mockResolvedValue(undefined);
   vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 });
 
@@ -73,6 +126,7 @@ afterEach(() => {
   vi.mocked(runAiTool).mockReset();
   vi.mocked(runAiToolHelp).mockReset();
   vi.mocked(buildStorybookCommandsHelp).mockReset();
+  vi.unstubAllEnvs();
   process.exitCode = undefined;
 });
 
@@ -140,7 +194,11 @@ describe('with the feature flag (passthrough registered)', () => {
 
   it('writes the result to the file given via --output instead of stdout', async () => {
     const { program } = buildProgram({ withPassthrough: true });
-    vi.mocked(runAiTool).mockResolvedValue({ exitCode: 0, output: 'markdown result' });
+    vi.mocked(runAiTool).mockResolvedValue({
+      exitCode: 0,
+      output: 'markdown result',
+      outcome: { kind: 'success' },
+    });
     await parse(program, ['ai', '-o', '/out/result.md', 'tool-x']);
     expect(writeFile).toHaveBeenCalledWith('/out/result.md', 'markdown result\n', 'utf-8');
     expect(process.stdout.write).not.toHaveBeenCalledWith('markdown result\n');
@@ -148,7 +206,11 @@ describe('with the feature flag (passthrough registered)', () => {
 
   it('writes the result to stdout', async () => {
     const { program } = buildProgram({ withPassthrough: true });
-    vi.mocked(runAiTool).mockResolvedValue({ exitCode: 0, output: 'markdown result' });
+    vi.mocked(runAiTool).mockResolvedValue({
+      exitCode: 0,
+      output: 'markdown result',
+      outcome: { kind: 'success' },
+    });
     await parse(program, ['ai', 'tool-x']);
     expect(process.stdout.write).toHaveBeenCalledWith('markdown result\n');
     expect(process.exitCode).toBeUndefined();
@@ -156,7 +218,11 @@ describe('with the feature flag (passthrough registered)', () => {
 
   it('sets a non-zero exit code on failure', async () => {
     const { program } = buildProgram({ withPassthrough: true });
-    vi.mocked(runAiTool).mockResolvedValue({ exitCode: 1, output: 'repair instructions' });
+    vi.mocked(runAiTool).mockResolvedValue({
+      exitCode: 1,
+      output: 'repair instructions',
+      outcome: { kind: 'intercept', reason: 'no-instance' },
+    });
     await parse(program, ['ai', 'tool-x']);
     expect(process.stdout.write).toHaveBeenCalledWith('repair instructions\n');
     expect(process.exitCode).toBe(1);
@@ -208,5 +274,146 @@ describe('with the feature flag (passthrough registered)', () => {
       port: undefined,
       json: undefined,
     });
+  });
+});
+
+describe('ai-command telemetry', () => {
+  it('wraps the command execution in withTelemetry with the opt-out cli options', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, ['ai', 'tool-x']);
+    expect(withTelemetry).toHaveBeenCalledWith(
+      'ai-command',
+      { cliOptions: { disableTelemetry: undefined, logfile: undefined } },
+      expect.any(Function)
+    );
+  });
+
+  it('fires ai-command with a success payload and no interceptReason', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, ['ai', 'tool-x']);
+    expect(telemetry).toHaveBeenCalledWith('ai-command', {
+      command: 'tool-x',
+      success: true,
+      duration: expect.any(Number),
+    });
+    expect(aiCommandPayloads()).toHaveLength(1);
+    expect(aiCommandPayloads()[0]).not.toHaveProperty('interceptReason');
+    expect(sendTelemetryError).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'no-instance',
+    'port-mismatch',
+    'addon-missing',
+    'mcp-starting',
+    'mcp-error',
+    'invalid-arguments',
+    'unknown-command',
+  ] as const)(
+    'fires ai-command with interceptReason %s on intercepted invocations',
+    async (reason) => {
+      const { program } = buildProgram({ withPassthrough: true });
+      vi.mocked(runAiTool).mockResolvedValue({
+        exitCode: 1,
+        output: 'repair instructions',
+        outcome: { kind: 'intercept', reason },
+      });
+      await parse(program, ['ai', 'tool-x']);
+      expect(telemetry).toHaveBeenCalledWith('ai-command', {
+        command: 'tool-x',
+        success: false,
+        interceptReason: reason,
+        duration: expect.any(Number),
+      });
+      expect(sendTelemetryError).not.toHaveBeenCalled();
+    }
+  );
+
+  it('routes server-reached errors through the standard sanitized error path', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    const error = new Error('connection reset');
+    vi.mocked(runAiTool).mockResolvedValue({
+      exitCode: 1,
+      output: 'Failed to reach the Storybook server',
+      outcome: { kind: 'error', error },
+    });
+    await parse(program, ['ai', 'tool-x']);
+    expect(telemetry).toHaveBeenCalledWith('ai-command', {
+      command: 'tool-x',
+      success: false,
+      duration: expect.any(Number),
+    });
+    expect(sendTelemetryError).toHaveBeenCalledWith(error, 'ai-command', {
+      cliOptions: { disableTelemetry: undefined, logfile: undefined },
+    });
+  });
+
+  it('collapses non-command-shaped names to a placeholder (no paths in payloads)', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    vi.mocked(runAiTool).mockResolvedValue({
+      exitCode: 1,
+      output: 'repair instructions',
+      outcome: { kind: 'intercept', reason: 'no-instance' },
+    });
+    await parse(program, ['ai', './projects/secret-app']);
+    expect(telemetry).toHaveBeenCalledWith(
+      'ai-command',
+      expect.objectContaining({ command: '(invalid)' })
+    );
+  });
+
+  it.each([[['ai']], [['ai', '--help']], [['ai', '--help', 'tool-x']]])(
+    'does not fire ai-command for the help path %j, but still wraps it in withTelemetry',
+    async (argv) => {
+      const { program } = buildProgram({ withPassthrough: true });
+      await parse(program, argv);
+      expect(withTelemetry).toHaveBeenCalledWith(
+        'ai-command',
+        expect.anything(),
+        expect.any(Function)
+      );
+      expect(aiCommandPayloads()).toHaveLength(0);
+    }
+  );
+
+  it('does not fire ai-command when a --help token after the command name turns the run into a help lookup', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    vi.mocked(runAiTool).mockResolvedValue({
+      exitCode: 0,
+      output: 'tool help',
+      outcome: { kind: 'help' },
+    });
+    await parse(program, ['ai', 'tool-x', '--help']);
+    expect(aiCommandPayloads()).toHaveLength(0);
+  });
+
+  it('passes --disable-telemetry through to withTelemetry', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, ['ai', '--disable-telemetry', 'tool-x']);
+    expect(withTelemetry).toHaveBeenCalledWith(
+      'ai-command',
+      { cliOptions: expect.objectContaining({ disableTelemetry: true }) },
+      expect.any(Function)
+    );
+  });
+
+  it('defaults --disable-telemetry from STORYBOOK_DISABLE_TELEMETRY (as registered in bin/run.ts)', async () => {
+    vi.stubEnv('STORYBOOK_DISABLE_TELEMETRY', 'true');
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, ['ai', 'tool-x']);
+    expect(withTelemetry).toHaveBeenCalledWith(
+      'ai-command',
+      { cliOptions: expect.objectContaining({ disableTelemetry: true }) },
+      expect.any(Function)
+    );
+  });
+
+  it('hands unexpected failures to the command failure handler with the --logfile value', async () => {
+    const { program, handleCommandFailure, failures } = buildProgram({ withPassthrough: true });
+    const error = new Error('unexpected');
+    vi.mocked(runAiTool).mockRejectedValue(error);
+    await parse(program, ['ai', '--logfile', 'debug.log', 'tool-x']);
+    expect(handleCommandFailure).toHaveBeenCalledWith('debug.log');
+    expect(failures).toEqual([error]);
   });
 });

--- a/code/lib/cli-storybook/src/ai/mcp/register.test.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/register.test.ts
@@ -313,17 +313,46 @@ describe('ai-command telemetry', () => {
     }
   );
 
+  it('honors the --cwd target opt-out even when the remaining args are malformed', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    // `--json '{bad'` makes full arg parsing fail (invalid-arguments intercept), but the
+    // target project's core.disableTelemetry must still be the one consulted.
+    await parse(program, ['ai', 'tool-x', '--cwd', '/target/project', '--json', '{bad']);
+    expect(withTelemetry).toHaveBeenCalledWith(
+      'ai-command',
+      expect.objectContaining({
+        cliOptions: expect.objectContaining({
+          configDir: resolve('/target/project', '.storybook'),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
   it('fires ai-command with a success payload and no interceptReason', async () => {
     const { program } = buildProgram({ withPassthrough: true });
     await parse(program, ['ai', 'tool-x']);
-    expect(telemetry).toHaveBeenCalledWith('ai-command', {
-      command: 'tool-x',
-      success: true,
-      duration: expect.any(Number),
-    });
+    expect(telemetry).toHaveBeenCalledWith(
+      'ai-command',
+      {
+        command: 'tool-x',
+        success: true,
+        duration: expect.any(Number),
+      },
+      // Metadata is collected from the target project, like the opt-out resolution.
+      { configDir: resolve(process.cwd(), '.storybook') }
+    );
     expect(aiCommandPayloads()).toHaveLength(1);
     expect(aiCommandPayloads()[0]).not.toHaveProperty('interceptReason');
     expect(sendTelemetryError).not.toHaveBeenCalled();
+  });
+
+  it('collects the event metadata from the --cwd target project', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, ['ai', '--cwd', '/target/project', 'tool-x']);
+    expect(telemetry).toHaveBeenCalledWith('ai-command', expect.anything(), {
+      configDir: resolve('/target/project', '.storybook'),
+    });
   });
 
   it.each([
@@ -344,12 +373,16 @@ describe('ai-command telemetry', () => {
         outcome: { kind: 'intercept', reason },
       });
       await parse(program, ['ai', 'tool-x']);
-      expect(telemetry).toHaveBeenCalledWith('ai-command', {
-        command: 'tool-x',
-        success: false,
-        interceptReason: reason,
-        duration: expect.any(Number),
-      });
+      expect(telemetry).toHaveBeenCalledWith(
+        'ai-command',
+        {
+          command: 'tool-x',
+          success: false,
+          interceptReason: reason,
+          duration: expect.any(Number),
+        },
+        expect.anything()
+      );
       expect(sendTelemetryError).not.toHaveBeenCalled();
     }
   );
@@ -363,11 +396,15 @@ describe('ai-command telemetry', () => {
       outcome: { kind: 'error', error },
     });
     await parse(program, ['ai', 'tool-x']);
-    expect(telemetry).toHaveBeenCalledWith('ai-command', {
-      command: 'tool-x',
-      success: false,
-      duration: expect.any(Number),
-    });
+    expect(telemetry).toHaveBeenCalledWith(
+      'ai-command',
+      {
+        command: 'tool-x',
+        success: false,
+        duration: expect.any(Number),
+      },
+      expect.anything()
+    );
     expect(sendTelemetryError).toHaveBeenCalledWith(error, 'ai-command', {
       cliOptions: {
         disableTelemetry: undefined,
@@ -382,11 +419,15 @@ describe('ai-command telemetry', () => {
     const writeError = new Error('EACCES: permission denied');
     vi.mocked(writeFile).mockRejectedValue(writeError);
     await parse(program, ['ai', '-o', '/readonly/out.md', 'tool-x']);
-    expect(telemetry).toHaveBeenCalledWith('ai-command', {
-      command: 'tool-x',
-      success: true,
-      duration: expect.any(Number),
-    });
+    expect(telemetry).toHaveBeenCalledWith(
+      'ai-command',
+      {
+        command: 'tool-x',
+        success: true,
+        duration: expect.any(Number),
+      },
+      expect.anything()
+    );
     expect(failures).toEqual([writeError]);
   });
 
@@ -400,7 +441,8 @@ describe('ai-command telemetry', () => {
     await parse(program, ['ai', './projects/secret-app']);
     expect(telemetry).toHaveBeenCalledWith(
       'ai-command',
-      expect.objectContaining({ command: '(invalid)' })
+      expect.objectContaining({ command: '(invalid)' }),
+      expect.anything()
     );
   });
 

--- a/code/lib/cli-storybook/src/ai/mcp/register.test.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/register.test.ts
@@ -1,4 +1,5 @@
 import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 
 import { optionalEnvToBoolean } from 'storybook/internal/common';
 import { sendTelemetryError, withTelemetry } from 'storybook/internal/core-server';
@@ -279,13 +280,38 @@ describe('ai-command telemetry', () => {
     expect(withTelemetry).toHaveBeenCalledWith(
       'ai-command',
       {
-        cliOptions: { disableTelemetry: undefined, logfile: undefined },
+        cliOptions: {
+          disableTelemetry: undefined,
+          logfile: undefined,
+          configDir: resolve(process.cwd(), '.storybook'),
+        },
         // Keeps the no-instance intercept reportable from a cwd without a loadable main config.
         fallbackTelemetryState: true,
       },
       expect.any(Function)
     );
   });
+
+  it.each([
+    ['before the command name', ['ai', '--cwd', '/target/project', 'tool-x']],
+    ['after the command name', ['ai', 'tool-x', '--cwd', '/target/project']],
+  ])(
+    'resolves the opt-out configDir from the target Storybook when --cwd is passed %s',
+    async (_position, argv) => {
+      const { program } = buildProgram({ withPassthrough: true });
+      await parse(program, argv);
+      // The target project's core.disableTelemetry must apply, not the invoking cwd's.
+      expect(withTelemetry).toHaveBeenCalledWith(
+        'ai-command',
+        expect.objectContaining({
+          cliOptions: expect.objectContaining({
+            configDir: resolve('/target/project', '.storybook'),
+          }),
+        }),
+        expect.any(Function)
+      );
+    }
+  );
 
   it('fires ai-command with a success payload and no interceptReason', async () => {
     const { program } = buildProgram({ withPassthrough: true });
@@ -343,8 +369,25 @@ describe('ai-command telemetry', () => {
       duration: expect.any(Number),
     });
     expect(sendTelemetryError).toHaveBeenCalledWith(error, 'ai-command', {
-      cliOptions: { disableTelemetry: undefined, logfile: undefined },
+      cliOptions: {
+        disableTelemetry: undefined,
+        logfile: undefined,
+        configDir: resolve(process.cwd(), '.storybook'),
+      },
     });
+  });
+
+  it('still fires ai-command when writing the --output file fails after the command executed', async () => {
+    const { program, failures } = buildProgram({ withPassthrough: true });
+    const writeError = new Error('EACCES: permission denied');
+    vi.mocked(writeFile).mockRejectedValue(writeError);
+    await parse(program, ['ai', '-o', '/readonly/out.md', 'tool-x']);
+    expect(telemetry).toHaveBeenCalledWith('ai-command', {
+      command: 'tool-x',
+      success: true,
+      duration: expect.any(Number),
+    });
+    expect(failures).toEqual([writeError]);
   });
 
   it('collapses non-command-shaped names to a placeholder (no paths in payloads)', async () => {

--- a/code/lib/cli-storybook/src/ai/mcp/register.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/register.ts
@@ -83,24 +83,31 @@ export function registerAiMcpPassthrough(
     .action(
       async (command: string | undefined, commandArgs: string[], options: AiPassthroughOptions) =>
         // Only the opt-out tier is consumed from cliOptions; the passthrough's own options (cwd,
-        // port, json) are deliberately not forwarded — they may contain paths.
-        withTelemetry('ai-command', { cliOptions: pickCliOptions(options) }, async () => {
-          const target = { cwd: options.cwd, port: options.port };
-          if (options.help && command) {
-            await printResult(await runAiToolHelp(command, target), options.output);
-            return;
+        // port, json) are deliberately not forwarded — they may contain paths. Like `init`, the
+        // fallback keeps telemetry on when no main config is loadable: running from a cwd without
+        // a Storybook is the `no-instance` intercept this event exists to measure. The explicit
+        // opt-outs (env var, flag, loadable `core.disableTelemetry`) still apply.
+        withTelemetry(
+          'ai-command',
+          { cliOptions: pickCliOptions(options), fallbackTelemetryState: true },
+          async () => {
+            const target = { cwd: options.cwd, port: options.port };
+            if (options.help && command) {
+              await printResult(await runAiToolHelp(command, target), options.output);
+              return;
+            }
+            if (options.help || !command) {
+              const commandsSection = await buildStorybookCommandsHelp(target);
+              process.stdout.write(`${aiCommand.helpInformation()}\n${commandsSection}\n`);
+              return;
+            }
+            const start = Date.now();
+            const result = await runAiTool(command, commandArgs, { ...target, json: options.json });
+            const duration = Date.now() - start;
+            await printResult(result, options.output);
+            await reportAiCommandTelemetry(command, result.outcome, duration, options);
           }
-          if (options.help || !command) {
-            const commandsSection = await buildStorybookCommandsHelp(target);
-            process.stdout.write(`${aiCommand.helpInformation()}\n${commandsSection}\n`);
-            return;
-          }
-          const start = Date.now();
-          const result = await runAiTool(command, commandArgs, { ...target, json: options.json });
-          const duration = Date.now() - start;
-          await printResult(result, options.output);
-          await reportAiCommandTelemetry(command, result.outcome, duration, options);
-        }).catch(handleCommandFailure(options.logfile))
+        ).catch(handleCommandFailure(options.logfile))
     );
 }
 

--- a/code/lib/cli-storybook/src/ai/mcp/register.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/register.ts
@@ -2,11 +2,15 @@ import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 import { optionalEnvToBoolean } from 'storybook/internal/common';
+import { sendTelemetryError, withTelemetry } from 'storybook/internal/core-server';
 import { logger } from 'storybook/internal/node-logger';
+import { telemetry } from 'storybook/internal/telemetry';
+import type { CLIOptions } from 'storybook/internal/types';
 
 import type { Command } from 'commander';
 
 import {
+  type AiCommandOutcome,
   type AiToolRunResult,
   buildStorybookCommandsHelp,
   runAiTool,
@@ -26,6 +30,23 @@ const CWD_DESCRIPTION =
 const PORT_DESCRIPTION =
   'Port of the target Storybook, to address one specific instance when several run at the same cwd';
 
+type AiPassthroughOptions = {
+  cwd?: string;
+  port?: string;
+  json?: string;
+  output?: string;
+  help?: boolean;
+  /** From the shared command options in `bin/run.ts`; consumed by `withTelemetry`. */
+  disableTelemetry?: boolean;
+  /** From the shared command options in `bin/run.ts`; consumed by the failure handler. */
+  logfile?: string | boolean;
+};
+
+/** `handleCommandFailure` from `bin/run.ts`, passed in to avoid an import cycle. */
+export type CommandFailureHandler = (
+  logFilePath: string | boolean | undefined
+) => (error: unknown) => Promise<never>;
+
 /**
  * Register the passthrough on the `ai` command: a generic `[command] [args...]` argument pair that
  * forwards any command to the running Storybook's server (MCP under the hood, but that is an
@@ -36,7 +57,11 @@ const PORT_DESCRIPTION =
  * Commander's built-in (synchronous) help is replaced with our own `-h, --help` option so the help
  * output can include the commands fetched from the running Storybook.
  */
-export function registerAiMcpPassthrough(program: Command, aiCommand: Command): void {
+export function registerAiMcpPassthrough(
+  program: Command,
+  aiCommand: Command,
+  handleCommandFailure: CommandFailureHandler
+): void {
   program.enablePositionalOptions();
 
   aiCommand
@@ -56,25 +81,66 @@ export function registerAiMcpPassthrough(program: Command, aiCommand: Command): 
     .option('-h, --help', 'Show help, including the commands provided by the running Storybook')
     .passThroughOptions()
     .action(
-      async (
-        command: string | undefined,
-        commandArgs: string[],
-        options: { cwd?: string; port?: string; json?: string; output?: string; help?: boolean }
-      ) => {
-        const target = { cwd: options.cwd, port: options.port };
-        if (options.help && command) {
-          await printResult(await runAiToolHelp(command, target), options.output);
-          return;
-        }
-        if (options.help || !command) {
-          const commandsSection = await buildStorybookCommandsHelp(target);
-          process.stdout.write(`${aiCommand.helpInformation()}\n${commandsSection}\n`);
-          return;
-        }
-        const result = await runAiTool(command, commandArgs, { ...target, json: options.json });
-        await printResult(result, options.output);
-      }
+      async (command: string | undefined, commandArgs: string[], options: AiPassthroughOptions) =>
+        // Only the opt-out tier is consumed from cliOptions; the passthrough's own options (cwd,
+        // port, json) are deliberately not forwarded — they may contain paths.
+        withTelemetry('ai-command', { cliOptions: pickCliOptions(options) }, async () => {
+          const target = { cwd: options.cwd, port: options.port };
+          if (options.help && command) {
+            await printResult(await runAiToolHelp(command, target), options.output);
+            return;
+          }
+          if (options.help || !command) {
+            const commandsSection = await buildStorybookCommandsHelp(target);
+            process.stdout.write(`${aiCommand.helpInformation()}\n${commandsSection}\n`);
+            return;
+          }
+          const start = Date.now();
+          const result = await runAiTool(command, commandArgs, { ...target, json: options.json });
+          const duration = Date.now() - start;
+          await printResult(result, options.output);
+          await reportAiCommandTelemetry(command, result.outcome, duration, options);
+        }).catch(handleCommandFailure(options.logfile))
     );
+}
+
+function pickCliOptions(options: AiPassthroughOptions): CLIOptions {
+  return { disableTelemetry: options.disableTelemetry, logfile: options.logfile };
+}
+
+/**
+ * Command names are a fixed, server-defined vocabulary of short identifiers. Anything else is
+ * arbitrary agent input (a typo'd path, a stray flag value) that must not be sent verbatim, so it
+ * is collapsed to a placeholder. The intercept reason still tells the failure class apart.
+ */
+function sanitizeCommandName(command: string): string {
+  return /^[\w-]{1,64}$/.test(command) ? command : '(invalid)';
+}
+
+/**
+ * Fire the `ai-command` event, once per executed command (storybookjs/storybook#35131). Help
+ * lookups are excluded so they cannot skew command success rates. Server-side failures
+ * additionally go through the standard sanitized error path, like errors thrown under
+ * `withTelemetry`.
+ */
+async function reportAiCommandTelemetry(
+  command: string,
+  outcome: AiCommandOutcome,
+  duration: number,
+  options: AiPassthroughOptions
+): Promise<void> {
+  if (outcome.kind === 'help') {
+    return;
+  }
+  await telemetry('ai-command', {
+    command: sanitizeCommandName(command),
+    success: outcome.kind === 'success',
+    ...(outcome.kind === 'intercept' && { interceptReason: outcome.reason }),
+    duration,
+  });
+  if (outcome.kind === 'error') {
+    await sendTelemetryError(outcome.error, 'ai-command', { cliOptions: pickCliOptions(options) });
+  }
 }
 
 /** Print to stdout, or to the file given via the `ai` command's `-o, --output` option. */

--- a/code/lib/cli-storybook/src/ai/mcp/register.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/register.ts
@@ -16,6 +16,7 @@ import {
   runAiTool,
   runAiToolHelp,
 } from './run-tool.ts';
+import { parseToolArgs } from './tool-args.ts';
 
 /**
  * The `storybook ai <tool>` MCP passthrough is experimental (storybookjs/storybook#35124) and only
@@ -81,15 +82,15 @@ export function registerAiMcpPassthrough(
     .option('-h, --help', 'Show help, including the commands provided by the running Storybook')
     .passThroughOptions()
     .action(
-      async (command: string | undefined, commandArgs: string[], options: AiPassthroughOptions) =>
-        // Only the opt-out tier is consumed from cliOptions; the passthrough's own options (cwd,
-        // port, json) are deliberately not forwarded — they may contain paths. Like `init`, the
-        // fallback keeps telemetry on when no main config is loadable: running from a cwd without
-        // a Storybook is the `no-instance` intercept this event exists to measure. The explicit
-        // opt-outs (env var, flag, loadable `core.disableTelemetry`) still apply.
-        withTelemetry(
+      async (command: string | undefined, commandArgs: string[], options: AiPassthroughOptions) => {
+        const cliOptions = pickCliOptions(options, commandArgs);
+        // Like `init`, the fallback keeps telemetry on when no main config is loadable: running
+        // from a cwd without a Storybook is the `no-instance` intercept this event exists to
+        // measure. The explicit opt-outs (env var, flag, loadable `core.disableTelemetry`)
+        // still apply.
+        return withTelemetry(
           'ai-command',
-          { cliOptions: pickCliOptions(options), fallbackTelemetryState: true },
+          { cliOptions, fallbackTelemetryState: true },
           async () => {
             const target = { cwd: options.cwd, port: options.port };
             if (options.help && command) {
@@ -104,15 +105,39 @@ export function registerAiMcpPassthrough(
             const start = Date.now();
             const result = await runAiTool(command, commandArgs, { ...target, json: options.json });
             const duration = Date.now() - start;
-            await printResult(result, options.output);
-            await reportAiCommandTelemetry(command, result.outcome, duration, options);
+            try {
+              await printResult(result, options.output);
+            } finally {
+              // The command has executed either way, so a failed `--output` write must not lose
+              // the event. Reporting after printing keeps a slow telemetry endpoint from ever
+              // delaying the user's result.
+              await reportAiCommandTelemetry(command, result.outcome, duration, cliOptions);
+            }
           }
-        ).catch(handleCommandFailure(options.logfile))
+        ).catch(handleCommandFailure(options.logfile));
+      }
     );
 }
 
-function pickCliOptions(options: AiPassthroughOptions): CLIOptions {
-  return { disableTelemetry: options.disableTelemetry, logfile: options.logfile };
+/**
+ * The cliOptions handed to the telemetry machinery. Only the opt-out tier is forwarded — the
+ * passthrough's own options (cwd, port, json) may contain paths and are never sent in payloads.
+ * `configDir` points at the default config location of the *target* Storybook so `withTelemetry`
+ * resolves `core.disableTelemetry` from the project the command is aimed at (`--cwd` is accepted
+ * both before and after the command name); it is read locally, never sent.
+ */
+function pickCliOptions(options: AiPassthroughOptions, commandArgs: string[]): CLIOptions {
+  const parsed = parseToolArgs(commandArgs, {
+    cwd: options.cwd,
+    port: options.port,
+    json: options.json,
+  });
+  const targetCwd = (parsed.ok ? parsed.cwd : options.cwd) ?? process.cwd();
+  return {
+    disableTelemetry: options.disableTelemetry,
+    logfile: options.logfile,
+    configDir: resolve(targetCwd, '.storybook'),
+  };
 }
 
 /**
@@ -134,7 +159,7 @@ async function reportAiCommandTelemetry(
   command: string,
   outcome: AiCommandOutcome,
   duration: number,
-  options: AiPassthroughOptions
+  cliOptions: CLIOptions
 ): Promise<void> {
   if (outcome.kind === 'help') {
     return;
@@ -146,7 +171,7 @@ async function reportAiCommandTelemetry(
     duration,
   });
   if (outcome.kind === 'error') {
-    await sendTelemetryError(outcome.error, 'ai-command', { cliOptions: pickCliOptions(options) });
+    await sendTelemetryError(outcome.error, 'ai-command', { cliOptions });
   }
 }
 

--- a/code/lib/cli-storybook/src/ai/mcp/register.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/register.ts
@@ -16,7 +16,7 @@ import {
   runAiTool,
   runAiToolHelp,
 } from './run-tool.ts';
-import { parseToolArgs } from './tool-args.ts';
+import { scanCwdToken } from './tool-args.ts';
 
 /**
  * The `storybook ai <tool>` MCP passthrough is experimental (storybookjs/storybook#35124) and only
@@ -124,15 +124,11 @@ export function registerAiMcpPassthrough(
  * passthrough's own options (cwd, port, json) may contain paths and are never sent in payloads.
  * `configDir` points at the default config location of the *target* Storybook so `withTelemetry`
  * resolves `core.disableTelemetry` from the project the command is aimed at (`--cwd` is accepted
- * both before and after the command name); it is read locally, never sent.
+ * both before and after the command name, and is scanned leniently so even invocations rejected
+ * as `invalid-arguments` honor the target's opt-out); it is read locally, never sent.
  */
 function pickCliOptions(options: AiPassthroughOptions, commandArgs: string[]): CLIOptions {
-  const parsed = parseToolArgs(commandArgs, {
-    cwd: options.cwd,
-    port: options.port,
-    json: options.json,
-  });
-  const targetCwd = (parsed.ok ? parsed.cwd : options.cwd) ?? process.cwd();
+  const targetCwd = scanCwdToken(commandArgs) ?? options.cwd ?? process.cwd();
   return {
     disableTelemetry: options.disableTelemetry,
     logfile: options.logfile,
@@ -164,12 +160,17 @@ async function reportAiCommandTelemetry(
   if (outcome.kind === 'help') {
     return;
   }
-  await telemetry('ai-command', {
-    command: sanitizeCommandName(command),
-    success: outcome.kind === 'success',
-    ...(outcome.kind === 'intercept' && { interceptReason: outcome.reason }),
-    duration,
-  });
+  await telemetry(
+    'ai-command',
+    {
+      command: sanitizeCommandName(command),
+      success: outcome.kind === 'success',
+      ...(outcome.kind === 'intercept' && { interceptReason: outcome.reason }),
+      duration,
+    },
+    // Metadata must describe the target project, consistent with the opt-out resolution.
+    { configDir: cliOptions.configDir }
+  );
   if (outcome.kind === 'error') {
     await sendTelemetryError(outcome.error, 'ai-command', { cliOptions });
   }

--- a/code/lib/cli-storybook/src/ai/mcp/run-tool.test.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/run-tool.test.ts
@@ -39,7 +39,11 @@ describe('runAiTool', () => {
       { name: 'list-all-documentation', arguments: { withStoryIds: true } },
       undefined
     );
-    expect(result).toEqual({ exitCode: 0, output: 'upstream result' });
+    expect(result).toEqual({
+      exitCode: 0,
+      output: 'upstream result',
+      outcome: { kind: 'success' },
+    });
   });
 
   it('defaults the cwd to process.cwd()', async () => {
@@ -65,6 +69,7 @@ describe('runAiTool', () => {
     const result = await runAiTool('get-documentation', ['positional'], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Unexpected argument');
+    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'invalid-arguments' });
     expect(readRegistry).not.toHaveBeenCalled();
   });
 
@@ -73,6 +78,7 @@ describe('runAiTool', () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('No Storybook is running at this cwd');
     expect(result.output).toContain('/projects/foo');
+    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'no-instance' });
   });
 
   it('routes to the instance on the requested --port when several share the cwd', async () => {
@@ -93,6 +99,7 @@ describe('runAiTool', () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('not on port `9999`');
     expect(result.output).toContain('- port `6006`');
+    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'port-mismatch' });
   });
 
   it('rejects an invalid --port without contacting the registry', async () => {
@@ -105,20 +112,25 @@ describe('runAiTool', () => {
   });
 
   it.each([
-    ['starting', 'still starting up'],
-    ['not-installed', '`@storybook/addon-mcp` addon is missing'],
-    ['error', 'Inspect the Storybook terminal output'],
-  ] as const)('prints the repair markdown for mcp.status=%s', async (status, expected) => {
+    ['starting', 'still starting up', 'mcp-starting'],
+    ['not-installed', '`@storybook/addon-mcp` addon is missing', 'addon-missing'],
+    ['error', 'Inspect the Storybook terminal output', 'mcp-error'],
+  ] as const)('prints the repair markdown for mcp.status=%s', async (status, expected, reason) => {
     vi.mocked(readRegistry).mockResolvedValue([{ ...record, mcp: { status } }]);
     const result = await runAiTool('get-documentation', [], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain(expected);
+    expect(result.outcome).toEqual({ kind: 'intercept', reason });
   });
 
   it('prints a placeholder when the tool returns no content', async () => {
     vi.mocked(callMcpTool).mockResolvedValue({ content: [] });
     const result = await runAiTool('list-all-documentation', [], { cwd: '/projects/foo' });
-    expect(result).toEqual({ exitCode: 0, output: '(the command returned no content)' });
+    expect(result).toEqual({
+      exitCode: 0,
+      output: '(the command returned no content)',
+      outcome: { kind: 'success' },
+    });
   });
 
   it('surfaces a clean error when a ready record is missing its endpoint', async () => {
@@ -150,6 +162,7 @@ describe('runAiTool', () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Unknown command `no-such-tool`');
     expect(result.output).toContain('- `list-all-documentation`');
+    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'unknown-command' });
   });
 
   it('lists the available tools when the server reports the unknown tool as an error result', async () => {
@@ -162,6 +175,7 @@ describe('runAiTool', () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Unknown command `no-such-tool`');
     expect(result.output).toContain('- `list-all-documentation`');
+    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'unknown-command' });
   });
 
   it('keeps the original error result when the failing tool does exist', async () => {
@@ -170,30 +184,40 @@ describe('runAiTool', () => {
       isError: true,
     });
     const result = await runAiTool('list-all-documentation', [], { cwd: '/projects/foo' });
-    expect(result).toEqual({ exitCode: 1, output: 'tests failed' });
+    expect(result).toEqual({
+      exitCode: 1,
+      output: 'tests failed',
+      outcome: { kind: 'error', error: expect.objectContaining({ name: 'McpToolResultError' }) },
+    });
   });
 
   it('prints the original JSON-RPC error when the tool exists', async () => {
-    vi.mocked(callMcpTool).mockRejectedValue(new McpJsonRpcError(-32602, 'invalid arguments'));
+    const error = new McpJsonRpcError(-32602, 'invalid arguments');
+    vi.mocked(callMcpTool).mockRejectedValue(error);
     const result = await runAiTool('list-all-documentation', [], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Storybook server error -32602: invalid arguments');
+    expect(result.outcome).toEqual({ kind: 'error', error });
   });
 
   it('prints the original JSON-RPC error when the tool list cannot be fetched', async () => {
-    vi.mocked(callMcpTool).mockRejectedValue(new McpJsonRpcError(-32601, 'unknown tool'));
+    const error = new McpJsonRpcError(-32601, 'unknown tool');
+    vi.mocked(callMcpTool).mockRejectedValue(error);
     vi.mocked(listMcpTools).mockRejectedValue(new Error('boom'));
     const result = await runAiTool('no-such-tool', [], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Storybook server error -32601: unknown tool');
+    expect(result.outcome).toEqual({ kind: 'error', error });
   });
 
   it('surfaces a friendly error when the MCP server is unreachable', async () => {
-    vi.mocked(callMcpTool).mockRejectedValue(new Error('connection refused'));
+    const error = new Error('connection refused');
+    vi.mocked(callMcpTool).mockRejectedValue(error);
     const result = await runAiTool('get-documentation', [], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Failed to reach the Storybook server at /mcp');
     expect(result.output).toContain('connection refused');
+    expect(result.outcome).toEqual({ kind: 'error', error });
   });
 
   it('prepends a warning when multiple instances run at the same cwd', async () => {
@@ -307,6 +331,7 @@ describe('runAiToolHelp', () => {
     expect(result.output).toContain('Usage: storybook ai get-documentation');
     expect(result.output).toContain('Get docs for a component.');
     expect(result.output).toContain('- `--id` (string, required): Documentation id');
+    expect(result.outcome).toEqual({ kind: 'help' });
   });
 
   it('is reachable through runAiTool via a --help token after the tool name', async () => {
@@ -316,6 +341,7 @@ describe('runAiToolHelp', () => {
     const result = await runAiTool('get-documentation', ['--help'], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('Usage: storybook ai get-documentation');
+    expect(result.outcome).toEqual({ kind: 'help' });
     expect(callMcpTool).not.toHaveBeenCalled();
   });
 
@@ -334,11 +360,12 @@ describe('runAiToolHelp', () => {
     expect(result.output).toContain('- `list-all-documentation`');
   });
 
-  it('prints repair markdown and exits non-zero on intercepts', async () => {
+  it('prints repair markdown and exits non-zero on intercepts, still classified as help', async () => {
     vi.mocked(readRegistry).mockResolvedValue([]);
     const result = await runAiToolHelp('get-documentation', { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Storybook is not running at this cwd');
+    expect(result.outcome).toEqual({ kind: 'help' });
   });
 
   it('rejects an invalid --port', async () => {

--- a/code/lib/cli-storybook/src/ai/mcp/run-tool.test.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/run-tool.test.ts
@@ -189,6 +189,11 @@ describe('runAiTool', () => {
       output: 'tests failed',
       outcome: { kind: 'error', error: expect.objectContaining({ name: 'McpToolResultError' }) },
     });
+    // Constant message keeps the telemetry error hash aggregatable; the tool's error text only
+    // travels as `cause` (uploaded path-sanitized, and only with crash-reports consent).
+    const error = (result.outcome as { error: Error }).error;
+    expect(error.message).toBe('The Storybook MCP server returned an error result');
+    expect(error.cause).toBe('tests failed');
   });
 
   it('prints the original JSON-RPC error when the tool exists', async () => {

--- a/code/lib/cli-storybook/src/ai/mcp/run-tool.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/run-tool.ts
@@ -34,14 +34,15 @@ export type AiCommandOutcome =
 export type AiToolRunResult = { exitCode: 0 | 1; output: string; outcome: AiCommandOutcome };
 
 /**
- * The server executed the command and reported an error result. The result text is deliberately
- * not part of the message: it is arbitrary tool output (often containing project paths), while
- * this error feeds the telemetry error path, which reports the message hash by default and the
- * sanitized message when crash reports are enabled.
+ * The server executed the command and reported an error result. The message is deliberately
+ * constant — the result text is arbitrary tool output (often containing project paths), and a
+ * constant message keeps the telemetry error hash stable and aggregatable. The tool's error text
+ * travels as `cause` instead, which the standard error path only uploads — path-sanitized — when
+ * the user opted into crash reports.
  */
 class McpToolResultError extends Error {
-  constructor() {
-    super('The Storybook MCP server returned an error result');
+  constructor(options?: ErrorOptions) {
+    super('The Storybook MCP server returned an error result', options);
     this.name = 'McpToolResultError';
   }
 }
@@ -116,13 +117,18 @@ export async function runAiTool(
       }
     }
     const siblings = matches.filter((r) => r !== record);
+    const toolOutput = formatToolResult(result);
     const sections = [
       ...(siblings.length > 0 ? [formatMultiInstanceWarning(record, siblings)] : []),
-      formatToolResult(result),
+      toolOutput,
     ];
     const output = sections.join('\n\n');
     if (result.isError) {
-      return { exitCode: 1, output, outcome: { kind: 'error', error: new McpToolResultError() } };
+      return {
+        exitCode: 1,
+        output,
+        outcome: { kind: 'error', error: new McpToolResultError({ cause: toolOutput }) },
+      };
     }
     return { exitCode: 0, output, outcome: { kind: 'success' } };
   } catch (error) {

--- a/code/lib/cli-storybook/src/ai/mcp/run-tool.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/run-tool.ts
@@ -12,7 +12,39 @@ import type {
   ToolCallResult,
 } from './types.ts';
 
-export type AiToolRunResult = { exitCode: 0 | 1; output: string };
+/**
+ * Why an invocation failed before any command executed, for the `ai-command` telemetry event
+ * (storybookjs/storybook#35131). Extends the instance-resolution intercepts with the two CLI-level
+ * cases: arguments that never parsed, and command names the server does not provide.
+ */
+export type AiCommandInterceptReason = InterceptReason | 'invalid-arguments' | 'unknown-command';
+
+/**
+ * Telemetry-facing classification of a run. `help` marks lookups via `--help` flags, which are not
+ * command executions and are excluded from the `ai-command` event so they cannot skew command
+ * success rates. `error` carries failures from the server side (error results, transport
+ * failures, timeouts) for the standard sanitized error path.
+ */
+export type AiCommandOutcome =
+  | { kind: 'success' }
+  | { kind: 'help' }
+  | { kind: 'intercept'; reason: AiCommandInterceptReason }
+  | { kind: 'error'; error: unknown };
+
+export type AiToolRunResult = { exitCode: 0 | 1; output: string; outcome: AiCommandOutcome };
+
+/**
+ * The server executed the command and reported an error result. The result text is deliberately
+ * not part of the message: it is arbitrary tool output (often containing project paths), while
+ * this error feeds the telemetry error path, which reports the message hash by default and the
+ * sanitized message when crash reports are enabled.
+ */
+class McpToolResultError extends Error {
+  constructor() {
+    super('The Storybook MCP server returned an error result');
+    this.name = 'McpToolResultError';
+  }
+}
 
 /** Injectable dependencies for tests. */
 export type AiToolRunDeps = {
@@ -46,7 +78,11 @@ export async function runAiTool(
     json: options.json,
   });
   if (!parsed.ok) {
-    return { exitCode: 1, output: parsed.error };
+    return {
+      exitCode: 1,
+      output: parsed.error,
+      outcome: { kind: 'intercept', reason: 'invalid-arguments' },
+    };
   }
   if (parsed.help) {
     return toolHelp(toolName, parsed.cwd, parsed.port, deps);
@@ -54,7 +90,11 @@ export async function runAiTool(
 
   const resolution = await resolveReadyInstance(parsed.cwd, parsed.port, deps);
   if (resolution.kind === 'error') {
-    return { exitCode: 1, output: resolution.output };
+    return {
+      exitCode: 1,
+      output: resolution.output,
+      outcome: { kind: 'intercept', reason: resolution.reason },
+    };
   }
   const { record, matches } = resolution;
 
@@ -68,7 +108,11 @@ export async function runAiTool(
       // addon-mcp reports unknown tools as an error *result* rather than a JSON-RPC error.
       const unknownTool = await describeUnknownTool(record, toolName, deps.fetchImpl);
       if (unknownTool) {
-        return { exitCode: 1, output: unknownTool };
+        return {
+          exitCode: 1,
+          output: unknownTool,
+          outcome: { kind: 'intercept', reason: 'unknown-command' },
+        };
       }
     }
     const siblings = matches.filter((r) => r !== record);
@@ -76,13 +120,28 @@ export async function runAiTool(
       ...(siblings.length > 0 ? [formatMultiInstanceWarning(record, siblings)] : []),
       formatToolResult(result),
     ];
-    return { exitCode: result.isError ? 1 : 0, output: sections.join('\n\n') };
+    const output = sections.join('\n\n');
+    if (result.isError) {
+      return { exitCode: 1, output, outcome: { kind: 'error', error: new McpToolResultError() } };
+    }
+    return { exitCode: 0, output, outcome: { kind: 'success' } };
   } catch (error) {
     if (error instanceof McpJsonRpcError) {
       const unknownTool = await describeUnknownTool(record, toolName, deps.fetchImpl);
-      return { exitCode: 1, output: unknownTool ?? error.message };
+      if (unknownTool) {
+        return {
+          exitCode: 1,
+          output: unknownTool,
+          outcome: { kind: 'intercept', reason: 'unknown-command' },
+        };
+      }
+      return { exitCode: 1, output: error.message, outcome: { kind: 'error', error } };
     }
-    return { exitCode: 1, output: formatServerUnreachable(record, error) };
+    return {
+      exitCode: 1,
+      output: formatServerUnreachable(record, error),
+      outcome: { kind: 'error', error },
+    };
   }
 }
 
@@ -174,20 +233,23 @@ export async function runAiToolHelp(
 ): Promise<AiToolRunResult> {
   const parsed = parseToolArgs([], { cwd: options.cwd, port: options.port });
   if (!parsed.ok) {
-    return { exitCode: 1, output: parsed.error };
+    return { exitCode: 1, output: parsed.error, outcome: { kind: 'help' } };
   }
   return toolHelp(toolName, parsed.cwd, parsed.port, deps);
 }
 
+/** All paths are help lookups, so every outcome is `help` regardless of success. */
 async function toolHelp(
   toolName: string,
   cwd: string | undefined,
   port: number | undefined,
   deps: AiToolRunDeps
 ): Promise<AiToolRunResult> {
+  const outcome: AiCommandOutcome = { kind: 'help' };
+
   const resolution = await resolveReadyInstance(cwd, port, deps);
   if (resolution.kind === 'error') {
-    return { exitCode: 1, output: resolution.output };
+    return { exitCode: 1, output: resolution.output, outcome };
   }
   const { record } = resolution;
 
@@ -195,14 +257,14 @@ async function toolHelp(
   try {
     tools = await listMcpTools(record, deps.fetchImpl);
   } catch (error) {
-    return { exitCode: 1, output: formatServerUnreachable(record, error) };
+    return { exitCode: 1, output: formatServerUnreachable(record, error), outcome };
   }
 
   const tool = tools.find((candidate) => candidate.name === toolName);
   if (!tool) {
-    return { exitCode: 1, output: formatUnknownTool(toolName, tools, record) };
+    return { exitCode: 1, output: formatUnknownTool(toolName, tools, record), outcome };
   }
-  return { exitCode: 0, output: formatToolHelp(tool) };
+  return { exitCode: 0, output: formatToolHelp(tool), outcome };
 }
 
 function formatServerUnreachable(record: StorybookInstanceRecord, error: unknown): string {

--- a/code/lib/cli-storybook/src/ai/mcp/tool-args.test.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/tool-args.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseToolArgs } from './tool-args.ts';
+import { parseToolArgs, scanCwdToken } from './tool-args.ts';
 
 function args(tokens: string[], defaults?: { cwd?: string; port?: string; json?: string }) {
   const result = parseToolArgs(tokens, defaults);
@@ -168,5 +168,29 @@ describe('parseToolArgs', () => {
 
   it('errors on `--=value`', () => {
     expect(error(['--=x'])).toContain('Invalid flag');
+  });
+});
+
+describe('scanCwdToken', () => {
+  it('finds `--cwd value` and `--cwd=value`', () => {
+    expect(scanCwdToken(['--cwd', '/x'])).toBe('/x');
+    expect(scanCwdToken(['--cwd=/x'])).toBe('/x');
+  });
+
+  it('returns undefined without a --cwd token or without its value', () => {
+    expect(scanCwdToken([])).toBeUndefined();
+    expect(scanCwdToken(['--id', 'x'])).toBeUndefined();
+    expect(scanCwdToken(['--cwd'])).toBeUndefined();
+    expect(scanCwdToken(['--cwd', '--id'])).toBeUndefined();
+  });
+
+  it('lets the last occurrence win, matching the full parser', () => {
+    expect(scanCwdToken(['--cwd', '/a', '--cwd=/b'])).toBe('/b');
+  });
+
+  it('tolerates tokens the full parser rejects', () => {
+    expect(parseToolArgs(['positional', '--cwd', '/x'])).toMatchObject({ ok: false });
+    expect(scanCwdToken(['positional', '--cwd', '/x'])).toBe('/x');
+    expect(scanCwdToken(['--cwd', '/x', '--json', '{bad'])).toBe('/x');
   });
 });

--- a/code/lib/cli-storybook/src/ai/mcp/tool-args.ts
+++ b/code/lib/cli-storybook/src/ai/mcp/tool-args.ts
@@ -125,6 +125,27 @@ export function parseToolArgs(
   return { ok: true, cwd, port, help, args: { ...jsonArgs, ...flagArgs } };
 }
 
+/**
+ * Extract only the `--cwd` value from pass-through tokens, tolerating tokens that
+ * {@link parseToolArgs} would reject. Telemetry opt-out resolution must locate the target project
+ * even when the invocation itself fails as `invalid-arguments` — that intercept still fires an
+ * event (storybookjs/storybook#35131). Mirrors the full parser's `--cwd` grammar: `--cwd value`
+ * or `--cwd=value`, last occurrence wins.
+ */
+export function scanCwdToken(tokens: string[]): string | undefined {
+  let cwd: string | undefined;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token === '--cwd' && i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
+      cwd = tokens[i + 1];
+      i += 1;
+    } else if (token.startsWith('--cwd=')) {
+      cwd = token.slice('--cwd='.length);
+    }
+  }
+  return cwd;
+}
+
 function coerceValue(raw: string): unknown {
   try {
     return JSON.parse(raw);

--- a/code/lib/cli-storybook/src/bin/run.ts
+++ b/code/lib/cli-storybook/src/bin/run.ts
@@ -333,7 +333,7 @@ aiCommand.action(() => {
 // Experimental `storybook ai <tool>` passthrough to the local Storybook MCP server
 // (storybookjs/storybook#35124). Overrides the help-only action above when enabled.
 if (isAiCliFeatureEnabled()) {
-  registerAiMcpPassthrough(program, aiCommand);
+  registerAiMcpPassthrough(program, aiCommand, handleCommandFailure);
 }
 
 program.on('command:*', ([invalidCmd]) => {


### PR DESCRIPTION
Closes #35131

## What I did

Follow-up to #35124, which added the experimental `storybook ai <command>` CLI passthrough (behind `STORYBOOK_FEATURE_AI_CLI=1`). Telemetry was deferred there; this adds it per the design in #35131:

- **New `ai-command` event type**, fired once per executed command with payload `{ command, success, interceptReason?, duration }`.
  - `interceptReason` covers the failures nobody captures today, i.e. invocations that never reach a Storybook server: `no-instance`, `port-mismatch`, `addon-missing`, `mcp-starting`, `mcp-error`, plus the CLI-level `invalid-arguments` and `unknown-command`.
  - Help lookups (`storybook ai --help`, `ai <cmd> --help`) fire no `ai-command` event, so they can't skew command success rates.
  - No PII: no cwd, paths, or command arguments in payloads. Command names that don't look like a server-defined command identifier (e.g. a typo'd path) are collapsed to `(invalid)`.
- **Every passthrough invocation is wrapped in `withTelemetry('ai-command', ...)`**, consistent with `add`/`doctor`/`ai-setup`: boot event, `canceled` on Ctrl-C (cancellation tracking in `withTelemetry` is generalized from `init`-only to a tracked-events list), and sanitized error reporting. Like `init`, it passes `fallbackTelemetryState: true` so the `no-instance` intercept is still reported from a cwd without a loadable main config — that wrong-cwd case is precisely the data this event exists to measure. All opt-out tiers (`--disable-telemetry`, `STORYBOOK_DISABLE_TELEMETRY`, `core.disableTelemetry`) are respected.
- **Server-reached errors** (MCP error results, transport failures, timeouts) additionally go through the standard sanitized error path (`sendTelemetryError`); the MCP error-result case uses a constant-message `McpToolResultError` so no tool output text leaks into error telemetry.
- **The CLI identifies itself on the MCP connection.**
  - Before: the CLI sent bare JSON-RPC requests with no `initialize`, so `@storybook/addon-mcp`'s server-side `tool:*` events had `clientInfo: undefined` for CLI traffic — indistinguishable from an agent connected over MCP directly.
  - Now: the client first sends an `initialize` request with `clientInfo: { name: 'storybook-cli', version }`, then passes the returned `Mcp-Session-Id` header on the actual request. That is the mechanism tmcp already uses to associate `clientInfo` with requests, so the addon's existing events pick it up — **no server-side changes needed**.
  - The handshake is strictly best-effort: short timeout, and any failure (non-OK response, no session id, network error) degrades to a session-less request. It can never break or delay the actual command; error reporting stays anchored on the real call.

An independent code-quality review (thermo-nuclear-code-quality-review agent) was run; its one actionable finding (document the deliberate one-shot-session design) is addressed in the last commit, the rest were explicitly resolved (see review notes in the implementation session).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Unit tests cover: payload shape per outcome (success / every intercept class / server error), help-path exclusion, command-name sanitization, opt-out wiring (`--disable-telemetry` flag, `STORYBOOK_DISABLE_TELEMETRY` default), failure-handler threading, the `initialize` handshake (clientInfo payload, session-id threading, all best-effort failure modes, body-drain ordering), and `ai-command` cancellation tracking in `withTelemetry`.

#### Manual testing

Manual QA was performed against a project running `storybook dev` with `@storybook/addon-mcp` (the `internal-storybook` app in storybookjs/mcp), with `STORYBOOK_FEATURE_AI_CLI=1 STORYBOOK_TELEMETRY_DEBUG=1` and `STORYBOOK_TELEMETRY_URL` pointed at a local sink. All six verification steps from #35131 pass:

1. **Success**: `storybook ai list-all-documentation` → `ai-command` with `success: true`, correct `command`, plausible `duration` (~200ms). Addon-side `tool:listAllDocumentation` event constructed with `clientInfo: { name: 'storybook-cli', version }` (verified via probe in the addon's `collectTelemetry`).
2. **Stopped server**: → `success: false, interceptReason: 'no-instance'`.
3. **Cwd without Storybook**: → `interceptReason: 'no-instance'` (works thanks to `fallbackTelemetryState`); the `addon-missing` intercept verified via a registry record with `mcp.status: 'not-installed'`. Also verified `unknown-command` against the live server.
4. **Server-side error** (missing required args to `get-documentation`): → `ai-command` with `success: false` plus a standard `error` event (`name: McpToolResultError`, message hash only).
5. **Opt-outs**: `STORYBOOK_DISABLE_TELEMETRY=1`, `--disable-telemetry`, and `core.disableTelemetry: true` each produce zero events while the command output is unaffected.
6. **Ctrl-C mid-invocation** (during `run-story-tests`): → `canceled` event with `eventType: 'ai-command'`, no completion event.

To reproduce as a maintainer: run any Storybook with `@storybook/addon-mcp`, then from that project's cwd run `STORYBOOK_FEATURE_AI_CLI=1 STORYBOOK_TELEMETRY_DEBUG=1 npx storybook ai list-all-documentation` (using this branch's CLI build) and walk the six steps above.

> Note found during QA (pre-existing, unrelated to this PR): a second instance of `storybook/internal/telemetry` loading in the same process resets `globalThis.SB_TELEMETRY_STATE`, silently queueing addon-side events forever (hit in pnpm workspaces where the addon resolves its own `storybook` copy). Tracked separately.

### Documentation

- [ ] Add or update documentation reflecting your changes — not needed: the feature is experimental and flag-gated; telemetry payload docs live in the telemetry docs page which describes events generically.
- [ ] MIGRATION.md — not applicable.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry now records AI commands and emits cancellation events for tracked command paths.
  * Short session handshake added to MCP calls to segment telemetry per session.

* **Improvements**
  * AI command results now include explicit outcome classifications (success/help/intercept/error).
  * Better output routing, help handling, error reporting, and passthrough failure handling.
  * New helper to extract --cwd for telemetry opt-out resolution.

* **Tests**
  * Expanded coverage for telemetry, cancellation, handshake, argument parsing, and outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
