### PR TITLE
CLI: Show MCP workflow instructions in AI help

### DIFF
--- a/code/core/src/cli/ai/mcp/client.test.ts
+++ b/code/core/src/cli/ai/mcp/client.test.ts
@@ -27,10 +27,10 @@ const jsonResponse = (body: unknown, status = 200, headers: Record<string, strin
     headers: { 'Content-Type': 'application/json', ...headers },
   });
 
-const sseResponse = (body: string, status = 200) =>
+const sseResponse = (body: string, status = 200, headers: Record<string, string> = {}) =>
   new Response(body, {
     status,
-    headers: { 'Content-Type': 'text/event-stream' },
+    headers: { 'Content-Type': 'text/event-stream', ...headers },
   });
 
 /**
@@ -243,11 +243,35 @@ describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
       sessionId ? { 'mcp-session-id': sessionId } : {}
     );
 
+  const initializeSseResponse = (sessionId: string | undefined, instructions: unknown) => {
+    const envelope = {
+      jsonrpc: '2.0',
+      id: 'init',
+      result: {
+        protocolVersion: '2025-06-18',
+        serverInfo: {},
+        instructions,
+      },
+    };
+    return sseResponse(
+      `event: message\ndata: ${JSON.stringify(envelope)}\n\n`,
+      200,
+      sessionId ? { 'mcp-session-id': sessionId } : {}
+    );
+  };
+
   const toolResult = () =>
     jsonResponse({
       jsonrpc: '2.0',
       id: 'call',
       result: { content: [{ type: 'text', text: 'hi' }] },
+    });
+
+  const toolListResult = (tools: unknown[] = []) =>
+    jsonResponse({
+      jsonrpc: '2.0',
+      id: 'list',
+      result: { tools },
     });
 
   it('sends initialize with the storybook-cli clientInfo before the actual request', async () => {
@@ -390,7 +414,20 @@ describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
     });
   });
 
-  it.each([undefined, '', '   '])(
+  it('returns server instructions from an SSE initialize response', async () => {
+    const tools = [{ name: 'get-documentation', description: 'Get docs' }];
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(initializeSseResponse('session-1', '  Follow the story workflow.  '))
+      .mockResolvedValueOnce(toolListResult(tools)) as unknown as typeof fetch;
+
+    await expect(listMcpToolsWithServerMetadata(record, fetchImpl)).resolves.toEqual({
+      tools,
+      serverMetadata: { instructions: 'Follow the story workflow.' },
+    });
+  });
+
+  it.each([undefined, '', '   ', 123])(
     'omits server instructions when initialize returns %j',
     async (instructions) => {
       const fetchImpl = vi
@@ -406,6 +443,33 @@ describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
       });
     }
   );
+
+  it.each([
+    [
+      'malformed JSON',
+      () =>
+        new Response('not json', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', 'mcp-session-id': 'session-1' },
+        }),
+    ],
+    [
+      'a JSON-RPC error',
+      () => jsonResponse({ jsonrpc: '2.0', id: 'init', error: { code: -32000, message: 'bad' } }),
+    ],
+    ['no result', () => jsonResponse({ jsonrpc: '2.0', id: 'init' })],
+  ])('keeps tools/list working when initialize returns %s', async (_label, initResponse) => {
+    const tools = [{ name: 'get-documentation', description: 'Get docs' }];
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(initResponse())
+      .mockResolvedValueOnce(toolListResult(tools)) as unknown as typeof fetch;
+
+    await expect(listMcpToolsWithServerMetadata(record, fetchImpl)).resolves.toEqual({
+      tools,
+      serverMetadata: {},
+    });
+  });
 
   it('keeps listMcpTools returning only the tool descriptors', async () => {
     const tools = [{ name: 'get-documentation', description: 'Get docs' }];

--- a/code/core/src/cli/ai/mcp/client.test.ts
+++ b/code/core/src/cli/ai/mcp/client.test.ts
@@ -2,7 +2,13 @@ import { versions } from 'storybook/internal/common';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { MCP_CLIENT_INFO, McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
+import {
+  MCP_CLIENT_INFO,
+  McpJsonRpcError,
+  callMcpTool,
+  listMcpTools,
+  listMcpToolsWithServerMetadata,
+} from './client.ts';
 import type { StorybookInstanceRecord } from './types.ts';
 
 const record: StorybookInstanceRecord = {
@@ -222,9 +228,17 @@ describe('listMcpTools', () => {
 });
 
 describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
-  const initializeResponse = (sessionId?: string) =>
+  const initializeResponse = (sessionId?: string, instructions?: unknown) =>
     jsonResponse(
-      { jsonrpc: '2.0', id: 'init', result: { protocolVersion: '2025-06-18', serverInfo: {} } },
+      {
+        jsonrpc: '2.0',
+        id: 'init',
+        result: {
+          protocolVersion: '2025-06-18',
+          serverInfo: {},
+          ...(instructions !== undefined ? { instructions } : {}),
+        },
+      },
       200,
       sessionId ? { 'mcp-session-id': sessionId } : {}
     );
@@ -359,5 +373,49 @@ describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
       string
     >;
     expect(headers['Mcp-Session-Id']).toBe('session-7');
+  });
+
+  it('returns server instructions from the initialize response alongside tools/list results', async () => {
+    const tools = [{ name: 'get-documentation', description: 'Get docs' }];
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(initializeResponse('session-1', '  Follow the story workflow.  '))
+      .mockResolvedValueOnce(
+        jsonResponse({ jsonrpc: '2.0', id: 'x', result: { tools } })
+      ) as unknown as typeof fetch;
+
+    await expect(listMcpToolsWithServerMetadata(record, fetchImpl)).resolves.toEqual({
+      tools,
+      serverMetadata: { instructions: 'Follow the story workflow.' },
+    });
+  });
+
+  it.each([undefined, '', '   '])(
+    'omits server instructions when initialize returns %j',
+    async (instructions) => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(initializeResponse('session-1', instructions))
+        .mockResolvedValueOnce(
+          jsonResponse({ jsonrpc: '2.0', id: 'x', result: { tools: [] } })
+        ) as unknown as typeof fetch;
+
+      await expect(listMcpToolsWithServerMetadata(record, fetchImpl)).resolves.toEqual({
+        tools: [],
+        serverMetadata: {},
+      });
+    }
+  );
+
+  it('keeps listMcpTools returning only the tool descriptors', async () => {
+    const tools = [{ name: 'get-documentation', description: 'Get docs' }];
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(initializeResponse('session-1', 'Follow the story workflow.'))
+      .mockResolvedValueOnce(
+        jsonResponse({ jsonrpc: '2.0', id: 'x', result: { tools } })
+      ) as unknown as typeof fetch;
+
+    await expect(listMcpTools(record, fetchImpl)).resolves.toEqual(tools);
   });
 });

--- a/code/core/src/cli/ai/mcp/client.test.ts
+++ b/code/core/src/cli/ai/mcp/client.test.ts
@@ -337,10 +337,16 @@ describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
   });
 
   it('ignores the session id of a non-ok handshake response', async () => {
+    let canceled = false;
+    const initBody = new ReadableStream<Uint8Array>({
+      cancel() {
+        canceled = true;
+      },
+    });
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(
-        new Response('boom', { status: 500, headers: { 'mcp-session-id': 'session-broken' } })
+        new Response(initBody, { status: 500, headers: { 'mcp-session-id': 'session-broken' } })
       )
       .mockResolvedValueOnce(toolResult()) as unknown as typeof fetch;
 
@@ -348,6 +354,7 @@ describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
 
     const headers = (lastCall(fetchImpl)[1] as RequestInit).headers as Record<string, string>;
     expect(headers).not.toHaveProperty('Mcp-Session-Id');
+    expect(canceled).toBe(true);
   });
 
   it('drains the handshake response body before sending the actual request', async () => {

--- a/code/core/src/cli/ai/mcp/client.ts
+++ b/code/core/src/cli/ai/mcp/client.ts
@@ -33,14 +33,6 @@ export const MCP_CLIENT_INFO = { name: 'storybook-cli', version: versions.storyb
 /** Protocol version sent on `initialize`; tmcp (the addon-mcp server library) supports it. */
 const MCP_PROTOCOL_VERSION = '2025-06-18';
 
