### PR TITLE
Agentic Review [3]: Add /review/ generic route and rename review namespace

### DIFF
--- a/code/addons/review/src/constants.ts
+++ b/code/addons/review/src/constants.ts
@@ -1,4 +1,7 @@
-export const ADDON_ID = 'storybook/addon-review';
+// Core-owned namespace for the review ingest contract: channel events, session
+// keys, status type id, and page/route ids all live under `storybook/review/*`.
+// The external `@storybook/addon-mcp` producer must emit the same namespace.
+export const ADDON_ID = 'storybook/review';
 export const PAGE_ID = `${ADDON_ID}/page`;
 export const REVIEW_CHANGES_URL = '/review/';
 

--- a/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
@@ -9,7 +9,7 @@ import { expect, fn, userEvent } from 'storybook/test';
 
 import { ReviewWidget } from './ReviewWidget.tsx';
 
-const REVIEW_ADDON_ID = 'storybook/addon-review';
+const REVIEW_ADDON_ID = 'storybook/review';
 const DISPLAY_REVIEW = `${REVIEW_ADDON_ID}/display-review`;
 const REQUEST_REVIEW = `${REVIEW_ADDON_ID}/request-review`;
 const DISMISS_REVIEW = `${REVIEW_ADDON_ID}/dismiss-review`;

--- a/code/core/src/manager/components/sidebar/ReviewWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.tsx
@@ -15,8 +15,8 @@ import { styled } from 'storybook/theming';
 
 import { enterReviewMode } from './review-mode.ts';
 
