### PR TITLE
Cli: Install MCP when upgrade is ran by agent

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { JsPackageManager } from 'storybook/internal/common';
+import type { StorybookConfigRaw } from 'storybook/internal/types';
+
+import { add } from '../../add.ts';
+import type { CheckOptions, RunOptions } from '../types.ts';
+import { type AddonMcpOptions, addonMcp } from './addon-mcp.ts';
+
+vi.mock('../../add');
+
+const { detectAgent } = vi.hoisted(() => ({ detectAgent: vi.fn() }));
+vi.mock('storybook/internal/telemetry', () => ({ detectAgent }));
+
+const mockPackageManager = { type: 'npm' } as JsPackageManager;
+
+const baseCheckOptions: CheckOptions = {
+  packageManager: mockPackageManager,
+  mainConfig: {
+    stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+    addons: ['@storybook/addon-links'],
+  } as StorybookConfigRaw,
+  storybookVersion: '9.0.0',
+  configDir: '.storybook',
+  storiesPaths: [],
+  hasCsfFactoryPreview: false,
+};
+
+describe('addon-mcp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    detectAgent.mockReset();
+  });
+
+  describe('check phase', () => {
+    it('returns null when no AI agent is detected', async () => {
+      detectAgent.mockReturnValue(undefined);
+
+      const result = await addonMcp.check(baseCheckOptions);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns the agent name when an agent is detected and addon-mcp is missing', async () => {
+      detectAgent.mockReturnValue({ name: 'claude' });
+
+      const result = await addonMcp.check(baseCheckOptions);
+
+      expect(result).toEqual({ agentName: 'claude' });
+    });
+
+    it('returns null when addon-mcp is already configured', async () => {
+      detectAgent.mockReturnValue({ name: 'claude' });
+
+      const result = await addonMcp.check({
+        ...baseCheckOptions,
+        mainConfig: {
+          stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+          addons: ['@storybook/addon-links', '@storybook/addon-mcp'],
+        } as StorybookConfigRaw,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when addon-mcp is configured as an object', async () => {
+      detectAgent.mockReturnValue({ name: 'cursor' });
+
+      const result = await addonMcp.check({
+        ...baseCheckOptions,
+        mainConfig: {
+          stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+          addons: [{ name: '@storybook/addon-mcp' }],
+        } as StorybookConfigRaw,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('run phase', () => {
+    it('installs @storybook/addon-mcp without a redundant install', async () => {
+      await addonMcp.run?.({
+        result: { agentName: 'claude' },
+        packageManager: mockPackageManager,
+        configDir: '.storybook',
+      } as RunOptions<AddonMcpOptions>);
+
+      expect(vi.mocked(add)).toHaveBeenCalledWith('@storybook/addon-mcp', {
+        configDir: '.storybook',
+        packageManager: 'npm',
+        skipInstall: true,
+        skipPostinstall: true,
+        yes: true,
+      });
+    });
+
+    it('does nothing in dry run mode', async () => {
+      await addonMcp.run?.({
+        result: { agentName: 'claude' },
+        packageManager: mockPackageManager,
+        configDir: '.storybook',
+        dryRun: true,
+      } as RunOptions<AddonMcpOptions>);
+
+      expect(vi.mocked(add)).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.test.ts
@@ -1,16 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { JsPackageManager } from 'storybook/internal/common';
+import { detectAgent } from 'storybook/internal/telemetry';
 import type { StorybookConfigRaw } from 'storybook/internal/types';
 
 import { add } from '../../add.ts';
 import type { CheckOptions, RunOptions } from '../types.ts';
 import { type AddonMcpOptions, addonMcp } from './addon-mcp.ts';
 
-vi.mock('../../add');
-
-const { detectAgent } = vi.hoisted(() => ({ detectAgent: vi.fn() }));
-vi.mock('storybook/internal/telemetry', () => ({ detectAgent }));
+vi.mock('../../add', { spy: true });
+vi.mock('storybook/internal/common', { spy: true });
+vi.mock('storybook/internal/node-logger', { spy: true });
+vi.mock('storybook/internal/telemetry', { spy: true });
 
 const mockPackageManager = { type: 'npm' } as JsPackageManager;
 
@@ -26,70 +27,70 @@ const baseCheckOptions: CheckOptions = {
   hasCsfFactoryPreview: false,
 };
 
+const addArgs = {
+  configDir: '.storybook',
+  packageManager: 'npm',
+  skipInstall: true,
+  skipPostinstall: true,
+  yes: true,
+};
+
 describe('addon-mcp', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    detectAgent.mockReset();
+    vi.mocked(add).mockResolvedValue(undefined);
   });
 
   describe('check phase', () => {
-    it('returns null when no AI agent is detected', async () => {
-      detectAgent.mockReturnValue(undefined);
-
-      const result = await addonMcp.check(baseCheckOptions);
-
-      expect(result).toBeNull();
-    });
-
-    it('returns isInstalled: false when an agent is detected and addon-mcp is missing', async () => {
-      detectAgent.mockReturnValue({ name: 'claude' });
-
-      const result = await addonMcp.check(baseCheckOptions);
-
-      expect(result).toEqual({ agentName: 'claude', isInstalled: false });
-    });
-
-    it('returns isInstalled: true when addon-mcp is already configured (force update)', async () => {
-      detectAgent.mockReturnValue({ name: 'claude' });
-
-      const result = await addonMcp.check({
-        ...baseCheckOptions,
-        mainConfig: {
-          stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
-          addons: ['@storybook/addon-links', '@storybook/addon-mcp'],
-        } as StorybookConfigRaw,
+    describe('when no AI agent is detected', () => {
+      beforeEach(() => {
+        vi.mocked(detectAgent).mockReturnValue(undefined);
       });
 
-      expect(result).toEqual({ agentName: 'claude', isInstalled: true });
+      it('returns null', async () => {
+        await expect(addonMcp.check(baseCheckOptions)).resolves.toBeNull();
+      });
     });
 
-    it('detects addon-mcp when configured as an object', async () => {
-      detectAgent.mockReturnValue({ name: 'cursor' });
-
-      const result = await addonMcp.check({
-        ...baseCheckOptions,
-        mainConfig: {
-          stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
-          addons: [{ name: '@storybook/addon-mcp' }],
-        } as StorybookConfigRaw,
+    describe('when an AI agent is detected', () => {
+      beforeEach(() => {
+        vi.mocked(detectAgent).mockReturnValue({ name: 'claude' });
       });
 
-      expect(result).toEqual({ agentName: 'cursor', isInstalled: true });
+      it('returns isInstalled: false when addon-mcp is missing', async () => {
+        await expect(addonMcp.check(baseCheckOptions)).resolves.toEqual({
+          agentName: 'claude',
+          isInstalled: false,
+        });
+      });
+
+      it('returns isInstalled: true when addon-mcp is configured as a string', async () => {
+        await expect(
+          addonMcp.check({
+            ...baseCheckOptions,
+            mainConfig: {
+              stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+              addons: ['@storybook/addon-links', '@storybook/addon-mcp'],
+            } as StorybookConfigRaw,
+          })
+        ).resolves.toEqual({ agentName: 'claude', isInstalled: true });
+      });
+
+      it('returns isInstalled: true when addon-mcp is configured as an object', async () => {
+        await expect(
+          addonMcp.check({
+            ...baseCheckOptions,
+            mainConfig: {
+              stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+              addons: [{ name: '@storybook/addon-mcp' }],
+            } as StorybookConfigRaw,
+          })
+        ).resolves.toEqual({ agentName: 'claude', isInstalled: true });
+      });
     });
   });
 
   describe('run phase', () => {
-    const addArgs = {
-      configDir: '.storybook',
-      packageManager: 'npm',
-      skipInstall: true,
-      skipPostinstall: true,
-      yes: true,
-    };
-
     it('installs @storybook/addon-mcp when it is missing', async () => {
       await addonMcp.run?.({
         result: { agentName: 'claude', isInstalled: false },

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.test.ts
@@ -44,15 +44,15 @@ describe('addon-mcp', () => {
       expect(result).toBeNull();
     });
 
-    it('returns the agent name when an agent is detected and addon-mcp is missing', async () => {
+    it('returns isInstalled: false when an agent is detected and addon-mcp is missing', async () => {
       detectAgent.mockReturnValue({ name: 'claude' });
 
       const result = await addonMcp.check(baseCheckOptions);
 
-      expect(result).toEqual({ agentName: 'claude' });
+      expect(result).toEqual({ agentName: 'claude', isInstalled: false });
     });
 
-    it('returns null when addon-mcp is already configured', async () => {
+    it('returns isInstalled: true when addon-mcp is already configured (force update)', async () => {
       detectAgent.mockReturnValue({ name: 'claude' });
 
       const result = await addonMcp.check({
@@ -63,10 +63,10 @@ describe('addon-mcp', () => {
         } as StorybookConfigRaw,
       });
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ agentName: 'claude', isInstalled: true });
     });
 
-    it('returns null when addon-mcp is configured as an object', async () => {
+    it('detects addon-mcp when configured as an object', async () => {
       detectAgent.mockReturnValue({ name: 'cursor' });
 
       const result = await addonMcp.check({
@@ -77,30 +77,42 @@ describe('addon-mcp', () => {
         } as StorybookConfigRaw,
       });
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ agentName: 'cursor', isInstalled: true });
     });
   });
 
   describe('run phase', () => {
-    it('installs @storybook/addon-mcp without a redundant install', async () => {
+    const addArgs = {
+      configDir: '.storybook',
+      packageManager: 'npm',
+      skipInstall: true,
+      skipPostinstall: true,
+      yes: true,
+    };
+
+    it('installs @storybook/addon-mcp when it is missing', async () => {
       await addonMcp.run?.({
-        result: { agentName: 'claude' },
+        result: { agentName: 'claude', isInstalled: false },
         packageManager: mockPackageManager,
         configDir: '.storybook',
       } as RunOptions<AddonMcpOptions>);
 
-      expect(vi.mocked(add)).toHaveBeenCalledWith('@storybook/addon-mcp', {
+      expect(vi.mocked(add)).toHaveBeenCalledWith('@storybook/addon-mcp', addArgs);
+    });
+
+    it('force-updates @storybook/addon-mcp to latest when it is already installed', async () => {
+      await addonMcp.run?.({
+        result: { agentName: 'claude', isInstalled: true },
+        packageManager: mockPackageManager,
         configDir: '.storybook',
-        packageManager: 'npm',
-        skipInstall: true,
-        skipPostinstall: true,
-        yes: true,
-      });
+      } as RunOptions<AddonMcpOptions>);
+
+      expect(vi.mocked(add)).toHaveBeenCalledWith('@storybook/addon-mcp', addArgs);
     });
 
     it('does nothing in dry run mode', async () => {
       await addonMcp.run?.({
-        result: { agentName: 'claude' },
+        result: { agentName: 'claude', isInstalled: false },
         packageManager: mockPackageManager,
         configDir: '.storybook',
         dryRun: true,

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.ts
@@ -13,13 +13,16 @@ const ADDON_MCP = '@storybook/addon-mcp';
 export interface AddonMcpOptions {
   /** Name of the detected AI coding agent (e.g. `claude`, `cursor`), surfaced in the prompt. */
   agentName: string;
+  /** Whether `@storybook/addon-mcp` is already configured, so we update rather than install. */
+  isInstalled: boolean;
 }
 
 /**
- * When `storybook upgrade` is driven by an AI coding agent and `@storybook/addon-mcp` is not yet
- * configured, install it. The addon exposes the running Storybook to the agent over MCP, so an
- * agent that just ran an upgrade is exactly the audience that benefits from it. Humans never see
- * this migration — `check` returns null unless std-env detects an agent.
+ * When `storybook upgrade` is driven by an AI coding agent, install `@storybook/addon-mcp` — or, if
+ * it is already configured, pull it up to its latest version. The addon exposes the running
+ * Storybook to the agent over MCP, so an agent that just ran an upgrade is exactly the audience that
+ * benefits from it. Humans never see this migration — `check` returns null unless std-env detects an
+ * agent.
  */
 export const addonMcp: Fix<AddonMcpOptions> = {
   id: 'addon-mcp',
@@ -31,29 +34,29 @@ export const addonMcp: Fix<AddonMcpOptions> = {
       return null;
     }
 
-    const isAlreadyConfigured = getAddonNames(mainConfig).some((addon) =>
-      addon.includes(ADDON_MCP)
-    );
-    if (isAlreadyConfigured) {
-      return null;
-    }
+    const isInstalled = getAddonNames(mainConfig).some((addon) => addon.includes(ADDON_MCP));
 
-    return { agentName: agent.name };
+    return { agentName: agent.name, isInstalled };
   },
 
   prompt() {
     return dedent`
       We detected this upgrade is running through an AI coding agent.
-      We'll install ${picocolors.magenta(ADDON_MCP)} so the agent can talk to your running Storybook over MCP for more accurate assistance.
+      We'll add or update ${picocolors.magenta(ADDON_MCP)} to the latest version so the agent can talk to your running Storybook over MCP for more accurate assistance.
     `;
   },
 
-  async run({ packageManager, configDir, dryRun }) {
+  async run({ result, packageManager, configDir, dryRun }) {
     if (dryRun) {
       return;
     }
 
-    logger.log(`Installing ${picocolors.magenta(ADDON_MCP)}...`);
+    logger.log(
+      `${result.isInstalled ? 'Updating' : 'Installing'} ${picocolors.magenta(ADDON_MCP)} to the latest version...`
+    );
+    // `add` resolves the latest published version for satellite addons and, when the addon is
+    // already present, refreshes the dependency without duplicating it in the main config.
+    // skipInstall: the upgrade command runs a single dependency install after all automigrations.
     await add(ADDON_MCP, {
       configDir,
       packageManager: packageManager.type,

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-mcp.ts
@@ -1,0 +1,65 @@
+import { getAddonNames } from 'storybook/internal/common';
+import { logger } from 'storybook/internal/node-logger';
+import { detectAgent } from 'storybook/internal/telemetry';
+
+import picocolors from 'picocolors';
+import { dedent } from 'ts-dedent';
+
+import { add } from '../../add.ts';
+import type { Fix } from '../types.ts';
+
+const ADDON_MCP = '@storybook/addon-mcp';
+
+export interface AddonMcpOptions {
+  /** Name of the detected AI coding agent (e.g. `claude`, `cursor`), surfaced in the prompt. */
+  agentName: string;
+}
+
+/**
+ * When `storybook upgrade` is driven by an AI coding agent and `@storybook/addon-mcp` is not yet
+ * configured, install it. The addon exposes the running Storybook to the agent over MCP, so an
+ * agent that just ran an upgrade is exactly the audience that benefits from it. Humans never see
+ * this migration — `check` returns null unless std-env detects an agent.
+ */
+export const addonMcp: Fix<AddonMcpOptions> = {
+  id: 'addon-mcp',
+  link: 'https://github.com/storybookjs/mcp',
+
+  async check({ mainConfig }) {
+    const agent = detectAgent();
+    if (!agent) {
+      return null;
+    }
+
+    const isAlreadyConfigured = getAddonNames(mainConfig).some((addon) =>
+      addon.includes(ADDON_MCP)
+    );
+    if (isAlreadyConfigured) {
+      return null;
+    }
+
+    return { agentName: agent.name };
+  },
+
+  prompt() {
+    return dedent`
+      We detected this upgrade is running through an AI coding agent.
+      We'll install ${picocolors.magenta(ADDON_MCP)} so the agent can talk to your running Storybook over MCP for more accurate assistance.
+    `;
+  },
+
+  async run({ packageManager, configDir, dryRun }) {
+    if (dryRun) {
+      return;
+    }
+
+    logger.log(`Installing ${picocolors.magenta(ADDON_MCP)}...`);
+    await add(ADDON_MCP, {
+      configDir,
+      packageManager: packageManager.type,
+      skipInstall: true,
+      skipPostinstall: true,
+      yes: true,
+    });
+  },
+};

--- a/code/lib/cli-storybook/src/automigrate/fixes/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/index.ts
@@ -4,6 +4,7 @@ import { addonA11yAddonTest } from './addon-a11y-addon-test.ts';
 import { addonA11yParameters } from './addon-a11y-parameters.ts';
 import { addonExperimentalTest } from './addon-experimental-test.ts';
 import { addonGlobalsApi } from './addon-globals-api.ts';
+import { addonMcp } from './addon-mcp.ts';
 import { addonMdxGfmRemove } from './addon-mdx-gfm-remove.ts';
 import { addonStorysourceCodePanel } from './addon-storysource-code-panel.ts';
 import { consolidatedImports } from './consolidated-imports.ts';
@@ -41,6 +42,7 @@ export const allFixes: Fix[] = [
   nextjsToNextjsVite,
   reactViteToTanstackReact,
   removeAddonInteractions,
+  addonMcp,
   rendererToFramework,
   removeEssentials,
   addonA11yParameters,


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR add addon-mcp upgrade/installation when upgrade command is run through AI. 

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

verify upgrade command from AI correctly installs addon-mcp or update it 

Tested with Claude OK.

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35215-sha-cf433ce6`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35215-sha-cf433ce6 sandbox` or in an existing project with `npx storybook@0.0.0-pr-35215-sha-cf433ce6 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35215-sha-cf433ce6`](https://npmjs.com/package/storybook/v/0.0.0-pr-35215-sha-cf433ce6) |
| **Triggered by** | @huang-julien |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`feat/addon-mcp-agent-upgrade`](https://github.com/storybookjs/storybook/tree/feat/addon-mcp-agent-upgrade) |
| **Commit** | [`cf433ce6`](https://github.com/storybookjs/storybook/commit/cf433ce6bcc920081178eb1f15c608cfa4039a58) |
| **Datetime** | Thu Jun 18 15:29:08 UTC 2026 (`1781796548`) |
| **Workflow run** | [27770466961](https://github.com/storybookjs/storybook/actions/runs/27770466961) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35215`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Storybook upgrades to automatically ensure the MCP support addon (`@storybook/addon-mcp`) is present when an AI-powered agent is detected, installing or refreshing it as needed.

* **Tests**
  * Added a Vitest suite covering the upgrade automation flow, including agent-detection scenarios and verification that addon installation is skipped in dry-run mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->