### PR TITLE
UI: Hide onboarding menu with feature flag

### DIFF
--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -233,6 +233,7 @@ export const features: PresetProperty<'features'> = async (existing) => ({
   legacyDecoratorFileOrder: false,
   measure: true,
   outline: true,
+  menuOnboardingChecklist: true,
   sidebarOnboardingChecklist: true,
   viewport: true,
 });

--- a/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
@@ -15,12 +15,12 @@ import type { IndexHash } from 'storybook/manager-api';
 import { ManagerContext } from 'storybook/manager-api';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
+import { internal_fullStatusStore as internal_ctaStatusStore } from 'storybook/manager-api';
 import { initialState } from '../../../shared/checklist-store/checklistData.state.ts';
 import {
   internal_fullStatusStore,
   internal_universalChecklistStore,
 } from '../../manager-stores.mock.ts';
-import { internal_fullStatusStore as internal_ctaStatusStore } from 'storybook/manager-api';
 import { LayoutProvider } from '../layout/LayoutProvider.tsx';
 import { standardData as standardHeaderData } from './Heading.stories.tsx';
 import { DEFAULT_REF_ID, Sidebar } from './Sidebar.tsx';
@@ -228,7 +228,10 @@ export const SimpleNoChecklist: Story = {
   },
   beforeEach: () => {
     const features = global.FEATURES;
-    global.FEATURES = { ...features, sidebarOnboardingChecklist: false };
+    global.FEATURES = {
+      ...features,
+      sidebarOnboardingChecklist: false,
+    };
     return () => {
       global.FEATURES = features;
     };

--- a/code/core/src/manager/container/Menu.tsx
+++ b/code/core/src/manager/container/Menu.tsx
@@ -218,7 +218,10 @@ export const useMenu = ({
       [
         [
           about,
-          ...(global.CONFIG_TYPE === 'DEVELOPMENT' ? [guide] : []),
+          ...(global.CONFIG_TYPE === 'DEVELOPMENT' &&
+          global.FEATURES?.menuOnboardingChecklist !== false
+            ? [guide]
+            : []),
           ...(enableShortcuts ? [shortcuts] : []),
         ],
         [sidebarToggle, toolbarToogle, addonsToggle, up, down, prev, next, collapse],

--- a/code/core/src/manager/settings/index.tsx
+++ b/code/core/src/manager/settings/index.tsx
@@ -3,8 +3,8 @@ import React, { useMemo } from 'react';
 
 import { Button, ScrollArea, TabsView } from 'storybook/internal/components';
 import { Location, Route } from 'storybook/internal/router';
-import { Addon_TypesEnum } from 'storybook/internal/types';
 import type { Addon_PageType } from 'storybook/internal/types';
+import { Addon_TypesEnum } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
 import { CloseIcon } from '@storybook/icons';
@@ -81,7 +81,10 @@ const Pages: FC<{
       },
     ];
 
-    if (global.CONFIG_TYPE === 'DEVELOPMENT') {
+    if (
+      global.CONFIG_TYPE === 'DEVELOPMENT' &&
+      global.FEATURES?.menuOnboardingChecklist !== false
+    ) {
       tabsToInclude.push({
         id: 'guide',
         title: 'Guide',

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -538,6 +538,13 @@ export interface StorybookConfigRaw {
     sidebarOnboardingChecklist?: boolean;
 
     /**
+     * Enable the onboarding guide page in the menu
+     *
+     * @default true
+     */
+    menuOnboardingChecklist?: boolean;
+
+    /**
      * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
      *
      * Filter args with a "target" on the type from the render function (EXPERIMENTAL)

--- a/docs/api/main-config/main-config-features.mdx
+++ b/docs/api/main-config/main-config-features.mdx
@@ -28,6 +28,7 @@ Type:
   measure?: boolean;
   outline?: boolean;
   sidebarOnboardingChecklist?: boolean;
+  menuOnboardingChecklist?: boolean;
   toolbars?: boolean;
   viewport?: boolean;
 }
@@ -53,6 +54,7 @@ Type:
   measure?: boolean;
   outline?: boolean;
   sidebarOnboardingChecklist?: boolean;
+  menuOnboardingChecklist?: boolean;
   toolbars?: boolean;
   viewport?: boolean;
 }
@@ -77,6 +79,7 @@ Type:
   measure?: boolean;
   outline?: boolean;
   sidebarOnboardingChecklist?: boolean;
+  menuOnboardingChecklist?: boolean;
   toolbars?: boolean;
   viewport?: boolean;
 }
@@ -233,6 +236,14 @@ Type: `boolean`
 Default: `true`
 
 Enable the [Measure](../../essentials/measure-and-outline.mdx#measure) feature.
+
+## `menuOnboardingChecklist`
+
+Type: `boolean`
+
+Default: `true`
+
+Enable a link to the onboarding guide in the menu.
 
 ## `outline`
 


### PR DESCRIPTION
Closes #35274


## What I did

Added a feature flag to hide the onboarding guide in the menu `menuOnboardingChecklist`, similar to `sidebarOnboardingChecklist`, so users can choose how they want to expose it.

I created a new flag to avoid disrupting users who currently only want to hide the main sidebar widget.

## Checklist for Contributors

### Testing

Not testable via stories as the Sidebar stories emulate the menu.

#### Manual testing

* Checkout branch and compile
* Add `menuOnboardingChecklist` false to your `code/.storybook/main.ts` features
* Run local SB instance
* Check menu content

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new feature option to show an onboarding guide entry in the menu, enabled by default.
  * The “Guide” tab and related menu item now only appear when this feature is enabled.

* **Documentation**
  * Updated configuration docs to describe the new menu onboarding option, its default setting, and where it appears in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->