### PR TITLE
Tanstack-React: Fix pathless layout routes in stories

### DIFF
--- a/code/frameworks/tanstack-react/src/export-mocks/react-router.test.ts
+++ b/code/frameworks/tanstack-react/src/export-mocks/react-router.test.ts
@@ -1,16 +1,29 @@
-import { describe, expect, it, vi } from 'vitest';
 import { createRootRoute } from '@tanstack/react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('storybook/test', () => ({
-  fn: (implementation: unknown) => ({
+const storybookTestMock = vi.hoisted(() => ({
+  fn: vi.fn<(implementation: unknown) => { mockName: () => unknown }>(),
+}));
+const previewApiMock = vi.hoisted(() => ({
+  useEffect: vi.fn<() => undefined>(),
+}));
+
+// @ts-expect-error Vitest supports factory mocks with spy options, but the pinned types only expose the two-argument overload.
+vi.mock('storybook/test', () => storybookTestMock, { spy: true });
+// @ts-expect-error Vitest supports factory mocks with spy options, but the pinned types only expose the two-argument overload.
+vi.mock('storybook/internal/preview-api', () => previewApiMock, { spy: true });
+
+let createFileRoute: typeof import('./react-router.ts').createFileRoute;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.mocked(storybookTestMock.fn).mockImplementation((implementation: unknown) => ({
     mockName: () => implementation,
-  }),
-}));
-vi.mock('storybook/internal/preview-api', () => ({
-  useEffect: () => undefined,
-}));
+  }));
+  vi.mocked(previewApiMock.useEffect).mockImplementation(() => undefined);
 
-import { createFileRoute } from './react-router.ts';
+  ({ createFileRoute } = await import('./react-router.ts'));
+});
 
 const build = (path: string) => {
   const root = createRootRoute();

--- a/code/frameworks/tanstack-react/src/export-mocks/react-router.test.ts
+++ b/code/frameworks/tanstack-react/src/export-mocks/react-router.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createRootRoute } from '@tanstack/react-router';
+
+vi.mock('storybook/test', () => ({
+  fn: (implementation: unknown) => ({
+    mockName: () => implementation,
+  }),
+}));
+vi.mock('storybook/internal/preview-api', () => ({
+  useEffect: () => undefined,
+}));
 
 import { createFileRoute } from './react-router.ts';
 
