### PR TITLE
Review: Track reviewed progress across the review flow

### DIFF
--- a/code/core/src/components/components/Card/Card.stories.tsx
+++ b/code/core/src/components/components/Card/Card.stories.tsx
@@ -33,6 +33,15 @@ export const SpinningAgentic = meta.story(() => (
   </Card>
 ));
 
+// Filled agentic card with a spinning outline (as used by ReviewWidget). The
+// `agentic` content background is translucent in dark mode, so this guards
+// against the spinning gradient bleeding through the content instead of the ring.
+export const SpinningAgenticFilled = meta.story(() => (
+  <Card outlineAnimation="spin" color="agentic">
+    <Contents>Spinning agentic filled</Contents>
+  </Card>
+));
+
 export const Agentic = meta.story(() => (
   <Card color="agentic">
     <Contents>Agentic</Contents>

--- a/code/core/src/components/components/Card/Card.tsx
+++ b/code/core/src/components/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps, type DOMAttributes, forwardRef } from 'react';
+import React, { forwardRef, type ComponentProps, type DOMAttributes } from 'react';
 
 import type { StorybookTheme } from 'storybook/theming';
 import { keyframes, styled } from 'storybook/theming';
@@ -26,6 +26,15 @@ const getBorderColor = (
 const getBackgroundColor = (theme: StorybookTheme, color?: ThemeColor): string =>
   resolveThemeColor(theme.bgColor, color) ?? theme.background.content;
 
+// Compose the (possibly translucent) themed background over an opaque base. Some
+// themed bgColors are intentionally translucent for tinting (e.g. `agentic` in
+// dark mode), which would otherwise let the animated outline behind the content
+// bleed through the whole card instead of just the 1px ring.
+const getOpaqueBackground = (theme: StorybookTheme, color?: ThemeColor): string => {
+  const bg = getBackgroundColor(theme, color);
+  return `linear-gradient(${bg}, ${bg}), ${theme.background.content}`;
+};
+
 const fadeInOut = keyframes({
   '0%': { opacity: 0 },
   '5%': { opacity: 1 },
@@ -52,7 +61,7 @@ const slide = keyframes({
 const CardContent = styled.div<{ color?: ThemeColor }>(({ color, theme }) => ({
   color: getColor(theme, color),
   borderRadius: theme.appBorderRadius,
-  backgroundColor: getBackgroundColor(theme, color),
+  background: getOpaqueBackground(theme, color),
   position: 'relative',
 }));
 
@@ -111,7 +120,12 @@ const CardOutline = styled.div<{
         outlineColor === 'negative'
           ? `conic-gradient(transparent 90deg, #FC521F 150deg, #FFAE00 210deg, transparent 270deg)`
           : outlineColor === 'agentic'
-            ? `conic-gradient(#e1d2ef 90deg, #b6a7ff 150deg, #d8aeff 210deg, #e1d2ef 270deg)`
+            ? // Agentic is intentionally subtle. Pale lavender stays low-contrast on a
+              // light background, but the same colors read as a bright sweep on dark, so
+              // the dark arc is dimmed with low-alpha hues to keep it a faint glow.
+              theme.base === 'dark'
+              ? `conic-gradient(transparent 90deg, rgba(114,58,166,0.65) 150deg, rgba(157,98,214,0.6) 210deg, transparent 270deg)`
+              : `conic-gradient(transparent 90deg, #b6a7ff 150deg, #d8aeff 210deg, transparent 270deg)`
             : `conic-gradient(transparent 90deg, #029CFD 150deg, #37D5D3 210deg, transparent 270deg)`,
     }),
   },

--- a/code/core/src/manager/components/review/ReviewProvider.tsx
+++ b/code/core/src/manager/components/review/ReviewProvider.tsx
@@ -44,6 +44,13 @@ import {
   resolveActiveNavEntry,
   resolveNavIndex,
 } from './review-navigation.ts';
+import {
+  clearReviewProgress,
+  countReviewed,
+  readReviewProgress,
+  reviewEntryKey,
+  writeReviewProgress,
+} from './review-progress.ts';
 import type { ReviewState } from './review-state.ts';
 import { reviewStore, type ReviewStoreState } from './review-store.ts';
 import { clearReviewStatuses, collectReviewStoryIds, syncReviewStatuses } from './review-status.ts';
@@ -63,9 +70,23 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [pendingReview, setPendingReview] = useState<ReviewState | null>(null);
   const [isStale, setIsStale] = useState(false);
   const [isInReviewMode, setIsInReviewMode] = useState(() => isReviewModeActive());
+  const [reviewedStoryIds, setReviewedStoryIds] = useState<Set<string>>(() => new Set());
+  const [justCompletedEntryKey, setJustCompletedEntryKey] = useState<string | null>(null);
   const previousReviewStoryIdsRef = useRef<Set<string>>(new Set());
   const displayedReviewRef = useRef<ReviewState | null>(null);
   displayedReviewRef.current = state;
+
+  // Reset reviewed-progress synchronously when the displayed review changes
+  // identity (new payload, accepted update, or dismissal). Keying off the
+  // displayed `createdAt` means deferred pushes — which only set pendingReview —
+  // never reset progress; only first display or accepting an update does.
+  const progressKeyRef = useRef<string | undefined>(undefined);
+  const progressKey = state ? `created:${state.createdAt ?? 'none'}` : undefined;
+  if (progressKey !== progressKeyRef.current) {
+    progressKeyRef.current = progressKey;
+    setReviewedStoryIds(state ? readReviewProgress(state.createdAt) : new Set());
+    setJustCompletedEntryKey(null);
+  }
 
   const api = useStorybookApi();
   const navigate = useNavigate();
@@ -104,6 +125,7 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
     },
     [EVENTS.REVIEW_DISMISSED]: (returnSearch?: string | null) => {
       clearReviewStatuses(reviewStatusStore);
+      clearReviewProgress(displayedReviewRef.current?.createdAt);
       previousReviewStoryIdsRef.current = new Set();
       sessionStore.remove(AUTO_ENTERED_SESSION_KEY);
       setState(null);
@@ -225,6 +247,48 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
       : null;
   const activeIndex = activeEntry ? resolveNavIndex(flattenedEntries, activeEntry) : -1;
 
+  const reviewStoryIds = useMemo(
+    () => (state ? collectReviewStoryIds(state) : new Set<string>()),
+    [state]
+  );
+  const reviewedCount = useMemo(
+    () => countReviewed(reviewedStoryIds, reviewStoryIds),
+    [reviewedStoryIds, reviewStoryIds]
+  );
+  const totalReviewCount = reviewStoryIds.size;
+
+  // Mark-on-arrival: the active review story counts as reviewed the moment its
+  // screen resolves (covers Next/Prev, picker, thumbnail, shortcut, reload). The
+  // arrival that flips the set from incomplete to complete records a one-shot
+  // "just completed" key so the toolbar can offer Done while staying on it; the
+  // key clears as soon as the active entry changes (including back to summary).
+  const activeStoryId = activeEntry?.storyId;
+  const activeCollectionIndex = activeEntry?.collectionIndex;
+  useEffect(() => {
+    if (!state || activeStoryId === undefined || activeCollectionIndex === undefined) {
+      setJustCompletedEntryKey(null);
+      return;
+    }
+    const key = reviewEntryKey({ storyId: activeStoryId, collectionIndex: activeCollectionIndex });
+    if (reviewedStoryIds.has(activeStoryId)) {
+      setJustCompletedEntryKey((previous) => (previous === key ? previous : null));
+      return;
+    }
+    const next = new Set(reviewedStoryIds).add(activeStoryId);
+    const before = countReviewed(reviewedStoryIds, reviewStoryIds);
+    const after = countReviewed(next, reviewStoryIds);
+    setReviewedStoryIds(next);
+    writeReviewProgress(state.createdAt, next);
+    setJustCompletedEntryKey(before < totalReviewCount && after === totalReviewCount ? key : null);
+  }, [
+    state,
+    activeStoryId,
+    activeCollectionIndex,
+    reviewedStoryIds,
+    reviewStoryIds,
+    totalReviewCount,
+  ]);
+
   const isSummaryVisible = isReviewSummaryPath(path);
 
   // Re-sync the persisted review-mode flag on every navigation. Enter/exit
@@ -277,6 +341,10 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
       isSummaryVisible,
       getStoryPreviewHref,
       dismissReview,
+      reviewedStoryIds,
+      reviewedCount,
+      totalReviewCount,
+      justCompletedEntryKey,
     }),
     [
       state,
@@ -292,6 +360,10 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
       isSummaryVisible,
       getStoryPreviewHref,
       dismissReview,
+      reviewedStoryIds,
+      reviewedCount,
+      totalReviewCount,
+      justCompletedEntryKey,
     ]
   );
 

--- a/code/core/src/manager/components/review/ReviewSummaryPortal.tsx
+++ b/code/core/src/manager/components/review/ReviewSummaryPortal.tsx
@@ -99,6 +99,7 @@ export const ReviewSummaryPortal: FC = () => {
     dismissReview,
     isInReviewMode,
     isSummaryVisible,
+    reviewedStoryIds,
   } = useReview();
   const overlayShown = useSummaryOverlayShown();
   const [portalHost, setPortalHost] = useState<HTMLDivElement | null>(null);
@@ -145,6 +146,7 @@ export const ReviewSummaryPortal: FC = () => {
             previewsPaused={!overlayShown}
             onDismiss={dismissReview}
             returnSearch={sessionStore.read(PRE_REVIEW_RETURN_KEY)}
+            reviewedStoryIds={reviewedStoryIds}
           />,
           portalHost
         )}

