### PR TITLE
Addon-Vitest: Subscribe for run completion before triggering it

### DIFF
--- a/code/addons/vitest/src/preset.ts
+++ b/code/addons/vitest/src/preset.ts
@@ -233,8 +233,6 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
       return;
     }
 
-    // Subscribe before sending TRIGGER_RUN so a fast completion cannot fire the
-    // event before the listener is in place (closes #35289).
     const unsubscribe = store.subscribe((event) => {
       switch (event.type) {
         case 'TEST_RUN_COMPLETED': {

--- a/code/addons/vitest/src/preset.ts
+++ b/code/addons/vitest/src/preset.ts
@@ -233,17 +233,8 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
       return;
     }
 
-    store.send({
-      type: 'TRIGGER_RUN',
-      payload: {
-        storyIds,
-        triggeredBy: `external:${actor}`,
-        ...(configOverride && {
-          configOverride: { ...config, ...configOverride },
-        }),
-      },
-    });
-
+    // Subscribe before sending TRIGGER_RUN so a fast completion cannot fire the
+    // event before the listener is in place (closes #35289).
     const unsubscribe = store.subscribe((event) => {
       switch (event.type) {
         case 'TEST_RUN_COMPLETED': {
@@ -262,6 +253,17 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
           return;
         }
       }
+    });
+
+    store.send({
+      type: 'TRIGGER_RUN',
+      payload: {
+        storyIds,
+        triggeredBy: `external:${actor}`,
+        ...(configOverride && {
+          configOverride: { ...config, ...configOverride },
+        }),
+      },
     });
   });
 


### PR DESCRIPTION
Fixes #35289

The `TRIGGER_TEST_RUN_REQUEST` handler in `preset.ts` sends `TRIGGER_RUN` to the store and then subscribes to completion events. If the run finishes quickly — which happens for focused or small story sets via `@storybook/addon-mcp` — the `TEST_RUN_COMPLETED` event can fire before the subscription is in place. The response channel never emits `TRIGGER_TEST_RUN_RESPONSE`, and the MCP caller hangs until it times out.

The fix registers the `store.subscribe` call before `store.send`, so any completion event that fires synchronously or near-synchronously is captured. The logic inside the subscriber is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a timing issue in programmatic test runs where very fast completions could be missed.
  - Improved reliability by ensuring the test-run listener is set up before dispatching the trigger, so completion, error, and cancellation outcomes are captured consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- Maintainer edit -->
#### Manual testing
See instructions on #35289. Use canary `0.0.0-pr-35291-sha-a08be029`