### PR TITLE
Core: Include chromatic packages in ecosystem identifier

### DIFF
--- a/code/core/src/shared/utils/ecosystem-identifier.ts
+++ b/code/core/src/shared/utils/ecosystem-identifier.ts
@@ -19,6 +19,7 @@ export const TEST_PACKAGES = [
   'miragejs',
   'sinon',
   'chromatic',
+  '@chromatic-com/*',
 ] as const;
 
 export const STYLING_PACKAGES = [

--- a/code/core/src/telemetry/get-known-packages.test.ts
+++ b/code/core/src/telemetry/get-known-packages.test.ts
@@ -36,6 +36,7 @@ describe('get-known-packages', () => {
           vitest: '1.0.0',
           playwright: '1.30.0',
           '@testing-library/react': '1.0.0',
+          '@chromatic-com/vitest': '1.0.0',
         },
       };
 
@@ -48,6 +49,7 @@ describe('get-known-packages', () => {
         vitest: '1.0.0',
         playwright: '1.0.0',
         '@testing-library/react': '1.0.0',
+        '@chromatic-com/vitest': '1.0.0',
       });
     });
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Telemetry now includes `@chromatic-com` packages.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Add @chromatic-com/vitest
3. Open Storybook in your browser
4. Access /project.json
5. See it listed as testPackage

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of Chromatic test packages (`@chromatic-com/*`) as test-related dependencies in package analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->