--- a/code/core/src/manager/components/review/ReviewToolbarHeader.stories.tsx
+++ b/code/core/src/manager/components/review/ReviewToolbarHeader.stories.tsx
@@ -2,18 +2,18 @@ import type { ReactNode } from 'react';
 
 import { expect, fn, within } from 'storybook/test';
 
+import { MemoryRouter } from 'storybook/internal/router';
 import {
   ManagerContext,
+  internal_fullStatusStore,
   type API,
   type State,
-  internal_fullStatusStore,
 } from 'storybook/manager-api';
-import { MemoryRouter } from 'storybook/internal/router';
 
 import preview from '../../../../../.storybook/preview.tsx';
-import { ADDON_ID, EVENTS } from './constants.ts';
 import { ReviewProvider } from './ReviewProvider.tsx';
 import { ReviewToolbarHeader } from './ReviewToolbarHeader.tsx';
+import { ADDON_ID, EVENTS } from './constants.ts';
 import { buildReviewChangesSummaryHref, buildReviewStoryHref } from './review-navigation.ts';
 import { writeReviewProgress } from './review-progress.ts';
 import type { ReviewState } from './review-state.ts';
@@ -150,7 +150,47 @@ const ReviewShortcutsHarness = ({ children }: { children: ReactNode }) => {
   return children;
 };
 
