### PR TITLE
Telemetry: Preserve state machine when the module loads more than once

### DIFF
--- a/code/core/src/telemetry/index.test.ts
+++ b/code/core/src/telemetry/index.test.ts
@@ -23,6 +23,10 @@ vi.mock('./telemetry.ts', () => ({
 
 beforeEach(async () => {
   vi.resetModules();
+  // The state machine globals deliberately survive module re-loads, so reset them explicitly
+  delete (globalThis as any).SB_TELEMETRY_STATE;
+  delete (globalThis as any).SB_TELEMETRY_QUEUE;
+  delete (globalThis as any).PAYLOAD_ERROR_HANDLER;
   telemetryModule = await import('./index.ts');
 }, 30_000);
 
@@ -170,6 +174,74 @@ describe('telemetry state machine', () => {
 
     await telemetryModule.setTelemetryEnabled(true);
     expect(telemetryModule.isTelemetryModuleEnabled()).toBe(true);
+  });
+});
+
+describe('second module load (e.g. addon resolving its own copy of the storybook package)', () => {
+  it('preserves resolved state when the module loads a second time', async () => {
+    await telemetryModule.setTelemetryEnabled(true);
+
+    vi.resetModules();
+    const secondInstance = await import('./index.ts');
+
+    expect(secondInstance.isTelemetryStateResolved()).toBe(true);
+    expect(secondInstance.isTelemetryModuleEnabled()).toBe(true);
+  });
+
+  it('sends events from a second module instance after the first one resolved state', async () => {
+    await telemetryModule.setTelemetryEnabled(true);
+
+    vi.resetModules();
+    const secondInstance = await import('./index.ts');
+    const { sendTelemetry } = await import('./telemetry.ts');
+
+    await secondInstance.telemetry('dev', { foo: 'bar' }, { stripMetadata: true });
+
+    expect(sendTelemetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes events queued by the first instance when a second instance resolves state', async () => {
+    await telemetryModule.telemetry('boot', { eventType: 'dev' }, { stripMetadata: true });
+
+    vi.resetModules();
+    const secondInstance = await import('./index.ts');
+    const { sendTelemetry } = await import('./telemetry.ts');
+
+    await secondInstance.setTelemetryEnabled(true);
+
+    expect(sendTelemetry).toHaveBeenCalledTimes(1);
+    expect(sendTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'boot', payload: { eventType: 'dev' } }),
+      expect.anything()
+    );
+  });
+
+  it('preserves disabled state when the module loads a second time', async () => {
+    await telemetryModule.setTelemetryEnabled(false);
+
+    vi.resetModules();
+    const secondInstance = await import('./index.ts');
+    const { sendTelemetry } = await import('./telemetry.ts');
+
+    await secondInstance.telemetry('dev', { foo: 'bar' });
+
+    expect(secondInstance.isTelemetryStateResolved()).toBe(true);
+    expect(secondInstance.isTelemetryModuleEnabled()).toBe(false);
+    expect(sendTelemetry).not.toHaveBeenCalled();
+  });
+
+  it('keeps a payload error handler registered through the first instance', async () => {
+    const errorHandler = vi.fn().mockResolvedValue(undefined);
+    await telemetryModule.setTelemetryEnabled(true);
+    telemetryModule.onPayloadError(errorHandler);
+
+    vi.resetModules();
+    const secondInstance = await import('./index.ts');
+
+    const testError = new Error('payload failed');
+    await secondInstance.telemetry('dev', async () => ({ error: testError }));
+
+    expect(errorHandler).toHaveBeenCalledWith(testError, 'dev');
   });
 });
 

--- a/code/core/src/telemetry/index.ts
+++ b/code/core/src/telemetry/index.ts
@@ -48,16 +48,26 @@ export const isExampleStoryId = (storyId: string) =>
 
 type TelemetryState = undefined | 'enabled' | 'disabled';
 