-/**
- * The handshake is telemetry garnish sitting on the critical path of every command, so its budget
- * must stay small: a local tmcp `initialize` answers in milliseconds, and a few seconds is already
- * generous headroom for a busy dev server. On timeout (or any other failure) the command simply
- * proceeds without clientInfo.
- */
-const INITIALIZE_TIMEOUT_MS = 3 * 1000;
-
 export type ToolCallParams = {
   name: string;
   arguments?: Record<string, unknown>;
@@ -140,10 +132,14 @@ type InitializeMcpSessionResult = {
  * initialize result can also carry server instructions, so metadata is parsed from the response
  * body even when no session id is assigned.
  *
- * The handshake is strictly best-effort — when it fails (or a future server ignores sessions),
- * the actual command request proceeds without a session and keeps working; only the telemetry
- * segmentation and initialize metadata are lost, and error reporting stays anchored on the real
- * call.
+ * The handshake is best-effort — when it fails (or a future server ignores sessions), the actual
+ * request proceeds without a session and keeps working; only the telemetry segmentation and
+ * initialize metadata are lost, and error reporting stays anchored on the real call. It shares the
+ * full {@link REQUEST_TIMEOUT_MS} budget rather than a tighter one: `storybook ai --help` renders the
+ * server instructions carried here, and the only thing that slows the handshake is the dev server
+ * still starting up — which the command must wait through anyway. A tighter budget would just drop
+ * the instructions on that first slow request while the command list (sent right after) comes back
+ * fine.
  *
  * Sessions are deliberately one-shot: each JSON-RPC request gets its own handshake and the session
  * is never reused or closed. A CLI invocation makes one request on the happy path (two on error
@@ -172,7 +168,7 @@ async function initializeMcpSession(
           clientInfo: MCP_CLIENT_INFO,
         },
       }),
-      signal: AbortSignal.timeout(INITIALIZE_TIMEOUT_MS),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
     const sessionId = response.headers.get('mcp-session-id');
     if (!response.ok) {

--- a/code/core/src/cli/ai/mcp/client.ts
+++ b/code/core/src/cli/ai/mcp/client.ts
@@ -62,9 +62,22 @@ const JsonRpcEnvelopeSchema = v.looseObject({
   error: v.optional(v.looseObject({ code: v.number(), message: v.string() })),
 });
 
+const InitializeResultSchema = v.looseObject({
+  instructions: v.optional(v.string()),
+});
+
 const ToolListResultSchema = v.looseObject({
   tools: v.optional(v.array(McpToolDescriptorSchema)),
 });
+
+export type McpServerMetadata = {
+  instructions?: string;
+};
+
+export type McpToolList = {
+  tools: McpToolDescriptor[];
+  serverMetadata: McpServerMetadata;
+};
 
 /** Forward an MCP `tools/call` JSON-RPC request to a local Storybook MCP server. */
 export async function callMcpTool(
@@ -72,7 +85,14 @@ export async function callMcpTool(
   params: ToolCallParams,
   fetchImpl: typeof fetch = fetch
 ): Promise<ToolCallResult> {
-  return sendJsonRpcRequest(record, 'tools/call', params, ToolCallResultSchema, fetchImpl);
+  const { result } = await sendJsonRpcRequest(
+    record,
+    'tools/call',
+    params,
+    ToolCallResultSchema,
+    fetchImpl
+  );
+  return result;
 }
 
 /** List the tools exposed by a local Storybook MCP server via `tools/list`. */
@@ -80,14 +100,23 @@ export async function listMcpTools(
   record: StorybookInstanceRecord,
   fetchImpl: typeof fetch = fetch
 ): Promise<McpToolDescriptor[]> {
-  const result = await sendJsonRpcRequest(
+  const { tools } = await listMcpToolsWithServerMetadata(record, fetchImpl);
+  return tools;
+}
+
+/** List tools and include server metadata from the preceding MCP `initialize` response. */
+export async function listMcpToolsWithServerMetadata(
+  record: StorybookInstanceRecord,
+  fetchImpl: typeof fetch = fetch
+): Promise<McpToolList> {
+  const { result, serverMetadata } = await sendJsonRpcRequest(
     record,
     'tools/list',
     {},
     ToolListResultSchema,
     fetchImpl
   );
-  return result.tools ?? [];
+  return { tools: result.tools ?? [], serverMetadata };
 }
 
 const REQUEST_HEADERS = {
@@ -118,10 +147,15 @@ const REQUEST_HEADERS = {
  * server has processed the initialize message (and stored the clientInfo); returning on headers
  * alone would race the follow-up request against that processing.
  */
+type InitializeMcpSessionResult = {
+  sessionId: string | null;
+  serverMetadata: McpServerMetadata;
+};
+
 async function initializeMcpSession(
   target: string,
   fetchImpl: typeof fetch
-): Promise<string | null> {
+): Promise<InitializeMcpSessionResult> {
   try {
     const response = await fetchImpl(target, {
       method: 'POST',
@@ -139,13 +173,20 @@ async function initializeMcpSession(
       signal: AbortSignal.timeout(INITIALIZE_TIMEOUT_MS),
     });
     const sessionId = response.headers.get('mcp-session-id');
-    if (!response.ok || !sessionId) {
-      return null;
+    if (!response.ok) {
+      return { sessionId: null, serverMetadata: {} };
     }
-    await response.text();
-    return sessionId;
+
+    let serverMetadata: McpServerMetadata = {};
+    try {
+      serverMetadata = parseInitializeServerMetadata(await readJsonRpcResponse(response, target));
+    } catch {
+      // The initialize request is best-effort metadata; a malformed response must not block the
+      // actual tools/list or tools/call request from preserving its existing behavior.
+    }
+    return { sessionId, serverMetadata };
   } catch {
-    return null;
+    return { sessionId: null, serverMetadata: {} };
   }
 }
 
@@ -169,7 +210,7 @@ async function sendJsonRpcRequest<TResult>(
   params: unknown,
   resultSchema: v.GenericSchema<unknown, TResult>,
   fetchImpl: typeof fetch
-): Promise<TResult> {
+): Promise<{ result: TResult; serverMetadata: McpServerMetadata }> {
   const endpoint = record.mcp.endpoint;
   if (!endpoint) {
     throw new Error(`The Storybook instance at ${record.cwd} has no server endpoint registered`);
@@ -177,7 +218,7 @@ async function sendJsonRpcRequest<TResult>(
 
   const target = new URL(endpoint, record.url).href;
 
-  const sessionId = await initializeMcpSession(target, fetchImpl);
+  const { sessionId, serverMetadata } = await initializeMcpSession(target, fetchImpl);
 
   const response = await fetchImpl(target, {
     method: 'POST',
@@ -217,22 +258,38 @@ async function sendJsonRpcRequest<TResult>(
   if (!result.success) {
     throw unexpectedShapeError(target);
   }
-  return result.output;
+  return { result: result.output, serverMetadata };
 }
 
 function unexpectedShapeError(target: string): Error {
   return new Error(`The Storybook server at ${target} returned an unexpected response shape`);
 }
 
+function parseInitializeServerMetadata(payload: unknown): McpServerMetadata {
+  const envelope = v.safeParse(JsonRpcEnvelopeSchema, payload);
+  if (!envelope.success || envelope.output.error || envelope.output.result === undefined) {
+    return {};
+  }
+
+  const result = v.safeParse(InitializeResultSchema, envelope.output.result);
+  if (!result.success) {
+    return {};
+  }
+
+  const instructions = result.output.instructions?.trim();
+  return instructions ? { instructions } : {};
+}
+
 async function readJsonRpcResponse(response: Response, endpoint: string): Promise<unknown> {
   const contentType = (response.headers.get('content-type') ?? '').toLowerCase();
+  const body = await response.text();
 
   if (contentType.includes('application/json')) {
-    return await response.json();
+    return JSON.parse(body);
   }
 
   if (contentType.includes('text/event-stream')) {
-    return parseSseEnvelope(await response.text(), endpoint);
+    return parseSseEnvelope(body, endpoint);
   }
 
   throw new Error(

--- a/code/core/src/cli/ai/mcp/client.ts
+++ b/code/core/src/cli/ai/mcp/client.ts
@@ -125,18 +125,25 @@ const REQUEST_HEADERS = {
   [STORYBOOK_MCP_PROXY_HEADER]: STORYBOOK_MCP_PROXY_HEADER_VALUE,
 };
 
+type InitializeMcpSessionResult = {
+  sessionId: string | null;
+  serverMetadata: McpServerMetadata;
+};
+
 /**
  * Send a minimal MCP `initialize` request carrying {@link MCP_CLIENT_INFO} and return the session
- * id the transport assigned, or null when the handshake fails in any way.
+ * id plus any best-effort server metadata from the initialize response.
  *
- * Its only purpose is telemetry segmentation, and the flow is MCP Streamable HTTP spec behavior,
- * not a tmcp implementation detail: the server assigns a session id during initialization,
- * returns it in the `Mcp-Session-Id` response header, and associates the session's clientInfo
- * with later requests echoing that header. Any spec-compliant server (e.g. the official MCP SDK
- * transports) behaves the same, so addon-mcp can move off tmcp without breaking this client.
+ * The session id is MCP Streamable HTTP spec behavior, not a tmcp implementation detail: the
+ * server assigns it during initialization, returns it in the `Mcp-Session-Id` response header,
+ * and associates the session's clientInfo with later requests echoing that header. The same
+ * initialize result can also carry server instructions, so metadata is parsed from the response
+ * body even when no session id is assigned.
+ *
  * The handshake is strictly best-effort — when it fails (or a future server ignores sessions),
  * the actual command request proceeds without a session and keeps working; only the telemetry
- * segmentation is lost, and error reporting stays anchored on the real call.
+ * segmentation and initialize metadata are lost, and error reporting stays anchored on the real
+ * call.
  *
  * Sessions are deliberately one-shot: each JSON-RPC request gets its own handshake and the session
  * is never reused or closed. A CLI invocation makes one request on the happy path (two on error
@@ -147,11 +154,6 @@ const REQUEST_HEADERS = {
  * server has processed the initialize message (and stored the clientInfo); returning on headers
  * alone would race the follow-up request against that processing.
  */
-type InitializeMcpSessionResult = {
-  sessionId: string | null;
-  serverMetadata: McpServerMetadata;
-};
-
 async function initializeMcpSession(
   target: string,
   fetchImpl: typeof fetch
@@ -174,6 +176,7 @@ async function initializeMcpSession(
     });
     const sessionId = response.headers.get('mcp-session-id');
     if (!response.ok) {
+      await response.body?.cancel();
       return { sessionId: null, serverMetadata: {} };
     }
 

--- a/code/core/src/cli/ai/mcp/client.ts
+++ b/code/core/src/cli/ai/mcp/client.ts
@@ -178,7 +178,10 @@ async function initializeMcpSession(
 
     let serverMetadata: McpServerMetadata = {};
     try {
-      serverMetadata = parseInitializeServerMetadata(await readJsonRpcResponse(response, target));
+      serverMetadata = parseInitializeServerMetadata(
+        await readJsonRpcResponse(response, target),
+        target
+      );
     } catch {
       // The initialize request is best-effort metadata; a malformed response must not block the
       // actual tools/list or tools/call request from preserving its existing behavior.
@@ -242,18 +245,12 @@ async function sendJsonRpcRequest<TResult>(
 
   const payload = await readJsonRpcResponse(response, target);
 
-  const envelope = v.safeParse(JsonRpcEnvelopeSchema, payload);
-  if (!envelope.success) {
-    throw unexpectedShapeError(target);
-  }
-  if (envelope.output.error) {
-    throw new McpJsonRpcError(envelope.output.error.code, envelope.output.error.message);
-  }
-  if (envelope.output.result === undefined) {
-    throw new Error('The Storybook server returned no result');
+  const unwrapped = unwrapJsonRpcResult(payload, target);
+  if (!unwrapped.ok) {
+    throw unwrapped.error;
   }
 
-  const result = v.safeParse(resultSchema, envelope.output.result);
+  const result = v.safeParse(resultSchema, unwrapped.result);
   if (!result.success) {
     throw unexpectedShapeError(target);
   }
@@ -264,13 +261,38 @@ function unexpectedShapeError(target: string): Error {
   return new Error(`The Storybook server at ${target} returned an unexpected response shape`);
 }
 
-function parseInitializeServerMetadata(payload: unknown): McpServerMetadata {
+/**
+ * Unwrap a parsed JSON-RPC payload into its `result`, or report why it isn't usable. The command
+ * path throws on the reported error; the best-effort initialize-metadata parse falls back to empty
+ * — sharing this keeps the envelope handling in one place.
+ */
+function unwrapJsonRpcResult(
+  payload: unknown,
+  target: string
+): { ok: true; result: unknown } | { ok: false; error: Error } {
   const envelope = v.safeParse(JsonRpcEnvelopeSchema, payload);
-  if (!envelope.success || envelope.output.error || envelope.output.result === undefined) {
+  if (!envelope.success) {
+    return { ok: false, error: unexpectedShapeError(target) };
+  }
+  if (envelope.output.error) {
+    return {
+      ok: false,
+      error: new McpJsonRpcError(envelope.output.error.code, envelope.output.error.message),
+    };
+  }
+  if (envelope.output.result === undefined) {
+    return { ok: false, error: new Error('The Storybook server returned no result') };
+  }
+  return { ok: true, result: envelope.output.result };
+}
+
+function parseInitializeServerMetadata(payload: unknown, target: string): McpServerMetadata {
+  const unwrapped = unwrapJsonRpcResult(payload, target);
+  if (!unwrapped.ok) {
     return {};
   }
 
-  const result = v.safeParse(InitializeResultSchema, envelope.output.result);
+  const result = v.safeParse(InitializeResultSchema, unwrapped.result);
   if (!result.success) {
     return {};
   }

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
     .mockReset()
     .mockResolvedValue({
       tools: [{ name: 'list-all-documentation', description: 'List docs' }],
-      serverMetadata: {},
+      serverMetadata: { instructions: 'Follow the story workflow.' },
     });
 });
 
@@ -259,13 +259,14 @@ describe('buildStorybookCommandsHelp', () => {
         },
         { name: 'list-all-documentation' },
       ],
-      serverMetadata: {},
+      serverMetadata: { instructions: 'Follow the story workflow.' },
     });
 
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain(
-      'Storybook commands (from the Storybook running at http://localhost:6006):'
+      'Storybook help from the Storybook running at http://localhost:6006:'
     );
+    expect(section).toContain('# Storybook commands');
     expect(section).toContain('get-documentation');
     expect(section).toContain('Get docs for a component.');
     expect(section).not.toContain('Long details');
@@ -281,16 +282,26 @@ describe('buildStorybookCommandsHelp', () => {
     });
 
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
-    expect(section).toContain('Storybook workflow instructions:\nUse existing stories');
-    expect(section).toContain('Storybook commands (from the Storybook running');
-    expect(section.indexOf('Storybook workflow instructions:')).toBeLessThan(
-      section.indexOf('Storybook commands (from the Storybook running')
+    expect(section).toBe(
+      [
+        'Storybook help from the Storybook running at http://localhost:6006:',
+        '',
+        '# Storybook workflow instructions',
+        '',
+        'Use existing stories as examples.',
+        'Run tests after writing stories.',
+        '',
+        '# Storybook commands',
+        '',
+        '  get-documentation  Get docs for a component.',
+        '',
+        "Run 'storybook ai <command> --help' for a command's description and arguments.",
+      ].join('\n')
     );
-    expect(section).toContain('get-documentation');
   });
 
   it.each(['', '   ', undefined])(
-    'omits workflow instructions when initialize instructions are %j',
+    'treats missing workflow instructions as unavailable help metadata when initialize instructions are %j',
     async (instructions) => {
       vi.mocked(listMcpToolsWithServerMetadata).mockResolvedValue({
         tools: [{ name: 'get-documentation', description: 'Get docs for a component.' }],
@@ -298,9 +309,9 @@ describe('buildStorybookCommandsHelp', () => {
       });
 
       const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
-      expect(section).not.toContain('Storybook workflow instructions:');
-      expect(section).toContain('Storybook commands (from the Storybook running');
-      expect(section).toContain('get-documentation');
+      expect(section).not.toContain('# Storybook workflow instructions');
+      expect(section).toContain('Storybook commands: (unavailable');
+      expect(section).toContain('did not provide workflow instructions');
     }
   );
 
@@ -346,7 +357,7 @@ describe('buildStorybookCommandsHelp', () => {
     vi.mocked(readRegistry).mockResolvedValue([{ ...record, storybookVersion: '10.5.0' }]);
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain(
-      'Storybook commands (from the Storybook running at http://localhost:6006, Storybook 10.5.0):'
+      'Storybook help from the Storybook running at http://localhost:6006, Storybook 10.5.0:'
     );
   });
 

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
+import {
+  McpJsonRpcError,
+  callMcpTool,
+  listMcpTools,
+  listMcpToolsWithServerMetadata,
+} from './client.ts';
 import { readRegistry } from './registry.ts';
 import { buildStorybookCommandsHelp, runAiTool, runAiToolHelp } from './run-tool.ts';
 import type { StorybookInstanceRecord } from './types.ts';
@@ -26,6 +31,12 @@ beforeEach(() => {
   vi.mocked(listMcpTools)
     .mockReset()
     .mockResolvedValue([{ name: 'list-all-documentation', description: 'List docs' }]);
+  vi.mocked(listMcpToolsWithServerMetadata)
+    .mockReset()
+    .mockResolvedValue({
+      tools: [{ name: 'list-all-documentation', description: 'List docs' }],
+      serverMetadata: {},
+    });
 });
 
 describe('runAiTool', () => {
@@ -240,13 +251,16 @@ describe('runAiTool', () => {
 
 describe('buildStorybookCommandsHelp', () => {
   it('lists each tool with the first line of its description', async () => {
-    vi.mocked(listMcpTools).mockResolvedValue([
-      {
-        name: 'get-documentation',
-        description: 'Get docs for a component.\n\nLong details that should not appear.',
-      },
-      { name: 'list-all-documentation' },
-    ]);
+    vi.mocked(listMcpToolsWithServerMetadata).mockResolvedValue({
+      tools: [
+        {
+          name: 'get-documentation',
+          description: 'Get docs for a component.\n\nLong details that should not appear.',
+        },
+        { name: 'list-all-documentation' },
+      ],
+      serverMetadata: {},
+    });
 
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain(
@@ -257,6 +271,38 @@ describe('buildStorybookCommandsHelp', () => {
     expect(section).not.toContain('Long details');
     expect(section).toContain("Run 'storybook ai <command> --help'");
   });
+
+  it('prints workflow instructions before the dynamic commands list when initialize provides them', async () => {
+    vi.mocked(listMcpToolsWithServerMetadata).mockResolvedValue({
+      tools: [{ name: 'get-documentation', description: 'Get docs for a component.' }],
+      serverMetadata: {
+        instructions: 'Use existing stories as examples.\nRun tests after writing stories.',
+      },
+    });
+
+    const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
+    expect(section).toContain('Storybook workflow instructions:\nUse existing stories');
+    expect(section).toContain('Storybook commands (from the Storybook running');
+    expect(section.indexOf('Storybook workflow instructions:')).toBeLessThan(
+      section.indexOf('Storybook commands (from the Storybook running')
+    );
+    expect(section).toContain('get-documentation');
+  });
+
+  it.each(['', '   ', undefined])(
+    'omits workflow instructions when initialize instructions are %j',
+    async (instructions) => {
+      vi.mocked(listMcpToolsWithServerMetadata).mockResolvedValue({
+        tools: [{ name: 'get-documentation', description: 'Get docs for a component.' }],
+        serverMetadata: instructions === undefined ? {} : { instructions },
+      });
+
+      const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
+      expect(section).not.toContain('Storybook workflow instructions:');
+      expect(section).toContain('Storybook commands (from the Storybook running');
+      expect(section).toContain('get-documentation');
+    }
+  );
 
   it('degrades to a note when no Storybook is running (help must not fail)', async () => {
     vi.mocked(readRegistry).mockResolvedValue([]);
@@ -305,14 +351,17 @@ describe('buildStorybookCommandsHelp', () => {
   });
 
   it('degrades to a note when the MCP server is unreachable', async () => {
-    vi.mocked(listMcpTools).mockRejectedValue(new Error('connection refused'));
+    vi.mocked(listMcpToolsWithServerMetadata).mockRejectedValue(new Error('connection refused'));
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain('Storybook commands: (unavailable');
     expect(section).toContain('could not be reached');
   });
 
   it('degrades to a note when no tools are exposed', async () => {
-    vi.mocked(listMcpTools).mockResolvedValue([]);
+    vi.mocked(listMcpToolsWithServerMetadata).mockResolvedValue({
+      tools: [],
+      serverMetadata: {},
+    });
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain('provides no commands');
   });

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -300,21 +300,6 @@ describe('buildStorybookCommandsHelp', () => {
     );
   });
 
-  it.each(['', '   ', undefined])(
-    'treats missing workflow instructions as unavailable help metadata when initialize instructions are %j',
-    async (instructions) => {
-      vi.mocked(listMcpToolsWithServerMetadata).mockResolvedValue({
-        tools: [{ name: 'get-documentation', description: 'Get docs for a component.' }],
-        serverMetadata: instructions === undefined ? {} : { instructions },
-      });
-
-      const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
-      expect(section).not.toContain('# Storybook workflow instructions');
-      expect(section).toContain('Storybook commands: (unavailable');
-      expect(section).toContain('did not provide workflow instructions');
-    }
-  );
-
   it('degrades to a note when no Storybook is running (help must not fail)', async () => {
     vi.mocked(readRegistry).mockResolvedValue([]);
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -204,19 +204,27 @@ export async function buildStorybookCommandsHelp(
     return `  ${tool.name.padEnd(width)}${summary}`;
   });
   const version = record.storybookVersion ? `, Storybook ${record.storybookVersion}` : '';
+  const instructions = serverMetadata.instructions?.trim();
+  if (!instructions) {
+    // A ready addon-mcp command server is expected to provide workflow instructions. Treat missing
+    // instructions as a defensive contract failure, not as a normal commands-only help mode.
+    return unavailable(`the Storybook at ${record.url} did not provide workflow instructions`);
+  }
+
   return [
-    ...formatWorkflowInstructionsSection(serverMetadata.instructions),
-    `Storybook commands (from the Storybook running at ${record.url}${version}):`,
+    `Storybook help from the Storybook running at ${record.url}${version}:`,
     ...siblingNote,
+    '',
+    '# Storybook workflow instructions',
+    '',
+    instructions,
+    '',
+    '# Storybook commands',
+    '',
     ...lines,
     '',
     `Run 'storybook ai <command> --help' for a command's description and arguments.`,
   ].join('\n');
-}
-
-function formatWorkflowInstructionsSection(instructions: string | undefined): string[] {
-  const trimmed = instructions?.trim();
-  return trimmed ? ['Storybook workflow instructions:', trimmed, ''] : [];
 }
 
 /** One-line reason why the help section cannot list commands, accurate per intercept. */

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -1,5 +1,7 @@
 import { resolve } from 'node:path';
 
+import { invariant } from 'storybook/internal/common';
+
 import {
   McpJsonRpcError,
   type McpToolList,
@@ -204,12 +206,15 @@ export async function buildStorybookCommandsHelp(
     return `  ${tool.name.padEnd(width)}${summary}`;
   });
   const version = record.storybookVersion ? `, Storybook ${record.storybookVersion}` : '';
-  const instructions = serverMetadata.instructions?.trim();
-  if (!instructions) {
-    // A ready addon-mcp command server is expected to provide workflow instructions. Treat missing
-    // instructions as a defensive contract failure, not as a normal commands-only help mode.
-    return unavailable(`the Storybook at ${record.url} did not provide workflow instructions`);
-  }
+  const { instructions } = serverMetadata;
+  // Unreachable with a healthy addon-mcp: it gates instructions and tools on the same dev/test/docs
+  // toolsets (non-empty tools imply non-empty instructions), and the initialize handshake shares the
+  // request budget, so a slow server can't drop instructions while tools/list succeeds. Reaching here
+  // means the server returned commands but no instructions — a contract bug.
+  invariant(
+    instructions,
+    `The Storybook MCP server at ${record.url} exposed commands but no workflow instructions`
+  );
 
   return [
     `Storybook help from the Storybook running at ${record.url}${version}:`,

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -1,6 +1,11 @@
 import { resolve } from 'node:path';
 
-import { McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
+import {
+  McpJsonRpcError,
+  callMcpTool,
+  listMcpTools,
+  listMcpToolsWithServerMetadata,
+} from './client.ts';
 import { getInterceptMarkdown } from './intercepts.ts';
 import { readRegistry } from './registry.ts';
 import { resolveInstance } from './resolve-instance.ts';
@@ -173,12 +178,13 @@ export async function buildStorybookCommandsHelp(
   }
   const { record, matches } = resolution;
 
-  let tools: McpToolDescriptor[];
+  let toolList: Awaited<ReturnType<typeof listMcpToolsWithServerMetadata>>;
   try {
-    tools = await listMcpTools(record, deps.fetchImpl);
+    toolList = await listMcpToolsWithServerMetadata(record, deps.fetchImpl);
   } catch {
     return unavailable(`the Storybook at ${record.url} could not be reached`);
   }
+  const { tools, serverMetadata } = toolList;
   if (tools.length === 0) {
     return unavailable(`the Storybook at ${record.url} provides no commands`);
   }
@@ -198,12 +204,18 @@ export async function buildStorybookCommandsHelp(
   });
   const version = record.storybookVersion ? `, Storybook ${record.storybookVersion}` : '';
   return [
+    ...formatWorkflowInstructionsSection(serverMetadata.instructions),
     `Storybook commands (from the Storybook running at ${record.url}${version}):`,
     ...siblingNote,
     ...lines,
     '',
     `Run 'storybook ai <command> --help' for a command's description and arguments.`,
   ].join('\n');
+}
+
+function formatWorkflowInstructionsSection(instructions: string | undefined): string[] {
+  const trimmed = instructions?.trim();
+  return trimmed ? ['Storybook workflow instructions:', trimmed, ''] : [];
 }
 
 /** One-line reason why the help section cannot list commands, accurate per intercept. */

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 
 import {
   McpJsonRpcError,
+  type McpToolList,
   callMcpTool,
   listMcpTools,
   listMcpToolsWithServerMetadata,
@@ -178,7 +179,7 @@ export async function buildStorybookCommandsHelp(
   }
   const { record, matches } = resolution;
 
-  let toolList: Awaited<ReturnType<typeof listMcpToolsWithServerMetadata>>;
+  let toolList: McpToolList;
   try {
     toolList = await listMcpToolsWithServerMetadata(record, deps.fetchImpl);
   } catch {


### PR DESCRIPTION
Closes #35163

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

- Parse optional `initialize.result.instructions` from the existing MCP handshake used by `storybook ai`.
- Render non-empty workflow instructions in top-level `storybook ai --help` before the dynamic `Storybook commands` list.
- Keep the command list sourced from `tools/list`, preserve the existing degraded help states (no Storybook, addon missing/starting/erroring, server unreachable, no commands), and leave feature-flag-off behavior unchanged.
- Fetch the `initialize` metadata on the full request budget so a slow or still-starting dev server can't drop the instructions while `tools/list` succeeds — the only thing that slows the handshake is the dev server starting up, which the command waits through anyway.
- Require the instructions via an invariant rather than degrading to a note: addon-mcp gates instructions and tools on the same toolsets, so when commands are present, missing instructions can only be a server contract bug.
- Note: this also changes the `initialize` handshake budget for command execution (3s -> full request budget); the 3s originated with the telemetry handshake in #35131.
- Added unit coverage for initialize instruction parsing (JSON/SSE, malformed/error/empty responses) and the help workflow-instructions rendering.
- Manual QA on canary `0.0.0-pr-35164-sha-fe7f4278` against the `storybookjs/mcp` internal Storybook: feature-flagged help renders `Storybook workflow instructions` before `Storybook commands` and keeps the dynamic command list from `tools/list`; feature-flag-off help remains unchanged.
- Codex thermo-nuclear code-quality review: no actionable findings.
- Claude Opus 4.8 Max thermo-nuclear review: low-severity findings addressed in follow-up commit `9f2d2ff` (explicit tool-list type and initialize metadata tests for malformed/SSE responses).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Start a Storybook project with `@storybook/addon-mcp` installed and ready.
2. Run `STORYBOOK_FEATURE_AI_CLI=1 storybook ai --help`.
3. Confirm the output includes a `# Storybook workflow instructions` section (from the MCP `initialize` response) before the `# Storybook commands` list.
4. Confirm the command list still reflects the server's `tools/list` output.
5. Confirm help still degrades gracefully to an `unavailable` note when no Storybook is running, MCP is missing/starting/erroring, or the command server cannot be reached.
6. Confirm `storybook ai` without `STORYBOOK_FEATURE_AI_CLI=1` still exposes the pre-existing `setup` behavior only.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35164-sha-1aaf82d2`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35164-sha-1aaf82d2 sandbox` or in an existing project with `npx storybook@0.0.0-pr-35164-sha-1aaf82d2 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35164-sha-1aaf82d2`](https://npmjs.com/package/storybook/v/0.0.0-pr-35164-sha-1aaf82d2) |
| **Triggered by** | @huang-julien |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/ai-cli-mcp-instructions`](https://github.com/storybookjs/storybook/tree/kasper/ai-cli-mcp-instructions) |
| **Commit** | [`1aaf82d2`](https://github.com/storybookjs/storybook/commit/1aaf82d23cc0dc7562d98bf9384035add3933190) |
| **Datetime** | Mon Jun 15 13:47:37 UTC 2026 (`1781531257`) |
| **Workflow run** | [27550786817](https://github.com/storybookjs/storybook/actions/runs/27550786817) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35164`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Help output can now include server-provided “workflow instructions” when available via the MCP initialize handshake.
  * Tool discovery now carries server metadata to enrich help generation.
* **Bug Fixes**
  * Improved resilience across JSON vs SSE initialize responses, extracting and normalizing instructions when possible and falling back safely when missing/invalid.
  * Non-OK handshake responses no longer interfere with tool listing.
* **Tests**
  * Expanded MCP initialize/metadata normalization coverage and updated help-generation expectations (including new workflow instructions rendering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
