### PR TITLE
Tests: Distinguish output path when running test on Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,7 @@ When writing unit tests (utilities, hooks, non-React modules):
 - Test real behavior, not just syntax patterns
 - Use coverage when useful: `yarn vitest run --coverage <test-file>`
 - Mock external dependencies like file system access and loggers
+- Use Node's path.resolve to wrap expected FS paths when writing path-related tests, so they work on Windows
 
 ### Filesystem tests with `memfs`
 

--- a/code/core/src/cli/ai/mcp/local-metadata.test.ts
+++ b/code/core/src/cli/ai/mcp/local-metadata.test.ts
@@ -139,7 +139,7 @@ describe('resolveStorybookConfigDir', () => {
 
   it('keeps absolute config dirs unchanged', () => {
     expect(resolveStorybookConfigDir({ cwd: '/repo', configDir: '/custom/.storybook' })).toBe(
-      resolve('/custom/.storybook')
+      '/custom/.storybook'
     );
   });
 });

--- a/code/core/src/cli/ai/mcp/local-metadata.test.ts
+++ b/code/core/src/cli/ai/mcp/local-metadata.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { experimental_loadStorybook as loadStorybook } from 'storybook/internal/core-server';
 
-import { resolve } from 'node:path';
 import { loadStorybookAiMetadata, resolveStorybookConfigDir } from './local-metadata.ts';
 
 vi.mock('storybook/internal/core-server', { spy: true });

