### PR TITLE
CLI: Prefer agent-matched Storybook instances

### DIFF
--- a/code/core/src/cli/ai/mcp/registry.test.ts
+++ b/code/core/src/cli/ai/mcp/registry.test.ts
@@ -131,6 +131,13 @@ describe('readRegistry', () => {
     await expect(readRegistry(REGISTRY_DIR)).resolves.toEqual([minimal]);
   });
 
+  it('accepts records with optional agent provenance', async () => {
+    const agentRecord = { ...aliveRecord, agent: 'claude-preview' };
+    vol.fromNestedJSON({ [REGISTRY_DIR]: { 'agent.json': JSON.stringify(agentRecord) } });
+
+    await expect(readRegistry(REGISTRY_DIR)).resolves.toEqual([agentRecord]);
+  });
+
   it('rejects out-of-range ports', async () => {
     vol.fromNestedJSON({
       [REGISTRY_DIR]: {

--- a/code/core/src/cli/ai/mcp/resolve-instance.test.ts
+++ b/code/core/src/cli/ai/mcp/resolve-instance.test.ts
@@ -186,13 +186,134 @@ describe('resolveInstance', () => {
   });
 
   it('selects the instance matching BOTH cwd and port when a port is supplied', () => {
-    const a = record('/Users/x/projects/foo', 'ready', { pid: 100, port: 6006 });
-    const b = record('/Users/x/projects/foo', 'ready', { pid: 200, port: 6007 });
-    const result = resolveInstance([a, b], '/Users/x/projects/foo', 6007);
+    const a = record('/Users/x/projects/foo', 'ready', {
+      agent: 'claude-preview',
+      pid: 100,
+      port: 6006,
+    });
+    const b = record('/Users/x/projects/foo', 'ready', { agent: 'codex', pid: 200, port: 6007 });
+    const result = resolveInstance([a, b], '/Users/x/projects/foo', 6007, 'claude');
     expect(result.kind).toBe('instance');
     if (result.kind === 'instance') {
       expect(result.record).toBe(b);
       expect(result.matches).toEqual([b]);
+    }
+  });
+
+  it('prefers Claude preview records for Claude CLI invocations', () => {
+    const genericClaude = record('/Users/x/projects/foo', 'ready', {
+      agent: 'claude',
+      startedAt: '2026-06-09T11:00:00.000Z',
+    });
+    const claudePreview = record('/Users/x/projects/foo', 'ready', {
+      agent: 'claude-preview',
+      startedAt: '2026-06-09T10:00:00.000Z',
+    });
+    const newerCodex = record('/Users/x/projects/foo', 'ready', {
+      agent: 'codex',
+      startedAt: '2026-06-09T12:00:00.000Z',
+    });
+    const result = resolveInstance(
+      [genericClaude, claudePreview, newerCodex],
+      '/Users/x/projects/foo',
+      undefined,
+      'claude'
+    );
+
+    expect(result.kind).toBe('instance');
+    if (result.kind === 'instance') {
+      expect(result.record).toBe(claudePreview);
+      expect(result.matches).toEqual([claudePreview]);
+    }
+  });
+
+  it('falls back to generic Claude records when no Claude preview record matches', () => {
+    const genericClaude = record('/Users/x/projects/foo', 'ready', {
+      agent: 'claude',
+      startedAt: '2026-06-09T10:00:00.000Z',
+    });
+    const newerCodex = record('/Users/x/projects/foo', 'ready', {
+      agent: 'codex',
+      startedAt: '2026-06-09T11:00:00.000Z',
+    });
+    const result = resolveInstance(
+      [genericClaude, newerCodex],
+      '/Users/x/projects/foo',
+      undefined,
+      'claude'
+    );
+
+    expect(result.kind).toBe('instance');
+    if (result.kind === 'instance') {
+      expect(result.record).toBe(genericClaude);
+      expect(result.matches).toEqual([genericClaude]);
+    }
+  });
+
+  it('prefers records matching the current non-Claude agent', () => {
+    const codex = record('/Users/x/projects/foo', 'ready', {
+      agent: 'codex',
+      startedAt: '2026-06-09T10:00:00.000Z',
+    });
+    const newerCursor = record('/Users/x/projects/foo', 'ready', {
+      agent: 'cursor',
+      startedAt: '2026-06-09T11:00:00.000Z',
+    });
+    const result = resolveInstance(
+      [codex, newerCursor],
+      '/Users/x/projects/foo',
+      undefined,
+      'codex'
+    );
+
+    expect(result.kind).toBe('instance');
+    if (result.kind === 'instance') {
+      expect(result.record).toBe(codex);
+      expect(result.matches).toEqual([codex]);
+    }
+  });
+
+  it('chooses the latest-started ready instance inside the selected agent bucket', () => {
+    const olderPreview = record('/Users/x/projects/foo', 'ready', {
+      agent: 'claude-preview',
+      startedAt: '2026-06-09T10:00:00.000Z',
+    });
+    const newerPreview = record('/Users/x/projects/foo', 'ready', {
+      agent: 'claude-preview',
+      startedAt: '2026-06-09T11:00:00.000Z',
+    });
+    const newestCodex = record('/Users/x/projects/foo', 'ready', {
+      agent: 'codex',
+      startedAt: '2026-06-09T12:00:00.000Z',
+    });
+    const result = resolveInstance(
+      [olderPreview, newerPreview, newestCodex],
+      '/Users/x/projects/foo',
+      undefined,
+      'claude'
+    );
+
+    expect(result.kind).toBe('instance');
+    if (result.kind === 'instance') {
+      expect(result.record).toBe(newerPreview);
+      expect(result.matches).toEqual([newerPreview, olderPreview]);
+    }
+  });
+
+  it('falls back to latest-started behavior when no record matches the current agent', () => {
+    const older = record('/Users/x/projects/foo', 'ready', {
+      startedAt: '2026-06-09T10:00:00.000Z',
+    });
+    const newer = record('/Users/x/projects/foo', 'ready', {
+      agent: 'cursor',
+      startedAt: '2026-06-09T11:00:00.000Z',
+    });
+    const result = resolveInstance([older, newer], '/Users/x/projects/foo', undefined, 'codex');
+
+    expect(result.kind).toBe('instance');
+    if (result.kind === 'instance') {
+      expect(result.record).toBe(newer);
+      expect(result.matches).toEqual([newer, older]);
     }
   });
 

--- a/code/core/src/cli/ai/mcp/resolve-instance.test.ts
+++ b/code/core/src/cli/ai/mcp/resolve-instance.test.ts
@@ -273,6 +273,29 @@ describe('resolveInstance', () => {
     }
   });
 
+  it('reports errors from the preferred agent bucket instead of switching buckets', () => {
+    const erroredPreview = record('/Users/x/projects/foo', 'error', {
+      agent: 'claude-preview',
+      startedAt: '2026-06-09T11:00:00.000Z',
+    });
+    const readyClaude = record('/Users/x/projects/foo', 'ready', {
+      agent: 'claude',
+      startedAt: '2026-06-09T10:00:00.000Z',
+    });
+    const result = resolveInstance(
+      [erroredPreview, readyClaude],
+      '/Users/x/projects/foo',
+      undefined,
+      'claude'
+    );
+
+    expect(result.kind).toBe('intercept');
+    if (result.kind === 'intercept') {
+      expect(result.reason).toBe('mcp-error');
+      expect(result.matches).toEqual([erroredPreview]);
+    }
+  });
+
   it('prefers records matching the current non-Claude agent', () => {
     const codex = record('/Users/x/projects/foo', 'ready', {
       agent: 'codex',

--- a/code/core/src/cli/ai/mcp/resolve-instance.test.ts
+++ b/code/core/src/cli/ai/mcp/resolve-instance.test.ts
@@ -363,6 +363,24 @@ describe('resolveInstance', () => {
     }
   });
 
+  it('falls back to latest-started behavior when no current agent is detected', () => {
+    const olderPreview = record('/Users/x/projects/foo', 'ready', {
+      agent: 'claude-preview',
+      startedAt: '2026-06-09T10:00:00.000Z',
+    });
+    const newerCodex = record('/Users/x/projects/foo', 'ready', {
+      agent: 'codex',
+      startedAt: '2026-06-09T11:00:00.000Z',
+    });
+    const result = resolveInstance([olderPreview, newerCodex], '/Users/x/projects/foo');
+
+    expect(result.kind).toBe('instance');
+    if (result.kind === 'instance') {
+      expect(result.record).toBe(newerCodex);
+      expect(result.matches).toEqual([newerCodex, olderPreview]);
+    }
+  });
+
   it('ignores port when it is not supplied (routes by cwd alone)', () => {
     const a = record('/Users/x/projects/foo', 'ready', { pid: 100, port: 6006 });
     const b = record('/Users/x/projects/foo', 'ready', { pid: 200, port: 6007 });

--- a/code/core/src/cli/ai/mcp/resolve-instance.test.ts
+++ b/code/core/src/cli/ai/mcp/resolve-instance.test.ts
@@ -250,6 +250,29 @@ describe('resolveInstance', () => {
     }
   });
 
+  it('stays in the preferred agent bucket even when another bucket is ready', () => {
+    const startingPreview = record('/Users/x/projects/foo', 'starting', {
+      agent: 'claude-preview',
+      startedAt: '2026-06-09T11:00:00.000Z',
+    });
+    const readyCodex = record('/Users/x/projects/foo', 'ready', {
+      agent: 'codex',
+      startedAt: '2026-06-09T10:00:00.000Z',
+    });
+    const result = resolveInstance(
+      [startingPreview, readyCodex],
+      '/Users/x/projects/foo',
+      undefined,
+      'claude'
+    );
+
+    expect(result.kind).toBe('intercept');
+    if (result.kind === 'intercept') {
+      expect(result.reason).toBe('mcp-starting');
+      expect(result.matches).toEqual([startingPreview]);
+    }
+  });
+
   it('prefers records matching the current non-Claude agent', () => {
     const codex = record('/Users/x/projects/foo', 'ready', {
       agent: 'codex',

--- a/code/core/src/cli/ai/mcp/resolve-instance.ts
+++ b/code/core/src/cli/ai/mcp/resolve-instance.ts
@@ -1,9 +1,10 @@
 import { resolve } from 'node:path';
 
+import {
+  CLAUDE_AGENT_NAME,
+  CLAUDE_PREVIEW_AGENT_NAME,
+} from '../../../shared/constants/agent-provenance.ts';
 import type { InterceptReason, StorybookInstanceRecord } from './types.ts';
-
-const CLAUDE_AGENT = 'claude';
-const CLAUDE_PREVIEW_AGENT = 'claude-preview';
 
 export type ResolveResult =
   | {
@@ -121,8 +122,8 @@ function selectCompetingBucket(
 
   // std-env reports Claude CLI as `claude`; preview-launched Storybooks record `claude-preview`.
   const agentBuckets =
-    currentAgent === CLAUDE_AGENT
-      ? [CLAUDE_PREVIEW_AGENT, CLAUDE_AGENT]
+    currentAgent === CLAUDE_AGENT_NAME
+      ? [CLAUDE_PREVIEW_AGENT_NAME, CLAUDE_AGENT_NAME]
       : currentAgent
         ? [currentAgent]
         : [];

--- a/code/core/src/cli/ai/mcp/resolve-instance.ts
+++ b/code/core/src/cli/ai/mcp/resolve-instance.ts
@@ -34,15 +34,16 @@ export type ResolveResult =
  * - `error` → mcp-error intercept
  *
  * Zero matches → no-instance intercept (callers may surface running cwds). 2+ matches at the same
- * cwd → pick the most recently started instance (latest `startedAt` among `ready` records, else
- * latest overall), on the assumption that the freshest instance is the one the agent just started.
- * Records without a `startedAt` tie-break on lowest pid for determinism. All matches are returned
- * (most-recent first) as `matches` so callers can warn the agent without blocking the call.
+ * cwd → use the current agent to select the competing bucket, then pick the most recently started
+ * instance in that bucket (latest `startedAt` among `ready` records, else latest overall). Records
+ * without a `startedAt` tie-break on lowest pid for determinism. The selected bucket is returned
+ * (most-recent first) as `matches` so callers can warn only about instances that competed.
  */
 export function resolveInstance(
   records: StorybookInstanceRecord[],
   targetCwd: string,
-  targetPort?: number
+  targetPort?: number,
+  currentAgent?: string
 ): ResolveResult {
   const normalisedTarget = resolve(targetCwd);
   const cwdMatches = records.filter((r) => resolve(r.cwd) === normalisedTarget);
@@ -67,7 +68,7 @@ export function resolveInstance(
     };
   }
 
-  const sortedMatches = [...matches].sort(byMostRecentlyStarted);
+  const sortedMatches = selectCompetingBucket(matches, targetPort, currentAgent);
   const selected = sortedMatches.find((r) => r.mcp.status === 'ready') ?? sortedMatches[0];
 
   switch (selected.mcp.status) {
@@ -104,6 +105,24 @@ export function resolveInstance(
       throw new Error(`Unhandled MCP status: ${unhandled as string}`);
     }
   }
+}
+
+function selectCompetingBucket(
+  matches: StorybookInstanceRecord[],
+  targetPort: number | undefined,
+  currentAgent: string | undefined
+) {
+  if (targetPort != null) {
+    return [...matches].sort(byMostRecentlyStarted);
+  }
+
+  const agentBuckets = currentAgent === 'claude' ? ['claude-preview', 'claude'] : [currentAgent];
+  const selectedAgent = agentBuckets.find(
+    (agent): agent is string => agent != null && matches.some((r) => r.agent === agent)
+  );
+  const bucket = selectedAgent ? matches.filter((r) => r.agent === selectedAgent) : matches;
+
+  return [...bucket].sort(byMostRecentlyStarted);
 }
 
 /**

--- a/code/core/src/cli/ai/mcp/resolve-instance.ts
+++ b/code/core/src/cli/ai/mcp/resolve-instance.ts
@@ -2,6 +2,9 @@ import { resolve } from 'node:path';
 
 import type { InterceptReason, StorybookInstanceRecord } from './types.ts';
 
+const CLAUDE_AGENT = 'claude';
+const CLAUDE_PREVIEW_AGENT = 'claude-preview';
+
 export type ResolveResult =
   | {
       kind: 'instance';
@@ -116,10 +119,14 @@ function selectCompetingBucket(
     return [...matches].sort(byMostRecentlyStarted);
   }
 
-  const agentBuckets = currentAgent === 'claude' ? ['claude-preview', 'claude'] : [currentAgent];
-  const selectedAgent = agentBuckets.find(
-    (agent): agent is string => agent != null && matches.some((r) => r.agent === agent)
-  );
+  // std-env reports Claude CLI as `claude`; preview-launched Storybooks record `claude-preview`.
+  const agentBuckets =
+    currentAgent === CLAUDE_AGENT
+      ? [CLAUDE_PREVIEW_AGENT, CLAUDE_AGENT]
+      : currentAgent
+        ? [currentAgent]
+        : [];
+  const selectedAgent = agentBuckets.find((agent) => matches.some((r) => r.agent === agent));
   const bucket = selectedAgent ? matches.filter((r) => r.agent === selectedAgent) : matches;
 
   return [...bucket].sort(byMostRecentlyStarted);

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { McpJsonRpcError, callMcpTool, listMcpTools } from './client.ts';
 import { loadStorybookAiMetadata, type StorybookAiMetadata } from './local-metadata.ts';
@@ -37,6 +37,10 @@ beforeEach(() => {
     .mockReset()
     .mockResolvedValue([{ name: 'list-all-documentation', description: 'List docs' }]);
   vi.mocked(loadStorybookAiMetadata).mockReset().mockResolvedValue(defaultRuntimeMetadata);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe('runAiTool', () => {
@@ -464,6 +468,52 @@ describe('runAiTool', () => {
     expect(result.output).toContain('pid `2`');
     expect(result.output).toContain('(used)');
     expect(result.output).toContain('upstream result');
+  });
+
+  it('only warns about instances in the selected agent bucket', async () => {
+    vi.stubEnv('AI_AGENT', 'claude');
+    const olderPreview = {
+      ...record,
+      agent: 'claude-preview',
+      instanceId: 'inst-2',
+      pid: 2,
+      port: 6007,
+      startedAt: '2026-06-09T10:00:00.000Z',
+      url: 'http://localhost:6007',
+    };
+    const selectedPreview = {
+      ...record,
+      agent: 'claude-preview',
+      instanceId: 'inst-3',
+      pid: 3,
+      port: 6008,
+      startedAt: '2026-06-09T11:00:00.000Z',
+      url: 'http://localhost:6008',
+    };
+    const newerCodex = {
+      ...record,
+      agent: 'codex',
+      instanceId: 'inst-4',
+      pid: 4,
+      port: 6009,
+      startedAt: '2026-06-09T12:00:00.000Z',
+      url: 'http://localhost:6009',
+    };
+    vi.mocked(readRegistry).mockResolvedValue([olderPreview, selectedPreview, newerCodex]);
+
+    const result = await runAiTool('list-all-documentation', [], { cwd: '/projects/foo' });
+
+    expect(callMcpTool).toHaveBeenCalledWith(
+      selectedPreview,
+      { name: 'list-all-documentation', arguments: {} },
+      undefined
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Multiple Storybook instances');
+    expect(result.output).toContain('pid `2`');
+    expect(result.output).toContain('pid `3`');
+    expect(result.output).not.toContain('pid `4`');
+    expect(result.output).not.toContain('http://localhost:6009');
   });
 });
 

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -463,7 +463,8 @@ describe('runAiTool', () => {
     vi.mocked(readRegistry).mockResolvedValue([record, sibling]);
     const result = await runAiTool('list-all-documentation', [], { cwd: '/projects/foo' });
     expect(result.exitCode).toBe(0);
-    expect(result.output).toContain('Multiple Storybook instances');
+    expect(result.output).toContain('Multiple matching Storybook instances');
+    expect(result.output).toContain('Matching instances at `/projects/foo`');
     expect(result.output).toContain('pid `1`');
     expect(result.output).toContain('pid `2`');
     expect(result.output).toContain('(used)');
@@ -509,7 +510,8 @@ describe('runAiTool', () => {
       undefined
     );
     expect(result.exitCode).toBe(0);
-    expect(result.output).toContain('Multiple Storybook instances');
+    expect(result.output).toContain('Multiple matching Storybook instances');
+    expect(result.output).toContain('Matching instances at `/projects/foo`');
     expect(result.output).toContain('pid `2`');
     expect(result.output).toContain('pid `3`');
     expect(result.output).not.toContain('pid `4`');

--- a/code/core/src/cli/ai/mcp/run-tool.test.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.test.ts
@@ -471,8 +471,7 @@ describe('runAiTool', () => {
     expect(result.output).toContain('upstream result');
   });
 
-  it('only warns about instances in the selected agent bucket', async () => {
-    vi.stubEnv('AI_AGENT', 'claude');
+  describe('when multiple instances exist in the selected agent bucket', () => {
     const olderPreview = {
       ...record,
       agent: 'claude-preview',
@@ -500,22 +499,28 @@ describe('runAiTool', () => {
       startedAt: '2026-06-09T12:00:00.000Z',
       url: 'http://localhost:6009',
     };
-    vi.mocked(readRegistry).mockResolvedValue([olderPreview, selectedPreview, newerCodex]);
 
-    const result = await runAiTool('list-all-documentation', [], { cwd: '/projects/foo' });
+    beforeEach(() => {
+      vi.stubEnv('AI_AGENT', 'claude');
+      vi.mocked(readRegistry).mockResolvedValue([olderPreview, selectedPreview, newerCodex]);
+    });
 
-    expect(callMcpTool).toHaveBeenCalledWith(
-      selectedPreview,
-      { name: 'list-all-documentation', arguments: {} },
-      undefined
-    );
-    expect(result.exitCode).toBe(0);
-    expect(result.output).toContain('Multiple matching Storybook instances');
-    expect(result.output).toContain('Matching instances at `/projects/foo`');
-    expect(result.output).toContain('pid `2`');
-    expect(result.output).toContain('pid `3`');
-    expect(result.output).not.toContain('pid `4`');
-    expect(result.output).not.toContain('http://localhost:6009');
+    it('only warns about instances in the selected agent bucket', async () => {
+      const result = await runAiTool('list-all-documentation', [], { cwd: '/projects/foo' });
+
+      expect(callMcpTool).toHaveBeenCalledWith(
+        selectedPreview,
+        { name: 'list-all-documentation', arguments: {} },
+        undefined
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('Multiple matching Storybook instances');
+      expect(result.output).toContain('Matching instances at `/projects/foo`');
+      expect(result.output).toContain('pid `2`');
+      expect(result.output).toContain('pid `3`');
+      expect(result.output).not.toContain('pid `4`');
+      expect(result.output).not.toContain('http://localhost:6009');
+    });
   });
 });
 

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -566,9 +566,9 @@ function formatMultiInstanceWarning(
     const marker = r === chosen ? ' (used)' : '';
     return `> - pid \`${r.pid}\` at ${r.url} (status: \`${r.mcp.status}\`)${marker}`;
   });
-  return `> Warning: Multiple Storybook instances are running at this cwd. This call was sent to pid \`${chosen.pid}\`.
+  return `> Warning: Multiple matching Storybook instances are running at this cwd. This call was sent to pid \`${chosen.pid}\`.
 >
-> Instances at \`${chosen.cwd}\`:
+> Matching instances at \`${chosen.cwd}\`:
 ${lines.join('\n')}
 >
 > If results look unexpected, ask the user whether they want to stop the other instance(s).`;

--- a/code/core/src/cli/ai/mcp/run-tool.ts
+++ b/code/core/src/cli/ai/mcp/run-tool.ts
@@ -9,6 +9,7 @@ import {
   resolveStorybookConfigDir,
   type StorybookAiMetadata,
 } from './local-metadata.ts';
+import { detectAgent } from '../../../telemetry/detect-agent.ts';
 import { readRegistry } from './registry.ts';
 import { resolveInstance } from './resolve-instance.ts';
 import { parsePort, parseToolArgs } from './tool-args.ts';
@@ -458,7 +459,7 @@ async function resolveReadyInstance(
   const cwd = resolve(cwdInput ?? process.cwd());
 
   const records = await readRegistry(deps.registryDir);
-  const resolution = resolveInstance(records, cwd, port);
+  const resolution = resolveInstance(records, cwd, port, detectAgent()?.name);
 
   if (resolution.kind === 'intercept') {
     return {

--- a/code/core/src/cli/ai/mcp/types.ts
+++ b/code/core/src/cli/ai/mcp/types.ts
@@ -26,6 +26,7 @@ export const StorybookInstanceRecordSchema = v.object({
   cwd: v.string(),
   url: v.string(),
   port: v.pipe(v.number(), v.minValue(1), v.maxValue(65535), v.integer()),
+  agent: v.optional(v.string()),
   storybookVersion: v.optional(v.string()),
   startedAt: v.optional(v.string()),
   updatedAt: v.optional(v.string()),

--- a/code/core/src/core-server/utils/runtime-instance-registry.test.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.test.ts
@@ -538,6 +538,21 @@ describe('writeStorybookRuntimeInstanceRecord', () => {
     expect(registration.record.agent).toBe('codex');
   });
 
+  it('prefers explicit AI_AGENT provenance over the Claude preview launcher signal', async () => {
+    vi.stubEnv('CLAUDE_AGENT_SDK_VERSION', '0.1.0');
+    vi.stubEnv('AI_AGENT', 'claude');
+
+    const registration = await writeStorybookRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      port: 6006,
+      registerCleanup: false,
+      registryDir: makeTempDir(),
+      storybookVersion: '10.5.0-alpha.0',
+    });
+
+    expect(registration.record.agent).toBe('claude');
+  });
+
   it('cleans up the written instance record', async () => {
     const registryDir = makeTempDir();
     const registration = await writeStorybookRuntimeInstanceRecord({

--- a/code/core/src/core-server/utils/runtime-instance-registry.test.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.test.ts
@@ -100,6 +100,7 @@ async function writeCurrentRecord(registryDir: string) {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 
   while (tempDirs.length > 0) {
     rmSync(tempDirs.pop()!, { force: true, recursive: true });
@@ -178,6 +179,15 @@ describe('createRuntimeInstanceRecord', () => {
       status: 'ready',
       endpoint: '/storybook-mcp',
     });
+  });
+
+  it('stores provided agent provenance', () => {
+    const record = createRuntimeInstanceRecord({
+      ...baseOptions,
+      agent: 'codex',
+    });
+
+    expect(record.agent).toBe('codex');
   });
 
   it('stores only the Storybook origin in url and excludes initial path query params', () => {
@@ -498,6 +508,36 @@ describe('writeRuntimeInstanceRecord', () => {
 });
 
 describe('writeStorybookRuntimeInstanceRecord', () => {
+  it('records Claude preview provenance from the preview launcher environment', async () => {
+    vi.stubEnv('CLAUDE_AGENT_SDK_VERSION', '0.1.0');
+    vi.stubEnv('AI_AGENT', undefined);
+
+    const registration = await writeStorybookRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      port: 6006,
+      registerCleanup: false,
+      registryDir: makeTempDir(),
+      storybookVersion: '10.5.0-alpha.0',
+    });
+
+    expect(registration.record.agent).toBe('claude-preview');
+  });
+
+  it('records the detected agent provenance outside the Claude preview launcher', async () => {
+    vi.stubEnv('CLAUDE_AGENT_SDK_VERSION', undefined);
+    vi.stubEnv('AI_AGENT', 'codex');
+
+    const registration = await writeStorybookRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      port: 6006,
+      registerCleanup: false,
+      registryDir: makeTempDir(),
+      storybookVersion: '10.5.0-alpha.0',
+    });
+
+    expect(registration.record.agent).toBe('codex');
+  });
+
   it('cleans up the written instance record', async () => {
     const registryDir = makeTempDir();
     const registration = await writeStorybookRuntimeInstanceRecord({

--- a/code/core/src/core-server/utils/runtime-instance-registry.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.ts
@@ -75,7 +75,7 @@ export function getMcpMetadataFromMainConfig(
   return { status: 'ready', endpoint };
 }
 
-export function detectRuntimeInstanceAgent() {
+function detectRuntimeInstanceAgent() {
   if (process.env.CLAUDE_AGENT_SDK_VERSION && !process.env.AI_AGENT) {
     return CLAUDE_PREVIEW_AGENT;
   }

--- a/code/core/src/core-server/utils/runtime-instance-registry.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.ts
@@ -7,10 +7,13 @@ import type { StorybookConfig } from 'storybook/internal/types';
 
 import { join, resolve } from 'pathe';
 
+import { detectAgent } from '../../telemetry/detect-agent.ts';
+
 const STORYBOOK_MCP_ADDON = '@storybook/addon-mcp';
 const DEFAULT_MCP_ENDPOINT = '/mcp';
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * ONE_DAY_MS;
+const CLAUDE_PREVIEW_AGENT = 'claude-preview';
 
 export type RuntimeInstanceRecord = {
   schemaVersion: 1;
@@ -19,6 +22,7 @@ export type RuntimeInstanceRecord = {
   cwd: string;
   url: string;
   port: number;
+  agent?: string;
   storybookVersion: string;
   startedAt: string;
   updatedAt: string;
@@ -71,8 +75,17 @@ export function getMcpMetadataFromMainConfig(
   return { status: 'ready', endpoint };
 }
 
+export function detectRuntimeInstanceAgent() {
+  if (process.env.CLAUDE_AGENT_SDK_VERSION && !process.env.AI_AGENT) {
+    return CLAUDE_PREVIEW_AGENT;
+  }
+
+  return detectAgent()?.name;
+}
+
 export function createRuntimeInstanceRecord({
   address,
+  agent,
   cwd = process.cwd(),
   instanceId = randomUUID(),
   mcp = { status: 'not-installed' },
@@ -82,6 +95,7 @@ export function createRuntimeInstanceRecord({
   storybookVersion,
 }: {
   address: string;
+  agent?: string;
   cwd?: string;
   instanceId?: string;
   mcp?: RuntimeInstanceRecord['mcp'];
@@ -100,6 +114,7 @@ export function createRuntimeInstanceRecord({
     cwd: resolve(cwd),
     url: origin,
     port,
+    ...(agent ? { agent } : {}),
     storybookVersion,
     startedAt: timestamp,
     updatedAt: timestamp,
@@ -302,6 +317,7 @@ function registerProcessCleanup(recordPath: string) {
 
 export async function writeStorybookRuntimeInstanceRecord({
   address,
+  agent = detectRuntimeInstanceAgent(),
   cwd,
   mcp,
   pid,
@@ -311,6 +327,7 @@ export async function writeStorybookRuntimeInstanceRecord({
   storybookVersion,
 }: {
   address: string;
+  agent?: string;
   cwd?: string;
   mcp?: RuntimeInstanceRecord['mcp'];
   pid?: number;
@@ -321,6 +338,7 @@ export async function writeStorybookRuntimeInstanceRecord({
 }): Promise<RuntimeInstanceRegistration> {
   const record = createRuntimeInstanceRecord({
     address,
+    agent,
     cwd,
     mcp,
     pid,

--- a/code/core/src/core-server/utils/runtime-instance-registry.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.ts
@@ -7,13 +7,13 @@ import type { StorybookConfig } from 'storybook/internal/types';
 
 import { join, resolve } from 'pathe';
 
+import { CLAUDE_PREVIEW_AGENT_NAME } from '../../shared/constants/agent-provenance.ts';
 import { detectAgent } from '../../telemetry/detect-agent.ts';
 
 const STORYBOOK_MCP_ADDON = '@storybook/addon-mcp';
 const DEFAULT_MCP_ENDPOINT = '/mcp';
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * ONE_DAY_MS;
-const CLAUDE_PREVIEW_AGENT = 'claude-preview';
 
 export type RuntimeInstanceRecord = {
   schemaVersion: 1;
@@ -77,7 +77,7 @@ export function getMcpMetadataFromMainConfig(
 
 function detectRuntimeInstanceAgent() {
   if (process.env.CLAUDE_AGENT_SDK_VERSION && !process.env.AI_AGENT) {
-    return CLAUDE_PREVIEW_AGENT;
+    return CLAUDE_PREVIEW_AGENT_NAME;
   }
 
   return detectAgent()?.name;

--- a/code/core/src/shared/constants/agent-provenance.ts
+++ b/code/core/src/shared/constants/agent-provenance.ts
@@ -1,0 +1,2 @@
+export const CLAUDE_AGENT_NAME = 'claude';
+export const CLAUDE_PREVIEW_AGENT_NAME = 'claude-preview';

--- a/code/core/src/shared/constants/agent-provenance.ts
+++ b/code/core/src/shared/constants/agent-provenance.ts
@@ -1,2 +1,5 @@
+/** Agent name reported by std-env for Claude CLI invocations. */
 export const CLAUDE_AGENT_NAME = 'claude';
+
+/** Agent marker written when Claude's preview launcher starts Storybook without AI_AGENT. */
 export const CLAUDE_PREVIEW_AGENT_NAME = 'claude-preview';


### PR DESCRIPTION
Closes #35234

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Adds optional `agent` provenance to Storybook runtime instance records and uses it when `storybook ai` resolves a running Storybook instance without an explicit `--port`.

- Records Claude preview-launched Storybooks as `agent: 'claude-preview'` when `CLAUDE_AGENT_SDK_VERSION` is set and `AI_AGENT` is not set.
- Records other detected agent launches with `detectAgent()?.name`.
- Prefers `claude-preview` records for Claude CLI calls, then generic `claude` records; other agents prefer their matching records.
- Falls back to the existing latest-started behavior when no agent bucket matches.
- Limits multi-instance warnings to the selected competing bucket instead of every same-cwd instance.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

No browser story QA is necessary for this PR; the behavior is CLI runtime instance selection. To manually verify the intended surface, run:

1. `yarn vitest run code/core/src/cli/ai/mcp/resolve-instance.test.ts code/core/src/cli/ai/mcp/run-tool.test.ts code/core/src/cli/ai/mcp/registry.test.ts code/core/src/core-server/utils/runtime-instance-registry.test.ts`
2. Confirm the test named `only warns about instances in the selected agent bucket` passes. That test simulates a Claude CLI call with two `claude-preview` records and a newer `codex` record at the same cwd; the expected behavior is that the command routes to the latest Claude preview record and the warning excludes the Codex record.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35235-sha-7c9fa4b5`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35235-sha-7c9fa4b5 sandbox` or in an existing project with `npx storybook@0.0.0-pr-35235-sha-7c9fa4b5 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35235-sha-7c9fa4b5`](https://npmjs.com/package/storybook/v/0.0.0-pr-35235-sha-7c9fa4b5) |
| **Triggered by** | @huang-julien |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/ai-agent-instance-selection`](https://github.com/storybookjs/storybook/tree/kasper/ai-agent-instance-selection) |
| **Commit** | [`7c9fa4b5`](https://github.com/storybookjs/storybook/commit/7c9fa4b5bd0f4fdc35233a127356fd7f54b066ce) |
| **Datetime** | Fri Jun 19 14:37:29 UTC 2026 (`1781879849`) |
| **Workflow run** | [27832032547](https://github.com/storybookjs/storybook/actions/runs/27832032547) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35235`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-aware instance selection so Claude CLI runs prefer matching Claude preview instances over generic Claude instances when multiple Storybook instances are available.
  * Runtime instance records now optionally store agent provenance to improve disambiguation.

* **Bug Fixes**
  * Improved warning output consistency when multiple instances match (including updated wording and preview-specific targeting).

* **Tests**
  * Expanded coverage for agent-constrained selection, provenance precedence, and tie-breaking.
  * Improved test isolation by clearing environment overrides between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->