### PR TITLE
CLI: Load Storybook AI help from preset metadata

### DIFF
--- a/code/core/src/cli/ai/mcp/client.test.ts
+++ b/code/core/src/cli/ai/mcp/client.test.ts
@@ -2,13 +2,7 @@ import { versions } from 'storybook/internal/common';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  MCP_CLIENT_INFO,
-  McpJsonRpcError,
-  callMcpTool,
-  listMcpTools,
-  listMcpToolsWithServerMetadata,
-} from './client.ts';
+import { MCP_CLIENT_INFO, McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
 import type { StorybookInstanceRecord } from './types.ts';
 
 const record: StorybookInstanceRecord = {
@@ -228,7 +222,7 @@ describe('listMcpTools', () => {
 });
 
 describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
-  const initializeResponse = (sessionId?: string, instructions?: unknown) =>
+  const initializeResponse = (sessionId?: string) =>
     jsonResponse(
       {
         jsonrpc: '2.0',
@@ -236,29 +230,11 @@ describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
         result: {
           protocolVersion: '2025-06-18',
           serverInfo: {},
-          ...(instructions !== undefined ? { instructions } : {}),
         },
       },
       200,
       sessionId ? { 'mcp-session-id': sessionId } : {}
     );
-
-  const initializeSseResponse = (sessionId: string | undefined, instructions: unknown) => {
-    const envelope = {
-      jsonrpc: '2.0',
-      id: 'init',
-      result: {
-        protocolVersion: '2025-06-18',
-        serverInfo: {},
-        instructions,
-      },
-    };
-    return sseResponse(
-      `event: message\ndata: ${JSON.stringify(envelope)}\n\n`,
-      200,
-      sessionId ? { 'mcp-session-id': sessionId } : {}
-    );
-  };
 
   const toolResult = () =>
     jsonResponse({
@@ -406,51 +382,6 @@ describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
     expect(headers['Mcp-Session-Id']).toBe('session-7');
   });
 
-  it('returns server instructions from the initialize response alongside tools/list results', async () => {
-    const tools = [{ name: 'get-documentation', description: 'Get docs' }];
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(initializeResponse('session-1', '  Follow the story workflow.  '))
-      .mockResolvedValueOnce(
-        jsonResponse({ jsonrpc: '2.0', id: 'x', result: { tools } })
-      ) as unknown as typeof fetch;
-
-    await expect(listMcpToolsWithServerMetadata(record, fetchImpl)).resolves.toEqual({
-      tools,
-      serverMetadata: { instructions: 'Follow the story workflow.' },
-    });
-  });
-
-  it('returns server instructions from an SSE initialize response', async () => {
-    const tools = [{ name: 'get-documentation', description: 'Get docs' }];
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(initializeSseResponse('session-1', '  Follow the story workflow.  '))
-      .mockResolvedValueOnce(toolListResult(tools)) as unknown as typeof fetch;
-
-    await expect(listMcpToolsWithServerMetadata(record, fetchImpl)).resolves.toEqual({
-      tools,
-      serverMetadata: { instructions: 'Follow the story workflow.' },
-    });
-  });
-
-  it.each([undefined, '', '   ', 123])(
-    'omits server instructions when initialize returns %j',
-    async (instructions) => {
-      const fetchImpl = vi
-        .fn()
-        .mockResolvedValueOnce(initializeResponse('session-1', instructions))
-        .mockResolvedValueOnce(
-          jsonResponse({ jsonrpc: '2.0', id: 'x', result: { tools: [] } })
-        ) as unknown as typeof fetch;
-
-      await expect(listMcpToolsWithServerMetadata(record, fetchImpl)).resolves.toEqual({
-        tools: [],
-        serverMetadata: {},
-      });
-    }
-  );
-
   it.each([
     [
       'malformed JSON',
@@ -472,17 +403,14 @@ describe('initialize handshake (clientInfo for telemetry segmentation)', () => {
       .mockResolvedValueOnce(initResponse())
       .mockResolvedValueOnce(toolListResult(tools)) as unknown as typeof fetch;
 
-    await expect(listMcpToolsWithServerMetadata(record, fetchImpl)).resolves.toEqual({
-      tools,
-      serverMetadata: {},
-    });
+    await expect(listMcpTools(record, fetchImpl)).resolves.toEqual(tools);
   });
 
   it('keeps listMcpTools returning only the tool descriptors', async () => {
     const tools = [{ name: 'get-documentation', description: 'Get docs' }];
     const fetchImpl = vi
       .fn()
-      .mockResolvedValueOnce(initializeResponse('session-1', 'Follow the story workflow.'))
+      .mockResolvedValueOnce(initializeResponse('session-1'))
       .mockResolvedValueOnce(
         jsonResponse({ jsonrpc: '2.0', id: 'x', result: { tools } })
       ) as unknown as typeof fetch;

--- a/code/core/src/cli/ai/mcp/client.ts
+++ b/code/core/src/cli/ai/mcp/client.ts
@@ -54,22 +54,9 @@ const JsonRpcEnvelopeSchema = v.looseObject({
   error: v.optional(v.looseObject({ code: v.number(), message: v.string() })),
 });
 
-const InitializeResultSchema = v.looseObject({
-  instructions: v.optional(v.string()),
-});
-
 const ToolListResultSchema = v.looseObject({
   tools: v.optional(v.array(McpToolDescriptorSchema)),
 });
-
-export type McpServerMetadata = {
-  instructions?: string;
-};
-
-export type McpToolList = {
-  tools: McpToolDescriptor[];
-  serverMetadata: McpServerMetadata;
-};
 
 /** Forward an MCP `tools/call` JSON-RPC request to a local Storybook MCP server. */
 export async function callMcpTool(
@@ -92,23 +79,14 @@ export async function listMcpTools(
   record: StorybookInstanceRecord,
   fetchImpl: typeof fetch = fetch
 ): Promise<McpToolDescriptor[]> {
-  const { tools } = await listMcpToolsWithServerMetadata(record, fetchImpl);
-  return tools;
-}
-
-/** List tools and include server metadata from the preceding MCP `initialize` response. */
-export async function listMcpToolsWithServerMetadata(
-  record: StorybookInstanceRecord,
-  fetchImpl: typeof fetch = fetch
-): Promise<McpToolList> {
-  const { result, serverMetadata } = await sendJsonRpcRequest(
+  const { result } = await sendJsonRpcRequest(
     record,
     'tools/list',
     {},
     ToolListResultSchema,
     fetchImpl
   );
-  return { tools: result.tools ?? [], serverMetadata };
+  return result.tools ?? [];
 }
 
 const REQUEST_HEADERS = {
@@ -117,29 +95,21 @@ const REQUEST_HEADERS = {
   [STORYBOOK_MCP_PROXY_HEADER]: STORYBOOK_MCP_PROXY_HEADER_VALUE,
 };
 
-type InitializeMcpSessionResult = {
-  sessionId: string | null;
-  serverMetadata: McpServerMetadata;
-};
-
 /**
  * Send a minimal MCP `initialize` request carrying {@link MCP_CLIENT_INFO} and return the session
- * id plus any best-effort server metadata from the initialize response.
+ * id when the server assigns one.
  *
  * The session id is MCP Streamable HTTP spec behavior, not a tmcp implementation detail: the
  * server assigns it during initialization, returns it in the `Mcp-Session-Id` response header,
  * and associates the session's clientInfo with later requests echoing that header. The same
- * initialize result can also carry server instructions, so metadata is parsed from the response
- * body even when no session id is assigned.
+ * initialize response body is still consumed so the follow-up request cannot race ahead of the
+ * server storing clientInfo for telemetry segmentation.
  *
  * The handshake is best-effort — when it fails (or a future server ignores sessions), the actual
- * request proceeds without a session and keeps working; only the telemetry segmentation and
- * initialize metadata are lost, and error reporting stays anchored on the real call. It shares the
- * full {@link REQUEST_TIMEOUT_MS} budget rather than a tighter one: `storybook ai --help` renders the
- * server instructions carried here, and the only thing that slows the handshake is the dev server
- * still starting up — which the command must wait through anyway. A tighter budget would just drop
- * the instructions on that first slow request while the command list (sent right after) comes back
- * fine.
+ * request proceeds without a session and keeps working; only telemetry segmentation is lost, and
+ * error reporting stays anchored on the real call. It shares the full {@link REQUEST_TIMEOUT_MS}
+ * budget rather than a tighter one because the only thing that slows the handshake is the dev
+ * server still starting up, which the command must wait through anyway.
  *
  * Sessions are deliberately one-shot: each JSON-RPC request gets its own handshake and the session
  * is never reused or closed. A CLI invocation makes one request on the happy path (two on error
@@ -153,7 +123,7 @@ type InitializeMcpSessionResult = {
 async function initializeMcpSession(
   target: string,
   fetchImpl: typeof fetch
-): Promise<InitializeMcpSessionResult> {
+): Promise<string | null> {
   try {
     const response = await fetchImpl(target, {
       method: 'POST',
@@ -173,22 +143,18 @@ async function initializeMcpSession(
     const sessionId = response.headers.get('mcp-session-id');
     if (!response.ok) {
       await response.body?.cancel();
-      return { sessionId: null, serverMetadata: {} };
+      return null;
     }
 
-    let serverMetadata: McpServerMetadata = {};
     try {
-      serverMetadata = parseInitializeServerMetadata(
-        await readJsonRpcResponse(response, target),
-        target
-      );
+      await response.text();
     } catch {
-      // The initialize request is best-effort metadata; a malformed response must not block the
+      // The initialize request is best-effort telemetry setup; a malformed body must not block the
       // actual tools/list or tools/call request from preserving its existing behavior.
     }
-    return { sessionId, serverMetadata };
+    return sessionId;
   } catch {
-    return { sessionId: null, serverMetadata: {} };
+    return null;
   }
 }
 
@@ -212,7 +178,7 @@ async function sendJsonRpcRequest<TResult>(
   params: unknown,
   resultSchema: v.GenericSchema<unknown, TResult>,
   fetchImpl: typeof fetch
-): Promise<{ result: TResult; serverMetadata: McpServerMetadata }> {
+): Promise<{ result: TResult }> {
   const endpoint = record.mcp.endpoint;
   if (!endpoint) {
     throw new Error(`The Storybook instance at ${record.cwd} has no server endpoint registered`);
@@ -220,7 +186,7 @@ async function sendJsonRpcRequest<TResult>(
 
   const target = new URL(endpoint, record.url).href;
 
-  const { sessionId, serverMetadata } = await initializeMcpSession(target, fetchImpl);
+  const sessionId = await initializeMcpSession(target, fetchImpl);
 
   const response = await fetchImpl(target, {
     method: 'POST',
@@ -254,7 +220,7 @@ async function sendJsonRpcRequest<TResult>(
   if (!result.success) {
     throw unexpectedShapeError(target);
   }
-  return { result: result.output, serverMetadata };
+  return { result: result.output };
 }
 
 function unexpectedShapeError(target: string): Error {
@@ -263,8 +229,7 @@ function unexpectedShapeError(target: string): Error {
 
 /**
  * Unwrap a parsed JSON-RPC payload into its `result`, or report why it isn't usable. The command
- * path throws on the reported error; the best-effort initialize-metadata parse falls back to empty
- * — sharing this keeps the envelope handling in one place.
+ * path throws on the reported error.
  */
 function unwrapJsonRpcResult(
   payload: unknown,
@@ -284,21 +249,6 @@ function unwrapJsonRpcResult(
     return { ok: false, error: new Error('The Storybook server returned no result') };
   }
   return { ok: true, result: envelope.output.result };
-}
-
-function parseInitializeServerMetadata(payload: unknown, target: string): McpServerMetadata {
-  const unwrapped = unwrapJsonRpcResult(payload, target);
-  if (!unwrapped.ok) {
-    return {};
-  }
-
-  const result = v.safeParse(InitializeResultSchema, unwrapped.result);
-  if (!result.success) {
-    return {};
-  }
-
-  const instructions = result.output.instructions?.trim();
-  return instructions ? { instructions } : {};
 }
 
 async function readJsonRpcResponse(response: Response, endpoint: string): Promise<unknown> {

--- a/code/core/src/cli/ai/mcp/local-metadata.test.ts
+++ b/code/core/src/cli/ai/mcp/local-metadata.test.ts
@@ -31,7 +31,7 @@ describe('loadStorybookAiMetadata', () => {
       ],
       localTools: {
         'get-storybook-story-instructions': {
-          call: vi.fn(),
+          call: vi.fn().mockResolvedValue({ content: [] }),
         },
       },
     });
@@ -68,7 +68,7 @@ describe('loadStorybookAiMetadata', () => {
   });
 
   it('normalizes optional metadata fields and hides descriptor-less local tools', async () => {
-    const call = vi.fn();
+    const call = vi.fn().mockResolvedValue({ content: [] });
     mockLoadedStorybook(
       vi.fn().mockResolvedValue({
         instructions: 123,

--- a/code/core/src/cli/ai/mcp/local-metadata.test.ts
+++ b/code/core/src/cli/ai/mcp/local-metadata.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { experimental_loadStorybook as loadStorybook } from 'storybook/internal/core-server';
+
+import { loadStorybookAiMetadata, resolveStorybookConfigDir } from './local-metadata.ts';
+
+vi.mock('storybook/internal/core-server', { spy: true });
+
+type LoadedStorybook = Awaited<ReturnType<typeof loadStorybook>>;
+
+beforeEach(() => {
+  vi.mocked(loadStorybook).mockReset();
+});
+
+function mockLoadedStorybook(apply: ReturnType<typeof vi.fn>) {
+  vi.mocked(loadStorybook).mockResolvedValue({
+    presets: { apply },
+  } as unknown as LoadedStorybook);
+}
+
+describe('loadStorybookAiMetadata', () => {
+  it('loads AI metadata through the Storybook preset system', async () => {
+    const apply = vi.fn().mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [
+        { name: 'get-documentation', description: 'Get docs.' },
+        {
+          name: 'get-storybook-story-instructions',
+          description: 'Get story guidance.',
+        },
+      ],
+      localTools: {
+        'get-storybook-story-instructions': {
+          call: vi.fn(),
+        },
+      },
+    });
+    mockLoadedStorybook(apply);
+
+    const metadata = await loadStorybookAiMetadata({ cwd: '/repo' });
+
+    expect(loadStorybook).toHaveBeenCalledWith({ configDir: '/repo/.storybook' });
+    expect(apply).toHaveBeenCalledWith('experimental_storybookAi', undefined);
+    expect(metadata).toEqual({
+      instructions: 'Follow the story workflow.',
+      tools: [
+        { name: 'get-documentation', description: 'Get docs.' },
+        {
+          name: 'get-storybook-story-instructions',
+          description: 'Get story guidance.',
+        },
+      ],
+      localTools: {
+        'get-storybook-story-instructions': {
+          call: expect.any(Function),
+        },
+      },
+    });
+  });
+
+  it('loads AI metadata from a custom config dir relative to cwd', async () => {
+    const apply = vi.fn().mockResolvedValue({ tools: [] });
+    mockLoadedStorybook(apply);
+
+    await loadStorybookAiMetadata({ cwd: '/repo', configDir: 'config/storybook' });
+
+    expect(loadStorybook).toHaveBeenCalledWith({ configDir: '/repo/config/storybook' });
+  });
+
+  it('normalizes optional metadata fields and hides descriptor-less local tools', async () => {
+    const call = vi.fn();
+    mockLoadedStorybook(
+      vi.fn().mockResolvedValue({
+        instructions: 123,
+        tools: [{ name: 'get-documentation' }],
+        localTools: {
+          invalid: {},
+          notObject: true,
+          'get-documentation': { call },
+        },
+      })
+    );
+
+    const metadata = await loadStorybookAiMetadata({ cwd: '/repo' });
+
+    expect(metadata).toEqual({
+      instructions: undefined,
+      tools: [{ name: 'get-documentation' }],
+      localTools: {
+        'get-documentation': { call },
+      },
+    });
+  });
+
+  it('rejects malformed metadata tool descriptors', async () => {
+    mockLoadedStorybook(
+      vi.fn().mockResolvedValue({
+        tools: [{ name: 123 }],
+      })
+    );
+
+    await expect(loadStorybookAiMetadata({ cwd: '/repo' })).rejects.toThrow(
+      'invalid tool descriptor'
+    );
+  });
+
+  it('rejects malformed visible local tools', async () => {
+    mockLoadedStorybook(
+      vi.fn().mockResolvedValue({
+        tools: [{ name: 'get-storybook-story-instructions' }],
+        localTools: {
+          'get-storybook-story-instructions': {},
+        },
+      })
+    );
+
+    await expect(loadStorybookAiMetadata({ cwd: '/repo' })).rejects.toThrow('invalid local tool');
+  });
+
+  it('returns undefined when no preset provides metadata', async () => {
+    mockLoadedStorybook(vi.fn().mockResolvedValue(undefined));
+
+    await expect(loadStorybookAiMetadata({ cwd: '/repo' })).resolves.toBeUndefined();
+  });
+});
+
+describe('resolveStorybookConfigDir', () => {
+  it('defaults to .storybook under the target cwd', () => {
+    expect(resolveStorybookConfigDir({ cwd: '/repo' })).toBe('/repo/.storybook');
+  });
+
+  it('resolves relative config dirs from the target cwd', () => {
+    expect(resolveStorybookConfigDir({ cwd: '/repo', configDir: 'config/storybook' })).toBe(
+      '/repo/config/storybook'
+    );
+  });
+
+  it('keeps absolute config dirs unchanged', () => {
+    expect(resolveStorybookConfigDir({ cwd: '/repo', configDir: '/custom/.storybook' })).toBe(
+      '/custom/.storybook'
+    );
+  });
+});

--- a/code/core/src/cli/ai/mcp/local-metadata.ts
+++ b/code/core/src/cli/ai/mcp/local-metadata.ts
@@ -1,0 +1,120 @@
+import { isAbsolute, resolve } from 'node:path';
+
+import { experimental_loadStorybook as loadStorybook } from 'storybook/internal/core-server';
+
+import * as v from 'valibot';
+
+import { McpToolDescriptorSchema, type McpToolDescriptor, type ToolCallResult } from './types.ts';
+
+const STORYBOOK_AI_METADATA_PRESET = 'experimental_storybookAi';
+
+class StorybookAiMetadataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StorybookAiMetadataError';
+  }
+}
+
+export type StorybookAiMetadata = {
+  instructions?: string;
+  tools: McpToolDescriptor[];
+  localTools?: Record<
+    string,
+    { call: (input?: Record<string, unknown>) => Promise<ToolCallResult> }
+  >;
+};
+
+export type StorybookAiMetadataOptions = {
+  cwd?: string;
+  configDir?: string;
+};
+
+export function resolveStorybookConfigDir({ cwd, configDir }: StorybookAiMetadataOptions = {}) {
+  const projectCwd = resolve(cwd ?? process.cwd());
+  if (configDir) {
+    return isAbsolute(configDir) ? configDir : resolve(projectCwd, configDir);
+  }
+  return resolve(projectCwd, '.storybook');
+}
+
+export async function loadStorybookAiMetadata(
+  options: StorybookAiMetadataOptions = {}
+): Promise<StorybookAiMetadata | undefined> {
+  const configDir = resolveStorybookConfigDir(options);
+  const storybook = await loadStorybook({ configDir });
+
+  const metadata = await storybook.presets.apply<unknown>(STORYBOOK_AI_METADATA_PRESET, undefined);
+
+  return normalizeStorybookAiMetadata(metadata);
+}
+
+function normalizeStorybookAiMetadata(metadata: unknown): StorybookAiMetadata | undefined {
+  if (!metadata || typeof metadata !== 'object') {
+    return undefined;
+  }
+  const rawMetadata = metadata as Record<string, unknown>;
+  const tools = normalizeTools(rawMetadata.tools);
+
+  return {
+    instructions:
+      typeof rawMetadata.instructions === 'string' ? rawMetadata.instructions : undefined,
+    tools,
+    localTools: normalizeLocalTools(rawMetadata.localTools, tools),
+  };
+}
+
+function normalizeTools(metadata: unknown): McpToolDescriptor[] {
+  if (metadata === undefined) {
+    return [];
+  }
+  if (!Array.isArray(metadata)) {
+    throw new StorybookAiMetadataError('Storybook AI metadata must expose `tools` as an array');
+  }
+
+  return metadata.map((tool) => {
+    const result = v.safeParse(McpToolDescriptorSchema, tool);
+    if (!result.success) {
+      throw new StorybookAiMetadataError(
+        'Storybook AI metadata contains an invalid tool descriptor'
+      );
+    }
+    return result.output;
+  });
+}
+
+function normalizeLocalTools(
+  metadata: unknown,
+  tools: McpToolDescriptor[]
+): StorybookAiMetadata['localTools'] {
+  if (!metadata || typeof metadata !== 'object') {
+    return undefined;
+  }
+
+  const visibleToolNames = new Set(tools.map((tool) => tool.name));
+  const entries = Object.entries(metadata as Record<string, unknown>).flatMap(([name, tool]) => {
+    if (!visibleToolNames.has(name)) {
+      return [];
+    }
+    if (!tool || typeof tool !== 'object') {
+      throw new StorybookAiMetadataError(
+        `Storybook AI metadata contains an invalid local tool for \`${name}\``
+      );
+    }
+    const call = (tool as { call?: unknown }).call;
+    if (typeof call !== 'function') {
+      throw new StorybookAiMetadataError(
+        `Storybook AI metadata contains an invalid local tool for \`${name}\``
+      );
+    }
+    return [
+      [
+        name,
+        {
+          call: call as (input?: Record<string, unknown>) => Promise<ToolCallResult>,
+        },
+      ] as const,
+    ];
+  });
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}

--- a/code/core/src/cli/ai/mcp/register.test.ts
+++ b/code/core/src/cli/ai/mcp/register.test.ts
@@ -107,7 +107,7 @@ beforeEach(() => {
     outcome: { kind: 'help' },
   });
   vi.mocked(buildStorybookCommandsHelp).mockResolvedValue(
-    'Storybook commands (from the running Storybook):'
+    'Storybook commands (from the target Storybook configuration):'
   );
   vi.mocked(writeFile).mockResolvedValue(undefined);
   // Pass-through that mirrors the real contract: run the callback, propagate its rejection.
@@ -154,6 +154,7 @@ describe('with the feature flag (passthrough registered)', () => {
     await parse(program, ['ai', 'get-documentation', '--id', 'button-docs']);
     expect(runAiTool).toHaveBeenCalledWith('get-documentation', ['--id', 'button-docs'], {
       cwd: undefined,
+      configDir: undefined,
       port: undefined,
       json: undefined,
     });
@@ -173,8 +174,20 @@ describe('with the feature flag (passthrough registered)', () => {
     ]);
     expect(runAiTool).toHaveBeenCalledWith('get-documentation', [], {
       cwd: '/x',
+      configDir: undefined,
       port: '6006',
       json: '{"a":1}',
+    });
+  });
+
+  it('parses --config-dir before the tool name as a CLI option', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, ['ai', '--config-dir', 'config/storybook', 'get-documentation']);
+    expect(runAiTool).toHaveBeenCalledWith('get-documentation', [], {
+      cwd: undefined,
+      configDir: 'config/storybook',
+      port: undefined,
+      json: undefined,
     });
   });
 
@@ -183,6 +196,7 @@ describe('with the feature flag (passthrough registered)', () => {
     await parse(program, ['ai', 'tool-x', '--cwd', '/y', '--output', 'z']);
     expect(runAiTool).toHaveBeenCalledWith('tool-x', ['--cwd', '/y', '--output', 'z'], {
       cwd: undefined,
+      configDir: undefined,
       port: undefined,
       json: undefined,
     });
@@ -236,11 +250,15 @@ describe('with the feature flag (passthrough registered)', () => {
     async (argv) => {
       const { program } = buildProgram({ withPassthrough: true });
       await parse(program, argv);
-      expect(buildStorybookCommandsHelp).toHaveBeenCalledWith({ cwd: undefined, port: undefined });
+      expect(buildStorybookCommandsHelp).toHaveBeenCalledWith({
+        cwd: undefined,
+        configDir: undefined,
+        port: undefined,
+      });
       const output = stdoutText();
       expect(output).toContain('Usage:');
       expect(output).toContain('setup');
-      expect(output).toContain('Storybook commands (from the running Storybook):');
+      expect(output).toContain('Storybook commands (from the target Storybook configuration):');
       expect(runAiTool).not.toHaveBeenCalled();
     }
   );
@@ -248,7 +266,21 @@ describe('with the feature flag (passthrough registered)', () => {
   it('passes --cwd and --port through to the tool commands section', async () => {
     const { program } = buildProgram({ withPassthrough: true });
     await parse(program, ['ai', '--cwd', '/x', '--port', '6006', '--help']);
-    expect(buildStorybookCommandsHelp).toHaveBeenCalledWith({ cwd: '/x', port: '6006' });
+    expect(buildStorybookCommandsHelp).toHaveBeenCalledWith({
+      cwd: '/x',
+      configDir: undefined,
+      port: '6006',
+    });
+  });
+
+  it('passes --config-dir through to the tool commands section', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, ['ai', '--config-dir', 'config/storybook', '--help']);
+    expect(buildStorybookCommandsHelp).toHaveBeenCalledWith({
+      cwd: undefined,
+      configDir: 'config/storybook',
+      port: undefined,
+    });
   });
 
   it('shows single-tool help for `ai --help <tool>`', async () => {
@@ -256,6 +288,7 @@ describe('with the feature flag (passthrough registered)', () => {
     await parse(program, ['ai', '--help', 'get-documentation']);
     expect(runAiToolHelp).toHaveBeenCalledWith('get-documentation', {
       cwd: undefined,
+      configDir: undefined,
       port: undefined,
     });
     expect(process.stdout.write).toHaveBeenCalledWith('tool help\n');
@@ -267,6 +300,7 @@ describe('with the feature flag (passthrough registered)', () => {
     await parse(program, ['ai', 'get-documentation', '--help']);
     expect(runAiTool).toHaveBeenCalledWith('get-documentation', ['--help'], {
       cwd: undefined,
+      configDir: undefined,
       port: undefined,
       json: undefined,
     });
@@ -313,6 +347,33 @@ describe('ai-command telemetry', () => {
     }
   );
 
+  it.each([
+    [
+      'before the command name',
+      ['ai', '--cwd', '/target/project', '--config-dir', 'config/storybook', 'tool-x'],
+    ],
+    [
+      'after the command name',
+      ['ai', 'tool-x', '--cwd', '/target/project', '--config-dir', 'config/storybook'],
+    ],
+    [
+      'after the command name with short flag',
+      ['ai', 'tool-x', '--cwd', '/target/project', '-c', 'config/storybook'],
+    ],
+  ])('resolves the opt-out configDir from --config-dir when passed %s', async (_position, argv) => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, argv);
+    expect(withTelemetry).toHaveBeenCalledWith(
+      'ai-command',
+      expect.objectContaining({
+        cliOptions: expect.objectContaining({
+          configDir: resolve('/target/project', 'config/storybook'),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
   it('honors the --cwd target opt-out even when the remaining args are malformed', async () => {
     const { program } = buildProgram({ withPassthrough: true });
     // `--json '{bad'` makes full arg parsing fail (invalid-arguments intercept), but the
@@ -323,6 +384,32 @@ describe('ai-command telemetry', () => {
       expect.objectContaining({
         cliOptions: expect.objectContaining({
           configDir: resolve('/target/project', '.storybook'),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it.each([
+    ['long flag', '--config-dir'],
+    ['short flag', '-c'],
+  ])('honors --config-dir %s even when the remaining args are malformed', async (_label, flag) => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, [
+      'ai',
+      'tool-x',
+      '--cwd',
+      '/target/project',
+      flag,
+      'config/storybook',
+      '--json',
+      '{bad',
+    ]);
+    expect(withTelemetry).toHaveBeenCalledWith(
+      'ai-command',
+      expect.objectContaining({
+        cliOptions: expect.objectContaining({
+          configDir: resolve('/target/project', 'config/storybook'),
         }),
       }),
       expect.any(Function)

--- a/code/core/src/cli/ai/mcp/register.test.ts
+++ b/code/core/src/cli/ai/mcp/register.test.ts
@@ -44,13 +44,13 @@ function buildProgram({ withPassthrough }: { withPassthrough: boolean }) {
   const setupAction = vi.fn();
   const helpAction = vi.fn();
   const failures: unknown[] = [];
-  const handleCommandFailure = vi.fn(
-    (_logFilePath: string | boolean | undefined) =>
-      async (error: unknown): Promise<never> => {
-        failures.push(error);
-        return undefined as never;
-      }
-  );
+  const handleCommandFailure = vi.fn((logFilePath: string | boolean | undefined) => {
+    void logFilePath;
+    return async (error: unknown): Promise<never> => {
+      failures.push(error);
+      return undefined as never;
+    };
+  });
 
   const aiCommand = program
     .command('ai')
@@ -160,29 +160,46 @@ describe('with the feature flag (passthrough registered)', () => {
     });
   });
 
-  it('parses --cwd, --port and --json before the tool name as CLI options', async () => {
+  it('parses target options before the tool name and leaves later tokens as command args', async () => {
     const { program } = buildProgram({ withPassthrough: true });
     await parse(program, [
       'ai',
       '--cwd',
-      '/x',
+      '/repo',
+      '--config-dir',
+      'config/storybook',
       '--port',
-      '6006',
-      '--json',
-      '{"a":1}',
-      'get-documentation',
+      '6007',
+      'preview-stories',
+      '--storyIds',
+      '["button--primary"]',
     ]);
+    expect(runAiTool).toHaveBeenCalledWith(
+      'preview-stories',
+      ['--storyIds', '["button--primary"]'],
+      {
+        cwd: '/repo',
+        configDir: 'config/storybook',
+        port: '6007',
+        json: undefined,
+      }
+    );
+  });
+
+  it('parses --json before the tool name as the command argument escape hatch', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, ['ai', '--json', '{"a":1}', 'get-documentation']);
     expect(runAiTool).toHaveBeenCalledWith('get-documentation', [], {
-      cwd: '/x',
+      cwd: undefined,
       configDir: undefined,
-      port: '6006',
+      port: undefined,
       json: '{"a":1}',
     });
   });
 
-  it('parses --config-dir before the tool name as a CLI option', async () => {
+  it('parses -c before the tool name as a config-dir CLI option', async () => {
     const { program } = buildProgram({ withPassthrough: true });
-    await parse(program, ['ai', '--config-dir', 'config/storybook', 'get-documentation']);
+    await parse(program, ['ai', '-c', 'config/storybook', 'get-documentation']);
     expect(runAiTool).toHaveBeenCalledWith('get-documentation', [], {
       cwd: undefined,
       configDir: 'config/storybook',
@@ -193,13 +210,28 @@ describe('with the feature flag (passthrough registered)', () => {
 
   it('passes tokens after the tool name through verbatim, even option-like ones', async () => {
     const { program } = buildProgram({ withPassthrough: true });
-    await parse(program, ['ai', 'tool-x', '--cwd', '/y', '--output', 'z']);
-    expect(runAiTool).toHaveBeenCalledWith('tool-x', ['--cwd', '/y', '--output', 'z'], {
-      cwd: undefined,
-      configDir: undefined,
-      port: undefined,
-      json: undefined,
-    });
+    await parse(program, [
+      'ai',
+      'tool-x',
+      '--cwd',
+      '/y',
+      '--config-dir',
+      'config/storybook',
+      '--port',
+      '6007',
+      '--output',
+      'z',
+    ]);
+    expect(runAiTool).toHaveBeenCalledWith(
+      'tool-x',
+      ['--cwd', '/y', '--config-dir', 'config/storybook', '--port', '6007', '--output', 'z'],
+      {
+        cwd: undefined,
+        configDir: undefined,
+        port: undefined,
+        json: undefined,
+      }
+    );
   });
 
   it('writes the result to the file given via --output instead of stdout', async () => {
@@ -326,59 +358,10 @@ describe('ai-command telemetry', () => {
     );
   });
 
-  it.each([
-    ['before the command name', ['ai', '--cwd', '/target/project', 'tool-x']],
-    ['after the command name', ['ai', 'tool-x', '--cwd', '/target/project']],
-  ])(
-    'resolves the opt-out configDir from the target Storybook when --cwd is passed %s',
-    async (_position, argv) => {
-      const { program } = buildProgram({ withPassthrough: true });
-      await parse(program, argv);
-      // The target project's core.disableTelemetry must apply, not the invoking cwd's.
-      expect(withTelemetry).toHaveBeenCalledWith(
-        'ai-command',
-        expect.objectContaining({
-          cliOptions: expect.objectContaining({
-            configDir: resolve('/target/project', '.storybook'),
-          }),
-        }),
-        expect.any(Function)
-      );
-    }
-  );
-
-  it.each([
-    [
-      'before the command name',
-      ['ai', '--cwd', '/target/project', '--config-dir', 'config/storybook', 'tool-x'],
-    ],
-    [
-      'after the command name',
-      ['ai', 'tool-x', '--cwd', '/target/project', '--config-dir', 'config/storybook'],
-    ],
-    [
-      'after the command name with short flag',
-      ['ai', 'tool-x', '--cwd', '/target/project', '-c', 'config/storybook'],
-    ],
-  ])('resolves the opt-out configDir from --config-dir when passed %s', async (_position, argv) => {
+  it('resolves the opt-out configDir from pre-command --cwd', async () => {
     const { program } = buildProgram({ withPassthrough: true });
-    await parse(program, argv);
-    expect(withTelemetry).toHaveBeenCalledWith(
-      'ai-command',
-      expect.objectContaining({
-        cliOptions: expect.objectContaining({
-          configDir: resolve('/target/project', 'config/storybook'),
-        }),
-      }),
-      expect.any(Function)
-    );
-  });
-
-  it('honors the --cwd target opt-out even when the remaining args are malformed', async () => {
-    const { program } = buildProgram({ withPassthrough: true });
-    // `--json '{bad'` makes full arg parsing fail (invalid-arguments intercept), but the
-    // target project's core.disableTelemetry must still be the one consulted.
-    await parse(program, ['ai', 'tool-x', '--cwd', '/target/project', '--json', '{bad']);
+    await parse(program, ['ai', '--cwd', '/target/project', 'tool-x']);
+    // The target project's core.disableTelemetry must apply, not the invoking cwd's.
     expect(withTelemetry).toHaveBeenCalledWith(
       'ai-command',
       expect.objectContaining({
@@ -390,18 +373,75 @@ describe('ai-command telemetry', () => {
     );
   });
 
-  it.each([
-    ['long flag', '--config-dir'],
-    ['short flag', '-c'],
-  ])('honors --config-dir %s even when the remaining args are malformed', async (_label, flag) => {
+  it('resolves the opt-out configDir from pre-command --config-dir', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, [
+      'ai',
+      '--cwd',
+      '/target/project',
+      '--config-dir',
+      'config/storybook',
+      'tool-x',
+    ]);
+    expect(withTelemetry).toHaveBeenCalledWith(
+      'ai-command',
+      expect.objectContaining({
+        cliOptions: expect.objectContaining({
+          configDir: resolve('/target/project', 'config/storybook'),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('does not resolve the opt-out configDir from post-command target-looking flags', async () => {
     const { program } = buildProgram({ withPassthrough: true });
     await parse(program, [
       'ai',
       'tool-x',
       '--cwd',
       '/target/project',
-      flag,
+      '--config-dir',
       'config/storybook',
+      '--port',
+      '6007',
+    ]);
+    expect(withTelemetry).toHaveBeenCalledWith(
+      'ai-command',
+      expect.objectContaining({
+        cliOptions: expect.objectContaining({
+          configDir: resolve(process.cwd(), '.storybook'),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('honors pre-command --cwd target opt-out even when the command args are malformed', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    // `--json '{bad'` makes full arg parsing fail (invalid-arguments intercept), but the
+    // target project's core.disableTelemetry must still be the one consulted.
+    await parse(program, ['ai', '--cwd', '/target/project', 'tool-x', '--json', '{bad']);
+    expect(withTelemetry).toHaveBeenCalledWith(
+      'ai-command',
+      expect.objectContaining({
+        cliOptions: expect.objectContaining({
+          configDir: resolve('/target/project', '.storybook'),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('honors pre-command --config-dir even when the command args are malformed', async () => {
+    const { program } = buildProgram({ withPassthrough: true });
+    await parse(program, [
+      'ai',
+      '--cwd',
+      '/target/project',
+      '--config-dir',
+      'config/storybook',
+      'tool-x',
       '--json',
       '{bad',
     ]);

--- a/code/core/src/cli/ai/mcp/register.ts
+++ b/code/core/src/cli/ai/mcp/register.ts
@@ -16,7 +16,8 @@ import {
   runAiTool,
   runAiToolHelp,
 } from './run-tool.ts';
-import { scanCwdToken } from './tool-args.ts';
+import { resolveStorybookConfigDir } from './local-metadata.ts';
+import { scanConfigDirToken, scanCwdToken } from './tool-args.ts';
 
 /**
  * The `storybook ai <tool>` MCP passthrough is experimental (storybookjs/storybook#35124) and only
@@ -28,11 +29,14 @@ export function isAiCliFeatureEnabled(env: NodeJS.ProcessEnv = process.env): boo
 
 const CWD_DESCRIPTION =
   'Project directory of the target Storybook (defaults to the current working directory)';
+const CONFIG_DIR_DESCRIPTION =
+  'Directory where to load Storybook configuration from for help and local commands';
 const PORT_DESCRIPTION =
-  'Port of the target Storybook, to address one specific instance when several run at the same cwd';
+  'Port of the target Storybook for runtime commands when several instances run at the same cwd';
 
 type AiPassthroughOptions = {
   cwd?: string;
+  configDir?: string;
   port?: string;
   json?: string;
   output?: string;
@@ -50,13 +54,14 @@ export type CommandFailureHandler = (
 
 /**
  * Register the passthrough on the `ai` command: a generic `[command] [args...]` argument pair that
- * forwards any command to the running Storybook's server (MCP under the hood, but that is an
- * implementation detail — user-facing copy says "commands"). `passThroughOptions` hands every
- * token after the command name to the command untouched, which requires positional options on the
- * program.
+ * runs commands exposed by the target Storybook. Help and serverless local commands are loaded from
+ * Storybook configuration metadata; runtime-bound commands forward to the running Storybook's
+ * server (MCP under the hood, but that is an implementation detail — user-facing copy says
+ * "commands"). `passThroughOptions` hands every token after the command name to the command
+ * untouched, which requires positional options on the program.
  *
  * Commander's built-in (synchronous) help is replaced with our own `-h, --help` option so the help
- * output can include the commands fetched from the running Storybook.
+ * output can include the commands loaded from Storybook configuration.
  */
 export function registerAiMcpPassthrough(
   program: Command,
@@ -68,18 +73,22 @@ export function registerAiMcpPassthrough(
   aiCommand
     .helpOption(false)
     .usage('[options] [command] [args...]')
-    .argument('[command]', 'A command provided by the running Storybook')
+    .argument('[command]', 'A command loaded from the target Storybook configuration')
     .argument(
       '[args...]',
       'Command arguments as `--key value` flags; values are JSON-parsed when possible'
     )
     .option('--cwd <path>', CWD_DESCRIPTION)
+    .option('-c, --config-dir <dir-name>', CONFIG_DIR_DESCRIPTION)
     .option('--port <number>', PORT_DESCRIPTION)
     .option(
       '--json <object>',
       'Raw JSON object with the command arguments (escape hatch for complex values)'
     )
-    .option('-h, --help', 'Show help, including the commands provided by the running Storybook')
+    .option(
+      '-h, --help',
+      'Show help, including commands loaded from the target Storybook configuration'
+    )
     .passThroughOptions()
     .action(
       async (command: string | undefined, commandArgs: string[], options: AiPassthroughOptions) => {
@@ -92,7 +101,11 @@ export function registerAiMcpPassthrough(
           'ai-command',
           { cliOptions, fallbackTelemetryState: true },
           async () => {
-            const target = { cwd: options.cwd, port: options.port };
+            const target = {
+              cwd: options.cwd,
+              configDir: options.configDir,
+              port: options.port,
+            };
             if (options.help && command) {
               await printResult(await runAiToolHelp(command, target), options.output);
               return;
@@ -129,10 +142,11 @@ export function registerAiMcpPassthrough(
  */
 function pickCliOptions(options: AiPassthroughOptions, commandArgs: string[]): CLIOptions {
   const targetCwd = scanCwdToken(commandArgs) ?? options.cwd ?? process.cwd();
+  const targetConfigDir = scanConfigDirToken(commandArgs) ?? options.configDir;
   return {
     disableTelemetry: options.disableTelemetry,
     logfile: options.logfile,
-    configDir: resolve(targetCwd, '.storybook'),
+    configDir: resolveStorybookConfigDir({ cwd: targetCwd, configDir: targetConfigDir }),
   };
 }
 

--- a/code/core/src/cli/ai/mcp/register.ts
+++ b/code/core/src/cli/ai/mcp/register.ts
@@ -17,7 +17,6 @@ import {
   runAiToolHelp,
 } from './run-tool.ts';
 import { resolveStorybookConfigDir } from './local-metadata.ts';
-import { scanConfigDirToken, scanCwdToken } from './tool-args.ts';
 
 /**
  * The `storybook ai <tool>` MCP passthrough is experimental (storybookjs/storybook#35124) and only
@@ -27,12 +26,11 @@ export function isAiCliFeatureEnabled(env: NodeJS.ProcessEnv = process.env): boo
   return optionalEnvToBoolean(env.STORYBOOK_FEATURE_AI_CLI) === true;
 }
 
-const CWD_DESCRIPTION =
-  'Project directory of the target Storybook (defaults to the current working directory)';
+const CWD_DESCRIPTION = 'Project directory of the target Storybook; place before the command name';
 const CONFIG_DIR_DESCRIPTION =
-  'Directory where to load Storybook configuration from for help and local commands';
+  'Storybook config directory for help and local commands; place before the command name';
 const PORT_DESCRIPTION =
-  'Port of the target Storybook for runtime commands when several instances run at the same cwd';
+  'Port of the target Storybook for runtime commands; place before the command name';
 
 type AiPassthroughOptions = {
   cwd?: string;
@@ -61,7 +59,9 @@ export type CommandFailureHandler = (
  * untouched, which requires positional options on the program.
  *
  * Commander's built-in (synchronous) help is replaced with our own `-h, --help` option so the help
- * output can include the commands loaded from Storybook configuration.
+ * output can include the commands loaded from Storybook configuration. Target-selection options
+ * (`--cwd`, `--config-dir`, `--port`) belong before the command name; after the command name,
+ * tokens are command arguments.
  */
 export function registerAiMcpPassthrough(
   program: Command,
@@ -92,7 +92,7 @@ export function registerAiMcpPassthrough(
     .passThroughOptions()
     .action(
       async (command: string | undefined, commandArgs: string[], options: AiPassthroughOptions) => {
-        const cliOptions = pickCliOptions(options, commandArgs);
+        const cliOptions = pickCliOptions(options);
         // Like `init`, the fallback keeps telemetry on when no main config is loadable: running
         // from a cwd without a Storybook is the `no-instance` intercept this event exists to
         // measure. The explicit opt-outs (env var, flag, loadable `core.disableTelemetry`)
@@ -135,14 +135,14 @@ export function registerAiMcpPassthrough(
 /**
  * The cliOptions handed to the telemetry machinery. Only the opt-out tier is forwarded — the
  * passthrough's own options (cwd, port, json) may contain paths and are never sent in payloads.
- * `configDir` points at the default config location of the *target* Storybook so `withTelemetry`
- * resolves `core.disableTelemetry` from the project the command is aimed at (`--cwd` is accepted
- * both before and after the command name, and is scanned leniently so even invocations rejected
- * as `invalid-arguments` honor the target's opt-out); it is read locally, never sent.
+ * `configDir` points at the config location of the *target* Storybook so `withTelemetry` resolves
+ * `core.disableTelemetry` from the project the command is aimed at. Target-selection options are
+ * commander-owned and must appear before the command name; after the command name, tokens are tool
+ * arguments and do not affect telemetry opt-out resolution. It is read locally, never sent.
  */
-function pickCliOptions(options: AiPassthroughOptions, commandArgs: string[]): CLIOptions {
-  const targetCwd = scanCwdToken(commandArgs) ?? options.cwd ?? process.cwd();
-  const targetConfigDir = scanConfigDirToken(commandArgs) ?? options.configDir;
+function pickCliOptions(options: AiPassthroughOptions): CLIOptions {
+  const targetCwd = options.cwd ?? process.cwd();
+  const targetConfigDir = options.configDir;
   return {
     disableTelemetry: options.disableTelemetry,
     logfile: options.logfile,

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -57,7 +57,7 @@ describe('runAiTool', () => {
     });
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
       cwd: '/projects/foo',
-      configDir: undefined,
+      configDir: '/projects/foo/.storybook',
     });
   });
 
@@ -132,7 +132,7 @@ describe('runAiTool', () => {
     expect(result.output).toBe('custom config instructions');
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
       cwd: '/projects/foo',
-      configDir: 'config/storybook',
+      configDir: '/projects/foo/config/storybook',
     });
     expect(readRegistry).not.toHaveBeenCalled();
   });
@@ -417,7 +417,7 @@ describe('runAiTool', () => {
     // Constant message keeps the telemetry error hash aggregatable; the tool's error text only
     // travels as `cause` (uploaded path-sanitized, and only with crash-reports consent).
     const error = (result.outcome as { error: Error }).error;
-    expect(error.message).toBe('The Storybook MCP server returned an error result');
+    expect(error.message).toBe('The Storybook AI command returned an error result');
     expect(error.cause).toBe('tests failed');
   });
 
@@ -552,14 +552,15 @@ describe('buildStorybookCommandsHelp', () => {
     expect(section).toContain('provides no commands');
   });
 
-  it('degrades to a note when commands are exposed without workflow instructions', async () => {
+  it('still lists commands when workflow instructions are absent', async () => {
     vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
       tools: [{ name: 'get-documentation', description: 'Get docs for a component.' }],
       instructions: '   ',
     });
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
-    expect(section).toContain('Storybook commands: (unavailable');
-    expect(section).toContain('exposed commands but no workflow instructions');
+    expect(section).toContain('# Storybook commands');
+    expect(section).toContain('get-documentation');
+    expect(section).not.toContain('# Storybook workflow instructions');
   });
 
   it('ignores --port on the serverless help path', async () => {
@@ -568,7 +569,7 @@ describe('buildStorybookCommandsHelp', () => {
     expect(section).toContain('list-all-documentation');
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
       cwd: '/projects/foo',
-      configDir: undefined,
+      configDir: '/projects/foo/.storybook',
     });
   });
 
@@ -586,7 +587,7 @@ describe('buildStorybookCommandsHelp', () => {
     expect(section).toContain('get-documentation');
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
       cwd: '/projects/foo',
-      configDir: 'config/storybook',
+      configDir: '/projects/foo/config/storybook',
     });
   });
 });
@@ -661,7 +662,7 @@ describe('runAiToolHelp', () => {
     expect(result.exitCode).toBe(0);
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
       cwd: '/projects/foo',
-      configDir: 'config/storybook',
+      configDir: '/projects/foo/config/storybook',
     });
   });
 
@@ -727,7 +728,7 @@ describe('runAiToolHelp', () => {
     expect(result.exitCode).toBe(0);
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
       cwd: '/projects/foo',
-      configDir: 'config/storybook',
+      configDir: '/projects/foo/config/storybook',
     });
   });
 

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -1,17 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  McpJsonRpcError,
-  callMcpTool,
-  listMcpTools,
-  listMcpToolsWithServerMetadata,
-} from './client.ts';
+import { McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
+import { loadStorybookAiMetadata, type StorybookAiMetadata } from './local-metadata.ts';
 import { readRegistry } from './registry.ts';
 import { buildStorybookCommandsHelp, runAiTool, runAiToolHelp } from './run-tool.ts';
 import type { StorybookInstanceRecord } from './types.ts';
 
 vi.mock('./registry.ts', { spy: true });
 vi.mock('./client.ts', { spy: true });
+vi.mock('./local-metadata.ts', { spy: true });
 
 const record: StorybookInstanceRecord = {
   schemaVersion: 1,
@@ -23,6 +20,14 @@ const record: StorybookInstanceRecord = {
   mcp: { status: 'ready', endpoint: '/mcp' },
 };
 
+const defaultRuntimeMetadata: StorybookAiMetadata = {
+  instructions: 'Follow the story workflow.',
+  tools: [
+    { name: 'list-all-documentation', description: 'List docs' },
+    { name: 'get-documentation', description: 'Get docs.' },
+  ],
+};
+
 beforeEach(() => {
   vi.mocked(readRegistry).mockReset().mockResolvedValue([record]);
   vi.mocked(callMcpTool)
@@ -31,12 +36,7 @@ beforeEach(() => {
   vi.mocked(listMcpTools)
     .mockReset()
     .mockResolvedValue([{ name: 'list-all-documentation', description: 'List docs' }]);
-  vi.mocked(listMcpToolsWithServerMetadata)
-    .mockReset()
-    .mockResolvedValue({
-      tools: [{ name: 'list-all-documentation', description: 'List docs' }],
-      serverMetadata: { instructions: 'Follow the story workflow.' },
-    });
+  vi.mocked(loadStorybookAiMetadata).mockReset().mockResolvedValue(defaultRuntimeMetadata);
 });
 
 describe('runAiTool', () => {
@@ -54,6 +54,178 @@ describe('runAiTool', () => {
       exitCode: 0,
       output: 'upstream result',
       outcome: { kind: 'success' },
+    });
+    expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
+      cwd: '/projects/foo',
+      configDir: undefined,
+    });
+  });
+
+  it('runs local tools from Storybook AI metadata without contacting the MCP server', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-storybook-story-instructions', description: 'Get story guidance' }],
+      localTools: {
+        'get-storybook-story-instructions': {
+          call: vi.fn().mockResolvedValue({
+            content: [{ type: 'text', text: 'local story instructions' }],
+          }),
+        },
+      },
+    });
+
+    const result = await runAiTool('get-storybook-story-instructions', [], {
+      cwd: '/projects/foo',
+    });
+
+    expect(result).toEqual({
+      exitCode: 0,
+      output: 'local story instructions',
+      outcome: { kind: 'success' },
+    });
+    expect(readRegistry).not.toHaveBeenCalled();
+    expect(callMcpTool).not.toHaveBeenCalled();
+  });
+
+  it('runs any metadata-declared local tool locally even when a Storybook server is ready', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'custom-local-command', description: 'Run custom local work' }],
+      localTools: {
+        'custom-local-command': {
+          call: vi.fn().mockResolvedValue({
+            content: [{ type: 'text', text: 'custom local result' }],
+          }),
+        },
+      },
+    });
+
+    const result = await runAiTool('custom-local-command', [], {
+      cwd: '/projects/foo',
+    });
+
+    expect(result.output).toBe('custom local result');
+    expect(readRegistry).not.toHaveBeenCalled();
+    expect(callMcpTool).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['--config-dir', ['--config-dir', 'config/storybook']],
+    ['-c', ['-c', 'config/storybook']],
+  ])('loads known local tools from a custom config dir with %s', async (_label, tokens) => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-storybook-story-instructions', description: 'Get story guidance' }],
+      localTools: {
+        'get-storybook-story-instructions': {
+          call: vi.fn().mockResolvedValue({
+            content: [{ type: 'text', text: 'custom config instructions' }],
+          }),
+        },
+      },
+    });
+
+    const result = await runAiTool('get-storybook-story-instructions', tokens, {
+      cwd: '/projects/foo',
+    });
+
+    expect(result.output).toBe('custom config instructions');
+    expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
+      cwd: '/projects/foo',
+      configDir: 'config/storybook',
+    });
+    expect(readRegistry).not.toHaveBeenCalled();
+  });
+
+  it('ignores --port validation for metadata-declared local tools', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-storybook-story-instructions', description: 'Get story guidance' }],
+      localTools: {
+        'get-storybook-story-instructions': {
+          call: vi.fn().mockResolvedValue({
+            content: [{ type: 'text', text: 'local story instructions' }],
+          }),
+        },
+      },
+    });
+
+    const result = await runAiTool('get-storybook-story-instructions', ['--port', 'abc'], {
+      cwd: '/projects/foo',
+    });
+
+    expect(result).toEqual({
+      exitCode: 0,
+      output: 'local story instructions',
+      outcome: { kind: 'success' },
+    });
+    expect(readRegistry).not.toHaveBeenCalled();
+  });
+
+  it('surfaces metadata loading errors before checking for a server', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockRejectedValue(new Error('main config failed'));
+
+    const result = await runAiTool('get-storybook-story-instructions', [], {
+      cwd: '/projects/foo',
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Storybook command metadata is unavailable');
+    expect(result.output).toContain('main config failed');
+    expect(result.outcome).toEqual({
+      kind: 'error',
+      error: expect.objectContaining({ name: 'LocalAiToolError' }),
+    });
+    expect(readRegistry).not.toHaveBeenCalled();
+    expect(callMcpTool).not.toHaveBeenCalled();
+  });
+
+  it('surfaces local tool error results with the stable MCP error wrapper', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-storybook-story-instructions', description: 'Get story guidance' }],
+      localTools: {
+        'get-storybook-story-instructions': {
+          call: vi.fn().mockResolvedValue({
+            content: [{ type: 'text', text: 'local failure' }],
+            isError: true,
+          }),
+        },
+      },
+    });
+
+    const result = await runAiTool('get-storybook-story-instructions', [], {
+      cwd: '/projects/foo',
+    });
+
+    expect(result).toEqual({
+      exitCode: 1,
+      output: 'local failure',
+      outcome: { kind: 'error', error: expect.objectContaining({ name: 'McpToolResultError' }) },
+    });
+  });
+
+  it('wraps thrown local tool errors with a stable local command error', async () => {
+    const error = new Error('local command exploded');
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-storybook-story-instructions', description: 'Get story guidance' }],
+      localTools: {
+        'get-storybook-story-instructions': {
+          call: vi.fn().mockRejectedValue(error),
+        },
+      },
+    });
+
+    const result = await runAiTool('get-storybook-story-instructions', [], {
+      cwd: '/projects/foo',
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toBe('local command exploded');
+    expect(result.outcome).toEqual({
+      kind: 'error',
+      error: expect.objectContaining({ name: 'LocalAiToolError', cause: error }),
     });
   });
 
@@ -85,11 +257,31 @@ describe('runAiTool', () => {
   });
 
   it('prints the no-instance repair markdown and exits non-zero when nothing runs at the cwd', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-documentation', description: 'Get docs.' }],
+    });
+
     const result = await runAiTool('get-documentation', [], { cwd: '/projects/other' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('No Storybook is running at this cwd');
     expect(result.output).toContain('/projects/foo');
     expect(result.outcome).toEqual({ kind: 'intercept', reason: 'no-instance' });
+  });
+
+  it('prints metadata upgrade guidance when no metadata exists even if a server is ready', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue(undefined);
+
+    const result = await runAiTool('get-storybook-story-instructions', [], {
+      cwd: '/projects/foo',
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Storybook command metadata is unavailable');
+    expect(result.output).toContain('@storybook/addon-mcp');
+    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'unknown-command' });
+    expect(readRegistry).not.toHaveBeenCalled();
+    expect(callMcpTool).not.toHaveBeenCalled();
   });
 
   it('routes to the instance on the requested --port when several share the cwd', async () => {
@@ -167,9 +359,27 @@ describe('runAiTool', () => {
     expect(result.output).toContain('"resource_link"');
   });
 
-  it('lists the available tools when the call fails because the tool is unknown', async () => {
+  it('does not call live MCP for commands hidden by preset metadata', async () => {
+    const result = await runAiTool('run-story-tests', [], { cwd: '/projects/foo' });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Unknown command `run-story-tests`');
+    expect(result.output).toContain('- `list-all-documentation`');
+    expect(result.output).not.toContain('- `run-story-tests`');
+    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'unknown-command' });
+    expect(readRegistry).not.toHaveBeenCalled();
+    expect(callMcpTool).not.toHaveBeenCalled();
+  });
+
+  it('lists the server tools when a metadata-visible runtime command is missing server-side', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      ...defaultRuntimeMetadata,
+      tools: [...defaultRuntimeMetadata.tools, { name: 'no-such-tool', description: 'Stale tool' }],
+    });
     vi.mocked(callMcpTool).mockRejectedValue(new McpJsonRpcError(-32601, 'unknown tool'));
+
     const result = await runAiTool('no-such-tool', [], { cwd: '/projects/foo' });
+
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Unknown command `no-such-tool`');
     expect(result.output).toContain('- `list-all-documentation`');
@@ -177,6 +387,10 @@ describe('runAiTool', () => {
   });
 
   it('lists the available tools when the server reports the unknown tool as an error result', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      ...defaultRuntimeMetadata,
+      tools: [...defaultRuntimeMetadata.tools, { name: 'no-such-tool', description: 'Stale tool' }],
+    });
     // addon-mcp (tmcp) reports unknown tools as an isError result, not a JSON-RPC error.
     vi.mocked(callMcpTool).mockResolvedValue({
       content: [{ type: 'text', text: 'Tool no-such-tool not found' }],
@@ -218,6 +432,10 @@ describe('runAiTool', () => {
 
   it('prints the original JSON-RPC error when the tool list cannot be fetched', async () => {
     const error = new McpJsonRpcError(-32601, 'unknown tool');
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      ...defaultRuntimeMetadata,
+      tools: [...defaultRuntimeMetadata.tools, { name: 'no-such-tool', description: 'Stale tool' }],
+    });
     vi.mocked(callMcpTool).mockRejectedValue(error);
     vi.mocked(listMcpTools).mockRejectedValue(new Error('boom'));
     const result = await runAiTool('no-such-tool', [], { cwd: '/projects/foo' });
@@ -251,40 +469,47 @@ describe('runAiTool', () => {
 
 describe('buildStorybookCommandsHelp', () => {
   it('lists each tool with the first line of its description', async () => {
-    vi.mocked(listMcpToolsWithServerMetadata).mockResolvedValue({
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
       tools: [
         {
           name: 'get-documentation',
           description: 'Get docs for a component.\n\nLong details that should not appear.',
         },
         { name: 'list-all-documentation' },
+        { name: 'get-storybook-story-instructions', description: 'Get story guidance.' },
       ],
-      serverMetadata: { instructions: 'Follow the story workflow.' },
+      localTools: {
+        'get-storybook-story-instructions': {
+          call: vi.fn(),
+        },
+      },
+      instructions: 'Follow the story workflow.',
     });
 
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain(
-      'Storybook help from the Storybook running at http://localhost:6006:'
+      'Storybook help from the Storybook configuration at /projects/foo/.storybook:'
     );
     expect(section).toContain('# Storybook commands');
     expect(section).toContain('get-documentation');
+    expect(section).toContain('[requires Storybook] Get docs for a component.');
+    expect(section).toContain('get-storybook-story-instructions  [local]');
     expect(section).toContain('Get docs for a component.');
     expect(section).not.toContain('Long details');
     expect(section).toContain("Run 'storybook ai <command> --help'");
+    expect(readRegistry).not.toHaveBeenCalled();
   });
 
-  it('prints workflow instructions before the dynamic commands list when initialize provides them', async () => {
-    vi.mocked(listMcpToolsWithServerMetadata).mockResolvedValue({
+  it('prints workflow instructions before the dynamic commands list', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
       tools: [{ name: 'get-documentation', description: 'Get docs for a component.' }],
-      serverMetadata: {
-        instructions: 'Use existing stories as examples.\nRun tests after writing stories.',
-      },
+      instructions: 'Use existing stories as examples.\nRun tests after writing stories.',
     });
 
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toBe(
       [
-        'Storybook help from the Storybook running at http://localhost:6006:',
+        'Storybook help from the Storybook configuration at /projects/foo/.storybook:',
         '',
         '# Storybook workflow instructions',
         '',
@@ -293,144 +518,224 @@ describe('buildStorybookCommandsHelp', () => {
         '',
         '# Storybook commands',
         '',
-        '  get-documentation  Get docs for a component.',
+        '  get-documentation  [requires Storybook] Get docs for a component.',
+        '',
+        '[local] commands run from configuration metadata without a running Storybook.',
+        '[requires Storybook] commands are forwarded to the running Storybook server.',
         '',
         "Run 'storybook ai <command> --help' for a command's description and arguments.",
       ].join('\n')
     );
   });
 
-  it('degrades to a note when no Storybook is running (help must not fail)', async () => {
-    vi.mocked(readRegistry).mockResolvedValue([]);
+  it('degrades to a note when the metadata preset is unavailable', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue(undefined);
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain('Storybook commands: (unavailable');
-    expect(section).toContain('storybook dev');
+    expect(section).toContain('does not expose AI command metadata');
+    expect(section).toContain('@storybook/addon-mcp');
   });
 
-  it('lists the sibling ports when several instances run at the cwd', async () => {
-    const older = { ...record, instanceId: 'inst-2', pid: 2, port: 6007 };
-    const newest = { ...record, startedAt: '2026-06-10T12:00:00.000Z' };
-    vi.mocked(readRegistry).mockResolvedValue([newest, older]);
-    const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
-    expect(section).toContain('2 instances are running at this cwd');
-    expect(section).toContain('port 6006');
-    expect(section).toContain('other ports: 6007');
-    expect(section).toContain('`--port`');
-  });
-
-  it('names the port mismatch instead of claiming nothing is running', async () => {
-    const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo', port: '9999' });
-    expect(section).toContain('Storybook commands: (unavailable');
-    expect(section).toContain('no instance on port `9999`');
-    expect(section).toContain('running ports: 6006');
-    expect(section).not.toContain('no running Storybook detected');
-  });
-
-  it('says the Storybook is starting up instead of claiming nothing is running', async () => {
-    vi.mocked(readRegistry).mockResolvedValue([{ ...record, mcp: { status: 'starting' } }]);
-    const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
-    expect(section).toContain('still starting up');
-  });
-
-  it('points at the missing addon instead of claiming nothing is running', async () => {
-    vi.mocked(readRegistry).mockResolvedValue([{ ...record, mcp: { status: 'not-installed' } }]);
-    const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
-    expect(section).toContain('install `@storybook/addon-mcp`');
-  });
-
-  it('shows the Storybook version reported by the running instance', async () => {
-    vi.mocked(readRegistry).mockResolvedValue([{ ...record, storybookVersion: '10.5.0' }]);
-    const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
-    expect(section).toContain(
-      'Storybook help from the Storybook running at http://localhost:6006, Storybook 10.5.0:'
-    );
-  });
-
-  it('degrades to a note when the MCP server is unreachable', async () => {
-    vi.mocked(listMcpToolsWithServerMetadata).mockRejectedValue(new Error('connection refused'));
+  it('degrades to a note when metadata loading fails', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockRejectedValue(new Error('main config failed'));
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain('Storybook commands: (unavailable');
-    expect(section).toContain('could not be reached');
+    expect(section).toContain('could not be loaded');
   });
 
   it('degrades to a note when no tools are exposed', async () => {
-    vi.mocked(listMcpToolsWithServerMetadata).mockResolvedValue({
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
       tools: [],
-      serverMetadata: {},
+      instructions: '',
     });
     const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
     expect(section).toContain('provides no commands');
+  });
+
+  it('degrades to a note when commands are exposed without workflow instructions', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      tools: [{ name: 'get-documentation', description: 'Get docs for a component.' }],
+      instructions: '   ',
+    });
+    const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo' });
+    expect(section).toContain('Storybook commands: (unavailable');
+    expect(section).toContain('exposed commands but no workflow instructions');
+  });
+
+  it('ignores --port on the serverless help path', async () => {
+    const section = await buildStorybookCommandsHelp({ cwd: '/projects/foo', port: 'abc' });
+    expect(section).toContain('Storybook help from the Storybook configuration');
+    expect(section).toContain('list-all-documentation');
+    expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
+      cwd: '/projects/foo',
+      configDir: undefined,
+    });
+  });
+
+  it('loads the command section from a custom config dir', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      tools: [{ name: 'get-documentation', description: 'Get docs for a component.' }],
+      instructions: 'Follow the story workflow.',
+    });
+
+    const section = await buildStorybookCommandsHelp({
+      cwd: '/projects/foo',
+      configDir: 'config/storybook',
+    });
+
+    expect(section).toContain('get-documentation');
+    expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
+      cwd: '/projects/foo',
+      configDir: 'config/storybook',
+    });
   });
 });
 
 describe('runAiToolHelp', () => {
   it('prints the description and arguments of a single tool', async () => {
-    vi.mocked(listMcpTools).mockResolvedValue([
-      {
-        name: 'get-documentation',
-        description: 'Get docs for a component.',
-        inputSchema: {
-          properties: { id: { type: 'string', description: 'Documentation id' } },
-          required: ['id'],
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [
+        {
+          name: 'get-documentation',
+          description: 'Get docs for a component.',
+          inputSchema: {
+            properties: { id: { type: 'string', description: 'Documentation id' } },
+            required: ['id'],
+          },
         },
-      },
-    ]);
+      ],
+    });
 
     const result = await runAiToolHelp('get-documentation', { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('Usage: storybook ai get-documentation');
     expect(result.output).toContain('Get docs for a component.');
+    expect(result.output).toContain('Execution: requires a running Storybook.');
     expect(result.output).toContain('- `--id` (string, required): Documentation id');
     expect(result.outcome).toEqual({ kind: 'help' });
   });
 
+  it('marks local commands in single-command help', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-storybook-story-instructions', description: 'Get story guidance.' }],
+      localTools: {
+        'get-storybook-story-instructions': {
+          call: vi.fn(),
+        },
+      },
+    });
+
+    const result = await runAiToolHelp('get-storybook-story-instructions', {
+      cwd: '/projects/foo',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Execution: local (no running Storybook required).');
+  });
+
   it('is reachable through runAiTool via a --help token after the tool name', async () => {
-    vi.mocked(listMcpTools).mockResolvedValue([
-      { name: 'get-documentation', description: 'Get docs.' },
-    ]);
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-documentation', description: 'Get docs.' }],
+    });
     const result = await runAiTool('get-documentation', ['--help'], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('Usage: storybook ai get-documentation');
     expect(result.outcome).toEqual({ kind: 'help' });
     expect(callMcpTool).not.toHaveBeenCalled();
+    expect(readRegistry).not.toHaveBeenCalled();
   });
 
-  it('honors a --port token given after the command name on the help path', async () => {
-    const result = await runAiTool('get-documentation', ['--port', '9999', '--help'], {
+  it('honors --config-dir tokens on the help path after the tool name', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-documentation', description: 'Get docs.' }],
+    });
+    const result = await runAiTool(
+      'get-documentation',
+      ['--config-dir', 'config/storybook', '--help'],
+      { cwd: '/projects/foo' }
+    );
+    expect(result.exitCode).toBe(0);
+    expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
+      cwd: '/projects/foo',
+      configDir: 'config/storybook',
+    });
+  });
+
+  it('ignores --port tokens on the help path without needing a running server', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-documentation', description: 'Get docs.' }],
+    });
+    const result = await runAiTool('get-documentation', ['--port', 'not-a-port', '--help'], {
       cwd: '/projects/foo',
     });
-    expect(result.exitCode).toBe(1);
-    expect(result.output).toContain('not on port `9999`');
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Usage: storybook ai get-documentation');
+    expect(readRegistry).not.toHaveBeenCalled();
   });
 
   it('lists the available tools for an unknown tool name', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'list-all-documentation', description: 'List docs' }],
+    });
     const result = await runAiToolHelp('no-such-tool', { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Unknown command `no-such-tool`');
     expect(result.output).toContain('- `list-all-documentation`');
   });
 
-  it('prints repair markdown and exits non-zero on intercepts, still classified as help', async () => {
-    vi.mocked(readRegistry).mockResolvedValue([]);
+  it('prints metadata unavailable guidance when no preset metadata is exposed', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue(undefined);
     const result = await runAiToolHelp('get-documentation', { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(1);
-    expect(result.output).toContain('Storybook is not running at this cwd');
+    expect(result.output).toContain('Storybook command metadata is unavailable');
+    expect(result.output).toContain('@storybook/addon-mcp');
     expect(result.outcome).toEqual({ kind: 'help' });
   });
 
-  it('rejects an invalid --port', async () => {
+  it('ignores an invalid --port on direct help lookup', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-documentation', description: 'Get docs.' }],
+    });
+
     const result = await runAiToolHelp('get-documentation', {
       cwd: '/projects/foo',
       port: 'abc',
     });
-    expect(result.exitCode).toBe(1);
-    expect(result.output).toContain('`--port` must be a port number');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Usage: storybook ai get-documentation');
   });
 
-  it('surfaces a friendly error when the MCP server is unreachable', async () => {
-    vi.mocked(listMcpTools).mockRejectedValue(new Error('connection refused'));
+  it('loads direct help from a custom config dir', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
+      instructions: 'Follow the story workflow.',
+      tools: [{ name: 'get-documentation', description: 'Get docs.' }],
+    });
+
+    const result = await runAiToolHelp('get-documentation', {
+      cwd: '/projects/foo',
+      configDir: 'config/storybook',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
+      cwd: '/projects/foo',
+      configDir: 'config/storybook',
+    });
+  });
+
+  it('surfaces metadata loading errors', async () => {
+    vi.mocked(loadStorybookAiMetadata).mockRejectedValue(new Error('main config failed'));
     const result = await runAiToolHelp('get-documentation', { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(1);
-    expect(result.output).toContain('Failed to reach the Storybook server at /mcp');
+    expect(result.output).toContain('Storybook command metadata is unavailable');
+    expect(result.output).toContain('main config failed');
   });
 });

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -480,7 +480,7 @@ describe('buildStorybookCommandsHelp', () => {
       ],
       localTools: {
         'get-storybook-story-instructions': {
-          call: vi.fn(),
+          call: vi.fn().mockResolvedValue({ content: [] }),
         },
       },
       instructions: 'Follow the story workflow.',
@@ -622,7 +622,7 @@ describe('runAiToolHelp', () => {
       tools: [{ name: 'get-storybook-story-instructions', description: 'Get story guidance.' }],
       localTools: {
         'get-storybook-story-instructions': {
-          call: vi.fn(),
+          call: vi.fn().mockResolvedValue({ content: [] }),
         },
       },
     });

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -109,10 +109,7 @@ describe('runAiTool', () => {
     expect(callMcpTool).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ['--config-dir', ['--config-dir', 'config/storybook']],
-    ['-c', ['-c', 'config/storybook']],
-  ])('loads known local tools from a custom config dir with %s', async (_label, tokens) => {
+  it('loads known local tools from a custom config dir option', async () => {
     vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
       instructions: 'Follow the story workflow.',
       tools: [{ name: 'get-storybook-story-instructions', description: 'Get story guidance' }],
@@ -125,8 +122,9 @@ describe('runAiTool', () => {
       },
     });
 
-    const result = await runAiTool('get-storybook-story-instructions', tokens, {
+    const result = await runAiTool('get-storybook-story-instructions', [], {
       cwd: '/projects/foo',
+      configDir: 'config/storybook',
     });
 
     expect(result.output).toBe('custom config instructions');
@@ -287,8 +285,9 @@ describe('runAiTool', () => {
   it('routes to the instance on the requested --port when several share the cwd', async () => {
     const onOtherPort = { ...record, instanceId: 'inst-2', pid: 2, port: 6007 };
     vi.mocked(readRegistry).mockResolvedValue([record, onOtherPort]);
-    const result = await runAiTool('list-all-documentation', ['--port', '6007'], {
+    const result = await runAiTool('list-all-documentation', [], {
       cwd: '/projects/foo',
+      port: '6007',
     });
     expect(callMcpTool).toHaveBeenCalledWith(onOtherPort, expect.anything(), undefined);
     expect(result.exitCode).toBe(0);
@@ -306,8 +305,9 @@ describe('runAiTool', () => {
   });
 
   it('rejects an invalid --port without contacting the registry', async () => {
-    const result = await runAiTool('list-all-documentation', ['--port', 'abc'], {
+    const result = await runAiTool('list-all-documentation', [], {
       cwd: '/projects/foo',
+      port: 'abc',
     });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('`--port` must be a port number');
@@ -649,16 +649,15 @@ describe('runAiToolHelp', () => {
     expect(readRegistry).not.toHaveBeenCalled();
   });
 
-  it('honors --config-dir tokens on the help path after the tool name', async () => {
+  it('honors the config dir option on the help path after the tool name', async () => {
     vi.mocked(loadStorybookAiMetadata).mockResolvedValue({
       instructions: 'Follow the story workflow.',
       tools: [{ name: 'get-documentation', description: 'Get docs.' }],
     });
-    const result = await runAiTool(
-      'get-documentation',
-      ['--config-dir', 'config/storybook', '--help'],
-      { cwd: '/projects/foo' }
-    );
+    const result = await runAiTool('get-documentation', ['--help'], {
+      cwd: '/projects/foo',
+      configDir: 'config/storybook',
+    });
     expect(result.exitCode).toBe(0);
     expect(loadStorybookAiMetadata).toHaveBeenCalledWith({
       cwd: '/projects/foo',

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -279,7 +279,7 @@ describe('runAiTool', () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Storybook command metadata is unavailable');
     expect(result.output).toContain('@storybook/addon-mcp');
-    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'unknown-command' });
+    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'addon-missing' });
     expect(readRegistry).not.toHaveBeenCalled();
     expect(callMcpTool).not.toHaveBeenCalled();
   });

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -369,7 +369,7 @@ async function lookupAiTool(
       result: {
         exitCode: 1,
         output: `Storybook command metadata is unavailable for ${metadataResult.configDir}. Install or upgrade \`@storybook/addon-mcp\`.`,
-        outcome: { kind: 'intercept', reason: 'unknown-command' },
+        outcome: { kind: 'intercept', reason: 'addon-missing' },
       },
     };
   }

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -1,18 +1,18 @@
 import { resolve } from 'node:path';
 
-import { invariant } from 'storybook/internal/common';
+import * as v from 'valibot';
 
-import {
-  McpJsonRpcError,
-  type McpToolList,
-  callMcpTool,
-  listMcpTools,
-  listMcpToolsWithServerMetadata,
-} from './client.ts';
+import { McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
 import { getInterceptMarkdown } from './intercepts.ts';
+import {
+  loadStorybookAiMetadata,
+  resolveStorybookConfigDir,
+  type StorybookAiMetadata,
+} from './local-metadata.ts';
 import { readRegistry } from './registry.ts';
 import { resolveInstance } from './resolve-instance.ts';
-import { parseToolArgs } from './tool-args.ts';
+import { parsePort, parseToolArgs } from './tool-args.ts';
+import { ToolCallResultSchema } from './types.ts';
 import type {
   InterceptReason,
   McpToolDescriptor,
@@ -55,15 +55,25 @@ class McpToolResultError extends Error {
   }
 }
 
+class LocalAiToolError extends Error {
+  constructor(options?: ErrorOptions) {
+    super('The Storybook local AI command failed', options);
+    this.name = 'LocalAiToolError';
+  }
+}
+
 /** Injectable dependencies for tests. */
 export type AiToolRunDeps = {
   registryDir?: string;
   fetchImpl?: typeof fetch;
+  loadStorybookAiMetadata?: typeof loadStorybookAiMetadata;
 };
 
 export type AiToolOptions = {
   /** Project directory of the target Storybook; defaults to `process.cwd()`. */
   cwd?: string;
+  /** Directory where to load Storybook configuration from; relative paths resolve from `cwd`. */
+  configDir?: string;
   /** Port of the target Storybook, to address one specific instance when several share the cwd. */
   port?: string;
   /** Raw JSON object with tool arguments (escape hatch for complex values). */
@@ -71,9 +81,9 @@ export type AiToolOptions = {
 };
 
 /**
- * Run a single MCP tool against the Storybook running at the target cwd and return its result as
- * markdown. Intercept conditions (no running instance, addon missing, ...) return the same
- * repair-instruction markdown as `@storybook/mcp-proxy`, with exit code 1.
+ * Run a Storybook AI command and return its result as markdown. Commands exposed as local metadata
+ * run without a dev server; runtime-bound commands still go through the running Storybook MCP
+ * server and use the same repair-instruction markdown as `@storybook/mcp-proxy`.
  */
 export async function runAiTool(
   toolName: string,
@@ -83,6 +93,7 @@ export async function runAiTool(
 ): Promise<AiToolRunResult> {
   const parsed = parseToolArgs(toolArgTokens, {
     cwd: options.cwd,
+    configDir: options.configDir,
     port: options.port,
     json: options.json,
   });
@@ -94,10 +105,31 @@ export async function runAiTool(
     };
   }
   if (parsed.help) {
-    return toolHelp(toolName, parsed.cwd, parsed.port, deps);
+    return toolHelp(toolName, parsed.cwd, parsed.configDir, deps);
   }
 
-  const resolution = await resolveReadyInstance(parsed.cwd, parsed.port, deps);
+  const toolLookup = await lookupAiTool(toolName, parsed.cwd, parsed.configDir, deps);
+  if (toolLookup.kind === 'local') {
+    return runLocalAiTool(toolLookup.localTool, parsed.args);
+  }
+  if (
+    toolLookup.kind === 'metadata-error' ||
+    toolLookup.kind === 'metadata-missing' ||
+    toolLookup.kind === 'unknown'
+  ) {
+    return toolLookup.result;
+  }
+
+  const parsedPort = parsePort(parsed.port);
+  if (!parsedPort.ok) {
+    return {
+      exitCode: 1,
+      output: parsedPort.error,
+      outcome: { kind: 'intercept', reason: 'invalid-arguments' },
+    };
+  }
+
+  const resolution = await resolveReadyInstance(parsed.cwd, parsedPort.port, deps);
   if (resolution.kind === 'error') {
     return {
       exitCode: 1,
@@ -160,9 +192,9 @@ export async function runAiTool(
 }
 
 /**
- * Build the "Storybook commands" help section listing the commands provided by the running
- * Storybook, appended to `storybook ai --help`. Help must never fail, so any error degrades to a
- * short note explaining why no commands are listed.
+ * Build the "Storybook commands" help section from Storybook config metadata, appended to
+ * `storybook ai --help`. Help must never fail, so any error degrades to a short note explaining why
+ * no commands are listed.
  */
 export async function buildStorybookCommandsHelp(
   options: AiToolOptions = {},
@@ -170,91 +202,67 @@ export async function buildStorybookCommandsHelp(
 ): Promise<string> {
   const unavailable = (note: string) => `Storybook commands: (unavailable — ${note})`;
 
-  const parsed = parseToolArgs([], { cwd: options.cwd, port: options.port });
+  const parsed = parseToolArgs([], {
+    cwd: options.cwd,
+    configDir: options.configDir,
+    port: options.port,
+  });
   if (!parsed.ok) {
     return unavailable(parsed.error);
   }
 
-  const resolution = await resolveReadyInstance(parsed.cwd, parsed.port, deps);
-  if (resolution.kind === 'error') {
-    return unavailable(helpUnavailableNote(resolution, parsed.port));
+  const metadataResult = await loadLocalMetadata(parsed.cwd, parsed.configDir, deps);
+  if (metadataResult.kind === 'error') {
+    const detail =
+      metadataResult.error instanceof Error
+        ? `: ${metadataResult.error.message}`
+        : `: ${String(metadataResult.error)}`;
+    return unavailable(
+      `the Storybook config at ${metadataResult.configDir} could not be loaded${detail}`
+    );
   }
-  const { record, matches } = resolution;
-
-  let toolList: McpToolList;
-  try {
-    toolList = await listMcpToolsWithServerMetadata(record, deps.fetchImpl);
-  } catch {
-    return unavailable(`the Storybook at ${record.url} could not be reached`);
+  const { metadata, configDir } = metadataResult;
+  if (!metadata) {
+    return unavailable(
+      `the Storybook config at ${configDir} does not expose AI command metadata — install or upgrade \`@storybook/addon-mcp\``
+    );
   }
-  const { tools, serverMetadata } = toolList;
+  const { tools } = metadata;
   if (tools.length === 0) {
-    return unavailable(`the Storybook at ${record.url} provides no commands`);
+    return unavailable(`the Storybook config at ${configDir} provides no commands`);
   }
-
-  const siblingPorts = matches.filter((r) => r !== record).map((r) => r.port);
-  const siblingNote =
-    siblingPorts.length > 0
-      ? [
-          `(${matches.length} instances are running at this cwd — using the most recently started, port ${record.port}; other ports: ${siblingPorts.join(', ')}. Pass \`--port\` to target a specific one.)`,
-        ]
-      : [];
 
   const width = Math.max(...tools.map((tool) => tool.name.length)) + 2;
+  const localToolNames = getLocalToolNames(metadata);
   const lines = tools.map((tool) => {
+    const mode = localToolNames.has(tool.name) ? '[local]' : '[requires Storybook]';
     const summary = tool.description?.trim().split('\n')[0] ?? '';
-    return `  ${tool.name.padEnd(width)}${summary}`;
+    return `  ${tool.name.padEnd(width)}${mode.padEnd(21)}${summary}`;
   });
-  const version = record.storybookVersion ? `, Storybook ${record.storybookVersion}` : '';
-  const { instructions } = serverMetadata;
-  // Unreachable with a healthy addon-mcp: it gates instructions and tools on the same dev/test/docs
-  // toolsets (non-empty tools imply non-empty instructions), and the initialize handshake shares the
-  // request budget, so a slow server can't drop instructions while tools/list succeeds. Reaching here
-  // means the server returned commands but no instructions — a contract bug.
-  invariant(
-    instructions,
-    `The Storybook MCP server at ${record.url} exposed commands but no workflow instructions`
-  );
+  const { instructions } = metadata;
+  const trimmedInstructions = instructions?.trim();
+  if (!trimmedInstructions) {
+    return unavailable(
+      `the Storybook config at ${configDir} exposed commands but no workflow instructions`
+    );
+  }
 
   return [
-    `Storybook help from the Storybook running at ${record.url}${version}:`,
-    ...siblingNote,
+    `Storybook help from the Storybook configuration at ${configDir}:`,
     '',
     '# Storybook workflow instructions',
     '',
-    instructions,
+    trimmedInstructions,
     '',
     '# Storybook commands',
     '',
     ...lines,
     '',
+    '[local] commands run from configuration metadata without a running Storybook.',
+    '[requires Storybook] commands are forwarded to the running Storybook server.',
+    '',
     `Run 'storybook ai <command> --help' for a command's description and arguments.`,
   ].join('\n');
-}
-
-/** One-line reason why the help section cannot list commands, accurate per intercept. */
-function helpUnavailableNote(
-  error: Extract<InstanceResolution, { kind: 'error' }>,
-  port: number | undefined
-): string {
-  switch (error.reason) {
-    case 'no-instance':
-      return 'no running Storybook detected at this cwd; start `storybook dev` to list its commands';
-    case 'port-mismatch':
-      return `no instance on port \`${port}\` at this cwd — running ports: ${error.records
-        .map((r) => r.port)
-        .join(', ')}`;
-    case 'mcp-starting':
-      return 'the Storybook at this cwd is still starting up; retry in a moment';
-    case 'addon-missing':
-      return 'the running Storybook does not provide commands — install `@storybook/addon-mcp`';
-    case 'mcp-error':
-      return "the running Storybook's command server reported an error";
-    default: {
-      const unhandled: never = error.reason;
-      throw new Error(`Unhandled intercept reason: ${unhandled as string}`);
-    }
-  }
 }
 
 /** Show the description and arguments of a single command (`storybook ai <command> --help`). */
@@ -263,40 +271,186 @@ export async function runAiToolHelp(
   options: AiToolOptions = {},
   deps: AiToolRunDeps = {}
 ): Promise<AiToolRunResult> {
-  const parsed = parseToolArgs([], { cwd: options.cwd, port: options.port });
+  const parsed = parseToolArgs([], {
+    cwd: options.cwd,
+    configDir: options.configDir,
+    port: options.port,
+  });
   if (!parsed.ok) {
     return { exitCode: 1, output: parsed.error, outcome: { kind: 'help' } };
   }
-  return toolHelp(toolName, parsed.cwd, parsed.port, deps);
+  return toolHelp(toolName, parsed.cwd, parsed.configDir, deps);
 }
 
 /** All paths are help lookups, so every outcome is `help` regardless of success. */
 async function toolHelp(
   toolName: string,
   cwd: string | undefined,
-  port: number | undefined,
+  configDir: string | undefined,
   deps: AiToolRunDeps
 ): Promise<AiToolRunResult> {
   const outcome: AiCommandOutcome = { kind: 'help' };
 
-  const resolution = await resolveReadyInstance(cwd, port, deps);
-  if (resolution.kind === 'error') {
-    return { exitCode: 1, output: resolution.output, outcome };
+  const metadataResult = await loadLocalMetadata(cwd, configDir, deps);
+  if (metadataResult.kind === 'error') {
+    return {
+      exitCode: 1,
+      output: `Storybook command metadata is unavailable for ${metadataResult.configDir}: ${
+        metadataResult.error instanceof Error
+          ? metadataResult.error.message
+          : String(metadataResult.error)
+      }`,
+      outcome,
+    };
   }
-  const { record } = resolution;
-
-  let tools: McpToolDescriptor[];
-  try {
-    tools = await listMcpTools(record, deps.fetchImpl);
-  } catch (error) {
-    return { exitCode: 1, output: formatServerUnreachable(record, error), outcome };
+  const { metadata } = metadataResult;
+  if (!metadata) {
+    return {
+      exitCode: 1,
+      output: `Storybook command metadata is unavailable for ${metadataResult.configDir}. Install or upgrade \`@storybook/addon-mcp\`.`,
+      outcome,
+    };
   }
+  const { tools } = metadata;
 
   const tool = tools.find((candidate) => candidate.name === toolName);
   if (!tool) {
-    return { exitCode: 1, output: formatUnknownTool(toolName, tools, record), outcome };
+    return {
+      exitCode: 1,
+      output: formatUnknownMetadataTool(toolName, tools, metadataResult.configDir),
+      outcome,
+    };
   }
-  return { exitCode: 0, output: formatToolHelp(tool), outcome };
+  return {
+    exitCode: 0,
+    output: formatToolHelp(tool, { local: getLocalToolNames(metadata).has(tool.name) }),
+    outcome,
+  };
+}
+
+type StorybookAiLocalTool = NonNullable<StorybookAiMetadata['localTools']>[string];
+
+type AiToolLookup =
+  | { kind: 'local'; localTool: StorybookAiLocalTool }
+  | { kind: 'runtime' }
+  | { kind: 'metadata-error'; result: AiToolRunResult }
+  | { kind: 'metadata-missing'; result: AiToolRunResult }
+  | { kind: 'unknown'; result: AiToolRunResult };
+
+async function lookupAiTool(
+  toolName: string,
+  cwd: string | undefined,
+  configDir: string | undefined,
+  deps: AiToolRunDeps
+): Promise<AiToolLookup> {
+  const metadataResult = await loadLocalMetadata(cwd, configDir, deps);
+  if (metadataResult.kind === 'error') {
+    return {
+      kind: 'metadata-error',
+      result: {
+        exitCode: 1,
+        output: `Storybook command metadata is unavailable for ${metadataResult.configDir}: ${
+          metadataResult.error instanceof Error
+            ? metadataResult.error.message
+            : String(metadataResult.error)
+        }`,
+        outcome: {
+          kind: 'error',
+          error: new LocalAiToolError({ cause: metadataResult.error }),
+        },
+      },
+    };
+  }
+
+  const { metadata } = metadataResult;
+  if (!metadata) {
+    return {
+      kind: 'metadata-missing',
+      result: {
+        exitCode: 1,
+        output: `Storybook command metadata is unavailable for ${metadataResult.configDir}. Install or upgrade \`@storybook/addon-mcp\`.`,
+        outcome: { kind: 'intercept', reason: 'unknown-command' },
+      },
+    };
+  }
+
+  const visibleTool = metadata.tools.find((tool) => tool.name === toolName);
+  if (!visibleTool) {
+    return {
+      kind: 'unknown',
+      result: {
+        exitCode: 1,
+        output: formatUnknownMetadataTool(toolName, metadata.tools, metadataResult.configDir),
+        outcome: { kind: 'intercept', reason: 'unknown-command' },
+      },
+    };
+  }
+
+  const localTool = metadata.localTools?.[toolName];
+  if (!localTool) {
+    return { kind: 'runtime' };
+  }
+
+  return { kind: 'local', localTool };
+}
+
+async function runLocalAiTool(
+  localTool: StorybookAiLocalTool,
+  args: Record<string, unknown>
+): Promise<AiToolRunResult> {
+  try {
+    const rawResult = await localTool.call(args);
+    const parsedResult = v.safeParse(ToolCallResultSchema, rawResult);
+    if (!parsedResult.success) {
+      return {
+        exitCode: 1,
+        output: 'The Storybook local AI command returned an unexpected response shape',
+        outcome: {
+          kind: 'error',
+          error: new LocalAiToolError({ cause: parsedResult.issues }),
+        },
+      };
+    }
+    const result = parsedResult.output;
+    const output = formatToolResult(result);
+    if (result.isError) {
+      return {
+        exitCode: 1,
+        output,
+        outcome: { kind: 'error', error: new McpToolResultError({ cause: output }) },
+      };
+    }
+    return { exitCode: 0, output, outcome: { kind: 'success' } };
+  } catch (error) {
+    return {
+      exitCode: 1,
+      output: error instanceof Error ? error.message : String(error),
+      outcome: { kind: 'error', error: new LocalAiToolError({ cause: error }) },
+    };
+  }
+}
+
+async function loadLocalMetadata(
+  cwd: string | undefined,
+  configDir: string | undefined,
+  deps: AiToolRunDeps
+): Promise<
+  | { kind: 'ok'; cwd: string; configDir: string; metadata: StorybookAiMetadata | undefined }
+  | { kind: 'error'; cwd: string; configDir: string; error: unknown }
+> {
+  const resolvedCwd = resolve(cwd ?? process.cwd());
+  const resolvedConfigDir = resolveStorybookConfigDir({ cwd: resolvedCwd, configDir });
+  const loadMetadata = deps.loadStorybookAiMetadata ?? loadStorybookAiMetadata;
+  try {
+    return {
+      kind: 'ok',
+      cwd: resolvedCwd,
+      configDir: resolvedConfigDir,
+      metadata: await loadMetadata({ cwd: resolvedCwd, configDir }),
+    };
+  } catch (error) {
+    return { kind: 'error', cwd: resolvedCwd, configDir: resolvedConfigDir, error };
+  }
 }
 
 function formatServerUnreachable(record: StorybookInstanceRecord, error: unknown): string {
@@ -359,19 +513,23 @@ async function describeUnknownTool(
   if (tools.some((tool) => tool.name === toolName)) {
     return null;
   }
-  return formatUnknownTool(toolName, tools, record);
+  return formatUnknownTool(toolName, tools, `The Storybook running at ${record.url}`);
 }
 
-function formatUnknownTool(
-  toolName: string,
-  tools: McpToolDescriptor[],
-  record: StorybookInstanceRecord
-): string {
-  return `Unknown command \`${toolName}\`. The Storybook running at ${record.url} provides:
+function formatUnknownTool(toolName: string, tools: McpToolDescriptor[], source: string): string {
+  return `Unknown command \`${toolName}\`. ${source} provides:
 
 ${tools.map((tool) => `- \`${tool.name}\``).join('\n')}
 
 Run \`storybook ai --help\` for all commands, or \`storybook ai <command> --help\` for a command's arguments.`;
+}
+
+function formatUnknownMetadataTool(
+  toolName: string,
+  tools: McpToolDescriptor[],
+  configDir: string
+): string {
+  return formatUnknownTool(toolName, tools, `The Storybook configuration at ${configDir}`);
 }
 
 /** Render a tools/call result as markdown: text content verbatim, other content as JSON blocks. */
@@ -389,11 +547,21 @@ function formatToolResult(result: ToolCallResult): string {
     .join('\n\n');
 }
 
-function formatToolHelp(tool: McpToolDescriptor): string {
+function getLocalToolNames(metadata: StorybookAiMetadata): Set<string> {
+  return new Set(Object.keys(metadata.localTools ?? {}));
+}
+
+function formatToolHelp(tool: McpToolDescriptor, { local }: { local: boolean }): string {
   const lines = [`Usage: storybook ai ${tool.name} [--key value ...]`];
   if (tool.description) {
     lines.push('', tool.description.trim());
   }
+  lines.push(
+    '',
+    local
+      ? 'Execution: local (no running Storybook required).'
+      : 'Execution: requires a running Storybook.'
+  );
   const properties = Object.entries(tool.inputSchema?.properties ?? {});
   if (properties.length > 0) {
     const required = new Set(tool.inputSchema?.required ?? []);

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -91,9 +91,6 @@ export async function runAiTool(
   deps: AiToolRunDeps = {}
 ): Promise<AiToolRunResult> {
   const parsed = parseToolArgs(toolArgTokens, {
-    cwd: options.cwd,
-    configDir: options.configDir,
-    port: options.port,
     json: options.json,
   });
   if (!parsed.ok) {
@@ -104,10 +101,10 @@ export async function runAiTool(
     };
   }
   if (parsed.help) {
-    return toolHelp(toolName, parsed.cwd, parsed.configDir, deps);
+    return toolHelp(toolName, options.cwd, options.configDir, deps);
   }
 
-  const toolLookup = await lookupAiTool(toolName, parsed.cwd, parsed.configDir, deps);
+  const toolLookup = await lookupAiTool(toolName, options.cwd, options.configDir, deps);
   switch (toolLookup.kind) {
     case 'local':
       return runLocalAiTool(toolLookup.localTool, parsed.args);
@@ -121,7 +118,7 @@ export async function runAiTool(
     }
   }
 
-  const parsedPort = parsePort(parsed.port);
+  const parsedPort = parsePort(options.port);
   if (!parsedPort.ok) {
     return {
       exitCode: 1,
@@ -130,7 +127,7 @@ export async function runAiTool(
     };
   }
 
-  const resolution = await resolveReadyInstance(parsed.cwd, parsedPort.port, deps);
+  const resolution = await resolveReadyInstance(options.cwd, parsedPort.port, deps);
   if (resolution.kind === 'error') {
     return {
       exitCode: 1,
@@ -203,16 +200,7 @@ export async function buildStorybookCommandsHelp(
 ): Promise<string> {
   const unavailable = (note: string) => `Storybook commands: (unavailable — ${note})`;
 
-  const parsed = parseToolArgs([], {
-    cwd: options.cwd,
-    configDir: options.configDir,
-    port: options.port,
-  });
-  if (!parsed.ok) {
-    return unavailable(parsed.error);
-  }
-
-  const metadataResult = await loadLocalMetadata(parsed.cwd, parsed.configDir, deps);
+  const metadataResult = await loadLocalMetadata(options.cwd, options.configDir, deps);
   if (metadataResult.kind === 'error') {
     return unavailable(
       `the Storybook config at ${metadataResult.configDir} could not be loaded: ${formatErrorMessage(
@@ -262,15 +250,7 @@ export async function runAiToolHelp(
   options: AiToolOptions = {},
   deps: AiToolRunDeps = {}
 ): Promise<AiToolRunResult> {
-  const parsed = parseToolArgs([], {
-    cwd: options.cwd,
-    configDir: options.configDir,
-    port: options.port,
-  });
-  if (!parsed.ok) {
-    return { exitCode: 1, output: parsed.error, outcome: { kind: 'help' } };
-  }
-  return toolHelp(toolName, parsed.cwd, parsed.configDir, deps);
+  return toolHelp(toolName, options.cwd, options.configDir, deps);
 }
 
 /** All paths are help lookups, so every outcome is `help` regardless of success. */

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -30,8 +30,7 @@ export type AiCommandInterceptReason = InterceptReason | 'invalid-arguments' | '
 /**
  * Telemetry-facing classification of a run. `help` marks lookups via `--help` flags, which are not
  * command executions and are excluded from the `ai-command` event so they cannot skew command
- * success rates. `error` carries failures from the server side (error results, transport
- * failures, timeouts) for the standard sanitized error path.
+ * success rates. `error` carries command failures for the standard sanitized error path.
  */
 export type AiCommandOutcome =
   | { kind: 'success' }
@@ -42,7 +41,7 @@ export type AiCommandOutcome =
 export type AiToolRunResult = { exitCode: 0 | 1; output: string; outcome: AiCommandOutcome };
 
 /**
- * The server executed the command and reported an error result. The message is deliberately
+ * The command executed and reported an error result. The message is deliberately
  * constant — the result text is arbitrary tool output (often containing project paths), and a
  * constant message keeps the telemetry error hash stable and aggregatable. The tool's error text
  * travels as `cause` instead, which the standard error path only uploads — path-sanitized — when
@@ -50,7 +49,7 @@ export type AiToolRunResult = { exitCode: 0 | 1; output: string; outcome: AiComm
  */
 class McpToolResultError extends Error {
   constructor(options?: ErrorOptions) {
-    super('The Storybook MCP server returned an error result', options);
+    super('The Storybook AI command returned an error result', options);
     this.name = 'McpToolResultError';
   }
 }
@@ -109,15 +108,17 @@ export async function runAiTool(
   }
 
   const toolLookup = await lookupAiTool(toolName, parsed.cwd, parsed.configDir, deps);
-  if (toolLookup.kind === 'local') {
-    return runLocalAiTool(toolLookup.localTool, parsed.args);
-  }
-  if (
-    toolLookup.kind === 'metadata-error' ||
-    toolLookup.kind === 'metadata-missing' ||
-    toolLookup.kind === 'unknown'
-  ) {
-    return toolLookup.result;
+  switch (toolLookup.kind) {
+    case 'local':
+      return runLocalAiTool(toolLookup.localTool, parsed.args);
+    case 'result':
+      return toolLookup.result;
+    case 'runtime':
+      break;
+    default: {
+      const exhaustive: never = toolLookup;
+      return exhaustive;
+    }
   }
 
   const parsedPort = parsePort(parsed.port);
@@ -213,19 +214,15 @@ export async function buildStorybookCommandsHelp(
 
   const metadataResult = await loadLocalMetadata(parsed.cwd, parsed.configDir, deps);
   if (metadataResult.kind === 'error') {
-    const detail =
-      metadataResult.error instanceof Error
-        ? `: ${metadataResult.error.message}`
-        : `: ${String(metadataResult.error)}`;
     return unavailable(
-      `the Storybook config at ${metadataResult.configDir} could not be loaded${detail}`
+      `the Storybook config at ${metadataResult.configDir} could not be loaded: ${formatErrorMessage(
+        metadataResult.error
+      )}`
     );
   }
   const { metadata, configDir } = metadataResult;
   if (!metadata) {
-    return unavailable(
-      `the Storybook config at ${configDir} does not expose AI command metadata — install or upgrade \`@storybook/addon-mcp\``
-    );
+    return unavailable(formatMetadataMissingHelp(configDir));
   }
   const { tools } = metadata;
   if (tools.length === 0) {
@@ -241,19 +238,12 @@ export async function buildStorybookCommandsHelp(
   });
   const { instructions } = metadata;
   const trimmedInstructions = instructions?.trim();
-  if (!trimmedInstructions) {
-    return unavailable(
-      `the Storybook config at ${configDir} exposed commands but no workflow instructions`
-    );
+  const sections = [`Storybook help from the Storybook configuration at ${configDir}:`, ''];
+  if (trimmedInstructions) {
+    sections.push('# Storybook workflow instructions', '', trimmedInstructions, '');
   }
 
-  return [
-    `Storybook help from the Storybook configuration at ${configDir}:`,
-    '',
-    '# Storybook workflow instructions',
-    '',
-    trimmedInstructions,
-    '',
+  sections.push(
     '# Storybook commands',
     '',
     ...lines,
@@ -261,8 +251,9 @@ export async function buildStorybookCommandsHelp(
     '[local] commands run from configuration metadata without a running Storybook.',
     '[requires Storybook] commands are forwarded to the running Storybook server.',
     '',
-    `Run 'storybook ai <command> --help' for a command's description and arguments.`,
-  ].join('\n');
+    `Run 'storybook ai <command> --help' for a command's description and arguments.`
+  );
+  return sections.join('\n');
 }
 
 /** Show the description and arguments of a single command (`storybook ai <command> --help`). */
@@ -293,23 +284,11 @@ async function toolHelp(
 
   const metadataResult = await loadLocalMetadata(cwd, configDir, deps);
   if (metadataResult.kind === 'error') {
-    return {
-      exitCode: 1,
-      output: `Storybook command metadata is unavailable for ${metadataResult.configDir}: ${
-        metadataResult.error instanceof Error
-          ? metadataResult.error.message
-          : String(metadataResult.error)
-      }`,
-      outcome,
-    };
+    return metadataLoadFailureResult(metadataResult, outcome);
   }
   const { metadata } = metadataResult;
   if (!metadata) {
-    return {
-      exitCode: 1,
-      output: `Storybook command metadata is unavailable for ${metadataResult.configDir}. Install or upgrade \`@storybook/addon-mcp\`.`,
-      outcome,
-    };
+    return metadataMissingResult(metadataResult.configDir, outcome);
   }
   const { tools } = metadata;
 
@@ -333,9 +312,7 @@ type StorybookAiLocalTool = NonNullable<StorybookAiMetadata['localTools']>[strin
 type AiToolLookup =
   | { kind: 'local'; localTool: StorybookAiLocalTool }
   | { kind: 'runtime' }
-  | { kind: 'metadata-error'; result: AiToolRunResult }
-  | { kind: 'metadata-missing'; result: AiToolRunResult }
-  | { kind: 'unknown'; result: AiToolRunResult };
+  | { kind: 'result'; result: AiToolRunResult };
 
 async function lookupAiTool(
   toolName: string,
@@ -346,38 +323,29 @@ async function lookupAiTool(
   const metadataResult = await loadLocalMetadata(cwd, configDir, deps);
   if (metadataResult.kind === 'error') {
     return {
-      kind: 'metadata-error',
-      result: {
-        exitCode: 1,
-        output: `Storybook command metadata is unavailable for ${metadataResult.configDir}: ${
-          metadataResult.error instanceof Error
-            ? metadataResult.error.message
-            : String(metadataResult.error)
-        }`,
-        outcome: {
-          kind: 'error',
-          error: new LocalAiToolError({ cause: metadataResult.error }),
-        },
-      },
+      kind: 'result',
+      result: metadataLoadFailureResult(metadataResult, {
+        kind: 'error',
+        error: new LocalAiToolError({ cause: metadataResult.error }),
+      }),
     };
   }
 
   const { metadata } = metadataResult;
   if (!metadata) {
     return {
-      kind: 'metadata-missing',
-      result: {
-        exitCode: 1,
-        output: `Storybook command metadata is unavailable for ${metadataResult.configDir}. Install or upgrade \`@storybook/addon-mcp\`.`,
-        outcome: { kind: 'intercept', reason: 'addon-missing' },
-      },
+      kind: 'result',
+      result: metadataMissingResult(metadataResult.configDir, {
+        kind: 'intercept',
+        reason: 'addon-missing',
+      }),
     };
   }
 
   const visibleTool = metadata.tools.find((tool) => tool.name === toolName);
   if (!visibleTool) {
     return {
-      kind: 'unknown',
+      kind: 'result',
       result: {
         exitCode: 1,
         output: formatUnknownMetadataTool(toolName, metadata.tools, metadataResult.configDir),
@@ -434,10 +402,7 @@ async function loadLocalMetadata(
   cwd: string | undefined,
   configDir: string | undefined,
   deps: AiToolRunDeps
-): Promise<
-  | { kind: 'ok'; cwd: string; configDir: string; metadata: StorybookAiMetadata | undefined }
-  | { kind: 'error'; cwd: string; configDir: string; error: unknown }
-> {
+): Promise<LocalMetadataResult> {
   const resolvedCwd = resolve(cwd ?? process.cwd());
   const resolvedConfigDir = resolveStorybookConfigDir({ cwd: resolvedCwd, configDir });
   const loadMetadata = deps.loadStorybookAiMetadata ?? loadStorybookAiMetadata;
@@ -446,11 +411,44 @@ async function loadLocalMetadata(
       kind: 'ok',
       cwd: resolvedCwd,
       configDir: resolvedConfigDir,
-      metadata: await loadMetadata({ cwd: resolvedCwd, configDir }),
+      metadata: await loadMetadata({ cwd: resolvedCwd, configDir: resolvedConfigDir }),
     };
   } catch (error) {
     return { kind: 'error', cwd: resolvedCwd, configDir: resolvedConfigDir, error };
   }
+}
+
+type LocalMetadataResult =
+  | { kind: 'ok'; cwd: string; configDir: string; metadata: StorybookAiMetadata | undefined }
+  | { kind: 'error'; cwd: string; configDir: string; error: unknown };
+
+function metadataLoadFailureResult(
+  metadataResult: Extract<LocalMetadataResult, { kind: 'error' }>,
+  outcome: AiCommandOutcome
+): AiToolRunResult {
+  return {
+    exitCode: 1,
+    output: `Storybook command metadata is unavailable for ${
+      metadataResult.configDir
+    }: ${formatErrorMessage(metadataResult.error)}`,
+    outcome,
+  };
+}
+
+function metadataMissingResult(configDir: string, outcome: AiCommandOutcome): AiToolRunResult {
+  return {
+    exitCode: 1,
+    output: `Storybook command metadata is unavailable for ${configDir}. Install or upgrade \`@storybook/addon-mcp\`.`,
+    outcome,
+  };
+}
+
+function formatMetadataMissingHelp(configDir: string): string {
+  return `the Storybook config at ${configDir} does not expose AI command metadata — install or upgrade \`@storybook/addon-mcp\``;
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function formatServerUnreachable(record: StorybookInstanceRecord, error: unknown): string {
@@ -465,7 +463,6 @@ type InstanceResolution =
       kind: 'error';
       output: string;
       reason: InterceptReason;
-      records: StorybookInstanceRecord[];
     };
 
 /**
@@ -488,7 +485,6 @@ async function resolveReadyInstance(
       kind: 'error',
       output: getInterceptMarkdown(resolution.reason, { records: resolution.records, port }),
       reason: resolution.reason,
-      records: resolution.records ?? [],
     };
   }
 

--- a/code/core/src/cli/ai/mcp/tool-args.test.ts
+++ b/code/core/src/cli/ai/mcp/tool-args.test.ts
@@ -148,6 +148,15 @@ describe('parseToolArgs', () => {
     it.each(['--config-dir', '-c'])('errors when %s has no value', (flag) => {
       expect(error([flag])).toContain('`-c, --config-dir` requires a value');
     });
+
+    it('treats a single-dash value after -c as the config dir', () => {
+      expect(args(['-c', '-storybook', '--id', 'x'])).toMatchObject({
+        ok: true,
+        configDir: '-storybook',
+        args: { id: 'x' },
+      });
+      expect(error(['-c', '--port', '6006'])).toContain('`-c, --config-dir` requires a value');
+    });
   });
 
   describe('--port', () => {
@@ -264,5 +273,9 @@ describe('scanConfigDirToken', () => {
   it('ignores config-dir tokens without a value', () => {
     expect(scanConfigDirToken(['--config-dir', '--json', '{bad'])).toBeUndefined();
     expect(scanConfigDirToken(['-c', '--json', '{bad'])).toBeUndefined();
+  });
+
+  it('accepts single-dash config-dir values after -c', () => {
+    expect(scanConfigDirToken(['-c', '-storybook', '--json', '{bad'])).toBe('-storybook');
   });
 });

--- a/code/core/src/cli/ai/mcp/tool-args.test.ts
+++ b/code/core/src/cli/ai/mcp/tool-args.test.ts
@@ -1,16 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { parsePort, parseToolArgs, scanConfigDirToken, scanCwdToken } from './tool-args.ts';
+import { parsePort, parseToolArgs } from './tool-args.ts';
 
-function args(
-  tokens: string[],
-  defaults?: {
-    cwd?: string;
-    configDir?: string;
-    port?: string;
-    json?: string;
-  }
-) {
+function args(tokens: string[], defaults?: { json?: string }) {
   const result = parseToolArgs(tokens, defaults);
   if (!result.ok) {
     throw new Error(`expected ok, got error: ${result.error}`);
@@ -18,15 +10,7 @@ function args(
   return result;
 }
 
-function error(
-  tokens: string[],
-  defaults?: {
-    cwd?: string;
-    configDir?: string;
-    port?: string;
-    json?: string;
-  }
-) {
+function error(tokens: string[], defaults?: { json?: string }) {
   const result = parseToolArgs(tokens, defaults);
   if (result.ok) {
     throw new Error(`expected error, got ok: ${JSON.stringify(result.args)}`);
@@ -38,9 +22,6 @@ describe('parseToolArgs', () => {
   it('returns empty args for no tokens', () => {
     expect(args([])).toEqual({
       ok: true,
-      cwd: undefined,
-      configDir: undefined,
-      port: undefined,
       help: false,
       args: {},
     });
@@ -101,84 +82,22 @@ describe('parseToolArgs', () => {
     expect(args(['--id', 'a', '--id', 'b']).args).toEqual({ id: 'b' });
   });
 
-  describe('--cwd', () => {
-    it('consumes --cwd instead of forwarding it', () => {
-      expect(args(['--cwd', '/projects/foo', '--id', 'x'])).toEqual({
-        ok: true,
-        cwd: '/projects/foo',
-        configDir: undefined,
-        port: undefined,
-        help: false,
-        args: { id: 'x' },
-      });
-    });
-
-    it('uses the commander-parsed default when not repeated in the tokens', () => {
-      expect(args(['--id', 'x'], { cwd: '/projects/foo' }).cwd).toBe('/projects/foo');
-    });
-
-    it('prefers a --cwd token over the commander-parsed default', () => {
-      expect(args(['--cwd', '/b'], { cwd: '/a' }).cwd).toBe('/b');
-    });
-
-    it('errors when --cwd has no value', () => {
-      expect(error(['--cwd'])).toContain('`--cwd` requires a value');
+  it('treats target-looking long flags after the command name as tool arguments', () => {
+    expect(
+      args(['--cwd', '/projects/foo', '--config-dir', 'config/storybook', '--port', '6006']).args
+    ).toEqual({
+      cwd: '/projects/foo',
+      'config-dir': 'config/storybook',
+      port: 6006,
     });
   });
 
-  describe('--config-dir', () => {
-    it.each(['--config-dir', '-c'])('consumes %s instead of forwarding it', (flag) => {
-      expect(args([flag, 'config/storybook', '--id', 'x'])).toEqual({
-        ok: true,
-        cwd: undefined,
-        configDir: 'config/storybook',
-        port: undefined,
-        help: false,
-        args: { id: 'x' },
-      });
-    });
-
-    it('uses the commander-parsed default and lets a token override it', () => {
-      expect(args(['--id', 'x'], { configDir: 'config/a' }).configDir).toBe('config/a');
-      expect(args(['--config-dir', 'config/b'], { configDir: 'config/a' }).configDir).toBe(
-        'config/b'
-      );
-    });
-
-    it.each(['--config-dir', '-c'])('errors when %s has no value', (flag) => {
-      expect(error([flag])).toContain('`-c, --config-dir` requires a value');
-    });
-
-    it('treats a single-dash value after -c as the config dir', () => {
-      expect(args(['-c', '-storybook', '--id', 'x'])).toMatchObject({
-        ok: true,
-        configDir: '-storybook',
-        args: { id: 'x' },
-      });
-      expect(error(['-c', '--port', '6006'])).toContain('`-c, --config-dir` requires a value');
-    });
+  it('allows bare target-looking long flags as boolean tool arguments', () => {
+    expect(args(['--cwd', '--port']).args).toEqual({ cwd: true, port: true });
   });
 
-  describe('--port', () => {
-    it('consumes --port as a raw value instead of forwarding it', () => {
-      expect(args(['--port', '6006', '--id', 'x'])).toEqual({
-        ok: true,
-        cwd: undefined,
-        configDir: undefined,
-        port: '6006',
-        help: false,
-        args: { id: 'x' },
-      });
-    });
-
-    it('uses the commander-parsed default and lets a token override it', () => {
-      expect(args(['--id', 'x'], { port: '6006' }).port).toBe('6006');
-      expect(args(['--port', '6007'], { port: '6006' }).port).toBe('6007');
-    });
-
-    it('errors when --port has no value', () => {
-      expect(error(['--port'])).toContain('`--port` requires a value');
-    });
+  it('rejects short flags after the command name', () => {
+    expect(error(['-c', 'config/storybook'])).toContain('Unexpected argument `-c`');
   });
 
   describe('--json escape hatch', () => {
@@ -190,7 +109,7 @@ describe('parseToolArgs', () => {
       expect(args(['--json', '{"id":"x","n":1}', '--id', 'y']).args).toEqual({ id: 'y', n: 1 });
     });
 
-    it('accepts --json parsed by commander before the tool name', () => {
+    it('accepts --json parsed by commander before the command name', () => {
       expect(args(['--id', 'y'], { json: '{"id":"x","n":1}' }).args).toEqual({ id: 'y', n: 1 });
     });
 
@@ -236,46 +155,5 @@ describe('parsePort', () => {
     expect(parsePort('0')).toMatchObject({ ok: false });
     expect(parsePort('65536')).toMatchObject({ ok: false });
     expect(parsePort('6006.5')).toMatchObject({ ok: false });
-  });
-});
-
-describe('scanCwdToken', () => {
-  it('finds `--cwd value` and `--cwd=value`', () => {
-    expect(scanCwdToken(['--cwd', '/x'])).toBe('/x');
-    expect(scanCwdToken(['--cwd=/x'])).toBe('/x');
-  });
-
-  it('returns undefined without a --cwd token or without its value', () => {
-    expect(scanCwdToken([])).toBeUndefined();
-    expect(scanCwdToken(['--id', 'x'])).toBeUndefined();
-    expect(scanCwdToken(['--cwd'])).toBeUndefined();
-    expect(scanCwdToken(['--cwd', '--id'])).toBeUndefined();
-  });
-
-  it('lets the last occurrence win, matching the full parser', () => {
-    expect(scanCwdToken(['--cwd', '/a', '--cwd=/b'])).toBe('/b');
-  });
-
-  it('tolerates tokens the full parser rejects', () => {
-    expect(parseToolArgs(['positional', '--cwd', '/x'])).toMatchObject({ ok: false });
-    expect(scanCwdToken(['positional', '--cwd', '/x'])).toBe('/x');
-    expect(scanCwdToken(['--cwd', '/x', '--json', '{bad'])).toBe('/x');
-  });
-});
-
-describe('scanConfigDirToken', () => {
-  it('returns the last config-dir token value without validating the remaining args', () => {
-    expect(
-      scanConfigDirToken(['--config-dir', 'config/storybook', '--json', '{bad', '-c', 'alt'])
-    ).toBe('alt');
-  });
-
-  it('ignores config-dir tokens without a value', () => {
-    expect(scanConfigDirToken(['--config-dir', '--json', '{bad'])).toBeUndefined();
-    expect(scanConfigDirToken(['-c', '--json', '{bad'])).toBeUndefined();
-  });
-
-  it('accepts single-dash config-dir values after -c', () => {
-    expect(scanConfigDirToken(['-c', '-storybook', '--json', '{bad'])).toBe('-storybook');
   });
 });

--- a/code/core/src/cli/ai/mcp/tool-args.test.ts
+++ b/code/core/src/cli/ai/mcp/tool-args.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseToolArgs, scanCwdToken } from './tool-args.ts';
+import { parsePort, parseToolArgs, scanConfigDirToken, scanCwdToken } from './tool-args.ts';
 
-function args(tokens: string[], defaults?: { cwd?: string; port?: string; json?: string }) {
+function args(
+  tokens: string[],
+  defaults?: {
+    cwd?: string;
+    configDir?: string;
+    port?: string;
+    json?: string;
+  }
+) {
   const result = parseToolArgs(tokens, defaults);
   if (!result.ok) {
     throw new Error(`expected ok, got error: ${result.error}`);
@@ -10,7 +18,15 @@ function args(tokens: string[], defaults?: { cwd?: string; port?: string; json?:
   return result;
 }
 
-function error(tokens: string[], defaults?: { cwd?: string; port?: string; json?: string }) {
+function error(
+  tokens: string[],
+  defaults?: {
+    cwd?: string;
+    configDir?: string;
+    port?: string;
+    json?: string;
+  }
+) {
   const result = parseToolArgs(tokens, defaults);
   if (result.ok) {
     throw new Error(`expected error, got ok: ${JSON.stringify(result.args)}`);
@@ -20,7 +36,14 @@ function error(tokens: string[], defaults?: { cwd?: string; port?: string; json?
 
 describe('parseToolArgs', () => {
   it('returns empty args for no tokens', () => {
-    expect(args([])).toEqual({ ok: true, cwd: undefined, port: undefined, help: false, args: {} });
+    expect(args([])).toEqual({
+      ok: true,
+      cwd: undefined,
+      configDir: undefined,
+      port: undefined,
+      help: false,
+      args: {},
+    });
   });
 
   it('consumes --help and -h as a help request instead of forwarding them', () => {
@@ -83,6 +106,7 @@ describe('parseToolArgs', () => {
       expect(args(['--cwd', '/projects/foo', '--id', 'x'])).toEqual({
         ok: true,
         cwd: '/projects/foo',
+        configDir: undefined,
         port: undefined,
         help: false,
         args: { id: 'x' },
@@ -102,27 +126,45 @@ describe('parseToolArgs', () => {
     });
   });
 
-  describe('--port', () => {
-    it('consumes --port as a number instead of forwarding it', () => {
-      expect(args(['--port', '6006', '--id', 'x'])).toEqual({
+  describe('--config-dir', () => {
+    it.each(['--config-dir', '-c'])('consumes %s instead of forwarding it', (flag) => {
+      expect(args([flag, 'config/storybook', '--id', 'x'])).toEqual({
         ok: true,
         cwd: undefined,
-        port: 6006,
+        configDir: 'config/storybook',
+        port: undefined,
         help: false,
         args: { id: 'x' },
       });
     });
 
     it('uses the commander-parsed default and lets a token override it', () => {
-      expect(args(['--id', 'x'], { port: '6006' }).port).toBe(6006);
-      expect(args(['--port', '6007'], { port: '6006' }).port).toBe(6007);
+      expect(args(['--id', 'x'], { configDir: 'config/a' }).configDir).toBe('config/a');
+      expect(args(['--config-dir', 'config/b'], { configDir: 'config/a' }).configDir).toBe(
+        'config/b'
+      );
     });
 
-    it('errors on non-numeric or out-of-range ports', () => {
-      expect(error(['--port', 'abc'])).toContain('`--port` must be a port number');
-      expect(error(['--port', '0'])).toContain('`--port` must be a port number');
-      expect(error(['--port', '65536'])).toContain('`--port` must be a port number');
-      expect(error(['--port', '6006.5'])).toContain('`--port` must be a port number');
+    it.each(['--config-dir', '-c'])('errors when %s has no value', (flag) => {
+      expect(error([flag])).toContain('`-c, --config-dir` requires a value');
+    });
+  });
+
+  describe('--port', () => {
+    it('consumes --port as a raw value instead of forwarding it', () => {
+      expect(args(['--port', '6006', '--id', 'x'])).toEqual({
+        ok: true,
+        cwd: undefined,
+        configDir: undefined,
+        port: '6006',
+        help: false,
+        args: { id: 'x' },
+      });
+    });
+
+    it('uses the commander-parsed default and lets a token override it', () => {
+      expect(args(['--id', 'x'], { port: '6006' }).port).toBe('6006');
+      expect(args(['--port', '6007'], { port: '6006' }).port).toBe('6007');
     });
 
     it('errors when --port has no value', () => {
@@ -171,6 +213,23 @@ describe('parseToolArgs', () => {
   });
 });
 
+describe('parsePort', () => {
+  it('returns undefined when no port is provided', () => {
+    expect(parsePort(undefined)).toEqual({ ok: true, port: undefined });
+  });
+
+  it('parses valid port values', () => {
+    expect(parsePort('6006')).toEqual({ ok: true, port: 6006 });
+  });
+
+  it('rejects non-numeric or out-of-range ports', () => {
+    expect(parsePort('abc')).toMatchObject({ ok: false });
+    expect(parsePort('0')).toMatchObject({ ok: false });
+    expect(parsePort('65536')).toMatchObject({ ok: false });
+    expect(parsePort('6006.5')).toMatchObject({ ok: false });
+  });
+});
+
 describe('scanCwdToken', () => {
   it('finds `--cwd value` and `--cwd=value`', () => {
     expect(scanCwdToken(['--cwd', '/x'])).toBe('/x');
@@ -192,5 +251,18 @@ describe('scanCwdToken', () => {
     expect(parseToolArgs(['positional', '--cwd', '/x'])).toMatchObject({ ok: false });
     expect(scanCwdToken(['positional', '--cwd', '/x'])).toBe('/x');
     expect(scanCwdToken(['--cwd', '/x', '--json', '{bad'])).toBe('/x');
+  });
+});
+
+describe('scanConfigDirToken', () => {
+  it('returns the last config-dir token value without validating the remaining args', () => {
+    expect(
+      scanConfigDirToken(['--config-dir', 'config/storybook', '--json', '{bad', '-c', 'alt'])
+    ).toBe('alt');
+  });
+
+  it('ignores config-dir tokens without a value', () => {
+    expect(scanConfigDirToken(['--config-dir', '--json', '{bad'])).toBeUndefined();
+    expect(scanConfigDirToken(['-c', '--json', '{bad'])).toBeUndefined();
   });
 });

--- a/code/core/src/cli/ai/mcp/tool-args.ts
+++ b/code/core/src/cli/ai/mcp/tool-args.ts
@@ -2,7 +2,8 @@ export type ParsedToolArgs =
   | {
       ok: true;
       cwd: string | undefined;
-      port: number | undefined;
+      configDir: string | undefined;
+      port: string | undefined;
       help: boolean;
       args: Record<string, unknown>;
     }
@@ -16,17 +17,23 @@ export type ParsedToolArgs =
  * - A bare `--key` (no value) becomes `true`.
  * - `--json '<object>'` is an escape hatch providing the raw argument object; explicit `--key`
  *   flags override its entries.
- * - `--cwd <path>`, `--port <number>` and `--help`/`-h` are consumed by the CLI itself and never
- *   forwarded to the tool.
+ * - `--cwd <path>`, `--config-dir <path>`, `--port <number>` and `--help`/`-h` are consumed by
+ *   the CLI itself and never forwarded to the tool.
  *
- * `defaults` carries `--cwd`/`--port`/`--json` values that commander already parsed before the
- * tool name; the same flags appearing after the tool name take precedence.
+ * `defaults` carries `--cwd`/`--config-dir`/`--port`/`--json` values that commander already
+ * parsed before the tool name; the same flags appearing after the tool name take precedence.
  */
 export function parseToolArgs(
   tokens: string[],
-  defaults: { cwd?: string; port?: string; json?: string } = {}
+  defaults: {
+    cwd?: string;
+    configDir?: string;
+    port?: string;
+    json?: string;
+  } = {}
 ): ParsedToolArgs {
   let cwd = defaults.cwd;
+  let configDir = defaults.configDir;
   let rawPort = defaults.port;
   let rawJson = defaults.json;
   let help = false;
@@ -39,6 +46,15 @@ export function parseToolArgs(
 
     if (token === '--help' || token === '-h') {
       help = true;
+      continue;
+    }
+
+    if (token === '-c') {
+      if (i >= tokens.length || tokens[i].startsWith('-')) {
+        return { ok: false, error: '`-c, --config-dir` requires a value.' };
+      }
+      configDir = tokens[i];
+      i += 1;
       continue;
     }
 
@@ -72,6 +88,14 @@ export function parseToolArgs(
       continue;
     }
 
+    if (key === 'config-dir') {
+      if (value === undefined) {
+        return { ok: false, error: '`-c, --config-dir` requires a value.' };
+      }
+      configDir = value;
+      continue;
+    }
+
     if (key === 'port') {
       if (value === undefined) {
         return { ok: false, error: '`--port` requires a value.' };
@@ -89,17 +113,6 @@ export function parseToolArgs(
     }
 
     flagArgs[key] = value === undefined ? true : coerceValue(value);
-  }
-
-  let port: number | undefined;
-  if (rawPort !== undefined) {
-    port = Number(rawPort);
-    if (!Number.isInteger(port) || port < 1 || port > 65535) {
-      return {
-        ok: false,
-        error: `\`--port\` must be a port number (1-65535), got \`${rawPort}\`.`,
-      };
-    }
   }
 
   let jsonArgs: Record<string, unknown> = {};
@@ -122,7 +135,23 @@ export function parseToolArgs(
     jsonArgs = parsed as Record<string, unknown>;
   }
 
-  return { ok: true, cwd, port, help, args: { ...jsonArgs, ...flagArgs } };
+  return { ok: true, cwd, configDir, port: rawPort, help, args: { ...jsonArgs, ...flagArgs } };
+}
+
+export function parsePort(
+  rawPort: string | undefined
+): { ok: true; port: number | undefined } | { ok: false; error: string } {
+  if (rawPort === undefined) {
+    return { ok: true, port: undefined };
+  }
+  const port = Number(rawPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return {
+      ok: false,
+      error: `\`--port\` must be a port number (1-65535), got \`${rawPort}\`.`,
+    };
+  }
+  return { ok: true, port };
 }
 
 /**
@@ -144,6 +173,28 @@ export function scanCwdToken(tokens: string[]): string | undefined {
     }
   }
   return cwd;
+}
+
+/** Same lenient scanner as {@link scanCwdToken}, but for `--config-dir`. */
+export function scanConfigDirToken(tokens: string[]): string | undefined {
+  let configDir: string | undefined;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token === '-c' && i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) {
+      configDir = tokens[i + 1];
+      i += 1;
+      continue;
+    }
+    if (token === '--config-dir' && i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
+      configDir = tokens[i + 1];
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--config-dir=')) {
+      configDir = token.slice('--config-dir='.length);
+    }
+  }
+  return configDir;
 }
 
 function coerceValue(raw: string): unknown {

--- a/code/core/src/cli/ai/mcp/tool-args.ts
+++ b/code/core/src/cli/ai/mcp/tool-args.ts
@@ -50,7 +50,7 @@ export function parseToolArgs(
     }
 
     if (token === '-c') {
-      if (i >= tokens.length || tokens[i].startsWith('-')) {
+      if (i >= tokens.length || tokens[i].startsWith('--')) {
         return { ok: false, error: '`-c, --config-dir` requires a value.' };
       }
       configDir = tokens[i];
@@ -180,7 +180,7 @@ export function scanConfigDirToken(tokens: string[]): string | undefined {
   let configDir: string | undefined;
   for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i];
-    if (token === '-c' && i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) {
+    if (token === '-c' && i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
       configDir = tokens[i + 1];
       i += 1;
       continue;

--- a/code/core/src/cli/ai/mcp/tool-args.ts
+++ b/code/core/src/cli/ai/mcp/tool-args.ts
@@ -1,9 +1,6 @@
 export type ParsedToolArgs =
   | {
       ok: true;
-      cwd: string | undefined;
-      configDir: string | undefined;
-      port: string | undefined;
       help: boolean;
       args: Record<string, unknown>;
     }
@@ -17,24 +14,18 @@ export type ParsedToolArgs =
  * - A bare `--key` (no value) becomes `true`.
  * - `--json '<object>'` is an escape hatch providing the raw argument object; explicit `--key`
  *   flags override its entries.
- * - `--cwd <path>`, `--config-dir <path>`, `--port <number>` and `--help`/`-h` are consumed by
- *   the CLI itself and never forwarded to the tool.
+ * - `--help`/`-h` is consumed by the CLI itself and never forwarded to the tool.
  *
- * `defaults` carries `--cwd`/`--config-dir`/`--port`/`--json` values that commander already
- * parsed before the tool name; the same flags appearing after the tool name take precedence.
+ * Target-selection options (`--cwd`, `--config-dir`, `--port`) are commander-owned and must
+ * appear before the command name; the same-looking flags after the command name are normal tool
+ * arguments.
  */
 export function parseToolArgs(
   tokens: string[],
   defaults: {
-    cwd?: string;
-    configDir?: string;
-    port?: string;
     json?: string;
   } = {}
 ): ParsedToolArgs {
-  let cwd = defaults.cwd;
-  let configDir = defaults.configDir;
-  let rawPort = defaults.port;
   let rawJson = defaults.json;
   let help = false;
   const flagArgs: Record<string, unknown> = {};
@@ -46,15 +37,6 @@ export function parseToolArgs(
 
     if (token === '--help' || token === '-h') {
       help = true;
-      continue;
-    }
-
-    if (token === '-c') {
-      if (i >= tokens.length || tokens[i].startsWith('--')) {
-        return { ok: false, error: '`-c, --config-dir` requires a value.' };
-      }
-      configDir = tokens[i];
-      i += 1;
       continue;
     }
 
@@ -78,30 +60,6 @@ export function parseToolArgs(
 
     if (key === '') {
       return { ok: false, error: `Invalid flag \`${token}\`.` };
-    }
-
-    if (key === 'cwd') {
-      if (value === undefined) {
-        return { ok: false, error: '`--cwd` requires a value.' };
-      }
-      cwd = value;
-      continue;
-    }
-
-    if (key === 'config-dir') {
-      if (value === undefined) {
-        return { ok: false, error: '`-c, --config-dir` requires a value.' };
-      }
-      configDir = value;
-      continue;
-    }
-
-    if (key === 'port') {
-      if (value === undefined) {
-        return { ok: false, error: '`--port` requires a value.' };
-      }
-      rawPort = value;
-      continue;
     }
 
     if (key === 'json') {
@@ -135,7 +93,7 @@ export function parseToolArgs(
     jsonArgs = parsed as Record<string, unknown>;
   }
 
-  return { ok: true, cwd, configDir, port: rawPort, help, args: { ...jsonArgs, ...flagArgs } };
+  return { ok: true, help, args: { ...jsonArgs, ...flagArgs } };
 }
 
 export function parsePort(
@@ -152,49 +110,6 @@ export function parsePort(
     };
   }
   return { ok: true, port };
-}
-
-/**
- * Extract only the `--cwd` value from pass-through tokens, tolerating tokens that
- * {@link parseToolArgs} would reject. Telemetry opt-out resolution must locate the target project
- * even when the invocation itself fails as `invalid-arguments` — that intercept still fires an
- * event (storybookjs/storybook#35131). Mirrors the full parser's `--cwd` grammar: `--cwd value`
- * or `--cwd=value`, last occurrence wins.
- */
-export function scanCwdToken(tokens: string[]): string | undefined {
-  let cwd: string | undefined;
-  for (let i = 0; i < tokens.length; i += 1) {
-    const token = tokens[i];
-    if (token === '--cwd' && i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
-      cwd = tokens[i + 1];
-      i += 1;
-    } else if (token.startsWith('--cwd=')) {
-      cwd = token.slice('--cwd='.length);
-    }
-  }
-  return cwd;
-}
-
-/** Same lenient scanner as {@link scanCwdToken}, but for `--config-dir`. */
-export function scanConfigDirToken(tokens: string[]): string | undefined {
-  let configDir: string | undefined;
-  for (let i = 0; i < tokens.length; i += 1) {
-    const token = tokens[i];
-    if (token === '-c' && i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
-      configDir = tokens[i + 1];
-      i += 1;
-      continue;
-    }
-    if (token === '--config-dir' && i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
-      configDir = tokens[i + 1];
-      i += 1;
-      continue;
-    }
-    if (token.startsWith('--config-dir=')) {
-      configDir = token.slice('--config-dir='.length);
-    }
-  }
-  return configDir;
 }
 
 function coerceValue(raw: string): unknown {


### PR DESCRIPTION
Closes #35210

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

- Added a Storybook config/preset metadata loader for the addon MCP `experimental_storybookAi` hook, using Storybook's canonical no-server `experimental_loadStorybook` preset loader.
- Changed `storybook ai --help` and `storybook ai <command> --help` to read workflow instructions and command descriptors from that metadata instead of contacting a running dev server.
- Added local execution for metadata-provided local tools before falling back to the live MCP server for runtime-bound commands.

Depends on storybookjs/mcp#298 and the Storybook 10.5 upgrade that brings the newer `@storybook/addon-mcp` into this repo.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Use a project with the `@storybook/addon-mcp` preset hook from storybookjs/mcp#298 available.
2. Make sure `storybook dev` is not running, then run `storybook ai --help` from the project root.
3. Confirm the output includes Storybook workflow instructions and the command list instead of asking for a running Storybook.
4. Run `storybook ai get-storybook-story-instructions` without `storybook dev` running and confirm it returns story-writing instructions.
5. Run a runtime-bound command, such as `storybook ai list-all-documentation`, without `storybook dev` running and confirm it still shows the normal repair guidance.
6. Start Storybook and confirm the same runtime-bound command still executes through the live MCP server.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35212-sha-77bf5a6e`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35212-sha-77bf5a6e sandbox` or in an existing project with `npx storybook@0.0.0-pr-35212-sha-77bf5a6e upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35212-sha-77bf5a6e`](https://npmjs.com/package/storybook/v/0.0.0-pr-35212-sha-77bf5a6e) |
| **Triggered by** | @huang-julien |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/ai-serverless-help`](https://github.com/storybookjs/storybook/tree/kasper/ai-serverless-help) |
| **Commit** | [`77bf5a6e`](https://github.com/storybookjs/storybook/commit/77bf5a6e3abae57258f302426288a99cb235c9c7) |
| **Datetime** | Fri Jun 19 12:54:40 UTC 2026 (`1781873680`) |
| **Workflow run** | [27826926851](https://github.com/storybookjs/storybook/actions/runs/27826926851) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35212`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--config-dir`/`-c` to target the Storybook configuration for tool help and execution.
  * Tools can now be discovered via Storybook AI metadata, including running eligible **local** tools directly without a running Storybook MCP server.

* **Improvements**
  * Tool listing/help now uses local AI metadata and degrades gracefully when metadata/tools are unavailable.
  * Tool help clearly labels commands as **[local]** or **[requires Storybook]**.

* **Breaking/Behavior Change**
  * MCP tool listing no longer exposes server “instructions” metadata alongside tools.
  * Refined CLI parsing, including stricter `--port` validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->