### PR TITLE
fix: infer select/radio controls for large union types misclassified by docgen

### DIFF
--- a/code/core/src/preview-api/modules/store/inferControls.test.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.test.ts
@@ -133,4 +133,187 @@ describe('inferControls', () => {
     expect(Object.keys(excludeArray)).toEqual(['labelName', 'borderWidth']);
     expect(Object.keys(excludeRegex)).toEqual(['borderWidth']);
   });
+
+  describe('large union types (keyof typeof with many keys)', () => {
+    it('should infer select control when type has value array with >5 string literals', () => {
+      // Simulates react-docgen-typescript misclassifying a large `keyof typeof` union
+      // as a non-enum type (e.g. 'other') while still providing the value array
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            variant: {
+              type: {
+                name: 'other',
+                value: [
+                  'option1',
+                  'option2',
+                  'option3',
+                  'option4',
+                  'option5',
+                  'option6',
+                  'option7',
+                  'option8',
+                ],
+              },
+              name: 'variant',
+            },
+          },
+        })
+      );
+
+      const control = inferredControls.variant.control;
+      expect(typeof control === 'object' && control.type).toEqual('select');
+      expect(inferredControls.variant.options).toEqual([
+        'option1',
+        'option2',
+        'option3',
+        'option4',
+        'option5',
+        'option6',
+        'option7',
+        'option8',
+      ]);
+    });
+
+    it('should infer radio control when type has value array with <=5 string literals', () => {
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            size: {
+              type: {
+                name: 'other',
+                value: ['sm', 'md', 'lg'],
+              },
+              name: 'size',
+            },
+          },
+        })
+      );
+
+      const control = inferredControls.size.control;
+      expect(typeof control === 'object' && control.type).toEqual('radio');
+      expect(inferredControls.size.options).toEqual(['sm', 'md', 'lg']);
+    });
+
+    it('should fall back to object control when type has no value array', () => {
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            config: {
+              type: {
+                name: 'other',
+              },
+              name: 'config',
+            },
+          },
+        })
+      );
+
+      const control = inferredControls.config.control;
+      expect(typeof control === 'object' && control.type).toEqual('object');
+    });
+
+    it('should prefer explicit options over inferred value array', () => {
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            variant: {
+              type: {
+                name: 'other',
+                value: ['a', 'b', 'c', 'd', 'e', 'f'],
+              },
+              options: ['x', 'y', 'z'],
+              name: 'variant',
+            },
+          },
+        })
+      );
+
+      const control = inferredControls.variant.control;
+      expect(typeof control === 'object' && control.type).toEqual('select');
+    });
+
+    it('should not treat mixed-type value arrays as enums', () => {
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            config: {
+              type: {
+                name: 'other',
+                value: ['string', 42, true, null],
+              },
+              name: 'config',
+            },
+          },
+        })
+      );
+
+      const control = inferredControls.config.control;
+      expect(typeof control === 'object' && control.type).toEqual('object');
+    });
+
+    it('should handle numeric value arrays correctly', () => {
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            columns: {
+              type: {
+                name: 'other',
+                value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+              },
+              name: 'columns',
+            },
+          },
+        })
+      );
+
+      const control = inferredControls.columns.control;
+      expect(typeof control === 'object' && control.type).toEqual('select');
+      expect(inferredControls.columns.options).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    });
+
+    it('should handle intersection type name with value array (29+ keys scenario)', () => {
+      // This is the exact scenario from issue #12641 — keyof typeof with 29+ keys
+      // causes react-docgen-typescript to report type.name as 'intersection'
+      const manyKeys = Array.from({ length: 30 }, (_, i) => `key${i}`);
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            iconName: {
+              type: {
+                name: 'intersection',
+                value: manyKeys,
+              },
+              name: 'iconName',
+            },
+          },
+        })
+      );
+
+      const control = inferredControls.iconName.control;
+      expect(typeof control === 'object' && control.type).toEqual('select');
+      expect(inferredControls.iconName.options).toEqual(manyKeys);
+      expect(inferredControls.iconName.options).toHaveLength(30);
+    });
+
+    it('should not infer enum from empty value arrays', () => {
+      const inferredControls = inferControls(
+        getStoryContext({
+          argTypes: {
+            empty: {
+              type: {
+                name: 'other',
+                value: [],
+              },
+              name: 'empty',
+            },
+          },
+        })
+      );
+
+      const control = inferredControls.empty.control;
+      expect(typeof control === 'object' && control.type).toEqual('object');
+    });
+  });
 });
+