--- a/code/core/src/cli/ai/mcp/local-metadata.test.ts
+++ b/code/core/src/cli/ai/mcp/local-metadata.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { experimental_loadStorybook as loadStorybook } from 'storybook/internal/core-server';
@@ -39,7 +41,7 @@ describe('loadStorybookAiMetadata', () => {
 
     const metadata = await loadStorybookAiMetadata({ cwd: '/repo' });
 
-    expect(loadStorybook).toHaveBeenCalledWith({ configDir: '/repo/.storybook' });
+    expect(loadStorybook).toHaveBeenCalledWith({ configDir: resolve('/repo/.storybook') });
     expect(apply).toHaveBeenCalledWith('experimental_storybookAi', undefined);
     expect(metadata).toEqual({
       instructions: 'Follow the story workflow.',
@@ -64,7 +66,7 @@ describe('loadStorybookAiMetadata', () => {
 
     await loadStorybookAiMetadata({ cwd: '/repo', configDir: 'config/storybook' });
 
-    expect(loadStorybook).toHaveBeenCalledWith({ configDir: '/repo/config/storybook' });
+    expect(loadStorybook).toHaveBeenCalledWith({ configDir: resolve('/repo/config/storybook') });
   });
 
   it('normalizes optional metadata fields and hides descriptor-less local tools', async () => {
@@ -126,18 +128,18 @@ describe('loadStorybookAiMetadata', () => {
 
 describe('resolveStorybookConfigDir', () => {
   it('defaults to .storybook under the target cwd', () => {
-    expect(resolveStorybookConfigDir({ cwd: '/repo' })).toBe('/repo/.storybook');
+    expect(resolveStorybookConfigDir({ cwd: '/repo' })).toBe(resolve('/repo/.storybook'));
   });
 
   it('resolves relative config dirs from the target cwd', () => {
     expect(resolveStorybookConfigDir({ cwd: '/repo', configDir: 'config/storybook' })).toBe(
-      '/repo/config/storybook'
+      resolve('/repo/config/storybook')
     );
   });
 
   it('keeps absolute config dirs unchanged', () => {
     expect(resolveStorybookConfigDir({ cwd: '/repo', configDir: '/custom/.storybook' })).toBe(
-      '/custom/.storybook'
+      resolve('/custom/.storybook')
     );
   });
 });

--- a/code/core/src/cli/ai/mcp/local-metadata.test.ts
+++ b/code/core/src/cli/ai/mcp/local-metadata.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { experimental_loadStorybook as loadStorybook } from 'storybook/internal/core-server';
 
+import { resolve } from 'node:path';
 import { loadStorybookAiMetadata, resolveStorybookConfigDir } from './local-metadata.ts';
 
 vi.mock('storybook/internal/core-server', { spy: true });

--- a/code/core/src/cli/ai/mcp/register.test.ts
+++ b/code/core/src/cli/ai/mcp/register.test.ts
@@ -1,6 +1,5 @@
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import os from 'node:os';
 
 import { optionalEnvToBoolean } from 'storybook/internal/common';
 import { sendTelemetryError, withTelemetry } from 'storybook/internal/core-server';
@@ -243,8 +242,7 @@ describe('with the feature flag (passthrough registered)', () => {
       outcome: { kind: 'success' },
     });
     await parse(program, ['ai', '-o', '/out/result.md', 'tool-x']);
-    const expectedPath = os.platform() === 'win32' ? 'C:\\out\\result.md' : '/out/result.md';
-    expect(writeFile).toHaveBeenCalledWith(expectedPath, 'markdown result\n', 'utf-8');
+    expect(writeFile).toHaveBeenCalledWith(resolve('/out/result.md'), 'markdown result\n', 'utf-8');
     expect(process.stdout.write).not.toHaveBeenCalledWith('markdown result\n');
   });
 

--- a/code/core/src/cli/ai/mcp/register.test.ts
+++ b/code/core/src/cli/ai/mcp/register.test.ts
@@ -1,5 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import os from 'node:os';
 
 import { optionalEnvToBoolean } from 'storybook/internal/common';
 import { sendTelemetryError, withTelemetry } from 'storybook/internal/core-server';
@@ -242,7 +243,8 @@ describe('with the feature flag (passthrough registered)', () => {
       outcome: { kind: 'success' },
     });
     await parse(program, ['ai', '-o', '/out/result.md', 'tool-x']);
-    expect(writeFile).toHaveBeenCalledWith('/out/result.md', 'markdown result\n', 'utf-8');
+    const expectedPath = os.platform() === 'win32' ? 'C:\\out\\result.md' : '/out/result.md';
+    expect(writeFile).toHaveBeenCalledWith(expectedPath, 'markdown result\n', 'utf-8');
     expect(process.stdout.write).not.toHaveBeenCalledWith('markdown result\n');
   });
 

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -268,7 +268,7 @@ describe('runAiTool', () => {
     const result = await runAiTool('get-documentation', [], { cwd: '/projects/other' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('No Storybook is running at this cwd');
-    expect(result.output).toContain(resolve('/projects/foo'));
+    expect(result.output).toContain('/projects/foo');
     expect(result.outcome).toEqual({ kind: 'intercept', reason: 'no-instance' });
   });
 
@@ -465,7 +465,7 @@ describe('runAiTool', () => {
     const result = await runAiTool('list-all-documentation', [], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('Multiple matching Storybook instances');
-    expect(result.output).toContain(`Matching instances at \`${resolve('/projects/foo')}\``);
+    expect(result.output).toContain('Matching instances at `/projects/foo`');
     expect(result.output).toContain('pid `1`');
     expect(result.output).toContain('pid `2`');
     expect(result.output).toContain('(used)');
@@ -516,7 +516,7 @@ describe('runAiTool', () => {
       );
       expect(result.exitCode).toBe(0);
       expect(result.output).toContain('Multiple matching Storybook instances');
-      expect(result.output).toContain(`Matching instances at \`${resolve('/projects/foo')}\``);
+      expect(result.output).toContain('Matching instances at `/projects/foo`');
       expect(result.output).toContain('pid `2`');
       expect(result.output).toContain('pid `3`');
       expect(result.output).not.toContain('pid `4`');

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { resolve } from 'node:path';
 import { McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
 import { loadStorybookAiMetadata, type StorybookAiMetadata } from './local-metadata.ts';
 import { readRegistry } from './registry.ts';
@@ -60,8 +61,8 @@ describe('runAiTool', () => {
       outcome: { kind: 'success' },
     });
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
-      cwd: '/projects/foo',
-      configDir: '/projects/foo/.storybook',
+      cwd: resolve('/projects/foo'),
+      configDir: resolve('/projects/foo/.storybook'),
     });
   });
 
@@ -133,8 +134,8 @@ describe('runAiTool', () => {
 
     expect(result.output).toBe('custom config instructions');
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
-      cwd: '/projects/foo',
-      configDir: '/projects/foo/config/storybook',
+      cwd: resolve('/projects/foo'),
+      configDir: resolve('/projects/foo/config/storybook'),
     });
     expect(readRegistry).not.toHaveBeenCalled();
   });
@@ -267,7 +268,7 @@ describe('runAiTool', () => {
     const result = await runAiTool('get-documentation', [], { cwd: '/projects/other' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('No Storybook is running at this cwd');
-    expect(result.output).toContain('/projects/foo');
+    expect(result.output).toContain(resolve('/projects/foo'));
     expect(result.outcome).toEqual({ kind: 'intercept', reason: 'no-instance' });
   });
 
@@ -464,7 +465,7 @@ describe('runAiTool', () => {
     const result = await runAiTool('list-all-documentation', [], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('Multiple matching Storybook instances');
-    expect(result.output).toContain('Matching instances at `/projects/foo`');
+    expect(result.output).toContain(`Matching instances at \`${resolve('/projects/foo')}\``);
     expect(result.output).toContain('pid `1`');
     expect(result.output).toContain('pid `2`');
     expect(result.output).toContain('(used)');
@@ -515,7 +516,7 @@ describe('runAiTool', () => {
       );
       expect(result.exitCode).toBe(0);
       expect(result.output).toContain('Multiple matching Storybook instances');
-      expect(result.output).toContain('Matching instances at `/projects/foo`');
+      expect(result.output).toContain(`Matching instances at \`${resolve('/projects/foo')}\``);
       expect(result.output).toContain('pid `2`');
       expect(result.output).toContain('pid `3`');
       expect(result.output).not.toContain('pid `4`');
@@ -545,7 +546,7 @@ describe('buildStorybookCommandsHelp', () => {
 
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain(
-      'Storybook help from the Storybook configuration at /projects/foo/.storybook:'
+      `Storybook help from the Storybook configuration at ${resolve('/projects/foo/.storybook')}:`
     );
     expect(section).toContain('# Storybook commands');
     expect(section).toContain('get-documentation');
@@ -566,7 +567,7 @@ describe('buildStorybookCommandsHelp', () => {
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toBe(
       [
-        'Storybook help from the Storybook configuration at /projects/foo/.storybook:',
+        `Storybook help from the Storybook configuration at ${resolve('/projects/foo/.storybook')}:`,
         '',
         '# Storybook workflow instructions',
         '',
@@ -625,8 +626,8 @@ describe('buildStorybookCommandsHelp', () => {
     expect(section).toContain('Storybook help from the Storybook configuration');
     expect(section).toContain('list-all-documentation');
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
-      cwd: '/projects/foo',
-      configDir: '/projects/foo/.storybook',
+      cwd: resolve('/projects/foo'),
+      configDir: resolve('/projects/foo/.storybook'),
     });
   });
 
@@ -643,8 +644,8 @@ describe('buildStorybookCommandsHelp', () => {
 
     expect(section).toContain('get-documentation');
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
-      cwd: '/projects/foo',
-      configDir: '/projects/foo/config/storybook',
+      cwd: resolve('/projects/foo'),
+      configDir: resolve('/projects/foo/config/storybook'),
     });
   });
 });
@@ -717,8 +718,8 @@ describe('runAiToolHelp', () => {
     });
     expect(result.exitCode).toBe(0);
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
-      cwd: '/projects/foo',
-      configDir: '/projects/foo/config/storybook',
+      cwd: resolve('/projects/foo'),
+      configDir: resolve('/projects/foo/config/storybook'),
     });
   });
 
@@ -783,8 +784,8 @@ describe('runAiToolHelp', () => {
 
     expect(result.exitCode).toBe(0);
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
-      cwd: '/projects/foo',
-      configDir: '/projects/foo/config/storybook',
+      cwd: resolve('/projects/foo'),
+      configDir: resolve('/projects/foo/config/storybook'),
     });
   });
 

--- a/scripts/eval/sync-baselines.test.ts
+++ b/scripts/eval/sync-baselines.test.ts
@@ -18,428 +18,408 @@ afterEach(() => {
   }
 });
 
-skipWindows(() => {
-  describe('syncBaselines', () => {
-    it('syncs authoritative mealdrop files into root and nested repos, removes old eval-results, and pushes main', async () => {
-      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-'));
-      const reposRoot = join(TMP, 'repos');
-      const remotesRoot = join(TMP, 'remotes');
-      await mkdir(reposRoot, { recursive: true });
-      await mkdir(remotesRoot, { recursive: true });
+describe('syncBaselines', () => {
+  it('syncs authoritative mealdrop files into root and nested repos, removes old eval-results, and pushes main', async () => {
+    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-'));
+    const reposRoot = join(TMP, 'repos');
+    const remotesRoot = join(TMP, 'remotes');
+    await mkdir(reposRoot, { recursive: true });
+    await mkdir(remotesRoot, { recursive: true });
 
-      const projects: Project[] = [
-        {
-          name: 'mealdrop',
-          repo: join(remotesRoot, 'mealdrop.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/mealdrop',
-        },
-        {
-          name: 'edgy',
-          repo: join(remotesRoot, 'edgy.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/edgy',
-        },
-        {
-          name: 'wikitok',
-          repo: join(remotesRoot, 'wikitok.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/wikitok',
-          projectDir: 'frontend',
-        },
-      ];
+    const projects: Project[] = [
+      {
+        name: 'mealdrop',
+        repo: join(remotesRoot, 'mealdrop.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+      {
+        name: 'edgy',
+        repo: join(remotesRoot, 'edgy.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/edgy',
+      },
+      {
+        name: 'wikitok',
+        repo: join(remotesRoot, 'wikitok.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/wikitok',
+        projectDir: 'frontend',
+      },
+    ];
 
-      setupRepo({
-        repoRoot: join(reposRoot, 'mealdrop'),
-        remoteRoot: join(remotesRoot, 'mealdrop.git'),
-        storybookDir: '.storybook',
-        mainFile: 'main.ts',
-        mainContents: [
-          "import type { StorybookConfig } from '@storybook/react-vite';",
-          '',
-          'const config: StorybookConfig = {',
-          "  stories: ['../src/**/*.stories.tsx', './eval-support/*.mdx'],",
-          '};',
-          '',
-          'export default config;',
-        ].join('\n'),
-        evalSupportFiles: {
-          'summary.mdx': "import data from '../../eval-results/data.json';\n\n# Source Summary\n",
-          'transcript.mdx':
-            "import data from '../../eval-results/data.json';\nimport { Transcript } from './transcript';\n\n# Transcript\n\n<Transcript {...data.docs.transcript} />\n",
-          'transcript.tsx': 'export const Transcript = () => null;\n',
-          'transcript.types.ts':
-            'export interface TranscriptProps { messages: unknown[]; prompt: string; promptTokenCount: number; promptCost: number; }\n',
-        },
-        previewContents: "export default { parameters: { a11y: { test: 'todo' } } };\n",
-        rootEvalResultsFiles: {
-          'summary.json': '{ "empty": true }\n',
-          'transcript.json': '[]\n',
-        },
-      });
+    setupRepo({
+      repoRoot: join(reposRoot, 'mealdrop'),
+      remoteRoot: join(remotesRoot, 'mealdrop.git'),
+      storybookDir: '.storybook',
+      mainFile: 'main.ts',
+      mainContents: [
+        "import type { StorybookConfig } from '@storybook/react-vite';",
+        '',
+        'const config: StorybookConfig = {',
+        "  stories: ['../src/**/*.stories.tsx', './eval-support/*.mdx'],",
+        '};',
+        '',
+        'export default config;',
+      ].join('\n'),
+      evalSupportFiles: {
+        'summary.mdx': "import data from '../../eval-results/data.json';\n\n# Source Summary\n",
+        'transcript.mdx':
+          "import data from '../../eval-results/data.json';\nimport { Transcript } from './transcript';\n\n# Transcript\n\n<Transcript {...data.docs.transcript} />\n",
+        'transcript.tsx': 'export const Transcript = () => null;\n',
+        'transcript.types.ts':
+          'export interface TranscriptProps { messages: unknown[]; prompt: string; promptTokenCount: number; promptCost: number; }\n',
+      },
+      previewContents: "export default { parameters: { a11y: { test: 'todo' } } };\n",
+      rootEvalResultsFiles: {
+        'summary.json': '{ "empty": true }\n',
+        'transcript.json': '[]\n',
+      },
+    });
 
-      setupRepo({
-        repoRoot: join(reposRoot, 'edgy'),
-        remoteRoot: join(remotesRoot, 'edgy.git'),
-        storybookDir: '.storybook',
-        mainFile: 'main.js',
-        mainContents: [
-          '/** @type { import("@storybook/react-vite").StorybookConfig } */',
-          'const config = {',
-          "  stories: ['../src/**/*.stories.tsx'],",
-          '};',
-          '',
-          'export default config;',
-        ].join('\n'),
-        evalSupportFiles: {
-          'old-helper.ts': 'export const stale = true;\n',
-        },
-        previewContents: 'export default { parameters: { old: true } };\n',
-        rootEvalResultsFiles: {
-          'data.json': '{}\n',
-          'summary.json': '{ "empty": true }\n',
-        },
-      });
+    setupRepo({
+      repoRoot: join(reposRoot, 'edgy'),
+      remoteRoot: join(remotesRoot, 'edgy.git'),
+      storybookDir: '.storybook',
+      mainFile: 'main.js',
+      mainContents: [
+        '/** @type { import("@storybook/react-vite").StorybookConfig } */',
+        'const config = {',
+        "  stories: ['../src/**/*.stories.tsx'],",
+        '};',
+        '',
+        'export default config;',
+      ].join('\n'),
+      evalSupportFiles: {
+        'old-helper.ts': 'export const stale = true;\n',
+      },
+      previewContents: 'export default { parameters: { old: true } };\n',
+      rootEvalResultsFiles: {
+        'data.json': '{}\n',
+        'summary.json': '{ "empty": true }\n',
+      },
+    });
 
-      setupRepo({
-        repoRoot: join(reposRoot, 'wikitok'),
-        remoteRoot: join(remotesRoot, 'wikitok.git'),
-        storybookDir: 'frontend/.storybook',
-        mainFile: 'main.ts',
-        mainContents: [
-          "import type { StorybookConfig } from '@storybook/react-vite';",
-          '',
-          'const config: StorybookConfig = {',
-          '  stories: [',
-          "    '../src/**/*.stories.tsx',",
-          '  ],',
-          '};',
-          '',
-          'export default config;',
-        ].join('\n'),
-        evalSupportFiles: {
-          'old.txt': 'stale\n',
-        },
-        previewContents: 'export default { parameters: { old: true } };\n',
-        rootEvalResultsFiles: {
-          'transcript.json': '[]\n',
-        },
-      });
+    setupRepo({
+      repoRoot: join(reposRoot, 'wikitok'),
+      remoteRoot: join(remotesRoot, 'wikitok.git'),
+      storybookDir: 'frontend/.storybook',
+      mainFile: 'main.ts',
+      mainContents: [
+        "import type { StorybookConfig } from '@storybook/react-vite';",
+        '',
+        'const config: StorybookConfig = {',
+        '  stories: [',
+        "    '../src/**/*.stories.tsx',",
+        '  ],',
+        '};',
+        '',
+        'export default config;',
+      ].join('\n'),
+      evalSupportFiles: {
+        'old.txt': 'stale\n',
+      },
+      previewContents: 'export default { parameters: { old: true } };\n',
+      rootEvalResultsFiles: {
+        'transcript.json': '[]\n',
+      },
+    });
 
-      await syncBaselines({
+    await syncBaselines({
+      reposRoot,
+      projects,
+      push: true,
+      log: () => {},
+    });
+
+    expect(
+      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+    ).toContain('../eval-results/data.json');
+    expect(
+      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+    ).toContain('# Eval Summary');
+    expect(
+      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+    ).toContain("{data.project?.name ?? '-'}");
+    expect(
+      readFileSync(
+        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
+        'utf-8'
+      )
+    ).toContain('../eval-results/data.json');
+    expect(
+      readFileSync(
+        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
+        'utf-8'
+      )
+    ).toContain(
+      "<Transcript {...(data.docs?.transcript ?? { prompt: '', promptTokenCount: 0, promptCost: 0, messages: [] })} />"
+    );
+
+    expect(
+      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'), 'utf-8')
+    ).toBe('{}\n');
+    expect(
+      readFileSync(
+        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
+        'utf-8'
+      )
+    ).toBe('{}\n');
+
+    expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
+    expect(existsSync(join(reposRoot, 'wikitok', 'frontend', 'eval-results'))).toBe(false);
+    expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'main.js'))).toBe(false);
+    expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'old-helper.ts'))).toBe(
+      false
+    );
+    expect(
+      existsSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'old.txt'))
+    ).toBe(false);
+
+    expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'main.ts'), 'utf-8')).toContain(
+      './eval-support/*.mdx'
+    );
+    expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'preview.tsx'), 'utf-8')).toBe(
+      baselineTemplate('.storybook/preview.tsx')
+    );
+    expect(
+      readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
+    ).toContain('./eval-support/*.mdx');
+    expect(
+      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'transcript.tsx'), 'utf-8')
+    ).toBe(resultDocTemplate('transcript.tsx'));
+    expect(
+      readFileSync(
+        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.types.ts'),
+        'utf-8'
+      )
+    ).toBe(resultDocTemplate('transcript.types.ts'));
+
+    expect(getHead(join(reposRoot, 'edgy'))).toBe(getRemoteHead(join(remotesRoot, 'edgy.git')));
+    expect(getHead(join(reposRoot, 'wikitok'))).toBe(
+      getRemoteHead(join(remotesRoot, 'wikitok.git'))
+    );
+  }, 30_000);
+
+  it('fails fast when a non-source target repo is dirty', async () => {
+    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-dirty-'));
+    const reposRoot = join(TMP, 'repos');
+    const remotesRoot = join(TMP, 'remotes');
+    await mkdir(reposRoot, { recursive: true });
+    await mkdir(remotesRoot, { recursive: true });
+
+    const projects: Project[] = [
+      {
+        name: 'mealdrop',
+        repo: join(remotesRoot, 'mealdrop.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+      {
+        name: 'edgy',
+        repo: join(remotesRoot, 'edgy.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/edgy',
+      },
+    ];
+
+    setupRepo({
+      repoRoot: join(reposRoot, 'mealdrop'),
+      remoteRoot: join(remotesRoot, 'mealdrop.git'),
+      storybookDir: '.storybook',
+      mainFile: 'main.ts',
+      mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
+      evalSupportFiles: {
+        'summary.mdx': "import data from '../../eval-results/data.json';\n",
+        'transcript.mdx': "import data from '../../eval-results/data.json';\n",
+        'transcript.tsx': 'export const Transcript = () => null;\n',
+        'transcript.types.ts': 'export interface TranscriptProps {}\n',
+      },
+      previewContents: 'export default {};\n',
+      rootEvalResultsFiles: {
+        'summary.json': '{ "empty": true }\n',
+      },
+    });
+
+    setupRepo({
+      repoRoot: join(reposRoot, 'edgy'),
+      remoteRoot: join(remotesRoot, 'edgy.git'),
+      storybookDir: '.storybook',
+      mainFile: 'main.js',
+      mainContents: 'export default { stories: [] };\n',
+      evalSupportFiles: {},
+      previewContents: 'export default {};\n',
+      rootEvalResultsFiles: {},
+    });
+
+    writeFileSync(join(reposRoot, 'edgy', 'README.md'), 'dirty\n');
+
+    await expect(
+      syncBaselines({
         reposRoot,
         projects,
         push: true,
         log: () => {},
-      });
+      })
+    ).rejects.toThrow('edgy has local changes');
 
-      expect(
-        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-      ).toContain('../eval-results/data.json');
-      expect(
-        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-      ).toContain('# Eval Summary');
-      expect(
-        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-      ).toContain("{data.project?.name ?? '-'}");
-      expect(
-        readFileSync(
-          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
-          'utf-8'
-        )
-      ).toContain('../eval-results/data.json');
-      expect(
-        readFileSync(
-          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
-          'utf-8'
-        )
-      ).toContain(
-        "<Transcript {...(data.docs?.transcript ?? { prompt: '', promptTokenCount: 0, promptCost: 0, messages: [] })} />"
-      );
+    expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'))).toBe(
+      false
+    );
+    expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
+  });
 
-      expect(
-        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'), 'utf-8')
-      ).toBe('{}\n');
-      expect(
-        readFileSync(
-          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
-          'utf-8'
-        )
-      ).toBe('{}\n');
+  it('syncs nested project baselines even when there is no legacy eval-results directory', async () => {
+    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-nested-no-legacy-'));
+    const reposRoot = join(TMP, 'repos');
+    const remotesRoot = join(TMP, 'remotes');
+    await mkdir(reposRoot, { recursive: true });
+    await mkdir(remotesRoot, { recursive: true });
 
-      expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
-      expect(existsSync(join(reposRoot, 'wikitok', 'frontend', 'eval-results'))).toBe(false);
-      expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'main.js'))).toBe(false);
-      expect(
-        existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'old-helper.ts'))
-      ).toBe(false);
-      expect(
-        existsSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'old.txt'))
-      ).toBe(false);
+    const projects: Project[] = [
+      {
+        name: 'mealdrop',
+        repo: join(remotesRoot, 'mealdrop.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+      {
+        name: 'excalidraw',
+        repo: join(remotesRoot, 'excalidraw.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/excalidraw',
+        projectDir: 'excalidraw-app',
+      },
+    ];
 
-      expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'main.ts'), 'utf-8')).toContain(
-        './eval-support/*.mdx'
-      );
-      expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'preview.tsx'), 'utf-8')).toBe(
-        baselineTemplate('.storybook/preview.tsx')
-      );
-      expect(
-        readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
-      ).toContain('./eval-support/*.mdx');
-      expect(
-        readFileSync(
-          join(reposRoot, 'edgy', '.storybook', 'eval-support', 'transcript.tsx'),
-          'utf-8'
-        )
-      ).toBe(resultDocTemplate('transcript.tsx'));
-      expect(
-        readFileSync(
-          join(
-            reposRoot,
-            'wikitok',
-            'frontend',
-            '.storybook',
-            'eval-support',
-            'transcript.types.ts'
-          ),
-          'utf-8'
-        )
-      ).toBe(resultDocTemplate('transcript.types.ts'));
-
-      expect(getHead(join(reposRoot, 'edgy'))).toBe(getRemoteHead(join(remotesRoot, 'edgy.git')));
-      expect(getHead(join(reposRoot, 'wikitok'))).toBe(
-        getRemoteHead(join(remotesRoot, 'wikitok.git'))
-      );
-    }, 30_000);
-
-    it('fails fast when a non-source target repo is dirty', async () => {
-      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-dirty-'));
-      const reposRoot = join(TMP, 'repos');
-      const remotesRoot = join(TMP, 'remotes');
-      await mkdir(reposRoot, { recursive: true });
-      await mkdir(remotesRoot, { recursive: true });
-
-      const projects: Project[] = [
-        {
-          name: 'mealdrop',
-          repo: join(remotesRoot, 'mealdrop.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/mealdrop',
-        },
-        {
-          name: 'edgy',
-          repo: join(remotesRoot, 'edgy.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/edgy',
-        },
-      ];
-
-      setupRepo({
-        repoRoot: join(reposRoot, 'mealdrop'),
-        remoteRoot: join(remotesRoot, 'mealdrop.git'),
-        storybookDir: '.storybook',
-        mainFile: 'main.ts',
-        mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
-        evalSupportFiles: {
-          'summary.mdx': "import data from '../../eval-results/data.json';\n",
-          'transcript.mdx': "import data from '../../eval-results/data.json';\n",
-          'transcript.tsx': 'export const Transcript = () => null;\n',
-          'transcript.types.ts': 'export interface TranscriptProps {}\n',
-        },
-        previewContents: 'export default {};\n',
-        rootEvalResultsFiles: {
-          'summary.json': '{ "empty": true }\n',
-        },
-      });
-
-      setupRepo({
-        repoRoot: join(reposRoot, 'edgy'),
-        remoteRoot: join(remotesRoot, 'edgy.git'),
-        storybookDir: '.storybook',
-        mainFile: 'main.js',
-        mainContents: 'export default { stories: [] };\n',
-        evalSupportFiles: {},
-        previewContents: 'export default {};\n',
-        rootEvalResultsFiles: {},
-      });
-
-      writeFileSync(join(reposRoot, 'edgy', 'README.md'), 'dirty\n');
-
-      await expect(
-        syncBaselines({
-          reposRoot,
-          projects,
-          push: true,
-          log: () => {},
-        })
-      ).rejects.toThrow('edgy has local changes');
-
-      expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'))).toBe(
-        false
-      );
-      expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
+    setupRepo({
+      repoRoot: join(reposRoot, 'mealdrop'),
+      remoteRoot: join(remotesRoot, 'mealdrop.git'),
+      storybookDir: '.storybook',
+      mainFile: 'main.ts',
+      mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
+      evalSupportFiles: {
+        'summary.mdx': '# Source Summary\n',
+        'transcript.mdx': '# Transcript\n',
+        'transcript.tsx': 'export const Transcript = () => null;\n',
+        'transcript.types.ts': 'export interface TranscriptProps {}\n',
+      },
+      previewContents: 'export default {};\n',
+      rootEvalResultsFiles: {
+        'summary.json': '{ "empty": true }\n',
+      },
     });
 
-    it('syncs nested project baselines even when there is no legacy eval-results directory', async () => {
-      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-nested-no-legacy-'));
-      const reposRoot = join(TMP, 'repos');
-      const remotesRoot = join(TMP, 'remotes');
-      await mkdir(reposRoot, { recursive: true });
-      await mkdir(remotesRoot, { recursive: true });
-
-      const projects: Project[] = [
-        {
-          name: 'mealdrop',
-          repo: join(remotesRoot, 'mealdrop.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/mealdrop',
-        },
-        {
-          name: 'excalidraw',
-          repo: join(remotesRoot, 'excalidraw.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/excalidraw',
-          projectDir: 'excalidraw-app',
-        },
-      ];
-
-      setupRepo({
-        repoRoot: join(reposRoot, 'mealdrop'),
-        remoteRoot: join(remotesRoot, 'mealdrop.git'),
-        storybookDir: '.storybook',
-        mainFile: 'main.ts',
-        mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
-        evalSupportFiles: {
-          'summary.mdx': '# Source Summary\n',
-          'transcript.mdx': '# Transcript\n',
-          'transcript.tsx': 'export const Transcript = () => null;\n',
-          'transcript.types.ts': 'export interface TranscriptProps {}\n',
-        },
-        previewContents: 'export default {};\n',
-        rootEvalResultsFiles: {
-          'summary.json': '{ "empty": true }\n',
-        },
-      });
-
-      setupRepo({
-        repoRoot: join(reposRoot, 'excalidraw'),
-        remoteRoot: join(remotesRoot, 'excalidraw.git'),
-        storybookDir: 'excalidraw-app/.storybook',
-        mainFile: 'main.ts',
-        mainContents: 'export default { stories: ["../stories/**/*.stories.tsx"] };\n',
-        evalSupportFiles: {},
-        previewContents: 'export default { parameters: { old: true } };\n',
-        rootEvalResultsFiles: {},
-      });
-
-      await syncBaselines({
-        reposRoot,
-        projects,
-        push: true,
-        log: () => {},
-      });
-
-      expect(
-        readFileSync(
-          join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'main.ts'),
-          'utf-8'
-        )
-      ).toContain('./eval-support/*.mdx');
-      expect(
-        existsSync(join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'eval-support'))
-      ).toBe(true);
-      expect(
-        readFileSync(
-          join(
-            reposRoot,
-            'excalidraw',
-            'excalidraw-app',
-            '.storybook',
-            'eval-results',
-            'data.json'
-          ),
-          'utf-8'
-        )
-      ).toBe('{}\n');
-      expect(getHead(join(reposRoot, 'excalidraw'))).toBe(
-        getRemoteHead(join(remotesRoot, 'excalidraw.git'))
-      );
+    setupRepo({
+      repoRoot: join(reposRoot, 'excalidraw'),
+      remoteRoot: join(remotesRoot, 'excalidraw.git'),
+      storybookDir: 'excalidraw-app/.storybook',
+      mainFile: 'main.ts',
+      mainContents: 'export default { stories: ["../stories/**/*.stories.tsx"] };\n',
+      evalSupportFiles: {},
+      previewContents: 'export default { parameters: { old: true } };\n',
+      rootEvalResultsFiles: {},
     });
 
-    it('auto-clones repos that have not been cloned yet', async () => {
-      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-auto-clone-'));
-      const reposRoot = join(TMP, 'repos');
-      const remotesRoot = join(TMP, 'remotes');
-      await mkdir(reposRoot, { recursive: true });
-      await mkdir(remotesRoot, { recursive: true });
-
-      const projects: Project[] = [
-        {
-          name: 'mealdrop',
-          repo: join(remotesRoot, 'mealdrop.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/mealdrop',
-        },
-        {
-          name: 'wikitok',
-          repo: join(remotesRoot, 'wikitok.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/wikitok',
-          projectDir: 'frontend',
-        },
-      ];
-
-      // Set up bare remotes with some initial content, but do NOT clone them locally.
-      setupBareRemoteWithContent({
-        remoteRoot: join(remotesRoot, 'mealdrop.git'),
-        files: { 'src/index.ts': 'export {};\n' },
-      });
-      setupBareRemoteWithContent({
-        remoteRoot: join(remotesRoot, 'wikitok.git'),
-        files: { 'frontend/src/index.ts': 'export {};\n' },
-      });
-
-      expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
-      expect(existsSync(join(reposRoot, 'wikitok'))).toBe(false);
-
-      await syncBaselines({
-        reposRoot,
-        projects,
-        push: true,
-        log: () => {},
-      });
-
-      expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
-      expect(existsSync(join(reposRoot, 'wikitok', '.git'))).toBe(true);
-
-      expect(readFileSync(join(reposRoot, 'mealdrop', '.storybook', 'main.ts'), 'utf-8')).toContain(
-        './eval-support/*.mdx'
-      );
-      expect(
-        readFileSync(
-          join(reposRoot, 'mealdrop', '.storybook', 'eval-results', 'data.json'),
-          'utf-8'
-        )
-      ).toBe('{}\n');
-
-      expect(
-        readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
-      ).toContain('./eval-support/*.mdx');
-      expect(
-        readFileSync(
-          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
-          'utf-8'
-        )
-      ).toBe('{}\n');
-
-      expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
-        getRemoteHead(join(remotesRoot, 'mealdrop.git'))
-      );
-      expect(getHead(join(reposRoot, 'wikitok'))).toBe(
-        getRemoteHead(join(remotesRoot, 'wikitok.git'))
-      );
+    await syncBaselines({
+      reposRoot,
+      projects,
+      push: true,
+      log: () => {},
     });
 
+    expect(
+      readFileSync(
+        join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'main.ts'),
+        'utf-8'
+      )
+    ).toContain('./eval-support/*.mdx');
+    expect(
+      existsSync(join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'eval-support'))
+    ).toBe(true);
+    expect(
+      readFileSync(
+        join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'eval-results', 'data.json'),
+        'utf-8'
+      )
+    ).toBe('{}\n');
+    expect(getHead(join(reposRoot, 'excalidraw'))).toBe(
+      getRemoteHead(join(remotesRoot, 'excalidraw.git'))
+    );
+  });
+
+  it('auto-clones repos that have not been cloned yet', async () => {
+    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-auto-clone-'));
+    const reposRoot = join(TMP, 'repos');
+    const remotesRoot = join(TMP, 'remotes');
+    await mkdir(reposRoot, { recursive: true });
+    await mkdir(remotesRoot, { recursive: true });
+
+    const projects: Project[] = [
+      {
+        name: 'mealdrop',
+        repo: join(remotesRoot, 'mealdrop.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+      {
+        name: 'wikitok',
+        repo: join(remotesRoot, 'wikitok.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/wikitok',
+        projectDir: 'frontend',
+      },
+    ];
+
+    // Set up bare remotes with some initial content, but do NOT clone them locally.
+    setupBareRemoteWithContent({
+      remoteRoot: join(remotesRoot, 'mealdrop.git'),
+      files: { 'src/index.ts': 'export {};\n' },
+    });
+    setupBareRemoteWithContent({
+      remoteRoot: join(remotesRoot, 'wikitok.git'),
+      files: { 'frontend/src/index.ts': 'export {};\n' },
+    });
+
+    expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
+    expect(existsSync(join(reposRoot, 'wikitok'))).toBe(false);
+
+    await syncBaselines({
+      reposRoot,
+      projects,
+      push: true,
+      log: () => {},
+    });
+
+    expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
+    expect(existsSync(join(reposRoot, 'wikitok', '.git'))).toBe(true);
+
+    expect(readFileSync(join(reposRoot, 'mealdrop', '.storybook', 'main.ts'), 'utf-8')).toContain(
+      './eval-support/*.mdx'
+    );
+    expect(
+      readFileSync(join(reposRoot, 'mealdrop', '.storybook', 'eval-results', 'data.json'), 'utf-8')
+    ).toBe('{}\n');
+
+    expect(
+      readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
+    ).toContain('./eval-support/*.mdx');
+    expect(
+      readFileSync(
+        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
+        'utf-8'
+      )
+    ).toBe('{}\n');
+
+    expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
+      getRemoteHead(join(remotesRoot, 'mealdrop.git'))
+    );
+    expect(getHead(join(reposRoot, 'wikitok'))).toBe(
+      getRemoteHead(join(remotesRoot, 'wikitok.git'))
+    );
+  });
+
+  skipWindows(() => {
     it('fast-forwards a clean target repo before copying the baseline', async () => {
       TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-target-behind-'));
       const reposRoot = join(TMP, 'repos');

--- a/scripts/eval/sync-baselines.test.ts
+++ b/scripts/eval/sync-baselines.test.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { skipWindows } from '../../code/vitest.helpers.ts';
 import { BASELINE_STORYBOOK_FILES } from './lib/baseline-template-files.ts';
 import type { Project } from './lib/projects.ts';
 import { syncBaselines } from './sync-baselines.ts';
@@ -17,487 +18,509 @@ afterEach(() => {
   }
 });
 
-describe('syncBaselines', () => {
-  it('syncs authoritative mealdrop files into root and nested repos, removes old eval-results, and pushes main', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
+skipWindows(() => {
+  describe('syncBaselines', () => {
+    it('syncs authoritative mealdrop files into root and nested repos, removes old eval-results, and pushes main', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
 
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'edgy',
-        repo: join(remotesRoot, 'edgy.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/edgy',
-      },
-      {
-        name: 'wikitok',
-        repo: join(remotesRoot, 'wikitok.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/wikitok',
-        projectDir: 'frontend',
-      },
-    ];
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'edgy',
+          repo: join(remotesRoot, 'edgy.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/edgy',
+        },
+        {
+          name: 'wikitok',
+          repo: join(remotesRoot, 'wikitok.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/wikitok',
+          projectDir: 'frontend',
+        },
+      ];
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.ts',
-      mainContents: [
-        "import type { StorybookConfig } from '@storybook/react-vite';",
-        '',
-        'const config: StorybookConfig = {',
-        "  stories: ['../src/**/*.stories.tsx', './eval-support/*.mdx'],",
-        '};',
-        '',
-        'export default config;',
-      ].join('\n'),
-      evalSupportFiles: {
-        'summary.mdx': "import data from '../../eval-results/data.json';\n\n# Source Summary\n",
-        'transcript.mdx':
-          "import data from '../../eval-results/data.json';\nimport { Transcript } from './transcript';\n\n# Transcript\n\n<Transcript {...data.docs.transcript} />\n",
-        'transcript.tsx': 'export const Transcript = () => null;\n',
-        'transcript.types.ts':
-          'export interface TranscriptProps { messages: unknown[]; prompt: string; promptTokenCount: number; promptCost: number; }\n',
-      },
-      previewContents: "export default { parameters: { a11y: { test: 'todo' } } };\n",
-      rootEvalResultsFiles: {
-        'summary.json': '{ "empty": true }\n',
-        'transcript.json': '[]\n',
-      },
-    });
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.ts',
+        mainContents: [
+          "import type { StorybookConfig } from '@storybook/react-vite';",
+          '',
+          'const config: StorybookConfig = {',
+          "  stories: ['../src/**/*.stories.tsx', './eval-support/*.mdx'],",
+          '};',
+          '',
+          'export default config;',
+        ].join('\n'),
+        evalSupportFiles: {
+          'summary.mdx': "import data from '../../eval-results/data.json';\n\n# Source Summary\n",
+          'transcript.mdx':
+            "import data from '../../eval-results/data.json';\nimport { Transcript } from './transcript';\n\n# Transcript\n\n<Transcript {...data.docs.transcript} />\n",
+          'transcript.tsx': 'export const Transcript = () => null;\n',
+          'transcript.types.ts':
+            'export interface TranscriptProps { messages: unknown[]; prompt: string; promptTokenCount: number; promptCost: number; }\n',
+        },
+        previewContents: "export default { parameters: { a11y: { test: 'todo' } } };\n",
+        rootEvalResultsFiles: {
+          'summary.json': '{ "empty": true }\n',
+          'transcript.json': '[]\n',
+        },
+      });
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'edgy'),
-      remoteRoot: join(remotesRoot, 'edgy.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.js',
-      mainContents: [
-        '/** @type { import("@storybook/react-vite").StorybookConfig } */',
-        'const config = {',
-        "  stories: ['../src/**/*.stories.tsx'],",
-        '};',
-        '',
-        'export default config;',
-      ].join('\n'),
-      evalSupportFiles: {
-        'old-helper.ts': 'export const stale = true;\n',
-      },
-      previewContents: 'export default { parameters: { old: true } };\n',
-      rootEvalResultsFiles: {
-        'data.json': '{}\n',
-        'summary.json': '{ "empty": true }\n',
-      },
-    });
+      setupRepo({
+        repoRoot: join(reposRoot, 'edgy'),
+        remoteRoot: join(remotesRoot, 'edgy.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.js',
+        mainContents: [
+          '/** @type { import("@storybook/react-vite").StorybookConfig } */',
+          'const config = {',
+          "  stories: ['../src/**/*.stories.tsx'],",
+          '};',
+          '',
+          'export default config;',
+        ].join('\n'),
+        evalSupportFiles: {
+          'old-helper.ts': 'export const stale = true;\n',
+        },
+        previewContents: 'export default { parameters: { old: true } };\n',
+        rootEvalResultsFiles: {
+          'data.json': '{}\n',
+          'summary.json': '{ "empty": true }\n',
+        },
+      });
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'wikitok'),
-      remoteRoot: join(remotesRoot, 'wikitok.git'),
-      storybookDir: 'frontend/.storybook',
-      mainFile: 'main.ts',
-      mainContents: [
-        "import type { StorybookConfig } from '@storybook/react-vite';",
-        '',
-        'const config: StorybookConfig = {',
-        '  stories: [',
-        "    '../src/**/*.stories.tsx',",
-        '  ],',
-        '};',
-        '',
-        'export default config;',
-      ].join('\n'),
-      evalSupportFiles: {
-        'old.txt': 'stale\n',
-      },
-      previewContents: 'export default { parameters: { old: true } };\n',
-      rootEvalResultsFiles: {
-        'transcript.json': '[]\n',
-      },
-    });
+      setupRepo({
+        repoRoot: join(reposRoot, 'wikitok'),
+        remoteRoot: join(remotesRoot, 'wikitok.git'),
+        storybookDir: 'frontend/.storybook',
+        mainFile: 'main.ts',
+        mainContents: [
+          "import type { StorybookConfig } from '@storybook/react-vite';",
+          '',
+          'const config: StorybookConfig = {',
+          '  stories: [',
+          "    '../src/**/*.stories.tsx',",
+          '  ],',
+          '};',
+          '',
+          'export default config;',
+        ].join('\n'),
+        evalSupportFiles: {
+          'old.txt': 'stale\n',
+        },
+        previewContents: 'export default { parameters: { old: true } };\n',
+        rootEvalResultsFiles: {
+          'transcript.json': '[]\n',
+        },
+      });
 
-    await syncBaselines({
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
-    });
-
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-    ).toContain('../eval-results/data.json');
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-    ).toContain('# Eval Summary');
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-    ).toContain("{data.project?.name ?? '-'}");
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
-        'utf-8'
-      )
-    ).toContain('../eval-results/data.json');
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
-        'utf-8'
-      )
-    ).toContain(
-      "<Transcript {...(data.docs?.transcript ?? { prompt: '', promptTokenCount: 0, promptCost: 0, messages: [] })} />"
-    );
-
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'), 'utf-8')
-    ).toBe('{}\n');
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
-        'utf-8'
-      )
-    ).toBe('{}\n');
-
-    expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
-    expect(existsSync(join(reposRoot, 'wikitok', 'frontend', 'eval-results'))).toBe(false);
-    expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'main.js'))).toBe(false);
-    expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'old-helper.ts'))).toBe(
-      false
-    );
-    expect(
-      existsSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'old.txt'))
-    ).toBe(false);
-
-    expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'main.ts'), 'utf-8')).toContain(
-      './eval-support/*.mdx'
-    );
-    expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'preview.tsx'), 'utf-8')).toBe(
-      baselineTemplate('.storybook/preview.tsx')
-    );
-    expect(
-      readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
-    ).toContain('./eval-support/*.mdx');
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'transcript.tsx'), 'utf-8')
-    ).toBe(resultDocTemplate('transcript.tsx'));
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.types.ts'),
-        'utf-8'
-      )
-    ).toBe(resultDocTemplate('transcript.types.ts'));
-
-    expect(getHead(join(reposRoot, 'edgy'))).toBe(getRemoteHead(join(remotesRoot, 'edgy.git')));
-    expect(getHead(join(reposRoot, 'wikitok'))).toBe(
-      getRemoteHead(join(remotesRoot, 'wikitok.git'))
-    );
-  }, 30_000);
-
-  it('fails fast when a non-source target repo is dirty', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-dirty-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
-
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'edgy',
-        repo: join(remotesRoot, 'edgy.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/edgy',
-      },
-    ];
-
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.ts',
-      mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
-      evalSupportFiles: {
-        'summary.mdx': "import data from '../../eval-results/data.json';\n",
-        'transcript.mdx': "import data from '../../eval-results/data.json';\n",
-        'transcript.tsx': 'export const Transcript = () => null;\n',
-        'transcript.types.ts': 'export interface TranscriptProps {}\n',
-      },
-      previewContents: 'export default {};\n',
-      rootEvalResultsFiles: {
-        'summary.json': '{ "empty": true }\n',
-      },
-    });
-
-    setupRepo({
-      repoRoot: join(reposRoot, 'edgy'),
-      remoteRoot: join(remotesRoot, 'edgy.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.js',
-      mainContents: 'export default { stories: [] };\n',
-      evalSupportFiles: {},
-      previewContents: 'export default {};\n',
-      rootEvalResultsFiles: {},
-    });
-
-    writeFileSync(join(reposRoot, 'edgy', 'README.md'), 'dirty\n');
-
-    await expect(
-      syncBaselines({
+      await syncBaselines({
         reposRoot,
         projects,
         push: true,
         log: () => {},
-      })
-    ).rejects.toThrow('edgy has local changes');
+      });
 
-    expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'))).toBe(
-      false
-    );
-    expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
-  });
+      expect(
+        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+      ).toContain('../eval-results/data.json');
+      expect(
+        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+      ).toContain('# Eval Summary');
+      expect(
+        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+      ).toContain("{data.project?.name ?? '-'}");
+      expect(
+        readFileSync(
+          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
+          'utf-8'
+        )
+      ).toContain('../eval-results/data.json');
+      expect(
+        readFileSync(
+          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
+          'utf-8'
+        )
+      ).toContain(
+        "<Transcript {...(data.docs?.transcript ?? { prompt: '', promptTokenCount: 0, promptCost: 0, messages: [] })} />"
+      );
 
