### PR TITLE
CI: Resolve Webpack to 5.107 to ensure we have a unique version

### DIFF
--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -715,6 +715,9 @@ export const baseTemplates = {
     modifications: {
       // Move this to latest or 22 once ng new creates v22 projects
       extraDependencies: ['@angular/forms@21.2.16', '@angular/animations@21.2.16'],
+      resolutions: {
+        webpack: '5.107.2',
+      },
       useCsfFactory: true,
     },
     extraCiSteps: {


### PR DESCRIPTION
## What I did

Our Angular CLI sandbox was mixing 5.106 (from Angular) and 5.108 (from us), resulting in files transpiled with export syntaxes that Angular misparsed. This prevented builds from completing.

See https://app.circleci.com/pipelines/github/storybookjs/storybook/126019/workflows/aa3c4bbe-d483-4683-a356-6da58deb805d/jobs/1665811

#### Manual testing

Build Angular CLI sandbox. Run SB build. It completes. Remove resolution in package.json, yarn, build Sb, it fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a sandbox template to pin a specific webpack version, helping improve consistency and reduce setup-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->