### PR TITLE
PseudoStates: Preserve URL globals on story change

### DIFF
--- a/code/addons/pseudo-states/src/preview/withPseudoState.ts
+++ b/code/addons/pseudo-states/src/preview/withPseudoState.ts
@@ -148,10 +148,16 @@ export const withPseudoState: DecoratorFunction = (
   const globalsRef = useRef(globals);
 
   // Sync parameter to globals, used by the toolbar (only in canvas as this
-  // doesn't make sense for docs because many stories are displayed at once)
+  // doesn't make sense for docs because many stories are displayed at once).
+  // Skip when the parameter has no pseudo states to sync; otherwise we'd wipe
+  // globals set via URL or toolbar on stories that don't declare pseudo states.
   useEffect(() => {
     const config = pseudoConfig(parameter);
-    if (viewMode === 'story' && !equals(config, globalsRef.current)) {
+    if (
+      viewMode === 'story' &&
+      Object.keys(config).length > 0 &&
+      !equals(config, globalsRef.current)
+    ) {
       channel.emit(UPDATE_GLOBALS, {
         globals: { pseudo: config },
       });

--- a/code/e2e-internal/addon-pseudo-states.spec.ts
+++ b/code/e2e-internal/addon-pseudo-states.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+import process from 'process';
+
+import { PREVIEW_STORY_TIMEOUT, waitForPreviewReady } from './helpers.ts';
+
+/**
+ * E2E regression for issue #32221: the pseudo-states decorator used to wipe globals
+ * during the parameter->globals sync whenever a story did not declare its own
+ * `parameters.pseudo`, dropping any selection set via URL or toolbar as soon as
+ * the user navigated to such a story.
+ */
+
+const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:6006';
+
+/** A story that does not declare `parameters.pseudo` itself. */
+const STORY_A_PATH = '/story/button-component--base';
+
+test.describe('pseudo-states addon', () => {
+  test.setTimeout(60_000);
+
+  test('preserves toolbar selection across navigation between unrelated stories', async ({
+    page,
+  }) => {
+    await page.goto(`${storybookUrl}/?path=${STORY_A_PATH}`);
+    await waitForPreviewReady(page);
+
+    const toolbarTrigger = page.getByRole('button', { name: 'CSS pseudo states' });
+    await toolbarTrigger.click();
+    await page.getByRole('option', { name: ':hover' }).click();
+    // Click the toolbar heading to dismiss the listbox before navigating.
+    await page.getByRole('heading', { name: 'Toolbar' }).click({ force: true });
+
+    const storyARoot = page.frameLocator('#storybook-preview-iframe').locator('#storybook-root');
+    await expect(storyARoot).toHaveClass(/pseudo-hover-all/, { timeout: PREVIEW_STORY_TIMEOUT });
+
+    // Navigate via the sidebar so Storybook preserves globals across the URL change.
+    const selectGroup = page.locator('#components-select');
+    if ((await selectGroup.getAttribute('aria-expanded')) !== 'true') {
+      await selectGroup.click();
+    }
+    await page.locator('#select-component--base').click();
+    await page.waitForURL((url) => url.search.includes('select-component--base'));
+    await waitForPreviewReady(page);
+
+    // The hover class on the root only appears if the decorator did NOT wipe globals.
+    const storyBRoot = page.frameLocator('#storybook-preview-iframe').locator('#storybook-root');
+    await expect(storyBRoot).toHaveClass(/pseudo-hover-all/, { timeout: PREVIEW_STORY_TIMEOUT });
+  });
+});


### PR DESCRIPTION
Closes #32221

## What I did

The decorator's parameter->globals sync effect was emitting UPDATE_GLOBALS
with an empty config on every story that didn't declare 'parameters.pseudo'.
On initial load, this overwrote pseudo state globals supplied via URL or
toolbar (e.g. ?globals=pseudo.focusVisible:!true) with {}, dropping the
user's selection before it could be applied.

Skip the sync when the parameter has no pseudo states to push, so URL and
toolbar globals survive on stories that don't set the parameter themselves.

## Checklist for Contributors

### Testing


#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

* Navigate to SB instance
* Open a story without a pseudostates param, e.g. Components / Select / *
* Set a pseudo state
* Navigate to the next story
* Notice it persists
* Unset it
* Navigate to the next story
* Notice it stays unset

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where pseudo-state styling could be unintentionally cleared when navigating between stories that don't define pseudo-states, ensuring toolbar selections persist correctly.

* **Tests**
  * Added end-to-end regression test to verify pseudo-state decorators persist across unrelated story navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->