-  it('syncs nested project baselines even when there is no legacy eval-results directory', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-nested-no-legacy-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
+      expect(
+        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'), 'utf-8')
+      ).toBe('{}\n');
+      expect(
+        readFileSync(
+          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
+          'utf-8'
+        )
+      ).toBe('{}\n');
 
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'excalidraw',
-        repo: join(remotesRoot, 'excalidraw.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/excalidraw',
-        projectDir: 'excalidraw-app',
-      },
-    ];
+      expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
+      expect(existsSync(join(reposRoot, 'wikitok', 'frontend', 'eval-results'))).toBe(false);
+      expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'main.js'))).toBe(false);
+      expect(
+        existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'old-helper.ts'))
+      ).toBe(false);
+      expect(
+        existsSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'old.txt'))
+      ).toBe(false);
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.ts',
-      mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
-      evalSupportFiles: {
-        'summary.mdx': '# Source Summary\n',
-        'transcript.mdx': '# Transcript\n',
-        'transcript.tsx': 'export const Transcript = () => null;\n',
-        'transcript.types.ts': 'export interface TranscriptProps {}\n',
-      },
-      previewContents: 'export default {};\n',
-      rootEvalResultsFiles: {
-        'summary.json': '{ "empty": true }\n',
-      },
+      expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'main.ts'), 'utf-8')).toContain(
+        './eval-support/*.mdx'
+      );
+      expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'preview.tsx'), 'utf-8')).toBe(
+        baselineTemplate('.storybook/preview.tsx')
+      );
+      expect(
+        readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
+      ).toContain('./eval-support/*.mdx');
+      expect(
+        readFileSync(
+          join(reposRoot, 'edgy', '.storybook', 'eval-support', 'transcript.tsx'),
+          'utf-8'
+        )
+      ).toBe(resultDocTemplate('transcript.tsx'));
+      expect(
+        readFileSync(
+          join(
+            reposRoot,
+            'wikitok',
+            'frontend',
+            '.storybook',
+            'eval-support',
+            'transcript.types.ts'
+          ),
+          'utf-8'
+        )
+      ).toBe(resultDocTemplate('transcript.types.ts'));
+
+      expect(getHead(join(reposRoot, 'edgy'))).toBe(getRemoteHead(join(remotesRoot, 'edgy.git')));
+      expect(getHead(join(reposRoot, 'wikitok'))).toBe(
+        getRemoteHead(join(remotesRoot, 'wikitok.git'))
+      );
+    }, 30_000);
+
+    it('fails fast when a non-source target repo is dirty', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-dirty-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
+
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'edgy',
+          repo: join(remotesRoot, 'edgy.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/edgy',
+        },
+      ];
+
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.ts',
+        mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
+        evalSupportFiles: {
+          'summary.mdx': "import data from '../../eval-results/data.json';\n",
+          'transcript.mdx': "import data from '../../eval-results/data.json';\n",
+          'transcript.tsx': 'export const Transcript = () => null;\n',
+          'transcript.types.ts': 'export interface TranscriptProps {}\n',
+        },
+        previewContents: 'export default {};\n',
+        rootEvalResultsFiles: {
+          'summary.json': '{ "empty": true }\n',
+        },
+      });
+
+      setupRepo({
+        repoRoot: join(reposRoot, 'edgy'),
+        remoteRoot: join(remotesRoot, 'edgy.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.js',
+        mainContents: 'export default { stories: [] };\n',
+        evalSupportFiles: {},
+        previewContents: 'export default {};\n',
+        rootEvalResultsFiles: {},
+      });
+
+      writeFileSync(join(reposRoot, 'edgy', 'README.md'), 'dirty\n');
+
+      await expect(
+        syncBaselines({
+          reposRoot,
+          projects,
+          push: true,
+          log: () => {},
+        })
+      ).rejects.toThrow('edgy has local changes');
+
+      expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'))).toBe(
+        false
+      );
+      expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
     });
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'excalidraw'),
-      remoteRoot: join(remotesRoot, 'excalidraw.git'),
-      storybookDir: 'excalidraw-app/.storybook',
-      mainFile: 'main.ts',
-      mainContents: 'export default { stories: ["../stories/**/*.stories.tsx"] };\n',
-      evalSupportFiles: {},
-      previewContents: 'export default { parameters: { old: true } };\n',
-      rootEvalResultsFiles: {},
+    it('syncs nested project baselines even when there is no legacy eval-results directory', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-nested-no-legacy-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
+
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'excalidraw',
+          repo: join(remotesRoot, 'excalidraw.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/excalidraw',
+          projectDir: 'excalidraw-app',
+        },
+      ];
+
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.ts',
+        mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
+        evalSupportFiles: {
+          'summary.mdx': '# Source Summary\n',
+          'transcript.mdx': '# Transcript\n',
+          'transcript.tsx': 'export const Transcript = () => null;\n',
+          'transcript.types.ts': 'export interface TranscriptProps {}\n',
+        },
+        previewContents: 'export default {};\n',
+        rootEvalResultsFiles: {
+          'summary.json': '{ "empty": true }\n',
+        },
+      });
+
+      setupRepo({
+        repoRoot: join(reposRoot, 'excalidraw'),
+        remoteRoot: join(remotesRoot, 'excalidraw.git'),
+        storybookDir: 'excalidraw-app/.storybook',
+        mainFile: 'main.ts',
+        mainContents: 'export default { stories: ["../stories/**/*.stories.tsx"] };\n',
+        evalSupportFiles: {},
+        previewContents: 'export default { parameters: { old: true } };\n',
+        rootEvalResultsFiles: {},
+      });
+
+      await syncBaselines({
+        reposRoot,
+        projects,
+        push: true,
+        log: () => {},
+      });
+
+      expect(
+        readFileSync(
+          join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'main.ts'),
+          'utf-8'
+        )
+      ).toContain('./eval-support/*.mdx');
+      expect(
+        existsSync(join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'eval-support'))
+      ).toBe(true);
+      expect(
+        readFileSync(
+          join(
+            reposRoot,
+            'excalidraw',
+            'excalidraw-app',
+            '.storybook',
+            'eval-results',
+            'data.json'
+          ),
+          'utf-8'
+        )
+      ).toBe('{}\n');
+      expect(getHead(join(reposRoot, 'excalidraw'))).toBe(
+        getRemoteHead(join(remotesRoot, 'excalidraw.git'))
+      );
     });
 