-/** Matches `@storybook/addon-review` channel event names. */
-const REVIEW_ADDON_ID = 'storybook/addon-review';
+/** Matches the `storybook/review` channel event names owned by the review module. */
+const REVIEW_ADDON_ID = 'storybook/review';
 const REVIEW_EVENTS = {
   DISPLAY_REVIEW: `${REVIEW_ADDON_ID}/display-review`,
   REQUEST_REVIEW: `${REVIEW_ADDON_ID}/request-review`,

--- a/code/core/src/manager/components/sidebar/review-mode.ts
+++ b/code/core/src/manager/components/sidebar/review-mode.ts
@@ -1,8 +1,8 @@
 import type { API } from 'storybook/manager-api';
 import type { StatusValue } from 'storybook/internal/types';
 
-/** Matches `@storybook/addon-review` sessionStorage keys. */
-const REVIEW_ADDON_ID = 'storybook/addon-review';
+/** Matches the `storybook/review` sessionStorage keys owned by the review module. */
+const REVIEW_ADDON_ID = 'storybook/review';
 
 // Persisted flag marking the manager as being in review mode. Review mode is
 // interaction-driven (never inferred from the URL) and survives reloads via

--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -684,7 +684,6 @@ export default {
     'getMatch',
     'parsePath',
     'queryFromLocation',
-    'resolvePathQueryParam',
     'stringifyQuery',
     'useNavigate',
   ],

--- a/code/core/src/manager/utils/status.test.ts
+++ b/code/core/src/manager/utils/status.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest';
+import { REVIEW_STATUS_TYPE_ID } from 'storybook/internal/types';
 import type { StatusByTypeId, StatusValue } from 'storybook/internal/types';
 
 import { mockDataset } from '../components/sidebar/mockdata.ts';
@@ -235,7 +236,7 @@ describe('dual-slot status splitting', () => {
 
   it('ignores reviewing status for sidebar test slot', () => {
     const statuses = {
-      'storybook/addon-review': makeStatus('storybook/addon-review', 'status-value:reviewing'),
+      [REVIEW_STATUS_TYPE_ID]: makeStatus(REVIEW_STATUS_TYPE_ID, 'status-value:reviewing'),
       'storybook/vitest': makeStatus('storybook/vitest', 'status-value:success'),
     };
     const { changeStatus, testStatus } = getChangeDetectionStatus(statuses);

--- a/code/core/src/router/router.tsx
+++ b/code/core/src/router/router.tsx
@@ -6,7 +6,7 @@ import { global } from '@storybook/global';
 import * as R from 'react-router-dom';
 
 import type { LinkProps, NavigateOptions, RenderData } from './types.ts';
-import { getMatch, parsePath, queryFromLocation, resolvePathQueryParam } from './utils.ts';
+import { getMatch, parsePath, queryFromLocation } from './utils.ts';
 
 const { document } = global;
 
@@ -80,8 +80,7 @@ Link.displayName = 'QueryLink';
  */
 export const Location = ({ children }: LocationProps) => {
   const location = R.useLocation();
-  const { path: pathFromQuery, singleStory } = queryFromLocation(location);
-  const path = resolvePathQueryParam(location.search, pathFromQuery);
+  const { path = '', singleStory } = queryFromLocation(location);
   const { viewMode, storyId, refId } = parsePath(path);
 
   return (

--- a/code/core/src/router/utils.test.ts
+++ b/code/core/src/router/utils.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  DEEPLY_EQUAL,
-  buildArgsParam,
-  deepDiff,
-  getMatch,
-  parsePath,
-  resolvePathQueryParam,
-} from './utils.ts';
+import { DEEPLY_EQUAL, buildArgsParam, deepDiff, getMatch, parsePath } from './utils.ts';
 
 vi.mock('storybook/internal/client-logger', () => ({
   once: { warn: vi.fn() },
@@ -251,17 +244,5 @@ describe('buildArgsParam', () => {
       );
       expect(param).toEqual('obj.nested[1].three:3');
     });
-  });
-});
-
-describe('resolvePathQueryParam', () => {
-  it('returns the sole path query param', () => {
-    expect(resolvePathQueryParam('?path=/review/')).toBe('/review/');
-  });
-
-  it('prefers story paths when duplicate path params exist', () => {
-    expect(resolvePathQueryParam('?path=/story/button-component--sizes&path=/review/=')).toBe(
-      '/story/button-component--sizes'
-    );
   });
 });

--- a/code/core/src/router/utils.ts
+++ b/code/core/src/router/utils.ts
@@ -223,34 +223,6 @@ export const queryFromLocation = (location?: Partial<Location>) => {
   return queryFromString(location?.search ? location.search.slice(1) : '');
 };
 
-/**
- * Read the active Storybook route from the `path` query param. When duplicate
- * `path` keys exist (a malformed URL), prefer canvas routes over review pages.
- */
-export const resolvePathQueryParam = (search?: string, fallback = ''): string => {
-  if (!search) {
-    return fallback;
-  }
-  const query = search.startsWith('?') ? search.slice(1) : search;
-  const paths = new URLSearchParams(query).getAll('path');
-  if (paths.length === 0) {
-    return fallback;
-  }
-  if (paths.length === 1) {
-    return paths[0] ?? fallback;
-  }
-  return (
-    paths.find(
-      (candidate) =>
-        candidate.startsWith('/story/') ||
-        candidate.startsWith('/docs/') ||
-        candidate.startsWith('/settings/')
-    ) ??
-    paths[0] ??
-    fallback
-  );
-};
-
 export const stringifyQuery = (query: Query) => {
   const queryStr = stringify(query);
   return queryStr ? '?' + queryStr : '';

--- a/code/core/src/shared/status-store/index.ts
+++ b/code/core/src/shared/status-store/index.ts
@@ -72,7 +72,7 @@ export interface Status {
 }
 
 export const CHANGE_DETECTION_STATUS_TYPE_ID = 'storybook/change-detection';
-export const REVIEW_STATUS_TYPE_ID = 'storybook/addon-review';
+export const REVIEW_STATUS_TYPE_ID = 'storybook/review';
 
 /**
  * Status types that are quality/meta signals rather than test results, so they're excluded from the


### PR DESCRIPTION
## What I did

Two changes that promote review from an addon-routed page to a core-routed, core-namespaced feature. **PR3 of a 5-PR stack**, telescoping on **PR2** (#35219) → PR1 (#35218) → #34837.

### 1. `/review/` as a generic core route (M6 / Q6)
- Deleted `resolvePathQueryParam` from `router/utils.ts` and reverted the router's `Location` to plain `queryFromLocation`.
- That helper was a review-specific band-aid: it hardcoded `/story/`, `/docs/`, `/settings/` prefixes to disambiguate a duplicate `path=` query param. **PR1** (#35218) removed the root cause — `customQueryParams` no longer carries a stale `path`, and `buildNavigationUrl` filters `path` — so a duplicate `path=` is unproducible and the guard is dead code.
- `/review/` is now recognized by the **same** generic `viewMode`-prefix mechanism as `/story/`, `/docs/`, `/settings/` (there is no central route registry; `parsePath` derives `viewMode: 'review'` for free, and the Layout already treats any non-story/docs viewMode as a full-screen page). The route is owned by the router, not a review special case.

### 2. Rename the namespace `storybook/addon-review` → `storybook/review` (Q7 / Q1)
- Status type id `REVIEW_STATUS_TYPE_ID`, the channel events (`PUSH_REVIEW`/`DISPLAY_REVIEW`/`REQUEST_REVIEW`/`REVIEW_STALE`/`DISMISS_REVIEW`/`REVIEW_DISMISSED`), the page/toolbar ids, and the sessionStorage keys all move under `storybook/review/*`.
- Updated the two in-core clones (`review-mode.ts`, `ReviewWidget.tsx`) and the test literal so the contract stays consistent across every emitter/listener.
- The **package name** `@storybook/addon-review` is intentionally unchanged — it's distinct from the namespace string.

### Stack position
Base: `review-core/02-delete-compare` (PR2, #35219).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

For a maintainer:

1. Run a sandbox or `cd code && yarn storybook:ui`.
2. Push a review (via the **updated** `@storybook/addon-mcp` / a producer emitting the new `storybook/review/*` namespace — see coordination note). The review summary should load at `/review/`.
3. Navigate from the summary into a story and back. **Expected:** URL params stay clean (no duplicate `path=`, no canvas blanking), the `reviewing` sidebar status still appears, and prev/next + dismiss still work.
4. Confirm the `reviewing` status filter behaves under the renamed type id `storybook/review`.
5. (Optional) Confirm a review pushed with the **old** `storybook/addon-review/*` namespace no longer displays — that breakage is expected and intentional.

### Documentation

- [x] Add or update documentation reflecting your changes (addon README channel-contract section already references `src/constants.ts`, which now carries the new namespace; no literal to update)
- [ ] MIGRATION — N/A, the contract is unreleased (see note)

## Checklist for Maintainers

- [x] `ci:normal`
- [x] `qa:needed`
- [x] One changelog label: `maintenance`

---

> 🤖 _AI note (Claude Code), not written by Yann — coordination required before merge:_
>
> **Breaking namespace rename (handoff Cost #2).** Renaming `storybook/addon-review/*` → `storybook/review/*` breaks any producer still emitting the old event names — notably the external **`@storybook/addon-mcp`** `display-review` tool, which is out of this repo. This PR must land **in lockstep** with the addon-mcp change. Old canary producers (`0.0.0-pr-35110-*`) will break. Blast radius is low today (review is new/unreleased).
>
> **Decisions I made:**
> - The in-repo reference producer `scripts/display-review.ts` carries **no** namespace literal — it drives the flow through an MCP `tools/call` (`name: 'display-review'`), so there was nothing to rename there. The real coordination point is addon-mcp, flagged above. (The PRD anticipated editing the script; it turned out to be a no-op.)
> - I did **not** add an inert core `reviewPageAddon` page object yet. There is no route registry to add to, and a `render: () => null` core page would be dead code until the mount is internalized. The explicit core page registration + moving the `persistentRender` mount into core is **PR4**, where it becomes load-bearing. This PR makes the *router* generic; PR4 makes the *render* core-owned.
> - I marked `BREAKING CHANGE` as **not** applicable (kept `maintenance`) because the contract is unreleased per the stack README. Flip to `BREAKING CHANGE` if the team treats the canary contract as published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated the review integration to the core-owned `storybook/review` namespace, keeping review event handling and persisted review-mode state consistent.
  * Updated manager routing to stop using the legacy `path` query resolution and instead derive location path inputs directly, which can change match behavior based on query parameters.
  * Refreshed exported router-related globals to align with the updated routing utilities.
* **Tests**
  * Updated review status and router utility tests for the new namespace and removed coverage for the dropped helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->