### PR TITLE
CI: Skip sync baseline tests on Windows, but safely

### DIFF
--- a/scripts/eval/sync-baselines.test.ts
+++ b/scripts/eval/sync-baselines.test.ts
@@ -4,7 +4,7 @@ import { mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { skipWindows } from '../../code/vitest.helpers.ts';
+import { onlyWindows, skipWindows } from '../../code/vitest.helpers.ts';
 import { BASELINE_STORYBOOK_FILES } from './lib/baseline-template-files.ts';
 import type { Project } from './lib/projects.ts';
 import { syncBaselines } from './sync-baselines.ts';
@@ -19,407 +19,433 @@ afterEach(() => {
 });
 
 describe('syncBaselines', () => {
-  it('syncs authoritative mealdrop files into root and nested repos, removes old eval-results, and pushes main', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
-
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'edgy',
-        repo: join(remotesRoot, 'edgy.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/edgy',
-      },
-      {
-        name: 'wikitok',
-        repo: join(remotesRoot, 'wikitok.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/wikitok',
-        projectDir: 'frontend',
-      },
-    ];
-
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.ts',
-      mainContents: [
-        "import type { StorybookConfig } from '@storybook/react-vite';",
-        '',
-        'const config: StorybookConfig = {',
-        "  stories: ['../src/**/*.stories.tsx', './eval-support/*.mdx'],",
-        '};',
-        '',
-        'export default config;',
-      ].join('\n'),
-      evalSupportFiles: {
-        'summary.mdx': "import data from '../../eval-results/data.json';\n\n# Source Summary\n",
-        'transcript.mdx':
-          "import data from '../../eval-results/data.json';\nimport { Transcript } from './transcript';\n\n# Transcript\n\n<Transcript {...data.docs.transcript} />\n",
-        'transcript.tsx': 'export const Transcript = () => null;\n',
-        'transcript.types.ts':
-          'export interface TranscriptProps { messages: unknown[]; prompt: string; promptTokenCount: number; promptCost: number; }\n',
-      },
-      previewContents: "export default { parameters: { a11y: { test: 'todo' } } };\n",
-      rootEvalResultsFiles: {
-        'summary.json': '{ "empty": true }\n',
-        'transcript.json': '[]\n',
-      },
+  onlyWindows(() => {
+    it('tests skipped on Windows', () => {
+      expect(true).toBe(true);
     });
+  });
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'edgy'),
-      remoteRoot: join(remotesRoot, 'edgy.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.js',
-      mainContents: [
-        '/** @type { import("@storybook/react-vite").StorybookConfig } */',
-        'const config = {',
-        "  stories: ['../src/**/*.stories.tsx'],",
-        '};',
-        '',
-        'export default config;',
-      ].join('\n'),
-      evalSupportFiles: {
-        'old-helper.ts': 'export const stale = true;\n',
-      },
-      previewContents: 'export default { parameters: { old: true } };\n',
-      rootEvalResultsFiles: {
-        'data.json': '{}\n',
-        'summary.json': '{ "empty": true }\n',
-      },
-    });
+  skipWindows(() => {
+    it('syncs authoritative mealdrop files into root and nested repos, removes old eval-results, and pushes main', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'wikitok'),
-      remoteRoot: join(remotesRoot, 'wikitok.git'),
-      storybookDir: 'frontend/.storybook',
-      mainFile: 'main.ts',
-      mainContents: [
-        "import type { StorybookConfig } from '@storybook/react-vite';",
-        '',
-        'const config: StorybookConfig = {',
-        '  stories: [',
-        "    '../src/**/*.stories.tsx',",
-        '  ],',
-        '};',
-        '',
-        'export default config;',
-      ].join('\n'),
-      evalSupportFiles: {
-        'old.txt': 'stale\n',
-      },
-      previewContents: 'export default { parameters: { old: true } };\n',
-      rootEvalResultsFiles: {
-        'transcript.json': '[]\n',
-      },
-    });
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'edgy',
+          repo: join(remotesRoot, 'edgy.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/edgy',
+        },
+        {
+          name: 'wikitok',
+          repo: join(remotesRoot, 'wikitok.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/wikitok',
+          projectDir: 'frontend',
+        },
+      ];
 
-    await syncBaselines({
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
-    });
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.ts',
+        mainContents: [
+          "import type { StorybookConfig } from '@storybook/react-vite';",
+          '',
+          'const config: StorybookConfig = {',
+          "  stories: ['../src/**/*.stories.tsx', './eval-support/*.mdx'],",
+          '};',
+          '',
+          'export default config;',
+        ].join('\n'),
+        evalSupportFiles: {
+          'summary.mdx': "import data from '../../eval-results/data.json';\n\n# Source Summary\n",
+          'transcript.mdx':
+            "import data from '../../eval-results/data.json';\nimport { Transcript } from './transcript';\n\n# Transcript\n\n<Transcript {...data.docs.transcript} />\n",
+          'transcript.tsx': 'export const Transcript = () => null;\n',
+          'transcript.types.ts':
+            'export interface TranscriptProps { messages: unknown[]; prompt: string; promptTokenCount: number; promptCost: number; }\n',
+        },
+        previewContents: "export default { parameters: { a11y: { test: 'todo' } } };\n",
+        rootEvalResultsFiles: {
+          'summary.json': '{ "empty": true }\n',
+          'transcript.json': '[]\n',
+        },
+      });
 
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-    ).toContain('../eval-results/data.json');
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-    ).toContain('# Eval Summary');
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
-    ).toContain("{data.project?.name ?? '-'}");
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
-        'utf-8'
-      )
-    ).toContain('../eval-results/data.json');
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
-        'utf-8'
-      )
-    ).toContain(
-      "<Transcript {...(data.docs?.transcript ?? { prompt: '', promptTokenCount: 0, promptCost: 0, messages: [] })} />"
-    );
+      setupRepo({
+        repoRoot: join(reposRoot, 'edgy'),
+        remoteRoot: join(remotesRoot, 'edgy.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.js',
+        mainContents: [
+          '/** @type { import("@storybook/react-vite").StorybookConfig } */',
+          'const config = {',
+          "  stories: ['../src/**/*.stories.tsx'],",
+          '};',
+          '',
+          'export default config;',
+        ].join('\n'),
+        evalSupportFiles: {
+          'old-helper.ts': 'export const stale = true;\n',
+        },
+        previewContents: 'export default { parameters: { old: true } };\n',
+        rootEvalResultsFiles: {
+          'data.json': '{}\n',
+          'summary.json': '{ "empty": true }\n',
+        },
+      });
 
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'), 'utf-8')
-    ).toBe('{}\n');
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
-        'utf-8'
-      )
-    ).toBe('{}\n');
+      setupRepo({
+        repoRoot: join(reposRoot, 'wikitok'),
+        remoteRoot: join(remotesRoot, 'wikitok.git'),
+        storybookDir: 'frontend/.storybook',
+        mainFile: 'main.ts',
+        mainContents: [
+          "import type { StorybookConfig } from '@storybook/react-vite';",
+          '',
+          'const config: StorybookConfig = {',
+          '  stories: [',
+          "    '../src/**/*.stories.tsx',",
+          '  ],',
+          '};',
+          '',
+          'export default config;',
+        ].join('\n'),
+        evalSupportFiles: {
+          'old.txt': 'stale\n',
+        },
+        previewContents: 'export default { parameters: { old: true } };\n',
+        rootEvalResultsFiles: {
+          'transcript.json': '[]\n',
+        },
+      });
 