-    await syncBaselines({
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
+    it('auto-clones repos that have not been cloned yet', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-auto-clone-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
+
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'wikitok',
+          repo: join(remotesRoot, 'wikitok.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/wikitok',
+          projectDir: 'frontend',
+        },
+      ];
+
+      // Set up bare remotes with some initial content, but do NOT clone them locally.
+      setupBareRemoteWithContent({
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        files: { 'src/index.ts': 'export {};\n' },
+      });
+      setupBareRemoteWithContent({
+        remoteRoot: join(remotesRoot, 'wikitok.git'),
+        files: { 'frontend/src/index.ts': 'export {};\n' },
+      });
+
+      expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
+      expect(existsSync(join(reposRoot, 'wikitok'))).toBe(false);
+
+      await syncBaselines({
+        reposRoot,
+        projects,
+        push: true,
+        log: () => {},
+      });
+
+      expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
+      expect(existsSync(join(reposRoot, 'wikitok', '.git'))).toBe(true);
+
+      expect(readFileSync(join(reposRoot, 'mealdrop', '.storybook', 'main.ts'), 'utf-8')).toContain(
+        './eval-support/*.mdx'
+      );
+      expect(
+        readFileSync(
+          join(reposRoot, 'mealdrop', '.storybook', 'eval-results', 'data.json'),
+          'utf-8'
+        )
+      ).toBe('{}\n');
+
+      expect(
+        readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
+      ).toContain('./eval-support/*.mdx');
+      expect(
+        readFileSync(
+          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
+          'utf-8'
+        )
+      ).toBe('{}\n');
+
+      expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
+        getRemoteHead(join(remotesRoot, 'mealdrop.git'))
+      );
+      expect(getHead(join(reposRoot, 'wikitok'))).toBe(
+        getRemoteHead(join(remotesRoot, 'wikitok.git'))
+      );
     });
 
