### PR TITLE
Core: Inline open-service static loader instead of dependency injection

### DIFF
--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -422,7 +422,7 @@ If multiple tasks resolve to the same path, their states are deep-merged.
 
 `writeOpenServiceStaticFiles(outputDir)` then writes those logical paths underneath `<outputDir>/services`, converting slash-separated logical keys into native filesystem paths for the current operating system.
 
-In a static Storybook build (`CONFIG_TYPE === 'PRODUCTION'`), manager and preview runtimes pass a browser static loader into `registerService`. For every query that declares `staticPath`, the runtime swaps the authored `load` hook for a fetch of `./services/<serviceId>/<staticPath>` relative to the served HTML root (the same convention as `./index.json`), then applies the JSON snapshot via `applyStatePatch(..., { preserveMissingKeys: true })` so snapshots for one query input do not delete state populated by other inputs. Development mode keeps running `load` normally against the dev server.
+In a static Storybook build (`CONFIG_TYPE === 'PRODUCTION'`), the manager and preview runtimes detect the static build inline via `shouldUseBrowserStaticLoader()` rather than having a loader injected. For every query that declares `staticPath`, the runtime swaps the authored `load` hook for `fetchStaticSnapshot()`, which fetches `./services/<serviceId>/<staticPath>` relative to the served HTML root (the same convention as `./index.json`), then applies the JSON snapshot via `applyStatePatch(..., { preserveMissingKeys: true })` so snapshots for one query input do not delete state populated by other inputs. Development mode and the Node static-build pipeline keep running `load` normally (the static build generates these files by running the real loads).
 
 Static path rules:
 

--- a/code/core/src/shared/open-service/manager.ts
+++ b/code/core/src/shared/open-service/manager.ts
@@ -20,7 +20,6 @@
  */
 
 import { getService, registerService as registerServiceCore } from './service-registry.ts';
-import { createBrowserStaticLoader } from './static-fetch.ts';
 import type {
   Commands,
   Queries,
@@ -49,8 +48,5 @@ export function registerService<
   definition: ServiceDefinition<TState, TQueries, TCommands>,
   registration?: ServiceRegistrationOptions<TState, TQueries, TCommands>
 ): ServiceInstance<TState, TQueries, TCommands> & ServiceRegistryApi {
-  return registerServiceCore(definition, registration, {
-    relay: true,
-    staticLoader: createBrowserStaticLoader(),
-  });
+  return registerServiceCore(definition, registration, { relay: true });
 }

--- a/code/core/src/shared/open-service/preview.ts
+++ b/code/core/src/shared/open-service/preview.ts
@@ -22,7 +22,6 @@
  */
 
 import { getService, registerService as registerServiceCore } from './service-registry.ts';
-import { createBrowserStaticLoader } from './static-fetch.ts';
 import type {
   Commands,
   Queries,
@@ -48,7 +47,5 @@ export function registerService<
   definition: ServiceDefinition<TState, TQueries, TCommands>,
   registration?: ServiceRegistrationOptions<TState, TQueries, TCommands>
 ): ServiceInstance<TState, TQueries, TCommands> & ServiceRegistryApi {
-  return registerServiceCore(definition, registration, {
-    staticLoader: createBrowserStaticLoader(),
-  });
+  return registerServiceCore(definition, registration, {});
 }

