### PR TITLE
Nextjs Vite: Fix Root Package Import

### DIFF
--- a/code/frameworks/nextjs-vite/build-config.ts
+++ b/code/frameworks/nextjs-vite/build-config.ts
@@ -25,6 +25,11 @@ const config: BuildEntries = {
         entryPoint: './src/export-mocks/headers/index.ts',
       },
       {
+        exportEntries: ['./image-context'],
+        entryPoint: './src/image-context.ts',
+        dts: false,
+      },
+      {
         exportEntries: ['./navigation.mock'],
         entryPoint: './src/export-mocks/navigation/index.ts',
       },

--- a/code/frameworks/nextjs-vite/build-config.ts
+++ b/code/frameworks/nextjs-vite/build-config.ts
@@ -27,7 +27,6 @@ const config: BuildEntries = {
       {
         exportEntries: ['./image-context'],
         entryPoint: './src/image-context.ts',
-        dts: false,
       },
       {
         exportEntries: ['./navigation.mock'],

--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -43,7 +43,11 @@
       "code": "./src/export-mocks/headers/index.ts",
       "default": "./dist/export-mocks/headers/index.js"
     },
-    "./image-context": "./dist/image-context.js",
+    "./image-context": {
+      "types": "./dist/image-context.d.ts",
+      "code": "./src/image-context.ts",
+      "default": "./dist/image-context.js"
+    },
     "./link.mock": {
       "types": "./dist/export-mocks/link/index.d.ts",
       "code": "./src/export-mocks/link/index.tsx",

--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -43,6 +43,7 @@
       "code": "./src/export-mocks/headers/index.ts",
       "default": "./dist/export-mocks/headers/index.js"
     },
+    "./image-context": "./dist/image-context.js",
     "./link.mock": {
       "types": "./dist/export-mocks/link/index.d.ts",
       "code": "./src/export-mocks/link/index.tsx",
@@ -77,7 +78,6 @@
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",

--- a/code/frameworks/nextjs-vite/src/image-context.ts
+++ b/code/frameworks/nextjs-vite/src/image-context.ts
@@ -1,0 +1,17 @@
+import { createContext } from 'react';
+
+import type { ImageProps, StaticImageData } from 'next/image';
+import type { ImageProps as LegacyImageProps } from 'next/legacy/image';
+
+// StaticRequire needs to be in scope for the TypeScript compiler to work.
+// See: https://github.com/microsoft/TypeScript/issues/5711
+// Since next/image doesn't export StaticRequire we need to re-define it here and set src's type to it.
+interface StaticRequire {
+  default: StaticImageData;
+}
+
+declare type StaticImport = StaticRequire | StaticImageData;
+
+export const ImageContext = createContext<
+  Partial<Omit<ImageProps, 'src'> & { src: string | StaticImport }> & Omit<LegacyImageProps, 'src'>
+>({});

--- a/code/frameworks/nextjs-vite/src/images/decorator.tsx
+++ b/code/frameworks/nextjs-vite/src/images/decorator.tsx
@@ -2,13 +2,7 @@ import * as React from 'react';
 
 import type { Addon_StoryContext } from 'storybook/internal/types';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore-error (this only errors during compilation for production)
-import { ImageContext as ImageContextValue } from '@storybook/nextjs-vite/image-context';
-
-import { type ImageContext as ImageContextType } from '../image-context.ts';
-
-const ImageContext = ImageContextValue as typeof ImageContextType;
+import { ImageContext } from '@storybook/nextjs-vite/image-context';
 
 export const ImageDecorator = (
   Story: React.FC,

--- a/code/frameworks/nextjs-vite/src/images/decorator.tsx
+++ b/code/frameworks/nextjs-vite/src/images/decorator.tsx
@@ -2,7 +2,13 @@ import * as React from 'react';
 
 import type { Addon_StoryContext } from 'storybook/internal/types';
 
-import { ImageContext } from 'sb-original/image-context';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore-error (this only errors during compilation for production)
+import { ImageContext as ImageContextValue } from '@storybook/nextjs-vite/image-context';
+
+import { type ImageContext as ImageContextType } from '../image-context.ts';
+
+const ImageContext = ImageContextValue as typeof ImageContextType;
 
 export const ImageDecorator = (
   Story: React.FC,

--- a/code/frameworks/nextjs-vite/src/index.ts
+++ b/code/frameworks/nextjs-vite/src/index.ts
@@ -5,8 +5,6 @@ import type { ReactPreview } from '@storybook/react';
 import { __definePreview } from '@storybook/react';
 import type { ReactTypes } from '@storybook/react';
 
-import type vitePluginStorybookNextJs from 'vite-plugin-storybook-nextjs';
-
 import * as nextPreview from './preview.tsx';
 import type { NextJsTypes } from './types.ts';
 
@@ -14,12 +12,6 @@ export * from '@storybook/react';
 // @ts-expect-error (double exports)
 export * from './portable-stories.ts';
 export * from './types.ts';
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-declare module '@storybook/nextjs-vite/vite-plugin' {
-  export const storybookNextJsPlugin: typeof vitePluginStorybookNextJs;
-}
 
 export function definePreview<Addons extends PreviewAddon<never>[]>(
   preview: { addons?: Addons } & ProjectAnnotations<ReactTypes & NextJsTypes & InferTypes<Addons>>

--- a/code/frameworks/nextjs-vite/src/preview.tsx
+++ b/code/frameworks/nextjs-vite/src/preview.tsx
@@ -33,25 +33,29 @@ function isAsyncClientComponentError(error: unknown) {
       error.includes('async/await is not yet supported in Client Components'))
   );
 }
-addNextHeadCount();
+if (typeof document !== 'undefined') {
+  addNextHeadCount();
+}
 
-// Copying Next patch of console.error:
-// https://github.com/vercel/next.js/blob/a74deb63e310df473583ab6f7c1783bc609ca236/packages/next/src/client/app-index.tsx#L15
-const origConsoleError = globalThis.console.error;
-globalThis.console.error = (...args: unknown[]) => {
-  const error = args[0];
-  if (isNextRouterError(error) || isAsyncClientComponentError(error)) {
-    return;
-  }
-  origConsoleError.apply(globalThis.console, args);
-};
+if (typeof globalThis.addEventListener === 'function') {
+  // Copying Next patch of console.error:
+  // https://github.com/vercel/next.js/blob/a74deb63e310df473583ab6f7c1783bc609ca236/packages/next/src/client/app-index.tsx#L15
+  const origConsoleError = globalThis.console.error;
+  globalThis.console.error = (...args: unknown[]) => {
+    const error = args[0];
+    if (isNextRouterError(error) || isAsyncClientComponentError(error)) {
+      return;
+    }
+    origConsoleError.apply(globalThis.console, args);
+  };
 
-globalThis.addEventListener('error', (ev: WindowEventMap['error']): void => {
-  if (isNextRouterError(ev.error) || isAsyncClientComponentError(ev.error)) {
-    ev.preventDefault();
-    return;
-  }
-});
+  globalThis.addEventListener('error', (ev: WindowEventMap['error']): void => {
+    if (isNextRouterError(ev.error) || isAsyncClientComponentError(ev.error)) {
+      ev.preventDefault();
+      return;
+    }
+  });
+}
 
 // Type assertion to handle the decorator type mismatch
 const asDecorator = (decorator: (Story: React.FC, context?: any) => React.ReactNode) =>


### PR DESCRIPTION
﻿## Summary

- Add a package-owned `@storybook/nextjs-vite/image-context` subpath and build entry.
- Use that self-contained image context from the Next.js Vite image decorator instead of the unpublished `sb-original/image-context` alias.
- Guard preview-only browser side effects so the root `@storybook/nextjs-vite` package entrypoint can load in Node.
- Remove the stale `module` field that pointed at an unshipped `dist/index.mjs`, and remove the redundant ambient `vite-plugin` subpath declaration.

## Why

The published root package entrypoint can be pulled into Node by tooling or package-contract checks. Today it eagerly reaches the preview/image decorator path, where `sb-original/image-context` is not a published dependency/subpath and root `import('@storybook/nextjs-vite')` / `require('@storybook/nextjs-vite')` fail.

This mirrors the existing `@storybook/nextjs` package pattern by exporting a package-local image context instead of relying on an internal alias.

#### Manual testing

- `yarn install --immutable --mode=skip-build`
- `yarn nx run nextjs-vite:compile --skip-nx-cache`
- `yarn exec jiti ./scripts/check/check-package.ts --cwd code/frameworks/nextjs-vite`
- `node -e "import('@storybook/nextjs-vite').then((m)=>console.log('import_ok', typeof m.definePreview)).catch((e)=>{console.error(e); process.exit(1)})"`
- `node -e "try { const m = require('@storybook/nextjs-vite'); console.log('require_ok', typeof m.definePreview) } catch (e) { console.error(e); process.exit(1) }"`
- `node -e "import('@storybook/nextjs-vite/node').then(()=>import('@storybook/nextjs-vite/vite-plugin')).then(()=>import('@storybook/nextjs-vite/image-context')).then(()=>console.log('subpaths_ok')).catch((e)=>{console.error(e); process.exit(1)})"`

Note: a plain `yarn install --immutable` initially failed locally because `fast-folder-size` timed out while downloading Sysinternals `DU.zip`; rerunning with `--mode=skip-build` completed dependency linking for the package-level checks above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image-context support to improve Next.js image handling in Storybook previews.

* **Chores**
  * Updated package exports and build configuration for the new image-context.
  * Improved runtime checks to avoid browser-dependent errors and enhance compatibility across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->