-    expect(
-      readFileSync(
-        join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'main.ts'),
-        'utf-8'
-      )
-    ).toContain('./eval-support/*.mdx');
-    expect(
-      existsSync(join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'eval-support'))
-    ).toBe(true);
-    expect(
-      readFileSync(
-        join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'eval-results', 'data.json'),
-        'utf-8'
-      )
-    ).toBe('{}\n');
-    expect(getHead(join(reposRoot, 'excalidraw'))).toBe(
-      getRemoteHead(join(remotesRoot, 'excalidraw.git'))
-    );
-  });
+    it('fast-forwards a clean target repo before copying the baseline', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-target-behind-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
 
-  it('auto-clones repos that have not been cloned yet', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-auto-clone-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'edgy',
+          repo: join(remotesRoot, 'edgy.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/edgy',
+        },
+      ];
 
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'wikitok',
-        repo: join(remotesRoot, 'wikitok.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/wikitok',
-        projectDir: 'frontend',
-      },
-    ];
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.ts',
+        mainContents: 'export default { stories: [] };\n',
+        evalSupportFiles: {
+          'summary.mdx': '# Old Summary\n',
+          'transcript.mdx': '# Transcript\n',
+          'transcript.tsx': 'export const Transcript = () => null;\n',
+          'transcript.types.ts': 'export interface TranscriptProps {}\n',
+        },
+        previewContents: 'export default {};\n',
+        rootEvalResultsFiles: {
+          'summary.json': '{ "empty": true }\n',
+        },
+      });
 
-    // Set up bare remotes with some initial content, but do NOT clone them locally.
-    setupBareRemoteWithContent({
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      files: { 'src/index.ts': 'export {};\n' },
+      setupRepo({
+        repoRoot: join(reposRoot, 'edgy'),
+        remoteRoot: join(remotesRoot, 'edgy.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.ts',
+        mainContents: 'export default { stories: [] };\n',
+        evalSupportFiles: {},
+        previewContents: 'export default {};\n',
+        rootEvalResultsFiles: {},
+      });
+
+      const targetRemoteWorktree = join(TMP, 'edgy-remote-worktree');
+      execFileSync('git', ['clone', join(remotesRoot, 'edgy.git'), targetRemoteWorktree]);
+      execFileSync('git', ['-C', targetRemoteWorktree, 'config', 'user.name', 'Test User']);
+      execFileSync('git', ['-C', targetRemoteWorktree, 'config', 'user.email', 'test@example.com']);
+      writeFileSync(join(targetRemoteWorktree, 'README.md'), 'updated upstream\n');
+      execFileSync('git', ['-C', targetRemoteWorktree, 'add', '-A']);
+      execFileSync('git', ['-C', targetRemoteWorktree, 'commit', '-m', 'update target upstream']);
+      execFileSync('git', ['-C', targetRemoteWorktree, 'push', 'origin', 'main']);
+
+      await syncBaselines({
+        reposRoot,
+        projects,
+        push: true,
+        log: () => {},
+      });
+
+      expect(
+        readFileSync(
+          join(reposRoot, 'mealdrop', '.storybook', 'eval-support', 'summary.mdx'),
+          'utf-8'
+        )
+      ).toBe(baselineTemplate('.storybook/eval-support/summary.mdx'));
+      expect(
+        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+      ).toBe(baselineTemplate('.storybook/eval-support/summary.mdx'));
+      expect(
+        readFileSync(join(reposRoot, 'edgy', 'README.md'), 'utf-8').replace(/\r\n/g, '\n')
+      ).toBe('updated upstream\n');
+      expect(getHead(join(reposRoot, 'edgy'))).toBe(getRemoteHead(join(remotesRoot, 'edgy.git')));
     });
-    setupBareRemoteWithContent({
-      remoteRoot: join(remotesRoot, 'wikitok.git'),
-      files: { 'frontend/src/index.ts': 'export {};\n' },
-    });
-
-    expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
-    expect(existsSync(join(reposRoot, 'wikitok'))).toBe(false);
-
-    await syncBaselines({
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
-    });
-
-    expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
-    expect(existsSync(join(reposRoot, 'wikitok', '.git'))).toBe(true);
-
-    expect(readFileSync(join(reposRoot, 'mealdrop', '.storybook', 'main.ts'), 'utf-8')).toContain(
-      './eval-support/*.mdx'
-    );
-    expect(
-      readFileSync(join(reposRoot, 'mealdrop', '.storybook', 'eval-results', 'data.json'), 'utf-8')
-    ).toBe('{}\n');
-
-    expect(
-      readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
-    ).toContain('./eval-support/*.mdx');
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
-        'utf-8'
-      )
-    ).toBe('{}\n');
-
-    expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
-      getRemoteHead(join(remotesRoot, 'mealdrop.git'))
-    );
-    expect(getHead(join(reposRoot, 'wikitok'))).toBe(
-      getRemoteHead(join(remotesRoot, 'wikitok.git'))
-    );
-  });
-
-  it('fast-forwards a clean target repo before copying the baseline', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-target-behind-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
-
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'edgy',
-        repo: join(remotesRoot, 'edgy.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/edgy',
-      },
-    ];
-
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.ts',
-      mainContents: 'export default { stories: [] };\n',
-      evalSupportFiles: {
-        'summary.mdx': '# Old Summary\n',
-        'transcript.mdx': '# Transcript\n',
-        'transcript.tsx': 'export const Transcript = () => null;\n',
-        'transcript.types.ts': 'export interface TranscriptProps {}\n',
-      },
-      previewContents: 'export default {};\n',
-      rootEvalResultsFiles: {
-        'summary.json': '{ "empty": true }\n',
-      },
-    });
-
-    setupRepo({
-      repoRoot: join(reposRoot, 'edgy'),
-      remoteRoot: join(remotesRoot, 'edgy.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.ts',
-      mainContents: 'export default { stories: [] };\n',
-      evalSupportFiles: {},
-      previewContents: 'export default {};\n',
-      rootEvalResultsFiles: {},
-    });
-
-    const targetRemoteWorktree = join(TMP, 'edgy-remote-worktree');
-    execFileSync('git', ['clone', join(remotesRoot, 'edgy.git'), targetRemoteWorktree]);
-    execFileSync('git', ['-C', targetRemoteWorktree, 'config', 'user.name', 'Test User']);
-    execFileSync('git', ['-C', targetRemoteWorktree, 'config', 'user.email', 'test@example.com']);
-    writeFileSync(join(targetRemoteWorktree, 'README.md'), 'updated upstream\n');
-    execFileSync('git', ['-C', targetRemoteWorktree, 'add', '-A']);
-    execFileSync('git', ['-C', targetRemoteWorktree, 'commit', '-m', 'update target upstream']);
-    execFileSync('git', ['-C', targetRemoteWorktree, 'push', 'origin', 'main']);
-
-    await syncBaselines({
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
-    });
-
-    expect(
-      readFileSync(
-        join(reposRoot, 'mealdrop', '.storybook', 'eval-support', 'summary.mdx'),
-        'utf-8'
-      )
-    ).toBe(baselineTemplate('.storybook/eval-support/summary.mdx'));
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-    ).toBe(baselineTemplate('.storybook/eval-support/summary.mdx'));
-    expect(readFileSync(join(reposRoot, 'edgy', 'README.md'), 'utf-8').replace(/\r\n/g, '\n')).toBe(
-      'updated upstream\n'
-    );
-    expect(getHead(join(reposRoot, 'edgy'))).toBe(getRemoteHead(join(remotesRoot, 'edgy.git')));
   });
 });
 

