### PR TITLE
CLI: Add path filter for story loading

### DIFF
--- a/code/builders/builder-vite/src/transform-iframe-html.ts
+++ b/code/builders/builder-vite/src/transform-iframe-html.ts
@@ -19,9 +19,16 @@ export async function transformIframeHtml(html: string, options: Options) {
   const stories = normalizeStories(await options.presets.apply('stories', [], options), {
     configDir: options.configDir,
     workingDir: process.cwd(),
+    pathFilters: options.pathFilters,
   }).map((specifier) => ({
-    ...specifier,
+    directory: specifier.directory,
+    files: specifier.files,
+    titlePrefix: specifier.titlePrefix,
     importPathMatcher: specifier.importPathMatcher.source,
+    ...(specifier.pathFilters ? { pathFilters: specifier.pathFilters } : {}),
+    ...(specifier.pathFilterMatcher
+      ? { pathFilterMatcher: specifier.pathFilterMatcher.source }
+      : {}),
   }));
 
   const otherGlobals = {

--- a/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -78,6 +78,7 @@ export default async (
   const stories = normalizeStories(nonNormalizedStories, {
     configDir: options.configDir,
     workingDir,
+    pathFilters: options.pathFilters,
   });
 
   const builderOptions = await getBuilderOptions<BuilderOptions>(options);

--- a/code/builders/builder-webpack5/src/preview/virtual-module-mapping.ts
+++ b/code/builders/builder-webpack5/src/preview/virtual-module-mapping.ts
@@ -29,6 +29,7 @@ export const getVirtualModules = async (options: Options) => {
   const stories = normalizeStories(nonNormalizedStories, {
     configDir: options.configDir,
     workingDir,
+    pathFilters: options.pathFilters,
   });
 
   const previewAnnotations = [

--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -9,7 +9,7 @@ import { withTelemetry } from 'storybook/internal/core-server';
 import { logTracker, logger } from 'storybook/internal/node-logger';
 import { addToGlobalContext } from 'storybook/internal/telemetry';
 
-import { Option, program } from 'commander';
+import { InvalidArgumentError, Option, program } from 'commander';
 import leven from 'leven';
 import picocolors from 'picocolors';
 
@@ -93,6 +93,24 @@ const command = (name: string) =>
       }
     });
 
+const pathOption = () =>
+  new Option('--path <glob>', 'Only load stories matching a project-root-relative glob').argParser(
+    (value: string, previous?: string) => {
+      if (previous) {
+        throw new InvalidArgumentError('The --path option accepts a single glob in this release.');
+      }
+      return value;
+    }
+  );
+
+const withPathFilters = <T extends { path?: string }>(options: T) => {
+  const { path, ...rest } = options;
+  return {
+    ...rest,
+    ...(path ? { pathFilters: [path] } : {}),
+  };
+};
+
 command('dev')
   .option('-p, --port <number>', 'Port to run Storybook', (str) => parseInt(str, 10))
   .option('-h, --host <string>', 'Host to run Storybook')
@@ -130,6 +148,7 @@ command('dev')
     '--initial-path [path]',
     'URL path to be appended when visiting Storybook for the first time'
   )
+  .addOption(pathOption())
   .option('--preview-only', 'Use the preview without the manager UI')
   .action(async (options) => {
     const { default: packageJson } = await import('storybook/package.json', {
@@ -152,7 +171,7 @@ command('dev')
       options.port = parseInt(`${options.port}`, 10);
     }
 
-    await dev({ ...options, packageJson }).catch(() => {
+    await dev(withPathFilters(options)).catch(() => {
       handleCommandFailure(options.logfile);
     });
   });
@@ -174,6 +193,7 @@ command('build')
   .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
   .option('--docs', 'Build a documentation-only site using addon-docs')
   .option('--test', 'Build stories optimized for testing purposes.')
+  .addOption(pathOption())
   .option('--preview-only', 'Use the preview without the manager UI')
   .action(async (options) => {
     const { env } = process;
@@ -194,7 +214,7 @@ command('build')
     });
 
     await build({
-      ...options,
+      ...withPathFilters(options),
       packageJson,
       test: !!options.test || optionalEnvToBoolean(process.env.SB_TESTBUILD),
     }).catch(() => {
@@ -209,6 +229,7 @@ command('index')
   .option('-o, --output-file <file-name>', 'JSON file to output index')
   .option('-c, --config-dir <dir-name>', 'Directory where to load Storybook configurations from')
   .option('--quiet', 'Suppress verbose build output')
+  .addOption(pathOption())
   .action(async (options) => {
     const { env } = process;
     env.NODE_ENV = env.NODE_ENV || 'production';
@@ -227,7 +248,7 @@ command('index')
     });
 
     await index({
-      ...options,
+      ...withPathFilters(options),
       packageJson,
     }).catch(() => process.exit(1));
   });

--- a/code/core/src/cli/buildIndex.ts
+++ b/code/core/src/cli/buildIndex.ts
@@ -6,6 +6,7 @@ import type { BuilderOptions, CLIBaseOptions } from 'storybook/internal/types';
 export interface CLIIndexOptions extends CLIBaseOptions {
   configDir?: string;
   outputFile?: string;
+  pathFilters?: string[];
 }
 
 export const buildIndex = async (

--- a/code/core/src/common/utils/__tests__/normalize-stories.test.ts
+++ b/code/core/src/common/utils/__tests__/normalize-stories.test.ts
@@ -316,4 +316,42 @@ describe('normalizeStories', () => {
   it('should throw InvalidStoriesEntryError for empty entries', () => {
     expect(() => normalizeStories([], options)).toThrow(InvalidStoriesEntryError);
   });
+
+  it('adds path filters without replacing configured story matching', () => {
+    const [specifier] = normalizeStories(['../**/*.stories.jsx'], {
+      ...options,
+      pathFilters: ['src/payments/**'],
+    });
+
+    expect(specifier).toEqual(
+      expect.objectContaining({
+        directory: '.',
+        files: '**/*.stories.jsx',
+        pathFilters: ['src/payments/**'],
+      })
+    );
+
+    expect(specifier.importPathMatcher).toMatchPaths([
+      './src/payments/Button.stories.jsx',
+      './src/accounts/Profile.stories.jsx',
+    ]);
+    expect(specifier.pathFilterMatcher).toMatchPaths([
+      'src/payments/Button.stories.jsx',
+      './src/payments/Button.stories.jsx',
+    ]);
+    expect(specifier.pathFilterMatcher).not.toMatchPaths([
+      'src/accounts/Profile.stories.jsx',
+      './src/accounts/Profile.stories.jsx',
+    ]);
+  });
+
+  it('normalizes windows path filters', () => {
+    const [specifier] = normalizeStories(['../**/*.stories.jsx'], {
+      ...options,
+      pathFilters: ['src\\payments\\**'],
+    });
+
+    expect(specifier.pathFilters).toEqual(['src/payments/**']);
+    expect(specifier.pathFilterMatcher).toMatchPaths(['./src/payments/Button.stories.jsx']);
+  });
 });

--- a/code/core/src/common/utils/normalize-stories.ts
+++ b/code/core/src/common/utils/normalize-stories.ts
@@ -37,7 +37,12 @@ export const getDirectoryFromWorkingDir = ({
 
 export const normalizeStoriesEntry = (
   entry: StoriesEntry,
-  { configDir, workingDir, defaultFilesPattern = DEFAULT_FILES_PATTERN }: NormalizeOptions
+  {
+    configDir,
+    workingDir,
+    defaultFilesPattern = DEFAULT_FILES_PATTERN,
+    pathFilters,
+  }: NormalizeOptions
 ): NormalizedStoriesSpecifier => {
   let specifierWithoutMatcher: Omit<NormalizedStoriesSpecifier, 'importPathMatcher'>;
 
@@ -91,11 +96,15 @@ export const normalizeStoriesEntry = (
 
   // Now make the importFn matcher.
   const importPathMatcher = globToRegexp(`${directory}/${files}`);
+  const pathFilterMatcher = toPathFilterRegexp(pathFilters);
 
   return {
     ...specifierWithoutMatcher,
     directory,
     importPathMatcher,
+    ...(pathFilterMatcher
+      ? { pathFilterMatcher, pathFilters: pathFilters?.map(normalizePathFilter) }
+      : {}),
   };
 };
 
@@ -103,7 +112,23 @@ interface NormalizeOptions {
   configDir: string;
   workingDir: string;
   defaultFilesPattern?: string;
+  pathFilters?: string[];
 }
+
+const normalizePathFilter = (pathFilter: string) => slash(pathFilter).replace(/^\.\//, '');
+
+const toPathFilterRegexp = (pathFilters?: string[]) => {
+  if (!pathFilters?.length) {
+    return undefined;
+  }
+
+  const regexps = pathFilters.flatMap((pathFilter) => {
+    const normalized = normalizePathFilter(pathFilter);
+    return [globToRegexp(normalized), globToRegexp(`./${normalized}`)];
+  });
+
+  return new RegExp(regexps.map((regexp) => `(?:${regexp.source})`).join('|'));
+};
 
 export const normalizeStories = (entries: StoriesEntry[], options: NormalizeOptions) => {
   if (!entries || (Array.isArray(entries) && entries.length === 0)) {

--- a/code/core/src/core-server/build-index.ts
+++ b/code/core/src/core-server/build-index.ts
@@ -22,6 +22,7 @@ export const buildIndex = async (options: BuildIndexOptions) => {
   const directories = {
     configDir,
     workingDir,
+    pathFilters: options.pathFilters,
   };
   const normalizedStories = normalizeStories(stories, directories);
 

--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -44,6 +44,7 @@ export async function storybookDevServer(
   const normalizedStories = normalizeStories(stories, {
     configDir,
     workingDir,
+    pathFilters: options.pathFilters,
   });
 
   const storyIndexGeneratorPromise =

--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -384,6 +384,7 @@ export const storyIndexGenerator: PresetPropertyFn<
     const normalizedStories = normalizeStories(stories, {
       configDir,
       workingDir,
+      pathFilters: options.pathFilters,
     });
 
     const [indexers, docs] = await Promise.all([

--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -60,6 +60,31 @@ describe('StoryIndexGenerator', () => {
     getStorySortParameterMock.mockClear();
     StoryIndexGenerator.clearFindMatchingFilesCache();
   });
+
+  it('filters matched files before passing them into the indexer', async () => {
+    const createIndex = vi.fn(async (absolutePath: string) => [
+      {
+        type: 'story' as const,
+        exportName: 'Default',
+        name: 'Default',
+        title: absolutePath.includes('A.stories') ? 'A' : 'Other',
+      },
+    ]);
+    const specifier = normalizeStoriesEntry('./src/*.stories.@(ts|js)', {
+      ...options,
+      pathFilters: ['src/A.stories.js'],
+    });
+    const generator = new StoryIndexGenerator([specifier], {
+      ...options,
+      indexers: [{ test: /\.(stories|story)\.[tj]s$/, createIndex }],
+    });
+
+    await generator.initialize();
+
+    expect(createIndex).toHaveBeenCalledTimes(1);
+    expect(createIndex.mock.calls[0]?.[0]).toMatch(/src[/\\]A\.stories\.js$/);
+  });
+
   describe('extraction', () => {
     const storiesSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
       './src/A.stories.(ts|js|mjs|jsx)',

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -130,6 +130,7 @@ export class StoryIndexGenerator {
     return JSON.stringify({
       directory: specifier.directory,
       files: specifier.files,
+      pathFilterMatcher: specifier.pathFilterMatcher?.source,
       workingDir,
       ignoreWarnings,
     });
@@ -170,15 +171,27 @@ export class StoryIndexGenerator {
       onlyFiles: true,
     });
 
-    if (files.length === 0 && !ignoreWarnings) {
+    const filteredFiles = specifier.pathFilterMatcher
+      ? files.filter((absolutePath) => {
+          const relativePath = relative(workingDir, absolutePath);
+          const importPath = slash(normalizeStoryPath(relativePath));
+          return specifier.pathFilterMatcher?.exec(importPath);
+        })
+      : files;
+
+    if (filteredFiles.length === 0 && !ignoreWarnings) {
       once.warn(
-        `No story files found for the specified pattern: ${picocolors.blue(
-          join(specifier.directory, specifier.files)
-        )}`
+        specifier.pathFilters?.length
+          ? `No story files found for the specified path filter: ${picocolors.blue(
+              specifier.pathFilters.join(', ')
+            )}`
+          : `No story files found for the specified pattern: ${picocolors.blue(
+              join(specifier.directory, specifier.files)
+            )}`
       );
     }
 
-    files.sort().forEach((absolutePath: Path) => {
+    filteredFiles.sort().forEach((absolutePath: Path) => {
       const ext = extname(absolutePath);
       if (ext === '.storyshot') {
         const relativePath = relative(workingDir, absolutePath);
@@ -805,8 +818,10 @@ export class StoryIndexGenerator {
 
   invalidate(importPath: Path, removed: boolean) {
     const absolutePath = slash(resolve(this.options.workingDir, importPath));
-    const specifier = Array.from(this.specifierToCache.keys()).find((ns) =>
-      ns.importPathMatcher.exec(importPath)
+    const specifier = Array.from(this.specifierToCache.keys()).find(
+      (ns) =>
+        ns.importPathMatcher.exec(importPath) &&
+        (!ns.pathFilterMatcher || ns.pathFilterMatcher.exec(importPath))
     );
     if (!specifier) {
       // not a story file

--- a/code/core/src/core-server/utils/get-stories-paths-from-config.ts
+++ b/code/core/src/core-server/utils/get-stories-paths-from-config.ts
@@ -20,16 +20,18 @@ export const getStoriesPathsFromConfig = async ({
   stories,
   configDir,
   workingDir,
+  pathFilters,
 }: {
   stories: StorybookConfigRaw['stories'];
   configDir: string;
   workingDir: string;
+  pathFilters?: string[];
 }) => {
   if (stories.length === 0) {
     return [];
   }
 
-  const normalizedStories = normalizeStories(stories, { configDir, workingDir });
+  const normalizedStories = normalizeStories(stories, { configDir, workingDir, pathFilters });
 
   const matchingStoryFiles = await StoryIndexGenerator.findMatchingFilesForSpecifiers(
     normalizedStories,

--- a/code/core/src/core-server/utils/watch-story-specifiers.ts
+++ b/code/core/src/core-server/utils/watch-story-specifiers.ts
@@ -69,7 +69,11 @@ export function watchStorySpecifiers(
     // to watch. Convert to an import path so we can run against the specifiers.
     const importPath = toImportPath(absolutePath);
 
-    const matchingSpecifier = specifiers.find((ns) => ns.importPathMatcher.exec(importPath));
+    const matchingSpecifier = specifiers.find(
+      (ns) =>
+        ns.importPathMatcher.exec(importPath) &&
+        (!ns.pathFilterMatcher || ns.pathFilterMatcher.exec(importPath))
+    );
     if (matchingSpecifier) {
       onInvalidate(importPath, removed);
       return;
@@ -107,7 +111,10 @@ export function watchStorySpecifiers(
             addedFiles.forEach((filePath: Path) => {
               const fileImportPath = toImportPath(filePath);
 
-              if (specifier.importPathMatcher.exec(fileImportPath)) {
+              if (
+                specifier.importPathMatcher.exec(fileImportPath) &&
+                (!specifier.pathFilterMatcher || specifier.pathFilterMatcher.exec(fileImportPath))
+              ) {
                 onInvalidate(fileImportPath, removed);
               }
             });

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -260,6 +260,7 @@ export interface CLIOptions extends CLIBaseOptions {
   statsJson?: string | boolean;
   outputDir?: string;
   previewOnly?: boolean;
+  pathFilters?: string[];
 }
 
 export interface BuilderOptions {

--- a/code/core/src/types/modules/indexer.ts
+++ b/code/core/src/types/modules/indexer.ts
@@ -23,6 +23,12 @@ export type NormalizedStoriesSpecifier = Required<StoriesSpecifier> & {
    * relative to the current working directory.
    */
   importPathMatcher: RegExp;
+  /*
+   * Match active CLI path filters against normalized story file paths. These filters narrow the
+   * configured story universe, but do not replace the user's configured stories specifier.
+   */
+  pathFilterMatcher?: RegExp;
+  pathFilters?: string[];
 };
 
 export interface IndexerOptions {

--- a/code/lib/core-webpack/src/to-importFn.test.ts
+++ b/code/lib/core-webpack/src/to-importFn.test.ts
@@ -212,6 +212,22 @@ describe('toImportFn - webpackIncludeRegexp', () => {
     expect(isNotMatchedForValidPaths).toEqual([]);
     expect(isMatchedForInvalidPaths).toEqual([]);
   });
+
+  it('intersects story globs with path filters', () => {
+    const regex = webpackIncludeRegexp(
+      Object.assign(
+        normalizeStoriesEntry('../src/**/*.stories.tsx', {
+          configDir: '/Users/user/code/.storybook',
+          workingDir: '/Users/user/code/',
+        }),
+        { pathFilters: ['src/payments/**'] }
+      )
+    );
+
+    expect(regex.test('/Users/user/code/src/payments/Button.stories.tsx')).toBe(true);
+    expect(regex.test('/Users/user/code/src/accounts/Profile.stories.tsx')).toBe(false);
+    expect(regex.test('/Users/user/code/src/payments/Button.tsx')).toBe(false);
+  });
 });
 
 describe('toImportFn - generated code', () => {
@@ -274,5 +290,24 @@ describe('toImportFn - generated code', () => {
     // Should have multiple async functions in the importers array
     expect(generated).toContain('const importers = [');
     expect(generated.match(/async \(path\) =>/g)?.length).toBe(2);
+  });
+
+  it('guards generated imports with path filters', () => {
+    const generated = toImportFn([
+      Object.assign(
+        normalizeStoriesEntry('../src/**/*.stories.tsx', {
+          configDir: '/Users/user/code/.storybook',
+          workingDir: '/Users/user/code/',
+        }),
+        {
+          pathFilterMatcher: /(?:^src\/payments\/)|(?:^\.[\\/]src\/payments[\\/])/,
+          pathFilters: ['src/payments/**'],
+        }
+      ),
+    ]);
+
+    expect(generated).toContain('if (!');
+    expect(generated).toContain('src\\/payments');
+    expect(generated).toContain('return;');
   });
 });

--- a/code/lib/core-webpack/src/to-importFn.ts
+++ b/code/lib/core-webpack/src/to-importFn.ts
@@ -36,16 +36,41 @@ export function webpackIncludeRegexp(specifier: NormalizedStoriesSpecifier) {
     ? globToRegexp(webpackIncludeGlob)
     : adjustRegexToExcludeNodeModules(globToRegexp(webpackIncludeGlob));
   // picomatch is creating an exact match, but we are only matching the end of the filename
-  return new RegExp(webpackIncludeRegexpWithCaret.source.replace(/^\^/, ''));
+  const storyFilesRegexp = new RegExp(webpackIncludeRegexpWithCaret.source.replace(/^\^/, ''));
+
+  if (!specifier.pathFilters?.length) {
+    return storyFilesRegexp;
+  }
+
+  const filterRegexps = specifier.pathFilters.map((pathFilter) => {
+    const filterWithoutLeadingDots = pathFilter.replace(/^(\.+\/)+/, '/');
+    const filterGlob = filterWithoutLeadingDots.startsWith('/')
+      ? filterWithoutLeadingDots
+      : `/${filterWithoutLeadingDots}`;
+    return globToRegexp(filterGlob).source.replace(/^\^/, '');
+  });
+
+  return new RegExp(
+    `(?=${storyFilesRegexp.source})(?:${filterRegexps.map((source) => `(?:${source})`).join('|')})`
+  );
 }
 
 export function toImportFnPart(specifier: NormalizedStoriesSpecifier) {
-  const { directory, importPathMatcher } = specifier;
+  const { directory, importPathMatcher, pathFilterMatcher } = specifier;
 
   return dedent`
       async (path) => {
         if (!${importPathMatcher}.exec(path)) {
           return;
+        }
+        ${
+          pathFilterMatcher
+            ? dedent`
+              if (!${pathFilterMatcher}.exec(path)) {
+                return;
+              }
+            `
+            : ''
         }
 
         const pathRemainder = path.substring(${directory.length + 1});


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Adds a `--path <glob>` option to `storybook dev`, `storybook build`, and `storybook index` so a command can operate on only the story files that match a project-root-relative path filter.

Design decisions:

- The CLI accepts one `--path` value in this release and rejects repeated `--path` flags. Internally this is represented as `pathFilters` so future multi-filter support has a natural extension point.
- `pathFilters` are attached during story normalization as an intersection layer. They do not rewrite or replace the user's configured `stories` entries, so the filter can only narrow the configured story universe.
- `StoryIndexGenerator.findMatchingFiles` filters the discovered file set before populating the cache that is later passed to index extraction. Unmatched files are not parsed or indexed.
- Dev watcher invalidation also respects the active path filter, so file changes outside the filter do not invalidate the focused index.
- Vite receives the filtered story index for generated imports. Webpack also receives filtered normalized specifiers and guards the generated `importFn` / `webpackInclude` path so unmatched story files are not included in the focused preview import surface.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. From the repo root, run `yarn nx compile core` and confirm the core package compiles.
2. Run `yarn vitest run --config code/core/vitest.config.ts code/core/src/common/utils/__tests__/normalize-stories.test.ts code/core/src/core-server/utils/StoryIndexGenerator.test.ts code/lib/core-webpack/src/to-importFn.test.ts` and confirm all tests pass.
3. Generate or use a Storybook with multiple story folders, then run `storybook index --path "src/features/billing/**"` and confirm the written index contains only matching story entries.
4. In a Vite-backed Storybook, run `storybook dev --path "src/features/billing/**"` and confirm matching stories render while stories outside the glob are absent from the sidebar.
5. In a Webpack-backed Storybook, run `storybook dev --path "src/features/billing/**"` and confirm matching stories render while stories outside the glob are absent from the sidebar.
6. Run `storybook dev --path "src/a/**" --path "src/b/**"` and confirm the CLI rejects repeated `--path` flags with a clear error.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35227-sha-2711e81c`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35227-sha-2711e81c sandbox` or in an existing project with `npx storybook@0.0.0-pr-35227-sha-2711e81c upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35227-sha-2711e81c`](https://npmjs.com/package/storybook/v/0.0.0-pr-35227-sha-2711e81c) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/cli-path-filter`](https://github.com/storybookjs/storybook/tree/shilman/cli-path-filter) |
| **Commit** | [`2711e81c`](https://github.com/storybookjs/storybook/commit/2711e81c5cf9f17c7bba5a41dbc7eb3cb6b16cbf) |
| **Datetime** | Fri Jun 19 08:29:43 UTC 2026 (`1781857783`) |
| **Workflow run** | [27814712684](https://github.com/storybookjs/storybook/actions/runs/27814712684) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35227`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
