### PR TITLE
Pass through language in SNIPPET_RENDERED event

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Source.tsx
+++ b/code/addons/docs/src/blocks/blocks/Source.tsx
@@ -151,7 +151,7 @@ export const useSourceProps = (
   const sourceParameters = (story?.parameters?.docs?.source || {}) as SourceParameters;
   let format = props.format;
 
-  const language = props.language ?? sourceParameters.language ?? 'jsx';
+  let language = props.language ?? sourceParameters.language ?? 'jsx';
   const dark = props.dark ?? sourceParameters.dark ?? false;
 
   if (props.code === undefined && !story) {
@@ -168,6 +168,7 @@ export const useSourceProps = (
   }
 
   format = source?.format ?? true;
+  language = source?.language ?? language;
 
   return {
     code: transformedCode,

--- a/code/addons/docs/src/blocks/blocks/SourceContainer.tsx
+++ b/code/addons/docs/src/blocks/blocks/SourceContainer.tsx
@@ -1,7 +1,10 @@
 import type { Context, FC, PropsWithChildren } from 'react';
 import React, { createContext, useEffect, useState } from 'react';
 
-import type { SyntaxHighlighterFormatTypes } from 'storybook/internal/components';
+import type {
+  SyntaxHighlighterFormatTypes,
+  SupportedLanguage,
+} from 'storybook/internal/components';
 import { SNIPPET_RENDERED } from 'storybook/internal/docs-tools';
 import type { Args, DocsContextProps, StoryId } from 'storybook/internal/types';
 
@@ -15,6 +18,7 @@ export function argsHash(args: Args): ArgsHash {
 export interface SourceItem {
   code: string;
   format?: SyntaxHighlighterFormatTypes;
+  language?: SupportedLanguage;
 }
 
 export type StorySources = Record<StoryId, Record<ArgsHash, SourceItem>>;
@@ -31,6 +35,7 @@ type SnippetRenderedEvent = {
   source: string;
   args?: Args;
   format?: SyntaxHighlighterFormatTypes;
+  language?: SupportedLanguage;
 };
 
 export const UNKNOWN_ARGS_HASH = '--unknown--';
@@ -52,11 +57,13 @@ export const SourceContainer: FC<PropsWithChildren<{ channel: DocsContextProps['
         args = undefined,
         source,
         format,
+        language,
       } = typeof idOrEvent === 'string'
         ? {
             id: idOrEvent,
             source: inputSource,
             format: inputFormat,
+            language: undefined,
           }
         : idOrEvent;
 
@@ -75,7 +82,7 @@ export const SourceContainer: FC<PropsWithChildren<{ channel: DocsContextProps['
           ...current,
           [id]: {
             ...current[id],
-            [hash]: { code: source || '', format },
+            [hash]: { code: source || '', format, language },
           },
         };
 

--- a/code/addons/docs/src/manager.tsx
+++ b/code/addons/docs/src/manager.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 
-import { AddonPanel, type SyntaxHighlighterFormatTypes } from 'storybook/internal/components';
+import {
+  AddonPanel,
+  type SupportedLanguage,
+  type SyntaxHighlighterFormatTypes,
+} from 'storybook/internal/components';
 
 import { addons, types, useChannel, useParameter } from 'storybook/manager-api';
 import { ignoreSsrWarning, styled, useTheme } from 'storybook/theming';
@@ -22,6 +26,7 @@ type SnippetRenderedEvent = {
   id?: StoryId;
   source?: string;
   format?: SyntaxHighlighterFormatTypes;
+  language?: SupportedLanguage;
 };
 
 const CodePanel = ({
@@ -41,9 +46,11 @@ const CodePanel = ({
   const [codeSnippet, setSourceCode] = useState<{
     source: string | undefined;
     format: SyntaxHighlighterFormatTypes | undefined;
+    language: SupportedLanguage | undefined;
   }>({
     source: lastEventMatchesCurrentStory ? lastEvent?.source : undefined,
-    format: lastEventMatchesCurrentStory ? (lastEvent?.format ?? undefined) : undefined,
+    format: lastEventMatchesCurrentStory ? lastEvent?.format : undefined,
+    language: lastEventMatchesCurrentStory ? lastEvent?.language : undefined,
   });
 
   const parameter = useParameter(PARAM_KEY, {
@@ -55,12 +62,13 @@ const CodePanel = ({
     setSourceCode({
       source: undefined,
       format: undefined,
+      language: undefined,
     });
   }, [currentStoryId]);
 
   useChannel(
     {
-      [SNIPPET_RENDERED]: ({ id, source, format }) => {
+      [SNIPPET_RENDERED]: ({ id, source, format, language }) => {
         // Ignore snippets emitted for other stories: a slow extraction for the previously selected
         // story can resolve after navigation and would otherwise overwrite the current panel.
         // `useChannel` captures this handler per `deps`, so it must list `currentStoryId` to compare
@@ -68,7 +76,7 @@ const CodePanel = ({
         if (id !== undefined && id !== currentStoryId) {
           return;
         }
-        setSourceCode({ source, format });
+        setSourceCode({ source, format, language });
       },
     },
     [currentStoryId]
@@ -83,10 +91,18 @@ const CodePanel = ({
     codeSnippet.source ||
     (awaitingServiceSnippet ? '' : parameter.source?.originalSource);
 
+  const language = parameter.source?.language ?? codeSnippet.language;
+
   return (
     <AddonPanel active={!!active}>
       <SourceStyles>
-        <Source {...parameter.source} code={code} format={codeSnippet.format} dark={isDark} />
+        <Source
+          {...parameter.source}
+          code={code}
+          language={language}
+          format={codeSnippet.format}
+          dark={isDark}
+        />
       </SourceStyles>
     </AddonPanel>
   );


### PR DESCRIPTION
## What I did

This adds the `language` option to the `SNIPPET_RENDERED` event, allowing users to render code snippets in languages other than the default. This is of significant use to anyone serving multiple languages from a single storybook.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

TBD

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

TODO! I will create an example in a sandbox...

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
