### PR TITLE
fix: allow async function for stories config type (#21524)

### DIFF
--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -626,7 +626,7 @@ export interface StorybookConfigRaw {
 
   build?: TestBuildConfig;
 
-  stories: StoriesEntry[];
+  stories: StoriesEntry[] | (() => StoriesEntry[]) | (() => Promise<StoriesEntry[]>);
 
   framework?: Preset;
 


### PR DESCRIPTION
## Problem

The `stories` config field in `main.ts` only accepts `StoriesEntry[]`, but users can pass an async function that returns the array. Storybook already supports this at runtime, but TypeScript complains.

```ts
// Works at runtime, fails type check
stories: async () => [...(await myCustomStoriesEntryBuilderFunc())]
```

## Solution

Updated the `stories` type in `core-common.ts` to accept `StoriesEntry[] | (() => StoriesEntry[]) | (() => Promise<StoriesEntry[]>)`.

## Changes

- `code/core/src/types/modules/core-common.ts`: Updated `stories` type definition

Closes #21524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The stories configuration option now supports dynamic generation. You can provide an array of stories, or a function that returns stories synchronously or asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->