### PR TITLE
Addon-vitest: Add an initialGlobals option to pin a project's globals

### DIFF
--- a/code/addons/vitest/src/components/InitialGlobals.stories.tsx
+++ b/code/addons/vitest/src/components/InitialGlobals.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { expect } from 'storybook/test';
+
+// The `storybook-ui` Vitest project pins `initialGlobals: { initialGlobalsWork: true }` in
+// vitest.config.storybook.ts. This story renders that global and asserts it arrived, exercising the
+// `initialGlobals` plugin option end to end (config -> provide/inject -> composed story globals).
+const meta = {
+  title: 'InitialGlobals',
+  render: (_args, { globals }) => (
+    <pre data-testid="initial-globals">{JSON.stringify(globals.initialGlobalsWork)}</pre>
+  ),
+  // The pinned global only exists in the `storybook-ui` Vitest project, so this story is meaningful
+  // only there. Drop the `test` tag so the Chromatic/test-runner build (which has no such global)
+  // does not run the play, and skip the snapshot since there is nothing visual to capture. It keeps
+  // the `vitest` tag from the preview, so the `tests-stories` Vitest project still runs it.
+  tags: ['!test'],
+  parameters: { chromatic: { disableSnapshot: true } },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const FromVitestConfig: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByTestId('initial-globals')).toHaveTextContent('true');
+  },
+};

--- a/code/addons/vitest/src/constants.ts
+++ b/code/addons/vitest/src/constants.ts
@@ -70,6 +70,7 @@ export const STATUS_TYPE_ID_A11Y = 'storybook/a11y';
 export const STORYBOOK_TEST_PROVIDE_KEY = 'storybook/test-provided';
 export const STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY = 'storybook/core-ghost-stories';
 export const STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY = 'storybook/core-render-analysis';
+export const STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY = 'storybook/test-initial-globals';
 
 // Channel event names for programmatic test triggering
 export const TRIGGER_TEST_RUN_REQUEST = `${ADDON_ID}/trigger-test-run-request`;

--- a/code/addons/vitest/src/vitest-plugin/compose-initial-globals.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/compose-initial-globals.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { STORYBOOK_TEST_PROVIDE_KEY } from '../constants.ts';
+import { composeInitialGlobals } from './compose-initial-globals.ts';
+
+describe('composeInitialGlobals', () => {
+  const base = {
+    runConfig: { a11y: true },
+    ghostStoriesEnabled: false,
+    renderAnalysisEnabled: false,
+    shouldRunA11yTests: true,
+  };
+
+  it('applies the project initialGlobals', () => {
+    const globals = composeInitialGlobals({ ...base, userInitialGlobals: { theme: 'dark' } });
+    expect(globals.theme).toBe('dark');
+  });
+
+  it("keeps Storybook's run-control globals overriding user values", () => {
+    const globals = composeInitialGlobals({
+      ...base,
+      shouldRunA11yTests: false,
+      userInitialGlobals: {
+        a11y: { manual: false, config: { rules: [] } },
+        ghostStories: { enabled: true },
+        [STORYBOOK_TEST_PROVIDE_KEY]: { hijacked: true },
+      },
+    });
+    // `manual` is derived from the run, but other a11y fields the project set are kept
+    expect(globals.a11y).toEqual({ manual: true, config: { rules: [] } });
+    // the test-provided run config can't be clobbered by a user global
+    expect(globals[STORYBOOK_TEST_PROVIDE_KEY]).toEqual({ a11y: true });
+    // a project can't inject the internal ghost-stories flag when the feature is off
+    expect(globals.ghostStories).toBeUndefined();
+  });
+
+  it('adds ghost-stories and render-analysis flags when enabled', () => {
+    const globals = composeInitialGlobals({
+      ...base,
+      userInitialGlobals: {},
+      ghostStoriesEnabled: true,
+      renderAnalysisEnabled: true,
+    });
+    expect(globals.ghostStories).toEqual({ enabled: true });
+    expect(globals.renderAnalysis).toEqual({ enabled: true });
+  });
+});

