### PR TITLE
Agentic Review: Reload frozen preview iframes on hot update

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
@@ -22,9 +22,16 @@ import {
   MdxFileWithNoCsfReferencesError,
   NoStoryMatchError,
 } from 'storybook/internal/preview-errors';
-import type { StoryIndex } from 'storybook/internal/types';
-import type { Args, Globals, Renderer, StoryId, ViewMode } from 'storybook/internal/types';
-import type { ModuleImportFn, ProjectAnnotations } from 'storybook/internal/types';
+import type {
+  Args,
+  Globals,
+  ModuleImportFn,
+  ProjectAnnotations,
+  Renderer,
+  StoryId,
+  StoryIndex,
+  ViewMode,
+} from 'storybook/internal/types';
 
 import invariant from 'tiny-invariant';
 
@@ -32,7 +39,6 @@ import { Tag } from '../../../shared/constants/tags.ts';
 import { isMdxEntry } from '../../../shared/utils/story-index-filters.ts';
 import type { StorySpecifier } from '../store/StoryIndexStore.ts';
 import type { MaybePromise } from './Preview.tsx';
-import { setupStoryFreezer } from './setupStoryFreezer.ts';
 import { Preview } from './Preview.tsx';
 import type { Selection, SelectionStore } from './SelectionStore.ts';
 import type { View } from './View.ts';
@@ -40,6 +46,7 @@ import { CsfDocsRender } from './render/CsfDocsRender.ts';
 import { MdxDocsRender } from './render/MdxDocsRender.ts';
 import { PREPARE_ABORTED } from './render/Render.ts';
 import { StoryRender } from './render/StoryRender.ts';
+import { setupStoryFreezer } from './setupStoryFreezer.ts';
 
 const globalWindow = globalThis;
 

--- a/code/core/src/preview-api/modules/preview-web/setupStoryFreezer.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/setupStoryFreezer.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { STORY_RENDER_PHASE_CHANGED } from 'storybook/internal/core-events';
 import { global as globalRef } from '@storybook/global';
+import { STORY_HOT_UPDATED, STORY_RENDER_PHASE_CHANGED } from 'storybook/internal/core-events';
 
 import { setupStoryFreezer, shouldFreeze } from './setupStoryFreezer.ts';
 
@@ -76,6 +76,8 @@ describe('setupStoryFreezer', () => {
   let previousHref: string;
   let previousBody: string;
   let originalGlobals: Record<string, unknown>;
+  let originalReload: Location['reload'];
+  let reloadSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     previousHref = window.location.href;
@@ -83,6 +85,13 @@ describe('setupStoryFreezer', () => {
     originalGlobals = Object.fromEntries(
       SCHEDULING_GLOBALS.map((key) => [key, (window as unknown as Record<string, unknown>)[key]])
     );
+    originalReload = window.location.reload.bind(window.location);
+    reloadSpy = vi.fn();
+    Object.defineProperty(window.location, 'reload', {
+      configurable: true,
+      writable: true,
+      value: reloadSpy,
+    });
   });
 
   afterEach(() => {
@@ -95,6 +104,11 @@ describe('setupStoryFreezer', () => {
         writable: true,
         value: originalGlobals[key],
       });
+    });
+    Object.defineProperty(window.location, 'reload', {
+      configurable: true,
+      writable: true,
+      value: originalReload,
     });
     delete window.__freezeInlineClicked;
     delete window.__freezeScriptExecuted;
@@ -154,6 +168,28 @@ describe('setupStoryFreezer', () => {
 
     button.click();
     expect(interactionSpy).not.toHaveBeenCalled();
+  });
+
+  it('reloads the iframe on a hot update so it re-renders fresh and re-freezes', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/iframe.html?id=example--story&viewMode=story&freeze=finished'
+    );
+    const channel = createChannel();
+    expect(setupStoryFreezer(channel)).toBe(true);
+
+    channel.emit(STORY_HOT_UPDATED, undefined);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload on a hot update when freeze mode is disabled', () => {
+    window.history.replaceState({}, '', '/iframe.html?id=example--story&viewMode=story');
+    const channel = createChannel();
+    expect(setupStoryFreezer(channel)).toBe(false);
+
+    channel.emit(STORY_HOT_UPDATED, undefined);
+    expect(reloadSpy).not.toHaveBeenCalled();
   });
 
   describe('animation freezing', () => {

--- a/code/core/src/preview-api/modules/preview-web/setupStoryFreezer.ts
+++ b/code/core/src/preview-api/modules/preview-web/setupStoryFreezer.ts
@@ -1,5 +1,5 @@
 import type { Channel } from 'storybook/internal/channels';
-import { STORY_RENDER_PHASE_CHANGED } from 'storybook/internal/core-events';
+import { STORY_HOT_UPDATED, STORY_RENDER_PHASE_CHANGED } from 'storybook/internal/core-events';
 
 import { global } from '@storybook/global';
 
@@ -298,5 +298,15 @@ export const setupStoryFreezer = (channel: Pick<Channel, 'on'>) => {
       }
     }
   });
+
+  // The HMR connection stays live (we no longer block reloads or skip the builder's HMR handler),
+  // but applying a hot update in place would re-render into an already-frozen document, where
+  // scripts are stripped, timers and animations are paused, and interactions are blocked, so the
+  // updated story would never come alive. Instead, reload the whole iframe on any hot update so it
+  // boots fresh and re-freezes cleanly once the new render finishes.
+  channel.on(STORY_HOT_UPDATED, () => {
+    windowRef.location.reload();
+  });
+
   return true;
 };


### PR DESCRIPTION
## What I did

Frozen review previews (`freeze=finished`) keep their HMR connection live — we don't block `location.reload()` or skip the builder's HMR handler. But applying a hot update **in place** would re-render into an already-frozen document, where `setupStoryFreezer` has stripped scripts, paused timers/animations, and blocked interactions. The updated story would render into that dead document and never come alive, so HMR appeared broken on frozen thumbnails.

Now `setupStoryFreezer` also listens for `STORY_HOT_UPDATED` (emitted on the channel by both the Vite and Webpack builders) and, when the preview is actually frozen, reloads the whole iframe. It boots fresh and re-freezes cleanly once the new render finishes. The listener only registers when `shouldFreeze` is true, so normal previews keep their usual in-place HMR.

This builds on the freeze work that lives on `yann/agentic-review-mcp-integration` (not yet on `next`), which is why this PR targets that branch.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Check out this branch and run the internal Storybook UI: `cd code && yarn storybook:ui`
2. Open the review summary so the grid of frozen preview thumbnails renders (each thumbnail iframe uses `freeze=finished`).
3. Wait for a thumbnail to reach its finished/frozen state.
4. Edit the source of a story shown in a thumbnail (e.g. change some visible text) and save.
5. Verify the frozen thumbnail iframe fully reloads, re-renders with your change, and freezes again — rather than staying stale or rendering into a dead/half-frozen document.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hot update behavior when story freezing is enabled
* **Tests**
  * Enhanced test coverage for hot update scenarios with story freezing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->