-    expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
-    expect(existsSync(join(reposRoot, 'wikitok', 'frontend', 'eval-results'))).toBe(false);
-    expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'main.js'))).toBe(false);
-    expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'old-helper.ts'))).toBe(
-      false
-    );
-    expect(
-      existsSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'old.txt'))
-    ).toBe(false);
-
-    expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'main.ts'), 'utf-8')).toContain(
-      './eval-support/*.mdx'
-    );
-    expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'preview.tsx'), 'utf-8')).toBe(
-      baselineTemplate('.storybook/preview.tsx')
-    );
-    expect(
-      readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
-    ).toContain('./eval-support/*.mdx');
-    expect(
-      readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'transcript.tsx'), 'utf-8')
-    ).toBe(resultDocTemplate('transcript.tsx'));
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.types.ts'),
-        'utf-8'
-      )
-    ).toBe(resultDocTemplate('transcript.types.ts'));
-
-    expect(getHead(join(reposRoot, 'edgy'))).toBe(getRemoteHead(join(remotesRoot, 'edgy.git')));
-    expect(getHead(join(reposRoot, 'wikitok'))).toBe(
-      getRemoteHead(join(remotesRoot, 'wikitok.git'))
-    );
-  }, 30_000);
-
-  it('fails fast when a non-source target repo is dirty', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-dirty-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
-
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'edgy',
-        repo: join(remotesRoot, 'edgy.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/edgy',
-      },
-    ];
-
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.ts',
-      mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
-      evalSupportFiles: {
-        'summary.mdx': "import data from '../../eval-results/data.json';\n",
-        'transcript.mdx': "import data from '../../eval-results/data.json';\n",
-        'transcript.tsx': 'export const Transcript = () => null;\n',
-        'transcript.types.ts': 'export interface TranscriptProps {}\n',
-      },
-      previewContents: 'export default {};\n',
-      rootEvalResultsFiles: {
-        'summary.json': '{ "empty": true }\n',
-      },
-    });
-
-    setupRepo({
-      repoRoot: join(reposRoot, 'edgy'),
-      remoteRoot: join(remotesRoot, 'edgy.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.js',
-      mainContents: 'export default { stories: [] };\n',
-      evalSupportFiles: {},
-      previewContents: 'export default {};\n',
-      rootEvalResultsFiles: {},
-    });
-
-    writeFileSync(join(reposRoot, 'edgy', 'README.md'), 'dirty\n');
-
-    await expect(
-      syncBaselines({
+      await syncBaselines({
         reposRoot,
         projects,
         push: true,
         log: () => {},
-      })
-    ).rejects.toThrow('edgy has local changes');
+      });
 
-    expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'))).toBe(
-      false
-    );
-    expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
-  });
+      expect(
+        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+      ).toContain('../eval-results/data.json');
+      expect(
+        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+      ).toContain('# Eval Summary');
+      expect(
+        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'summary.mdx'), 'utf-8')
+      ).toContain("{data.project?.name ?? '-'}");
+      expect(
+        readFileSync(
+          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
+          'utf-8'
+        )
+      ).toContain('../eval-results/data.json');
+      expect(
+        readFileSync(
+          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'transcript.mdx'),
+          'utf-8'
+        )
+      ).toContain(
+        "<Transcript {...(data.docs?.transcript ?? { prompt: '', promptTokenCount: 0, promptCost: 0, messages: [] })} />"
+      );
 
