### PR TITLE
[vitest-addon] Treat already-exited process codes as success in treeKill teardown

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/global-setup.ts
+++ b/code/addons/vitest/src/vitest-plugin/global-setup.ts
@@ -84,6 +84,18 @@ export const teardown = async () => {
     if (storybookProcess?.pid) {
       treeKill(storybookProcess.pid, 'SIGTERM', (error) => {
         if (error) {
+          const errno = error as NodeJS.ErrnoException;
+          const alreadyGone =
+            errno.code === 128 ||
+            errno.code === 'ESRCH' ||
+            /not found|no running instance|no tasks/i.test(errno.message ?? '');
+
+          if (alreadyGone) {
+            logger.verbose('Storybook process already exited');
+            resolve();
+            return;
+          }
+
           logger.error('Failed to stop Storybook process:');
           reject(error);
           return;


### PR DESCRIPTION
When Storybook is killed by a signal or crashes before Vitest teardown runs, `treeKill` on Windows returns an error with `errno.code === 128`, `errno.code === 'ESRCH'`, or a message matching "not found / no running instance / no tasks". The current callback rejects unconditionally on any error, which fails the global teardown step and leaves the test run in an error state even though the process is already gone.

This fix checks for those "already gone" signals before rejecting. If the process simply isn't there anymore, teardown resolves normally. Any other error (genuine kill failure, permission denied, etc.) still rejects as before.

Fixes #35277. Related: #28890, #30012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling so stopping Storybook is less likely to fail when the process has already exited.
  * Common “process not found” cases are now treated as non-fatal, reducing noisy errors during teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->