### PR TITLE
Docgen: Fix inferred argTypes from initial args overriding docgen and custom argTypes in experimentalDocgenServer mode

### DIFF
--- a/code/core/src/controls/components/ControlsPanel.tsx
+++ b/code/core/src/controls/components/ControlsPanel.tsx
@@ -156,9 +156,9 @@ function ServiceControlsPanel({
   const storyData = api.getCurrentStoryData();
   const [, , , initialArgs] = useArgs();
   const [docgenReady, setDocgenReady] = useState(false);
-  // Custom argTypes (project + meta + story, already inferred) for the selected story arrive over
-  // the channel via STORY_PREPARED — the same source the legacy panel reads. The service only needs
-  // to contribute server-extracted component props.
+  // Custom argTypes (project + meta + story annotations) for the selected story arrive over the
+  // channel via STORY_PREPARED. With experimentalDocgenServer, prepareStory skips second-pass
+  // enhancers so these stay annotation-only; mergeServiceArgTypes layers them on server docgen.
   const customArgTypes = useArgTypes();
   const id = storyData.id.split('--')[0];
   // `useServiceQuery` mis-infers its types for services with more than one query (it unifies across

--- a/code/core/src/docs-tools/argTypes/docgenServiceArgTypes.test.ts
+++ b/code/core/src/docs-tools/argTypes/docgenServiceArgTypes.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeServiceArgTypes } from './docgenServiceArgTypes.ts';
+
+describe('mergeServiceArgTypes', () => {
+  const payload = {
+    id: 'button',
+    name: 'Button',
+    path: './Button.tsx',
+    jsDocTags: {},
+    stories: [],
+    argTypes: {
+      size: {
+        name: 'size',
+        type: { name: 'enum' as const, value: ['small', 'medium', 'large'] },
+      },
+      label: {
+        name: 'label',
+        type: { name: 'string' as const },
+      },
+    },
+  };
+
+  it('preserves enum control when story args include an enum value', () => {
+    const result = mergeServiceArgTypes({
+      payload,
+      storyId: 'example-button--large',
+      parameters: { __isArgsStory: true },
+      initialArgs: { size: 'large', label: 'Button' },
+      customArgTypes: {
+        backgroundColor: { control: 'color' },
+        // prepareStory already ran inferArgTypes with size in initialArgs
+        size: { name: 'size', type: { name: 'string' }, control: { type: 'text' } },
+      },
+    });
+
+    expect(result.size?.type).toEqual({ name: 'enum', value: ['small', 'medium', 'large'] });
+    expect(result.size?.control).toEqual({ type: 'radio' });
+  });
+
+  it('keeps user-authored argType overrides that are not type inference', () => {
+    const result = mergeServiceArgTypes({
+      payload,
+      storyId: 'example-button--large',
+      parameters: { __isArgsStory: true },
+      initialArgs: { size: 'large', label: 'Button' },
+      customArgTypes: {
+        size: {
+          name: 'size',
+          type: { name: 'string' },
+          control: { type: 'text' },
+          description: 'How large should the button be?',
+        },
+      },
+    });
+
+    expect(result.size?.type).toEqual({ name: 'enum', value: ['small', 'medium', 'large'] });
+    expect(result.size?.control).toEqual({ type: 'radio' });
+    expect(result.size?.description).toBe('How large should the button be?');
+  });
+
+  it('preserves enum control when story args omit the enum prop', () => {
+    const result = mergeServiceArgTypes({
+      payload,
+      storyId: 'example-button--primary',
+      parameters: { __isArgsStory: true },
+      initialArgs: { label: 'Button', primary: true },
+      customArgTypes: {
+        backgroundColor: { control: 'color' },
+      },
+    });
+
+    expect(result.size?.type).toEqual({ name: 'enum', value: ['small', 'medium', 'large'] });
+    expect(result.size?.control).toEqual({ type: 'radio' });
+  });
+});

--- a/code/core/src/docs-tools/argTypes/docgenServiceArgTypes.test.ts
+++ b/code/core/src/docs-tools/argTypes/docgenServiceArgTypes.test.ts
@@ -29,8 +29,6 @@ describe('mergeServiceArgTypes', () => {
       initialArgs: { size: 'large', label: 'Button' },
       customArgTypes: {
         backgroundColor: { control: 'color' },
-        // prepareStory already ran inferArgTypes with size in initialArgs
-        size: { name: 'size', type: { name: 'string' }, control: { type: 'text' } },
       },
     });
 
@@ -38,7 +36,7 @@ describe('mergeServiceArgTypes', () => {
     expect(result.size?.control).toEqual({ type: 'radio' });
   });
 
-  it('keeps user-authored argType overrides that are not type inference', () => {
+  it('keeps user-authored argType overrides from annotations', () => {
     const result = mergeServiceArgTypes({
       payload,
       storyId: 'example-button--large',
@@ -46,9 +44,6 @@ describe('mergeServiceArgTypes', () => {
       initialArgs: { size: 'large', label: 'Button' },
       customArgTypes: {
         size: {
-          name: 'size',
-          type: { name: 'string' },
-          control: { type: 'text' },
           description: 'How large should the button be?',
         },
       },
@@ -57,6 +52,21 @@ describe('mergeServiceArgTypes', () => {
     expect(result.size?.type).toEqual({ name: 'enum', value: ['small', 'medium', 'large'] });
     expect(result.size?.control).toEqual({ type: 'radio' });
     expect(result.size?.description).toBe('How large should the button be?');
+  });
+
+  it('respects user control overrides over inferred controls', () => {
+    const result = mergeServiceArgTypes({
+      payload,
+      storyId: 'example-button--large',
+      parameters: { __isArgsStory: true },
+      initialArgs: { size: 'large', label: 'Button' },
+      customArgTypes: {
+        size: { control: 'select' },
+      },
+    });
+
+    expect(result.size?.type).toEqual({ name: 'enum', value: ['small', 'medium', 'large'] });
+    expect(result.size?.control).toBe('select');
   });
 
   it('preserves enum control when story args omit the enum prop', () => {

--- a/code/core/src/docs-tools/argTypes/docgenServiceArgTypes.ts
+++ b/code/core/src/docs-tools/argTypes/docgenServiceArgTypes.ts
@@ -14,41 +14,15 @@ import { combineParameters } from '../../preview-api/modules/store/parameters.ts
 /**
  * Builds the Controls/ArgTypes table shape from server docgen and custom argTypes.
  *
- * The server payload contributes component prop extraction (`payload.argTypes`); custom argTypes
- * (project + meta + story annotations, already inferred by `prepareStory`) are merged so extracted
- * prop types win over arg-inferred types from `prepareStory`. Callers source custom argTypes from
- * the prepared meta/story they already hold — the docs blocks resolve it locally through `useOf`
- * (as `StrictArgTypes`), the manager Controls panel reads it from the `STORY_PREPARED` channel via
- * `useArgTypes` (as the looser `ArgTypes`); both are accepted here and normalized by the inference
- * passes below.
+ * Mirrors the legacy `prepareStory` enhancer chain when `experimentalDocgenServer` is enabled:
+ * server docgen stands in for `enhanceArgTypes`, user annotations from `customArgTypes` layer on
+ * top, then `inferArgTypes` and `inferControls` run the second pass that `prepareStory` skips.
  *
- * `inferArgTypes` fills in rows for args that only exist in `initialArgs`, and `inferControls`
- * assigns the default control widget from each final argType's type/options — mirroring the
- * second-pass enhancers that run in `prepareStory`.
+ * Callers source custom argTypes from the prepared meta/story they already hold — the docs blocks
+ * resolve it locally through `useOf` (as `StrictArgTypes`), the manager Controls panel reads it
+ * from the `STORY_PREPARED` channel via `useArgTypes` (as the looser `ArgTypes`); both are
+ * accepted here and normalized by the inference passes below.
  */
-function stripPrepareStoryInference(
-  customArgTypes: ArgTypes | undefined,
-  docgenArgTypes: ArgTypes | undefined
-): ArgTypes | undefined {
-  if (!customArgTypes) {
-    return customArgTypes;
-  }
-
-  return Object.fromEntries(
-    Object.entries(customArgTypes).flatMap(([key, argType]) => {
-      if (!argType || !docgenArgTypes?.[key]?.type || !argType.type) {
-        return [[key, argType]];
-      }
-
-      const userOverrides = { ...argType };
-      delete userOverrides.type;
-      delete userOverrides.control;
-      delete userOverrides.options;
-      return Object.keys(userOverrides).length > 0 ? [[key, userOverrides]] : [];
-    })
-  );
-}
-
 export function mergeServiceArgTypes({
   payload,
   storyId,
@@ -63,10 +37,7 @@ export function mergeServiceArgTypes({
   initialArgs?: Args;
   customArgTypes?: ArgTypes;
 }): StrictArgTypes {
-  const merged = combineParameters(
-    stripPrepareStoryInference(customArgTypes, payload.argTypes) ?? {},
-    payload.argTypes ?? {}
-  ) as StrictArgTypes;
+  const merged = combineParameters(payload.argTypes ?? {}, customArgTypes ?? {}) as StrictArgTypes;
 
   const withInferredTypes = inferArgTypes({
     id: storyId,

--- a/code/core/src/docs-tools/argTypes/docgenServiceArgTypes.ts
+++ b/code/core/src/docs-tools/argTypes/docgenServiceArgTypes.ts
@@ -15,16 +15,40 @@ import { combineParameters } from '../../preview-api/modules/store/parameters.ts
  * Builds the Controls/ArgTypes table shape from server docgen and custom argTypes.
  *
  * The server payload contributes component prop extraction (`payload.argTypes`); custom argTypes
- * (project + meta + story annotations, already inferred by `prepareStory`) are layered on top via
- * `customArgTypes`. Callers source those from the prepared meta/story they already hold — the docs
- * blocks resolve it locally through `useOf` (as `StrictArgTypes`), the manager Controls panel reads
- * it from the `STORY_PREPARED` channel via `useArgTypes` (as the looser `ArgTypes`); both are
- * accepted here and normalized by the inference passes below.
+ * (project + meta + story annotations, already inferred by `prepareStory`) are merged so extracted
+ * prop types win over arg-inferred types from `prepareStory`. Callers source custom argTypes from
+ * the prepared meta/story they already hold — the docs blocks resolve it locally through `useOf`
+ * (as `StrictArgTypes`), the manager Controls panel reads it from the `STORY_PREPARED` channel via
+ * `useArgTypes` (as the looser `ArgTypes`); both are accepted here and normalized by the inference
+ * passes below.
  *
  * `inferArgTypes` fills in rows for args that only exist in `initialArgs`, and `inferControls`
  * assigns the default control widget from each final argType's type/options — mirroring the
  * second-pass enhancers that run in `prepareStory`.
  */
+function stripPrepareStoryInference(
+  customArgTypes: ArgTypes | undefined,
+  docgenArgTypes: ArgTypes | undefined
+): ArgTypes | undefined {
+  if (!customArgTypes) {
+    return customArgTypes;
+  }
+
+  return Object.fromEntries(
+    Object.entries(customArgTypes).flatMap(([key, argType]) => {
+      if (!argType || !docgenArgTypes?.[key]?.type || !argType.type) {
+        return [[key, argType]];
+      }
+
+      const userOverrides = { ...argType };
+      delete userOverrides.type;
+      delete userOverrides.control;
+      delete userOverrides.options;
+      return Object.keys(userOverrides).length > 0 ? [[key, userOverrides]] : [];
+    })
+  );
+}
+
 export function mergeServiceArgTypes({
   payload,
   storyId,
@@ -39,7 +63,10 @@ export function mergeServiceArgTypes({
   initialArgs?: Args;
   customArgTypes?: ArgTypes;
 }): StrictArgTypes {
-  const merged = combineParameters(payload.argTypes ?? {}, customArgTypes ?? {}) as StrictArgTypes;
+  const merged = combineParameters(
+    stripPrepareStoryInference(customArgTypes, payload.argTypes) ?? {},
+    payload.argTypes ?? {}
+  ) as StrictArgTypes;
 
   const withInferredTypes = inferArgTypes({
     id: storyId,

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
@@ -11,8 +11,6 @@ import type {
   StoryContext,
 } from 'storybook/internal/types';
 
-import { global } from '@storybook/global';
-
 import type { UserEventObject } from 'storybook/test';
 
 import { Tag } from '../../../../shared/constants/tags.ts';
@@ -23,9 +21,7 @@ import { normalizeProjectAnnotations } from './normalizeProjectAnnotations.ts';
 import { prepareContext, prepareMeta, prepareStory as realPrepareStory } from './prepareStory.ts';
 
 vi.mock('@storybook/global', async (importOriginal) => ({
-  global: {
-    ...(await importOriginal<typeof import('@storybook/global')>()),
-  },
+  ...(await importOriginal<typeof import('@storybook/global')>()),
 }));
 
 const id = 'id';
@@ -618,8 +614,13 @@ describe('prepareStory', () => {
 
   describe('with `FEATURES.argTypeTargetsV7`', () => {
     beforeEach(() => {
-      global.FEATURES = { argTypeTargetsV7: true };
+      vi.stubGlobal('FEATURES', { argTypeTargetsV7: true });
     });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     it('filters out targeted args', () => {
       const renderMock = vi.fn();
       const firstStory = prepareStory(
@@ -728,11 +729,11 @@ describe('prepareStory', () => {
 
   describe('with `FEATURES.experimentalDocgenServer`', () => {
     beforeEach(() => {
-      global.FEATURES = { experimentalDocgenServer: true };
+      vi.stubGlobal('FEATURES', { experimentalDocgenServer: true });
     });
 
     afterEach(() => {
-      global.FEATURES = {};
+      vi.unstubAllGlobals();
     });
 
     it('skips second-pass argTypes enhancers so args are not inferred in prepareStory', () => {

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
@@ -20,9 +20,7 @@ import { composeConfigs } from './composeConfigs.ts';
 import { normalizeProjectAnnotations } from './normalizeProjectAnnotations.ts';
 import { prepareContext, prepareMeta, prepareStory as realPrepareStory } from './prepareStory.ts';
 
-vi.mock('@storybook/global', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@storybook/global')>()),
-}));
+vi.mock('@storybook/global', { spy: true });
 
 const id = 'id';
 const name = 'name';
@@ -747,12 +745,12 @@ describe('prepareStory', () => {
         {
           id,
           title,
-          argTypes: { backgroundColor: { control: 'color' } },
+          argTypes: { backgroundColor: { name: 'backgroundColor', control: 'color' } },
         },
         { render }
       );
 
-      expect(argTypes.backgroundColor).toEqual({ control: 'color' });
+      expect(argTypes.backgroundColor).toEqual({ name: 'backgroundColor', control: 'color' });
       expect(argTypes.size).toBeUndefined();
       expect(argTypes.label).toBeUndefined();
     });
@@ -768,12 +766,12 @@ describe('prepareStory', () => {
         {
           id,
           title,
-          argTypes: { size: { control: 'select' } },
+          argTypes: { size: { name: 'size', control: 'select' } },
         },
         { render }
       );
 
-      expect(argTypes.size).toEqual({ control: 'select' });
+      expect(argTypes.size).toEqual({ name: 'size', control: 'select' });
       expect(argTypes.size?.type).toBeUndefined();
     });
   });

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type {
   ArgsEnhancer,
@@ -723,6 +723,57 @@ describe('prepareStory', () => {
       const context = prepareContext({ args: firstStory.initialArgs, globals: {}, ...firstStory });
       firstStory.unboundStoryFn(addExtraContext(context));
       expect(renderMock).toHaveBeenCalledWith({}, expect.objectContaining({ argsByTarget: {} }));
+    });
+  });
+
+  describe('with `FEATURES.experimentalDocgenServer`', () => {
+    beforeEach(() => {
+      global.FEATURES = { experimentalDocgenServer: true };
+    });
+
+    afterEach(() => {
+      global.FEATURES = {};
+    });
+
+    it('skips second-pass argTypes enhancers so args are not inferred in prepareStory', () => {
+      const { argTypes } = prepareStory(
+        {
+          id,
+          name,
+          args: { size: 'large', label: 'Button' },
+          moduleExport,
+        },
+        {
+          id,
+          title,
+          argTypes: { backgroundColor: { control: 'color' } },
+        },
+        { render }
+      );
+
+      expect(argTypes.backgroundColor).toEqual({ control: 'color' });
+      expect(argTypes.size).toBeUndefined();
+      expect(argTypes.label).toBeUndefined();
+    });
+
+    it('keeps user-authored control overrides without inferring types from args', () => {
+      const { argTypes } = prepareStory(
+        {
+          id,
+          name,
+          args: { size: 'large' },
+          moduleExport,
+        },
+        {
+          id,
+          title,
+          argTypes: { size: { control: 'select' } },
+        },
+        { render }
+      );
+
+      expect(argTypes.size).toEqual({ control: 'select' });
+      expect(argTypes.size?.type).toBeUndefined();
     });
   });
 });

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.ts
@@ -265,11 +265,20 @@ function preparePartialAnnotations<TRenderer extends Renderer>(
     storyGlobals,
   };
 
-  contextForEnhancers.argTypes = argTypesEnhancers.reduce(
-    (accumulatedArgTypes, enhancer) =>
-      enhancer({ ...contextForEnhancers, argTypes: accumulatedArgTypes }),
-    contextForEnhancers.argTypes
-  );
+  contextForEnhancers.argTypes = argTypesEnhancers
+    .filter((enhancer) => {
+      // Server docgen merges component prop metadata at UI read time (`mergeServiceArgTypes`).
+      // Second-pass enhancers run there instead so `customArgTypes` stays annotation-only.
+      if (global.FEATURES?.experimentalDocgenServer && enhancer.secondPass) {
+        return false;
+      }
+      return true;
+    })
+    .reduce(
+      (accumulatedArgTypes, enhancer) =>
+        enhancer({ ...contextForEnhancers, argTypes: accumulatedArgTypes }),
+      contextForEnhancers.argTypes
+    );
 
   const initialArgsBeforeEnhancers = { ...passedArgs };
 

--- a/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
@@ -143,4 +143,27 @@ describe('inferArgTypes', () => {
       },
     });
   });
+
+  it('does not infer types for args that already have an argType', () => {
+    expect(
+      inferArgTypes({
+        initialArgs: {
+          size: 'large',
+        },
+        argTypes: {
+          size: {
+            type: {
+              name: 'enum',
+              value: ['small', 'medium', 'large'],
+            },
+          },
+        },
+      } as any)
+    ).toEqual({
+      size: {
+        name: 'size',
+        type: { name: 'enum', value: ['small', 'medium', 'large'] },
+      },
+    });
+  });
 });

--- a/code/core/src/preview-api/modules/store/inferArgTypes.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.ts
@@ -83,10 +83,17 @@ export const inferArgTypes: ((context: InferArgTypesContext) => StrictArgTypes) 
 } = (context) => {
   const { id, argTypes: userArgTypes = {}, initialArgs = {} } = context;
   const cache = new Map<any, SBType>();
-  const argTypes = mapValues(initialArgs, (arg, key) => ({
-    name: key,
-    type: inferType(arg, `${id}.${key}`, new Set(), cache),
-  }));
+  const argTypes = Object.fromEntries(
+    Object.entries(initialArgs)
+      .filter(([key]) => !userArgTypes[key]?.type)
+      .map(([key, arg]) => [
+        key,
+        {
+          name: key,
+          type: inferType(arg, `${id}.${key}`, new Set(), cache),
+        },
+      ])
+  );
   const userArgTypesNames = mapValues(userArgTypes, (argType, key) => ({
     name: key,
   }));


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed a regression in the Controls table when `experimentalDocgenServer` is enabled. Stories that set an enum prop in `args` (for example the Example Button **Large** story with `size: 'large'`) showed a text control instead of the radio control inferred from the component prop type.
When the docgen server flag is on, `prepareStory` now skips second-pass argTypes enhancers (`inferArgTypes`, `inferControls`) so `customArgTypes` stays annotation-only. `mergeServiceArgTypes` mirrors the legacy pipeline: server docgen as the extracted base, user annotations on top, then inference and control assignment.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Open Storybook in the browser and navigate to the Primary button example: https://635781f3500dd2c49e189caf-yesmdjkodf.chromatic.com/?path=/story/example-button--primary
2. Verify the `size` control is a radio with three options
3. Navigate to the Large story: https://635781f3500dd2c49e189caf-yesmdjkodf.chromatic.com/?path=/story/example-button--large
4. Verify the `size` control is still a radio button with three options. (before, it was a `text` control here)

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35196-sha-b881a098`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35196-sha-b881a098 sandbox` or in an existing project with `npx storybook@0.0.0-pr-35196-sha-b881a098 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35196-sha-b881a098`](https://npmjs.com/package/storybook/v/0.0.0-pr-35196-sha-b881a098) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`jeppe-cursor/fix-docgen-controls-enum-regression-2c03`](https://github.com/storybookjs/storybook/tree/jeppe-cursor/fix-docgen-controls-enum-regression-2c03) |
| **Commit** | [`b881a098`](https://github.com/storybookjs/storybook/commit/b881a0987b69faf315f1958011b0e945d3a5cd22) |
| **Datetime** | Tue Jun 23 12:04:13 UTC 2026 (`1782216253`) |
| **Workflow run** | [28024804272](https://github.com/storybookjs/storybook/actions/runs/28024804272) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35196`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added/extended coverage for argument-type merging and argTypes inference, including enum controls and precedence rules.
  * Added assertions around experimental docgen server behavior for second-pass enhancer handling.

* **Bug Fixes**
  * Improved argument type inference to avoid re-inference when user-authored `argTypes` already specify types.
  * When experimental docgen server is enabled, second-pass `argTypes` enhancers are skipped to prevent overriding expected structure.

* **Documentation**
  * Clarified how custom `argTypes` and controls are layered during story preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->