-export const OnReviewedStory = meta.story({
+// On the first story, flagged as newly added: the "New" badge shows and, with
+// later stories still unreviewed, the forward control is a solid "Next".
+export const FirstStory = meta.story({
+  parameters: {
+    routerInitialEntries: ['/?path=/story/manager-settings-checklist--default&collection=0'],
+    managerState: {
+      path: '/story/manager-settings-checklist--default',
+      viewMode: 'story',
+      customQueryParams: { collection: '0' },
+    },
+  },
+  // A story is "newly added" when change detection reports it as new.
+  beforeEach: () => {
+    internal_fullStatusStore.set([
+      {
+        storyId: 'manager-settings-checklist--default',
+        typeId: 'storybook/change-detection',
+        value: 'status-value:new',
+        title: 'Change Detection',
+        description: '',
+      },
+    ]);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    applyReviewState();
+
+    await expect(await canvas.findByText('New')).toBeInTheDocument();
+    await expect(await canvas.findByRole('link', { name: 'Next' })).toHaveAttribute(
+      'href',
+      buildReviewStoryHref({
+        collectionIndex: 0,
+        storyId: 'manager-settings-guidepage--default',
+      })
+    );
+  },
+});
+
+// On a middle story: the baseline toolbar chrome — counter, story-list picker,
+// keyboard shortcut, heading and back-to-summary link, no "New" badge.
+export const MiddleStory = meta.story({
   parameters: {
     routerInitialEntries: ['/?path=/story/manager-settings-guidepage--default&collection=0'],
     managerState: {
@@ -181,7 +221,9 @@ export const OnReviewedStory = meta.story({
   },
 });
 
-export const Progress = meta.story({
+// On the last story: the positional progress bar is full and the forward control
+// becomes "Done" (back to summary) instead of advancing.
+export const LastStory = meta.story({
   parameters: {
     routerInitialEntries: ['/?path=/story/manager-settings-aboutscreen--default&collection=0'],
     managerState: {
@@ -198,60 +240,6 @@ export const Progress = meta.story({
     await expect(counter).toHaveTextContent('3/3');
     const fill = await canvas.findByTestId<HTMLElement>('review-progress-fill');
     await expect(Math.round(parseFloat(fill.style.width))).toBe(100);
-  },
-});
-
-export const NewStory = meta.story({
-  parameters: {
-    routerInitialEntries: ['/?path=/story/manager-settings-checklist--default&collection=0'],
-    managerState: {
-      path: '/story/manager-settings-checklist--default',
-      viewMode: 'story',
-      customQueryParams: { collection: '0' },
-    },
-  },
-  // A story is "newly added" when change detection reports it as new.
-  beforeEach: () => {
-    internal_fullStatusStore.set([
-      {
-        storyId: 'manager-settings-checklist--default',
-        typeId: 'storybook/change-detection',
-        value: 'status-value:new',
-        title: 'Change Detection',
-        description: '',
-      },
-    ]);
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    applyReviewState();
-
-    await expect(await canvas.findByText('New')).toBeInTheDocument();
-    // First story, others still unreviewed: forward control is a solid "Next".
-    await expect(await canvas.findByRole('link', { name: 'Next' })).toHaveAttribute(
-      'href',
-      buildReviewStoryHref({
-        collectionIndex: 0,
-        storyId: 'manager-settings-guidepage--default',
-      })
-    );
-  },
-});
-
-// Landing on the last story in the set offers "Done" (back to summary) instead
-// of a forward control, regardless of whether earlier stories were reviewed.
-export const LastStoryDone = meta.story({
-  parameters: {
-    routerInitialEntries: ['/?path=/story/manager-settings-aboutscreen--default&collection=0'],
-    managerState: {
-      path: '/story/manager-settings-aboutscreen--default',
-      viewMode: 'story',
-      customQueryParams: { collection: '0' },
-    },
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    applyReviewState();
 
     const done = await canvas.findByRole('link', { name: 'Done' });
     await expect(done).toHaveAttribute('href', buildReviewChangesSummaryHref());
@@ -259,9 +247,9 @@ export const LastStoryDone = meta.story({
   },
 });
 
-// Every story reviewed but standing on a non-last story: the forward control
-// reverts to the plain ghost chevron ("Next story"), not a solid Next/Done.
-export const AllReviewedChevron = meta.story({
+// Every story already reviewed but standing on a non-last story: the forward
+// control reverts to the plain ghost chevron ("Next story"), not a solid one.
+export const AllReviewed = meta.story({
   parameters: {
     routerInitialEntries: ['/?path=/story/manager-settings-guidepage--default&collection=0'],
     managerState: {

--- a/code/core/src/manager/components/review/ReviewToolbarHeader.stories.tsx
+++ b/code/core/src/manager/components/review/ReviewToolbarHeader.stories.tsx
@@ -15,6 +15,7 @@ import { ADDON_ID, EVENTS } from './constants.ts';
 import { ReviewProvider } from './ReviewProvider.tsx';
 import { ReviewToolbarHeader } from './ReviewToolbarHeader.tsx';
 import { buildReviewChangesSummaryHref, buildReviewStoryHref } from './review-navigation.ts';
+import { writeReviewProgress } from './review-progress.ts';
 import type { ReviewState } from './review-state.ts';
 import { useReviewShortcuts } from './useReviewShortcuts.ts';
 
@@ -255,5 +256,32 @@ export const LastStoryDone = meta.story({
     const done = await canvas.findByRole('link', { name: 'Done' });
     await expect(done).toHaveAttribute('href', buildReviewChangesSummaryHref());
     await expect(canvas.queryByRole('link', { name: 'Next' })).not.toBeInTheDocument();
+  },
+});
+
+// Every story reviewed but standing on a non-last story: the forward control
+// reverts to the plain ghost chevron ("Next story"), not a solid Next/Done.
+export const AllReviewedChevron = meta.story({
+  parameters: {
+    routerInitialEntries: ['/?path=/story/manager-settings-guidepage--default&collection=0'],
+    managerState: {
+      path: '/story/manager-settings-guidepage--default',
+      viewMode: 'story',
+      customQueryParams: { collection: '0' },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Seed progress for this review so all stories read as already reviewed.
+    writeReviewProgress(reviewState.createdAt, new Set(reviewState.collections[0].storyIds));
+    applyReviewState();
+
+    const next = await canvas.findByRole('link', { name: 'Next story' });
+    await expect(next).toHaveAttribute(
+      'href',
+      buildReviewStoryHref({ collectionIndex: 0, storyId: 'manager-settings-aboutscreen--default' })
+    );
+    await expect(canvas.queryByRole('link', { name: 'Next' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('link', { name: 'Done' })).not.toBeInTheDocument();
   },
 });

--- a/code/core/src/manager/components/review/ReviewToolbarHeader.stories.tsx
+++ b/code/core/src/manager/components/review/ReviewToolbarHeader.stories.tsx
@@ -226,12 +226,34 @@ export const NewStory = meta.story({
     applyReviewState();
 
     await expect(await canvas.findByText('New')).toBeInTheDocument();
-    await expect(await canvas.findByRole('link', { name: 'Next story' })).toHaveAttribute(
+    // First story, others still unreviewed: forward control is a solid "Next".
+    await expect(await canvas.findByRole('link', { name: 'Next' })).toHaveAttribute(
       'href',
       buildReviewStoryHref({
         collectionIndex: 0,
         storyId: 'manager-settings-guidepage--default',
       })
     );
+  },
+});
+
+// Landing on the last story in the set offers "Done" (back to summary) instead
+// of a forward control, regardless of whether earlier stories were reviewed.
+export const LastStoryDone = meta.story({
+  parameters: {
+    routerInitialEntries: ['/?path=/story/manager-settings-aboutscreen--default&collection=0'],
+    managerState: {
+      path: '/story/manager-settings-aboutscreen--default',
+      viewMode: 'story',
+      customQueryParams: { collection: '0' },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    applyReviewState();
+
+    const done = await canvas.findByRole('link', { name: 'Done' });
+    await expect(done).toHaveAttribute('href', buildReviewChangesSummaryHref());
+    await expect(canvas.queryByRole('link', { name: 'Next' })).not.toBeInTheDocument();
   },
 });

--- a/code/core/src/manager/components/review/ReviewToolbarHeader.tsx
+++ b/code/core/src/manager/components/review/ReviewToolbarHeader.tsx
@@ -13,6 +13,7 @@ import {
   buildReviewStoryHref,
   getAdjacentReviewEntries,
 } from './review-navigation.ts';
+import { countReviewed, reviewEntryKey } from './review-progress.ts';
 import { useReview } from './review-store.ts';
 
 const Root = styled.div(({ theme }) => ({
@@ -85,6 +86,8 @@ export const ReviewToolbarHeader: FC = () => {
     newlyAddedStoryIds,
     activeEntry,
     activeIndex,
+    reviewedStoryIds,
+    justCompletedEntryKey,
   } = useReview();
 
   if (!state || !activeEntry || activeIndex < 0) {
@@ -100,6 +103,18 @@ export const ReviewToolbarHeader: FC = () => {
   const progress = totalStories > 1 ? activeIndex / (totalStories - 1) : 0;
   const currentStoryInfo = storyInfo[activeEntry.storyId];
   const isNewlyAdded = newlyAddedStoryIds.has(activeEntry.storyId);
+
+  // Forward control state machine (first match wins). The current story always
+  // counts as reviewed: it is marked on arrival, but this guards the render frame
+  // before that effect commits.
+  const uniqueStoryIds = new Set(flattenedEntries.map((entry) => entry.storyId));
+  const reviewedWithCurrent = reviewedStoryIds.has(activeEntry.storyId)
+    ? reviewedStoryIds
+    : new Set(reviewedStoryIds).add(activeEntry.storyId);
+  const allReviewed = countReviewed(reviewedWithCurrent, uniqueStoryIds) >= uniqueStoryIds.size;
+  const isLastEntry = activeIndex === flattenedEntries.length - 1;
+  const justCompleted = justCompletedEntryKey === reviewEntryKey(activeEntry);
+  const showDone = isLastEntry || justCompleted;
 
   const metadataSubtitle =
     currentStoryInfo?.title && currentStoryInfo.name ? (
@@ -192,11 +207,21 @@ export const ReviewToolbarHeader: FC = () => {
                   <ChevronSmallLeftIcon />
                 </a>
               </Button>
-              <Button variant="ghost" size="small" padding="small" ariaLabel="Next story" asChild>
-                <a href={buildReviewStoryHref(nextEntry)}>
-                  <ChevronSmallRightIcon />
-                </a>
-              </Button>
+              {showDone ? (
+                <Button variant="solid" size="small" padding="small" ariaLabel={false} asChild>
+                  <a href={buildReviewChangesSummaryHref()}>Done</a>
+                </Button>
+              ) : !allReviewed ? (
+                <Button variant="solid" size="small" padding="small" ariaLabel={false} asChild>
+                  <a href={buildReviewStoryHref(nextEntry)}>Next</a>
+                </Button>
+              ) : (
+                <Button variant="ghost" size="small" padding="small" ariaLabel="Next story" asChild>
+                  <a href={buildReviewStoryHref(nextEntry)}>
+                    <ChevronSmallRightIcon />
+                  </a>
+                </Button>
+              )}
             </>
           }
         />

--- a/code/core/src/manager/components/review/constants.ts
+++ b/code/core/src/manager/components/review/constants.ts
@@ -17,3 +17,9 @@ export const PRE_REVIEW_RETURN_KEY = `${REVIEW_NAMESPACE}/pre-review-return`;
 // sessionStorage marker deduplicating the one-time auto-enter on first landing
 // on the review summary. Reset on dismiss and when a new review payload arrives.
 export const AUTO_ENTERED_SESSION_KEY = `${REVIEW_NAMESPACE}/auto-entered`;
+
+// sessionStorage key prefix for per-review reviewed-progress (the set of visited
+// story ids). Suffixed with the review's server-stamped `createdAt` so each
+// review tracks its own progress and a new review starts fresh, while reloads of
+// the same review keep it. Cleared on full dismiss.
+export const REVIEW_PROGRESS_KEY_PREFIX = `${REVIEW_NAMESPACE}/progress`;

--- a/code/core/src/manager/components/review/review-progress.test.ts
+++ b/code/core/src/manager/components/review/review-progress.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { ReviewNavEntry } from './review-navigation.ts';
+import {
+  clearReviewProgress,
+  countReviewed,
+  findFirstUnreviewedEntry,
+  readReviewProgress,
+  reviewEntryKey,
+  writeReviewProgress,
+} from './review-progress.ts';
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe('persistence', () => {
+  it('round-trips reviewed ids keyed by createdAt', () => {
+    writeReviewProgress(123, new Set(['a', 'b']));
+    expect(readReviewProgress(123)).toEqual(new Set(['a', 'b']));
+    // A different review (createdAt) starts empty.
+    expect(readReviewProgress(456)).toEqual(new Set());
+  });
+
+  it('clears only the targeted review', () => {
+    writeReviewProgress(123, new Set(['a']));
+    writeReviewProgress(456, new Set(['b']));
+    clearReviewProgress(123);
+    expect(readReviewProgress(123)).toEqual(new Set());
+    expect(readReviewProgress(456)).toEqual(new Set(['b']));
+  });
+
+  it('does not persist reviews without a createdAt', () => {
+    writeReviewProgress(undefined, new Set(['a']));
+    expect(readReviewProgress(undefined)).toEqual(new Set());
+  });
+
+  it('returns an empty set for corrupt values', () => {
+    sessionStorage.setItem('storybook/review/progress/123', '{not json');
+    expect(readReviewProgress(123)).toEqual(new Set());
+  });
+});
+
+describe('helpers', () => {
+  const entries: ReviewNavEntry[] = [
+    { storyId: 'a', collectionIndex: 0 },
+    { storyId: 'b', collectionIndex: 0 },
+    { storyId: 'a', collectionIndex: 1 },
+  ];
+
+  it('counts only reviewed stories in the review set', () => {
+    expect(countReviewed(new Set(['a', 'x']), new Set(['a', 'b']))).toBe(1);
+  });
+
+  it('finds the first unreviewed entry in collection order', () => {
+    expect(findFirstUnreviewedEntry(entries, new Set(['a']))).toEqual({
+      storyId: 'b',
+      collectionIndex: 0,
+    });
+    expect(findFirstUnreviewedEntry(entries, new Set(['a', 'b']))).toBeNull();
+  });
+
+  it('keys entries by occurrence, not just story id', () => {
+    expect(reviewEntryKey(entries[0])).toBe('0:a');
+    expect(reviewEntryKey(entries[2])).toBe('1:a');
+  });
+});

--- a/code/core/src/manager/components/review/review-progress.ts
+++ b/code/core/src/manager/components/review/review-progress.ts
@@ -1,0 +1,74 @@
+// Reviewed-progress tracking: which stories the user has visited within the
+// active review. A story counts as reviewed the moment its review story screen
+// becomes active (mark-on-arrival, see ReviewProvider). Progress is per unique
+// storyId and persisted in sessionStorage keyed by the review's `createdAt`, so
+// it survives reload but resets when a new review is displayed or accepted.
+import { REVIEW_PROGRESS_KEY_PREFIX } from './constants.ts';
+import type { ReviewNavEntry } from './review-navigation.ts';
+import { sessionStore } from './session-store.ts';
+
+const progressKey = (createdAt: number): string => `${REVIEW_PROGRESS_KEY_PREFIX}/${createdAt}`;
+
+/**
+ * Read persisted reviewed story ids for a review. Reviews without a `createdAt`
+ * cannot be keyed, so they start empty and live in memory for the session.
+ */
+export const readReviewProgress = (createdAt: number | undefined): Set<string> => {
+  if (createdAt === undefined) {
+    return new Set();
+  }
+  const raw = sessionStore.read(progressKey(createdAt));
+  if (!raw) {
+    return new Set();
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((id): id is string => typeof id === 'string'));
+    }
+  } catch {
+    // Corrupt value — start fresh.
+  }
+  return new Set();
+};
+
+export const writeReviewProgress = (
+  createdAt: number | undefined,
+  reviewedStoryIds: Set<string>
+): void => {
+  if (createdAt === undefined) {
+    return;
+  }
+  sessionStore.write(progressKey(createdAt), JSON.stringify([...reviewedStoryIds]));
+};
+
+export const clearReviewProgress = (createdAt: number | undefined): void => {
+  if (createdAt === undefined) {
+    return;
+  }
+  sessionStore.remove(progressKey(createdAt));
+};
+
+/** Count reviewed stories that belong to the current review (intersection). */
+export const countReviewed = (
+  reviewedStoryIds: Set<string>,
+  reviewStoryIds: Set<string>
+): number => {
+  let count = 0;
+  for (const storyId of reviewStoryIds) {
+    if (reviewedStoryIds.has(storyId)) {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+/** First flattened slot whose story has not been reviewed, in collection order. */
+export const findFirstUnreviewedEntry = (
+  entries: readonly ReviewNavEntry[],
+  reviewedStoryIds: Set<string>
+): ReviewNavEntry | null => entries.find((entry) => !reviewedStoryIds.has(entry.storyId)) ?? null;
+
+/** Stable key identifying a flattened nav slot (story occurrence). */
+export const reviewEntryKey = (entry: ReviewNavEntry): string =>
+  `${entry.collectionIndex}:${entry.storyId}`;

--- a/code/core/src/manager/components/review/review-store.ts
+++ b/code/core/src/manager/components/review/review-store.ts
@@ -18,6 +18,14 @@ export interface ReviewStoreState {
   isSummaryVisible: boolean;
   getStoryPreviewHref: (storyId: string) => string;
   dismissReview: () => void;
+  /** Stories visited (reviewed) in the active review, by unique storyId. */
+  reviewedStoryIds: Set<string>;
+  /** Reviewed stories that belong to the active review. */
+  reviewedCount: number;
+  /** Total unique stories in the active review. */
+  totalReviewCount: number;
+  /** Entry key of the arrival that just completed the set (one-shot), else null. */
+  justCompletedEntryKey: string | null;
 }
 
 const emptyStore: ReviewStoreState = {
@@ -34,6 +42,10 @@ const emptyStore: ReviewStoreState = {
   isSummaryVisible: false,
   getStoryPreviewHref: () => '',
   dismissReview: () => {},
+  reviewedStoryIds: new Set(),
+  reviewedCount: 0,
+  totalReviewCount: 0,
+  justCompletedEntryKey: null,
 };
 
 let currentStore: ReviewStoreState = emptyStore;

--- a/code/core/src/manager/components/review/screens/SummaryScreen.stories.tsx
+++ b/code/core/src/manager/components/review/screens/SummaryScreen.stories.tsx
@@ -5,6 +5,7 @@ import { expect, within } from 'storybook/test';
 import { IconSymbols } from '../../sidebar/IconSymbols.tsx';
 import preview from '../../../../../../.storybook/preview.tsx';
 import type { StoryInfo } from '../components/CollectionGrid.tsx';
+import { buildReviewStoryHref } from '../review-navigation.ts';
 import type { ReviewState } from '../review-state.ts';
 import { SummaryScreen } from './SummaryScreen.tsx';
 
@@ -555,6 +556,46 @@ export const LargeCollectionOverflow = meta.story({
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('Large collection overflow')).toBeInTheDocument();
     await expect(await canvas.findByRole('button', { name: /Review all 40/i })).toBeInTheDocument();
+  },
+});
+
+// No story reviewed yet: the progress CTA reads "Start review" and links to the
+// first story in collection order.
+export const StartReview = meta.story({
+  args: { state: minimal },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const cta = await canvas.findByRole('link', { name: 'Start review' });
+    await expect(cta).toHaveAttribute(
+      'href',
+      buildReviewStoryHref({ collectionIndex: 0, storyId: 'button-component--variants' })
+    );
+  },
+});
+
+// Some but not all reviewed: the CTA reads "Continue review" and links to the
+// first unreviewed story.
+export const ContinueReview = meta.story({
+  args: { state: minimal, reviewedStoryIds: new Set(['button-component--variants']) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const cta = await canvas.findByRole('link', { name: 'Continue review' });
+    await expect(cta).toHaveAttribute(
+      'href',
+      buildReviewStoryHref({ collectionIndex: 0, storyId: 'button-component--base' })
+    );
+  },
+});
+
+// All reviewed: the CTA reads "Close review" and exits review mode (back link).
+export const CloseReview = meta.story({
+  args: {
+    state: minimal,
+    reviewedStoryIds: new Set(['button-component--variants', 'button-component--base']),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('link', { name: 'Close review' })).toBeInTheDocument();
   },
 });
 

--- a/code/core/src/manager/components/review/screens/SummaryScreen.tsx
+++ b/code/core/src/manager/components/review/screens/SummaryScreen.tsx
@@ -27,9 +27,11 @@ import { AttentionBanner } from '../components/AttentionBanner.tsx';
 import { ReviewHeader } from '../components/ReviewHeader.tsx';
 import {
   REVIEW_SUMMARY_BACK_ATTR,
+  buildFlattenedNavEntries,
   buildReviewStoryHref,
   buildSummaryBackHref,
 } from '../review-navigation.ts';
+import { countReviewed, findFirstUnreviewedEntry } from '../review-progress.ts';
 import type { ReviewState } from '../review-state.ts';
 
 const MarkdownWrapper = styled(DocumentWrapper)(({ theme }) => ({
@@ -206,6 +208,8 @@ export interface SummaryScreenProps {
   onDismiss: () => void;
   /** Pre-review canvas search, or root when none is recorded yet. */
   returnSearch?: string | null;
+  /** Stories already visited in this review, by unique storyId. */
+  reviewedStoryIds?: Set<string>;
 }
 
 export const SummaryScreen: FC<SummaryScreenProps> = ({
@@ -218,6 +222,7 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
   previewsPaused = false,
   onDismiss,
   returnSearch = null,
+  reviewedStoryIds,
 }) => {
   const [expandedCollections, setExpandedCollections] = useState<Set<number>>(() => new Set());
   const [showAllCollections, setShowAllCollections] = useState<Set<number>>(() => new Set());
@@ -297,6 +302,23 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
   const storyCount = new Set(state.collections.flatMap((collection) => collection.storyIds)).size;
   const createdAgo = state.createdAt ? formatCreatedAgo(state.createdAt, nowMs) : null;
 
+  // Progress CTA: walk the full set in collection order (ignoring the "new"
+  // filter) to the first unreviewed story, or offer to close once all are done.
+  const reviewed = reviewedStoryIds ?? new Set<string>();
+  const reviewedCount = countReviewed(
+    reviewed,
+    new Set(state.collections.flatMap((collection) => collection.storyIds))
+  );
+  const allReviewed = storyCount > 0 && reviewedCount >= storyCount;
+  const firstUnreviewed = allReviewed
+    ? null
+    : findFirstUnreviewedEntry(buildFlattenedNavEntries(state), reviewed);
+  const reviewCtaLabel = allReviewed
+    ? 'Close review'
+    : reviewedCount > 0
+      ? 'Continue review'
+      : 'Start review';
+
   const toggleCollection = (index: number) => {
     setExpandedCollections((previous) => {
       const next = new Set(previous);
@@ -345,19 +367,37 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
           </>
         }
         actions={
-          newStoryCount > 0 ? (
-            <Button
-              variant="ghost"
-              size="small"
-              padding="small"
-              ariaLabel={false}
-              tooltip="Toggle filtering of new stories"
-              active={showNewOnly}
-              onClick={() => setShowNewOnly((v) => !v)}
-            >
-              {newStoryCount} new
-            </Button>
-          ) : null
+          <>
+            {newStoryCount > 0 ? (
+              <Button
+                variant="ghost"
+                size="small"
+                padding="small"
+                ariaLabel={false}
+                tooltip="Toggle filtering of new stories"
+                active={showNewOnly}
+                onClick={() => setShowNewOnly((v) => !v)}
+              >
+                {newStoryCount} new
+              </Button>
+            ) : null}
+            {storyCount > 0 ? (
+              allReviewed ? (
+                <Button variant="solid" size="small" padding="small" ariaLabel={false} asChild>
+                  <a
+                    href={buildSummaryBackHref(returnSearch)}
+                    {...{ [REVIEW_SUMMARY_BACK_ATTR]: '' }}
+                  >
+                    {reviewCtaLabel}
+                  </a>
+                </Button>
+              ) : firstUnreviewed ? (
+                <Button variant="solid" size="small" padding="small" ariaLabel={false} asChild>
+                  <a href={buildReviewStoryHref(firstUnreviewed)}>{reviewCtaLabel}</a>
+                </Button>
+              ) : null
+            ) : null}
+          </>
         }
       />
 

--- a/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
@@ -7,7 +7,15 @@ import { REVIEW_STATUS_TYPE_ID } from 'storybook/internal/types';
 import { ManagerContext, internal_fullStatusStore } from 'storybook/manager-api';
 import { expect, fn, userEvent } from 'storybook/test';
 
+import { reviewStore } from '../review/review-store.ts';
 import { ReviewWidget } from './ReviewWidget.tsx';
+
+// The widget reads reviewed progress from the shared review store singleton.
+// Stories mount the widget without a ReviewProvider, so seed it directly and
+// reset between stories to avoid leaking the count across runs.
+const setReviewedCount = (reviewedCount: number) => {
+  reviewStore.setState({ ...reviewStore.getState(), reviewedCount });
+};
 
 const REVIEW_ADDON_ID = 'storybook/review';
 const DISPLAY_REVIEW = `${REVIEW_ADDON_ID}/display-review`;
@@ -152,12 +160,49 @@ export const Default: Story = {
   },
   beforeEach: () => {
     eventListeners.clear();
+    setReviewedCount(0);
     return setReviewingStatuses(storyIds);
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText('Quick review')).toBeVisible();
     await expect(canvas.getByText('Review 12 stories')).toBeVisible();
-    await expect(canvas.findByText('Button style changes on Shop screen')).resolves.toBeVisible();
+    await expect(canvas.getByText('12 left to review')).toBeVisible();
+  },
+};
+
+export const PartialProgress: Story = {
+  parameters: {
+    contextOptions: {
+      storyIds,
+      reviewTitle: 'Button style changes on Shop screen',
+    },
+  },
+  beforeEach: () => {
+    eventListeners.clear();
+    setReviewedCount(5);
+    return setReviewingStatuses(storyIds);
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Review 12 stories')).toBeVisible();
+    await expect(canvas.getByText('7 left to review')).toBeVisible();
+  },
+};
+
+export const Complete: Story = {
+  parameters: {
+    contextOptions: {
+      storyIds,
+      reviewTitle: 'Button style changes on Shop screen',
+    },
+  },
+  beforeEach: () => {
+    eventListeners.clear();
+    setReviewedCount(storyIds.length);
+    return setReviewingStatuses(storyIds);
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Review 12 stories')).toBeVisible();
+    await expect(canvas.getByText('Review complete')).toBeVisible();
   },
 };
 
@@ -170,11 +215,12 @@ export const SingleStory: Story = {
   },
   beforeEach: () => {
     eventListeners.clear();
+    setReviewedCount(0);
     return setReviewingStatuses(['s1']);
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText('Review 1 story')).toBeVisible();
-    await expect(canvas.findByText('Primary button visual refresh')).resolves.toBeVisible();
+    await expect(canvas.getByText('1 left to review')).toBeVisible();
   },
 };
 
@@ -209,6 +255,7 @@ export const OpenReview: Story = {
   beforeEach: () => {
     eventListeners.clear();
     sessionStorage.clear();
+    setReviewedCount(0);
     navigateMock.mockClear();
     toggleNavMock.mockClear();
     togglePanelMock.mockClear();
@@ -248,6 +295,7 @@ export const DismissReview: Story = {
   beforeEach: () => {
     eventListeners.clear();
     emitMock.mockClear();
+    setReviewedCount(0);
     return setReviewingStatuses(['s1']);
   },
   play: async ({ canvas }) => {

--- a/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
@@ -166,7 +166,7 @@ export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByText('Quick review')).toBeVisible();
     await expect(canvas.getByText('Review 12 stories')).toBeVisible();
-    await expect(canvas.getByText('12 left to review')).toBeVisible();
+    await expect(canvas.getByText('Button style changes on Shop screen')).toBeVisible();
   },
 };
 
@@ -183,8 +183,7 @@ export const PartialProgress: Story = {
     return setReviewingStatuses(storyIds);
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText('Review 12 stories')).toBeVisible();
-    await expect(canvas.getByText('7 left to review')).toBeVisible();
+    await expect(canvas.getByText('7 stories left to review')).toBeVisible();
   },
 };
 
@@ -201,7 +200,6 @@ export const Complete: Story = {
     return setReviewingStatuses(storyIds);
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText('Review 12 stories')).toBeVisible();
     await expect(canvas.getByText('Review complete')).toBeVisible();
   },
 };
@@ -220,7 +218,6 @@ export const SingleStory: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText('Review 1 story')).toBeVisible();
-    await expect(canvas.getByText('1 left to review')).toBeVisible();
   },
 };
 

--- a/code/core/src/manager/components/sidebar/ReviewWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.tsx
@@ -132,10 +132,15 @@ export const ReviewWidget = () => {
 
   const storyLabel = storyCount === 1 ? 'story' : 'stories';
   const remaining = Math.max(0, storyCount - reviewedCount);
-  const progressText = remaining === 0 ? 'Review complete' : `${remaining} left to review`;
+  const isComplete = remaining === 0;
+  const progressText = isComplete ? 'Review complete' : `${remaining} left to review`;
 
   return (
-    <Card color="agentic" outlineAnimation="spin" id="storybook-review-widget">
+    <Card
+      color="agentic"
+      outlineAnimation={isComplete ? 'none' : 'spin'}
+      id="storybook-review-widget"
+    >
       <ActionList as="div">
         <ActionList.Item as="div">
           <HeaderContent>

--- a/code/core/src/manager/components/sidebar/ReviewWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.tsx
@@ -133,7 +133,11 @@ export const ReviewWidget = () => {
   const storyLabel = storyCount === 1 ? 'story' : 'stories';
   const remaining = Math.max(0, storyCount - reviewedCount);
   const isComplete = remaining === 0;
-  const progressText = isComplete ? 'Review complete' : `${remaining} left to review`;
+  const progressText = isComplete
+    ? 'Review complete'
+    : reviewedCount === 0
+      ? `Review ${storyCount} ${storyLabel}`
+      : `${remaining} ${remaining === 1 ? 'story' : 'stories'} left to review`;
 
   return (
     <Card
@@ -155,20 +159,14 @@ export const ReviewWidget = () => {
       <ActionList>
         <ActionList.Item>
           <ActionList.Action
-            ariaLabel={
-              reviewTitle
-                ? `Review ${storyCount} ${storyLabel}: ${reviewTitle}`
-                : `Review ${storyCount} ${storyLabel}`
-            }
+            ariaLabel={reviewTitle ? `${progressText}: ${reviewTitle}` : progressText}
             disableAllTooltips
             appearance="agentic"
             onClick={onOpen}
           >
             <ActionList.Text>
-              <strong>
-                Review {storyCount} {storyLabel}
-              </strong>
-              <small>{progressText}</small>
+              <strong>{progressText}</strong>
+              {reviewTitle ? <small>{reviewTitle}</small> : null}
             </ActionList.Text>
           </ActionList.Action>
         </ActionList.Item>

--- a/code/core/src/manager/components/sidebar/ReviewWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.tsx
@@ -16,6 +16,7 @@ import { styled } from 'storybook/theming';
 import { REVIEW_EVENTS } from '../../../shared/review/index.ts';
 import { REVIEW_CHANGES_URL } from '../review/constants.ts';
 import { enterReviewMode } from '../review/review-mode.ts';
+import { useReview } from '../review/review-store.ts';
 import { REVIEWING_STATUS_VALUE as REVIEWING } from '../review/review-status.ts';
 
 type ReviewPayload = {
@@ -90,6 +91,7 @@ export const ReviewWidget = () => {
   const api = useStorybookApi();
   const storyCount = useReviewingStoryCount();
   const reviewTitle = useActiveReviewTitle();
+  const { reviewedCount } = useReview();
   const {
     includedStatusFilters = [],
     excludedStatusFilters = [],
@@ -129,6 +131,8 @@ export const ReviewWidget = () => {
   };
 
   const storyLabel = storyCount === 1 ? 'story' : 'stories';
+  const remaining = Math.max(0, storyCount - reviewedCount);
+  const progressText = remaining === 0 ? 'Review complete' : `${remaining} left to review`;
 
   return (
     <Card color="agentic" outlineAnimation="spin" id="storybook-review-widget">
@@ -159,7 +163,7 @@ export const ReviewWidget = () => {
               <strong>
                 Review {storyCount} {storyLabel}
               </strong>
-              {reviewTitle ? <small>{reviewTitle}</small> : null}
+              <small>{progressText}</small>
             </ActionList.Text>
           </ActionList.Action>
         </ActionList.Item>


### PR DESCRIPTION
## What I did

Adds **reviewed-progress tracking** to the Storybook review flow. A story is marked as reviewed the moment its review story screen becomes active (covers Next/Prev, the story picker, thumbnails, keyboard shortcuts and reloads). Progress is tracked per unique `storyId` and persisted in `sessionStorage`, keyed by the review's server-stamped `createdAt`, so it survives reloads but resets when a new review is displayed/accepted and is cleared on full dismissal. "Close review" keeps progress so it can be resumed from the widget.

https://github.com/user-attachments/assets/9f3b6457-0f1d-46b6-a976-882dc352a58c

Progress is surfaced in three places:

- **Summary screen** — a solid CTA in the header actions slot (right of the `{n} new` filter): **Start review** (none reviewed) / **Continue review** (some reviewed) jumps to the first unreviewed story in collection order (ignoring the new-only filter), and **Close review** (all reviewed) exits review mode while keeping the review.
- **Story toolbar** — a forward control state machine: **Done** on the last story or on the arrival that just completed the set (one-shot), a solid **Next** while unreviewed stories remain, and the existing ghost chevron once everything is reviewed. Prev is unchanged.
- **Quick review widget** — the subline now reads **`{n} left to review`**, or **`Review complete`** when nothing remains.

No story-grid checkmarks, picker markers, or progress-bar repurposing — progress only surfaces through the widget text and button labels, as designed. The existing positional progress bar in the toolbar is untouched.

Implementation lives in a new `review-progress.ts` (sessionStorage persistence + pure helpers) plus a reviewed-progress slice in `ReviewProvider`/`review-store`. Navigation reuses the established href + click-interceptor pattern.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

New/updated coverage:
- `review-progress.test.ts` — persistence round-trip, per-review clearing, no-`createdAt`/corrupt-value handling, and the `countReviewed` / `findFirstUnreviewedEntry` / `reviewEntryKey` helpers.
- `SummaryScreen.stories.tsx` — `StartReview` / `ContinueReview` / `CloseReview` CTA states and hrefs.
- `ReviewToolbarHeader.stories.tsx` — `LastStoryDone` plus updated `NewStory` forward control ("Next").
- `ReviewWidget.stories.tsx` — `PartialProgress` and `Complete` subline states.

#### Manual testing

1. Run a sandbox / the internal UI: `cd code && yarn storybook:ui`.
2. Trigger a review (e.g. via the MCP `display-review` tool) so the Quick review widget appears in the sidebar — it should read `{n} left to review`.
3. Open the summary and click **Start review** → you land on the first story; the toolbar shows a solid **Next**.
4. Walk through with **Next**; the arrival that completes the set shows **Done** (back to summary). The last story always shows **Done**.
5. Back on the summary the CTA now reads **Continue review** (and **Close review** once every story has been visited). **Close review** returns to the canvas but keeps the review/progress (reopenable from the widget); the widget reads **Review complete**.
6. Reload mid-review → progress is preserved. Dismiss the review from the widget → progress is cleared.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update MIGRATION.MD

This is an internal, experimental review-feature change with no public docs impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reviewed-story progress tracking that persists per review session and resets when a review is dismissed.
  * Stories are automatically marked reviewed on arrival, with “completion” handling once all stories are done.
  * Summary screen now shows **Start review**, **Continue review**, or **Close review** based on progress.
  * Review toolbar updates to show **Done** when complete; otherwise **Next**.
  * Review widget now displays remaining stories (or **Review complete**) using live progress.
* **Visual / Style**
  * Improved Card “agentic” dark-mode outline/background rendering.
* **Tests**
  * Added and updated automated and Storybook coverage for progress, CTA, and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->