### PR TITLE
Tests: Pre-warm svelte/compiler import in svelteImportParser

### DIFF
--- a/code/renderers/svelte/src/parsers/svelteImportParser.test.ts
+++ b/code/renderers/svelte/src/parsers/svelteImportParser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import type { ImportEdge, ImportParserContext } from 'storybook/internal/core-server';
 import { ChangeDetectionFailureError } from 'storybook/internal/core-server';
@@ -20,6 +20,16 @@ function makeContext(behavior: (source: string, virtualFilePath: string) => Impo
 }
 
 describe('svelteImportParser', () => {
+  beforeAll(async () => {
+    // Pre-warm the svelte/compiler dynamic import. The first cold load in CI can
+    // exceed vitest's default 10 s per-test timeout; loading it once here means
+    // individual tests always get the already-resolved promise.
+    await svelteImportParser.parse(
+      { filePath: '/tmp/__warmup__.svelte', source: '<div/>' },
+      makeContext(() => []).ctx
+    );
+  }, 30_000);
+
   it('claims the `.svelte` extension', () => {
     expect(svelteImportParser.extensions).toEqual(['.svelte']);
   });


### PR DESCRIPTION
## What I did

CircleCI Chunk said:

> The first test to call svelteImportParser.parse() dynamically imports svelte/compiler, which can take >10s on a cold CI runner and exceeds vitest's default per-test timeout. Add a beforeAll hook (30s timeout) that loads the compiler once before any test runs; subsequent tests all hit the already-resolved module-level promise.
> 
> AI-Generated: true

### Testing

#### Manual testing
Run CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test execution reliability through improved initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->