### PR TITLE
Angular: Handle single-quote unions in compodoc type extraction

### DIFF
--- a/code/frameworks/angular/src/client/compodoc.test.ts
+++ b/code/frameworks/angular/src/client/compodoc.test.ts
@@ -32,6 +32,15 @@ const getDummyCompodocJson = () => {
           description: '',
           kind: 168,
         },
+        {
+          name: 'SingleQuoteTypeAlias',
+          ctype: 'miscellaneous',
+          subtype: 'typealias',
+          rawtype: "'Option A' | 'Option B' | 'Option C'",
+          file: 'src/stories/component-with-enums/enums.component.ts',
+          description: '',
+          kind: 168,
+        },
       ],
       enumerations: [
         {
@@ -111,7 +120,15 @@ describe('extractType', () => {
       // ['T[]', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       ['[]', { name: 'other', value: 'empty-enum' }],
       ['"primary" | "secondary"', { name: 'enum', value: ['primary', 'secondary'] }],
+      ["'primary' | 'secondary'", { name: 'enum', value: ['primary', 'secondary'] }],
+      ["'S' | 'M' | 'L'", { name: 'enum', value: ['S', 'M', 'L'] }],
+      ['1 | 2 | 3', { name: 'enum', value: [1, 2, 3] }],
+      ["'hello \"world\"'", { name: 'enum', value: ['hello "world"'] }],
       ['TypeAlias', { name: 'enum', value: ['Type Alias 1', 'Type Alias 2', 'Type Alias 3'] }],
+      [
+        'SingleQuoteTypeAlias',
+        { name: 'enum', value: ['Option A', 'Option B', 'Option C'] },
+      ],
       // ['EnumNumeric', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       // ['EnumNumericInitial', { name: 'other', value: 'empty-enum' }], // seems to be wrong | TODO: REVISIT
       ['EnumStringValues', { name: 'enum', value: ['PRIMARY', 'SECONDARY', 'TERTIARY'] }],

--- a/code/frameworks/angular/src/client/compodoc.ts
+++ b/code/frameworks/angular/src/client/compodoc.ts
@@ -131,7 +131,21 @@ const extractEnumValues = (compodocType: any) => {
   }
 
   try {
-    return compodocType.split('|').map((value) => JSON.parse(value));
+    return compodocType.split('|').map((value) => {
+      const trimmed = value.trim();
+      // Strip matching surrounding quotes (compodoc emits 'foo' | 'bar' or "foo" | "bar")
+      const unquoted =
+        (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+        (trimmed.startsWith('"') && trimmed.endsWith('"'))
+          ? trimmed.slice(1, -1)
+          : trimmed;
+      // Try JSON.parse with double quotes; fall back to the raw trimmed string
+      try {
+        return JSON.parse(`"${unquoted.replace(/"/g, '\\"')}"`);
+      } catch {
+        return unquoted;
+      }
+    });
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
## What

Fixes #33779

## Why

Compodoc emits single-quoted literal union types (e.g. `'S' | 'M' | 'L'`) for Angular component inputs. The `extractEnumValues` function in the compodoc path passed these directly to `JSON.parse`, which only handles double-quoted strings. This caused the entire union to fall back to `null`, rendering controls as `object` type instead of the expected `select` or `radio` dropdown.

This is a regression in Storybook 10 for Angular components. The React path was already fixed in #33200, but the Angular/compodoc text-parsing path was not.

## How

The fix in `extractEnumValues` now:
1. Trims whitespace from each union segment
2. Strips matching surrounding quotes (single or double)
3. Re-wraps in double quotes for `JSON.parse`
4. Falls back to the raw string if parsing still fails

### Example
Before (broken):
```typescript
// compodoc emits: 'S' | 'M' | 'L'
// extractEnumValues returns null → control renders as 'object'
size = input<'S' | 'M' | 'L'>()
```

After (fixed):
```typescript
// extractEnumValues returns ['S', 'M', 'L'] → control renders as 'radio' (3 options)
size = input<'S' | 'M' | 'L'>()
```

## Tests

Added test cases for:
- Single-quoted unions: `'primary' | 'secondary'` → `['primary', 'secondary']`
- Single-quoted 3+ unions: `'S' | 'M' | 'L'` → `['S', 'M', 'L']`
- Numeric unions: `1 | 2 | 3` → `[1, 2, 3]`
- Strings with inner quotes: `'hello "world"'` → `['hello "world"']`
- Single-quoted typealias resolution: `'Option A' | 'Option B' | 'Option C'` → `['Option A', 'Option B', 'Option C']`

## How to test manually

1. Create an Angular sandbox: `yarn task --task dev --template angular-cli/default-ts`
2. Create a component with single-quoted union input:
   ```typescript
   size = input<'S' | 'M' | 'L'>()
   ```
3. Open the story in Storybook
4. Verify the Controls panel shows `size` as radio buttons (3 options) instead of 'object'
5. Verify selecting an option updates the component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced type extraction to reliably parse single-quoted and double-quoted enum values, escaped quotation marks, and numeric unions.

* **Tests**
  * Expanded test fixtures and cases to cover additional type alias formats and edge cases in type extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->