### PR TITLE
Addons: Fix icon peer dependencies

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 - [From version 10.4.0 to 10.5.0](#from-version-1040-to-1050)
   - [ExternalDocs and ExternalDocsContainer are deprecated](#externaldocs-and-externaldocscontainer-are-deprecated)
 - [From version 10.3.0 to 10.4.0](#from-version-1030-to-1040)
+  - [Addons now declare `react` and `react-dom` as peer dependencies](#addons-now-declare-react-and-react-dom-as-peer-dependencies)
   - [React Native: on-device addons moved to `deviceAddons`](#react-native-on-device-addons-moved-to-deviceaddons)
   - [TanStack Router projects: migrate from `@storybook/react-vite` to `@storybook/tanstack-react`](#tanstack-router-projects-migrate-from-storybookreact-vite-to-storybooktanstack-react)
 - [From version 10.0.0 to 10.1.0](#from-version-1000-to-1010)
@@ -534,6 +535,25 @@ The `ExternalDocs` and `ExternalDocsContainer` components from `@storybook/addon
 If you are currently using `ExternalDocs` or `ExternalDocsContainer`, please open an issue describing your use case so the team can consider alternative solutions.
 
 ## From version 10.3.0 to 10.4.0
+
+### Addons now declare `react` and `react-dom` as peer dependencies
+
+The first-party Storybook addons listed below now declare `react` and `react-dom` as peer dependencies (range `^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0`), to correctly propagate the peer requirements of [`@storybook/icons`](https://github.com/storybookjs/icons):
+
+- `@storybook/addon-a11y`
+- `@storybook/addon-docs`
+- `@storybook/addon-onboarding`
+- `@storybook/addon-themes`
+- `@storybook/addon-vitest`
+- `storybook-addon-pseudo-states`
+
+Most projects already have `react` and `react-dom` installed via their framework (e.g. `@storybook/react-vite`) or application dependencies, so no action is required. However, in strict package managers (Yarn 4 / Yarn PnP, pnpm with `strict-peer-dependencies`), you may now see warnings if `react` or `react-dom` are not present in your project. To fix this, install them:
+
+```sh
+npm install --save-dev react react-dom
+```
+
+In addition, `@storybook/addon-docs` no longer ships `react` and `react-dom` as direct `dependencies` — they have moved to `peerDependencies`, ensuring a single React copy is used in your project. If you previously relied on the addon to install React for you, install it explicitly as shown above.
 
 ### React Native: on-device addons moved to `deviceAddons`
 

--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -59,11 +59,11 @@
   ],
   "dependencies": {
     "@storybook/global": "^5.0.0",
+    "@storybook/icons": "^2.0.2",
     "axe-core": "^4.2.0"
   },
   "devDependencies": {
     "@radix-ui/react-tabs": "1.0.4",
-    "@storybook/icons": "^2.0.2",
     "@testing-library/react": "^14.0.0",
     "execa": "^9.6.1",
     "react": "^18.2.0",
@@ -73,6 +73,8 @@
     "vitest-axe": "^0.1.0"
   },
   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "storybook": "workspace:^"
   },
   "publishConfig": {

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -90,8 +90,6 @@
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/icons": "^2.0.2",
     "@storybook/react-dom-shim": "workspace:*",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
@@ -117,6 +115,8 @@
   },
   "peerDependencies": {
     "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "storybook": "workspace:^"
   },
   "peerDependenciesMeta": {

--- a/code/addons/onboarding/package.json
+++ b/code/addons/onboarding/package.json
@@ -47,15 +47,19 @@
     "*.d.ts",
     "!src/**/*"
   ],
+  "dependencies": {
+    "@storybook/icons": "^2.0.2"
+  },
   "devDependencies": {
     "@neoconfetti/react": "^1.0.0",
-    "@storybook/icons": "^2.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-joyride": "^2.8.2",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "storybook": "workspace:^"
   },
   "publishConfig": {

--- a/code/addons/pseudo-states/package.json
+++ b/code/addons/pseudo-states/package.json
@@ -52,13 +52,17 @@
     "dist/**/*",
     "!src/**/*"
   ],
+  "dependencies": {
+    "@storybook/icons": "^2.0.2"
+  },
   "devDependencies": {
-    "@storybook/icons": "^2.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "storybook": "workspace:^"
   },
   "publishConfig": {

--- a/code/addons/themes/package.json
+++ b/code/addons/themes/package.json
@@ -56,15 +56,17 @@
     "!src/**/*"
   ],
   "dependencies": {
+    "@storybook/icons": "^2.0.2",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
-    "@storybook/icons": "^2.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "storybook": "workspace:^"
   },
   "publishConfig": {

--- a/code/addons/vitest/package.json
+++ b/code/addons/vitest/package.json
@@ -111,6 +111,8 @@
     "@vitest/browser": "^3.0.0 || ^4.0.0",
     "@vitest/browser-playwright": "^4.0.0",
     "@vitest/runner": "^3.0.0 || ^4.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "storybook": "workspace:^",
     "vitest": "^3.0.0 || ^4.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9125,6 +9125,8 @@ __metadata:
     typescript: "npm:^5.9.3"
     vitest-axe: "npm:^0.1.0"
   peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     storybook: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -9180,6 +9182,8 @@ __metadata:
     vite: "npm:^7.0.4"
   peerDependencies:
     "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     storybook: "workspace:^"
   peerDependenciesMeta:
     "@types/react":
@@ -9236,6 +9240,8 @@ __metadata:
     react-joyride: "npm:^2.8.2"
     typescript: "npm:^5.9.3"
   peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     storybook: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -9250,6 +9256,8 @@ __metadata:
     ts-dedent: "npm:^2.0.0"
     typescript: "npm:^5.9.3"
   peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     storybook: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -9288,6 +9296,8 @@ __metadata:
     "@vitest/browser": ^3.0.0 || ^4.0.0
     "@vitest/browser-playwright": ^4.0.0
     "@vitest/runner": ^3.0.0 || ^4.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     storybook: "workspace:^"
     vitest: ^3.0.0 || ^4.0.0
   peerDependenciesMeta:
@@ -31311,6 +31321,8 @@ __metadata:
     react-dom: "npm:^18.2.0"
     typescript: "npm:^5.9.3"
   peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     storybook: "workspace:^"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Closes #34610

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

This updates first-party addon package metadata so addons that import `@storybook/icons` correctly declare both the runtime `@storybook/icons` dependency and the `react` / `react-dom` peer dependency contract required by `@storybook/icons`.

It also moves `@storybook/addon-docs` from direct `react` / `react-dom` dependencies to peer dependencies, and documents the now-explicit peer requirement in `MIGRATION.md`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Run `yarn install --immutable` from the repository root.
2. Verify the install completes without lockfile changes and without peer warnings that say one of the updated addons does not provide `react` or `react-dom` to `@storybook/icons`.
3. Inspect the package metadata for `@storybook/addon-a11y`, `@storybook/addon-docs`, `@storybook/addon-onboarding`, `@storybook/addon-themes`, `@storybook/addon-vitest`, and `storybook-addon-pseudo-states`; each should expose `react` and `react-dom` as peers when it depends on `@storybook/icons`.


#### Regression guide

The issue can be reproduced against the published `10.4.0` packages with Yarn PnP. These commands are meant to verify the old failure mode and the package metadata behavior this PR fixes.

Failure 1: `@storybook/addon-a11y@10.4.0` imports `@storybook/icons` from its manager bundle, but the published package metadata lists `@storybook/icons` only in `devDependencies`.

`package.json`:

```json
{
  "private": true,
  "packageManager": "yarn@4.12.0",
  "scripts": {
    "storybook": "storybook dev -p 6006 --no-open"
  },
  "devDependencies": {
    "@storybook/addon-a11y": "10.4.0",
    "@storybook/react-vite": "10.4.0",
    "react": "^18.2.0",
    "react-dom": "^18.2.0",
    "storybook": "10.4.0",
    "vite": "^7.0.0"
  }
}
```

`.yarnrc.yml`:

```yaml
nodeLinker: pnp
```

Run:

```sh
npm exec --yes --package=@yarnpkg/cli-dist@4.12.0 -- yarn install
npm exec --yes --package=@yarnpkg/cli-dist@4.12.0 -- yarn node -e "require('@storybook/addon-a11y/manager')"
```

Expected old failure: Yarn reports that `@storybook/addon-a11y` tried to access `@storybook/icons`, but `@storybook/icons` is not declared in its dependencies. Running Storybook with the same fixture can also skip the addon as unresolved.

Failure 2: `@storybook/addon-vitest@10.4.0` declares `@storybook/icons` as a dependency, but does not declare the `react` and `react-dom` peers required by `@storybook/icons`.

`package.json`:

```json
{
  "private": true,
  "packageManager": "yarn@4.12.0",
  "devDependencies": {
    "@storybook/addon-vitest": "10.4.0",
    "@vitest/browser": "^4.0.0",
    "@vitest/browser-playwright": "^4.0.0",
    "@vitest/runner": "^4.0.0",
    "react": "^18.2.0",
    "react-dom": "^18.2.0",
    "storybook": "10.4.0",
    "vitest": "^4.0.0"
  }
}
```

`.yarnrc.yml`:

```yaml
nodeLinker: pnp
```

Run:

```sh
npm exec --yes --package=@yarnpkg/cli-dist@4.12.0 -- yarn install
npm exec --yes --package=@yarnpkg/cli-dist@4.12.0 -- yarn explain peer-requirements | rg "addon-vitest|@storybook/icons|react-dom|react to"
```

Expected old failure: Yarn reports that `@storybook/addon-vitest` does not provide `react` and `react-dom` to `@storybook/icons`.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for transitioning from version 10.3.0 to 10.4.0, detailing dependency updates for Storybook addons.

* **Chores**
  * Updated addon dependencies: React and React DOM are now declared as peer dependencies across multiple addons, reducing redundant installations.
  * The `@storybook/addon-docs` no longer ships React directly; users must have React installed independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->