--- a/scripts/eval/sync-storybook-version.test.ts
+++ b/scripts/eval/sync-storybook-version.test.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { skipWindows } from '../../code/vitest.helpers.ts';
 import type { Project } from './lib/projects.ts';
 import { syncStorybookVersion } from './sync-storybook-version.ts';
 
@@ -16,398 +17,400 @@ afterEach(() => {
   }
 });
 
-describe('syncStorybookVersion', () => {
-  it('runs the upgrade for each project, commits, and pushes', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
+skipWindows(() => {
+  describe('syncStorybookVersion', () => {
+    it('runs the upgrade for each project, commits, and pushes', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
 
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'wikitok',
-        repo: join(remotesRoot, 'wikitok.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/wikitok',
-        projectDir: 'frontend',
-      },
-    ];
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'wikitok',
+          repo: join(remotesRoot, 'wikitok.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/wikitok',
+          projectDir: 'frontend',
+        },
+      ];
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      packageJsonPath: 'package.json',
-      packageJson: {
-        name: 'mealdrop',
-        dependencies: { '@storybook/react-vite': '9.0.0', storybook: '9.0.0' },
-      },
-    });
-    setupRepo({
-      repoRoot: join(reposRoot, 'wikitok'),
-      remoteRoot: join(remotesRoot, 'wikitok.git'),
-      packageJsonPath: 'frontend/package.json',
-      packageJson: {
-        name: 'wikitok-frontend',
-        dependencies: { '@storybook/react-vite': '9.0.0', storybook: '9.0.0' },
-      },
-    });
-
-    const upgradeCalls: Array<{
-      version: string;
-      project: string;
-      repoRoot: string;
-      projectPath: string;
-      configDir: string;
-    }> = [];
-
-    const hookOrder: string[] = [];
-
-    const results = await syncStorybookVersion({
-      version: '9.1.0',
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
-      installProjectDeps: async ({ project }) => {
-        hookOrder.push(`install:${project.name}`);
-      },
-      runUpgrade: async ({ version, project, repoRoot, projectPath, configDir }) => {
-        hookOrder.push(`upgrade:${project.name}`);
-        upgradeCalls.push({
-          version,
-          project: project.name,
-          repoRoot,
-          projectPath,
-          configDir,
-        });
-        const pkgPath = join(projectPath, 'package.json');
-        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-        for (const key of Object.keys(pkg.dependencies ?? {})) {
-          if (key === 'storybook' || key.startsWith('@storybook/')) {
-            pkg.dependencies[key] = version;
-          }
-        }
-        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-      },
-    });
-
-    expect(hookOrder).toEqual([
-      'install:mealdrop',
-      'upgrade:mealdrop',
-      'install:mealdrop',
-      'install:wikitok',
-      'upgrade:wikitok',
-      'install:wikitok',
-    ]);
-
-    expect(upgradeCalls).toEqual([
-      {
-        version: '9.1.0',
-        project: 'mealdrop',
+      setupRepo({
         repoRoot: join(reposRoot, 'mealdrop'),
-        projectPath: join(reposRoot, 'mealdrop'),
-        configDir: '.storybook',
-      },
-      {
-        version: '9.1.0',
-        project: 'wikitok',
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        packageJsonPath: 'package.json',
+        packageJson: {
+          name: 'mealdrop',
+          dependencies: { '@storybook/react-vite': '9.0.0', storybook: '9.0.0' },
+        },
+      });
+      setupRepo({
         repoRoot: join(reposRoot, 'wikitok'),
-        projectPath: join(reposRoot, 'wikitok', 'frontend'),
-        configDir: 'frontend/.storybook',
-      },
-    ]);
+        remoteRoot: join(remotesRoot, 'wikitok.git'),
+        packageJsonPath: 'frontend/package.json',
+        packageJson: {
+          name: 'wikitok-frontend',
+          dependencies: { '@storybook/react-vite': '9.0.0', storybook: '9.0.0' },
+        },
+      });
 
-    const mealdropPkg = JSON.parse(
-      readFileSync(join(reposRoot, 'mealdrop', 'package.json'), 'utf-8')
-    );
-    const wikitokPkg = JSON.parse(
-      readFileSync(join(reposRoot, 'wikitok', 'frontend', 'package.json'), 'utf-8')
-    );
-    expect(mealdropPkg.dependencies.storybook).toBe('9.1.0');
-    expect(mealdropPkg.dependencies['@storybook/react-vite']).toBe('9.1.0');
-    expect(wikitokPkg.dependencies.storybook).toBe('9.1.0');
-    expect(wikitokPkg.dependencies['@storybook/react-vite']).toBe('9.1.0');
+      const upgradeCalls: Array<{
+        version: string;
+        project: string;
+        repoRoot: string;
+        projectPath: string;
+        configDir: string;
+      }> = [];
 
-    expect(results.map((r) => r.project)).toEqual(['mealdrop', 'wikitok']);
-    expect(results.every((r) => r.changed)).toBe(true);
-    expect(results.every((r) => typeof r.commitSha === 'string' && r.commitSha.length > 0)).toBe(
-      true
-    );
+      const hookOrder: string[] = [];
 
-    expect(getLatestCommitMessage(join(reposRoot, 'mealdrop'))).toBe(
-      'Eval: upgrade Storybook to 9.1.0'
-    );
-    expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
-      getRemoteHead(join(remotesRoot, 'mealdrop.git'))
-    );
-    expect(getHead(join(reposRoot, 'wikitok'))).toBe(
-      getRemoteHead(join(remotesRoot, 'wikitok.git'))
-    );
-  });
+      const results = await syncStorybookVersion({
+        version: '9.1.0',
+        reposRoot,
+        projects,
+        push: true,
+        log: () => {},
+        installProjectDeps: async ({ project }) => {
+          hookOrder.push(`install:${project.name}`);
+        },
+        runUpgrade: async ({ version, project, repoRoot, projectPath, configDir }) => {
+          hookOrder.push(`upgrade:${project.name}`);
+          upgradeCalls.push({
+            version,
+            project: project.name,
+            repoRoot,
+            projectPath,
+            configDir,
+          });
+          const pkgPath = join(projectPath, 'package.json');
+          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+          for (const key of Object.keys(pkg.dependencies ?? {})) {
+            if (key === 'storybook' || key.startsWith('@storybook/')) {
+              pkg.dependencies[key] = version;
+            }
+          }
+          writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+        },
+      });
 
-  it('reports no change and skips commit when upgrade does not modify files', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-noop-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
+      expect(hookOrder).toEqual([
+        'install:mealdrop',
+        'upgrade:mealdrop',
+        'install:mealdrop',
+        'install:wikitok',
+        'upgrade:wikitok',
+        'install:wikitok',
+      ]);
 
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-    ];
+      expect(upgradeCalls).toEqual([
+        {
+          version: '9.1.0',
+          project: 'mealdrop',
+          repoRoot: join(reposRoot, 'mealdrop'),
+          projectPath: join(reposRoot, 'mealdrop'),
+          configDir: '.storybook',
+        },
+        {
+          version: '9.1.0',
+          project: 'wikitok',
+          repoRoot: join(reposRoot, 'wikitok'),
+          projectPath: join(reposRoot, 'wikitok', 'frontend'),
+          configDir: 'frontend/.storybook',
+        },
+      ]);
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      packageJsonPath: 'package.json',
-      packageJson: {
-        name: 'mealdrop',
-        dependencies: { storybook: '9.1.0' },
-      },
+      const mealdropPkg = JSON.parse(
+        readFileSync(join(reposRoot, 'mealdrop', 'package.json'), 'utf-8')
+      );
+      const wikitokPkg = JSON.parse(
+        readFileSync(join(reposRoot, 'wikitok', 'frontend', 'package.json'), 'utf-8')
+      );
+      expect(mealdropPkg.dependencies.storybook).toBe('9.1.0');
+      expect(mealdropPkg.dependencies['@storybook/react-vite']).toBe('9.1.0');
+      expect(wikitokPkg.dependencies.storybook).toBe('9.1.0');
+      expect(wikitokPkg.dependencies['@storybook/react-vite']).toBe('9.1.0');
+
+      expect(results.map((r) => r.project)).toEqual(['mealdrop', 'wikitok']);
+      expect(results.every((r) => r.changed)).toBe(true);
+      expect(results.every((r) => typeof r.commitSha === 'string' && r.commitSha.length > 0)).toBe(
+        true
+      );
+
+      expect(getLatestCommitMessage(join(reposRoot, 'mealdrop'))).toBe(
+        'Eval: upgrade Storybook to 9.1.0'
+      );
+      expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
+        getRemoteHead(join(remotesRoot, 'mealdrop.git'))
+      );
+      expect(getHead(join(reposRoot, 'wikitok'))).toBe(
+        getRemoteHead(join(remotesRoot, 'wikitok.git'))
+      );
     });
 
-    const headBefore = getHead(join(reposRoot, 'mealdrop'));
+    it('reports no change and skips commit when upgrade does not modify files', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-noop-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
 
-    const results = await syncStorybookVersion({
-      version: '9.1.0',
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
-      installProjectDeps: async () => {},
-      runUpgrade: async () => {},
-    });
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+      ];
 
-    expect(results).toEqual([{ project: 'mealdrop', changed: false }]);
-    expect(getHead(join(reposRoot, 'mealdrop'))).toBe(headBefore);
-  });
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        packageJsonPath: 'package.json',
+        packageJson: {
+          name: 'mealdrop',
+          dependencies: { storybook: '9.1.0' },
+        },
+      });
 
-  it('fails fast when a target repo is dirty', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-dirty-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
+      const headBefore = getHead(join(reposRoot, 'mealdrop'));
 
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-    ];
-
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      packageJsonPath: 'package.json',
-      packageJson: {
-        name: 'mealdrop',
-        dependencies: { storybook: '9.0.0' },
-      },
-    });
-
-    writeFileSync(join(reposRoot, 'mealdrop', 'README.md'), 'dirty\n');
-
-    const upgradeCalls: string[] = [];
-
-    await expect(
-      syncStorybookVersion({
+      const results = await syncStorybookVersion({
         version: '9.1.0',
         reposRoot,
         projects,
         push: true,
         log: () => {},
         installProjectDeps: async () => {},
-        runUpgrade: async ({ project }) => {
-          upgradeCalls.push(project.name);
+        runUpgrade: async () => {},
+      });
+
+      expect(results).toEqual([{ project: 'mealdrop', changed: false }]);
+      expect(getHead(join(reposRoot, 'mealdrop'))).toBe(headBefore);
+    });
+
+    it('fails fast when a target repo is dirty', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-dirty-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
+
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
         },
-      })
-    ).rejects.toThrow('mealdrop has local changes');
+      ];
 
