### PR TITLE
ModuleGraph: Stop bumping the graph revision on story-index invalidation

### DIFF
--- a/code/core/src/core-server/change-detection/change-detection-service.test.ts
+++ b/code/core/src/core-server/change-detection/change-detection-service.test.ts
@@ -1085,10 +1085,10 @@ describe('ChangeDetectionService', () => {
     await expect(service.dispose()).resolves.toBeUndefined();
   });
 
-  it('rescans the working tree when the story index is invalidated', async () => {
+  it('rescans the working tree when the module graph revision advances', async () => {
     // Graph-side reconciliation (replaying add/unlink, the refreshInFlight guard) is covered by
-    // module-graph-engine.test.ts; here we assert the status side of the seam: an index
-    // invalidation re-runs the git-diff scan.
+    // module-graph-engine.test.ts; here we assert the status side of the seam: a graph revision
+    // bump (from a file change or story-index reconciliation) re-runs the git-diff scan.
     const reverseIndex = buildReverseIndex([]);
     installDependencyGraphMocks(reverseIndex);
 

--- a/code/core/src/core-server/change-detection/change-detection.test-helpers.ts
+++ b/code/core/src/core-server/change-detection/change-detection.test-helpers.ts
@@ -137,7 +137,6 @@ export function createWiredChangeDetection(
     workingDir: options.workingDir,
     onSnapshot: () => moduleGraphMockRef.current?.applySnapshot(),
     onUpdate: ({ bumpedStoryFiles }) => moduleGraphMockRef.current?.applyUpdate(bumpedStoryFiles),
-    onStoryIndexInvalidated: () => moduleGraphMockRef.current?.bumpGraphRevision(),
     onError: (error) => moduleGraphMockRef.current?.applyError(error),
     onUnavailable: (reason, error) => moduleGraphMockRef.current?.applyUnavailable(reason, error),
   });

--- a/code/core/src/shared/open-service/services/module-graph/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph/definition.ts
@@ -257,19 +257,6 @@ export const moduleGraphServiceDef = defineService({
         });
       },
     },
-    _bumpGraphRevision: {
-      internal: true,
-      description:
-        'Bumps the graph revision when the story index invalidates without an immediate graph snapshot/update.',
-      input: noInputSchema,
-      output: v.void(),
-      handler: async (_input, ctx) => {
-        ctx.self.setState((state) => {
-          state.graphRevision += 1;
-          state.latestChangedStoryFiles = [];
-        });
-      },
-    },
     _setStatus: {
       internal: true,
       description:

--- a/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.test.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.test.ts
@@ -28,7 +28,6 @@ function setup(options?: {
   const callbacks = {
     onSnapshot: vi.fn(),
     onUpdate: vi.fn(),
-    onStoryIndexInvalidated: vi.fn(),
     onError: vi.fn(),
     onUnavailable: vi.fn(),
   };
@@ -230,8 +229,32 @@ describe('ModuleGraphEngine', () => {
     await vi.runAllTimersAsync();
 
     expect(patchSpy).toHaveBeenCalledWith({ kind: 'add', path: '/repo/src/B.stories.tsx' });
-    // The index changed, so the service wrapper is notified to bump graph revision.
-    expect(callbacks.onStoryIndexInvalidated).toHaveBeenCalled();
+    // The replayed add flows through the normal patch path, so the new story is reported as a
+    // targeted update — no separate untargeted index-invalidation bump is needed.
+    expect(callbacks.onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ bumpedStoryFiles: ['./src/B.stories.tsx'] })
+    );
+  });
+
+  it('does not emit an update when an invalidation leaves the story set unchanged', async () => {
+    // A content-only story edit (or a config invalidation) re-fires the index without changing the
+    // set of story files. The builder's own file-change event carries any content change; the
+    // invalidation itself must not produce an untargeted update.
+    installDependencyGraphMocks(buildReverseIndex([]));
+    const { service, adapter, callbacks } = setup({
+      storyIndex: createStoryIndex([
+        { storyId: 'a--default', importPath: './src/A.stories.tsx', title: 'A' },
+      ]),
+    });
+
+    service.start(adapter);
+    await vi.runAllTimersAsync();
+    expect(callbacks.onUpdate).not.toHaveBeenCalled();
+
+    service.onStoryIndexInvalidated();
+    await vi.runAllTimersAsync();
+
+    expect(callbacks.onUpdate).not.toHaveBeenCalled();
   });
 
   it('guards duplicate onStoryIndexInvalidated so a newly-added story is replayed only once', async () => {

--- a/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.ts
@@ -269,11 +269,6 @@ export class ModuleGraphEngine {
           this.refreshInFlight = false;
         });
     }
-    // Index invalidation does not bump the graph revision on its own. Any change that consumers
-    // care about already flows through a precise `onUpdate`: a story-file content edit (including a
-    // story renamed within a file) arrives as a builder file-change event, and a story that entered
-    // or left the index is replayed as an add/unlink by `refreshStoryFiles` above. A blanket bump
-    // here would only add an untargeted revision and clobber the latest changed-story set.
   }
 
   /**

--- a/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.ts
@@ -30,8 +30,6 @@ export interface ModuleGraphEngineOptions {
   onError?: (error: Error) => void;
   /** Fired when the builder adapter reports a startup failure. */
   onUnavailable?: (reason: string, error?: Error) => void;
-  /** Fired when the story index invalidates, even if no graph edges changed. */
-  onStoryIndexInvalidated?: () => void;
   /** Mirrors the built reverse index into the `core/module-graph` open service. */
   onSnapshot?: (storiesByFile: ReturnType<typeof reverseIndexToStoriesByFile>) => void;
   /** Mirrors state after each settled patch; includes story files whose graph may have changed. */
@@ -271,9 +269,11 @@ export class ModuleGraphEngine {
           this.refreshInFlight = false;
         });
     }