--- a/code/addons/vitest/src/vitest-plugin/compose-initial-globals.ts
+++ b/code/addons/vitest/src/vitest-plugin/compose-initial-globals.ts
@@ -1,0 +1,48 @@
+import { STORYBOOK_TEST_PROVIDE_KEY } from '../constants.ts';
+
+/**
+ * Build the globals each story runs under: the project's `initialGlobals` (set via
+ * `storybookTest({ initialGlobals })`) merged BENEATH Storybook's own run-control globals, so those
+ * always win and a consumer can't clobber them (`a11y.manual`, the test-provided run config, and the
+ * ghost-stories / render-analysis flags).
+ */
+export const composeInitialGlobals = ({
+  userInitialGlobals,
+  runConfig,
+  ghostStoriesEnabled,
+  renderAnalysisEnabled,
+  shouldRunA11yTests,
+}: {
+  userInitialGlobals: Record<string, unknown>;
+  runConfig: Record<string, unknown>;
+  ghostStoriesEnabled: boolean;
+  renderAnalysisEnabled: boolean;
+  shouldRunA11yTests: boolean;
+}): Record<string, unknown> => {
+  // Start from the project's globals, then force Storybook's run-control globals on top so a
+  // project's `initialGlobals` can never override them (whatever value it set for these keys).
+  const globals: Record<string, unknown> = { ...userInitialGlobals };
+
+  globals[STORYBOOK_TEST_PROVIDE_KEY] = runConfig;
+
+  // Match the original behaviour: the key is present only when the feature is enabled, so a
+  // project-supplied value is dropped when it isn't.
+  if (ghostStoriesEnabled) {
+    globals.ghostStories = { enabled: true };
+  } else {
+    delete globals.ghostStories;
+  }
+  if (renderAnalysisEnabled) {
+    globals.renderAnalysis = { enabled: true };
+  } else {
+    delete globals.renderAnalysis;
+  }
+
+  // Keep any other a11y globals the project set; only `manual` is owned by the run.
+  globals.a11y = {
+    ...(globals.a11y as Record<string, unknown> | undefined),
+    manual: !shouldRunA11yTests,
+  };
+
+  return globals;
+};

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -44,6 +44,7 @@ import { withoutVitePlugins } from '../../../../builders/builder-vite/src/utils/
 import {
   STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY,
   STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY,
+  STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY,
 } from '../constants.ts';
 import type { InternalOptions, UserOptions } from './types.ts';
 import { requiresProjectAnnotations } from './utils.ts';
@@ -56,6 +57,7 @@ const defaultOptions = {
   configDir: resolve(join(WORKING_DIR, '.storybook')),
   storybookUrl: 'http://localhost:6006',
   disableAddonDocs: true,
+  initialGlobals: {},
 } satisfies UserOptions;
 
 const extractTagsFromPreview = async (configDir: string) => {
@@ -374,6 +376,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
             [STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY]: !!process.env.STORYBOOK_COMPONENT_PATHS,
             [STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY]:
               !!process.env.STORYBOOK_COMPONENT_PATHS || withinAgenticSetupSession,
+            [STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY]: finalOptions.initialGlobals,
           },
 
           include: [...includeStories, ...getComponentTestPaths()],

--- a/code/addons/vitest/src/vitest-plugin/test-utils.ts
+++ b/code/addons/vitest/src/vitest-plugin/test-utils.ts
@@ -8,8 +8,10 @@ import { type Report, composeStory, getCsfFactoryAnnotations } from 'storybook/p
 import {
   STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY,
   STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY,
+  STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY,
   STORYBOOK_TEST_PROVIDE_KEY,
 } from '../constants.ts';
+import { composeInitialGlobals } from './compose-initial-globals.ts';
 import { setViewport } from './viewports.ts';
 
 /**
@@ -77,27 +79,24 @@ export const testStory = ({
       // Standalone Vitest runs might not provide Storybook render analysis config.
     }
 
+    // Globals the consumer pinned on this project via `storybookTest({ initialGlobals })`, e.g.
+    // `{ theme: 'dark' }` to run the suite under a specific theme. Spread first so Storybook's own
+    // run-control globals below always win.
+    let userInitialGlobals: Record<string, unknown> = {};
+    try {
+      userInitialGlobals = inject(STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY) ?? {};
+    } catch {
+      // Standalone Vitest runs might not provide project initial globals.
+    }
+
     const shouldRunA11yTests = !!runConfig.a11y;
-    const initialGlobals = {
-      [STORYBOOK_TEST_PROVIDE_KEY]: runConfig,
-      ...(ghostStoriesEnabled
-        ? {
-            ghostStories: {
-              enabled: true,
-            },
-          }
-        : {}),
-      ...(renderAnalysisEnabled
-        ? {
-            renderAnalysis: {
-              enabled: true,
-            },
-          }
-        : {}),
-      a11y: {
-        manual: !shouldRunA11yTests,
-      },
-    };
+    const initialGlobals = composeInitialGlobals({
+      userInitialGlobals,
+      runConfig,
+      ghostStoriesEnabled,
+      renderAnalysisEnabled,
+      shouldRunA11yTests,
+    });
 
     const composedStory = composeStory(
       storyAnnotations,

--- a/code/addons/vitest/src/vitest-plugin/types.ts
+++ b/code/addons/vitest/src/vitest-plugin/types.ts
@@ -37,6 +37,17 @@ export type UserOptions = {
    * @default true
    */
   disableAddonDocs?: boolean;
