### PR TITLE
Core: Categorize __dirname/__filename ESM config errors with migration guidance

### DIFF
--- a/code/core/src/common/utils/load-main-config.test.ts
+++ b/code/core/src/common/utils/load-main-config.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MainFileESMOnlyError } from 'storybook/internal/server-errors';
+
+import * as moduleUtils from '../../shared/utils/module.ts';
+import { getInterpretedFile } from './interpret-files.ts';
+import { loadMainConfig } from './load-main-config.ts';
+import { validateConfigurationFiles } from './validate-configuration-files.ts';
+
+vi.mock('../../shared/utils/module.ts', { spy: true });
+vi.mock('./interpret-files.ts', { spy: true });
+vi.mock('./validate-configuration-files.ts', { spy: true });
+
+describe('loadMainConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validateConfigurationFiles).mockResolvedValue(undefined);
+    vi.mocked(getInterpretedFile).mockReturnValue('/project/.storybook/main.ts');
+  });
+
+  it('returns the evaluated config when the main file loads successfully', async () => {
+    const config = { stories: ['../src/**/*.stories.tsx'] };
+    vi.mocked(moduleUtils.importModule).mockResolvedValue(config);
+
+    await expect(loadMainConfig({ configDir: '.storybook' })).resolves.toEqual(config);
+  });
+
+  it('categorizes "__dirname is not defined" as a MainFileESMOnlyError with ESM migration guidance', async () => {
+    vi.mocked(moduleUtils.importModule).mockRejectedValue(
+      new ReferenceError('__dirname is not defined')
+    );
+
+    const promise = loadMainConfig({ configDir: '.storybook' });
+
+    await expect(promise).rejects.toBeInstanceOf(MainFileESMOnlyError);
+    await expect(promise).rejects.toThrowError(/__dirname/);
+    await expect(promise).rejects.toThrowError(/import\.meta\.url/);
+    await expect(promise).rejects.toThrowError(/main\.ts/);
+  });
+
+  it('categorizes "__filename is not defined" as a MainFileESMOnlyError', async () => {
+    vi.mocked(moduleUtils.importModule).mockRejectedValue(
+      new ReferenceError('__filename is not defined')
+    );
+
+    await expect(loadMainConfig({ configDir: '.storybook' })).rejects.toBeInstanceOf(
+      MainFileESMOnlyError
+    );
+  });
+});

--- a/code/core/src/common/utils/load-main-config.ts
+++ b/code/core/src/common/utils/load-main-config.ts
@@ -2,7 +2,7 @@ import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join, parse, relative, resolve } from 'node:path';
 
 import { logger } from 'storybook/internal/node-logger';
-import { MainFileEvaluationError } from 'storybook/internal/server-errors';
+import { MainFileESMOnlyError, MainFileEvaluationError } from 'storybook/internal/server-errors';
 import type { StorybookConfig } from 'storybook/internal/types';
 
 import { dedent } from 'ts-dedent';
@@ -61,6 +61,18 @@ export async function loadMainConfig({
         }
         return out;
       }
+    }
+
+    // CommonJS globals like `__dirname`/`__filename` are not available when the config is
+    // evaluated as ESM. Surface actionable migration guidance instead of a raw ReferenceError
+    // whose stack runs through Storybook internals and looks like an internal failure.
+    const esmGlobalMatch = e.message.match(/\b(__dirname|__filename)\b is not defined/);
+    if (e instanceof ReferenceError && esmGlobalMatch) {
+      throw new MainFileESMOnlyError({
+        location: relative(process.cwd(), mainPath),
+        missingGlobal: esmGlobalMatch[1],
+        error: e,
+      });
     }
 
     throw new MainFileEvaluationError({

--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -553,6 +553,27 @@ export class MainFileEvaluationError extends StorybookError {
   }
 }
 
+export class MainFileESMOnlyError extends StorybookError {
+  constructor(public data: { location: string; missingGlobal: string; error: Error }) {
+    super({
+      name: 'MainFileESMOnlyError',
+      category: Category.CORE_SERVER,
+      code: 17,
+      documentation: 'https://storybook.js.org/docs/configure/overview?ref=error#es-modules',
+      message: dedent`
+        Storybook couldn't evaluate your ${picocolors.yellow(data.location)} file because it references ${picocolors.yellow(data.missingGlobal)}, which is not available in ESM.
+
+        Storybook loads your config as an ES module, where the CommonJS globals \`__dirname\` and \`__filename\` do not exist.
+        Recreate them from \`import.meta.url\`, or otherwise rewrite the config to avoid CommonJS globals:
+
+        import { dirname } from 'node:path';
+        import { fileURLToPath } from 'node:url';
+
+        const __dirname = dirname(fileURLToPath(import.meta.url));`,
+    });
+  }
+}
+
 export class StatusTypeIdMismatchError extends StorybookError {
   constructor(
     public data: {


### PR DESCRIPTION
## What I did

When a `main` config file uses CommonJS globals (`__dirname` / `__filename`) but is evaluated as ESM, Storybook threw a raw `ReferenceError: __dirname is not defined` with no guidance (#35070).

This categorizes that error:
- A new `MainFileESMOnlyError` (`code/core/src/server-errors.ts`) that names the failing config file and the missing global, explains they don't exist in ESM, and shows the `import.meta.url` + `fileURLToPath` replacement — using the same ESM-migration doc URL as the existing `CommonJsConfigNotSupportedError`.
- `load-main-config.ts` catches `ReferenceError: (__dirname|__filename) is not defined` and throws the categorized error instead of falling through to the generic `MainFileEvaluationError`.

## Testing

New `load-main-config.test.ts` (3 tests): happy path, the `__dirname` ESM case, and `__filename` — red→green. `yarn nx run core:check` (typecheck) exit 0, lint clean, full `common/utils` suite (161 tests) passing.

Closes #35070


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when Storybook configuration files reference CommonJS globals in an ESM environment. Enhanced error messages now include specific details about missing globals and provide migration guidance for updating configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->