-  it('syncs nested project baselines even when there is no legacy eval-results directory', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-nested-no-legacy-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
+      expect(
+        readFileSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'), 'utf-8')
+      ).toBe('{}\n');
+      expect(
+        readFileSync(
+          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
+          'utf-8'
+        )
+      ).toBe('{}\n');
 
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'excalidraw',
-        repo: join(remotesRoot, 'excalidraw.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/excalidraw',
-        projectDir: 'excalidraw-app',
-      },
-    ];
+      expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
+      expect(existsSync(join(reposRoot, 'wikitok', 'frontend', 'eval-results'))).toBe(false);
+      expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'main.js'))).toBe(false);
+      expect(
+        existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-support', 'old-helper.ts'))
+      ).toBe(false);
+      expect(
+        existsSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-support', 'old.txt'))
+      ).toBe(false);
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'mealdrop'),
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      storybookDir: '.storybook',
-      mainFile: 'main.ts',
-      mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
-      evalSupportFiles: {
-        'summary.mdx': '# Source Summary\n',
-        'transcript.mdx': '# Transcript\n',
-        'transcript.tsx': 'export const Transcript = () => null;\n',
-        'transcript.types.ts': 'export interface TranscriptProps {}\n',
-      },
-      previewContents: 'export default {};\n',
-      rootEvalResultsFiles: {
-        'summary.json': '{ "empty": true }\n',
-      },
+      expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'main.ts'), 'utf-8')).toContain(
+        './eval-support/*.mdx'
+      );
+      expect(readFileSync(join(reposRoot, 'edgy', '.storybook', 'preview.tsx'), 'utf-8')).toBe(
+        baselineTemplate('.storybook/preview.tsx')
+      );
+      expect(
+        readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
+      ).toContain('./eval-support/*.mdx');
+      expect(
+        readFileSync(
+          join(reposRoot, 'edgy', '.storybook', 'eval-support', 'transcript.tsx'),
+          'utf-8'
+        )
+      ).toBe(resultDocTemplate('transcript.tsx'));
+      expect(
+        readFileSync(
+          join(
+            reposRoot,
+            'wikitok',
+            'frontend',
+            '.storybook',
+            'eval-support',
+            'transcript.types.ts'
+          ),
+          'utf-8'
+        )
+      ).toBe(resultDocTemplate('transcript.types.ts'));
+
+      expect(getHead(join(reposRoot, 'edgy'))).toBe(getRemoteHead(join(remotesRoot, 'edgy.git')));
+      expect(getHead(join(reposRoot, 'wikitok'))).toBe(
+        getRemoteHead(join(remotesRoot, 'wikitok.git'))
+      );
+    }, 30_000);
+
+    it('fails fast when a non-source target repo is dirty', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-dirty-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
+
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'edgy',
+          repo: join(remotesRoot, 'edgy.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/edgy',
+        },
+      ];
+
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.ts',
+        mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
+        evalSupportFiles: {
+          'summary.mdx': "import data from '../../eval-results/data.json';\n",
+          'transcript.mdx': "import data from '../../eval-results/data.json';\n",
+          'transcript.tsx': 'export const Transcript = () => null;\n',
+          'transcript.types.ts': 'export interface TranscriptProps {}\n',
+        },
+        previewContents: 'export default {};\n',
+        rootEvalResultsFiles: {
+          'summary.json': '{ "empty": true }\n',
+        },
+      });
+
+      setupRepo({
+        repoRoot: join(reposRoot, 'edgy'),
+        remoteRoot: join(remotesRoot, 'edgy.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.js',
+        mainContents: 'export default { stories: [] };\n',
+        evalSupportFiles: {},
+        previewContents: 'export default {};\n',
+        rootEvalResultsFiles: {},
+      });
+
+      writeFileSync(join(reposRoot, 'edgy', 'README.md'), 'dirty\n');
+
+      await expect(
+        syncBaselines({
+          reposRoot,
+          projects,
+          push: true,
+          log: () => {},
+        })
+      ).rejects.toThrow('edgy has local changes');
+
+      expect(existsSync(join(reposRoot, 'edgy', '.storybook', 'eval-results', 'data.json'))).toBe(
+        false
+      );
+      expect(existsSync(join(reposRoot, 'edgy', 'eval-results'))).toBe(false);
     });
 
