### PR TITLE
Tanstack-React: Skip Tanstack Start document roots in stories

### DIFF
--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { createRootRoute } from '@tanstack/react-router';
+
+import { duplicateRouteTree } from './duplicate-tree.ts';
+
+describe('duplicateRouteTree', () => {
+  it('uses a fresh preview root instead of copying source root options', () => {
+    const SourceRootComponent = () => null;
+    const sourceRootBeforeLoad = () => ({ fromSourceRoot: true });
+    const root = createRootRoute({
+      component: SourceRootComponent,
+      beforeLoad: sourceRootBeforeLoad,
+    });
+
+    const { root: duplicatedRoot } = duplicateRouteTree(root);
+
+    expect((duplicatedRoot as any).options.component).toBeUndefined();
+    expect((duplicatedRoot as any).options.beforeLoad).toBeUndefined();
+  });
+
+  it('applies explicit root overrides to the fresh preview root', () => {
+    const SourceRootComponent = () => null;
+    const OverrideRootComponent = () => null;
+    const overrideBeforeLoad = () => ({ fromOverrideRoot: true });
+    const root = createRootRoute({
+      component: SourceRootComponent,
+    });
+
+    const { root: duplicatedRoot } = duplicateRouteTree(root, {
+      overrides: {
+        __root__: {
+          component: OverrideRootComponent,
+          beforeLoad: overrideBeforeLoad,
+        },
+      } as any,
+    });
+
+    expect((duplicatedRoot as any).options.component).toBe(OverrideRootComponent);
+    expect((duplicatedRoot as any).options.beforeLoad).toBe(overrideBeforeLoad);
+  });
+});

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
@@ -109,18 +109,17 @@ export function duplicateRouteTree(
   initSourceTree(rootRoute, { i: 0 });
 
   const byId = new Map<string, AnyRoute>();
-  const rootOptions = (rootRoute as any).options ?? {};
   const rootOverride = getOverrideFor(overrides, '__root__');
 
   // Always build a fresh `RootRoute` instead of reusing / mutating the
   // caller's root. Reusing the same root across multiple story routers is
   // what causes TanStack to report a duplicated `__root__` id when more than
   // one story is mounted in the same browser session (e.g. HMR, navigation).
-  // We strip `id` from spread options so TanStack assigns the canonical
-  // `__root__` id itself.
-  const { id: _rootId, getParentRoute: _rootGetParent, ...restRoot } = rootOptions;
+  // Do not copy source root options into the duplicate: TanStack Start roots
+  // often render the full document (`html`, `head`, `body`), which is invalid
+  // inside Storybook's preview root. Storybook-specific root behavior can still
+  // be supplied with an explicit `routeOverrides.__root__` entry.
   const newRoot = createRootRouteWithContext()({
-    ...restRoot,
     ...rootOverride,
   } as any);
   byId.set('__root__', newRoot as unknown as AnyRoute);

--- a/code/frameworks/tanstack-react/template/stories/StartDocumentRoot.stories.tsx
+++ b/code/frameworks/tanstack-react/template/stories/StartDocumentRoot.stories.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+
+import { Outlet, createRootRoute, createRoute } from '@tanstack/react-router';
+import { expect, within } from 'storybook/test';
+
+function DocumentRoot() {
+  return (
+    <html lang="en" data-testid="tanstack-start-document-root">
+      <head>
+        <title>TanStack Start document root</title>
+      </head>
+      <body>
+        <Outlet />
+      </body>
+    </html>
+  );
+}
+
+function AppLayout() {
+  return (
+    <main data-testid="tanstack-start-app-layout">
+      <h1>Start route layout</h1>
+      <Outlet />
+    </main>
+  );
+}
+
+function LeafContent() {
+  return <p data-testid="tanstack-start-leaf">leaf rendered without the document root</p>;
+}
+
+const RootRoute = createRootRoute({
+  component: DocumentRoot,
+});
+
+const AppRoute = createRoute({
+  getParentRoute: () => RootRoute,
+  path: '/',
+  component: AppLayout,
+});
+
+const LeafRoute = createRoute({
+  getParentRoute: () => AppRoute,
+  path: 'dashboard',
+  component: LeafContent,
+});
+
+RootRoute.addChildren([AppRoute.addChildren([LeafRoute])]);
+
+const meta = {
+  component: LeafContent,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof LeafContent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SkipsTanStackStartDocumentRoot: Story = {
+  parameters: {
+    tanstack: {
+      router: {
+        route: LeafRoute,
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole('heading', { level: 1, name: 'Start route layout' })
+    ).toBeVisible();
+    await expect(canvas.getByTestId('tanstack-start-leaf')).toBeVisible();
+    await expect(canvas.queryByTestId('tanstack-start-document-root')).not.toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixes TanStack Start stories whose application root route renders the full document shell (`html`, `head`, `body`). Storybook now duplicates the route tree with a fresh preview-safe root instead of copying the app document root options, while still allowing explicit `routeOverrides.__root__` behavior.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Generate the TanStack React Start sandbox:
   `yarn task sandbox --template tanstack-react-start/default-ts --start-from auto`
2. Start the generated sandbox Storybook:
   `cd ../storybook-sandboxes/tanstack-react-start-default-ts && yarn storybook`
3. Open the `StartDocumentRoot / Skips TanStack Start Document Root` story.
4. Verify the story renders `Start route layout` and `leaf rendered without the document root`, with no nested `html` document-root rendering error.

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### ðŸ¦‹ Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for route tree duplication behavior, verifying proper handling of root configuration options and override parameters.

* **Documentation**
  * Added Storybook story for testing document root rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->