### PR TITLE
React: Stop docgen warmup on file changes

### DIFF
--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.test.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { dedent } from 'ts-dedent';
 import ts from 'typescript';
@@ -80,6 +80,8 @@ describe('multi-project management', () => {
   let manager: ComponentMetaManager;
 
   afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     manager?.dispose();
     if (tempDir) {
       cleanup(tempDir);
@@ -199,6 +201,54 @@ describe('multi-project management', () => {
     expect(entries2[0].component?.reactComponentMeta).toMatchObject({
       props: { color: expect.anything() },
     });
+  });
+
+  it('does not re-extract cached entries after file changes', { timeout: 30_000 }, () => {
+    tempDir = createTempDir();
+
+    const files = writeFiles(tempDir, {
+      'tsconfig.json': tsconfigJSON(),
+      'Tag.tsx': dedent`
+        import React from 'react';
+        export const Tag = (_props: { text: string }) => <span />;
+      `,
+      'Tag.stories.tsx': dedent`
+        import { Tag } from './Tag';
+        export default { component: Tag };
+      `,
+    });
+
+    manager = new ComponentMetaManager(ts);
+    const tagPath = path.join(tempDir, 'Tag.tsx');
+    const project = manager.getProjectForFile(tagPath);
+    const entries: StoryRef[] = [
+      {
+        storyPath: files['Tag.stories.tsx'],
+        component: {
+          componentName: 'Tag',
+          importName: 'Tag',
+          path: tagPath,
+          isPackage: false,
+        },
+      },
+    ];
+
+    project.extractPropsFromStories(entries);
+    const extractSpy = vi.spyOn(project, 'extractPropsFromStories');
+
+    fs.writeFileSync(
+      tagPath,
+      dedent`
+        import React from 'react';
+        export const Tag = (_props: { text: string; color?: string }) => <span />;
+      `
+    );
+
+    vi.useFakeTimers();
+    manager.onFilesChanged([{ filePath: tagPath, type: 'changed' }]);
+    vi.advanceTimersByTime(150);
+
+    expect(extractSpy).not.toHaveBeenCalled();
   });
 
   it('handles config change: deleted tsconfig disposes project', () => {

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -41,9 +41,6 @@ export class ComponentMetaProject {
   private ls: ts.LanguageService;
   private projectVersion = 0;
   private shouldCheckRootFiles = false;
-  private warmupTimer?: ReturnType<typeof setTimeout>;
-  /** Entries to extract — set by the generator, replayed during warmup for targeted type resolution. */
-  private entries: StoryRef[] = [];
 
   constructor(
     private typescript: typeof ts,
@@ -132,7 +129,6 @@ export class ComponentMetaProject {
   }
 
   dispose() {
-    clearTimeout(this.warmupTimer);
     this.ls.dispose();
   }
 
@@ -213,7 +209,6 @@ export class ComponentMetaProject {
       this.fsFileSnapshots.delete(filePath);
     }
 
-    const oldVersion = this.projectVersion;
     const program = this.ls.getProgram();
     for (const { filePath, type } of changes) {
       if (type === 'changed') {
@@ -231,22 +226,6 @@ export class ComponentMetaProject {
         break;
       }
     }
-
-    // Targeted warmup: re-extract in the background so the next request is instant.
-    // Only resolves the specific types we need (story JSX → getResolvedSignature),
-    // not the entire program. TypeScript caches resolved types on AST nodes —
-    // the real extraction then hits cached results.
-    if (this.projectVersion !== oldVersion && this.entries.length > 0) {
-      clearTimeout(this.warmupTimer);
-      this.warmupTimer = setTimeout(() => {
-        try {
-          this.extractPropsFromStories(this.entries);
-        } catch {
-          // Warmup failure is non-fatal — extraction will still work on demand.
-        }
-      }, 100);
-      this.warmupTimer?.unref?.();
-    }
   }
 
   // ---------------------------------------------------------------------------
@@ -254,8 +233,6 @@ export class ComponentMetaProject {
   // ---------------------------------------------------------------------------
 
   extractPropsFromStories(entries: StoryRef[]): void {
-    this.entries = entries;
-
     const allFiles = entries.flatMap((entry) =>
       entry.component?.path ? [entry.storyPath, entry.component.path] : [entry.storyPath]
     );


### PR DESCRIPTION
Closes #35260

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Stop the React component metadata project from replaying prop extraction in the background after every watched file change. File changes still invalidate snapshots and bump the TypeScript project version, so the next manifest request extracts fresh metadata on demand without repeating the whole story list after every save.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. From `code`, start the internal Storybook with the docgen server path enabled:
   ```sh
   STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true NODE_OPTIONS="--max_old_space_size=4096" node core/dist/bin/dispatcher.js dev --port 6006 --config-dir ./.storybook
   ```
2. Open `http://localhost:6006/manifests/components.html` once so the component metadata project is initialized.
3. Save a React component file a few times while the server is running.
4. Confirm the dev server keeps running and component metadata is refreshed when the manifest is requested again, without a background full-index extraction after each save.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test cleanup and stability with improved Vitest state management.
  * Added test coverage for cache validation behavior.

* **Refactor**
  * Simplified internal caching mechanism for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->