+
+  /**
+   * Globals applied to every story run by this project, merged under the values Storybook sets
+   * internally. Use it to pin a toolbar global for the whole run — most usefully to test a
+   * specific theme: define one Vitest project per theme, each with a different value, e.g.
+   * `storybookTest({ initialGlobals: { theme: 'dark' } })`. Equivalent to `initialGlobals` in
+   * `.storybook/preview`, but per project instead of global.
+   *
+   * @default {}
+   */
+  initialGlobals?: Record<string, unknown>;
 };
 
 export type InternalOptions = Required<UserOptions> & {

--- a/code/addons/vitest/src/vitest-provided-context.d.ts
+++ b/code/addons/vitest/src/vitest-provided-context.d.ts
@@ -3,6 +3,7 @@ import 'vitest';
 import type {
   STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY,
   STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY,
+  STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY,
   STORYBOOK_TEST_PROVIDE_KEY,
 } from './constants.ts';
 
@@ -11,5 +12,6 @@ declare module 'vitest' {
     [STORYBOOK_TEST_PROVIDE_KEY]: Record<string, unknown>;
     [STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY]: boolean;
     [STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY]: boolean;
+    [STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY]: Record<string, unknown>;
   }
 }

--- a/code/vitest.config.storybook.ts
+++ b/code/vitest.config.storybook.ts
@@ -25,6 +25,9 @@ export default defineProject({
       tags: {
         include: ['vitest'],
       },
+      // Pinned for the InitialGlobals story, which asserts this reaches the run (see
+      // addons/vitest/src/components/InitialGlobals.stories.tsx).
+      initialGlobals: { initialGlobalsWork: true },
     }),
     ...extraPlugins,
   ],

--- a/docs/writing-tests/integrations/vitest-addon/index.mdx
+++ b/docs/writing-tests/integrations/vitest-addon/index.mdx
@@ -475,6 +475,62 @@ Whether to disable addon docs MDX parsing while running tests.
 When either the preview config or stories import mdx files, they are mocked as normally they are not needed for tests.
 You might set `disableAddonDocs` to `false` only in case your stories actually need to read and parse MDX files as part of rendering your components.
 
+#### `initialGlobals`
+
+Type: `Record<string, unknown>`
+
+Default: `{}`
+
+Configures a set of initial global values that will be applied to every story this project runs. Useful for running tests with different options, such as testing every story in a specific theme. It can be further configured with multiple Vitest projects, each pinning a different global value.
+
+```ts title="vitest.config.js|ts"
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import viteConfig from './vite.config';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const storybookProject = (theme: string) => ({
+  extends: true,
+  plugins: [
+    storybookTest({
+      configDir: path.join(dirname, '.storybook'),
+      // Pin the `theme` global for every story in this project
+      initialGlobals: { theme },
+    }),
+  ],
+  test: {
+    name: `storybook-${theme}`,
+    browser: {
+      enabled: true,
+      provider: 'playwright',
+      headless: true,
+      instances: [{ browser: 'chromium' }],
+    },
+    setupFiles: ['./.storybook/vitest.setup.ts'],
+  },
+});
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      // One project per theme, so every story is tested in both
+      projects: [storybookProject('light'), storybookProject('dark')],
+    },
+  }),
+);
+```
+
+<Callout variant="info">
+
+This option mirrors the [`initialGlobals`](../../../essentials/toolbars-and-globals.mdx#globals) configuration in `.storybook/preview.*`, applied per-project instead of globally, however the plugin's own values always take precedence over Storybook's own values.
+
+</Callout>
+
 </If>
 {/* End supported renderers */}
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #35224. Until that merges this PR also shows its portable-stories commit; review only the `Addon-vitest: add an initialGlobals option ...` commit here. Kept as a draft until #35224 lands.

## What I did

Adds an `initialGlobals` option to `storybookTest()`. It's threaded into each test run via Vitest's `provide`/`inject` and merged underneath Storybook's own run-control globals (so `a11y.manual` and the internal keys still win). It's the per-project equivalent of `initialGlobals` in `.storybook/preview`.

The motivating use is theme testing. Once #35224 makes `@storybook/addon-themes` decorators apply under the test runner, you can run the a11y/interaction gate across every theme by defining one Vitest project per theme:

```ts
// vitest.config.ts
test: {
  projects: ['light', 'dark', 'light-contrast', 'dark-contrast'].map((theme) => ({
    extends: true,
    plugins: [storybookTest({ configDir: '.storybook', initialGlobals: { theme } })],
    test: { name: theme, browser: { enabled: true, provider: playwright(), instances: [{ browser: 'chromium' }] } },
  })),
}
```

## How it works

- `UserOptions.initialGlobals` (default `{}`).
- `storybookTest()` provides it under a new key in `test.provide`.
- `testStory()` injects it and spreads it first into the composed story's `initialGlobals`, so the addon's own globals override it.

## Open questions

- Option name/shape (`initialGlobals` vs `globals`).
- Verification: the end-to-end proof is a consumer running per-theme projects, which depends on #35224. Happy to add an integration test wherever you'd prefer it lives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring project-wide Storybook globals in Vitest. Users can now pin toolbar values (such as theme) across test runs on a per-Vitest-project basis, complementing global `.storybook/preview` settings.

* **Tests**
  * Added comprehensive test suite for globals composition logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->