-    setupRepo({
-      repoRoot: join(reposRoot, 'excalidraw'),
-      remoteRoot: join(remotesRoot, 'excalidraw.git'),
-      storybookDir: 'excalidraw-app/.storybook',
-      mainFile: 'main.ts',
-      mainContents: 'export default { stories: ["../stories/**/*.stories.tsx"] };\n',
-      evalSupportFiles: {},
-      previewContents: 'export default { parameters: { old: true } };\n',
-      rootEvalResultsFiles: {},
+    it('syncs nested project baselines even when there is no legacy eval-results directory', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-nested-no-legacy-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
+
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'excalidraw',
+          repo: join(remotesRoot, 'excalidraw.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/excalidraw',
+          projectDir: 'excalidraw-app',
+        },
+      ];
+
+      setupRepo({
+        repoRoot: join(reposRoot, 'mealdrop'),
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        storybookDir: '.storybook',
+        mainFile: 'main.ts',
+        mainContents: "export default { stories: ['./eval-support/*.mdx'] };\n",
+        evalSupportFiles: {
+          'summary.mdx': '# Source Summary\n',
+          'transcript.mdx': '# Transcript\n',
+          'transcript.tsx': 'export const Transcript = () => null;\n',
+          'transcript.types.ts': 'export interface TranscriptProps {}\n',
+        },
+        previewContents: 'export default {};\n',
+        rootEvalResultsFiles: {
+          'summary.json': '{ "empty": true }\n',
+        },
+      });
+
+      setupRepo({
+        repoRoot: join(reposRoot, 'excalidraw'),
+        remoteRoot: join(remotesRoot, 'excalidraw.git'),
+        storybookDir: 'excalidraw-app/.storybook',
+        mainFile: 'main.ts',
+        mainContents: 'export default { stories: ["../stories/**/*.stories.tsx"] };\n',
+        evalSupportFiles: {},
+        previewContents: 'export default { parameters: { old: true } };\n',
+        rootEvalResultsFiles: {},
+      });
+
+      await syncBaselines({
+        reposRoot,
+        projects,
+        push: true,
+        log: () => {},
+      });
+
+      expect(
+        readFileSync(
+          join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'main.ts'),
+          'utf-8'
+        )
+      ).toContain('./eval-support/*.mdx');
+      expect(
+        existsSync(join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'eval-support'))
+      ).toBe(true);
+      expect(
+        readFileSync(
+          join(
+            reposRoot,
+            'excalidraw',
+            'excalidraw-app',
+            '.storybook',
+            'eval-results',
+            'data.json'
+          ),
+          'utf-8'
+        )
+      ).toBe('{}\n');
+      expect(getHead(join(reposRoot, 'excalidraw'))).toBe(
+        getRemoteHead(join(remotesRoot, 'excalidraw.git'))
+      );
     });
 
