### PR TITLE
CI: Fix PR description tests

### DIFF
--- a/scripts/dangerfile.js
+++ b/scripts/dangerfile.js
@@ -177,6 +177,7 @@ const checkManualTestingSection = (body) => {
  * - Renaming freeform commits that are missing a changelog category
  * - Cherry-picking PRs with conflicts
  * - Any other task you choose to add during the release process!
+ * @param {string} body
  */
 const checkReleaseChecklist = (body) => {
   if (!isReleasePr) {

--- a/scripts/release/__tests__/generate-pr-description.test.ts
+++ b/scripts/release/__tests__/generate-pr-description.test.ts
@@ -100,20 +100,20 @@ describe('Generate PR Description', () => {
   describe('mapToChangelist', () => {
     it('should return a correct string for patch PRs', () => {
       expect(mapToChangelist({ changes, unpickedPatches: true })).toMatchInlineSnapshot(`
-        "- [ ] **🐛 Bug**: Some PR title for a bug [#42](https://github.com/storybookjs/storybook/pull/42)
-        - [ ] **✨ Feature Request**: Some PR title for a 'new' feature [#48](https://github.com/storybookjs/storybook/pull/48)
+        "- **🐛 Bug**: Some PR title for a bug [#42](https://github.com/storybookjs/storybook/pull/42)
+        - **✨ Feature Request**: Some PR title for a 'new' feature [#48](https://github.com/storybookjs/storybook/pull/48)
         - [ ] **⚠️ Direct commit**: Some title for a "direct commit" [22bb11](https://github.com/storybookjs/storybook/commit/22bb11)
-        - [ ] **📝 Documentation**: Another PR \`title\` for docs [#11](https://github.com/storybookjs/storybook/pull/11)
-        - [ ] **❔ Missing Label**: Some PR title with a missing label [#77](https://github.com/storybookjs/storybook/pull/77)"
+        - **📝 Documentation**: Another PR \`title\` for docs [#11](https://github.com/storybookjs/storybook/pull/11)
+        - **❔ Missing Label**: Some PR title with a missing label [#77](https://github.com/storybookjs/storybook/pull/77)"
       `);
     });
     it('should return a correct string for prerelease PRs', () => {
       expect(mapToChangelist({ changes, unpickedPatches: false })).toMatchInlineSnapshot(`
-        "- [ ] **🐛 Bug**: Some PR title for a bug [#42](https://github.com/storybookjs/storybook/pull/42) (will also be patched)
-        - [ ] **✨ Feature Request**: Some PR title for a 'new' feature [#48](https://github.com/storybookjs/storybook/pull/48)
+        "- **🐛 Bug**: Some PR title for a bug [#42](https://github.com/storybookjs/storybook/pull/42) (will also be patched)
+        - **✨ Feature Request**: Some PR title for a 'new' feature [#48](https://github.com/storybookjs/storybook/pull/48)
         - [ ] **⚠️ Direct commit**: Some title for a "direct commit" [22bb11](https://github.com/storybookjs/storybook/commit/22bb11)
-        - [ ] **📝 Documentation**: Another PR \`title\` for docs [#11](https://github.com/storybookjs/storybook/pull/11) (will also be patched)
-        - [ ] **❔ Missing Label**: Some PR title with a missing label [#77](https://github.com/storybookjs/storybook/pull/77)"
+        - **📝 Documentation**: Another PR \`title\` for docs [#11](https://github.com/storybookjs/storybook/pull/11) (will also be patched)
+        - **❔ Missing Label**: Some PR title with a missing label [#77](https://github.com/storybookjs/storybook/pull/77)"
       `);
     });
   });


### PR DESCRIPTION
Fixes a recent regression I introduced in a test suite used for CI tools: https://app.circleci.com/pipelines/github/storybookjs/storybook/125284/workflows/92325e66-19b9-4913-a8d1-7877d6678454/jobs/1622501

#### Manual testing

Unit tests for PR descriptions should pass again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated PR description generation test snapshots to match the new checklist/checkbox formatting.

* **Changes**
  * PR descriptions now show only “Direct commit” as an unchecked todo checkbox, while other changelist sections (Bug, Feature Request, Documentation, Missing Label) render as plain bullet points for clearer readability.

* **Documentation**
  * Added a JSDoc `@param` annotation for the release checklist helper’s `body` argument.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->