### PR TITLE
CLI: Prompt when framework detection fails

### DIFF
--- a/code/lib/create-storybook/src/commands/ProjectDetectionCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/ProjectDetectionCommand.test.ts
@@ -107,6 +107,68 @@ describe('ProjectDetectionCommand', () => {
       expect(logger.debug).toHaveBeenCalledWith('Project type detected: vue3');
     });
 
+    it('should prompt for HTML when detection fails in interactive mode', async () => {
+      options.type = undefined;
+      options.yes = false;
+      vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(
+        ProjectType.UNDETECTED
+      );
+      vi.mocked(prompt.select).mockResolvedValue('html');
+
+      const result = await command.execute();
+
+      expect(result.projectType).toBe(ProjectType.HTML);
+      expect(prompt.select).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "We couldn't detect a supported framework. What would you like to do?",
+        }),
+        expect.objectContaining({ onCancel: expect.any(Function) })
+      );
+    });
+
+    it('should prompt for a framework when detection fails and user chooses manual selection', async () => {
+      options.type = undefined;
+      options.yes = false;
+      vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(
+        ProjectType.UNDETECTED
+      );
+      vi.mocked(prompt.select)
+        .mockResolvedValueOnce('framework')
+        .mockResolvedValueOnce(ProjectType.REACT);
+
+      const result = await command.execute();
+
+      expect(result.projectType).toBe(ProjectType.REACT);
+      expect(prompt.select).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          message: "We couldn't detect a supported framework. What would you like to do?",
+        }),
+        expect.objectContaining({ onCancel: expect.any(Function) })
+      );
+      expect(prompt.select).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          message: 'Choose a framework to install:',
+        }),
+        expect.objectContaining({ onCancel: expect.any(Function) })
+      );
+    });
+
+    it('should error in non-interactive mode when detection fails', async () => {
+      options.type = undefined;
+      options.yes = true;
+      vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(
+        ProjectType.UNDETECTED
+      );
+
+      await expect(command.execute()).rejects.toThrow(HandledError);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Unable to initialize Storybook in this directory.')
+      );
+      expect(prompt.select).not.toHaveBeenCalled();
+    });
+
     it('should throw error for invalid provided type', async () => {
       options.type = ProjectType.UNSUPPORTED;
       const error = new HandledError('Unknown project type supplied: unsupported');

--- a/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
+++ b/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
@@ -41,9 +41,13 @@ export class ProjectDetectionCommand {
       logger.step(`Installing Storybook for user specified project type: ${projectTypeProvided}`);
     } else {
       const detected = await this.projectTypeService.autoDetectProjectType(this.options);
-      projectType = detected;
-      if (detected === ProjectType.REACT_NATIVE && !this.options.yes) {
-        projectType = await this.promptReactNativeVariant();
+      if (detected === ProjectType.UNDETECTED) {
+        projectType = await this.handleUndetectedProjectType();
+      } else {
+        projectType = detected;
+        if (detected === ProjectType.REACT_NATIVE && !this.options.yes) {
+          projectType = await this.promptReactNativeVariant();
+        }
       }
       logger.debug(`Project type detected: ${projectType}`);
     }
@@ -95,6 +99,134 @@ export class ProjectDetectionCommand {
       createPromptCancelOptions(this.telemetryService, 'react-native-variant')
     );
     return manualType as ProjectType;
+  }
+
+  /** Handle the case where Storybook cannot auto-detect a project type */
+  private async handleUndetectedProjectType(): Promise<ProjectType> {
+    if (this.options.yes) {
+      this.reportUndetectedProjectType();
+    }
+
+    const choice = await prompt.select(
+      {
+        message: "We couldn't detect a supported framework. What would you like to do?",
+        options: [
+          {
+            label: `${picocolors.bold('HTML')}: install Storybook for a plain HTML project`,
+            value: 'html',
+          },
+          {
+            label: `${picocolors.bold('Select a framework')}: choose a supported framework manually`,
+            value: 'framework',
+          },
+          {
+            label: `${picocolors.bold('Abort')}: exit without installing Storybook`,
+            value: 'abort',
+          },
+        ],
+      },
+      createPromptCancelOptions(this.telemetryService, 'project-type-undetected')
+    );
+
+    if (choice === 'html') {
+      return ProjectType.HTML;
+    }
+
+    if (choice === 'framework') {
+      return this.promptFrameworkType();
+    }
+
+    logger.warn('Aborting Storybook initialization...');
+    return process.exit(0);
+  }
+
+  /** Prompt user to select a framework after auto-detection failed */
+  private async promptFrameworkType(): Promise<ProjectType> {
+    const manualType = await prompt.select(
+      {
+        message: 'Choose a framework to install:',
+        options: Object.values(ProjectType)
+          .filter(
+            (type) =>
+              ![
+                ProjectType.UNDETECTED,
+                ProjectType.UNSUPPORTED,
+                ProjectType.NX,
+                ProjectType.HTML,
+              ].includes(type)
+          )
+          .map((type) => ({
+            label: this.formatProjectTypeLabel(type),
+            value: type,
+          })),
+      },
+      createPromptCancelOptions(this.telemetryService, 'project-type-manual')
+    );
+
+    return manualType as ProjectType;
+  }
+
+  /** Emit the undetected project type error that non-interactive flows need */
+  private reportUndetectedProjectType(): never {
+    logger.error(dedent`
+      Unable to initialize Storybook in this directory.
+
+      Storybook couldn't detect a supported framework or configuration for your project.
+
+      If this is a plain HTML project, rerun Storybook with:
+        --type html
+
+      For example:
+        npm create storybook@latest -- --type html
+
+      Otherwise, make sure you're inside a framework project (for example React, Vue, Svelte, Angular, or Next.js) and that its dependencies are installed.
+    `);
+    throw new HandledError('Storybook failed to detect your project type');
+  }
+
+  private formatProjectTypeLabel(type: ProjectType) {
+    switch (type) {
+      case ProjectType.ANGULAR:
+        return 'Angular';
+      case ProjectType.EMBER:
+        return 'Ember';
+      case ProjectType.HTML:
+        return 'HTML';
+      case ProjectType.NEXTJS:
+        return 'Next.js';
+      case ProjectType.NUXT:
+        return 'Nuxt';
+      case ProjectType.PREACT:
+        return 'Preact';
+      case ProjectType.QWIK:
+        return 'Qwik';
+      case ProjectType.REACT:
+        return 'React';
+      case ProjectType.REACT_NATIVE:
+        return 'React Native';
+      case ProjectType.REACT_NATIVE_AND_RNW:
+        return 'React Native + React Native Web';
+      case ProjectType.REACT_NATIVE_WEB:
+        return 'React Native Web';
+      case ProjectType.REACT_SCRIPTS:
+        return 'React Scripts';
+      case ProjectType.SERVER:
+        return 'Server';
+      case ProjectType.SOLID:
+        return 'Solid';
+      case ProjectType.SVELTE:
+        return 'Svelte';
+      case ProjectType.SVELTEKIT:
+        return 'SvelteKit';
+      case ProjectType.TANSTACK_REACT:
+        return 'TanStack React';
+      case ProjectType.VUE3:
+        return 'Vue 3';
+      case ProjectType.WEB_COMPONENTS:
+        return 'Web Components';
+      default:
+        return type;
+    }
   }
 
   /** Check if Storybook is already installed and handle force option */

--- a/code/lib/create-storybook/src/services/ProjectTypeService.test.ts
+++ b/code/lib/create-storybook/src/services/ProjectTypeService.test.ts
@@ -26,18 +26,14 @@ describe('ProjectTypeService', () => {
   });
 
   describe('autoDetectProjectType', () => {
-    it('logs a helpful message when framework cannot be detected', async () => {
+    it('returns UNDETECTED when framework cannot be detected', async () => {
       const service = new ProjectTypeService(pm);
       const options = { html: false } as unknown as CommandOptions;
       // @ts-expect-error accessing private for test
       vi.spyOn(service, 'detectProjectType').mockResolvedValue(ProjectType.UNDETECTED);
 
-      await expect(service.autoDetectProjectType(options)).rejects.toThrowError(
-        'Storybook failed to detect your project type'
-      );
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Unable to initialize Storybook in this directory.')
-      );
+      await expect(service.autoDetectProjectType(options)).resolves.toBe(ProjectType.UNDETECTED);
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('throws NxProjectDetectedError when NX project is detected', async () => {

--- a/code/lib/create-storybook/src/services/ProjectTypeService.ts
+++ b/code/lib/create-storybook/src/services/ProjectTypeService.ts
@@ -14,7 +14,6 @@ import type { SupportedLanguage } from 'storybook/internal/types';
 
 import * as find from 'empathic/find';
 import semver from 'semver';
-import { dedent } from 'ts-dedent';
 
 import type { CommandOptions } from '../generators/types.ts';
 
@@ -181,21 +180,6 @@ export class ProjectTypeService {
     try {
       const detectedType = await this.detectProjectType(options);
 
-      // prompting handled by command layer
-
-      if (detectedType === ProjectType.UNDETECTED || detectedType === null) {
-        logger.error(dedent`
-          Unable to initialize Storybook in this directory.
-
-          Storybook couldn't detect a supported framework or configuration for your project. Make sure you're inside a framework project (e.g., React, Vue, Svelte, Angular, Next.js) and that its dependencies are installed.
-
-          Tips:
-          - Run init in an empty directory or create a new framework app first.
-          - If this directory contains unrelated files, try a new directory for Storybook.
-        `);
-        throw new HandledError('Storybook failed to detect your project type');
-      }
-
       if (detectedType === ProjectType.NX) {
         throw new NxProjectDetectedError();
       }
@@ -227,7 +211,7 @@ export class ProjectTypeService {
     return false;
   }
 
-  private async detectProjectType(options: CommandOptions): Promise<ProjectType | null> {
+  private async detectProjectType(options: CommandOptions): Promise<ProjectType> {
     try {
       if (this.isNxProject()) {
         return ProjectType.NX;
@@ -242,7 +226,7 @@ export class ProjectTypeService {
     }
   }
 
-  private detectFrameworkPreset(packageJson: PackageJsonWithMaybeDeps): ProjectType | null {
+  private detectFrameworkPreset(packageJson: PackageJsonWithMaybeDeps): ProjectType {
     const result = [...this.getSupportedTemplates(), this.getUnsupportedTemplate()].find(
       (framework) => {
         return this.getProjectType(packageJson, framework) !== null;


### PR DESCRIPTION
Refs #35045

When Storybook cant detect a framework during init, it now gives an interactive choice: continue as plain HTML, pick a framework manually, or abort. In non-interactive runs, it prints a clearer hint that points to `--type html`.

Validation:
- node --check on the changed TypeScript files