### PR TITLE
Open Service: Mark module-graph engine commands as internal

### DIFF
--- a/code/core/src/shared/open-service/services/module-graph/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph/definition.ts
@@ -129,7 +129,7 @@ export const moduleGraphServiceDef = defineService({
       input: noInputSchema,
       output: moduleGraphStatusSchema,
       load: async (_input, ctx) => {
-        await ctx.self.commands.waitForSettledEngine(undefined);
+        await ctx.self.commands._waitForSettledEngine(undefined);
       },
       handler: (_input, ctx) => ctx.self.state.status,
     },
@@ -192,9 +192,10 @@ export const moduleGraphServiceDef = defineService({
     },
   },
   commands: {
-    applyGraphSnapshot: {
+    _applyGraphSnapshot: {
+      internal: true,
       description:
-        'Internal use only: replaces the reverse index after the initial graph build. Called by the graph engine, not by external consumers.',
+        'Replaces the reverse index after the initial graph build. Called by the graph engine, not by external consumers.',
       input: v.object({
         storiesByFile: v.pipe(
           storiesByFileSchema,
@@ -221,9 +222,10 @@ export const moduleGraphServiceDef = defineService({
         });
       },
     },
-    applyGraphUpdate: {
+    _applyGraphUpdate: {
+      internal: true,
       description:
-        'Internal use only: replaces the reverse index after an incremental patch and bumps versions for affected story files. Called by the graph engine, not by external consumers.',
+        'Replaces the reverse index after an incremental patch and bumps versions for affected story files. Called by the graph engine, not by external consumers.',
       input: v.object({
         storiesByFile: v.pipe(
           storiesByFileSchema,
@@ -255,9 +257,10 @@ export const moduleGraphServiceDef = defineService({
         });
       },
     },
-    bumpGraphRevision: {
+    _bumpGraphRevision: {
+      internal: true,
       description:
-        'Internal use only: bumps the graph revision when the story index invalidates without an immediate graph snapshot/update.',
+        'Bumps the graph revision when the story index invalidates without an immediate graph snapshot/update.',
       input: noInputSchema,
       output: v.void(),
       handler: async (_input, ctx) => {
@@ -267,9 +270,10 @@ export const moduleGraphServiceDef = defineService({
         });
       },
     },
-    setStatus: {
+    _setStatus: {
+      internal: true,
       description:
-        'Internal use only: sets the module graph lifecycle status after engine startup, failure, or adapter availability changes.',
+        'Sets the module graph lifecycle status after engine startup, failure, or adapter availability changes.',
       input: moduleGraphStatusSchema,
       output: v.void(),
       handler: async (input, ctx) => {
@@ -278,9 +282,10 @@ export const moduleGraphServiceDef = defineService({
         });
       },
     },
-    waitForSettledEngine: {
+    _waitForSettledEngine: {
+      internal: true,
       description:
-        'Internal use only: waits for the module graph engine to finish its current build or patch cycle. Handler is supplied at server registration.',
+        'Waits for the module graph engine to finish its current build or patch cycle. Handler is supplied at server registration.',
       input: noInputSchema,
       output: v.void(),
     },

--- a/code/core/src/shared/open-service/services/module-graph/module-graph.test-helpers.ts
+++ b/code/core/src/shared/open-service/services/module-graph/module-graph.test-helpers.ts
@@ -133,7 +133,7 @@ export function registerTestModuleGraphService(workingDir = process.cwd()) {
     },
     {
       commands: {
-        waitForSettledEngine: {
+        _waitForSettledEngine: {
           handler: async () => undefined,
         },
       },

--- a/code/core/src/shared/open-service/services/module-graph/server.test.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.test.ts
@@ -40,11 +40,11 @@ describe('module-graph open service', () => {
     });
   });
 
-  describe('applyGraphSnapshot command', () => {
+  describe('_applyGraphSnapshot command', () => {
     it('marks the service ready and stores the reverse index without advancing the revision', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: {
           './src/Button.tsx': { './src/Button.stories.tsx': 1 },
         },
@@ -65,7 +65,7 @@ describe('module-graph open service', () => {
     it('seeds every known story to revision 0 for scoped reads', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: {
           './src/Button.tsx': { './src/Button.stories.tsx': 1 },
           './src/Card.tsx': { './src/Card.stories.tsx': 1 },
@@ -81,10 +81,10 @@ describe('module-graph open service', () => {
     it('replaces (not merges) the reverse index on a subsequent snapshot', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/A.tsx': { './src/A.stories.tsx': 0 } },
       });
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/B.tsx': { './src/B.stories.tsx': 0 } },
       });
 
@@ -100,7 +100,7 @@ describe('module-graph open service', () => {
     it('marks the graph failed with a serializable error', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.setStatus({
+      await runtime.commands._setStatus({
         value: 'error',
         error: { message: 'graph build blew up', name: 'ModuleGraphFailureError' },
       });
@@ -114,7 +114,7 @@ describe('module-graph open service', () => {
     it('marks the graph unavailable with a reason and optional error', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.setStatus({
+      await runtime.commands._setStatus({
         value: 'unavailable',
         reason: 'builder does not support change detection',
         error: { message: 'adapter missing' },
@@ -131,7 +131,7 @@ describe('module-graph open service', () => {
   describe('getStoriesForFiles query', () => {
     it('returns one result array per input file, positionally', async () => {
       const runtime = registerBareModuleGraph();
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: {
           './src/Button.tsx': { './src/Button.stories.tsx': 1 },
           './src/Card.tsx': {
@@ -157,7 +157,7 @@ describe('module-graph open service', () => {
 
     it('accepts absolute, relative-with-dot, and relative-without-dot input paths', async () => {
       const runtime = registerBareModuleGraph();
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
       });
 
@@ -174,7 +174,7 @@ describe('module-graph open service', () => {
 
     it('accepts Windows-style absolute and relative input paths', async () => {
       const runtime = registerBareModuleGraph('C:\\repo');
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
       });
 
@@ -195,14 +195,14 @@ describe('module-graph open service', () => {
     });
   });
 
-  describe('applyGraphUpdate command', () => {
+  describe('_applyGraphUpdate command', () => {
     it('replaces the reverse index, bumps the revision, and records latest changed stories', async () => {
       const runtime = registerBareModuleGraph();
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
       });
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {
           './src/Button.tsx': { './src/Button.stories.tsx': 1 },
           './src/Icon.tsx': { './src/Button.stories.tsx': 2 },
@@ -223,14 +223,14 @@ describe('module-graph open service', () => {
 
     it('stamps each bumped story with the new revision and leaves untouched stories at 0', async () => {
       const runtime = registerBareModuleGraph();
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: {
           './src/Button.tsx': { './src/Button.stories.tsx': 1 },
           './src/Card.tsx': { './src/Card.stories.tsx': 1 },
         },
       });
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {
           './src/Button.tsx': { './src/Button.stories.tsx': 1 },
           './src/Card.tsx': { './src/Card.stories.tsx': 1 },
@@ -248,11 +248,11 @@ describe('module-graph open service', () => {
     it('replaces latest story changes with the newest revision payload', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./a.stories.tsx', './b.stories.tsx'],
       });
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./a.stories.tsx'],
       });
@@ -266,11 +266,11 @@ describe('module-graph open service', () => {
 
     it('does not advance the revision for an out-of-graph change (no bumped stories)', async () => {
       const runtime = registerBareModuleGraph();
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
       });
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
         bumpedStoryFiles: [],
       });
@@ -292,7 +292,7 @@ describe('module-graph open service', () => {
         storyFiles: [],
       });
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./src/Button.stories.tsx', './src/Card.stories.tsx'],
       });
@@ -306,11 +306,11 @@ describe('module-graph open service', () => {
     it('replaces the previous change set when a newer update bumps different stories', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./a.stories.tsx', './b.stories.tsx'],
       });
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./c.stories.tsx'],
       });
@@ -324,11 +324,11 @@ describe('module-graph open service', () => {
     it('preserves the prior change set when an update bumps no stories', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./src/Button.stories.tsx'],
       });
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
         bumpedStoryFiles: [],
       });
@@ -342,11 +342,11 @@ describe('module-graph open service', () => {
     it('clears story files after a snapshot without resetting the graph revision', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./src/Button.stories.tsx'],
       });
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
       });
 
@@ -356,14 +356,14 @@ describe('module-graph open service', () => {
       });
     });
 
-    it('clears story files but keeps the current revision after bumpGraphRevision', async () => {
+    it('clears story files but keeps the current revision after _bumpGraphRevision', async () => {
       const runtime = registerBareModuleGraph();
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./src/Button.stories.tsx'],
       });
-      await runtime.commands.bumpGraphRevision(undefined);
+      await runtime.commands._bumpGraphRevision(undefined);
 
       expect(runtime.queries.getLatestStoryChanges(undefined)).toEqual({
         revision: 2,
@@ -378,11 +378,11 @@ describe('module-graph open service', () => {
         seen.push(value);
       });
 
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./a.stories.tsx'],
       });
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./b.stories.tsx'],
       });
@@ -397,10 +397,10 @@ describe('module-graph open service', () => {
   describe('getGraphRevision query scopes', () => {
     it('returns 0 for an empty watch list and ignores unknown stories', async () => {
       const runtime = registerBareModuleGraph();
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
       });
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
         bumpedStoryFiles: ['./src/Button.stories.tsx'],
       });
@@ -417,10 +417,10 @@ describe('module-graph open service', () => {
 
     it('accepts absolute and relative scope paths', async () => {
       const runtime = registerBareModuleGraph();
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
       });
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
         bumpedStoryFiles: ['./src/Button.stories.tsx'],
       });
@@ -436,11 +436,11 @@ describe('module-graph open service', () => {
 
     it('advances watch-all but not scoped reads on a bare revision bump', async () => {
       const runtime = registerBareModuleGraph();
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
       });
 
-      await runtime.commands.bumpGraphRevision(undefined);
+      await runtime.commands._bumpGraphRevision(undefined);
 
       // Index reconciliation advances the global (watch-all) revision...
       expect(runtime.queries.getGraphRevision(undefined)).toBe(1);
@@ -459,8 +459,8 @@ describe('module-graph open service', () => {
         seen.push(revision);
       });
 
-      await runtime.commands.applyGraphSnapshot({ storiesByFile: {} });
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphSnapshot({ storiesByFile: {} });
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {},
         bumpedStoryFiles: ['./a.stories.tsx'],
       });
@@ -471,7 +471,7 @@ describe('module-graph open service', () => {
 
     it('notifies a scoped subscriber only when its story is bumped', async () => {
       const runtime = registerBareModuleGraph();
-      await runtime.commands.applyGraphSnapshot({
+      await runtime.commands._applyGraphSnapshot({
         storiesByFile: {
           './src/Button.tsx': { './src/Button.stories.tsx': 1 },
           './src/Card.tsx': { './src/Card.stories.tsx': 1 },
@@ -487,7 +487,7 @@ describe('module-graph open service', () => {
       );
 
       // Bump an unrelated story: the Button-scoped subscriber must not advance.
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {
           './src/Button.tsx': { './src/Button.stories.tsx': 1 },
           './src/Card.tsx': { './src/Card.stories.tsx': 1 },
@@ -495,7 +495,7 @@ describe('module-graph open service', () => {
         bumpedStoryFiles: ['./src/Card.stories.tsx'],
       });
       // Now bump Button itself.
-      await runtime.commands.applyGraphUpdate({
+      await runtime.commands._applyGraphUpdate({
         storiesByFile: {
           './src/Button.tsx': { './src/Button.stories.tsx': 1 },
           './src/Card.tsx': { './src/Card.stories.tsx': 1 },

--- a/code/core/src/shared/open-service/services/module-graph/server.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.ts
@@ -59,7 +59,7 @@ export function registerModuleGraphService(options: RegisterModuleGraphServiceOp
     },
     {
       commands: {
-        waitForSettledEngine: {
+        _waitForSettledEngine: {
           handler: async () => {
             await engine!.whenSettled();
           },
@@ -73,19 +73,19 @@ export function registerModuleGraphService(options: RegisterModuleGraphServiceOp
     workingDir,
     presets: options.presets,
     onSnapshot: (storiesByFile) => {
-      void runtime.commands.applyGraphSnapshot({ storiesByFile });
+      void runtime.commands._applyGraphSnapshot({ storiesByFile });
     },
     onUpdate: ({ storiesByFile, bumpedStoryFiles }) => {
-      void runtime.commands.applyGraphUpdate({ storiesByFile, bumpedStoryFiles });
+      void runtime.commands._applyGraphUpdate({ storiesByFile, bumpedStoryFiles });
     },
     onStoryIndexInvalidated: () => {
-      void runtime.commands.bumpGraphRevision(undefined);
+      void runtime.commands._bumpGraphRevision(undefined);
     },
     onError: (error) => {
-      void runtime.commands.setStatus({ value: 'error', error: errorToErrorLike(error) });
+      void runtime.commands._setStatus({ value: 'error', error: errorToErrorLike(error) });
     },
     onUnavailable: (reason, error) => {
-      void runtime.commands.setStatus({
+      void runtime.commands._setStatus({
         value: 'unavailable',
         reason,
         ...(error ? { error: errorToErrorLike(error) } : {}),
@@ -99,7 +99,7 @@ export function registerModuleGraphService(options: RegisterModuleGraphServiceOp
 
   void changeDetectionAdapterPromise.then((adapter) => {
     if (!adapter) {
-      void runtime.commands.setStatus({
+      void runtime.commands._setStatus({
         value: 'unavailable',
         reason: 'builder does not support change detection',
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Marked the module-graph open-service commands that are only used by the module graph engine as internal operations, following open-service conventions (`internal: true` and `_`-prefixed names):

- `_applyGraphSnapshot`
- `_applyGraphUpdate`
- `_bumpGraphRevision`
- `_setStatus`
- `_waitForSettledEngine`

Updated the service definition, server registration, and unit tests accordingly. Public queries (`getStoriesForFiles`, `getStatus`, `getGraphRevision`, `getLatestStoryChanges`) are unchanged.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual testing is necessary. This is an internal API naming and visibility change for engine-only open-service commands; behavior is unchanged and covered by existing unit tests.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83c090f0-6a69-435d-b6dc-a88dc7f6df57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83c090f0-6a69-435d-b6dc-a88dc7f6df57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal module-graph service architecture reorganized to improve code organization and maintainability.
  * Test infrastructure updated to align with service restructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->