--- a/code/core/src/preview-api/modules/store/inferControls.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.ts
@@ -65,8 +65,26 @@ const inferControl = (argType: StrictInputType, name: string, matchers: Controls
     case 'function':
     case 'symbol':
       return null;
-    default:
+    default: {
+      // When type parsers (e.g. react-docgen-typescript) encounter large union types
+      // such as `keyof typeof obj` with many keys, they may fail to classify the type
+      // as 'enum' and instead report it as 'other', 'intersection', etc.
+      // However, the type metadata often still contains a `value` array with the
+      // individual union members. Detect this case and infer a select/radio control.
+      const enumValues = (type as SBEnumType).value;
+      if (
+        !options &&
+        Array.isArray(enumValues) &&
+        enumValues.length > 0 &&
+        enumValues.every((v) => typeof v === 'string' || typeof v === 'number')
+      ) {
+        return {
+          control: { type: enumValues.length <= 5 ? 'radio' : 'select' },
+          options: enumValues,
+        };
+      }
       return { control: { type: options ? 'select' : 'object' } };
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
Fixes #12641

## Problem
When a component prop is typed as `keyof typeof customObject` where the object has **29 or more key-value pairs**, Storybook renders an `object` control (JSON editor) instead of a `select` dropdown.

### Reproduction
```typescript
// Object with 29+ keys
const customObject = {
  key0: "value0",
  key1: "value1",
  // ... 
  key28: "value28",
};

type Props = { variant: keyof typeof customObject };
```

- With **≤28 keys**: ✅ Correct `select` dropdown appears
- With **≥29 keys**: ❌ Broken `object` control (JSON editor) appears

### Root Cause
`react-docgen-typescript` fails to classify `keyof typeof` unions with many members as `enum`. Instead, it reports the type as `"other"`, `"intersection"`, or similar non-enum names. However, the type metadata **still contains** a `value` array with all string literals.

In `inferControls.ts`, the `inferControl` function's `switch (type.name)` statement falls through to `default`, which returns `{ control: { type: "object" } }` — rendering a JSON editor instead of a select dropdown.

## Fix
Added a defensive guard in the `default` case of `inferControl()` that checks if the type's `value` property is an array of primitive literals (strings/numbers). When detected, it treats the type as an enum and infers `select` (>5 options) or `radio` (≤5 options) — matching the existing `enum` case logic.

```typescript
default: {
  const enumValues = (type as SBEnumType).value;
  if (
    !options &&
    Array.isArray(enumValues) &&
    enumValues.length > 0 &&
    enumValues.every((v) => typeof v === "string" || typeof v === "number")
  ) {
    return {
      control: { type: enumValues.length <= 5 ? "radio" : "select" },
      options: enumValues,
    };
  }
  return { control: { type: options ? "select" : "object" } };
}
```

## Backwards Compatibility

| Scenario | Before | After |
|----------|--------|-------|
| `keyof typeof` with 28 keys | ✅ select | ✅ select (no change) |
| `keyof typeof` with 29+ keys | ❌ object (broken) | ✅ **select** (fixed) |
| `keyof typeof` with ≤5 keys | ✅ radio | ✅ radio (no change) |
| Explicit `argTypes.options` set | ✅ select | ✅ select (no change) |
| Properly classified `enum` type | ✅ select/radio | ✅ select/radio (no change) |
| Non-enum with no value array | object | object (no change) |
| Mixed-type value arrays | object | object (no change) |

**Zero breaking changes.** The fix only activates for types that were previously incorrectly rendered as `object`.

## Tests Added
Added **8 comprehensive test cases** in `inferControls.test.ts`:

| Test | Description |
|------|-------------|
| ✅ | Select control for type with >5 string literals |
| ✅ | Radio control for type with ≤5 string literals |
| ✅ | Fallback to object when no value array |
| ✅ | Explicit options take priority over inferred values |
| ✅ | Mixed-type value arrays not treated as enums |
| ✅ | Numeric value arrays work correctly |
| ✅ | Exact reproduction of issue #12641 (29+ keys as intersection type) |
| ✅ | Empty value arrays fall through to object |

## Checklist
- [x] Fix is minimal (18 lines in production code)
- [x] All existing tests preserved and passing
- [x] 8 new tests covering the fix + edge cases
- [x] Backwards compatible — no behavior change for existing users
- [x] Follows existing code patterns (mirrors the `enum` case logic)
- [x] Well-documented with inline comments explaining the root cause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved control inference for complex union types to automatically select appropriate control styles
  * Enhanced value detection to use radio controls for small sets (≤5 values) and select controls for larger sets (>5 values)
  * Better fallback handling when type information is incomplete or misclassified

* **Tests**
  * Added comprehensive test coverage for edge cases in control inference logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->