### PR TITLE
Agentic Review [1]: Standalone review core quality fixes

### DIFF
--- a/code/core/src/components/components/Card/Card.tsx
+++ b/code/core/src/components/components/Card/Card.tsx
@@ -5,30 +5,26 @@ import { keyframes, styled } from 'storybook/theming';
 
 type ThemeColor = keyof StorybookTheme['color'] | keyof StorybookTheme['fgColor'];
 
-const getColor = (theme: StorybookTheme, color?: ThemeColor) => {
-  if (color && color in theme.fgColor) {
-    return theme.fgColor[color as keyof typeof theme.fgColor];
-  }
-  if (color && color in theme.color) {
-    return theme.color[color as keyof typeof theme.color];
-  }
-};
+// A ThemeColor may live in any of theme.color / fgColor / bgColor / borderColor, which don't share
+// a key space, so each lookup is a presence check rather than a direct index. Returning undefined
+// when absent is intentional: it lets the CSS property fall back to inherit/default.
+const resolveThemeColor = (
+  colors: Partial<Record<string, string>>,
+  key?: ThemeColor
+): string | undefined => (key && key in colors ? colors[key] : undefined);
 
-const getBorderColor = (theme: StorybookTheme, color?: ThemeColor, outlineColor?: ThemeColor) => {
-  if (color && color in theme.borderColor) {
-    return theme.borderColor[color as keyof typeof theme.borderColor];
-  }
-  if (outlineColor && outlineColor in theme.color) {
-    return theme.color[outlineColor as keyof typeof theme.color];
-  }
-};
+const getColor = (theme: StorybookTheme, color?: ThemeColor): string | undefined =>
+  resolveThemeColor(theme.fgColor, color) ?? resolveThemeColor(theme.color, color);
 
