### PR TITLE
CI: Make CircleCI generated workflow name stable

### DIFF
--- a/scripts/ci/main.ts
+++ b/scripts/ci/main.ts
@@ -135,7 +135,7 @@ function generateConfig(workflow: Workflow) {
       {} as Record<string, JobImplementationObj | NoOpJobImplementationObj>
     ),
     workflows: {
-      [`${workflow}-generated${isDebugging ? '-debug' : ''}`]: {
+      [`circleci-generated${isDebugging ? '-debug' : ''}`]: {
         jobs: sortedJobs.map((t) =>
           t.requires && t.requires.length > 0
             ? { [t.id]: { requires: t.requires.map((r) => r.id) } }


### PR DESCRIPTION

## What I did

Renamed the generated CircleCI workflow to have a stable name. This lets us make the workflow required.

> [!CAUTION]
> Side effect: we'd no longer be able to recognise which workflow is running in CircleCI without checking the linked PR/commit on GitHub.

## Checklist for Contributors

### Testing

Not tested.

#### Manual testing

Should just not cause any crash in CI.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration workflow naming convention for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->