### PR TITLE
Core: Recognize addon-mcp registered via getAbsolutePath() in runtime instance registry

### DIFF
--- a/code/core/src/common/utils/get-addon-names.test.ts
+++ b/code/core/src/common/utils/get-addon-names.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getAddonNames } from './get-addon-names.ts';
+import { getAddonNames, normalizeAddonName } from './get-addon-names.ts';
 
 describe('getAddonNames', () => {
   it('should extract addon names from simple strings', () => {
@@ -92,5 +92,25 @@ describe('getAddonNames', () => {
       '@storybook/addon-outline',
       '@storybook/addon-controls',
     ]);
+  });
+});
+
+describe('normalizeAddonName', () => {
+  it('returns the bare name for a string entry', () => {
+    expect(normalizeAddonName('@storybook/addon-mcp')).toBe('@storybook/addon-mcp');
+  });
+
+  it('returns the name for an object entry', () => {
+    expect(normalizeAddonName({ name: '@storybook/addon-mcp' })).toBe('@storybook/addon-mcp');
+  });
+
+  it('resolves an absolute path to its bare package name', () => {
+    expect(normalizeAddonName('/sandbox/project/node_modules/@storybook/addon-mcp')).toBe(
+      '@storybook/addon-mcp'
+    );
+  });
+
+  it('returns undefined for relative local addon paths', () => {
+    expect(normalizeAddonName('./local-addon')).toBeUndefined();
   });
 });

--- a/code/core/src/common/utils/get-addon-names.ts
+++ b/code/core/src/common/utils/get-addon-names.ts
@@ -2,35 +2,43 @@ import type { StorybookConfig } from 'storybook/internal/types';
 
 import { normalizePath } from './normalize-path.ts';
 
+type AddonEntry = NonNullable<StorybookConfig['addons']>[number];
+
+/**
+ * Resolve an addon config entry (string, object, or absolute path) to its bare package name.
+ * Returns `undefined` for relative-path local addons.
+ */
+export const normalizeAddonName = (addon: AddonEntry): string | undefined => {
+  let name = '';
+  if (typeof addon === 'string') {
+    name = addon;
+  } else if (typeof addon === 'object') {
+    name = addon.name;
+  }
+
+  if (name.startsWith('.')) {
+    return undefined;
+  }
+
+  // Ensure posix paths for plugin name sniffing
+  name = normalizePath(name);
+
+  // For absolute paths, pnpm and yarn pnp,
+  // Remove everything before and including "node_modules/"
+  name = name.replace(/.*node_modules\//, '');
+
+  // Further clean up package names
+  return name
+    .replace(/\/dist\/.*$/, '')
+    .replace(/\.[mc]?[tj]?sx?$/, '')
+    .replace(/\/register$/, '')
+    .replace(/\/manager$/, '')
+    .replace(/\/preset$/, '');
+};
+
 export const getAddonNames = (mainConfig: StorybookConfig): string[] => {
   const addons = mainConfig.addons || [];
-  const addonList = addons.map((addon) => {
-    let name = '';
-    if (typeof addon === 'string') {
-      name = addon;
-    } else if (typeof addon === 'object') {
-      name = addon.name;
-    }
-
-    if (name.startsWith('.')) {
-      return undefined;
-    }
-
-    // Ensure posix paths for plugin name sniffing
-    name = normalizePath(name);
-
-    // For absolute paths, pnpm and yarn pnp,
-    // Remove everything before and including "node_modules/"
-    name = name.replace(/.*node_modules\//, '');
-
-    // Further clean up package names
-    return name
-      .replace(/\/dist\/.*$/, '')
-      .replace(/\.[mc]?[tj]?sx?$/, '')
-      .replace(/\/register$/, '')
-      .replace(/\/manager$/, '')
-      .replace(/\/preset$/, '');
-  });
+  const addonList = addons.map(normalizeAddonName);
 
   return addonList.filter((item): item is NonNullable<typeof item> => item != null);
 };

--- a/code/core/src/core-server/utils/runtime-instance-registry.test.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.test.ts
@@ -131,6 +131,54 @@ describe('getMcpMetadataFromMainConfig', () => {
       endpoint: '/custom-mcp',
     });
   });
