### PR TITLE
Addon-Vitest: Support vite+ projects in storybook init

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -407,7 +407,7 @@
   "peerDependencies": {
     "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "prettier": "^2 || ^3",
-    "vite-plus": "^0.1.15"
+    "vite-plus": "^0.1.15 || ^0.2.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/code/core/src/cli/AddonVitestService.test.ts
+++ b/code/core/src/cli/AddonVitestService.test.ts
@@ -29,6 +29,7 @@ describe('AddonVitestService', () => {
     mockPackageManager = {
       getAllDependencies: vi.fn(),
       getInstalledVersion: vi.fn(),
+      getOverrides: vi.fn().mockReturnValue({}),
       runPackageCommand: vi.fn(),
       getPackageCommand: vi.fn(),
     } as Partial<JsPackageManager> as JsPackageManager;
@@ -155,6 +156,55 @@ describe('AddonVitestService', () => {
       expect(deps).toContain('@vitest/browser@3.2.0');
       expect(deps).toContain('@vitest/coverage-v8@3.2.0');
       expect(deps).toContain('playwright'); // no version for playwright
+    });
+
+    // Regression: Vite+ aliases `vitest` to its own fork via npm `overrides`
+    // (`vitest: npm:@voidzero-dev/vite-plus-test@latest`). Adding a direct `vitest`
+    // dependency alongside that alias makes the manifest uninstallable — npm fails with
+    // EOVERRIDE ("Override for vitest@... conflicts with direct dependency").
+    it('does not add a package that is aliased via overrides', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
+      vi.mocked(mockPackageManager.getOverrides).mockReturnValue({
+        vite: 'npm:@voidzero-dev/vite-plus-core@latest',
+        vitest: 'npm:@voidzero-dev/vite-plus-test@latest',
+      });
+      vi.mocked(mockPackageManager.getInstalledVersion)
+        .mockResolvedValueOnce(null) // vitest version check
+        .mockResolvedValueOnce(null) // @vitest/coverage-v8
+        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
+
+      const deps = await service.collectDependencies();
+
+      // vitest is supplied by the alias, so it must not be added as a direct dependency...
+      expect(deps).not.toContain('vitest');
+      expect(deps.some((d) => d.startsWith('vitest@'))).toBe(false);
+      // ...while the non-aliased packages are still added.
+      expect(deps).toContain('playwright');
+      expect(deps).toContain('@vitest/browser-playwright');
+      expect(deps).toContain('@vitest/coverage-v8');
+    });
+
+    // When vitest is aliased to the Vite+ fork, `getInstalledVersion` still reports the *real*
+    // vendored vitest version (not the wrapper), so the non-aliased sibling @vitest/* packages are
+    // still pinned to that version — only the aliased `vitest` itself is omitted.
+    it('still pins non-aliased sibling packages to the resolved vitest version', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
+      vi.mocked(mockPackageManager.getOverrides).mockReturnValue({
+        vitest: 'npm:@voidzero-dev/vite-plus-test@latest',
+      });
+      vi.mocked(mockPackageManager.getInstalledVersion)
+        .mockResolvedValueOnce('3.2.0') // vendored vitest version reported for the alias
+        .mockResolvedValueOnce(null) // @vitest/coverage-v8
+        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
+
+      const deps = await service.collectDependencies();
+
+      // The aliased vitest is omitted, but its siblings track the vendored version (3.2.0 < 4 →
+      // @vitest/browser).
+      expect(deps.some((d) => d.startsWith('vitest@') || d === 'vitest')).toBe(false);
+      expect(deps).toContain('@vitest/browser@3.2.0');
+      expect(deps).toContain('@vitest/coverage-v8@3.2.0');
+      expect(deps).toContain('playwright');
     });
   });
 