-    expect(upgradeCalls).toEqual([]);
-  });
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        packageJsonPath: 'package.json',
+        packageJson: {
+          name: 'mealdrop',
+          dependencies: { storybook: '9.0.0' },
+        },
+      });
 
-  it('auto-clones repos that have not been cloned yet', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-auto-clone-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
+      writeFileSync(join(reposRoot, 'mealdrop', 'README.md'), 'dirty\n');
 
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-    ];
+      const upgradeCalls: string[] = [];
 
-    setupBareRemoteWithContent({
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      files: {
-        'package.json': `${JSON.stringify(
-          { name: 'mealdrop', dependencies: { storybook: '9.0.0' } },
-          null,
-          2
-        )}\n`,
-      },
+      await expect(
+        syncStorybookVersion({
+          version: '9.1.0',
+          reposRoot,
+          projects,
+          push: true,
+          log: () => {},
+          installProjectDeps: async () => {},
+          runUpgrade: async ({ project }) => {
+            upgradeCalls.push(project.name);
+          },
+        })
+      ).rejects.toThrow('mealdrop has local changes');
+
+      expect(upgradeCalls).toEqual([]);
     });
 
-    expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
+    it('auto-clones repos that have not been cloned yet', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-auto-clone-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
 
-    const results = await syncStorybookVersion({
-      version: '9.1.0',
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
-      installProjectDeps: async () => {},
-      runUpgrade: async ({ version, projectPath }) => {
-        const pkgPath = join(projectPath, 'package.json');
-        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-        pkg.dependencies.storybook = version;
-        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-      },
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+      ];
+
+      setupBareRemoteWithContent({
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        files: {
+          'package.json': `${JSON.stringify(
+            { name: 'mealdrop', dependencies: { storybook: '9.0.0' } },
+            null,
+            2
+          )}\n`,
+        },
+      });
+
+      expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
+
+      const results = await syncStorybookVersion({
+        version: '9.1.0',
+        reposRoot,
+        projects,
+        push: true,
+        log: () => {},
+        installProjectDeps: async () => {},
+        runUpgrade: async ({ version, projectPath }) => {
+          const pkgPath = join(projectPath, 'package.json');
+          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+          pkg.dependencies.storybook = version;
+          writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+        },
+      });
+
+      expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
+      const pkg = JSON.parse(readFileSync(join(reposRoot, 'mealdrop', 'package.json'), 'utf-8'));
+      expect(pkg.dependencies.storybook).toBe('9.1.0');
+      expect(results).toEqual([
+        { project: 'mealdrop', changed: true, commitSha: getHead(join(reposRoot, 'mealdrop')) },
+      ]);
+      expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
+        getRemoteHead(join(remotesRoot, 'mealdrop.git'))
+      );
     });
 
-    expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
-    const pkg = JSON.parse(readFileSync(join(reposRoot, 'mealdrop', 'package.json'), 'utf-8'));
-    expect(pkg.dependencies.storybook).toBe('9.1.0');
-    expect(results).toEqual([
-      { project: 'mealdrop', changed: true, commitSha: getHead(join(reposRoot, 'mealdrop')) },
-    ]);
-    expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
-      getRemoteHead(join(remotesRoot, 'mealdrop.git'))
-    );
-  });
+    it('honors push=false by committing locally but not pushing', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-skip-push-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
 
-  it('honors push=false by committing locally but not pushing', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-skip-push-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+      ];
 
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-    ];
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        packageJsonPath: 'package.json',
+        packageJson: {
+          name: 'mealdrop',
+          dependencies: { storybook: '9.0.0' },
+        },
+      });
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      packageJsonPath: 'package.json',
-      packageJson: {
-        name: 'mealdrop',
-        dependencies: { storybook: '9.0.0' },
-      },
+      const remoteHeadBefore = getRemoteHead(join(remotesRoot, 'mealdrop.git'));
+
+      await syncStorybookVersion({
+        version: '9.1.0',
+        reposRoot,
+        projects,
+        push: false,
+        log: () => {},
+        installProjectDeps: async () => {},
+        runUpgrade: async ({ version, projectPath }) => {
+          const pkgPath = join(projectPath, 'package.json');
+          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+          pkg.dependencies.storybook = version;
+          writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+        },
+      });
+
+      const localHead = getHead(join(reposRoot, 'mealdrop'));
+      expect(localHead).not.toBe(remoteHeadBefore);
+      expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(remoteHeadBefore);
     });
 
-    const remoteHeadBefore = getRemoteHead(join(remotesRoot, 'mealdrop.git'));
+    it('pushes an existing local upgrade commit on a rerun after skip-push', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-resume-push-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
 
-    await syncStorybookVersion({
-      version: '9.1.0',
-      reposRoot,
-      projects,
-      push: false,
-      log: () => {},
-      installProjectDeps: async () => {},
-      runUpgrade: async ({ version, projectPath }) => {
-        const pkgPath = join(projectPath, 'package.json');
-        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-        pkg.dependencies.storybook = version;
-        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-      },
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+      ];
+
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        packageJsonPath: 'package.json',
+        packageJson: {
+          name: 'mealdrop',
+          dependencies: { storybook: '9.0.0' },
+        },
+      });
+
+      const remoteHeadBefore = getRemoteHead(join(remotesRoot, 'mealdrop.git'));
+
+      await syncStorybookVersion({
+        version: '9.1.0',
+        reposRoot,
+        projects,
+        push: false,
+        log: () => {},
+        installProjectDeps: async () => {},
+        runUpgrade: async ({ version, projectPath }) => {
+          const pkgPath = join(projectPath, 'package.json');
+          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+          pkg.dependencies.storybook = version;
+          writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+        },
+      });
+
+      const localHead = getHead(join(reposRoot, 'mealdrop'));
+      expect(localHead).not.toBe(remoteHeadBefore);
+      expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(remoteHeadBefore);
+
+      const results = await syncStorybookVersion({
+        version: '9.1.0',
+        reposRoot,
+        projects,
+        push: true,
+        log: () => {},
+        installProjectDeps: async () => {},
+        runUpgrade: async ({ version, projectPath }) => {
+          const pkgPath = join(projectPath, 'package.json');
+          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+          pkg.dependencies.storybook = version;
+          writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+        },
+      });
+
+      expect(results).toEqual([{ project: 'mealdrop', changed: true, commitSha: localHead }]);
+      expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(localHead);
     });
-
-    const localHead = getHead(join(reposRoot, 'mealdrop'));
-    expect(localHead).not.toBe(remoteHeadBefore);
-    expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(remoteHeadBefore);
-  });
-
-  it('pushes an existing local upgrade commit on a rerun after skip-push', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-resume-push-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
-
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-    ];
-
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      packageJsonPath: 'package.json',
-      packageJson: {
-        name: 'mealdrop',
-        dependencies: { storybook: '9.0.0' },
-      },
-    });
-
-    const remoteHeadBefore = getRemoteHead(join(remotesRoot, 'mealdrop.git'));
-
-    await syncStorybookVersion({
-      version: '9.1.0',
-      reposRoot,
-      projects,
-      push: false,
-      log: () => {},
-      installProjectDeps: async () => {},
-      runUpgrade: async ({ version, projectPath }) => {
-        const pkgPath = join(projectPath, 'package.json');
-        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-        pkg.dependencies.storybook = version;
-        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-      },
-    });
-
-    const localHead = getHead(join(reposRoot, 'mealdrop'));
-    expect(localHead).not.toBe(remoteHeadBefore);
-    expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(remoteHeadBefore);
-
-    const results = await syncStorybookVersion({
-      version: '9.1.0',
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
-      installProjectDeps: async () => {},
-      runUpgrade: async ({ version, projectPath }) => {
-        const pkgPath = join(projectPath, 'package.json');
-        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-        pkg.dependencies.storybook = version;
-        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-      },
-    });
-
-    expect(results).toEqual([{ project: 'mealdrop', changed: true, commitSha: localHead }]);
-    expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(localHead);
   });
 });
 

--- a/scripts/eval/sync-storybook-version.test.ts
+++ b/scripts/eval/sync-storybook-version.test.ts
@@ -17,8 +17,8 @@ afterEach(() => {
   }
 });
 
