### PR TITLE
ESLint Plugin: Avoid ESLint Unstable API Load

### DIFF
--- a/code/lib/eslint-plugin/package.json
+++ b/code/lib/eslint-plugin/package.json
@@ -43,6 +43,7 @@
     "prep": "jiti ../../../scripts/build/build-package.ts"
   },
   "dependencies": {
+    "@typescript-eslint/types": "^8.48.0",
     "@typescript-eslint/utils": "^8.48.0"
   },
   "devDependencies": {

--- a/code/lib/eslint-plugin/src/rules/await-interactions.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.ts
@@ -2,7 +2,8 @@
  * @file Interactions should be awaited
  * @author Yann Braga
  */
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 import {
   isArrowFunctionExpression,

--- a/code/lib/eslint-plugin/src/rules/context-in-play-function.ts
+++ b/code/lib/eslint-plugin/src/rules/context-in-play-function.ts
@@ -2,7 +2,7 @@
  * @file Pass a context object when invoking a play function
  * @author Yann Braga
  */
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
 import {
   isArrowFunctionExpression,

--- a/code/lib/eslint-plugin/src/rules/csf-component.ts
+++ b/code/lib/eslint-plugin/src/rules/csf-component.ts
@@ -2,7 +2,7 @@
  * @file Component property should be set
  * @author Yann Braga
  */
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
 import { getMetaObjectExpression } from '../utils/index.ts';
 import { isSpreadElement } from '../utils/ast.ts';

--- a/code/lib/eslint-plugin/src/rules/default-exports.ts
+++ b/code/lib/eslint-plugin/src/rules/default-exports.ts
@@ -2,7 +2,8 @@
  * @file Story files should have a default export
  * @author Yann Braga
  */
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
+import type { TSESLint } from '@typescript-eslint/utils';
 import path from 'path';
 
 import { isIdentifier, isImportDeclaration, isLiteral } from '../utils/ast.ts';

--- a/code/lib/eslint-plugin/src/rules/hierarchy-separator.ts
+++ b/code/lib/eslint-plugin/src/rules/hierarchy-separator.ts
@@ -2,7 +2,7 @@
  * @file Deprecated hierarchy separator
  * @author Yann Braga
  */
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
 import { getMetaObjectExpression } from '../utils/index.ts';
 import { isLiteral, isSpreadElement } from '../utils/ast.ts';

--- a/code/lib/eslint-plugin/src/rules/meta-inline-properties.ts
+++ b/code/lib/eslint-plugin/src/rules/meta-inline-properties.ts
@@ -2,7 +2,7 @@
  * @file Meta should have inline properties
  * @author Yann Braga
  */
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
 import { getMetaObjectExpression } from '../utils/index.ts';
 import { CategoryId } from '../utils/constants.ts';

--- a/code/lib/eslint-plugin/src/rules/meta-satisfies-type.ts
+++ b/code/lib/eslint-plugin/src/rules/meta-satisfies-type.ts
@@ -2,11 +2,12 @@
  * @file Meta should be followed by `satisfies Meta`
  * @author Tiger Oakes
  */
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
-import { ASTUtils, AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/types';
+import type { TSESTree } from '@typescript-eslint/types';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 import { getMetaObjectExpression } from '../utils/index.ts';
-import { isTSSatisfiesExpression } from '../utils/ast.ts';
+import { ASTUtils, isTSSatisfiesExpression } from '../utils/ast.ts';
 import { createStorybookRule } from '../utils/create-storybook-rule.ts';
 
 //------------------------------------------------------------------------------

--- a/code/lib/eslint-plugin/src/rules/no-renderer-packages.ts
+++ b/code/lib/eslint-plugin/src/rules/no-renderer-packages.ts
@@ -2,7 +2,7 @@
  * @file Do not import renderer packages directly in stories
  * @author Norbert De Langen
  */
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
 import { CategoryId } from '../utils/constants.ts';
 import { createStorybookRule } from '../utils/create-storybook-rule.ts';

--- a/code/lib/eslint-plugin/src/rules/no-title-property-in-meta.ts
+++ b/code/lib/eslint-plugin/src/rules/no-title-property-in-meta.ts
@@ -2,7 +2,7 @@
  * @file No title property in meta
  * @author Yann Braga
  */
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
 import { getMetaObjectExpression } from '../utils/index.ts';
 import { isSpreadElement } from '../utils/ast.ts';

--- a/code/lib/eslint-plugin/src/rules/no-uninstalled-addons.ts
+++ b/code/lib/eslint-plugin/src/rules/no-uninstalled-addons.ts
@@ -3,7 +3,7 @@
  *   installed or contain a typo in their name.
  * @author Andre "andrelas1" Santos
  */
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 import { readFileSync } from 'fs';
 import { relative, resolve, sep } from 'path';
 import { dedent } from 'ts-dedent';

--- a/code/lib/eslint-plugin/src/rules/prefer-pascal-case.ts
+++ b/code/lib/eslint-plugin/src/rules/prefer-pascal-case.ts
@@ -5,11 +5,11 @@
 import type { IncludeExcludeOptions } from 'storybook/internal/csf';
 import { isExportStory } from 'storybook/internal/csf';
 
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
-import { ASTUtils } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 import { getDescriptor, getMetaObjectExpression } from '../utils/index.ts';
-import { isIdentifier, isVariableDeclaration } from '../utils/ast.ts';
+import { ASTUtils, isIdentifier, isVariableDeclaration } from '../utils/ast.ts';
 import { CategoryId } from '../utils/constants.ts';
 import { createStorybookRule } from '../utils/create-storybook-rule.ts';
 

--- a/code/lib/eslint-plugin/src/rules/story-exports.ts
+++ b/code/lib/eslint-plugin/src/rules/story-exports.ts
@@ -4,7 +4,7 @@
  */
 import type { IncludeExcludeOptions } from 'storybook/internal/csf';
 
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
 import {
   getAllNamedExports,

--- a/code/lib/eslint-plugin/src/rules/use-storybook-expect.ts
+++ b/code/lib/eslint-plugin/src/rules/use-storybook-expect.ts
@@ -2,7 +2,7 @@
  * @file Use expect from '@storybook/jest'
  * @author Yann Braga
  */
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
 import { isIdentifier, isImportSpecifier } from '../utils/ast.ts';
 import { CategoryId } from '../utils/constants.ts';

--- a/code/lib/eslint-plugin/src/rules/use-storybook-testing-library.ts
+++ b/code/lib/eslint-plugin/src/rules/use-storybook-testing-library.ts
@@ -2,7 +2,7 @@
  * @file Do not use testing library directly on stories
  * @author Yann Braga
  */
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
 import { isImportDefaultSpecifier } from '../utils/ast.ts';
 import { CategoryId } from '../utils/constants.ts';

--- a/code/lib/eslint-plugin/src/utils/ast.ts
+++ b/code/lib/eslint-plugin/src/utils/ast.ts
@@ -1,7 +1,8 @@
-import type { TSESTree } from '@typescript-eslint/utils';
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/types';
+import * as ASTUtils from '@typescript-eslint/utils/ast-utils';
+import type { TSESTree } from '@typescript-eslint/types';
 
-export { ASTUtils } from '@typescript-eslint/utils';
+export { ASTUtils };
 
 const isNodeOfType =
   <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) =>

--- a/code/lib/eslint-plugin/src/utils/create-storybook-rule.ts
+++ b/code/lib/eslint-plugin/src/utils/create-storybook-rule.ts
@@ -1,5 +1,5 @@
 import type { TSESLint } from '@typescript-eslint/utils';
-import { ESLintUtils } from '@typescript-eslint/utils';
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
 
 import type { StorybookRuleMeta } from '../types/index.ts';
 import { docsUrl } from './index.ts';
@@ -21,7 +21,7 @@ export function createStorybookRule<
     optionsWithDefault: Readonly<TOptions>
   ) => TRuleListener;
 }>) {
-  const ruleCreator = ESLintUtils.RuleCreator(docsUrl);
+  const ruleCreator = RuleCreator(docsUrl);
   return ruleCreator({
     ...remainingConfig,
     create,

--- a/code/lib/eslint-plugin/src/utils/index.ts
+++ b/code/lib/eslint-plugin/src/utils/index.ts
@@ -1,10 +1,11 @@
 import type { IncludeExcludeOptions } from 'storybook/internal/csf';
 import { isExportStory } from 'storybook/internal/csf';
 
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
-import { ASTUtils } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/types';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 import {
+  ASTUtils,
   isFunctionDeclaration,
   isIdentifier,
   isObjectExpression,

--- a/code/lib/eslint-plugin/tests/eslint-compatibility.spec.ts
+++ b/code/lib/eslint-plugin/tests/eslint-compatibility.spec.ts
@@ -19,14 +19,14 @@ describe('ESLint compatibility', () => {
   it('does not import runtime values from the @typescript-eslint/utils barrel', () => {
     const violations = getSourceFiles(srcDir).flatMap((file) => {
       const source = readFileSync(file, 'utf8');
-      const matches = source
-        .split('\n')
-        .filter(
-          (line) =>
-            /^import\s+/.test(line) &&
-            !/^import\s+type\b/.test(line) &&
-            /from ['"]@typescript-eslint\/utils['"];$/.test(line)
-        );
+      const matches = Array.from(
+        source.matchAll(/^\s*import\s+(?:type\s+)?[\s\S]*?\sfrom\s+['"][^'"]+['"];?/gm),
+        ([statement]) => statement
+      ).filter(
+        (statement) =>
+          !/^\s*import\s+type\b/.test(statement) &&
+          /\sfrom\s+['"]@typescript-eslint\/utils['"];?\s*$/.test(statement)
+      );
       return matches?.map((statement) => `${relative(srcDir, file)}: ${statement}`) ?? [];
     });
 

--- a/code/lib/eslint-plugin/tests/eslint-compatibility.spec.ts
+++ b/code/lib/eslint-plugin/tests/eslint-compatibility.spec.ts
@@ -1,0 +1,35 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), '../src');
+
+const getSourceFiles = (dir: string): string[] =>
+  readdirSync(dir).flatMap((entry) => {
+    const fullPath = join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      return getSourceFiles(fullPath);
+    }
+    return fullPath.endsWith('.ts') && !fullPath.endsWith('.test.ts') ? [fullPath] : [];
+  });
+
+describe('ESLint compatibility', () => {
+  it('does not import runtime values from the @typescript-eslint/utils barrel', () => {
+    const violations = getSourceFiles(srcDir).flatMap((file) => {
+      const source = readFileSync(file, 'utf8');
+      const matches = source
+        .split('\n')
+        .filter(
+          (line) =>
+            /^import\s+/.test(line) &&
+            !/^import\s+type\b/.test(line) &&
+            /from ['"]@typescript-eslint\/utils['"];$/.test(line)
+        );
+      return matches?.map((statement) => `${relative(srcDir, file)}: ${statement}`) ?? [];
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -18706,6 +18706,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.48.0"
     "@typescript-eslint/parser": "npm:^8.48.0"
     "@typescript-eslint/rule-tester": "npm:^8.48.0"
+    "@typescript-eslint/types": "npm:^8.48.0"
     "@typescript-eslint/utils": "npm:^8.48.0"
     "@vitest/coverage-v8": "npm:^3.2.4"
     eslint: "npm:^8.57.1"


### PR DESCRIPTION
Fixes #35097.

This avoids loading the `@typescript-eslint/utils` barrel at runtime from `eslint-plugin-storybook`. With ESLint 10, that barrel eagerly loads the `TSESLint` namespace, which reaches `@typescript-eslint/utils/dist/ts-eslint/eslint/FlatESLint.js` and fails because `eslint/use-at-your-own-risk` no longer exposes the expected `FlatESLint` value.

Changes:

- Import `RuleCreator` from `@typescript-eslint/utils/eslint-utils` instead of the top-level barrel.
- Import `ASTUtils` from `@typescript-eslint/utils/ast-utils`.
- Import AST node runtime values and `TSESTree` types from `@typescript-eslint/types`.
- Add a small regression test that prevents runtime imports from the `@typescript-eslint/utils` barrel in plugin source files, including multiline imports.

Verification:

- `yarn install`
- `yarn exec tsc -p code/lib/eslint-plugin/tsconfig.json --noEmit`
- `node ../../../node_modules/vitest/vitest.mjs run --config vitest.integration.config.ts tests/eslint-compatibility.spec.ts`
- `yarn exec oxfmt --check ...changed eslint-plugin files...`
- Temporary clean ESLint 10.4.1 project loaded the locally bundled plugin and linted `Button.stories.js` successfully.
- In the same temporary ESLint 10.4.1 project, `require('@typescript-eslint/utils')` still reproduces the original `Class extends value undefined is not a constructor or null` failure, so this change specifically avoids that load path.

I could not run the full eslint-plugin package build in this local checkout because its prebuild step requires generated `storybook/internal/csf` dist files that were not present locally. The targeted type, format, and ESLint 10 load checks above pass.

#### Manual testing

Manual testing is not required for this package-level compatibility fix. I verified the plugin by loading the locally bundled `eslint-plugin-storybook` in a temporary ESLint 10.4.1 project and linting a Storybook file successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new TypeScript ESLint types dependency
  * Refactored internal module imports across ESLint plugin rules and utilities

* **Tests**
  * Added compatibility test to validate proper dependency usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->