@@ -42,6 +51,14 @@ describe('createFileRoute', () => {
     expect(Route.options.id).toBe('/_layout/page');
     expect(Route.options.path).toBe('/page');
     expect(Route.options.fullPath).toBe('/page');
+  });
+
+  it('keeps pure pathless `_layout` routes id-only', () => {
+    const Route = build('/_layout');
+
+    expect(Route.options.id).toBe('/_layout');
+    expect(Route.options.path).toBeUndefined();
+    expect(Route.options.fullPath).toBeUndefined();
   });
 
   it('normalizes a mix of `_layout` and `(group)` segments', () => {

--- a/code/frameworks/tanstack-react/src/export-mocks/react-router.ts
+++ b/code/frameworks/tanstack-react/src/export-mocks/react-router.ts
@@ -84,16 +84,24 @@ export const Link = ({
  */
 export function createFileRoute(path: string) {
   const normalizedPath = normalizeFileRoutePath(path);
+  const segments = path.split('/').filter(Boolean);
+  const lastSegment = segments[segments.length - 1];
+  const isPurePathlessLayoutRoute =
+    (lastSegment?.startsWith('_') ?? false) && normalizedPath === '/';
 
   return (options: any) => {
     return createRoute({
-      path: normalizedPath,
+      ...(isPurePathlessLayoutRoute ? { id: path } : { path: normalizedPath }),
       ...options,
       isRoot: false,
     }).update({
       id: path,
-      path: normalizedPath,
-      fullPath: normalizedPath,
+      ...(isPurePathlessLayoutRoute
+        ? {}
+        : {
+            path: normalizedPath,
+            fullPath: normalizedPath,
+          }),
       // any because tanstack router does that
     } as any);
   };

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router';
+
+import { duplicateRouteTree } from './duplicate-tree.ts';
+
+describe('duplicateRouteTree', () => {
+  it('preserves pathless layout routes as id-only routes', async () => {
+    const root = createRootRoute();
+    const authed = createRoute({
+      id: '/_authed',
+      getParentRoute: () => root,
+      component: () => null,
+    });
+    const race = createRoute({
+      path: 'races/$racePublicId/$raceSlug',
+      getParentRoute: () => authed,
+      component: () => null,
+    });
+    const test = createRoute({
+      path: 'test',
+      getParentRoute: () => race,
+      component: () => null,
+    });
+
+    root.addChildren([authed.addChildren([race.addChildren([test])])]);
+
+    const { root: duplicatedRoot, byId } = duplicateRouteTree(root);
+    const clonedAuthed = byId.get(authed.id) as any;
+    const clonedRace = byId.get(race.id) as any;
+    const clonedTest = byId.get(test.id) as any;
+
+    expect(clonedAuthed.options.id).toBe('/_authed');
+    expect(clonedAuthed.options.path).toBeUndefined();
+
+    const router = createRouter({
+      routeTree: duplicatedRoot,
+      history: createMemoryHistory({
+        initialEntries: ['/races/dragonborn/dragonborn/test'],
+      }),
+    });
+    await router.load();
+
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      duplicatedRoot.id,
+      clonedAuthed.id,
+      clonedRace.id,
+      clonedTest.id,
+    ]);
+  });
+});

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
@@ -62,10 +62,10 @@ function cloneChild(
   byId: Map<string, AnyRoute>
 ): AnyRoute {
   const options = (oldRoute as any).options ?? {};
-  // Strip identity / parent-link options so the cloned route gets its identity
-  // derived from the new parent + path, and its parent linked to the cloned
-  // parent below. Keeping the original `id` would cause TanStack to register
-  // two routes with the same generated id (e.g. `__root__/about`).
+  // Strip parent-link options so the cloned route gets linked to the cloned
+  // parent below. Path routes derive identity from the new parent + path, then
+  // preserve the source file-route id after creation. Pathless layout routes
+  // are id-only, so giving them a path would turn the layout into a URL route.
   const { id: _id, getParentRoute: _g, ...rest } = options;
   const override = getOverrideFor(overrides, oldRoute.id);
 
@@ -73,11 +73,16 @@ function cloneChild(
   // registers the route in TanStack's global file-route registry by path, so
   // re-running the duplication on every story re-render registers a duplicate
   // and TanStack throws `Duplicate routeIds found: __root__`.
-  const cloned = createRoute({
+  let cloned = createRoute({
+    ...(options.id && options.path === undefined ? { id: options.id } : {}),
     ...rest,
     ...override,
     getParentRoute: () => parent as any,
   } as any);
+
+  if (options.id && options.path !== undefined) {
+    cloned = cloned.update({ id: options.id } as any);
+  }
 
   byId.set(oldRoute.id, cloned as unknown as AnyRoute);
 

--- a/code/frameworks/tanstack-react/template/stories/PathlessLayoutRoutes.stories.tsx
+++ b/code/frameworks/tanstack-react/template/stories/PathlessLayoutRoutes.stories.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+
+import { Outlet, createRootRoute, createRoute, getRouteApi } from '@tanstack/react-router';
+import { expect, within } from 'storybook/test';
+
+const authenticatedRouteApi = getRouteApi('/_authenticated');
+const testRouteApi = getRouteApi('/_authenticated/races/$racePublicId/$raceSlug/test');
+
+function AuthenticatedLayout() {
+  return (
+    <section data-testid="pathless-layout">
+      <h1>pathless layout</h1>
+      <Outlet />
+    </section>
+  );
+}
+
+function RaceLayout() {
+  return (
+    <section data-testid="race-layout">
+      <h2>nested race layout</h2>
+      <Outlet />
+    </section>
+  );
+}
+
+function RouteStateProbe() {
+  const context = authenticatedRouteApi.useRouteContext() as { sessionLabel: string };
+  const params = testRouteApi.useParams() as {
+    racePublicId: string;
+    raceSlug: string;
+  };
+
+  return (
+    <dl>
+      <dt>route context</dt>
+      <dd>{context.sessionLabel}</dd>
+      <dt>route params</dt>
+      <dd>
+        {params.racePublicId}:{params.raceSlug}
+      </dd>
+    </dl>
+  );
+}
+
+const RootRoute = createRootRoute();
+
+const AuthenticatedRoute = createRoute({
+  id: '/_authenticated',
+  getParentRoute: () => RootRoute,
+  beforeLoad: () => ({ sessionLabel: 'pathless route context' }),
+  component: AuthenticatedLayout,
+});
+
+const RaceRoute = createRoute({
+  path: 'races/$racePublicId/$raceSlug',
+  getParentRoute: () => AuthenticatedRoute,
+  component: RaceLayout,
+});
+
+const TestRoute = createRoute({
+  path: 'test',
+  getParentRoute: () => RaceRoute,
+  component: RouteStateProbe,
+});
+
+RootRoute.addChildren([AuthenticatedRoute.addChildren([RaceRoute.addChildren([TestRoute])])]);
+
+const meta = {
+  component: RouteStateProbe,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof RouteStateProbe>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const PreservesPathlessLayoutRouteState: Story = {
+  parameters: {
+    tanstack: {
+      router: {
+        route: TestRoute,
+        params: {
+          racePublicId: 'dragonborn',
+          raceSlug: 'dragonborn',
+        },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { level: 1, name: 'pathless layout' })).toBeVisible();
+    await expect(
+      canvas.getByRole('heading', { level: 2, name: 'nested race layout' })
+    ).toBeVisible();
+    await expect(canvas.getByText('pathless route context')).toBeVisible();
+    await expect(canvas.getByText('dragonborn:dragonborn')).toBeVisible();
+  },
+};


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixes TanStack React stories that use file-route style pathless layout routes, so pure underscore layout routes stay id-only and duplicated story route trees preserve those id-only layout routes. Adds focused unit coverage and a framework template story that reproduces a pathless authenticated layout with nested dynamic routes.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Generate the TanStack React Router sandbox:
   `yarn task sandbox --template tanstack-react-router/default-ts --start-from auto`
2. Start the generated sandbox Storybook:
   `cd ../storybook-sandboxes/tanstack-react-router-default-ts && yarn storybook`
3. Open the `PathlessLayoutRoutes / Preserves pathless layout route state` story.
4. Verify the story renders the pathless layout, nested race layout, route context text `pathless route context`, and route params text `dragonborn:dragonborn`.

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### ðŸ¦‹ Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pathless layout routes to emit the correct route configuration and preserve route context/state across nested routes.
  * Improved route cloning/duplication so pathless layout routes are represented consistently (id-only) without duplicate registration.
* **Tests**
  * Added/expanded Vitest coverage for pathless layout routing and duplicated route tree behavior.
* **Documentation**
  * Added a Storybook story to demonstrate and verify pathless layout state preservation through nested routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->