### PR TITLE
Core: Flush preview-api hook effects in portable stories

### DIFF
--- a/code/core/src/preview-api/modules/store/csf/portable-stories.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.ts
@@ -198,6 +198,21 @@ export function composeStory<TRenderer extends Renderer = Renderer, TArgs extend
         if (unmount) {
           cleanups.push(unmount);
         }
+        // `hooks` is loosely typed (`unknown`) on the portable story context.
+        const hooks = context.hooks as HooksContext<TRenderer>;
+        // Register the hook teardown BEFORE flushing so a throwing effect can't skip it: `clean()`
+        // runs the effect destroy fns on the next run/explicit cleanup (mirroring
+        // `StoryStore.cleanupStory`), so the applied effects survive through play + the a11y
+        // `afterEach` of this run.
+        cleanups.push(() => hooks.clean());
+        // In the browser (PreviewWeb) path, preview-api `useEffect` callbacks registered during
+        // render are flushed when `StoryRender` emits `STORY_RENDERED`, whose listener also detaches
+        // the hooks context. The portable path never emits that event, so invoke the same listener
+        // directly here (after the render resolves, before play + the a11y `afterEach` observe the
+        // DOM): it triggers the effects (e.g. `@storybook/addon-themes` setting `data-theme` on
+        // `<html>`), clears the current context, and removes the now-stale render listener. (Effect-
+        // only decorators; preview-api state updates that re-render are a separate, unsupported case.)
+        hooks.renderListener(context.id);
       };
     }
 

--- a/code/renderers/react/src/__test__/portable-stories.test.tsx
+++ b/code/renderers/react/src/__test__/portable-stories.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import type { Meta } from '@storybook/react';
 
 import { expectTypeOf } from 'expect-type';
-import { addons } from 'storybook/preview-api';
+import { addons, useEffect } from 'storybook/preview-api';
 
 import { composeStories, composeStory, setProjectAnnotations } from '../index.ts';
 import type { Button } from './Button.tsx';
@@ -184,6 +184,31 @@ it('should pass with decorators that need addons channel', () => {
   render(<PrimaryWithChannels>Hello world</PrimaryWithChannels>);
   const buttonElement = screen.getByText(/Hello world/i);
   expect(buttonElement).not.toBeNull();
+});
+
+// Regression: preview-api `useEffect` (the hook addon-themes' withThemeByDataAttribute uses, not
+// React's) registered by a decorator must run under portable stories, so theme/direction side
+// effects actually apply to the DOM before the play function / a11y check observe it.
+it('flushes preview-api useEffect side-effects from decorators after run', async () => {
+  const WithThemeEffect = composeStory(ButtonStories.CSF3Primary, ButtonStories.default, {
+    decorators: [
+      (StoryFn: any) => {
+        useEffect(() => {
+          document.documentElement.setAttribute('data-theme', 'dark');
+          return () => document.documentElement.removeAttribute('data-theme');
+        }, []);
+        return StoryFn();
+      },
+    ],
+  });
+
+  try {
+    expect(document.documentElement.getAttribute('data-theme')).toBeNull();
+    await WithThemeEffect.run();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  } finally {
+    document.documentElement.removeAttribute('data-theme');
+  }
 });
 
 describe('ComposeStories types', () => {


### PR DESCRIPTION
Fixes #35225

## What I did

Decorators (and stories) that register a `storybook/preview-api` `useEffect` relied on `HooksContext.triggerEffects()` being driven by the `STORY_RENDERED` channel event that `StoryRender` emits in the browser (`preview-web/render/StoryRender.ts`). Portable stories — `composeStory().run()`, the path `@storybook/addon-vitest` uses — never emit `STORY_RENDERED`, so those effects never ran in tests.

The visible symptom: `@storybook/addon-themes`' `withThemeByDataAttribute` / `withThemeByClassName` set `data-theme` / classes inside a preview-api `useEffect`, so under the Vitest addon the theme is **never applied** — `document.documentElement` stays unthemed, and the a11y gate (and any DOM-mutating effect decorator) only ever sees the default theme. This is the gap the existing `UseState` test exclusion in `code/vitest.config.storybook.ts` alludes to ("bring this back once portable stories support storybook/preview-api hooks").

The fix flushes effects explicitly after the portable render resolves, inside the **portable-only** `renderToCanvas` override in `portable-stories.ts`:
- Covers both the non-destructured mount (`runStory` awaits `context.mount()`) and the destructured mount-in-play path — both flow through `context.renderToCanvas()`.
- Does **not** touch the shared `defaultMount`/`renderToCanvas` in `prepareStory.ts`, so the PreviewWeb runtime is unaffected (it still flushes via `STORY_RENDERED`).
- Registers `hooks.clean()` as a cleanup to run effect destroy fns and remove the dangling `STORY_RENDERED` listener on teardown, mirroring `StoryStore.cleanupStory`.

**Scope:** effects only. Preview-api `useState`-driven re-renders remain a separate, unsupported case, so the `UseState` exclusion is intentionally left in place.

## How to test

Added a regression test in `code/renderers/react/src/__test__/portable-stories.test.tsx`: a decorator using preview-api `useEffect` sets `data-theme` on `<html>`; after `await Story.run()` the attribute must be present. It fails on `next` (`expected null to be 'dark'`) and passes with this change; the other 32 tests in the file are unaffected.

Manual: in a project using `@storybook/addon-vitest` + `@storybook/addon-themes`, a story under `withThemeByDataAttribute({ defaultTheme: 'dark' })` now renders with `data-theme="dark"` during the test (so the a11y addon evaluates the themed DOM), instead of unthemed.

## Checklist

- Source change is two lines in the portable-only `renderToCanvas` override; no change to `hooks.ts`, `StoryRender.ts`, or the shared mount path.
- New regression test added and verified to fail without the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portable story rendering to ensure decorator hook lifecycles are properly invoked and cleaned up after canvas rendering, so side effects flush reliably and are removed for subsequent runs.

* **Tests**
  * Added a regression test for `useEffect`-driven decorators that verifies expected document changes occur after `run()` and are reliably reverted during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