-globalThis.SB_TELEMETRY_STATE = undefined as TelemetryState; // Start in uninitialized state until we know whether telemetry is enabled or disabled based on presets and CLI options. In the meantime, events are queued.
-
-type QueuedEvent = {
+export type QueuedEvent = {
   eventType: EventType;
   payload: PayloadInput;
   options: Partial<Options>;
   timestamp: number;
 };
 
-let _queue: QueuedEvent[] = [];
+// State and queue live on globalThis and are only initialized when absent, because this module
+// can load more than once in the same process (e.g. an addon resolving its own copy of the
+// storybook package, or dual CJS/ESM loading). An unconditional assignment would reset
+// already-resolved state back to uninitialized, silently queueing all subsequent events forever.
+if (!('SB_TELEMETRY_STATE' in globalThis)) {
+  // Start in uninitialized state until we know whether telemetry is enabled or disabled based on
+  // presets and CLI options. In the meantime, events are queued.
+  globalThis.SB_TELEMETRY_STATE = undefined as TelemetryState;
+}
+
+if (!('SB_TELEMETRY_QUEUE' in globalThis)) {
+  globalThis.SB_TELEMETRY_QUEUE = [];
+}
 
 const isPayloadFactory = (payload: PayloadInput): payload is PayloadFactory =>
   typeof payload === 'function';
@@ -75,8 +85,8 @@ export async function setTelemetryEnabled(enabled: boolean) {
 
   if (enabled && previousState === undefined) {
     // Flush the queue
-    const pending = _queue;
-    _queue = [];
+    const pending = globalThis.SB_TELEMETRY_QUEUE;
+    globalThis.SB_TELEMETRY_QUEUE = [];
     for (const event of pending) {
       try {
         await _processAndSend(event.eventType, event.payload, {
@@ -90,7 +100,7 @@ export async function setTelemetryEnabled(enabled: boolean) {
     }
   } else {
     // Clear the queue (disabled, or already resolved)
-    _queue = [];
+    globalThis.SB_TELEMETRY_QUEUE = [];
   }
 }
 
@@ -112,7 +122,12 @@ export function isTelemetryStateResolved() {
  * (presets, cache, error levels, sub-errors).
  */
 type PayloadErrorHandler = (error: Error, eventType: EventType) => Promise<void>;
-globalThis.PAYLOAD_ERROR_HANDLER = undefined as PayloadErrorHandler | undefined;
+
+// Guarded for the same reason as SB_TELEMETRY_STATE above: a second load of this module must not
+// clear a handler registered through the first one.
+if (!('PAYLOAD_ERROR_HANDLER' in globalThis)) {
+  globalThis.PAYLOAD_ERROR_HANDLER = undefined as PayloadErrorHandler | undefined;
+}
 
 /**
  * Register a handler for payload factory errors. When a telemetry payload factory
@@ -205,7 +220,7 @@ export const telemetry = async (
   }
 
   if (globalThis.SB_TELEMETRY_STATE === undefined && !options.force) {
-    _queue.push({ eventType, payload, options, timestamp: Date.now() });
+    globalThis.SB_TELEMETRY_QUEUE.push({ eventType, payload, options, timestamp: Date.now() });
     return;
   }
 

--- a/code/core/src/telemetry/index.ts
+++ b/code/core/src/telemetry/index.ts
@@ -59,6 +59,8 @@ export type QueuedEvent = {
 // can load more than once in the same process (e.g. an addon resolving its own copy of the
 // storybook package, or dual CJS/ESM loading). An unconditional assignment would reset
 // already-resolved state back to uninitialized, silently queueing all subsequent events forever.
+// The `in` check (rather than `=== undefined`) is load-bearing: the uninitialized state is
+// literally `undefined`, so only key presence distinguishes "seeded" from "never loaded".
 if (!('SB_TELEMETRY_STATE' in globalThis)) {
   // Start in uninitialized state until we know whether telemetry is enabled or disabled based on
   // presets and CLI options. In the meantime, events are queued.
@@ -121,7 +123,7 @@ export function isTelemetryStateResolved() {
  * Registered by withTelemetry() to delegate to sendTelemetryError with full context
  * (presets, cache, error levels, sub-errors).
  */
-type PayloadErrorHandler = (error: Error, eventType: EventType) => Promise<void>;
+export type PayloadErrorHandler = (error: Error, eventType: EventType) => Promise<void>;
 
 // Guarded for the same reason as SB_TELEMETRY_STATE above: a second load of this module must not
 // clear a handler registered through the first one.

--- a/code/core/src/typings.d.ts
+++ b/code/core/src/typings.d.ts
@@ -17,6 +17,7 @@ declare var STORYBOOK_RENDERER: import('./types/modules/renderers').SupportedRen
 declare var STORYBOOK_HOOKS_CONTEXT: any;
 declare var STORYBOOK_CURRENT_TASK_LOG: undefined | null | Array<any>;
 declare var SB_TELEMETRY_STATE: 'enabled' | 'disabled' | undefined;
+declare var SB_TELEMETRY_QUEUE: Array<import('./telemetry').QueuedEvent>;
 declare var PAYLOAD_ERROR_HANDLER: PayloadErrorHandler | undefined;
 
 declare var STORYBOOK_LAST_EVENTS: Record<

--- a/code/core/src/typings.d.ts
+++ b/code/core/src/typings.d.ts
@@ -18,7 +18,7 @@ declare var STORYBOOK_HOOKS_CONTEXT: any;
 declare var STORYBOOK_CURRENT_TASK_LOG: undefined | null | Array<any>;
 declare var SB_TELEMETRY_STATE: 'enabled' | 'disabled' | undefined;
 declare var SB_TELEMETRY_QUEUE: Array<import('./telemetry').QueuedEvent>;
-declare var PAYLOAD_ERROR_HANDLER: PayloadErrorHandler | undefined;
+declare var PAYLOAD_ERROR_HANDLER: import('./telemetry').PayloadErrorHandler | undefined;
 
 declare var STORYBOOK_LAST_EVENTS: Record<
   import('./telemetry').EventType,


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The telemetry module initializes its state machine with an unconditional assignment at load time:

```ts
globalThis.SB_TELEMETRY_STATE = undefined as TelemetryState;
```

When a second copy of the module loads in the same process — e.g. an addon like `@storybook/addon-mcp` resolving its own copy of the `storybook` package in a pnpm workspace, or dual CJS/ESM loading — this resets the already-resolved state (`'enabled'`/`'disabled'`) back to `undefined`. From that point on, every `telemetry()` call is pushed onto a queue that is never flushed, so events are silently dropped.

Observed during manual QA of #35131: the dev server resolved telemetry state at startup (boot event sent), but `@storybook/addon-mcp`'s module instance had wiped `globalThis.SB_TELEMETRY_STATE` back to `undefined`, so all of its server-side `tool:*` events were queued forever and never sent.

Changes:

- Guard-initialize `SB_TELEMETRY_STATE` with `if (!('SB_TELEMETRY_STATE' in globalThis))` so a late-loading module instance doesn't reset resolved state.
- Move the event queue from a module-local variable to a guard-initialized `globalThis.SB_TELEMETRY_QUEUE`, so events queued by one module instance are flushed when *any* instance resolves the state via `setTelemetryEnabled()`.
- Apply the same guard to `PAYLOAD_ERROR_HANDLER`, which had the identical wipe-on-reload bug (a second load would clear a handler registered through `withTelemetry()`).
- Add unit tests that simulate a second module load (`vi.resetModules()` + re-import) and assert that resolved state, queued events, and the registered payload error handler all survive.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. In a pnpm workspace where an addon resolves its own copy of the `storybook` package (e.g. `apps/internal-storybook` in [storybookjs/mcp](https://github.com/storybookjs/mcp) with `@storybook/addon-mcp`), point `storybook` at a canary of this PR.
2. Start the dev server with `STORYBOOK_TELEMETRY_DEBUG=1`.
3. Trigger an MCP tool call (e.g. connect an MCP client and run any tool).
4. Before this fix, the addon's `tool:*` telemetry events were never logged/sent (its module instance saw `SB_TELEMETRY_STATE === undefined`); with the fix, the debug output shows the events being sent.

The regression is also covered by the new "second module load" unit tests in `code/core/src/telemetry/index.test.ts`.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved telemetry state persistence across module reloads to ensure event data is not lost during re-initialization.
  * Enhanced error handler reliability to ensure error callbacks remain active across module reloads.
  * Fixed event queue management to properly flush queued events when telemetry is enabled.

* **Tests**
  * Added comprehensive test coverage for scenarios involving multiple module loads and state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->