-const getBackgroundColor = (theme: StorybookTheme, color?: ThemeColor) => {
-  if (color && color in theme.bgColor) {
-    return theme.bgColor[color as keyof typeof theme.bgColor];
-  }
-  return theme.background.content;
-};
+const getBorderColor = (
+  theme: StorybookTheme,
+  color?: ThemeColor,
+  outlineColor?: ThemeColor
+): string | undefined =>
+  resolveThemeColor(theme.borderColor, color) ?? resolveThemeColor(theme.color, outlineColor);
+
+const getBackgroundColor = (theme: StorybookTheme, color?: ThemeColor): string =>
+  resolveThemeColor(theme.bgColor, color) ?? theme.background.content;
 
 const fadeInOut = keyframes({
   '0%': { opacity: 0 },

--- a/code/core/src/manager-api/modules/url.ts
+++ b/code/core/src/manager-api/modules/url.ts
@@ -57,6 +57,16 @@ const mergeSerializedParams = (params: string, extraParams: string) => {
     .join(';');
 };
 
+// URL query params the manager consumes for layout/navigation. Everything else is a custom param
+// passed through to the preview iframe. Listing the boundary once keeps customQueryParams derived
+// identically at init (initialUrlSupport) and on every navigation (root.tsx), so they can't diverge.
+const LAYOUT_QUERY_PARAM_KEYS = ['full', 'panel', 'nav', 'shortcuts', 'addonPanel', 'tabs', 'path'];
+
+/** Single source of truth for the custom (non-layout) query params derived from the URL. */
+export const getCustomQueryParams = (
+  location: Parameters<typeof queryFromLocation>[0]
+): QueryParams => omit(queryFromLocation(location), LAYOUT_QUERY_PARAM_KEYS);
+
 // Initialize the state based on the URL.
 // NOTE:
 //   Although we don't change the URL when you change the state, we do support setting initial state
@@ -66,21 +76,12 @@ const mergeSerializedParams = (params: string, extraParams: string) => {
 //     - nav: 0/1 -- show or hide the story list
 //
 //   We also support legacy URLs from storybook <5
-let prevParams: ReturnType<typeof queryFromLocation>;
+let prevParams: QueryParams;
 const initialUrlSupport = ({
   state: { location, path, viewMode, storyId: storyIdFromUrl },
   singleStory,
 }: ModuleArgs) => {
-  const {
-    full,
-    panel,
-    nav,
-    shortcuts,
-    addonPanel,
-    tabs,
-    path: queryPath,
-    ...otherParams // the rest gets passed to the iframe
-  } = queryFromLocation(location);
+  const { full, panel, nav, shortcuts, addonPanel, tabs } = queryFromLocation(location);
 
   let navSize;
   let bottomPanelHeight;
@@ -124,6 +125,7 @@ const initialUrlSupport = ({
   const selectedPanel = addonPanel || undefined;
 
   const storyId = storyIdFromUrl;
+  const otherParams = getCustomQueryParams(location);
   // Avoid returning a new object each time if no params actually changed.
   const customQueryParams = deepEqual(prevParams, otherParams) ? prevParams : otherParams;
   prevParams = customQueryParams;

--- a/code/core/src/manager-api/root.tsx
+++ b/code/core/src/manager-api/root.tsx
@@ -20,7 +20,6 @@ import {
   STORY_PREPARED,
 } from 'storybook/internal/core-events';
 import type { RouterData } from 'storybook/internal/router';
-import { queryFromLocation } from 'storybook/internal/router';
 import type {
   API_ComponentEntry,
   API_ComposedRef,
@@ -206,8 +205,6 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
     const pathChanged = state.path !== props.path;
 
     if (pathChanged || locationSearchChanged) {
-      const { path: _queryPath, ...customQueryParams } = queryFromLocation(props.location);
-
       return {
         ...state,
         location: props.location,
@@ -215,7 +212,7 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
         refId: props.refId,
         viewMode: props.viewMode,
         storyId: props.storyId!,
-        customQueryParams,
+        customQueryParams: url.getCustomQueryParams(props.location),
       };
     }
     return null!;

--- a/code/core/src/manager-api/tests/url.test.js
+++ b/code/core/src/manager-api/tests/url.test.js
@@ -119,6 +119,35 @@ describe('initial state', () => {
         rightPanelWidth: 0,
       });
     });
+
+    it('keeps layout params out of customQueryParams, passing through only custom params', () => {
+      const navigate = vi.fn();
+      const location = {
+        search:
+          '?' +
+          new URLSearchParams({
+            // every layout key consumed by the manager (the full LAYOUT_QUERY_PARAM_KEYS set)
+            full: '1',
+            panel: 'right',
+            nav: '0',
+            shortcuts: '0',
+            addonPanel: 'controls',
+            tabs: '0',
+            path: '/story/button--primary',
+            // genuinely custom params that must survive
+            collection: '2',
+            tags: 'a11y',
+          }).toString(),
+      };
+
+      const {
+        state: { customQueryParams },
+      } = initURL({ navigate, state: { location }, provider: { channel: new EventEmitter() } });
+
+      // Layout params (full/panel/nav/...) are consumed by the manager and must not leak into the
+      // params forwarded to the preview iframe; only genuinely custom params remain.
+      expect(customQueryParams).toEqual({ collection: '2', tags: 'a11y' });
+    });
   });
 });
 

--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -37,6 +37,7 @@ import {
   getMostCriticalStatusValue,
   getSidebarVisibleStatus,
   getStatus,
+  shouldShowChangeStatus,
   statusPriority,
 } from '../../utils/status.tsx';
 import {
@@ -252,12 +253,9 @@ const Node = React.memo<NodeProps>(function Node(props) {
     const LeafNode = item.type === 'docs' ? DocumentNode : StoryLeafNode;
 
     const { changeStatus, testStatus } = getChangeDetectionStatus(statuses || {});
-    const leafChangeIcon =
-      changeStatus === 'status-value:unknown' ||
-      changeStatus === 'status-value:affected' ||
-      (changeStatus === 'status-value:modified' && !isModifiedFilterActive)
-        ? null
-        : getStatus(theme, changeStatus).icon;
+    const leafChangeIcon = shouldShowChangeStatus(changeStatus, isModifiedFilterActive)
+      ? getStatus(theme, changeStatus).icon
+      : null;
     const { icon: testIcon } = getStatus(theme, testStatus);
     const overallStoryStatus = getMostCriticalStatusValue([changeStatus, testStatus]);
     const { textColor } = getStatus(theme, overallStoryStatus);
@@ -409,11 +407,7 @@ const Node = React.memo<NodeProps>(function Node(props) {
     const branchChange = getMostCriticalStatusValue([localChange, groupDual.change]);
     const branchTest = getMostCriticalStatusValue([localTest, groupDual.test]);
 
-    const shouldShowBranchChangeIcon =
-      branchChange !== 'status-value:unknown' &&
-      branchChange !== 'status-value:affected' &&
-      (branchChange !== 'status-value:modified' || isModifiedFilterActive);
-    const branchChangeIcon = shouldShowBranchChangeIcon
+    const branchChangeIcon = shouldShowChangeStatus(branchChange, isModifiedFilterActive)
       ? getStatus(theme, branchChange).icon
       : null;
     const branchTestIcon = getStatus(theme, branchTest).icon;

--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -693,6 +693,7 @@ export default {
     'CHANGE_DETECTION_STATUS_TYPE_ID',
     'CoreWebpackCompiler',
     'Feature',
+    'NON_AGGREGATED_STATUS_TYPE_IDS',
     'REVIEW_STATUS_TYPE_ID',
     'SupportedBuilder',
     'SupportedFramework',

--- a/code/core/src/manager/utils/status.tsx
+++ b/code/core/src/manager/utils/status.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import type { StatusValue } from 'storybook/internal/types';
 import {
   CHANGE_DETECTION_STATUS_TYPE_ID,
+  NON_AGGREGATED_STATUS_TYPE_IDS,
   REVIEW_STATUS_TYPE_ID,
   type API_HashEntry,
   type StatusByTypeId,
@@ -138,6 +139,22 @@ export const getStatus = memoizerific(10)((theme: Theme, status: StatusValue): S
   return statusMapping[status];
 });
 
+/**
+ * Whether a row should surface its change-detection icon (vs. falling back to the test icon).
+ * Shared by the sidebar tree and the status helpers so the decision lives in exactly one place.
+ */
+export const shouldShowChangeStatus = (
+  changeStatus: StatusValue,
+  isModifiedFilterActive: boolean
+): boolean =>
+  changeStatus !== 'status-value:unknown' &&
+  changeStatus !== 'status-value:affected' &&
+  (changeStatus !== 'status-value:modified' || isModifiedFilterActive);
+
+/** A status that contributes to the aggregated test status (i.e. not a quality/meta status). */
+const isAggregatedTestStatus = (status: { typeId: string }): boolean =>
+  !NON_AGGREGATED_STATUS_TYPE_IDS.includes(status.typeId);
+
 /** Matches the status icon shown on a sidebar row before hover. */
 export function getSidebarVisibleStatus({
   theme,
@@ -174,11 +191,7 @@ export function getSidebarVisibleStatus({
     const branchChange = getMostCriticalStatusValue([localChange, groupDual.change]);
     const branchTest = getMostCriticalStatusValue([localTest, groupDual.test]);
 
-    const shouldShowBranchChangeIcon =
-      branchChange !== 'status-value:unknown' &&
-      branchChange !== 'status-value:affected' &&
-      (branchChange !== 'status-value:modified' || isModifiedFilterActive);
-    if (shouldShowBranchChangeIcon) {
+    if (shouldShowChangeStatus(branchChange, isModifiedFilterActive)) {
       return { icon: getStatus(theme, branchChange).icon, status: branchChange };
     }
     return { icon: getStatus(theme, branchTest).icon, status: branchTest };
@@ -192,19 +205,15 @@ export function getSidebarVisibleStatus({
 
   if (isStoryOrDocsLeaf) {
     const { changeStatus, testStatus } = getChangeDetectionStatus(statusByType);
-    const showChange =
-      changeStatus !== 'status-value:unknown' &&
-      changeStatus !== 'status-value:affected' &&
-      (changeStatus !== 'status-value:modified' || isModifiedFilterActive);
-    if (showChange) {
+    if (shouldShowChangeStatus(changeStatus, isModifiedFilterActive)) {
       return { icon: getStatus(theme, changeStatus).icon, status: changeStatus };
     }
     return { icon: getStatus(theme, testStatus).icon, status: testStatus };
   }
 
-  const leafStatuses = statusesExcludingReview(Object.values(statusByType)).filter(
-    (status) =>
-      status.typeId !== CHANGE_DETECTION_STATUS_TYPE_ID || status.value === 'status-value:new'
+  // Test/other leaf: roll up the test statuses, but keep a "new" change-detection status visible.
+  const leafStatuses = Object.values(statusByType).filter(
+    (status) => isAggregatedTestStatus(status) || status.value === 'status-value:new'
   );
   const leafStatus = getMostCriticalStatusValue(leafStatuses.map((s) => s.value));
   return { icon: getStatus(theme, leafStatus).icon, status: leafStatus };
@@ -217,8 +226,8 @@ export function getChangeDetectionStatus(statuses: StatusByTypeId): {
   const changeValues = Object.values(statuses)
     .filter((status) => status.typeId === CHANGE_DETECTION_STATUS_TYPE_ID)
     .map((status) => status.value);
-  const testValues = statusesExcludingReview(Object.values(statuses))
-    .filter((status) => status.typeId !== CHANGE_DETECTION_STATUS_TYPE_ID)
+  const testValues = Object.values(statuses)
+    .filter(isAggregatedTestStatus)
     .map((status) => status.value);
   return {
     changeStatus: getMostCriticalStatusValue(changeValues),
@@ -233,8 +242,10 @@ export const getMostCriticalStatusValue = (statusValues: StatusValue[]): StatusV
   );
 };
 
-/** Drop the review (reviewing) status type, which never contributes to sidebar/group rollups. */
-export const statusesExcludingReview = <T extends { typeId: string }>(statuses: T[]): T[] =>
+// Drop the review (reviewing) status type. Unlike the aggregated test status, the single group
+// aggregate (getGroupStatus) intentionally keeps change-detection so a group still surfaces a
+// modified/new indicator; only review is meaningless at that level.
+const statusesExcludingReview = <T extends { typeId: string }>(statuses: T[]): T[] =>
   statuses.filter((status) => status.typeId !== REVIEW_STATUS_TYPE_ID);
 
 export function getGroupStatus(
@@ -297,8 +308,8 @@ export function getGroupDualStatus(
       const changeValues = allDescendantStatuses
         .filter((s: { typeId: string }) => s.typeId === CHANGE_DETECTION_STATUS_TYPE_ID)
         .map((s: { value: StatusValue }) => s.value);
-      const testValues = statusesExcludingReview(allDescendantStatuses)
-        .filter((s: { typeId: string }) => s.typeId !== CHANGE_DETECTION_STATUS_TYPE_ID)
+      const testValues = allDescendantStatuses
+        .filter(isAggregatedTestStatus)
         .map((s: { value: StatusValue }) => s.value);
 
       // @ts-expect-error (non strict)

--- a/code/core/src/shared/status-store/index.ts
+++ b/code/core/src/shared/status-store/index.ts
@@ -74,6 +74,16 @@ export interface Status {
 export const CHANGE_DETECTION_STATUS_TYPE_ID = 'storybook/change-detection';
 export const REVIEW_STATUS_TYPE_ID = 'storybook/addon-review';
 
+/**
+ * Status types that are quality/meta signals rather than test results, so they're excluded from the
+ * aggregated test status that surfaces a story's most critical result. Both are excluded by the same
+ * mechanism wherever that aggregate is computed.
+ */
+export const NON_AGGREGATED_STATUS_TYPE_IDS: string[] = [
+  CHANGE_DETECTION_STATUS_TYPE_ID,
+  REVIEW_STATUS_TYPE_ID,
+];
+
 export const UNIVERSAL_STATUS_STORE_OPTIONS: StoreOptions<StatusesByStoryIdAndTypeId> = {
   id: 'storybook/status',
   leader: true,

--- a/code/core/src/types/modules/status.ts
+++ b/code/core/src/types/modules/status.ts
@@ -1,6 +1,7 @@
 export {
   CHANGE_DETECTION_STATUS_TYPE_ID,
   REVIEW_STATUS_TYPE_ID,
+  NON_AGGREGATED_STATUS_TYPE_IDS,
 } from '../../shared/status-store/index.ts';
 export type {
   Status,


### PR DESCRIPTION
## What I did

Standalone core quality fixes for the manager — net-positive regardless of the review integration, no breaking changes. This is **PR1 of a 5-PR stack** integrating the review feature into core; it telescopes off `yann/agentic-review-mcp-integration` (#34837) and resolves review findings **M5, M7, M10/B3-residual, M11**.

- **M5 — single source for `customQueryParams` (the bug fix).** A new canonical helper `getCustomQueryParams` in [`manager-api/modules/url.ts`](code/core/src/manager-api/modules/url.ts) strips the layout params (`full, panel, nav, shortcuts, addonPanel, tabs, path`) in exactly one place. Previously `root.tsx`'s `getDerivedStateFromProps` re-derived `customQueryParams` stripping **only** `path`, so layout params leaked into the params forwarded to the preview iframe — blanking the canvas when navigating out of a review. Both init and navigation now use the same helper, so they can't diverge.
- **M7 — dedupe sidebar status-icon logic.** Extracted a shared `shouldShowChangeStatus(changeStatus, isModifiedFilterActive)` predicate so [`Tree.tsx`](code/core/src/manager/components/sidebar/Tree.tsx) and `getSidebarVisibleStatus` no longer each re-implement the change-vs-test icon decision.
- **M10 / B3-residual — unify the rollup exclusion mechanism.** Introduced one `NON_ROLLUP_STATUS_TYPE_IDS` set (in the canonical `shared/status-store`) so change-detection and review are excluded from the test-status rollup by the **same** mechanism. The single group rollup (`getGroupStatus`) intentionally still keeps change-detection — documented inline.
- **M11 — `Card` color resolution.** Replaced the three `in`-probe helpers (cast-heavy, silent `undefined`) with a single typed `resolveThemeColor` accessor — zero casts, explicit fallbacks.

### Stack position
Base: `yann/agentic-review-mcp-integration` (#34837). This is the bottom of the stack; PR2–PR5 telescope on top. Review bottom-up.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Steps for a maintainer to verify the M5 fix (canvas no longer blanks):

1. Run a sandbox: `yarn task sandbox --template react-vite/default-ts --start-from auto` (or `cd code && yarn storybook:ui`).
2. Push a review so the review summary appears (via the `display-review` MCP tool / `scripts/display-review.ts`), enter review mode, and open one of the curated stories.
3. Navigate back out to a normal story.
4. **Expected:** the canvas renders the story normally. Before this fix, layout params leaked into the URL's custom params and the canvas blanked.
5. Sanity-check unrelated URL behavior: open a story with `?full=1` / `?nav=0` — fullscreen/nav still toggle, and those params are not echoed into preview-forwarded query params.
6. Sidebar: confirm status icons (change/test/reviewing) on stories, components and groups are unchanged. `Card` stories render identically in light/dark (including the `agentic` color).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update MIGRATION.MD

No docs/MIGRATION changes — internal manager refactors with a single user-visible bug fix.

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it
- [x] Declare whether manual QA will be needed (`qa:needed` / `qa:skip`)
- [x] Make sure this PR contains **one** of the changelog labels (`bug`)

---

> 🤖 _AI note (Claude Code), not written by Yann — Decisions I made / open questions:_
>
> - **M5 deviation from the PRD wording.** The PRD suggested removing the `customQueryParams` derivation from `getDerivedStateFromProps` entirely and relocating it "into the url module." Review genuinely needs `customQueryParams` to update on URL navigation (it reads `customQueryParams.collection`), and the url module has no subscription to router/location changes — only the React layer (`getDerivedStateFromProps`) observes them. So I kept the recomputation **but** pointed it at the single canonical `getCustomQueryParams` helper, eliminating the divergence (the actual bug) without inventing a new location-subscription mechanism. The derivation *logic* is single-sourced; only the *trigger* stays at the React layer.
> - **`lib/url.ts` `k !== 'path'` filter — kept.** With the single-source fix, `customQueryParams` can no longer contain `path`, so the filter is now unreachable for that flow. I kept it because `buildNavigationUrl` is a generic URL builder where `path` is the positional first arg; guarding against a `path` key in `queryParams` is intrinsic to the helper's contract, not review-specific debt. Removing it would couple the helper's correctness to upstream stripping.
> - **M10 asymmetry is deliberate, not a miss.** `getGroupStatus` (the single group rollup feeding `StatusContext` + search-result fallback) still excludes only review and keeps change-detection — otherwise a component with only "modified" changes would lose its rollup indicator. Unifying it under the full non-rollup set would be a behavior change, which PR1 explicitly avoids. This is the documented B3-residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separated layout/navigation URL query parameters from custom parameters and reused the same derivation across initialization and derived state.
  * Centralized sidebar change-status icon visibility logic for both leaf and branch nodes.
  * Improved theme color resolution for card content/outline styling.
* **Bug Fixes**
  * Corrected test-status rollup and change-detection behavior to better align with expected status visibility.
* **Tests**
  * Added coverage confirming layout-related URL parameters are consumed and omitted from `customQueryParams`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->