--- a/code/core/src/cli/AddonVitestService.ts
+++ b/code/core/src/cli/AddonVitestService.ts
@@ -52,6 +52,18 @@ export class AddonVitestService {
     const allDeps = this.packageManager.getAllDependencies();
     const dependencies: string[] = [];
 
+    // A package is "aliased" when an override/resolution remaps its name to a *different* package
+    // via npm's `npm:other@spec` form — e.g. Vite+ ships its own test runner as
+    // `vitest: npm:@voidzero-dev/vite-plus-test@latest`. Adding a direct dependency on such a
+    // package is both redundant (the alias already supplies it) and breaks the manifest: npm
+    // rejects a direct dependency that also has a top-level override with `EOVERRIDE`
+    // ("Override for X conflicts with direct dependency"). So we never add an aliased package as a
+    // direct dependency. We still pin the non-aliased sibling @vitest/* packages to the resolved
+    // vitest version — for Vite+ `getInstalledVersion` reports the real vendored vitest version
+    // (not the wrapper), so that version is a valid one to match them against.
+    const overrides = this.packageManager.getOverrides();
+    const isAliased = (pkg: string) => (overrides[pkg] ?? '').startsWith('npm:');
+
     // Determine Vitest version/range from installed or declared dependency to avoid pulling
     // incompatible majors by default.
     let vitestVersionSpecifier = await this.packageManager.getInstalledVersion('vitest');
@@ -75,9 +87,9 @@ export class AddonVitestService {
       isVitest4OrNewer ? '@vitest/browser-playwright' : '@vitest/browser',
     ];
 
-    // Only install these dependencies if they are not already installed
+    // Only install these dependencies if they are not already installed or aliased via overrides
     for (const pkg of basePackages) {
-      if (!allDeps[pkg]) {
+      if (!allDeps[pkg] && !isAliased(pkg)) {
         dependencies.push(pkg);
       }
     }
@@ -88,7 +100,7 @@ export class AddonVitestService {
       '@vitest/coverage-istanbul'
     );
 
-    if (!v8Version && !istanbulVersion) {
+    if (!v8Version && !istanbulVersion && !isAliased('@vitest/coverage-v8')) {
       dependencies.push('@vitest/coverage-v8');
     }
 

--- a/code/core/src/common/js-package-manager/JsPackageManager.test.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.test.ts
@@ -22,6 +22,50 @@ describe('JsPackageManager', () => {
     vi.clearAllMocks();
   });
 
+  describe('getOverrides method', () => {
+    const mockPackageJson = (
+      packageJson: Record<string, unknown>,
+      packageJsonPath = '/fake/package.json'
+    ) => {
+      jsPackageManager.packageJsonPaths = [packageJsonPath];
+      vi.spyOn(JsPackageManager, 'getPackageJson').mockReturnValue(packageJson as any);
+    };
+
+    it('reads npm `overrides`', () => {
+      mockPackageJson({
+        overrides: { vitest: 'npm:@voidzero-dev/vite-plus-test@latest', foo: '1.0.0' },
+      });
+
+      expect(jsPackageManager.getOverrides()).toEqual({
+        vitest: 'npm:@voidzero-dev/vite-plus-test@latest',
+        foo: '1.0.0',
+      });
+    });
+
+    it('reads Yarn `resolutions` and pnpm `pnpm.overrides`', () => {
+      mockPackageJson({
+        resolutions: { foo: '2.0.0' },
+        pnpm: { overrides: { bar: '3.0.0' } },
+      });
+
+      expect(jsPackageManager.getOverrides()).toEqual({ foo: '2.0.0', bar: '3.0.0' });
+    });
+
+    it('skips nested (object-valued) override entries', () => {
+      mockPackageJson({
+        overrides: { foo: '1.0.0', bar: { baz: '2.0.0' } },
+      });
+
+      expect(jsPackageManager.getOverrides()).toEqual({ foo: '1.0.0' });
+    });
+
+    it('returns an empty object when no overrides are declared', () => {
+      mockPackageJson({ dependencies: { react: '18.0.0' } });
+
+      expect(jsPackageManager.getOverrides()).toEqual({});
+    });
+  });
+
   describe('getVersionedPackages method', () => {
     it('should return the latest stable release version when current version is the latest stable release', async () => {
       mockLatestVersion.mockResolvedValue('8.3.0');

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -297,6 +297,40 @@ export abstract class JsPackageManager {
   }
 
   /**
+   * Collect the dependency override/resolution entries declared across the project's package.json
+   * files, normalizing the three package-manager dialects into a single map:
+   *
+   * - Npm: `overrides`
+   * - Pnpm: `pnpm.overrides`
+   * - Yarn: `resolutions`
+   *
+   * Only top-level, string-valued entries are returned (nested override objects are skipped), as a
+   * flat `name -> spec` map. Later package.json files win on key collisions, matching the merge
+   * order of {@link getAllDependencies}.
+   */
+  getOverrides(): Record<string, string> {
+    const overrides: Record<string, string> = {};
+
+    for (const packageJsonPath of this.packageJsonPaths) {
+      const packageJson = JsPackageManager.getPackageJson(packageJsonPath);
+      const maps = [packageJson.overrides, packageJson.pnpm?.overrides, packageJson.resolutions];
+
+      for (const map of maps) {
+        if (!map) {
+          continue;
+        }
+        for (const [name, spec] of Object.entries(map)) {
+          if (typeof spec === 'string') {
+            overrides[name] = spec;
+          }
+        }
+      }
+    }
+
+    return overrides;
+  }
+
+  /**
    * Add dependencies to a project using `yarn add` or `npm install`.
    *
    * @example

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -720,7 +720,7 @@ export abstract class JsPackageManager {
       // When vite-plus is used, packages like vite and vitest are vendored and their node_modules entries report the vite-plus wrapper version (e.g. 0.1.16) instead of the actual vendored version.
       // Check vite-plus first so we always get the real version when it's available.
       let version: string | null = null;
-      const vitePlusVersions = await getVitePlusVersions();
+      const vitePlusVersions = await getVitePlusVersions(this.cwd);
       if (vitePlusVersions?.[packageName]) {
         version = vitePlusVersions[packageName]!;
       }

--- a/code/core/src/common/js-package-manager/vite-plus-versions.test.ts
+++ b/code/core/src/common/js-package-manager/vite-plus-versions.test.ts
@@ -49,6 +49,39 @@ describe('getVitePlusVersions', () => {
     vi.doUnmock('vite-plus/versions');
   });
 
+  // Regression: during `npx storybook init` the CLI runs from the npx cache, so the project's
+  // vite-plus must be resolved from the target `cwd` rather than from the CLI's own location.
+  // A non-existent cwd has no resolvable vite-plus, and the bare-import fallback isn't mocked here,
+  // so the result must be null rather than throwing.
+  it('resolves vite-plus relative to the provided cwd', async () => {
+    clearVitePlusCache();
+    const { getVitePlusVersions: fn } = await import('./vite-plus-versions.ts');
+    clearVitePlusCache();
+
+    await expect(fn('/non/existent/project')).resolves.toBeNull();
+  });
+
+  it('caches results per cwd', async () => {
+    vi.doMock('vite-plus/versions', () => ({
+      versions: { vite: '6.1.0', vitest: '3.2.0' },
+    }));
+
+    clearVitePlusCache();
+    const { getVitePlusVersions: fn } = await import('./vite-plus-versions.ts');
+    clearVitePlusCache();
+
+    // The bare-import fallback (mocked here) is hit when the cwd has no resolvable vite-plus.
+    const fromA = await fn('/project/a');
+    const fromB = await fn('/project/b');
+
+    expect(fromA?.vite).toBe('6.1.0');
+    expect(fromB?.vite).toBe('6.1.0');
+    // A repeated call for the same cwd returns the cached reference.
+    expect(await fn('/project/a')).toBe(fromA);
+
+    vi.doUnmock('vite-plus/versions');
+  });
+
   it('caches results across calls', async () => {
     vi.doMock('vite-plus/versions', () => ({
       versions: { vite: '6.1.0', vitest: '3.2.0' },

--- a/code/core/src/common/js-package-manager/vite-plus-versions.ts
+++ b/code/core/src/common/js-package-manager/vite-plus-versions.ts
@@ -1,7 +1,37 @@
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
 import { logger } from 'storybook/internal/node-logger';
 
-/** Cached result: undefined = not yet checked, null = not available */
-let cachedVersions: Record<string, string> | null | undefined;
+/** Cached results keyed by resolution root. Absence = not yet checked, null = not available. */
+const cachedVersions = new Map<string, Record<string, string> | null>();
+
+/**
+ * Loads the `vite-plus/versions` map, resolving it from the target project first.
+ *
+ * During `npx storybook init` the CLI runs out of the npx cache, so a bare
+ * `import('vite-plus/versions')` resolves the specifier against the CLI's own location (where
+ * vite-plus isn't installed) rather than the user's project — and silently misses it. We therefore
+ * resolve the subpath from `cwd` (the project) explicitly, and only fall back to a bare import (for
+ * setups where Storybook and vite-plus share a node_modules, and for the unit tests that mock it).
+ */
+async function loadVitePlusVersions(cwd: string): Promise<Record<string, string> | null> {
+  try {
+    const require = createRequire(join(cwd, 'package.json'));
+    const resolved = require.resolve('vite-plus/versions');
+    const mod = await import(pathToFileURL(resolved).href);
+    return mod.versions ?? mod.default?.versions ?? mod.default ?? mod;
+  } catch {}
+
+  try {
+    // @ts-expect-error - This is a dynamic import of a potentially non-existent package. Vite-plus is currently a peer dependency.
+    const mod = await import('vite-plus/versions');
+    return mod.versions ?? mod.default?.versions ?? mod.default ?? mod;
+  } catch {}
+
+  return null;
+}
 
 /**
  * Attempts to load vendored package versions from `vite-plus/versions`.
@@ -10,29 +40,30 @@ let cachedVersions: Record<string, string> | null | undefined;
  * vendored rather than installed as separate packages. This function retrieves their actual versions
  * from the `vite-plus/versions` subpath export.
  *
- * Returns null when vite-plus is not installed or lacks the `/versions` export (older versions).
+ * @param cwd The project directory to resolve `vite-plus` from. Defaults to `process.cwd()`, which
+ *   is the target project during `npx storybook init` and `storybook upgrade`.
+ * @returns Null when vite-plus is not installed or lacks the `/versions` export (older versions).
  */
-export async function getVitePlusVersions(): Promise<Record<string, string> | null> {
-  if (cachedVersions !== undefined) {
-    return cachedVersions;
+export async function getVitePlusVersions(
+  cwd: string = process.cwd()
+): Promise<Record<string, string> | null> {
+  const cached = cachedVersions.get(cwd);
+  if (cached !== undefined) {
+    return cached;
   }
 
-  try {
-    // @ts-expect-error - This is a dynamic import of a potentially non-existent package. Vite-plus is currently a peer dependency.
-    const mod = await import('vite-plus/versions');
-    const versions = mod.versions ?? mod;
+  const versions = await loadVitePlusVersions(cwd);
 
-    if (versions && typeof versions.vite === 'string') {
-      logger.debug(`Detected vite-plus: vite=${versions.vite}, vitest=${versions.vitest ?? 'N/A'}`);
-      cachedVersions = versions;
-      return versions;
-    }
-  } catch {}
+  let result: Record<string, string> | null = null;
+  if (versions && typeof versions.vite === 'string') {
+    logger.debug(`Detected vite-plus: vite=${versions.vite}, vitest=${versions.vitest ?? 'N/A'}`);
+    result = versions;
+  }
 
-  cachedVersions = null;
-  return null;
+  cachedVersions.set(cwd, result);
+  return result;
 }
 
 export function clearVitePlusCache(): void {
-  cachedVersions = undefined;
+  cachedVersions.clear();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -29774,7 +29774,7 @@ __metadata:
   peerDependencies:
     "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     prettier: ^2 || ^3
-    vite-plus: ^0.1.15
+    vite-plus: ^0.1.15 || ^0.2.0
   peerDependenciesMeta:
     "@types/react":
       optional: true


### PR DESCRIPTION
Makes `@storybook/addon-vitest` init work in **Vite+** projects. Three fixes, each addressing a distinct blocker found while taking a real Vite+ project through `npx storybook init` + running the story tests.

## 1. `EOVERRIDE` — don't add an aliased package as a direct dependency

Vite+ 0.1.x aliases `vitest` to its own bundled fork (`vitest: npm:@voidzero-dev/vite-plus-test@latest`). npm rejects a manifest where a package is both a direct dependency and a top-level override:

```
npm error code EOVERRIDE
npm error Override for vitest@^4.1.9 conflicts with direct dependency
```

- **`JsPackageManager.getOverrides()`** (new) — normalizes npm `overrides`, pnpm `pnpm.overrides`, and Yarn `resolutions` into one map.
- **`AddonVitestService.collectDependencies()`** — skips adding any base package (and `@vitest/coverage-v8`) that is aliased via an `npm:` override. Non-aliased siblings are still added, pinned to the resolved vitest version.

## 2. `ERESOLVE` — resolve `vite-plus/versions` from the target project

`getVitePlusVersions()` did a bare `import('vite-plus/versions')`, which ESM resolves relative to the importing module — during `npx storybook init` that's the npx cache, not the user's project, so it returned `null`, the vendored vitest version went undetected, and `@vitest/*` siblings were left unpinned (latest, conflicting with the fork's exact peer).

- **`getVitePlusVersions(cwd?)`** now resolves from `cwd` (default `process.cwd()`, the target project) via `createRequire`, with the bare import kept as a fallback. `getInstalledVersion` passes `this.cwd`.

## 3. Allow Vite+ 0.2.x — widen the core peer range

Storybook core declared `peerOptional vite-plus@"^0.1.15"`, which excludes 0.2.x. Since npm tries to satisfy optional peers, this **capped `vite-plus` at 0.1.x** in every Storybook project — pinning users to the deprecated bundled-vitest-fork scheme. Vite+ 0.2.x dropped that fork and pins real upstream Vitest via a plain `overrides` entry.

- **`core/package.json`** — `vite-plus` peer widened to `^0.1.15 || ^0.2.0`. Core's only Vite+ touch point is the version-agnostic `vite-plus/versions` export, so this is safe.

## Verification / notes

- Reproduced end-to-end against a real Vite+ project (canary `0.0.0-pr-35203-*`): before, `npm install` failed with `EOVERRIDE` then `ERESOLVE`; after #1+#2, install resolves and addons configure.
- Confirmed `EOVERRIDE` is exact-string-based (`^4.1.9` override vs `4.1.9` dep fails; identical strings pass). Under Vite+ 0.2.x's plain `vitest: "4.1.9"` override, `collectDependencies` writes the exact `"4.1.9"` (from the vendored version) — matching the override, so no `EOVERRIDE`. No extra change needed there.
- Behavior is unchanged for non-Vite+ projects (no overrides → nothing skipped; version helper falls back to the bare import).

## Tests

`AddonVitestService.test.ts`, `JsPackageManager.test.ts` (`getOverrides`), `vite-plus-versions.test.ts` (cwd resolution + per-cwd cache). All green: core cli + js-package-manager + addon-vitest suites, no type errors.

## Follow-up (separate PR): running tests under Vite+ 0.2.x

This PR fixes **install/init**. Actually *running* the story tests in a Vite+ project still needs integration work, best done against a 0.2.x project once a canary with the widened peer (#3) is available to verify end-to-end:
- Browser-mode config should import the provider from `vite-plus/test/browser-playwright` (Vite+'s vendored, version-aligned re-export) rather than the standalone `@vitest/browser-playwright`, per Vite+'s migrate guide — otherwise a duplicate Vitest copy is loaded.
- Storybook's `storybook/test` setup pulls CJS deps (e.g. `aria-query`) that need pre-bundling (`optimizeDeps.include`) for browser mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency detection to ignore packages that are only provided via npm overrides aliasing, preventing incorrect direct dependency additions (including vitest base packages and the coverage reporter).
  * Scoped vite-plus version detection per project directory; it now safely returns `null` for missing directories.
  * Expanded the `vite-plus` peer dependency version range to include additional releases.

* **Tests**
  * Added regression coverage for overrides aliasing and for reading overrides/resolutions across package managers.
  * Added tests for per-`cwd` vite-plus caching and handling non-existent `cwd` inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->