### PR TITLE
add yarn ui convenience script for internal Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "task": "yarn --cwd=./scripts task",
     "test": "NODE_OPTIONS=--max_old_space_size=4096 vitest run",
     "test:watch": "NODE_OPTIONS=--max_old_space_size=4096 vitest watch",
+    "ui": "yarn nx run-many -t compile && yarn --cwd code storybook:ui",
     "upload-bench": "cd scripts; yarn upload-bench",
     "vite-ecosystem-ci:before-test": "./scripts/ecosystem-ci/before-test.sh react-vite/default-ts",
     "vite-ecosystem-ci:build": "./scripts/ecosystem-ci/build.sh react-vite/default-ts",


### PR DESCRIPTION
## What I did

Added a `yarn ui` script to root `package.json` so contributors can start the internal Storybook UI directly from the repo root without `cd`-ing into `code/` or running the full sandbox task.

```bash
# before
yarn install
# ... cd code
yarn storybook:ui

# after
yarn ui
```

The script runs `yarn nx run-many -t compile` first (NX caching makes this near-instant on repeat runs after the first full build), then launches `yarn storybook:ui` in the `code/` workspace.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. From the repo root, run `yarn ui`
2. Confirm all packages compile (or are served from NX cache on a repeat run)
3. Confirm Storybook UI opens at `http://localhost:6006`
4. Run `yarn ui` a second time — confirm the NX cache hits and startup is significantly faster

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added `ui` script for convenient access to the Storybook UI environment with automatic compilation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->