### PR TITLE
Addon Vitest: Avoid erroring out on benign Win process exits

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/global-setup.ts
+++ b/code/addons/vitest/src/vitest-plugin/global-setup.ts
@@ -82,8 +82,19 @@ export const teardown = async () => {
   await new Promise<void>((resolve, reject) => {
     // Storybook starts multiple child processes, so we need to kill the whole tree
     if (storybookProcess?.pid) {
-      treeKill(storybookProcess.pid, 'SIGTERM', (error) => {
+      const pid = storybookProcess.pid;
+      treeKill(pid, 'SIGTERM', (error) => {
         if (error) {
+          // On Windows, tree-kill shells out to `taskkill`, which exits with code 128 when the
+          // target PID no longer exists (e.g. Storybook already exited or  was stopped by the user).
+          // On POSIX, tree-kill already swallows the equivalent ESRCH internally.
+          if (process.platform === 'win32' && 'code' in error && error.code === 128) {
+            logger.verbose(
+              `Storybook process (pid ${pid}) already exited; treating teardown as successful (code ${error.code}: ${error.message})`
+            );
+            resolve();
+            return;
+          }
           logger.error('Failed to stop Storybook process:');
           reject(error);
           return;


### PR DESCRIPTION
Closes #35277
Supersedes #35278 

## What I did

Applied OP's suggested patch, with a few differences:
* No POSIX ESRCH code, this is already done by tree-kill
* No error message, those may be localized in Windows so it's not reliable
* No type casting of errors
* Scoped down to Windows explicitly to avoid misinterpreting a POSIX error code

I'm not highly confident about the reproducibility of the crash. I'd like to ideally wait for others to confirm they can repro.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

NOT TESTED.

#### Manual testing

* Boot up Windows
* Create any sandbox or use the monorepo
* Configure Vitest with `storybookTest({ storybookScript: '... storybook -- --no-open' })` (shell spawn)
* Run story tests, e.g. `vitest run --project storybook` ideally in watch mode
* Play whack-a-mole with Storybook instances; kill them manually and observe if Vitest exits or not


### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35287-sha-b36fc664`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35287-sha-b36fc664 sandbox` or in an existing project with `npx storybook@0.0.0-pr-35287-sha-b36fc664 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35287-sha-b36fc664`](https://npmjs.com/package/storybook/v/0.0.0-pr-35287-sha-b36fc664) |
| **Triggered by** | @Sidnioulz |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`sidnioulz/issue-35277`](https://github.com/storybookjs/storybook/tree/sidnioulz/issue-35277) |
| **Commit** | [`b36fc664`](https://github.com/storybookjs/storybook/commit/b36fc664ec3abd8f67247e7a9b17aca6449b7b63) |
| **Datetime** | Thu Jun 25 14:19:57 UTC 2026 (`1782397197`) |
| **Workflow run** | [28176881619](https://github.com/storybookjs/storybook/actions/runs/28176881619) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35287`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup reliability when shutting down the Storybook process.
  - On Windows, teardown now treats a “process not found” response as a successful shutdown instead of failing the run.
  - Added safer shutdown handling so cleanup completes more gracefully when the process has already exited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->