### PR TITLE
Addon Controls: Fix select control for large union types

### DIFF
--- a/code/core/src/docs-tools/argTypes/convert/proptypes/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/proptypes/convert.ts
@@ -40,9 +40,21 @@ export const convert = (type: PTType): SBType | any => {
     case 'exact':
       const values = mapValues(value, (field) => convert(field));
       return { ...base, name: 'object', value: values };
-    case 'union':
-      return { ...base, name: 'union', value: value.map((v: PTType) => convert(v)) };
-    case 'instanceOf':
+    case 'union': {
+      const convertedValues = value.map((v: PTType) => convert(v));
+      const allEnum = convertedValues.every(
+        (v: any) => v?.name === 'enum' && Array.isArray(v.value)
+      );
+      if (allEnum && convertedValues.length > 0) {
+        return {
+          ...base,
+          name: 'enum',
+          value: convertedValues.flatMap((v: any) => v.value),
+        };
+      }
+      return { ...base, name: 'union', value: convertedValues };
+    }
+    case 'instanceOf'
     case 'element':
     case 'elementType':
     default: {
@@ -51,7 +63,7 @@ export const convert = (type: PTType): SBType | any => {
         // (like if a user has turned off shouldExtractValuesFromUnion) so here we
         // try to recover and construct one.
         try {
-          const literalValues = name.split('|').map((v: string) => JSON.parse(v));
+          const literalValues = name.split('|').map((v: string) => parseLiteral(v.trim()));
           return { ...base, name: 'enum', value: literalValues };
         } catch (err) {
           // fall through

--- a/code/core/src/docs-tools/argTypes/convert/proptypes/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/proptypes/convert.ts
@@ -54,7 +54,7 @@ export const convert = (type: PTType): SBType | any => {
       }
       return { ...base, name: 'union', value: convertedValues };
     }
-    case 'instanceOf'
+    case 'instanceOf':
     case 'element':
     case 'elementType':
     default: {


### PR DESCRIPTION
## What

Fixes #12641

## Why

When TypeScript union types have many literal members (e.g., `keyof typeof` on objects with >28 keys, or large inline unions like `'k1' | 'k2' | ... | 'k50'`), the controls panel renders them as "object" type instead of a "select" dropdown.

There are two root causes in the PropTypes converter (`proptypes/convert.ts`):

1. **Pipe-separated name fallback**: When react-docgen can't extract individual enum values and instead puts the raw type string in the `name` field (e.g., `'k1' | 'k2' | ...`), the fallback used `JSON.parse` which fails for single-quoted string literals. Replaced with `parseLiteral` which handles both single and double quotes.

2. **Union of single-value enums not flattened**: When react-docgen represents each union member as a separate single-value enum (`{name: 'union', value: [{name: 'enum', value: ['k1']}, ...]}`), the union type wasn't being recognized as an enum. Added logic to flatten unions where all members are single-value enums into a single enum type.

## How

- Replaced `JSON.parse(v)` with `parseLiteral(v.trim())` in the pipe-separated name fallback
- Added union flattening: when all union members are enum types with arrays of values, flatten them into a single enum

## Manual testing
- Created a test component with union prop types
- Verified select controls render correctly in Storybook UI
- Tested with both single-quoted and double-quoted string literals

## Checklist
- [x] Updated code
- [x] Tests pass
- [x] No breaking changes

## Testing

Verified that:
- `parseLiteral` correctly handles single-quoted strings (`'k1'` → `k1`)
- The old `JSON.parse` approach fails with single-quoted strings
- Union flattening correctly merges `[{name: 'enum', value: ['k1']}, {name: 'enum', value: ['k2']}]` into `{name: 'enum', value: ['k1', 'k2']}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved union type handling in documentation generation by consolidating enum values more reliably when unions resolve to compatible enum-like members.

* **Refactor**
  * Enhanced literal parsing during type conversion for more accurate results in enum-like union scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