+
+  it('detects addon-mcp registered as an absolute path via getAbsolutePath()', () => {
+    expect(
+      getMcpMetadataFromMainConfig({
+        addons: ['/Users/me/project/node_modules/@storybook/addon-mcp'],
+      })
+    ).toEqual({
+      status: 'ready',
+      endpoint: '/mcp',
+    });
+  });
+
+  it('detects addon-mcp registered as an object whose name is an absolute path', () => {
+    expect(
+      getMcpMetadataFromMainConfig({
+        addons: [
+          {
+            name: '/Users/me/project/node_modules/@storybook/addon-mcp',
+            options: { endpoint: '/custom-mcp' },
+          },
+        ],
+      })
+    ).toEqual({
+      status: 'ready',
+      endpoint: '/custom-mcp',
+    });
+  });
+
+  it('detects addon-mcp from a Windows-style absolute path', () => {
+    expect(
+      getMcpMetadataFromMainConfig({
+        addons: ['C:\\project\\node_modules\\@storybook\\addon-mcp'],
+      })
+    ).toEqual({
+      status: 'ready',
+      endpoint: '/mcp',
+    });
+  });
+
+  it('does not match unrelated addons that merely contain the addon-mcp name as a substring', () => {
+    expect(
+      getMcpMetadataFromMainConfig({
+        addons: ['@storybook/addon-mcp-extras', 'storybook-addon-mcp'],
+      })
+    ).toEqual({
+      status: 'not-installed',
+    });
+  });
 });
 
 describe('createRuntimeInstanceRecord', () => {

--- a/code/core/src/core-server/utils/runtime-instance-registry.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/p
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
+import { normalizeAddonName } from 'storybook/internal/common';
 import type { StorybookConfig } from 'storybook/internal/types';
 
 import { join, resolve } from 'pathe';
@@ -58,10 +59,9 @@ export function getOrigin(address: string) {
 export function getMcpMetadataFromMainConfig(
   mainConfig: Pick<StorybookConfig, 'addons'>
 ): RuntimeInstanceRecord['mcp'] {
+  // Normalize entries so addons registered via `getAbsolutePath()` are recognized, not just bare names.
   const addon = mainConfig.addons?.find(
-    (entry) =>
-      entry === STORYBOOK_MCP_ADDON ||
-      (typeof entry === 'object' && entry.name === STORYBOOK_MCP_ADDON)
+    (entry) => normalizeAddonName(entry) === STORYBOOK_MCP_ADDON
   );
 
   if (!addon) {


### PR DESCRIPTION
## What I did

Fixes `storybook ai` reporting `@storybook/addon-mcp` as missing ("Storybook is running but does not provide these commands") even though the addon is installed, loaded, and serving its `/mcp` endpoint normally.

### Root cause

The runtime instance registry decides MCP availability in `getMcpMetadataFromMainConfig` (`code/core/src/core-server/utils/runtime-instance-registry.ts`) by matching the addon config against the bare package name `@storybook/addon-mcp` — either the string or an object with `.name`:

```ts
const addon = mainConfig.addons?.find(
  (entry) =>
    entry === STORYBOOK_MCP_ADDON ||
    (typeof entry === 'object' && entry.name === STORYBOOK_MCP_ADDON)
);
```

But the `main.ts` generated by `storybook init` commonly registers addons through a `getAbsolutePath()` helper, which resolves the entry to an absolute path such as `/…/node_modules/@storybook/addon-mcp`. That matches neither branch, so `.find()` returns `undefined`, the instance record is written to `~/.storybook/instances/<uuid>.json` with `mcp.status: "not-installed"`, and the CLI (which trusts that record) prints "addon is missing." Meanwhile Storybook resolves the absolute path fine, so `/mcp` works — hence the contradiction.

This affects any config using the `getAbsolutePath` pattern, which is the default scaffold.

### Fix

Reuse the existing addon-name normalizer instead of a bare-string compare. I extracted `normalizeAddonName` from `getAddonNames` (`code/core/src/common/utils/get-addon-names.ts`) — it already handles absolute, pnpm, and yarn pnp paths — and used it for the lookup:

```ts
const addon = mainConfig.addons?.find(
  (entry) => normalizeAddonName(entry) === STORYBOOK_MCP_ADDON
);
```

No behavior change for `getAddonNames` (it now maps over the extracted function).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Added unit tests for `getMcpMetadataFromMainConfig` (absolute path string, object whose `name` is an absolute path, Windows-style path, and a negative case for substring-only matches) and for the new `normalizeAddonName` export.

#### Manual testing

1. Scaffold or use a project whose `.storybook/main.ts` registers the addon via the `getAbsolutePath` helper, e.g. `addons: [getAbsolutePath('@storybook/addon-mcp')]`.
2. Start Storybook (`storybook dev`).
3. Inspect the written record under `~/.storybook/instances/<uuid>.json`.
   - Before: `"mcp": { "status": "not-installed" }`
   - After: `"mcp": { "status": "ready", "endpoint": "/mcp" }`
4. Run a forwarded AI command, e.g. `STORYBOOK_FEATURE_AI_CLI=1 storybook ai get-changed-stories`.
   - Before: errors with "the `@storybook/addon-mcp` addon is missing".
   - After: the command runs against the addon.

### Documentation

- [ ] Add or update documentation reflecting your changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved addon detection so configured addons are recognized correctly whether they’re listed by package name, as an object, or as an absolute path.
  * Better handling of Windows and POSIX absolute paths, while still ignoring local relative addon paths.
  * MCP-related status and endpoint information now resolves more reliably in supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->