### PR TITLE
Core: Allow vite-plus 0.2.x in the optional peer range

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -407,7 +407,7 @@
   "peerDependencies": {
     "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "prettier": "^2 || ^3",
-    "vite-plus": "^0.1.15"
+    "vite-plus": "^0.1.15 || ^0.2.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -29774,7 +29774,7 @@ __metadata:
   peerDependencies:
     "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     prettier: ^2 || ^3
-    vite-plus: ^0.1.15
+    vite-plus: ^0.1.15 || ^0.2.0
   peerDependenciesMeta:
     "@types/react":
       optional: true


### PR DESCRIPTION
## What I did

`code/core`'s only use of `vite-plus` is the optional `vite-plus/versions` subpath in `getVitePlusVersions()` (toolchain version detection), and it's wrapped in a `try/catch` that degrades to `null` when the export is missing.

That `./versions` export ships identically in the `0.2.x` line — `export const versions = { vite, vitest, ... }` (verified against `0.1.24` and `0.2.1`) — so the `typeof versions.vite === 'string'` check holds without any code change.

This widens the optional peer from `^0.1.15` to `^0.1.15 || ^0.2.0`: a superset that keeps existing `0.1.x` consumers working while letting projects already on `vite-plus@0.2.x` install without a spurious peer warning (or a forced `peerDependencyRules` override).

## Why

`vite-plus@0.2.x` reworked how it provides the test runner (it now depends on `vitest@4.1.9` directly instead of vendoring its own `0.1.x`-versioned fork), so projects that have upgraded can't satisfy the current `^0.1.15` range even though the API Storybook relies on is unchanged.

## Checklist

- No source change beyond the peer range — the consumed surface (`vite-plus/versions`) is the same across `0.1.x` and `0.2.x`.
- It's an optional peer (`peerDependenciesMeta`), so non-vite-plus users are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended dependency version compatibility to support a broader range of releases, improving compatibility with both current and newer versions while maintaining backward support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->