-    // The story index changed even when no story files were added/removed (e.g. a story renamed
-    // within a file); signal consumers so derived state is recomputed.
-    this.options.onStoryIndexInvalidated?.();
+    // Index invalidation does not bump the graph revision on its own. Any change that consumers
+    // care about already flows through a precise `onUpdate`: a story-file content edit (including a
+    // story renamed within a file) arrives as a builder file-change event, and a story that entered
+    // or left the index is replayed as an add/unlink by `refreshStoryFiles` above. A blanket bump
+    // here would only add an untargeted revision and clobber the latest changed-story set.
   }
 
   /**

--- a/code/core/src/shared/open-service/services/module-graph/server.test.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.test.ts
@@ -6,6 +6,7 @@ import { clearRegistry } from '../../server.ts';
 import {
   buildReverseIndex,
   createMockAdapter,
+  createStoryIndex,
   installDependencyGraphMocks,
   registerTestModuleGraphService,
 } from './module-graph.test-helpers.ts';
@@ -356,21 +357,6 @@ describe('module-graph open service', () => {
       });
     });
 
-    it('clears story files but keeps the current revision after _bumpGraphRevision', async () => {
-      const runtime = registerBareModuleGraph();
-
-      await runtime.commands._applyGraphUpdate({
-        storiesByFile: {},
-        bumpedStoryFiles: ['./src/Button.stories.tsx'],
-      });
-      await runtime.commands._bumpGraphRevision(undefined);
-
-      expect(runtime.queries.getLatestStoryChanges(undefined)).toEqual({
-        revision: 2,
-        storyFiles: [],
-      });
-    });
-
     it('notifies subscribers when the latest change set updates', async () => {
       const runtime = registerBareModuleGraph();
       const seen: Array<{ revision: number; storyFiles: string[] }> = [];
@@ -432,22 +418,6 @@ describe('module-graph open service', () => {
         })
       ).toBe(1);
       expect(runtime.queries.getGraphRevision({ storyFiles: ['src/Button.stories.tsx'] })).toBe(1);
-    });
-
-    it('advances watch-all but not scoped reads on a bare revision bump', async () => {
-      const runtime = registerBareModuleGraph();
-      await runtime.commands._applyGraphSnapshot({
-        storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
-      });
-
-      await runtime.commands._bumpGraphRevision(undefined);
-
-      // Index reconciliation advances the global (watch-all) revision...
-      expect(runtime.queries.getGraphRevision(undefined)).toBe(1);
-      // ...but is not attributed to any specific story.
-      expect(runtime.queries.getGraphRevision({ storyFiles: ['./src/Button.stories.tsx'] })).toBe(
-        0
-      );
     });
   });
 
@@ -522,18 +492,33 @@ describe('module-graph open service', () => {
     });
 
     // Must run last: it resolves the process-global adapter promise, which cannot be un-resolved.
-    it('builds the graph once the adapter is provided and mirrors it into service state', async () => {
+    it('builds the graph from the adapter and turns index invalidations into targeted updates', async () => {
       const reverseIndex = buildReverseIndex([
         ['/repo/src/Button.tsx', '/repo/src/Button.stories.tsx', 1],
       ]);
       installDependencyGraphMocks(reverseIndex);
 
-      const channel = { on: vi.fn(() => () => undefined), emit: vi.fn() };
+      const baselineIndex = createStoryIndex([
+        { storyId: 'button--primary', importPath: './src/Button.stories.tsx', title: 'Button' },
+      ]);
+      const indexWithCard = createStoryIndex([
+        { storyId: 'button--primary', importPath: './src/Button.stories.tsx', title: 'Button' },
+        { storyId: 'card--primary', importPath: './src/Card.stories.tsx', title: 'Card' },
+      ]);
+      // Build reads the baseline; the first invalidation re-reads it unchanged, the second adds Card.
+      const getIndex = vi
+        .fn()
+        .mockResolvedValueOnce(baselineIndex)
+        .mockResolvedValueOnce(baselineIndex)
+        .mockResolvedValue(indexWithCard);
+
+      const on = vi.fn<(event: string, listener: () => void) => () => void>(() => () => undefined);
+      const channel = { on, emit: vi.fn() };
       const { adapter } = createMockAdapter({ resolveConfig: { projectRoot: '/repo' } });
 
       const runtime = registerModuleGraphService({
         channel: channel as never,
-        getIndex: vi.fn().mockResolvedValue({ v: 5, entries: {} }),
+        getIndex,
         workingDir: '/repo',
       });
 
@@ -548,6 +533,30 @@ describe('module-graph open service', () => {
       expect(runtime.queries.getStoriesForFiles({ files: ['/repo/src/Button.tsx'] })).toEqual([
         [{ storyFile: './src/Button.stories.tsx', depth: 1 }],
       ]);
+
+      const invalidate = channel.on.mock.calls.find(
+        ([event]) => event === STORY_INDEX_INVALIDATED
+      )?.[1];
+      expect(invalidate).toBeTypeOf('function');
+
+      // An invalidation that does not change the story set must not advance the revision on its own
+      // (no untargeted bump, no clobbered change set).
+      invalidate!();
+      await runtime.commands._waitForSettledEngine(undefined);
+      expect(runtime.queries.getGraphRevision(undefined)).toBe(0);
+      expect(runtime.queries.getLatestStoryChanges(undefined)).toEqual({
+        revision: 0,
+        storyFiles: [],
+      });
+
+      // A newly-indexed story is reconciled and reported as a targeted change.
+      invalidate!();
+      await vi.waitFor(() => {
+        expect(runtime.queries.getLatestStoryChanges(undefined)).toEqual({
+          revision: 1,
+          storyFiles: ['./src/Card.stories.tsx'],
+        });
+      });
     });
   });
 });

--- a/code/core/src/shared/open-service/services/module-graph/server.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.ts
@@ -78,9 +78,6 @@ export function registerModuleGraphService(options: RegisterModuleGraphServiceOp
     onUpdate: ({ storiesByFile, bumpedStoryFiles }) => {
       void runtime.commands._applyGraphUpdate({ storiesByFile, bumpedStoryFiles });
     },
-    onStoryIndexInvalidated: () => {
-      void runtime.commands._bumpGraphRevision(undefined);
-    },
     onError: (error) => {
       void runtime.commands._setStatus({ value: 'error', error: errorToErrorLike(error) });
     },


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

A story-index invalidation (any story file save, story add/remove/rename, or a `preview.*` config change) fired an untargeted `_bumpGraphRevision` on the `core/module-graph` service. That coarse bump advanced the global graph revision **and** reset `latestChangedStoryFiles` to empty.

That blanket bump is redundant with the precise change paths the engine already has:

- A **content edit** to a story file (or a story renamed within a file) arrives as a builder file-change event → `_applyGraphUpdate` with the affected story files.
- A story **entering or leaving** the index is replayed as an `add`/`unlink` by `refreshStoryFiles` → `_applyGraphUpdate` with the affected story files.

Because the coarse bump runs concurrently with those targeted updates, it races them and can clobber the latest changed-story set back to empty. `getLatestStoryChanges` subscribers (e.g. docgen) that key off that set then intermittently miss a refresh after a story save.

This PR:

- Removes the `_bumpGraphRevision` command and the engine `onStoryIndexInvalidated` callback (the coarse bump).
- Keeps the `STORY_INDEX_INVALIDATED` → `refreshStoryFiles` reconciliation, so newly added / removed story roots are still walked and reported as targeted updates.

I verified the targeting empirically in a live `react-vite/default-ts` sandbox (temporary engine instrumentation): editing a story file, a directly-imported component, and a deep transitive dependency each produced the correct targeted `bumpedStoryFiles` through the builder file-change path alone, while `STORY_INDEX_INVALIDATED` only ever fired for story-file saves.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox with the docgen server enabled, e.g. `yarn task sandbox --template react-vite/default-ts --start-from auto` (the default sandbox already sets `features.experimentalDocgenServer` and `features.changeDetection`).
2. Open Storybook and select a story; open the Code panel.
3. Edit the story file (e.g. change an arg or add a comment) and save. The Code panel snippet should update without needing a manual reload.
4. Edit a component imported by the story and save. The component's docgen/controls should update.
5. Add a new `*.stories.tsx` file; it should appear in the sidebar and its docgen/snippets should populate.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35178-sha-a7b9e5e7`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35178-sha-a7b9e5e7 sandbox` or in an existing project with `npx storybook@0.0.0-pr-35178-sha-a7b9e5e7 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35178-sha-a7b9e5e7`](https://npmjs.com/package/storybook/v/0.0.0-pr-35178-sha-a7b9e5e7) |
| **Triggered by** | @JReinhold |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`jeppe-cursor/module-graph-drop-coarse-bump`](https://github.com/storybookjs/storybook/tree/jeppe-cursor/module-graph-drop-coarse-bump) |
| **Commit** | [`a7b9e5e7`](https://github.com/storybookjs/storybook/commit/a7b9e5e7d1f3caf5b34798be55123723c51e922c) |
| **Datetime** | Wed Jun 17 07:46:38 UTC 2026 (`1781682398`) |
| **Workflow run** | [27673858090](https://github.com/storybookjs/storybook/actions/runs/27673858090) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35178`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection so graph revisions advance only when story files actually change, avoiding unnecessary refresh work when the story index is invalidated but the indexed story set remains the same.
  * Updated reconciliation behavior to emit focused update events for newly discovered story files instead of relying on story-index invalidation callbacks.
* **Tests**
  * Updated and added test coverage to verify the new invalidation/update trigger behavior and revision advancement rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->