### PR TITLE
UI: Hide Guide settings tab when sidebarOnboardingChecklist is false

### DIFF
--- a/code/core/src/manager/container/Menu.tsx
+++ b/code/core/src/manager/container/Menu.tsx
@@ -218,7 +218,10 @@ export const useMenu = ({
       [
         [
           about,
-          ...(global.CONFIG_TYPE === 'DEVELOPMENT' ? [guide] : []),
+          ...(global.CONFIG_TYPE === 'DEVELOPMENT' &&
+          global.FEATURES?.sidebarOnboardingChecklist !== false
+            ? [guide]
+            : []),
           ...(enableShortcuts ? [shortcuts] : []),
         ],
         [sidebarToggle, toolbarToogle, addonsToggle, up, down, prev, next, collapse],

--- a/code/core/src/manager/settings/index.tsx
+++ b/code/core/src/manager/settings/index.tsx
@@ -81,7 +81,7 @@ const Pages: FC<{
       },
     ];
 
-    if (global.CONFIG_TYPE === 'DEVELOPMENT') {
+    if (global.CONFIG_TYPE === 'DEVELOPMENT' && global.FEATURES?.sidebarOnboardingChecklist !== false) {
       tabsToInclude.push({
         id: 'guide',
         title: 'Guide',


### PR DESCRIPTION
Fixes #35274

Setting `features.sidebarOnboardingChecklist: false` already hides the checklist widget in the sidebar and the "Show in sidebar" link at the bottom of `GuidePage`. However, the "Guide" tab in the settings panel is added unconditionally whenever `CONFIG_TYPE === 'DEVELOPMENT'`, so the tab and its onboarding content remain visible even when the feature flag is off.

One-line fix: gate the tab inclusion on the same flag check used elsewhere. When `sidebarOnboardingChecklist` is `false` the Guide tab is omitted entirely from the settings panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

#### Manual testing
- Update the Storybook flag in `.storybook/main.ts`
- Run Storybook
- Open the settings menu and verify whether the **Guide** entry/tab appears or is hidden as expected

## Summary by CodeRabbit

* **Bug Fixes**
  * The Settings **Guide** tab/menu now appears only in development mode when onboarding checklist support is not explicitly disabled, preventing it from showing in unsupported setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->