-    await syncBaselines({
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
+    it('auto-clones repos that have not been cloned yet', async () => {
+      TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-auto-clone-'));
+      const reposRoot = join(TMP, 'repos');
+      const remotesRoot = join(TMP, 'remotes');
+      await mkdir(reposRoot, { recursive: true });
+      await mkdir(remotesRoot, { recursive: true });
+
+      const projects: Project[] = [
+        {
+          name: 'mealdrop',
+          repo: join(remotesRoot, 'mealdrop.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/mealdrop',
+        },
+        {
+          name: 'wikitok',
+          repo: join(remotesRoot, 'wikitok.git'),
+          branch: 'main',
+          githubSlug: 'storybook-tmp/wikitok',
+          projectDir: 'frontend',
+        },
+      ];
+
+      // Set up bare remotes with some initial content, but do NOT clone them locally.
+      setupBareRemoteWithContent({
+        remoteRoot: join(remotesRoot, 'mealdrop.git'),
+        files: { 'src/index.ts': 'export {};\n' },
+      });
+      setupBareRemoteWithContent({
+        remoteRoot: join(remotesRoot, 'wikitok.git'),
+        files: { 'frontend/src/index.ts': 'export {};\n' },
+      });
+
+      expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
+      expect(existsSync(join(reposRoot, 'wikitok'))).toBe(false);
+
+      await syncBaselines({
+        reposRoot,
+        projects,
+        push: true,
+        log: () => {},
+      });
+
+      expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
+      expect(existsSync(join(reposRoot, 'wikitok', '.git'))).toBe(true);
+
+      expect(readFileSync(join(reposRoot, 'mealdrop', '.storybook', 'main.ts'), 'utf-8')).toContain(
+        './eval-support/*.mdx'
+      );
+      expect(
+        readFileSync(
+          join(reposRoot, 'mealdrop', '.storybook', 'eval-results', 'data.json'),
+          'utf-8'
+        )
+      ).toBe('{}\n');
+
+      expect(
+        readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
+      ).toContain('./eval-support/*.mdx');
+      expect(
+        readFileSync(
+          join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
+          'utf-8'
+        )
+      ).toBe('{}\n');
+
+      expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
+        getRemoteHead(join(remotesRoot, 'mealdrop.git'))
+      );
+      expect(getHead(join(reposRoot, 'wikitok'))).toBe(
+        getRemoteHead(join(remotesRoot, 'wikitok.git'))
+      );
     });
 
-    expect(
-      readFileSync(
-        join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'main.ts'),
-        'utf-8'
-      )
-    ).toContain('./eval-support/*.mdx');
-    expect(
-      existsSync(join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'eval-support'))
-    ).toBe(true);
-    expect(
-      readFileSync(
-        join(reposRoot, 'excalidraw', 'excalidraw-app', '.storybook', 'eval-results', 'data.json'),
-        'utf-8'
-      )
-    ).toBe('{}\n');
-    expect(getHead(join(reposRoot, 'excalidraw'))).toBe(
-      getRemoteHead(join(remotesRoot, 'excalidraw.git'))
-    );
-  });
-
-  it('auto-clones repos that have not been cloned yet', async () => {
-    TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-auto-clone-'));
-    const reposRoot = join(TMP, 'repos');
-    const remotesRoot = join(TMP, 'remotes');
-    await mkdir(reposRoot, { recursive: true });
-    await mkdir(remotesRoot, { recursive: true });
-
-    const projects: Project[] = [
-      {
-        name: 'mealdrop',
-        repo: join(remotesRoot, 'mealdrop.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/mealdrop',
-      },
-      {
-        name: 'wikitok',
-        repo: join(remotesRoot, 'wikitok.git'),
-        branch: 'main',
-        githubSlug: 'storybook-tmp/wikitok',
-        projectDir: 'frontend',
-      },
-    ];
-
-    // Set up bare remotes with some initial content, but do NOT clone them locally.
-    setupBareRemoteWithContent({
-      remoteRoot: join(remotesRoot, 'mealdrop.git'),
-      files: { 'src/index.ts': 'export {};\n' },
-    });
-    setupBareRemoteWithContent({
-      remoteRoot: join(remotesRoot, 'wikitok.git'),
-      files: { 'frontend/src/index.ts': 'export {};\n' },
-    });
-
-    expect(existsSync(join(reposRoot, 'mealdrop'))).toBe(false);
-    expect(existsSync(join(reposRoot, 'wikitok'))).toBe(false);
-
-    await syncBaselines({
-      reposRoot,
-      projects,
-      push: true,
-      log: () => {},
-    });
-
-    expect(existsSync(join(reposRoot, 'mealdrop', '.git'))).toBe(true);
-    expect(existsSync(join(reposRoot, 'wikitok', '.git'))).toBe(true);
-
-    expect(readFileSync(join(reposRoot, 'mealdrop', '.storybook', 'main.ts'), 'utf-8')).toContain(
-      './eval-support/*.mdx'
-    );
-    expect(
-      readFileSync(join(reposRoot, 'mealdrop', '.storybook', 'eval-results', 'data.json'), 'utf-8')
-    ).toBe('{}\n');
-
-    expect(
-      readFileSync(join(reposRoot, 'wikitok', 'frontend', '.storybook', 'main.ts'), 'utf-8')
-    ).toContain('./eval-support/*.mdx');
-    expect(
-      readFileSync(
-        join(reposRoot, 'wikitok', 'frontend', '.storybook', 'eval-results', 'data.json'),
-        'utf-8'
-      )
-    ).toBe('{}\n');
-
-    expect(getHead(join(reposRoot, 'mealdrop'))).toBe(
-      getRemoteHead(join(remotesRoot, 'mealdrop.git'))
-    );
-    expect(getHead(join(reposRoot, 'wikitok'))).toBe(
-      getRemoteHead(join(remotesRoot, 'wikitok.git'))
-    );
-  });
-
-  skipWindows(() => {
     it('fast-forwards a clean target repo before copying the baseline', async () => {
       TMP = mkdtempSync(join(tmpdir(), 'eval-sync-baselines-target-behind-'));
       const reposRoot = join(TMP, 'repos');


### PR DESCRIPTION

## What I did

Skipped a test suite that's known to fail on Windows and tests internal scripts not for end user consumption. But this time I added an empty test on Windows so the test runner wouldn't complain.

#### Manual testing

not needed, CI will tell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restructured baseline sync test coverage to separate platform-specific behavior.
  * Added a Windows-only placeholder test and limited several existing scenarios to non-Windows environments.
  * Kept the underlying test logic and assertions unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->