### PR TITLE
addon-vitest: treat already-exited Storybook process as success in treeKill teardown

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/global-setup.ts
+++ b/code/addons/vitest/src/vitest-plugin/global-setup.ts
@@ -84,6 +84,21 @@ export const teardown = async () => {
     if (storybookProcess?.pid) {
       treeKill(storybookProcess.pid, 'SIGTERM', (error) => {
         if (error) {
+          const errno = error as NodeJS.ErrnoException;
+          // On Windows the process tree may already be gone by the time teardown runs
+          // (e.g. the user stopped Storybook, a port conflict caused an early exit, or
+          // watch mode finished before teardown). Treat those cases as success.
+          const alreadyGone =
+            errno.code === 128 ||
+            errno.code === 'ESRCH' ||
+            /not found|no running instance|no tasks/i.test(errno.message ?? '');
+
+          if (alreadyGone) {
+            logger.verbose('Storybook process already exited, skipping kill');
+            resolve();
+            return;
+          }
+
           logger.error('Failed to stop Storybook process:');
           reject(error);
           return;


### PR DESCRIPTION
Fixes #35277

When Vitest tears down after a standalone run, it calls `tree-kill` to stop the Storybook child process. On Windows, the process can already be gone by then — the user stopped it manually, a port conflict caused an early exit, or the shell-spawned process tree finished before teardown ran.

In those cases `tree-kill` returns an error with `code === 128`, `code === 'ESRCH'`, or a message matching `/not found|no running instance|no tasks/i`. The current code passes all `tree-kill` errors straight to `reject()`, which fails the entire Vitest run.

The fix checks for those "already gone" error shapes and resolves instead of rejecting. Genuine kill failures (the process exists but cannot be signalled) still reject as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Teardown now completes successfully when the target process is already gone, instead of failing.
  * Improved handling of “process not found” cases, including common Windows and exit-related scenarios.
  * Reduced noisy shutdown errors by treating missing-process conditions as a normal completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->