-skipWindows(() => {
-  describe('syncStorybookVersion', () => {
+describe('syncStorybookVersion', () => {
+  skipWindows(() => {
     it('runs the upgrade for each project, commits, and pushes', async () => {
       TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-'));
       const reposRoot = join(TMP, 'repos');
@@ -153,264 +153,264 @@ skipWindows(() => {
         getRemoteHead(join(remotesRoot, 'wikitok.git'))
       );
     });
+  });
 
-    it('reports no change and skips commit when upgrade does not modify files', async () => {
-      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-noop-'));
-      const reposRoot = join(TMP, 'repos');
-      const remotesRoot = join(TMP, 'remotes');
-      await mkdir(reposRoot, { recursive: true });
-      await mkdir(remotesRoot, { recursive: true });
+  it('reports no change and skips commit when upgrade does not modify files', async () => {
+    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-noop-'));
+    const reposRoot = join(TMP, 'repos');
+    const remotesRoot = join(TMP, 'remotes');
+    await mkdir(reposRoot, { recursive: true });
+    await mkdir(remotesRoot, { recursive: true });
 
-      const projects: Project[] = [
-        {
-          name: 'mealdrop',
-          repo: join(remotesRoot, 'mealdrop.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/mealdrop',
-        },
-      ];
+    const projects: Project[] = [
+      {
+        name: 'mealdrop',
+        repo: join(remotesRoot, 'mealdrop.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+    ];
 
-      setupRepo({
-        repoRoot: join(reposRoot, 'mealdrop'),
-        remoteRoot: join(remotesRoot, 'mealdrop.git'),
-        packageJsonPath: 'package.json',
-        packageJson: {
-          name: 'mealdrop',
-          dependencies: { storybook: '9.1.0' },
-        },
-      });
+    setupRepo({
+      repoRoot: join(reposRoot, 'mealdrop'),
+      remoteRoot: join(remotesRoot, 'mealdrop.git'),
+      packageJsonPath: 'package.json',
+      packageJson: {
+        name: 'mealdrop',
+        dependencies: { storybook: '9.1.0' },
+      },
+    });
 
-      const headBefore = getHead(join(reposRoot, 'mealdrop'));
+    const headBefore = getHead(join(reposRoot, 'mealdrop'));
 
-      const results = await syncStorybookVersion({
+    const results = await syncStorybookVersion({
+      version: '9.1.0',
+      reposRoot,
+      projects,
+      push: true,
+      log: () => {},
+      installProjectDeps: async () => {},
+      runUpgrade: async () => {},
+    });
+
+    expect(results).toEqual([{ project: 'mealdrop', changed: false }]);
+    expect(getHead(join(reposRoot, 'mealdrop'))).toBe(headBefore);
+  });
+
+  it('fails fast when a target repo is dirty', async () => {
+    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-dirty-'));
+    const reposRoot = join(TMP, 'repos');
+    const remotesRoot = join(TMP, 'remotes');
+    await mkdir(reposRoot, { recursive: true });
+    await mkdir(remotesRoot, { recursive: true });
+
+    const projects: Project[] = [
+      {
+        name: 'mealdrop',
+        repo: join(remotesRoot, 'mealdrop.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+    ];
+
+    setupRepo({
+      repoRoot: join(reposRoot, 'mealdrop'),
+      remoteRoot: join(remotesRoot, 'mealdrop.git'),
+      packageJsonPath: 'package.json',
+      packageJson: {
+        name: 'mealdrop',
+        dependencies: { storybook: '9.0.0' },
+      },
+    });
+
+    writeFileSync(join(reposRoot, 'mealdrop', 'README.md'), 'dirty\n');
+
+    const upgradeCalls: string[] = [];
+
+    await expect(
+      syncStorybookVersion({
         version: '9.1.0',
         reposRoot,
         projects,
         push: true,
         log: () => {},
         installProjectDeps: async () => {},
-        runUpgrade: async () => {},
-      });
+        runUpgrade: async ({ project }) => {
+          upgradeCalls.push(project.name);
+        },
+      })
+    ).rejects.toThrow('mealdrop has local changes');
 
-      expect(results).toEqual([{ project: 'mealdrop', changed: false }]);
-      expect(getHead(join(reposRoot, 'mealdrop'))).toBe(headBefore);
+    expect(upgradeCalls).toEqual([]);
+  });
+
+  it('auto-clones repos that have not been cloned yet', async () => {
+    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-auto-clone-'));
+    const reposRoot = join(TMP, 'repos');
+    const remotesRoot = join(TMP, 'remotes');
+    await mkdir(reposRoot, { recursive: true });
+    await mkdir(remotesRoot, { recursive: true });
+
+    const projects: Project[] = [
+      {
+        name: 'mealdrop',
+        repo: join(remotesRoot, 'mealdrop.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+    ];
+
+    setupBareRemoteWithContent({
+      remoteRoot: join(remotesRoot, 'mealdrop.git'),
+      files: {
+        'package.json': `${JSON.stringify(
+          { name: 'mealdrop', dependencies: { storybook: '9.0.0' } },
+          null,
+          2
+        )}\n`,
+      },
     });
 
-    it('fails fast when a target repo is dirty', async () => {
-      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-dirty-'));
-      const reposRoot = join(TMP, 'repos');
-      const remotesRoot = join(TMP, 'remotes');
-      await mkdir(reposRoot, { recursive: true });
-      await mkdir(remotesRoot, { recursive: true });
+    expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
 
-      const projects: Project[] = [
-        {
-          name: 'mealdrop',
-          repo: join(remotesRoot, 'mealdrop.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/mealdrop',
-        },
-      ];
-
-      setupRepo({
-        repoRoot: join(reposRoot, 'mealdrop'),
-        remoteRoot: join(remotesRoot, 'mealdrop.git'),
-        packageJsonPath: 'package.json',
-        packageJson: {
-          name: 'mealdrop',
-          dependencies: { storybook: '9.0.0' },
-        },
-      });
-
-      writeFileSync(join(reposRoot, 'mealdrop', 'README.md'), 'dirty\n');
-
-      const upgradeCalls: string[] = [];
-
-      await expect(
-        syncStorybookVersion({
-          version: '9.1.0',
-          reposRoot,
-          projects,
-          push: true,
-          log: () => {},
-          installProjectDeps: async () => {},
-          runUpgrade: async ({ project }) => {
-            upgradeCalls.push(project.name);
-          },
-        })
-      ).rejects.toThrow('mealdrop has local changes');
-
-      expect(upgradeCalls).toEqual([]);
+    const results = await syncStorybookVersion({
+      version: '9.1.0',
+      reposRoot,
+      projects,
+      push: true,
+      log: () => {},
+      installProjectDeps: async () => {},
+      runUpgrade: async ({ version, projectPath }) => {
+        const pkgPath = join(projectPath, 'package.json');
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        pkg.dependencies.storybook = version;
+        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+      },
     });
 
-    it('auto-clones repos that have not been cloned yet', async () => {
-      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-auto-clone-'));
-      const reposRoot = join(TMP, 'repos');
-      const remotesRoot = join(TMP, 'remotes');
-      await mkdir(reposRoot, { recursive: true });
-      await mkdir(remotesRoot, { recursive: true });
+    expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
+    const pkg = JSON.parse(readFileSync(join(reposRoot, 'mealdrop', 'package.json'), 'utf-8'));
+    expect(pkg.dependencies.storybook).toBe('9.1.0');
+    expect(results).toEqual([
+      { project: 'mealdrop', changed: true, commitSha: getHead(join(reposRoot, 'mealdrop')) },
+    ]);
+    expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
+      getRemoteHead(join(remotesRoot, 'mealdrop.git'))
+    );
+  });
 
-      const projects: Project[] = [
-        {
-          name: 'mealdrop',
-          repo: join(remotesRoot, 'mealdrop.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/mealdrop',
-        },
-      ];
+  it('honors push=false by committing locally but not pushing', async () => {
+    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-skip-push-'));
+    const reposRoot = join(TMP, 'repos');
+    const remotesRoot = join(TMP, 'remotes');
+    await mkdir(reposRoot, { recursive: true });
+    await mkdir(remotesRoot, { recursive: true });
 
-      setupBareRemoteWithContent({
-        remoteRoot: join(remotesRoot, 'mealdrop.git'),
-        files: {
-          'package.json': `${JSON.stringify(
-            { name: 'mealdrop', dependencies: { storybook: '9.0.0' } },
-            null,
-            2
-          )}\n`,
-        },
-      });
+    const projects: Project[] = [
+      {
+        name: 'mealdrop',
+        repo: join(remotesRoot, 'mealdrop.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+    ];
 
-      expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
-
-      const results = await syncStorybookVersion({
-        version: '9.1.0',
-        reposRoot,
-        projects,
-        push: true,
-        log: () => {},
-        installProjectDeps: async () => {},
-        runUpgrade: async ({ version, projectPath }) => {
-          const pkgPath = join(projectPath, 'package.json');
-          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-          pkg.dependencies.storybook = version;
-          writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-        },
-      });
-
-      expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
-      const pkg = JSON.parse(readFileSync(join(reposRoot, 'mealdrop', 'package.json'), 'utf-8'));
-      expect(pkg.dependencies.storybook).toBe('9.1.0');
-      expect(results).toEqual([
-        { project: 'mealdrop', changed: true, commitSha: getHead(join(reposRoot, 'mealdrop')) },
-      ]);
-      expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
-        getRemoteHead(join(remotesRoot, 'mealdrop.git'))
-      );
+    setupRepo({
+      repoRoot: join(reposRoot, 'mealdrop'),
+      remoteRoot: join(remotesRoot, 'mealdrop.git'),
+      packageJsonPath: 'package.json',
+      packageJson: {
+        name: 'mealdrop',
+        dependencies: { storybook: '9.0.0' },
+      },
     });
 
-    it('honors push=false by committing locally but not pushing', async () => {
-      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-skip-push-'));
-      const reposRoot = join(TMP, 'repos');
-      const remotesRoot = join(TMP, 'remotes');
-      await mkdir(reposRoot, { recursive: true });
-      await mkdir(remotesRoot, { recursive: true });
+    const remoteHeadBefore = getRemoteHead(join(remotesRoot, 'mealdrop.git'));
 
-      const projects: Project[] = [
-        {
-          name: 'mealdrop',
-          repo: join(remotesRoot, 'mealdrop.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/mealdrop',
-        },
-      ];
-
-      setupRepo({
-        repoRoot: join(reposRoot, 'mealdrop'),
-        remoteRoot: join(remotesRoot, 'mealdrop.git'),
-        packageJsonPath: 'package.json',
-        packageJson: {
-          name: 'mealdrop',
-          dependencies: { storybook: '9.0.0' },
-        },
-      });
-
-      const remoteHeadBefore = getRemoteHead(join(remotesRoot, 'mealdrop.git'));
-
-      await syncStorybookVersion({
-        version: '9.1.0',
-        reposRoot,
-        projects,
-        push: false,
-        log: () => {},
-        installProjectDeps: async () => {},
-        runUpgrade: async ({ version, projectPath }) => {
-          const pkgPath = join(projectPath, 'package.json');
-          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-          pkg.dependencies.storybook = version;
-          writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-        },
-      });
-
-      const localHead = getHead(join(reposRoot, 'mealdrop'));
-      expect(localHead).not.toBe(remoteHeadBefore);
-      expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(remoteHeadBefore);
+    await syncStorybookVersion({
+      version: '9.1.0',
+      reposRoot,
+      projects,
+      push: false,
+      log: () => {},
+      installProjectDeps: async () => {},
+      runUpgrade: async ({ version, projectPath }) => {
+        const pkgPath = join(projectPath, 'package.json');
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        pkg.dependencies.storybook = version;
+        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+      },
     });
 
-    it('pushes an existing local upgrade commit on a rerun after skip-push', async () => {
-      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-resume-push-'));
-      const reposRoot = join(TMP, 'repos');
-      const remotesRoot = join(TMP, 'remotes');
-      await mkdir(reposRoot, { recursive: true });
-      await mkdir(remotesRoot, { recursive: true });
+    const localHead = getHead(join(reposRoot, 'mealdrop'));
+    expect(localHead).not.toBe(remoteHeadBefore);
+    expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(remoteHeadBefore);
+  });
 
-      const projects: Project[] = [
-        {
-          name: 'mealdrop',
-          repo: join(remotesRoot, 'mealdrop.git'),
-          branch: 'main',
-          githubSlug: 'storybook-tmp/mealdrop',
-        },
-      ];
+  it('pushes an existing local upgrade commit on a rerun after skip-push', async () => {
+    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-storybook-version-resume-push-'));
+    const reposRoot = join(TMP, 'repos');
+    const remotesRoot = join(TMP, 'remotes');
+    await mkdir(reposRoot, { recursive: true });
+    await mkdir(remotesRoot, { recursive: true });
 
-      setupRepo({
-        repoRoot: join(reposRoot, 'mealdrop'),
-        remoteRoot: join(remotesRoot, 'mealdrop.git'),
-        packageJsonPath: 'package.json',
-        packageJson: {
-          name: 'mealdrop',
-          dependencies: { storybook: '9.0.0' },
-        },
-      });
+    const projects: Project[] = [
+      {
+        name: 'mealdrop',
+        repo: join(remotesRoot, 'mealdrop.git'),
+        branch: 'main',
+        githubSlug: 'storybook-tmp/mealdrop',
+      },
+    ];
 
-      const remoteHeadBefore = getRemoteHead(join(remotesRoot, 'mealdrop.git'));
-
-      await syncStorybookVersion({
-        version: '9.1.0',
-        reposRoot,
-        projects,
-        push: false,
-        log: () => {},
-        installProjectDeps: async () => {},
-        runUpgrade: async ({ version, projectPath }) => {
-          const pkgPath = join(projectPath, 'package.json');
-          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-          pkg.dependencies.storybook = version;
-          writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-        },
-      });
-
-      const localHead = getHead(join(reposRoot, 'mealdrop'));
-      expect(localHead).not.toBe(remoteHeadBefore);
-      expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(remoteHeadBefore);
-
-      const results = await syncStorybookVersion({
-        version: '9.1.0',
-        reposRoot,
-        projects,
-        push: true,
-        log: () => {},
-        installProjectDeps: async () => {},
-        runUpgrade: async ({ version, projectPath }) => {
-          const pkgPath = join(projectPath, 'package.json');
-          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-          pkg.dependencies.storybook = version;
-          writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-        },
-      });
-
-      expect(results).toEqual([{ project: 'mealdrop', changed: true, commitSha: localHead }]);
-      expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(localHead);
+    setupRepo({
+      repoRoot: join(reposRoot, 'mealdrop'),
+      remoteRoot: join(remotesRoot, 'mealdrop.git'),
+      packageJsonPath: 'package.json',
+      packageJson: {
+        name: 'mealdrop',
+        dependencies: { storybook: '9.0.0' },
+      },
     });
+
+    const remoteHeadBefore = getRemoteHead(join(remotesRoot, 'mealdrop.git'));
+
+    await syncStorybookVersion({
+      version: '9.1.0',
+      reposRoot,
+      projects,
+      push: false,
+      log: () => {},
+      installProjectDeps: async () => {},
+      runUpgrade: async ({ version, projectPath }) => {
+        const pkgPath = join(projectPath, 'package.json');
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        pkg.dependencies.storybook = version;
+        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+      },
+    });
+
+    const localHead = getHead(join(reposRoot, 'mealdrop'));
+    expect(localHead).not.toBe(remoteHeadBefore);
+    expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(remoteHeadBefore);
+
+    const results = await syncStorybookVersion({
+      version: '9.1.0',
+      reposRoot,
+      projects,
+      push: true,
+      log: () => {},
+      installProjectDeps: async () => {},
+      runUpgrade: async ({ version, projectPath }) => {
+        const pkgPath = join(projectPath, 'package.json');
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        pkg.dependencies.storybook = version;
+        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+      },
+    });
+
+    expect(results).toEqual([{ project: 'mealdrop', changed: true, commitSha: localHead }]);
+    expect(getRemoteHead(join(remotesRoot, 'mealdrop.git'))).toBe(localHead);
   });
 });
 


### PR DESCRIPTION
#### Manual testing

Passes if the windows UT pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved CLI output-file assertions by comparing against normalized, resolved paths instead of raw strings.
  * Updated Storybook metadata and configuration directory tests to expect resolved absolute paths for default, relative, and absolute cases.
  * Refreshed tool run/help test expectations to include normalized cwd and Storybook config paths for more consistent cross-platform behavior.
* **Documentation**
  * Added a testing guideline to use path resolution for path-related filesystem assertions to avoid Windows inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->