### PR TITLE
Addon-Docs: Shim all preview uses of React 18 API

### DIFF
--- a/code/addons/docs/src/blocks/blocks/use-service-story-docs.ts
+++ b/code/addons/docs/src/blocks/blocks/use-service-story-docs.ts
@@ -8,7 +8,7 @@ import {
   selectStoryDoc,
 } from 'storybook/open-service';
 import { getService } from 'storybook/preview-api';
-import { useSyncExternalStoreShim } from './useSyncExternalStoreShim';
+import { useSyncExternalStoreShim } from './useSyncExternalStoreShim.ts';
 
 type SnapshotCache<T> = {
   storyId: string | undefined;

--- a/code/addons/docs/src/blocks/blocks/use-service-story-docs.ts
+++ b/code/addons/docs/src/blocks/blocks/use-service-story-docs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import type { StoryDoc, StoryDocsPayload } from 'storybook/internal/types';
 
@@ -8,6 +8,7 @@ import {
   selectStoryDoc,
 } from 'storybook/open-service';
 import { getService } from 'storybook/preview-api';
+import { useSyncExternalStoreShim } from './useSyncExternalStoreShim';
 
 type SnapshotCache<T> = {
   storyId: string | undefined;
@@ -57,7 +58,7 @@ export function useServiceStory<TSelected>(
     [service, componentId, storyId, selector]
   );
 
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useSyncExternalStoreShim(subscribe, getSnapshot);
 }
 
 /** Convenience hook for the common case: the story-docs entry for one story. */

--- a/code/addons/docs/src/blocks/blocks/useServiceDocgen.ts
+++ b/code/addons/docs/src/blocks/blocks/useServiceDocgen.ts
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import type { DocgenPayload } from 'storybook/internal/types';
 
 import type { DocgenService } from 'storybook/open-service';
 import { getService } from 'storybook/preview-api';
+import { useSyncExternalStoreShim } from './useSyncExternalStoreShim';
 
 type SnapshotCache = {
   id: string | undefined;
@@ -37,70 +38,4 @@ export function useServiceDocgen(id: string | undefined): DocgenPayload | undefi
   );
 
   return useSyncExternalStoreShim(subscribe, getSnapshot);
-}
-
-/**
- * Inlined fallback for React's `useSyncExternalStore`.
- *
- * `addon-docs` still supports React 16.8 and 17 (see the `react` range in `package.json`), and
- * `useSyncExternalStore` only exists from React 18 onwards. This is a faithful port of the official
- * `use-sync-external-store/shim` fallback, which is safe on React 16/17 because those versions render
- * synchronously and therefore can't tear (the tearing problem the real hook guards against only
- * occurs with concurrent rendering, which doesn't exist before React 18).
- *
- * The snapshot is recomputed on every render and returned directly, so the value is always current
- * during render; the `useState` updater is used solely as a force-re-render mechanism when the store
- * emits a change. The layout effect re-checks the snapshot to catch a store mutation that happened
- * between render and commit.
- *
- * TODO: Delete this shim and go back to importing `useSyncExternalStore` from `react` once we drop
- * support for React < 18.
- */
-function useSyncExternalStoreShim<T>(
-  subscribe: (onStoreChange: () => void) => () => void,
-  getSnapshot: () => T
-): T {
-  const value = getSnapshot();
-  // `inst` is a stable mutable container that is never reassigned, so it is intentionally omitted
-  // from the effect dependency arrays below (matching React's upstream shim). The dependency arrays
-  // are deliberately `[subscribe, value, getSnapshot]` and `[subscribe]` to preserve the exact
-  // re-subscription semantics of `useSyncExternalStore`.
-  const [{ inst }, forceUpdate] = useState({ inst: { value, getSnapshot } });
-
-  useLayoutEffect(() => {
-    inst.value = value;
-    inst.getSnapshot = getSnapshot;
-
-    if (didSnapshotChange(inst)) {
-      forceUpdate({ inst });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subscribe, value, getSnapshot]);
-
-  useEffect(() => {
-    // Re-check on subscribe in case the store changed before the subscription was set up.
-    if (didSnapshotChange(inst)) {
-      forceUpdate({ inst });
-    }
-
-    return subscribe(() => {
-      if (didSnapshotChange(inst)) {
-        forceUpdate({ inst });
-      }
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subscribe]);
-
-  return value;
-}
-
-function didSnapshotChange<T>(inst: { value: T; getSnapshot: () => T }): boolean {
-  const latestGetSnapshot = inst.getSnapshot;
-  const prevValue = inst.value;
-  try {
-    const nextValue = latestGetSnapshot();
-    return !Object.is(prevValue, nextValue);
-  } catch {
-    return true;
-  }
 }

--- a/code/addons/docs/src/blocks/blocks/useServiceDocgen.ts
+++ b/code/addons/docs/src/blocks/blocks/useServiceDocgen.ts
@@ -4,7 +4,7 @@ import type { DocgenPayload } from 'storybook/internal/types';
 
 import type { DocgenService } from 'storybook/open-service';
 import { getService } from 'storybook/preview-api';
-import { useSyncExternalStoreShim } from './useSyncExternalStoreShim';
+import { useSyncExternalStoreShim } from './useSyncExternalStoreShim.ts';
 
 type SnapshotCache = {
   id: string | undefined;

--- a/code/addons/docs/src/blocks/blocks/useSyncExternalStoreShim.ts
+++ b/code/addons/docs/src/blocks/blocks/useSyncExternalStoreShim.ts
@@ -1,0 +1,67 @@
+import { useEffect, useLayoutEffect, useState } from 'react';
+
+/**
+ * Inlined fallback for React's `useSyncExternalStore`.
+ *
+ * `addon-docs` still supports React 16.8 and 17 (see the `react` range in `package.json`), and
+ * `useSyncExternalStore` only exists from React 18 onwards. This is a faithful port of the official
+ * `use-sync-external-store/shim` fallback, which is safe on React 16/17 because those versions render
+ * synchronously and therefore can't tear (the tearing problem the real hook guards against only
+ * occurs with concurrent rendering, which doesn't exist before React 18).
+ *
+ * The snapshot is recomputed on every render and returned directly, so the value is always current
+ * during render; the `useState` updater is used solely as a force-re-render mechanism when the store
+ * emits a change. The layout effect re-checks the snapshot to catch a store mutation that happened
+ * between render and commit.
+ *
+ * TODO: Delete this shim and go back to importing `useSyncExternalStore` from `react` once we drop
+ * support for React < 18.
+ */
+export function useSyncExternalStoreShim<T>(
+  subscribe: (onStoreChange: () => void) => () => void,
+  getSnapshot: () => T
+): T {
+  const value = getSnapshot();
+  // `inst` is a stable mutable container that is never reassigned, so it is intentionally omitted
+  // from the effect dependency arrays below (matching React's upstream shim). The dependency arrays
+  // are deliberately `[subscribe, value, getSnapshot]` and `[subscribe]` to preserve the exact
+  // re-subscription semantics of `useSyncExternalStore`.
+  const [{ inst }, forceUpdate] = useState({ inst: { value, getSnapshot } });
+
+  useLayoutEffect(() => {
+    inst.value = value;
+    inst.getSnapshot = getSnapshot;
+
+    if (didSnapshotChange(inst)) {
+      forceUpdate({ inst });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [subscribe, value, getSnapshot]);
+
+  useEffect(() => {
+    // Re-check on subscribe in case the store changed before the subscription was set up.
+    if (didSnapshotChange(inst)) {
+      forceUpdate({ inst });
+    }
+
+    return subscribe(() => {
+      if (didSnapshotChange(inst)) {
+        forceUpdate({ inst });
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [subscribe]);
+
+  return value;
+}
+
+function didSnapshotChange<T>(inst: { value: T; getSnapshot: () => T }): boolean {
+  const latestGetSnapshot = inst.getSnapshot;
+  const prevValue = inst.value;
+  try {
+    const nextValue = latestGetSnapshot();
+    return !Object.is(prevValue, nextValue);
+  } catch {
+    return true;
+  }
+}

--- a/code/core/src/shared/open-service/sync-test/local-command/local-command.stories.tsx
+++ b/code/core/src/shared/open-service/sync-test/local-command/local-command.stories.tsx
@@ -11,6 +11,7 @@ import { localCommandSyncService } from './preview.ts';
 const store = createDemoStore('');
 
 function LocalCommandDemo() {
+  // Safe to use React 18 API because this is only loaded in our own UI, not in React sandboxes.
   const value = useSyncExternalStore(store.subscribe, store.get, store.get);
 
   return (

--- a/code/core/src/shared/open-service/sync-test/remote-command/remote-command.stories.tsx
+++ b/code/core/src/shared/open-service/sync-test/remote-command/remote-command.stories.tsx
@@ -11,6 +11,7 @@ import { remoteCommandSyncService } from './preview.ts';
 const store = createDemoStore('');
 
 function RemoteCommandDemo() {
+  // Safe to use React 18 API because this is only loaded in our own UI, not in React sandboxes.
   const value = useSyncExternalStore(store.subscribe, store.get, store.get);
 
   return (

--- a/code/core/src/shared/open-service/sync-test/static-load/static-load.stories.tsx
+++ b/code/core/src/shared/open-service/sync-test/static-load/static-load.stories.tsx
@@ -21,6 +21,7 @@ const store = createDemoStore<StaticLoadSnapshot>({
 });
 
 function StaticLoadDemo() {
+  // Safe to use React 18 API because this is only loaded in our own UI, not in React sandboxes.
   const value = useSyncExternalStore(store.subscribe, store.get, store.get);
 
   return (

--- a/code/core/src/shared/open-service/use-service-query.ts
+++ b/code/core/src/shared/open-service/use-service-query.ts
@@ -90,5 +90,6 @@ export function useServiceQuery<TKey extends string, TInput, TOutput>(
     return snapshotRef.current as TOutput;
   }, []);
 
+  // Only runs in manager, so React 18 is available.
   return React.useSyncExternalStore(subscribe, getSnapshot);
 }

--- a/code/core/src/shared/universal-store/use-universal-store-manager.ts
+++ b/code/core/src/shared/universal-store/use-universal-store-manager.ts
@@ -74,6 +74,7 @@ export const useUniversalStore: {
     return snapshotRef.current;
   }, [universalStore, selector]);
 
+  // Manager-only, safe to use React 18 API
   const state = React.useSyncExternalStore(subscribe, getSnapshot);
 
   return [state, universalStore.setState];


### PR DESCRIPTION
Fixes https://app.circleci.com/jobs/github/storybookjs/storybook/1641177

## What I did

* Ensured all preview users of useSyncExternalStore consume the shim
* Annotated safe uses for future readers

#### Manual testing

Create react 17 webpack sandbox and attempt to run or build SB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized external-store synchronization into a shared shim and updated related service hooks to use it.
  * Removed duplicated fallback logic from individual hooks to improve consistency.

* **New Features**
  * Added a reusable external-store sync shim to support reliable updates in environments that can’t use the React API directly.

* **Documentation**
  * Added clarifying comments in manager-only code paths and related stories confirming React 18 compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->