### PR TITLE
Open Service: Fix docgen hot update controls refresh

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -156,9 +156,9 @@ const config = defineMain({
   features: {
     developmentModeForBuild: true,
     experimentalTestSyntax: true,
-    // Disabled for now: the docgen service does not yet work in production builds. Keeping it off
-    // ensures this branch exercises the normal (non-experimental) docgen path without regressions.
-    experimentalDocgenServer: false,
+    // Disabled by default for production builds; the internal dev server enables it via
+    // STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER so hot-update e2e covers the open-service path.
+    experimentalDocgenServer: process.env.STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER === 'true',
     experimentalReactComponentMeta: true,
     changeDetection: true,
   },

--- a/code/core/src/shared/open-service/service-runtime.test.ts
+++ b/code/core/src/shared/open-service/service-runtime.test.ts
@@ -80,6 +80,34 @@ describe('service runtime', () => {
       unsubscribe();
     });
 
+    it('emits detached snapshots when nested state changes', async () => {
+      const service = registerService(mutableRecordLookupServiceDef);
+      const calls: Array<Record<string, string> | null> = [];
+
+      const unsubscribe = service.queries.getRecordFields.subscribe(
+        { entryId: 'entry-a' },
+        (value) => {
+          calls.push(value);
+        }
+      );
+
+      await vi.waitFor(() => expect(calls).toEqual([null]));
+      await service.commands.assignRecordField({
+        entryId: 'entry-a',
+        fieldKey: 'marker',
+        fieldValue: 'first',
+      });
+      await service.commands.assignRecordField({
+        entryId: 'entry-a',
+        fieldKey: 'marker',
+        fieldValue: 'second',
+      });
+
+      expect(calls).toEqual([null, { marker: 'first' }, { marker: 'second' }]);
+      expect(calls[1]).not.toBe(calls[2]);
+      unsubscribe();
+    });
+
     it('stops notifying after unsubscribe', async () => {
       const service = registerService(mutableRecordLookupServiceDef);
       const calls: Array<Record<string, string> | null> = [];

--- a/code/core/src/shared/open-service/service-runtime.ts
+++ b/code/core/src/shared/open-service/service-runtime.ts
@@ -1102,7 +1102,7 @@ function subscribeToQuery<TState>(
         selector(output);
         return detachSnapshot(selector(validated));
       }
-      return validateQueryOutput(refs, queryName, queryDef, output);
+      return detachSnapshot(validateQueryOutput(refs, queryName, queryDef, output));
     });
 
     let hasEmitted = false;

--- a/code/core/src/shared/open-service/services/docgen/server.test.ts
+++ b/code/core/src/shared/open-service/services/docgen/server.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Tag } from '../../../../shared/constants/tags.ts';
 import type { DocsIndexEntry, IndexEntry, StoryIndex } from '../../../../types/modules/indexer.ts';
-import { buildStaticFiles, clearRegistry } from '../../server.ts';
+import { buildStaticFiles, clearRegistry, getService } from '../../server.ts';
+import type { ModuleGraphService } from '../module-graph/definition.ts';
 import { registerTestModuleGraphService } from '../module-graph/module-graph.test-helpers.ts';
 import { registerDocgenService } from './server.ts';
 import type { DocgenPayload, DocgenProvider } from './types.ts';
@@ -191,6 +192,39 @@ describe('docgen open service', () => {
 
       await expect(service.queries.getDocgen.loaded({ id: 'unknown' })).rejects.toThrow(
         /No story or attached docs entry was found for component id "unknown"/
+      );
+    });
+  });
+
+  describe('module graph hot refresh', () => {
+    it('refreshes already-extracted components without loading every bumped component', async () => {
+      const buttonEntry = makeStoryEntry('button--primary', 'Button');
+      const cardEntry = makeStoryEntry('card--primary', 'Card');
+      const provider = vi.fn<DocgenProvider>(async ({ entry }) =>
+        makeDocgenPayload({
+          id: entry.id.split('--')[0],
+          name: entry.title,
+          path: entry.importPath,
+        })
+      );
+      const service = registerDocgenService({
+        getIndex: makeGetIndex([buttonEntry, cardEntry]),
+        provider,
+      });
+
+      await service.queries.getDocgen.loaded({ id: 'button' });
+
+      const moduleGraph = getService<ModuleGraphService>('core/module-graph');
+      await moduleGraph.commands._applyGraphUpdate({
+        storiesByFile: {},
+        bumpedStoryFiles: ['./button.stories.tsx', './card.stories.tsx'],
+      });
+
+      await vi.waitFor(() =>
+        expect(provider.mock.calls.map(([input]) => input.entry.importPath)).toEqual([
+          './button.stories.tsx',
+          './button.stories.tsx',
+        ])
       );
     });
   });

