### PR TITLE
UI: Preserve story scroll position on HMR re-render

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
@@ -426,7 +426,8 @@ describe('PreviewWeb', () => {
         expect(preview.view.prepareForStory).toHaveBeenCalledWith(
           expect.objectContaining({
             id: 'component-one--a',
-          })
+          }),
+          { scrollReset: true }
         );
       });
 
@@ -2694,7 +2695,8 @@ describe('PreviewWeb', () => {
         expect(preview.view.prepareForStory).toHaveBeenCalledWith(
           expect.objectContaining({
             id: 'component-one--a',
-          })
+          }),
+          { scrollReset: true }
         );
       });
 
@@ -3219,6 +3221,22 @@ describe('PreviewWeb', () => {
         await waitForRender();
 
         expect(mockChannel.emit).toHaveBeenCalledWith(STORY_RENDERED, 'component-one--a');
+      });
+
+      // Regression test for https://github.com/storybookjs/storybook/issues/22057. The HMR
+      // re-render must pass scrollReset: false so the user's scroll position is preserved.
+      it('calls view.prepareForStory with scrollReset: false to preserve scroll on HMR', async () => {
+        document.location.search = '?id=component-one--a';
+        const preview = await createAndRenderPreview();
+
+        mockChannel.emit.mockClear();
+        preview.onStoriesChanged({ importFn: newImportFn });
+        await waitForRender();
+
+        expect(preview.view.prepareForStory).toHaveBeenLastCalledWith(
+          expect.objectContaining({ id: 'component-one--a' }),
+          { scrollReset: false }
+        );
       });
     });
 

--- a/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
@@ -450,7 +450,9 @@ export class PreviewWithSelection<TRenderer extends Renderer> extends Preview<TR
       invariant(!!render.story);
       this.storyRenders.push(render as StoryRender<TRenderer>);
       (this.currentRender as StoryRender<TRenderer>).renderToElement(
-        this.view.prepareForStory(render.story)
+        this.view.prepareForStory(render.story, {
+          scrollReset: storyIdChanged || viewModeChanged,
+        })
       );
     } else {
       this.currentRender.renderToElement(

--- a/code/core/src/preview-api/modules/preview-web/View.ts
+++ b/code/core/src/preview-api/modules/preview-web/View.ts
@@ -2,7 +2,7 @@ import type { PreparedStory } from 'storybook/internal/types';
 
 export interface View<TStorybookRoot> {
   // Get ready to render a story, returning the element to render to
-  prepareForStory(story: PreparedStory<any>): TStorybookRoot;
+  prepareForStory(story: PreparedStory<any>, options?: { scrollReset?: boolean }): TStorybookRoot;
 
   prepareForDocs(options?: { scrollReset?: boolean }): TStorybookRoot;
 

--- a/code/core/src/preview-api/modules/preview-web/WebView.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.ts
@@ -67,12 +67,20 @@ export class WebView implements View<HTMLElement> {
   }
 
   // Get ready to render a story, returning the element to render to
-  prepareForStory(story: PreparedStory<any>) {
+  prepareForStory(
+    story: PreparedStory<any>,
+    { scrollReset = true }: { scrollReset?: boolean } = {}
+  ) {
     this.showStory();
     this.applyLayout(story.parameters.layout);
 
-    document.documentElement.scrollTop = 0;
-    document.documentElement.scrollLeft = 0;
+    // Only reset scroll when navigating to a new story or switching view modes, not on HMR
+    // re-renders. Without this guard, hot-reloading a story file while scrolled down on a
+    // tall story causes the page to jump back to the top.
+    if (scrollReset) {
+      document.documentElement.scrollTop = 0;
+      document.documentElement.scrollLeft = 0;
+    }
 
     return this.storyRoot();
   }


### PR DESCRIPTION
Closes #22057

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`WebView.prepareForStory` unconditionally reset the iframe's scroll position on every call, so any HMR re-render of the currently selected story jumped a tall story back to the top after save. This mirrors the docs-side fix from #35021 to the story render path:

- Added `{ scrollReset?: boolean }` (defaults to `true`) to `prepareForStory` on the `View` interface and `WebView` implementation.
- `PreviewWithSelection.renderSelection` now passes `scrollReset: storyIdChanged || viewModeChanged` for story renders, matching the docs branch. HMR re-renders (same `storyId`, same `viewMode`) skip the scroll reset; navigating to a new story or switching from docs back to story still resets as before.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Spin up a React sandbox:
   ```bash
   yarn task sandbox --template react-vite/default-ts --start-from auto
   ```
2. Open the sandbox Storybook and navigate to **Example / Page → Logged Out** (the `Page` story used in the linked issue reproduction). Make sure the preview iframe is tall enough to scroll — narrow the manager panel if needed.
3. Inside the preview iframe, scroll down a few hundred pixels.
4. In your editor, open `../storybook-sandboxes/react-vite-default-ts/stories/Page.tsx` (or `.jsx`) and make a trivial edit, e.g. change the `<h2>` text. Save the file to trigger HMR.
5. **Expected:** the preview re-renders with the edited content and the scroll position is preserved (no jump to the top). On `next` without this PR, the iframe scrolls back to the top after every save.
6. Regression sweep — verify the existing scroll-reset behavior still triggers when it should:
   - Click a different story (e.g. **Example / Page → Logged In**). The preview should reset to the top.
   - Switch from a docs page back to a story (Example / Button → Docs, then back to a Button story). The preview should reset to the top.

Areas worth extra scrutiny: anything that re-renders the same story without changing `storyId`/`viewMode` (args panel, globals toolbar) — these paths go through `StoryRender.render` rather than `prepareForStory`, so scroll behavior is unaffected, but worth a quick check.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll handling when preparing stories: scroll position is now preserved during hot reloading-style re-renders, while still resetting when switching story or changing view mode.
* **Tests**
  * Updated existing assertions for the revised story-preparation call.
  * Added a regression test to verify scroll is preserved when re-rendering the current story during HMR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->