--- a/code/core/src/shared/open-service/service-registry.ts
+++ b/code/core/src/shared/open-service/service-registry.ts
@@ -22,7 +22,6 @@ import {
 import { getChannel } from '../../channels/channel-slot.ts';
 import { generateClientId } from './service-channel.ts';
 import { createServiceRuntime } from './service-runtime.ts';
-import type { StaticLoader } from './static-fetch.ts';
 import { createSnapshotReconciler } from './service-sync.ts';
 import { connectServiceToChannel } from './service-transport.ts';
 import type {
@@ -187,12 +186,6 @@ export interface ServiceRegisterOptions {
    * iframe) keep the default `false` — with a single transport there is nothing to forward.
    */
   relay?: boolean;
-  /**
-   * When set, queries with `staticPath` fetch prebuilt JSON snapshots instead of running their
-   * authored `load` hooks. Browser entrypoints pass {@link createBrowserStaticLoader}; the server
-   * omits this so static builds still run real loads to generate files.
-   */
-  staticLoader?: StaticLoader;
 }
 
 /**
@@ -211,7 +204,7 @@ export function registerService<
 >(
   definition: ServiceDefinition<TState, TQueries, TCommands>,
   registration?: ServiceRegistrationOptions<TState, TQueries, TCommands>,
-  { relay = false, staticLoader }: ServiceRegisterOptions = {}
+  { relay = false }: ServiceRegisterOptions = {}
 ): ServiceInstance<TState, TQueries, TCommands> & ServiceRegistryApi {
   const registry = getRegistry();
 
@@ -233,7 +226,7 @@ export function registerService<
   // shared `initialState` (which would otherwise leak state across registrations).
   const runtime = createServiceRuntime(
     resolvedDefinition,
-    { registryApi: serviceRegistryApi, staticLoader },
+    { registryApi: serviceRegistryApi },
     structuredClone(resolvedDefinition.initialState)
   );
 

--- a/code/core/src/shared/open-service/service-runtime.ts
+++ b/code/core/src/shared/open-service/service-runtime.ts
@@ -68,7 +68,7 @@ import {
   OpenServiceUnimplementedOperationError,
 } from '../../server-errors.ts';
 import { applyStatePatch } from './service-sync.ts';
-import type { StaticLoader } from './static-fetch.ts';
+import { fetchStaticSnapshot, shouldUseBrowserStaticLoader } from './static-fetch.ts';
 import { rethrowAsync, validateSchema, validateSchemaSync } from './service-validation.ts';
 import type {
   AnySchema,
@@ -1143,13 +1143,14 @@ function subscribeToQuery<TState>(
 }
 
 /**
- * When a browser static loader is active, queries with `staticPath` fetch prebuilt JSON instead of
- * running their authored `load` hook (which typically invokes server-only commands).
+ * In a static Storybook build, queries with `staticPath` fetch prebuilt JSON instead of running
+ * their authored `load` hook (which typically invokes server-only commands). The fetch is defined
+ * inline via {@link fetchStaticSnapshot} rather than injected, and is only reached when
+ * {@link shouldUseBrowserStaticLoader} is true.
  */
 function buildQueryDefinitionsWithStaticLoader<TState>(
   serviceId: ServiceId,
   queries: Record<string, RuntimeQueryDefinition<TState>>,
-  staticLoader: StaticLoader,
   setState: CommandSelf<TState>['setState']
 ): Map<string, RuntimeQueryDefinition<TState>> {
   return new Map(
@@ -1166,7 +1167,7 @@ function buildQueryDefinitionsWithStaticLoader<TState>(
           ...queryDef,
           load: async (input: unknown) => {
             const logicalPath = resolveStaticPath(serviceId, name, { staticPath }, input);
-            const snapshot = await staticLoader(logicalPath, {
+            const snapshot = await fetchStaticSnapshot(logicalPath, {
               serviceId,
               queryName: name,
               input,
@@ -1215,7 +1216,6 @@ export function createServiceRuntime<
   def: ServiceDefinition<TState, TQueries, TCommands>,
   runtimeOptions: {
     registryApi: ServiceRegistryApi;
-    staticLoader?: StaticLoader;
   },
   initialState: TState = def.initialState
 ): ServiceRuntime<TState, TQueries, TCommands> {
@@ -1229,7 +1229,7 @@ export function createServiceRuntime<
   const state = deepSignal(rawState as object) as TState;
   const getStateSnapshot = (): TState => structuredClone(rawState);
   const commandSelf = createCommandSelf(state);
-  const { registryApi, staticLoader } = runtimeOptions;
+  const { registryApi } = runtimeOptions;
   const createCommandCtx = (): CommandCtx<TState> => ({
     self: commandSelf,
     getService: registryApi.getService,
@@ -1250,11 +1250,13 @@ export function createServiceRuntime<
   let loadCommands = commands as CommandSelf<TState>['commands'];
   const remoteCommandNames = new Set<string>();
 
-  const queryDefinitions = staticLoader
+  // Static builds inject `CONFIG_TYPE = 'PRODUCTION'` into the browser, so `staticPath` queries
+  // fetch prebuilt snapshots inline. The dev server and the Node static-build pipeline leave it
+  // undefined, so they keep running the authored `load` hooks (the static build generates the files).
+  const queryDefinitions = shouldUseBrowserStaticLoader()
     ? buildQueryDefinitionsWithStaticLoader(
         def.id,
         def.queries as Record<string, RuntimeQueryDefinition<TState>>,
-        staticLoader,
         commandSelf.setState
       )
     : new Map<string, RuntimeQueryDefinition<TState>>(

--- a/code/core/src/shared/open-service/static-fetch.test.ts
+++ b/code/core/src/shared/open-service/static-fetch.test.ts
@@ -11,7 +11,11 @@ import { clearRegistry, serviceRegistryApi } from './service-registry.ts';
 import { registerService as registerPreviewService } from './preview.ts';
 import { createServiceRuntime } from './service-runtime.ts';
 import { staticLoadSyncServiceDef } from './sync-test/static-load/definition.ts';
-import { createBrowserStaticLoader, type StaticLoaderContext } from './static-fetch.ts';
+import {
+  fetchStaticSnapshot,
+  shouldUseBrowserStaticLoader,
+  type StaticLoaderContext,
+} from './static-fetch.ts';
 
 const staticFetchServiceDef = defineService({
   id: 'internal-fixture/static-fetch',
@@ -49,45 +53,53 @@ const staticLoaderContext = {
   input: { id: 'alpha' },
 } satisfies StaticLoaderContext;
 
-describe('createBrowserStaticLoader', () => {
-  const originalConfigType = globalThis.CONFIG_TYPE;
-
+describe('shouldUseBrowserStaticLoader', () => {
   afterEach(() => {
-    globalThis.CONFIG_TYPE = originalConfigType;
+    vi.unstubAllGlobals();
+  });
+
+  it('is false in development', () => {
+    vi.stubGlobal('CONFIG_TYPE', 'DEVELOPMENT');
+
+    expect(shouldUseBrowserStaticLoader()).toBe(false);
+  });
+
+  it('is true in production', () => {
+    vi.stubGlobal('CONFIG_TYPE', 'PRODUCTION');
+
+    expect(shouldUseBrowserStaticLoader()).toBe(true);
+  });
+});
+
+describe('fetchStaticSnapshot', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it('returns undefined in development', () => {
-    globalThis.CONFIG_TYPE = 'DEVELOPMENT';
-
-    expect(createBrowserStaticLoader()).toBeUndefined();
-  });
-
-  it('fetches snapshots from /services/<logicalPath> in production', async () => {
-    globalThis.CONFIG_TYPE = 'PRODUCTION';
+  it('fetches snapshots from /services/<logicalPath>', async () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       json: async () => ({ entries: { alpha: 'from-file' } }),
     }));
     vi.stubGlobal('fetch', fetchMock);
 
-    const loader = createBrowserStaticLoader();
-    const snapshot = await loader!('internal-fixture/static-fetch/alpha.json', staticLoaderContext);
+    const snapshot = await fetchStaticSnapshot(
+      'internal-fixture/static-fetch/alpha.json',
+      staticLoaderContext
+    );
 
     expect(fetchMock).toHaveBeenCalledWith('/services/internal-fixture/static-fetch/alpha.json');
     expect(snapshot).toEqual({ entries: { alpha: 'from-file' } });
   });
 
   it('rejects when the response is not ok', async () => {
-    globalThis.CONFIG_TYPE = 'PRODUCTION';
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => ({ ok: false, status: 404, statusText: 'Not Found' }))
     );
 
-    const loader = createBrowserStaticLoader();
-
-    const error = await loader!('missing.json', staticLoaderContext).catch(
+    const error = await fetchStaticSnapshot('missing.json', staticLoaderContext).catch(
       (caught: unknown) => caught
     );
     expect(error).toBeInstanceOf(OpenServiceStaticSnapshotLoadError);
@@ -106,7 +118,6 @@ describe('createBrowserStaticLoader', () => {
   });
 
   it('rejects when fetch fails', async () => {
-    globalThis.CONFIG_TYPE = 'PRODUCTION';
     const cause = new Error('network down');
     vi.stubGlobal(
       'fetch',
@@ -115,9 +126,7 @@ describe('createBrowserStaticLoader', () => {
       })
     );
 
-    const loader = createBrowserStaticLoader();
-
-    await expect(loader!('network.json', staticLoaderContext)).rejects.toMatchObject({
+    await expect(fetchStaticSnapshot('network.json', staticLoaderContext)).rejects.toMatchObject({
       data: {
         serviceId: staticFetchServiceDef.id,
         queryName: 'getEntry',
@@ -130,7 +139,6 @@ describe('createBrowserStaticLoader', () => {
   });
 
   it('rejects when JSON parsing fails', async () => {
-    globalThis.CONFIG_TYPE = 'PRODUCTION';
     const cause = new SyntaxError('bad json');
     vi.stubGlobal(
       'fetch',
@@ -142,9 +150,7 @@ describe('createBrowserStaticLoader', () => {
       }))
     );
 
-    const loader = createBrowserStaticLoader();
-
-    await expect(loader!('broken.json', staticLoaderContext)).rejects.toMatchObject({
+    await expect(fetchStaticSnapshot('broken.json', staticLoaderContext)).rejects.toMatchObject({
       data: {
         serviceId: staticFetchServiceDef.id,
         queryName: 'getEntry',
@@ -157,7 +163,6 @@ describe('createBrowserStaticLoader', () => {
   });
 
   it('rejects when the snapshot is not a plain object', async () => {
-    globalThis.CONFIG_TYPE = 'PRODUCTION';
     const received = ['not an object'];
     vi.stubGlobal(
       'fetch',
@@ -167,9 +172,7 @@ describe('createBrowserStaticLoader', () => {
       }))
     );
 
-    const loader = createBrowserStaticLoader();
-
-    const error = await loader!('invalid.json', staticLoaderContext).catch(
+    const error = await fetchStaticSnapshot('invalid.json', staticLoaderContext).catch(
       (caught: unknown) => caught
     );
     expect(error).toBeInstanceOf(OpenServiceStaticSnapshotInvalidError);
@@ -187,20 +190,27 @@ describe('createBrowserStaticLoader', () => {
 });
 
 describe('static loader in service runtime', () => {
-  it('applies fetched snapshots instead of running the authored load command', async () => {
-    const staticLoader = vi.fn(async (logicalPath: string) => {
-      if (logicalPath === 'internal-fixture/static-fetch/alpha.json') {
-        return { entries: { alpha: 'static-alpha' } };
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches snapshots inline instead of running the authored load command in production', async () => {
+    vi.stubGlobal('CONFIG_TYPE', 'PRODUCTION');
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/services/internal-fixture/static-fetch/alpha.json') {
+        return { ok: true, json: async () => ({ entries: { alpha: 'static-alpha' } }) };
       }
-      if (logicalPath === 'internal-fixture/static-fetch/beta.json') {
-        return { entries: { beta: 'static-beta' } };
+      if (url === '/services/internal-fixture/static-fetch/beta.json') {
+        return { ok: true, json: async () => ({ entries: { beta: 'static-beta' } }) };
       }
-      throw new Error(`Unexpected static path: ${logicalPath}`);
+      throw new Error(`Unexpected static url: ${url}`);
     });
+    vi.stubGlobal('fetch', fetchMock);
 
     const runtime = createServiceRuntime(
       staticFetchServiceDef,
-      { registryApi: serviceRegistryApi, staticLoader },
+      { registryApi: serviceRegistryApi },
       structuredClone(staticFetchServiceDef.initialState)
     );
 
@@ -209,30 +219,19 @@ describe('static loader in service runtime', () => {
 
     expect(runtime.queries.getEntry({ id: 'alpha' })).toBe('static-alpha');
     expect(runtime.queries.getEntry({ id: 'beta' })).toBe('static-beta');
-    expect(staticLoader).toHaveBeenCalledWith('internal-fixture/static-fetch/alpha.json', {
-      serviceId: staticFetchServiceDef.id,
-      queryName: 'getEntry',
-      input: { id: 'alpha' },
-    });
-    expect(staticLoader).toHaveBeenCalledWith('internal-fixture/static-fetch/beta.json', {
-      serviceId: staticFetchServiceDef.id,
-      queryName: 'getEntry',
-      input: { id: 'beta' },
-    });
+    expect(fetchMock).toHaveBeenCalledWith('/services/internal-fixture/static-fetch/alpha.json');
+    expect(fetchMock).toHaveBeenCalledWith('/services/internal-fixture/static-fetch/beta.json');
   });
 
   it('resolves static-load demo entries through the preview registerService path', async () => {
-    const originalConfigType = globalThis.CONFIG_TYPE;
-    globalThis.CONFIG_TYPE = 'PRODUCTION';
+    vi.stubGlobal('CONFIG_TYPE', 'PRODUCTION');
 
     const channel = createTestChannel();
     installTestChannel(channel);
     clearRegistry();
     onTestFinished(() => {
-      globalThis.CONFIG_TYPE = originalConfigType;
       clearRegistry();
       installTestChannel(null);
-      vi.restoreAllMocks();
     });
 
     vi.stubGlobal(
@@ -263,7 +262,7 @@ describe('static loader in service runtime', () => {
     );
   });
 
-  it('runs the authored load when no static loader is configured', async () => {
+  it('runs the authored load when not in a static build', async () => {
     const runtime = createServiceRuntime(
       staticFetchServiceDef,
       { registryApi: serviceRegistryApi },

--- a/code/core/src/shared/open-service/static-fetch.ts
+++ b/code/core/src/shared/open-service/static-fetch.ts
@@ -17,66 +17,67 @@ export type StaticLoaderContext = {
   input: unknown;
 };
 
-export type StaticLoader = (
-  logicalPath: string,
-  context: StaticLoaderContext
-) => Promise<Record<string, unknown>>;
-
 const STATIC_SERVICES_PREFIX = '/services/';
 
-function shouldUseBrowserStaticLoader(): boolean {
+/**
+ * Whether this runtime should fetch prebuilt static snapshots instead of running authored `load`
+ * hooks.
+ *
+ * Only static Storybook builds inject `CONFIG_TYPE = 'PRODUCTION'` into the browser bundles; the
+ * dev server and the Node static-build pipeline leave it undefined, so they keep running real loads.
+ */
+export function shouldUseBrowserStaticLoader(): boolean {
   return globalThis.CONFIG_TYPE === 'PRODUCTION';
 }
 
 /**
- * Returns a fetch-based loader for static build output, or `undefined` in development.
+ * Fetches one prebuilt open-service static snapshot from the served build output.
  *
  * Snapshot paths are logical keys such as `core/docgen/foo.json`, resolved from the Storybook
- * origin (absolute `/services/...` so preview iframes and the manager share the same base).
+ * origin (absolute `/services/...` so preview iframes and the manager share the same base). Callers
+ * gate this on {@link shouldUseBrowserStaticLoader}; in development the runtime runs the authored
+ * `load` hook against the live server instead.
  */
-export function createBrowserStaticLoader(): StaticLoader | undefined {
-  if (!shouldUseBrowserStaticLoader()) {
-    return undefined;
+export async function fetchStaticSnapshot(
+  logicalPath: string,
+  context: StaticLoaderContext
+): Promise<Record<string, unknown>> {
+  const url = `${STATIC_SERVICES_PREFIX}${logicalPath}`;
+  let res: Response;
+
+  try {
+    res = await fetch(url);
+  } catch (cause) {
+    throw new OpenServiceStaticSnapshotLoadError({ ...context, logicalPath, url, cause });
   }
 
-  return async (logicalPath, context) => {
-    const url = `${STATIC_SERVICES_PREFIX}${logicalPath}`;
-    let res: Response;
-
-    try {
-      res = await fetch(url);
-    } catch (cause) {
-      throw new OpenServiceStaticSnapshotLoadError({ ...context, logicalPath, url, cause });
-    }
-
-    if (!res.ok) {
-      const cause = { status: res.status, statusText: res.statusText };
-      throw new OpenServiceStaticSnapshotLoadError({
-        ...context,
-        logicalPath,
-        url,
-        cause,
-        status: res.status,
-        statusText: res.statusText,
-      });
-    }
-
-    let snapshot: unknown;
-    try {
-      snapshot = await res.json();
-    } catch (cause) {
-      throw new OpenServiceStaticSnapshotLoadError({ ...context, logicalPath, url, cause });
-    }
-
-    if (snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot)) {
-      return snapshot as Record<string, unknown>;
-    }
-
-    throw new OpenServiceStaticSnapshotInvalidError({
+  if (!res.ok) {
+    const cause = { status: res.status, statusText: res.statusText };
+    throw new OpenServiceStaticSnapshotLoadError({
       ...context,
       logicalPath,
       url,
-      received: snapshot,
+      cause,
+      status: res.status,
+      statusText: res.statusText,
     });
-  };
+  }
+
+  let snapshot: unknown;
+  try {
+    snapshot = await res.json();
+  } catch (cause) {
+    throw new OpenServiceStaticSnapshotLoadError({ ...context, logicalPath, url, cause });
+  }
+
+  if (snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot)) {
+    return snapshot as Record<string, unknown>;
+  }
+
+  throw new OpenServiceStaticSnapshotInvalidError({
+    ...context,
+    logicalPath,
+    url,
+    received: snapshot,
+  });
 }


### PR DESCRIPTION
Tracked by https://github.com/storybookjs/storybook/issues/34824

## What I did

Simplified the open-service static-loading mechanism, per the [Docgen Server tracking issue](https://github.com/storybookjs/storybook/issues/34824) stretch goal "Simplify staticLoader pattern to not be dependency injected but just defined inline".

Previously, `manager.ts` and `preview.ts` each built a `createBrowserStaticLoader()` function and threaded it through `registerService` → `ServiceRegisterOptions.staticLoader` → `createServiceRuntime`'s `runtimeOptions`. This dependency injection was redundant: the loader already self-gated on `CONFIG_TYPE === 'PRODUCTION'`, which is only ever set in browser bundles.

Now:

- The fetch logic lives inline in the runtime as a plain `fetchStaticSnapshot()` function (no longer an injected closure factory).
- `createServiceRuntime` decides whether to use it via an inline boolean (`shouldUseBrowserStaticLoader()` → `CONFIG_TYPE === 'PRODUCTION'`), computed at the point of use.
- The `staticLoader` option is removed from `ServiceRegisterOptions`, `createServiceRuntime`, `manager.ts`, and `preview.ts`.

Behavior is unchanged per runtime: browser+production fetches prebuilt JSON snapshots; browser+dev, the dev server, and the Node static build (`buildStaticFiles`, where `CONFIG_TYPE` is undefined) all run the real `load` hooks.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

This refactor is exercised by the open-service `static-load` sync-test story. To verify nothing regressed in either mode:

**Development (runs real `load` against the dev server):**

1. `cd code && yarn storybook:ui`
2. Open the Open Service `static-load` demo story in the internal Storybook.
3. Confirm the demo entries (`alpha`, `beta`) render their loaded values with no console errors.

**Production / static build (fetches prebuilt JSON snapshots inline):**

1. `cd code && yarn storybook:ui:build`
2. Serve the static output, e.g. `npx http-server ./storybook-static -p 8080`
3. Open the `static-load` demo story in the served build.
4. In the Network tab, confirm the story's data is loaded via `GET /services/<serviceId>/...json` (HTTP 200) and the entries render correctly — i.e. the inline `fetchStaticSnapshot` path is used instead of running the authored `load`.

**Automated:**

5. `yarn test static-fetch` plus the open-service suites (`service-registration`, `service-runtime`, `server`) — all green.

Most likely area to regress: the production static-fetch path (the inline `CONFIG_TYPE` gate must stay `false` on the Node server so `buildStaticFiles` still generates files by running real loads).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->