### PR TITLE
React: Fix importOverride extraction when using react-docgen-typescript

### DIFF
--- a/code/renderers/react/src/componentManifest/getComponentImports.test.ts
+++ b/code/renderers/react/src/componentManifest/getComponentImports.test.ts
@@ -5,11 +5,13 @@ import { loadCsf } from 'storybook/internal/csf-tools';
 import { dedent } from 'ts-dedent';
 
 import { getImports as buildImports, getComponentData } from './getComponentImports.ts';
+import { parseWithReactDocgenTypescript } from './reactDocgenTypescript.ts';
 import { setupMemfsMocks } from './memfs-test-setup.ts';
 
 vi.mock('node:fs');
 vi.mock('node:fs/promises');
 vi.mock(import('./utils.ts'), { spy: true });
+vi.mock(import('./reactDocgenTypescript.ts'), { spy: true });
 vi.mock('storybook/internal/common', { spy: true });
 vi.mock('empathic/find', { spy: true });
 vi.mock('tsconfig-paths', { spy: true });
@@ -1047,4 +1049,36 @@ test('importOverride: merges multiple components into a single declaration per s
       "import { DSButton as Button, Header } from \"@ds/ui\";",
     ]
   `);
+});
+
+test('importOverride: react-docgen-typescript tags.import is used (not description)', async () => {
+  vi.mocked(parseWithReactDocgenTypescript).mockResolvedValue([
+    {
+      exportName: 'Button',
+      displayName: 'Button',
+      description: '',
+      filePath: './src/stories/Button.tsx',
+      props: {},
+      methods: [],
+      tags: { import: "import { Button } from '@design-system/components/override';" },
+    },
+  ]);
+
+  const code = dedent`
+    import { Button } from '@design-system/button';
+
+    const meta = {};
+    export default meta;
+    export const S = <Button/>;
+  `;
+  const csf = loadCsf(code, { makeTitle: (t) => t ?? 'No title' }).parse();
+  const { components } = await getComponentData({
+    csf,
+    storyFilePath: '/app/src/stories/Button.stories.tsx',
+    docgenEngine: 'react-docgen-typescript',
+  });
+
+  expect(components[0].importOverride).toBe(
+    "import { Button } from '@design-system/components/override';"
+  );
 });

--- a/code/renderers/react/src/componentManifest/reactDocgen.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen.ts
@@ -293,7 +293,12 @@ export function getReactDocgenImporter() {
   });
 }
 
-export function getImportTag(docgen: { description?: string }) {
+export function getImportTag(docgen: { description?: string; tags?: Record<string, string> }) {
+  // react-docgen-typescript surfaces parsed JSDoc tags directly on docgen.tags
+  const importTag = docgen?.tags?.import;
+  if (importTag) {
+    return importTag;
+  }
   const jsdocComment = docgen?.description;
   const tags = jsdocComment ? extractJSDocInfo(jsdocComment).tags : undefined;
   return tags?.import?.[0];


### PR DESCRIPTION
## What I did

Fixed `importOverride` not being populated and respected when using `react-docgen-typescript` as the docgen engine.

`react-docgen-typescript` surfaces parsed JSDoc tags (e.g. `@import`) on a `tags` object and does not include them in the `description` string. The existing `getImportTag` function only extracted the tag from the description string via regex, so the `@import` tag was silently ignored when `react-docgen-typescript` was in use.

The fix checks `docgen.tags.import` first, and falls back to parsing the description string (which is how `react-docgen` still works).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Set up a React project with `@storybook/react-vite` (or `react-webpack5`) using `react-docgen-typescript` as the docgen engine in `.storybook/main.ts`:
   ```ts
   typescript: { reactDocgen: 'react-docgen-typescript' }
   ```
2. Add a component whose source JSDoc includes an `@import` tag:
   ```tsx
   /**
    * @import import { Button } from '@design-system/components/override';
    */
   export const Button = ...
   ```
3. Write a story for that component and run Storybook.
4. Verify the component manifest (or MCP component data) reflects `importOverride` with the `import` pointing to the `@design-system/components/override` path rather than the actual import path.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how component import overrides are detected when using React docgen tools.
  * Import tags are now read directly when available, with fallback support for older description-based metadata.
  * Added coverage to ensure the correct import value is chosen in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->