--- a/code/core/src/shared/open-service/services/docgen/server.ts
+++ b/code/core/src/shared/open-service/services/docgen/server.ts
@@ -8,7 +8,7 @@ import { getService, registerService } from '../../server.ts';
 import type { ModuleGraphService } from '../module-graph/definition.ts';
 import { toStoryIndexPath } from '../module-graph/types.ts';
 import { docgenServiceDef } from './definition.ts';
-import type { DocgenPayload, DocgenProvider } from './types.ts';
+import type { DocgenProvider } from './types.ts';
 
 export type RegisterDocgenServiceOptions = {
   workingDir?: string;
@@ -41,6 +41,7 @@ export type RegisterDocgenServiceOptions = {
  */
 export function registerDocgenService(options: RegisterDocgenServiceOptions) {
   const workingDir = options.workingDir ?? process.cwd();
+  const extractedComponentIds = new Set<string>();
 
   const runtime = registerService(docgenServiceDef, {
     queries: {
@@ -77,6 +78,7 @@ export function registerDocgenService(options: RegisterDocgenServiceOptions) {
           ctx.self.setState((state) => {
             state.components[input.id] = payload;
           });
+          extractedComponentIds.add(input.id);
           return payload;
         },
       },
@@ -137,7 +139,7 @@ export function registerDocgenService(options: RegisterDocgenServiceOptions) {
     // Only refresh components that already have extracted docgen in service state, so we never
     // eagerly extract docgen nobody has requested yet.
     const componentIdsToRefresh = Array.from(bumpedComponentIds).filter((id) => {
-      return runtime.queries.getDocgen({ id }) !== undefined;
+      return extractedComponentIds.has(id);
     });
 
     if (componentIdsToRefresh.length === 0) {

--- a/code/core/src/shared/open-service/use-service-query.test.tsx
+++ b/code/core/src/shared/open-service/use-service-query.test.tsx
@@ -134,27 +134,34 @@ describe('useServiceQuery', () => {
     expect(subscribeSpy.mock.calls.length).toBe(subscribeCallsAfterMount);
   });
 
-  it('maintains referential stability when result is deeply equal', async () => {
-    const service = registerService(mutableRecordLookupServiceDef);
-
-    await service.commands.assignRecordField({ entryId: 'a', fieldKey: 'k', fieldValue: 'v' });
-
+  it('uses emitted snapshots without deep-equal output filtering', async () => {
+    const subscribers: Array<(value: { k: string }) => void> = [];
+    const getRecordFields = Object.assign(
+      vi.fn(() => ({ k: 'v' })),
+      {
+        subscribe: vi.fn(
+          (_input: { entryId: string }, callback: (value: { k: string }) => void) => {
+            subscribers.push(callback);
+            return () => {};
+          }
+        ),
+      }
+    );
+    const service = { queries: { getRecordFields } };
     let renderCount = 0;
     const { result } = renderHook(() => {
       renderCount++;
-      return useServiceQuery(service, 'getRecordFields', { entryId: 'a' });
+      return useServiceQuery(service, 'getRecordFields', { entryId: 'a' }) as { k: string };
     });
 
     const firstRef = result.current;
     const countAfterMount = renderCount;
 
-    // Assign the same value again — deeply equal, so no re-render.
-    await service.commands.assignRecordField({ entryId: 'a', fieldKey: 'k', fieldValue: 'v' });
+    await waitFor(() => expect(subscribers).toHaveLength(1));
+    subscribers[0]({ k: 'v' });
 
-    // Wait a tick to let any spurious re-renders fire.
-    await new Promise<void>((resolve) => setTimeout(resolve, 20));
-
-    expect(result.current).toBe(firstRef);
-    expect(renderCount).toBe(countAfterMount);
+    await waitFor(() => expect(renderCount).toBe(countAfterMount + 1));
+    expect(result.current).toEqual(firstRef);
+    expect(result.current).not.toBe(firstRef);
   });
 });

--- a/code/core/src/shared/open-service/use-service-query.ts
+++ b/code/core/src/shared/open-service/use-service-query.ts
@@ -4,11 +4,10 @@
  * Backed by `useSyncExternalStore`, so it integrates correctly with React 18+ concurrent
  * features and works in both manager and preview contexts without any adapter.
  *
- * Re-renders only when the specific query result changes by value. Signal-level dedup
- * inside the service runtime ensures that a load which rewrites a deeply-equal payload does
- * not re-fire the subscription; `isEqual` in the subscription callback provides an additional
- * referential-stability layer at the React boundary so the component sees a stable object
- * reference across updates that return the same logical value.
+ * Re-renders only when the subscribed service query emits a new snapshot. Signal-level dedup inside
+ * the service runtime ensures that a load which rewrites a deeply-equal payload does not re-fire the
+ * subscription; this hook intentionally trusts those emissions rather than deep-comparing outputs a
+ * second time.
  *
  * Object inputs are compared with deep equality when deciding whether to re-subscribe, so inline
  * literals at the call site are safe.
@@ -79,9 +78,6 @@ export function useServiceQuery<TKey extends string, TInput, TOutput>(
   const subscribe = React.useCallback(
     (listener: () => void): (() => void) =>
       queryFn.subscribe(subscriptionKey.input, (value) => {
-        if (isEqual(value, snapshotRef.current)) {
-          return;
-        }
         snapshotRef.current = value;
         listener();
       }),

--- a/code/e2e-internal/docgen-hot-update.spec.ts
+++ b/code/e2e-internal/docgen-hot-update.spec.ts
@@ -20,6 +20,8 @@ const hotUpdatePropSource = `
   ${hotUpdatePropName}?: 'before' | 'after';
 `;
 
+// Start the internal dev server with STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true before running this
+// spec. CI sets that env var in the internal Storybook e2e job.
 let originalButtonSource: string | undefined;
 
 async function restoreFile(path: string, contents: string) {

--- a/code/e2e-internal/docgen-hot-update.spec.ts
+++ b/code/e2e-internal/docgen-hot-update.spec.ts
@@ -1,0 +1,126 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { expect, test } from '@playwright/test';
+import process from 'process';
+
+import { PREVIEW_STORY_TIMEOUT, waitForPreviewReady } from './helpers.ts';
+
+const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:6006';
+const runsAgainstDevServer = !['build', 'static'].includes(process.env.STORYBOOK_TYPE || 'dev');
+
+const codeDir = process.cwd();
+const mainConfigPath = join(codeDir, '.storybook/main.ts');
+const buttonSourcePath = join(codeDir, 'core/src/components/components/Button/Button.tsx');
+const storyPath = '/story/button-component--base';
+const hotUpdatePropName = 'e2eDocgenHotUpdateProp';
+const hotUpdatePropSource = `
+  /**
+   * E2E-only docgen hot update marker.
+   */
+  ${hotUpdatePropName}?: 'before' | 'after';
+`;
+
+let originalMainConfig: string | undefined;
+let originalButtonSource: string | undefined;
+
+async function restoreFile(path: string, contents: string) {
+  if ((await readFile(path, 'utf8')) !== contents) {
+    await writeFile(path, contents, 'utf8');
+  }
+}
+
+async function enableExperimentalDocgenServer() {
+  const current = await readFile(mainConfigPath, 'utf8');
+  originalMainConfig = current;
+
+  if (!current.includes('experimentalDocgenServer: false')) {
+    return;
+  }
+
+  await writeFile(
+    mainConfigPath,
+    current.replace('experimentalDocgenServer: false', 'experimentalDocgenServer: true')
+  );
+}
+
+async function addHotUpdateProp() {
+  const current = await readFile(buttonSourcePath, 'utf8');
+  if (current.includes(hotUpdatePropName)) {
+    return;
+  }
+
+  const marker = '  shortcut?: API_KeyCollection;\n';
+  expect(current, `Could not find ButtonProps insertion marker in ${buttonSourcePath}`).toContain(
+    marker
+  );
+
+  await writeFile(buttonSourcePath, current.replace(marker, `${marker}${hotUpdatePropSource}`));
+}
+
+async function waitForStorybookServer() {
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await fetch(storybookUrl);
+          return response.ok;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: PREVIEW_STORY_TIMEOUT }
+    )
+    .toBe(true);
+}
+
+test.describe('docgen open service hot updates', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(90_000);
+
+  test.beforeAll(async () => {
+    test.skip(!runsAgainstDevServer, 'Docgen hot updates require the dev server file watcher.');
+
+    originalButtonSource = await readFile(buttonSourcePath, 'utf8');
+    await enableExperimentalDocgenServer();
+    await waitForStorybookServer();
+  });
+
+  test.afterAll(async () => {
+    await Promise.all([
+      originalButtonSource ? restoreFile(buttonSourcePath, originalButtonSource) : undefined,
+      originalMainConfig ? restoreFile(mainConfigPath, originalMainConfig) : undefined,
+    ]);
+  });
+
+  test('updates manager Controls when a component prop type changes without navigation', async ({
+    page,
+  }) => {
+    await restoreFile(buttonSourcePath, originalButtonSource!);
+
+    await page.goto(`${storybookUrl}/?path=${storyPath}`);
+    await waitForPreviewReady(page);
+    await expect(
+      page.frameLocator('#storybook-preview-iframe').getByRole('button', { name: 'Button' })
+    ).toBeVisible({ timeout: PREVIEW_STORY_TIMEOUT });
+
+    await page.getByRole('tab', { name: 'Controls' }).click();
+    const controlsPanel = page.getByRole('tabpanel', { name: 'Controls' });
+    await expect(
+      controlsPanel.getByRole('cell', { name: 'ariaLabel', exact: true }).first()
+    ).toBeVisible({
+      timeout: PREVIEW_STORY_TIMEOUT,
+    });
+    await expect(controlsPanel.getByText(hotUpdatePropName)).toHaveCount(0);
+
+    try {
+      await addHotUpdateProp();
+
+      await expect(
+        controlsPanel.getByRole('cell', { name: hotUpdatePropName, exact: true }).first()
+      ).toBeVisible({ timeout: PREVIEW_STORY_TIMEOUT });
+    } finally {
+      await restoreFile(buttonSourcePath, originalButtonSource!);
+    }
+  });
+});

--- a/code/e2e-internal/docgen-hot-update.spec.ts
+++ b/code/e2e-internal/docgen-hot-update.spec.ts
@@ -10,7 +10,6 @@ const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:6006';
 const runsAgainstDevServer = !['build', 'static'].includes(process.env.STORYBOOK_TYPE || 'dev');
 
 const codeDir = process.cwd();
-const mainConfigPath = join(codeDir, '.storybook/main.ts');
 const buttonSourcePath = join(codeDir, 'core/src/components/components/Button/Button.tsx');
 const storyPath = '/story/button-component--base';
 const hotUpdatePropName = 'e2eDocgenHotUpdateProp';
@@ -21,27 +20,12 @@ const hotUpdatePropSource = `
   ${hotUpdatePropName}?: 'before' | 'after';
 `;
 
-let originalMainConfig: string | undefined;
 let originalButtonSource: string | undefined;
 
 async function restoreFile(path: string, contents: string) {
   if ((await readFile(path, 'utf8')) !== contents) {
     await writeFile(path, contents, 'utf8');
   }
-}
-
-async function enableExperimentalDocgenServer() {
-  const current = await readFile(mainConfigPath, 'utf8');
-  originalMainConfig = current;
-
-  if (!current.includes('experimentalDocgenServer: false')) {
-    return;
-  }
-
-  await writeFile(
-    mainConfigPath,
-    current.replace('experimentalDocgenServer: false', 'experimentalDocgenServer: true')
-  );
 }
 
 async function addHotUpdateProp() {
@@ -58,22 +42,6 @@ async function addHotUpdateProp() {
   await writeFile(buttonSourcePath, current.replace(marker, `${marker}${hotUpdatePropSource}`));
 }
 
-async function waitForStorybookServer() {
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await fetch(storybookUrl);
-          return response.ok;
-        } catch {
-          return false;
-        }
-      },
-      { timeout: PREVIEW_STORY_TIMEOUT }
-    )
-    .toBe(true);
-}
-
 test.describe('docgen open service hot updates', () => {
   test.describe.configure({ mode: 'serial' });
   test.setTimeout(90_000);
@@ -82,15 +50,12 @@ test.describe('docgen open service hot updates', () => {
     test.skip(!runsAgainstDevServer, 'Docgen hot updates require the dev server file watcher.');
 
     originalButtonSource = await readFile(buttonSourcePath, 'utf8');
-    await enableExperimentalDocgenServer();
-    await waitForStorybookServer();
   });
 
   test.afterAll(async () => {
-    await Promise.all([
-      originalButtonSource ? restoreFile(buttonSourcePath, originalButtonSource) : undefined,
-      originalMainConfig ? restoreFile(mainConfigPath, originalMainConfig) : undefined,
-    ]);
+    if (originalButtonSource) {
+      await restoreFile(buttonSourcePath, originalButtonSource);
+    }
   });
 
   test('updates manager Controls when a component prop type changes without navigation', async ({
@@ -99,6 +64,21 @@ test.describe('docgen open service hot updates', () => {
     await restoreFile(buttonSourcePath, originalButtonSource!);
 
     await page.goto(`${storybookUrl}/?path=${storyPath}`);
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() =>
+            Boolean(
+              (
+                globalThis as {
+                  FEATURES?: { experimentalDocgenServer?: boolean };
+                }
+              ).FEATURES?.experimentalDocgenServer
+            )
+          ),
+        { timeout: PREVIEW_STORY_TIMEOUT }
+      )
+      .toBe(true);
     await waitForPreviewReady(page);
     await expect(
       page.frameLocator('#storybook-preview-iframe').getByRole('button', { name: 'Button' })

--- a/code/package.json
+++ b/code/package.json
@@ -31,7 +31,7 @@
     "lint:package": "yarn --cwd ../scripts lint:package",
     "local-registry": "yarn --cwd ../scripts local-registry",
     "publish-sandboxes": "yarn --cwd ../scripts publish",
-    "storybook:ui": "NODE_OPTIONS=\"--max_old_space_size=4096 --trace-deprecation\" core/dist/bin/dispatcher.js dev --port 6006 --config-dir ./.storybook",
+    "storybook:ui": "STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true NODE_OPTIONS=\"--max_old_space_size=4096 --trace-deprecation\" core/dist/bin/dispatcher.js dev --port 6006 --config-dir ./.storybook",
     "storybook:ui:build": "NODE_OPTIONS=\"--max_old_space_size=5120\" core/dist/bin/dispatcher.js build --config-dir ./.storybook --webpack-stats-json",
     "storybook:ui:chromatic": "chromatic --storybook-build-dir storybook-static --exit-zero-on-changes --exit-once-uploaded",
     "task": "yarn --cwd ../scripts task"

--- a/code/package.json
+++ b/code/package.json
@@ -31,7 +31,7 @@
     "lint:package": "yarn --cwd ../scripts lint:package",
     "local-registry": "yarn --cwd ../scripts local-registry",
     "publish-sandboxes": "yarn --cwd ../scripts publish",
-    "storybook:ui": "STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true NODE_OPTIONS=\"--max_old_space_size=4096 --trace-deprecation\" core/dist/bin/dispatcher.js dev --port 6006 --config-dir ./.storybook",
+    "storybook:ui": "NODE_OPTIONS=\"--max_old_space_size=4096 --trace-deprecation\" core/dist/bin/dispatcher.js dev --port 6006 --config-dir ./.storybook",
     "storybook:ui:build": "NODE_OPTIONS=\"--max_old_space_size=5120\" core/dist/bin/dispatcher.js build --config-dir ./.storybook --webpack-stats-json",
     "storybook:ui:chromatic": "chromatic --storybook-build-dir storybook-static --exit-zero-on-changes --exit-once-uploaded",
     "task": "yarn --cwd ../scripts task"

--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -176,7 +176,7 @@ export const internalStorybookE2e = defineJob(
           name: 'Run internal Storybook',
           working_directory: 'code',
           background: true,
-          command: 'yarn storybook:ui',
+          command: 'STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true yarn storybook:ui',
         },
       },
       server.wait(['6006']),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixes experimental docgen open-service hot updates so the manager Controls panel receives fresh docgen after component source changes without requiring story navigation.

Clarifies the open-service React boundary: runtime query subscriptions emit detached snapshots and suppress redundant equal emissions; `useServiceQuery` now trusts those emissions instead of deep-comparing outputs a second time.

Adds an internal e2e regression that runs against an internal dev server booted with `experimentalDocgenServer`, edits `Button.tsx`, verifies the new prop appears in Controls, and restores source files even on failure. The normal `storybook:ui` script remains unchanged; CI opts into the experiment only for the internal e2e job.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Run `cd code && STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true yarn storybook:ui`.
2. Run `yarn playwright test -c e2e-internal/playwright.config.ts e2e-internal/docgen-hot-update.spec.ts --reporter=line` from `code/`.
3. Confirm the test passes and `Button.tsx` is restored after the run.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bc3a3ed-4106-4164-885a-1aa71dad1f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bc3a3ed-4106-4164-885a-1aa71dad1f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experimental docgen server can now be enabled via environment variable for development scenarios.

* **Bug Fixes**
  * Fixed hot updates to properly track extracted components and refresh when source changes.
  * Improved snapshot detachment in service queries to emit consistent object references.
  * Enhanced query hook to correctly use emitted snapshots without deep-equality filtering.

* **Tests**
  * Added E2E tests for component documentation hot updates and Controls UI updates.
  * Expanded service runtime and query hook subscription test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->