### PR TITLE
Preview API: Respect toJSON when inferring arg types

### DIFF
--- a/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
@@ -100,6 +100,79 @@ describe('inferArgTypes', () => {
     expect(logger.warn).toHaveBeenCalled();
   });
 
+  it('does not warn on cyclic args that define toJSON', () => {
+    // Repro from issue #35239: a Backbone-style collection holds a cyclic
+    // back-reference but defines toJSON, so its serialized output is finite.
+    const cyclic: any = { id: 1, name: 'item' };
+    cyclic.self = cyclic;
+    const collection = {
+      models: [cyclic],
+      toJSON() {
+        return [{ id: 1, name: 'item' }];
+      },
+    };
+
+    vi.mocked(logger.warn).mockClear();
+    expect(
+      inferArgTypes({
+        initialArgs: {
+          collection,
+        },
+      } as any)
+    ).toEqual({
+      collection: {
+        name: 'collection',
+        type: {
+          name: 'array',
+          value: { name: 'object', value: { id: { name: 'number' }, name: { name: 'string' } } },
+        },
+      },
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to normal inference when toJSON throws', () => {
+    const value = {
+      x: 1,
+      toJSON() {
+        throw new Error('serialization unavailable');
+      },
+    };
+
+    vi.mocked(logger.warn).mockClear();
+    expect(
+      inferArgTypes({
+        initialArgs: { a: value },
+      } as any)
+    ).toEqual({
+      a: {
+        name: 'a',
+        type: {
+          name: 'object',
+          // The `toJSON` method itself is walked as a function field.
+          value: { x: { name: 'number' }, toJSON: { name: 'function' } },
+        },
+      },
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to cycle detection when toJSON returns the value itself', () => {
+    // A toJSON that returns `this` must not cause infinite recursion; the
+    // existing cycle path should still fire.
+    const cyclic: any = {};
+    cyclic.foo = cyclic;
+    cyclic.toJSON = function () {
+      return this;
+    };
+
+    vi.mocked(logger.warn).mockClear();
+    inferArgTypes({
+      initialArgs: { a: cyclic },
+    } as any);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
   it('ensures names', () => {
     vi.mocked(logger.warn).mockClear();
     expect(

--- a/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { logger } from 'storybook/internal/client-logger';
 
@@ -7,6 +7,10 @@ import { inferArgTypes } from './inferArgTypes.ts';
 vi.mock('storybook/internal/client-logger');
 
 describe('inferArgTypes', () => {
+  beforeEach(() => {
+    vi.mocked(logger.warn).mockClear();
+  });
+
   it('infers scalar types', () => {
     expect(
       inferArgTypes({
@@ -84,7 +88,6 @@ describe('inferArgTypes', () => {
     const cyclic: any = {};
     cyclic.foo = cyclic;
 
-    vi.mocked(logger.warn).mockClear();
     expect(
       inferArgTypes({
         initialArgs: {
@@ -112,7 +115,6 @@ describe('inferArgTypes', () => {
       },
     };
 
-    vi.mocked(logger.warn).mockClear();
     expect(
       inferArgTypes({
         initialArgs: {
@@ -139,7 +141,6 @@ describe('inferArgTypes', () => {
       },
     };
 
-    vi.mocked(logger.warn).mockClear();
     expect(
       inferArgTypes({
         initialArgs: { a: value },
@@ -164,7 +165,6 @@ describe('inferArgTypes', () => {
     const toJSON = vi.fn(() => ({ id: 1 }));
     const shared = { foo: 'bar', toJSON };
 
-    vi.mocked(logger.warn).mockClear();
     inferArgTypes({
       initialArgs: {
         a: shared,
@@ -184,7 +184,6 @@ describe('inferArgTypes', () => {
       return this;
     };
 
-    vi.mocked(logger.warn).mockClear();
     inferArgTypes({
       initialArgs: { a: cyclic },
     } as any);
@@ -192,7 +191,6 @@ describe('inferArgTypes', () => {
   });
 
   it('ensures names', () => {
-    vi.mocked(logger.warn).mockClear();
     expect(
       inferArgTypes({
         initialArgs: {
@@ -216,7 +214,6 @@ describe('inferArgTypes', () => {
   });
 
   it('ensures names even with no arg', () => {
-    vi.mocked(logger.warn).mockClear();
     expect(
       inferArgTypes({
         argTypes: {

--- a/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
@@ -157,6 +157,24 @@ describe('inferArgTypes', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  it('memoizes the inferred type across repeated references to the same toJSON arg', () => {
+    // Verifies the toJSON branch writes to the shared cache so repeated
+    // references to the same value reuse the previous inference instead of
+    // re-running toJSON() and walking the serialized output again.
+    const toJSON = vi.fn(() => ({ id: 1 }));
+    const shared = { foo: 'bar', toJSON };
+
+    vi.mocked(logger.warn).mockClear();
+    inferArgTypes({
+      initialArgs: {
+        a: shared,
+        b: shared,
+      },
+    } as any);
+    expect(toJSON).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it('falls back to cycle detection when toJSON returns the value itself', () => {
     // A toJSON that returns `this` must not cause infinite recursion; the
     // existing cycle path should still fire.

--- a/code/core/src/preview-api/modules/store/inferArgTypes.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.ts
@@ -49,7 +49,9 @@ const inferType = (
       try {
         const serialized = value.toJSON();
         if (serialized !== value) {
-          return inferType(serialized, name, visited, cache);
+          const inferred = inferType(serialized, name, visited, cache);
+          cache.set(value, inferred);
+          return inferred;
         }
       } catch {
         // A throwing toJSON falls through to the regular inference path.

--- a/code/core/src/preview-api/modules/store/inferArgTypes.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.ts
@@ -40,6 +40,22 @@ const inferType = (
       return cache.get(value)!;
     }
 
+    // Values with a custom `toJSON()` define their own serialization
+    // (Backbone models, Moment, Decimal.js, etc.). Walking their internals
+    // can hit cycles that don't exist in the JSON output, which produced
+    // misleading "Args should be JSON-serializable" warnings even though
+    // `JSON.stringify` and the Controls panel both honor `toJSON`.
+    if (typeof value.toJSON === 'function') {
+      try {
+        const serialized = value.toJSON();
+        if (serialized !== value) {
+          return inferType(serialized, name, visited, cache);
+        }
+      } catch {
+        // A throwing toJSON falls through to the regular inference path.
+      }
+    }
+
     // Check for cycles (currently being processed in this path)
     if (visited.has(value)) {
       logger.warn(dedent`


### PR DESCRIPTION
Closes #35239.

## What

`inferArgTypes` walked an arg's internal field structure regardless of whether the value defined its own `toJSON()`. For objects that hold cyclic back-references — Backbone collections, ORM models, dependency graphs — this fired a "We've detected a cycle in arg '…'. Args should be JSON-serializable." warning, even though both `JSON.stringify` and the Controls panel honored `toJSON` and serialized the value just fine.

The walker now delegates to `toJSON()` first and infers the arg type from its output, which is what the rest of Storybook actually displays anyway. A throwing `toJSON`, or a `toJSON` that returns `this`, falls back to the existing inference + cycle path so nothing regresses in those edge cases. The result is also written back to the shared `cache` so repeated references to the same value don't re-serialize.

## What I changed

- `code/core/src/preview-api/modules/store/inferArgTypes.ts` — before the cycle check, if `typeof value.toJSON === 'function'`, recurse into `value.toJSON()` instead and memoize the result against the original value. Wrapped in `try/catch`; `serialized === value` short-circuits to avoid infinite recursion.
- `code/core/src/preview-api/modules/store/inferArgTypes.test.ts` — four new cases:
  - Cyclic collection with `toJSON` no longer emits the warning and the inferred type reflects the serialized shape (the repro from #35239).
  - `toJSON` that throws is treated as no `toJSON` and falls back to the regular inference path without warning.
  - Two refs to the same value call `toJSON` exactly once (memoization).
  - `toJSON` that returns `this` still triggers the original cycle warning rather than looping forever.

#### Manual testing

1. Clone the reporter's repro: https://github.com/blikblum/storybook-cyclic-references
2. Replace the `storybook` package's `inferArgTypes.ts` with this PR's build (or `yarn link` the local checkout).
3. `npm install && npm run storybook`.
4. Open the "Collection (Cyclic Ref)" story and the devtools console.
5. **Before:** `We've detected a cycle in arg 'collection-cyclic-ref--large.collection'. Args should be JSON-serializable.` **After:** no warning; Controls still shows the same `toJSON`-serialized value as before.

## Release notes

```releasenotes
Preview API: Respect toJSON() when inferring arg types so cyclic objects with custom serialization no longer trigger misleading "Args should be JSON-serializable" warnings
```

## Checklist for contributors

- [x] **Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)**
- [x] **Make sure to add/update documentation regarding your changes** — internal bugfix, no user-facing docs
- [x] **If your changes are visual: kindly add a snapshot or recording to your contribution** — no visual change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument type inference for values with custom `toJSON()` behavior, now deriving types from the `toJSON()` output when available.
  * Correctly handles `toJSON()` throwing, `toJSON()` returning derived data, and cyclic cases—reducing unnecessary warnings while keeping cycle detection intact.

* **Tests**
  * Added/extended test coverage for `toJSON()`-based inference, error fallback behavior, memoization (only invoking `toJSON()` once per value), and cycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->