### PR TITLE
CI: Add a final CircleCI job to require in GitHub

### DIFF
--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -411,7 +411,7 @@ export const defineCircleciCompletion = (requires: JobOrNoOpJob[]) =>
     'CircleCI completion',
     () => ({
       executor: {
-        name: 'sb_node_22_classic',
+        name: 'sb_barebones',
         class: 'small',
       },
       steps: [

--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -18,7 +18,7 @@ import {
   workspace,
 } from './utils/helpers.ts';
 import { isTrustedAuthor } from './utils/runtime.ts';
-import { defineJob, defineNoOpJob } from './utils/types.ts';
+import { type JobOrNoOpJob, defineJob, defineNoOpJob } from './utils/types.ts';
 
 const dirname = import.meta.dirname;
 
@@ -405,6 +405,26 @@ export const testUnit_windows = defineJob(
   }),
   [build_windows]
 );
+
+export const defineCircleciCompletion = (requires: JobOrNoOpJob[]) =>
+  defineJob(
+    'CircleCI completion',
+    () => ({
+      executor: {
+        name: 'sb_node_22_classic',
+        class: 'small',
+      },
+      steps: [
+        {
+          run: {
+            name: 'Workflow completed',
+            command: 'echo "All required jobs completed successfully"',
+          },
+        },
+      ],
+    }),
+    requires
+  );
 
 export const benchmarkPackages = defineJob(
   'Benchmark packages',

--- a/scripts/ci/main.ts
+++ b/scripts/ci/main.ts
@@ -10,6 +10,7 @@ import {
   build_windows,
   check,
   commonJobsNoOpJob,
+  defineCircleciCompletion,
   knip,
   lint,
   fmt,
@@ -106,6 +107,11 @@ function generateConfig(workflow: Workflow) {
   const isDebugging = filteredJobs.length !== jobs.length;
 
   const ensuredJobs = ensureRequiredJobs(filteredJobs);
+
+  // Append a completion job that depends on every other job in the workflow.
+  // It acts as a single status check for GitHub branch protection: it only runs
+  // (and reports success) once every required job has finished successfully.
+  ensuredJobs.push(defineCircleciCompletion([...ensuredJobs]));
 
   const sortedJobs = ensuredJobs.sort((a, b) => {
     if (a.requires.length && b.requires.length) {

--- a/scripts/ci/utils/executors.ts
+++ b/scripts/ci/utils/executors.ts
@@ -61,4 +61,21 @@ export const executors = {
     resource_class: '<<parameters.class>>',
     working_directory: `${LINUX_ROOT_DIR}/${WORKING_DIR}`,
   },
+  sb_barebones: {
+    docker: [
+      {
+        image: 'cimg/base:stable',
+      },
+    ],
+    parameters: {
+      class: {
+        default: 'small',
+        description: 'The Resource class',
+        enum: ['small', 'medium', 'medium+', 'large', 'xlarge'],
+        type: 'enum',
+      },
+    },
+    resource_class: '<<parameters.class>>',
+    working_directory: `${LINUX_ROOT_DIR}/${WORKING_DIR}`,
+  },
 } as const;


### PR DESCRIPTION
## What I did

Creates a systematic `CircleCI completion` job in all CircleCI workflows for us to depend on.

## Checklist for Contributors

#### Manual testing

Not testable

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CircleCI pipeline to include an aggregate “completion” job that runs after all required CI tasks finish.
  * This consolidates outcomes into a single status check, improving clarity for branch protection and reducing the need to review multiple individual job results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->