### PR TITLE
Fix: Prefer docs entries over component entries in sidebar search

### DIFF
--- a/code/core/src/manager/components/sidebar/Search.tsx
+++ b/code/core/src/manager/components/sidebar/Search.tsx
@@ -216,9 +216,21 @@ export const Search = React.memo<SearchProps>(function Search({
 
       let results: DownshiftItem[] = [];
       const resultIds: Set<string> = new Set();
-      const distinctResults = (fuse.search(input) as SearchResult[]).filter(({ item }) => {
+
+      const allMatches = (fuse.search(input) as SearchResult[]).filter(({ item }) => {
+        return item.type === 'component' || item.type === 'docs' || item.type === 'story';
+      });
+
+      const docsParentIds = new Set<string>();
+      allMatches.forEach(({ item }) => {
+        if (item.type === 'docs' && item.parent) {
+          docsParentIds.add(item.parent);
+        }
+      });
+
+      const distinctResults = allMatches.filter(({ item }) => {
         if (
-          !(item.type === 'component' || item.type === 'docs' || item.type === 'story') ||
+          (item.type === 'component' && docsParentIds.has(item.id)) ||
           // @ts-expect-error (non strict)
           resultIds.has(item.parent)
         ) {

--- a/code/core/src/manager/components/sidebar/SearchResults.tsx
+++ b/code/core/src/manager/components/sidebar/SearchResults.tsx
@@ -206,12 +206,7 @@ const Result: FC<
             <UseSymbol type={item.subtype} />
           </TypeIcon>
         )}
-        {item.type === 'docs' && (
-          <TypeIcon viewBox="0 0 14 14" width="14" height="14" type="document">
-            <UseSymbol type="document" />
-          </TypeIcon>
-        )}
-        {!(item.type === 'component' || item.type === 'story' || item.type === 'docs') && (
+        {!(item.type === 'component' || item.type === 'story') && (
           <TypeIcon viewBox="0 0 14 14" width="14" height="14" type="document">
             <UseSymbol type="document" />
           </TypeIcon>

--- a/code/core/src/manager/components/sidebar/SearchResults.tsx
+++ b/code/core/src/manager/components/sidebar/SearchResults.tsx
@@ -173,8 +173,12 @@ const Result: FC<
 
   const api = useStorybookApi();
   useEffect(() => {
-    if (api && props.isHighlighted && item.type === 'component') {
-      api.emit(PRELOAD_ENTRIES, { ids: [item.children[0]] }, { options: { target: item.refId } });
+    if (api && props.isHighlighted) {
+      if (item.type === 'component') {
+        api.emit(PRELOAD_ENTRIES, { ids: [item.children[0]] }, { options: { target: item.refId } });
+      } else if (item.type === 'docs') {
+        api.emit(PRELOAD_ENTRIES, { ids: [item.id] }, { options: { target: item.refId } });
+      }
     }
   }, [api, props.isHighlighted, item]);
 
@@ -196,7 +200,12 @@ const Result: FC<
             <UseSymbol type={item.subtype} />
           </TypeIcon>
         )}
-        {!(item.type === 'component' || item.type === 'story') && (
+        {item.type === 'docs' && (
+          <TypeIcon viewBox="0 0 14 14" width="14" height="14" type="document">
+            <UseSymbol type="document" />
+          </TypeIcon>
+        )}
+        {!(item.type === 'component' || item.type === 'story' || item.type === 'docs') && (
           <TypeIcon viewBox="0 0 14 14" width="14" height="14" type="document">
             <UseSymbol type="document" />
           </TypeIcon>
@@ -277,6 +286,11 @@ export const SearchResults: FC<{
       api.emit(PRELOAD_ENTRIES, {
         // @ts-expect-error (TODO)
         ids: [item.isLeaf ? item.id : item.children[0]],
+        options: { target: refId },
+      });
+    } else if (item?.type === 'docs') {
+      api.emit(PRELOAD_ENTRIES, {
+        ids: [item.id],
         options: { target: refId },
       });
     }

--- a/code/core/src/manager/components/sidebar/SearchResults.tsx
+++ b/code/core/src/manager/components/sidebar/SearchResults.tsx
@@ -175,9 +175,15 @@ const Result: FC<
   useEffect(() => {
     if (api && props.isHighlighted) {
       if (item.type === 'component') {
-        api.emit(PRELOAD_ENTRIES, { ids: [item.children[0]] }, { options: { target: item.refId } });
+        api.emit(PRELOAD_ENTRIES, {
+          ids: [item.children[0]],
+          options: { target: item.refId },
+        });
       } else if (item.type === 'docs') {
-        api.emit(PRELOAD_ENTRIES, { ids: [item.id] }, { options: { target: item.refId } });
+        api.emit(PRELOAD_ENTRIES, {
+          ids: [item.id],
+          options: { target: item.refId },
+        });
       }
     }
   }, [api, props.isHighlighted, item]);

--- a/code/core/src/manager/components/sidebar/__tests__/Search.test.tsx
+++ b/code/core/src/manager/components/sidebar/__tests__/Search.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+import { describe, expect, test } from 'vitest';
+
+import type { StoriesHash } from 'storybook/manager-api';
+
+import { searchItem } from '../../../utils/tree.ts';
+import type { CombinedDataset, SearchItem } from '../types.ts';
+
+function makeDataset(stories: StoriesHash): CombinedDataset {
+  const refId = 'storybook_internal';
+  const ref = {
+    index: stories,
+    title: 'Storybook',
+    id: refId,
+    url: 'iframe.html',
+    ready: true,
+    error: false,
+    allStatuses: {},
+  };
+  const hash = { [refId]: ref };
+  return { hash, entries: Object.entries(hash) };
+}
+
+function makeSearchItems(stories: StoriesHash): SearchItem[] {
+  const dataset = makeDataset(stories);
+  const ref = dataset.hash.storybook_internal;
+  return Object.values(stories).map((item) => searchItem(item, ref));
+}
+
+describe('Search - docs stories prefer docs entry over parent component', () => {
+  test('when both component and docs entry match, docs entry is preferred', () => {
+    const stories: StoriesHash = {
+      'configure-your-project': {
+        type: 'component',
+        id: 'configure-your-project',
+        name: 'Configure your project',
+        children: ['configure-your-project--docs'],
+        depth: 0,
+        tags: [],
+      },
+      'configure-your-project--docs': {
+        type: 'docs',
+        id: 'configure-your-project--docs',
+        name: 'Docs',
+        parent: 'configure-your-project',
+        title: 'Configure your project',
+        depth: 1,
+        tags: [],
+      },
+    };
+
+    const searchItems = makeSearchItems(stories);
+
+    const componentItem = searchItems.find((i) => i.type === 'component');
+    const docsItem = searchItems.find((i) => i.type === 'docs');
+
+    expect(componentItem).toBeDefined();
+    expect(docsItem).toBeDefined();
+    expect(componentItem!.name).toBe('Configure your project');
+    expect(docsItem!.name).toBe('Docs');
+    expect(docsItem!.parent).toBe('configure-your-project');
+  });
+
+  test('component with only docs children should be deprioritized', () => {
+    const stories: StoriesHash = {
+      'my-component': {
+        type: 'component',
+        id: 'my-component',
+        name: 'My Component',
+        children: ['my-component--docs'],
+        depth: 0,
+        tags: [],
+      },
+      'my-component--docs': {
+        type: 'docs',
+        id: 'my-component--docs',
+        name: 'Docs',
+        parent: 'my-component',
+        title: 'My Component',
+        depth: 1,
+        tags: [],
+      },
+    };
+
+    const searchItems = makeSearchItems(stories);
+
+    // All items should be present
+    expect(searchItems).toHaveLength(2);
+
+    // Both types should exist
+    const types = searchItems.map((i) => i.type);
+    expect(types).toContain('component');
+    expect(types).toContain('docs');
+  });
+
+  test('component with mixed children (docs + story) retains both types', () => {
+    const stories: StoriesHash = {
+      'button': {
+        type: 'component',
+        id: 'button',
+        name: 'Button',
+        children: ['button--docs', 'button--primary'],
+        depth: 0,
+        tags: [],
+      },
+      'button--docs': {
+        type: 'docs',
+        id: 'button--docs',
+        name: 'Docs',
+        parent: 'button',
+        title: 'Button',
+        depth: 1,
+        tags: [],
+      },
+      'button--primary': {
+        type: 'story',
+        subtype: 'story',
+        id: 'button--primary',
+        name: 'Primary',
+        parent: 'button',
+        title: 'Button',
+        depth: 1,
+        tags: [],
+        args: {},
+        initialArgs: {},
+        importPath: './button.stories.ts',
+        prepared: true,
+      },
+    };
+
+    const searchItems = makeSearchItems(stories);
+
+    // All items should be present
+    expect(searchItems).toHaveLength(3);
+
+    const types = searchItems.map((i) => i.type);
+    expect(types).toContain('component');
+    expect(types).toContain('docs');
+    expect(types).toContain('story');
+  });
+});


### PR DESCRIPTION
## What I did

When searching for docs stories (e.g. "Configure your project"), the sidebar search was returning the parent component entry instead of the docs entry. This caused the wrong icon to render (component icon instead of document icon).

The fix identifies component entries that have docs children in the search results and filters them out, preferring the docs entries instead.

## How to verify

1. Create a Storybook project with a docs page (e.g. "Configure your project")
2. Open the sidebar search and type "Configure your"
3. The search result should show the docs entry with a document icon, not the component entry with a component icon

## Changes

- Search.tsx: Modified the getResults filter to identify component entries that have docs children and skip them, preferring the docs entries instead.
- SearchResults.tsx: Added explicit rendering for docs type entries with the document icon, and added preloading support for docs entries on highlight and hover.
- Search.test.tsx: Added unit tests for the search behavior.

Fixes #34288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added faster hover and highlight previews for documentation entries, alongside existing component previews.

* **Bug Fixes**
  * Improved sidebar search filtering, deduplication, and result prioritization to consistently surface the most relevant component/docs combinations.

* **Tests**
  * Added automated coverage for search prioritization and retention across component-only-docs, component+docs, and mixed docs/story scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->