### PR TITLE
Docs: Improve DocsParameters types

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Stories.tsx
@@ -9,6 +9,7 @@ import { DocsContext } from './DocsContext';
 import { DocsStory } from './DocsStory';
 import { Heading } from './Heading';
 import { withMdxComponentOverride } from './with-mdx-component-override';
+import type { DocsParameters } from '../../types.ts';
 
 interface StoriesProps {
   title?: ReactElement | string;
@@ -35,7 +36,8 @@ const StoriesImpl: FC<StoriesProps> = ({ title = 'Stories', includePrimary = tru
   const { componentStories, projectAnnotations, getStoryContext } = useContext(DocsContext);
 
   let stories = componentStories();
-  const { stories: { filter } = { filter: undefined } } = projectAnnotations.parameters?.docs || {};
+  const filter = (projectAnnotations.parameters as DocsParameters | undefined)?.docs?.stories
+    ?.filter;
   if (filter) {
     stories = stories.filter((story) => filter(story, getStoryContext(story)));
   }

--- a/code/addons/docs/src/types.ts
+++ b/code/addons/docs/src/types.ts
@@ -1,6 +1,13 @@
 import type { ComponentType } from 'react';
 
-import type { ModuleExport, ModuleExports } from 'storybook/internal/types';
+import type {
+  Args,
+  DocsContextProps,
+  ModuleExport,
+  ModuleExports,
+  PreparedStory,
+  Renderer,
+} from 'storybook/internal/types';
 
 import type { ThemeVars } from 'storybook/theming';
 
@@ -29,6 +36,16 @@ type StoryBlockParameters = {
    * attached, the primary (first) story will be rendered.
    */
   of: ModuleExport;
+};
+
+type StoriesBlockParameters = {
+  /**
+   * Custom filter function for determining which stories to include in a <Stories> block
+   */
+  filter?: <TRenderer extends Renderer = Renderer, TArgs = Args>(
+    Story: PreparedStory<TRenderer>,
+    Context: ReturnType<DocsContextProps['getStoryContext']>
+  ) => boolean;
 };
 
 type ControlsBlockParameters = {
@@ -216,11 +233,18 @@ export interface DocsParameters {
     source?: Partial<SourceBlockParameters>;
 
     /**
-     * Story configuration
+     * Story block configuration
      *
      * @see https://storybook.js.org/docs/api/doc-blocks/doc-block-story
      */
     story?: Partial<StoryBlockParameters>;
+
+    /**
+     * Stories block configuration
+     *
+     * @see https://storybook.js.org/docs/api/doc-blocks/doc-block-stories
+     */
+    stories?: Partial<StoriesBlockParameters>;
 
     /**
      * The subtitle displayed when shown in docs page


### PR DESCRIPTION
## What I did

I wanted to exercise this useful bit of code:

https://github.com/storybookjs/storybook/blob/ff9d956b4c5971356747b5f90fa2e00015336852/code/addons/docs/src/blocks/blocks/Stories.tsx#L38-L41

However, I noticed that it was missing from the `DocsParameters` types, so I added it. Simple, right?

## Can of Worms

This filter function is defined for and used in the `Stories` block. However, that filter is not applied to `usePrimaryStory`:
https://github.com/storybookjs/storybook/blob/ff9d956b4c5971356747b5f90fa2e00015336852/code/addons/docs/src/blocks/blocks/usePrimaryStory.ts#L13-L20

Which is a shame, as it would be useful to define in a single place a filter for stories on the docs autodocs blocks.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests
- [x] type checking 

#### Manual testing

No manual testing required


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes (well, docstrings at least)
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added story filtering capabilities to documentation blocks, allowing a filter callback to control which stories are shown.
  * Introduced an optional `docs.stories` configuration parameter (typed) to support granular story selection.
  * Maintains compatibility with the existing `docs.story` option.
* **Bug Fixes**
  * Improved safe behavior when `docs`/`stories` configuration is not provided, preventing missing configuration from causing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->