### PR TITLE
Review: Embed thumbnails with scaling and full=1 layout navigation

### DIFF
--- a/code/core/src/manager-api/modules/layout.ts
+++ b/code/core/src/manager-api/modules/layout.ts
@@ -10,8 +10,8 @@ import { global } from '@storybook/global';
 
 import { pick, toMerged } from 'es-toolkit/object';
 import { isEqual as deepEqual } from 'es-toolkit/predicate';
-import type { ThemeVars } from 'storybook/theming';
 import { deprecate } from 'storybook/internal/client-logger';
+import type { ThemeVars } from 'storybook/theming';
 import { create } from 'storybook/theming/create';
 
 import merge from '../lib/merge.ts';
@@ -619,6 +619,14 @@ export const init: ModuleFn<SubAPI, SubState> = ({ store, provider, singleStory 
   };
 
   const persisted = pick(store.getState(), ['layout', 'selectedPanel']);
+  const initialOptions = api.getInitialOptions();
+  const merged = merge(initialOptions, persisted);
+  const layout = applyLayoutOptions(
+    merged.layout,
+    { layout: { showNav: merged.layout.showNav, showPanel: merged.layout.showPanel } },
+    !!singleStory
+  );
+  const state = { ...merged, layout };
 
   provider.channel?.on(SET_CONFIG, () => {
     api.setOptions(merge(api.getInitialOptions(), persisted));
@@ -626,6 +634,6 @@ export const init: ModuleFn<SubAPI, SubState> = ({ store, provider, singleStory 
 
   return {
     api,
-    state: merge(api.getInitialOptions(), persisted),
+    state,
   };
 };

--- a/code/core/src/manager-api/modules/url.ts
+++ b/code/core/src/manager-api/modules/url.ts
@@ -165,6 +165,9 @@ export interface SubAPI {
    * @param {QueryParams} [options.queryParams] - Query params to add to the URL.
    * @param {string} [options.refId] - ID of the ref to get the URL for (for composed Storybooks)
    * @param {string} [options.viewMode] - The view mode to use, defaults to 'story'.
+   * @param {boolean} [options.embed] - Append `embed=true` so the preview broadcasts
+   *   content dimensions to an embedding parent via `iframe.resize` postMessage. Affects
+   *   `previewHref` only.
    * @param {boolean} [options.freeze] - Append the `freeze=finished` preview contract so the
    *   preview settles to a static end frame and blocks interaction. Affects `previewHref` only.
    * @returns {Object} Manager and preview hrefs for the story.
@@ -178,6 +181,7 @@ export interface SubAPI {
       queryParams?: QueryParams;
       refId?: string;
       viewMode?: API_ViewMode;
+      embed?: boolean;
       freeze?: boolean;
     }
   ): { managerHref: string; previewHref: string };
@@ -250,6 +254,7 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
         queryParams = {},
         refId,
         viewMode = 'story',
+        embed = false,
         freeze = false,
       } = options;
 
@@ -289,11 +294,12 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
       customManagerParams = customManagerParams && `&${customManagerParams}`;
       customPreviewParams = customPreviewParams && `&${customPreviewParams}`;
 
+      const embedParam = embed ? '&embed=true' : '';
       const freezeParam = freeze ? '&freeze=finished' : '';
 
       return {
         managerHref: `${managerBase}?path=/${viewMode}/${refId ? `${refId}_` : ''}${storyId}${argsParam}${globalsParam}${customManagerParams}`,
-        previewHref: `${previewBase}?id=${storyId}&viewMode=${viewMode}${refParam}${argsParam}${refId ? '' : globalsParam}${customPreviewParams}${freezeParam}`,
+        previewHref: `${previewBase}?id=${storyId}&viewMode=${viewMode}${refParam}${argsParam}${refId ? '' : globalsParam}${customPreviewParams}${embedParam}${freezeParam}`,
       };
     },
     getQueryParam(key) {

--- a/code/core/src/manager-api/tests/layout.test.ts
+++ b/code/core/src/manager-api/tests/layout.test.ts
@@ -1,8 +1,8 @@
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { API_Provider } from 'storybook/internal/types';
 import * as clientLogger from 'storybook/internal/client-logger';
+import type { API_Provider } from 'storybook/internal/types';
 
 import EventEmitter from 'events';
 import { themes } from 'storybook/theming';
@@ -626,6 +626,30 @@ describe('layout API', () => {
 
       expect(state.layout.navSize).toBe(0);
       expect(state.layout.recentVisibleSizes.navSize).toBe(300);
+    });
+
+    it('should restore navSize from recentVisibleSizes when persisted showNav is true but navSize is 0', () => {
+      const storeWithCollapsedNav = {
+        ...store,
+        getState: () =>
+          ({
+            selectedPanel: currentState.selectedPanel,
+            layout: {
+              ...getDefaultLayoutState().layout,
+              navSize: 0,
+              showNav: true,
+            },
+          }) as unknown as State,
+      } as unknown as Store;
+
+      const { state } = initLayout({
+        store: storeWithCollapsedNav,
+        provider,
+        singleStory: false,
+      } as unknown as ModuleArgs);
+
+      expect(state.layout.showNav).toBe(true);
+      expect(state.layout.navSize).toBe(300);
     });
 
     it('should prioritize layout over top-level config keys', () => {

--- a/code/core/src/manager-api/tests/url.test.js
+++ b/code/core/src/manager-api/tests/url.test.js
@@ -623,4 +623,34 @@ describe('getStoryHrefs', () => {
     // Freezing is a preview-only contract; the manager href must be unaffected.
     expect(managerHref).toEqual('/?path=/story/test--story');
   });
+
+  it('opts the preview into embed mode when embed is set', () => {
+    const { api, state } = initURL({
+      store,
+      provider: { channel: new EventEmitter() },
+      state: { location: { pathname: '/', search: '' } },
+      navigate: vi.fn(),
+      fullAPI: { getCurrentStoryData: () => ({ id: 'test--story' }) },
+    });
+    store.setState(state);
+
+    const { previewHref } = api.getStoryHrefs('test--story', { embed: true });
+    expect(previewHref).toEqual('/iframe.html?id=test--story&viewMode=story&embed=true');
+  });
+
+  it('appends embed before freeze when both are set', () => {
+    const { api, state } = initURL({
+      store,
+      provider: { channel: new EventEmitter() },
+      state: { location: { pathname: '/', search: '' } },
+      navigate: vi.fn(),
+      fullAPI: { getCurrentStoryData: () => ({ id: 'test--story' }) },
+    });
+    store.setState(state);
+
+    const { previewHref } = api.getStoryHrefs('test--story', { embed: true, freeze: true });
+    expect(previewHref).toEqual(
+      '/iframe.html?id=test--story&viewMode=story&embed=true&freeze=finished'
+    );
+  });
 });

--- a/code/core/src/manager/components/review/ReviewCollectionPicker.tsx
+++ b/code/core/src/manager/components/review/ReviewCollectionPicker.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, type FC } from 'react';
 
 import { styled } from 'storybook/theming';
 
-import { type StoryInfo } from './components/CollectionGrid.tsx';
+import { type StoryInfo } from './review-types.ts';
 import {
   buildReviewStoryHref,
   prettifyComponentId,

--- a/code/core/src/manager/components/review/ReviewPage.stories.tsx
+++ b/code/core/src/manager/components/review/ReviewPage.stories.tsx
@@ -2,19 +2,19 @@ import React, { type ReactNode } from 'react';
 
 import { expect, fn, userEvent, within } from 'storybook/test';
 
+import { Location, MemoryRouter, parsePath, queryFromLocation } from 'storybook/internal/router';
 import {
   ManagerContext,
+  internal_fullStatusStore,
   type API,
   type State,
-  internal_fullStatusStore,
 } from 'storybook/manager-api';
-import { Location, MemoryRouter, parsePath, queryFromLocation } from 'storybook/internal/router';
 
 import preview from '../../../../../.storybook/preview.tsx';
-import { EVENTS } from './constants.ts';
 import { ReviewProvider } from './ReviewProvider.tsx';
 import { ReviewSummaryPortal } from './ReviewSummaryPortal.tsx';
 import { ReviewToolbarHeader } from './ReviewToolbarHeader.tsx';
+import { EVENTS } from './constants.ts';
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
   buildReviewStoryHref,
@@ -68,6 +68,7 @@ const managerState: State = {
   path: '/review/',
   viewMode: 'review',
   customQueryParams: {},
+  location: { search: '?full=1&path=/review/', pathname: '/', hash: '' },
 } as unknown as State;
 const managerApi: API = {
   on: onMock,
@@ -82,6 +83,8 @@ const managerApi: API = {
   resetStatusFilters: fn().mockName('api::resetStatusFilters'),
   addStatusFilters: fn().mockName('api::addStatusFilters'),
   removeStatusFilters: fn().mockName('api::removeStatusFilters'),
+  applyQueryParams: fn().mockName('api::applyQueryParams'),
+  setQueryParams: fn().mockName('api::setQueryParams'),
   getStoryHrefs: (storyId: string, options?: { freeze?: boolean }) => ({
     managerHref: `?path=/story/${storyId}`,
     previewHref: `iframe.html?id=${storyId}&viewMode=story${options?.freeze ? '&freeze=finished' : ''}`,
@@ -156,6 +159,7 @@ const ManagerStateSync = ({
         ...managerState,
         ...(parameters?.managerState ?? {}),
         path,
+        location,
         viewMode: deriveViewMode(path),
         customQueryParams,
       } as State;
@@ -179,7 +183,7 @@ const meta = preview.meta({
   },
   decorators: [
     (Story, { parameters }) => (
-      <MemoryRouter initialEntries={parameters?.routerInitialEntries ?? ['/?path=/review/']}>
+      <MemoryRouter initialEntries={parameters?.routerInitialEntries ?? ['/?full=1&path=/review/']}>
         <ManagerStateSync parameters={parameters}>
           <div
             id="main-content-wrapper"
@@ -286,11 +290,16 @@ export const PendingUpdateAccept = meta.story({
 
 export const PendingUpdateFromStoryNavigatesToSummary = meta.story({
   parameters: {
-    routerInitialEntries: ['/?path=/story/manager-settings-guidepage--default&collection=0'],
+    routerInitialEntries: ['/?full=1&path=/story/manager-settings-guidepage--default&collection=0'],
     managerState: {
       path: '/story/manager-settings-guidepage--default',
       viewMode: 'story',
       customQueryParams: { collection: '0' },
+      location: {
+        search: '?full=1&path=/story/manager-settings-guidepage--default&collection=0',
+        pathname: '/',
+        hash: '',
+      },
     },
   },
   play: async ({ canvasElement }) => {

--- a/code/core/src/manager/components/review/ReviewPage.stories.tsx
+++ b/code/core/src/manager/components/review/ReviewPage.stories.tsx
@@ -85,9 +85,9 @@ const managerApi: API = {
   removeStatusFilters: fn().mockName('api::removeStatusFilters'),
   applyQueryParams: fn().mockName('api::applyQueryParams'),
   setQueryParams: fn().mockName('api::setQueryParams'),
-  getStoryHrefs: (storyId: string, options?: { freeze?: boolean }) => ({
+  getStoryHrefs: (storyId: string, options?: { embed?: boolean; freeze?: boolean }) => ({
     managerHref: `?path=/story/${storyId}`,
-    previewHref: `iframe.html?id=${storyId}&viewMode=story${options?.freeze ? '&freeze=finished' : ''}`,
+    previewHref: `iframe.html?id=${storyId}&viewMode=story${options?.embed ? '&embed=true' : ''}${options?.freeze ? '&freeze=finished' : ''}`,
   }),
 } as unknown as API;
 

--- a/code/core/src/manager/components/review/ReviewPersistentLayer.tsx
+++ b/code/core/src/manager/components/review/ReviewPersistentLayer.tsx
@@ -1,27 +1,13 @@
 import React, { type FC } from 'react';
 
-import { useChannel, useStorybookApi } from 'storybook/manager-api';
-
-import { ReviewProvider, isReviewPath } from './ReviewProvider.tsx';
+import { ReviewProvider } from './ReviewProvider.tsx';
 import { ReviewSummaryPortal } from './ReviewSummaryPortal.tsx';
-import { EVENTS, REVIEW_CHANGES_URL } from './constants.ts';
 import { useReviewNavigationInterceptor } from './useReviewNavigationInterceptor.ts';
 import { useReviewShortcuts } from './useReviewShortcuts.ts';
 
 const ReviewNavigationLayer: FC = () => {
-  const api = useStorybookApi();
   useReviewNavigationInterceptor();
   useReviewShortcuts();
-
-  // Surface the summary when a review is pushed while the user is elsewhere.
-  useChannel({
-    [EVENTS.DISPLAY_REVIEW]: () => {
-      const currentPath = new URLSearchParams(window.location.search).get('path') ?? '';
-      if (!isReviewPath(currentPath)) {
-        api.navigate(REVIEW_CHANGES_URL);
-      }
-    },
-  });
 
   return <ReviewSummaryPortal />;
 };

--- a/code/core/src/manager/components/review/ReviewProvider.tsx
+++ b/code/core/src/manager/components/review/ReviewProvider.tsx
@@ -9,6 +9,9 @@ import {
   type ReactNode,
 } from 'react';
 
+import { useNavigate } from 'storybook/internal/router';
+import type { StatusesByStoryIdAndTypeId } from 'storybook/internal/types';
+import { CHANGE_DETECTION_STATUS_TYPE_ID, REVIEW_STATUS_TYPE_ID } from 'storybook/internal/types';
 import {
   experimental_getStatusStore,
   experimental_useStatusStore,
@@ -16,20 +19,11 @@ import {
   useStorybookApi,
   useStorybookState,
 } from 'storybook/manager-api';
-import { useNavigate } from 'storybook/internal/router';
-import type { StatusesByStoryIdAndTypeId } from 'storybook/internal/types';
-import { CHANGE_DETECTION_STATUS_TYPE_ID, REVIEW_STATUS_TYPE_ID } from 'storybook/internal/types';
 
-import {
-  fallbackStoryInfo,
-  type StoryChangeStatus,
-  type StoryInfo,
-} from './components/CollectionGrid.tsx';
 import { AUTO_ENTERED_SESSION_KEY, EVENTS, PRE_REVIEW_RETURN_KEY } from './constants.ts';
 import { navigateOutOfReview } from './review-actions.ts';
 import { enterReviewMode, exitReviewMode, isReviewModeActive } from './review-mode.ts';
 import {
-  REVIEW_COLLECTION_QUERY_PARAM,
   buildFlattenedNavEntries,
   buildReviewChangesSummaryHref,
   isReviewLayoutActive,
@@ -40,10 +34,12 @@ import {
   parseStoryIdFromPath,
   resolveActiveNavEntry,
   resolveNavIndex,
+  REVIEW_COLLECTION_QUERY_PARAM,
 } from './review-navigation.ts';
 import type { ReviewState } from './review-state.ts';
-import { reviewStore, type ReviewStoreState } from './review-store.ts';
 import { clearReviewStatuses, collectReviewStoryIds, syncReviewStatuses } from './review-status.ts';
+import { reviewStore, type ReviewStoreState } from './review-store.ts';
+import { fallbackStoryInfo, type StoryChangeStatus, type StoryInfo } from './review-types.ts';
 import { sessionStore } from './session-store.ts';
 import { useReviewFiltersRef } from './useReviewFiltersRef.ts';
 
@@ -82,7 +78,7 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   }, [api, filtersRef]);
 
   const getStoryPreviewHref = useCallback(
-    (storyId: string) => api.getStoryHrefs(storyId, { freeze: true }).previewHref,
+    (storyId: string) => api.getStoryHrefs(storyId, { embed: true, freeze: true }).previewHref,
     [api]
   );
 

--- a/code/core/src/manager/components/review/ReviewProvider.tsx
+++ b/code/core/src/manager/components/review/ReviewProvider.tsx
@@ -25,19 +25,16 @@ import {
   type StoryChangeStatus,
   type StoryInfo,
 } from './components/CollectionGrid.tsx';
-import {
-  AUTO_ENTERED_SESSION_KEY,
-  EVENTS,
-  PRE_REVIEW_RETURN_KEY,
-  REVIEW_CHANGES_URL,
-} from './constants.ts';
-import { enterReviewMode, isReviewModeActive } from './review-mode.ts';
+import { AUTO_ENTERED_SESSION_KEY, EVENTS, PRE_REVIEW_RETURN_KEY } from './constants.ts';
 import { navigateOutOfReview } from './review-actions.ts';
+import { enterReviewMode, exitReviewMode, isReviewModeActive } from './review-mode.ts';
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
   buildFlattenedNavEntries,
   buildReviewChangesSummaryHref,
+  isReviewLayoutActive,
   isReviewReturnSearch,
+  isReviewRoute,
   isReviewSummaryPath,
   parseCollectionIndex,
   parseStoryIdFromPath,
@@ -65,6 +62,8 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [isInReviewMode, setIsInReviewMode] = useState(() => isReviewModeActive());
   const previousReviewStoryIdsRef = useRef<Set<string>>(new Set());
   const displayedReviewRef = useRef<ReviewState | null>(null);
+  const replayExpectedRef = useRef(true);
+  const routeRef = useRef({ path: '/', collectionParam: undefined as string | undefined });
   displayedReviewRef.current = state;
 
   const api = useStorybookApi();
@@ -72,6 +71,7 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { index, path, viewMode, customQueryParams, location } = useStorybookState();
 
   const collectionParam = customQueryParams?.[REVIEW_COLLECTION_QUERY_PARAM] as string | undefined;
+  routeRef.current = { path, collectionParam };
 
   // Current sidebar filters, snapshotted by enterReviewMode and restored on exit.
   const filtersRef = useReviewFiltersRef();
@@ -98,6 +98,13 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
       sessionStore.remove(AUTO_ENTERED_SESSION_KEY);
       setState(next);
       setIsStale(!!next.stale);
+
+      const isReplay = replayExpectedRef.current;
+      replayExpectedRef.current = false;
+      const { path: currentPath, collectionParam: currentCollection } = routeRef.current;
+      if (!isReplay && !isReviewRoute(currentPath, currentCollection)) {
+        navigate(buildReviewChangesSummaryHref(), { plain: true });
+      }
     },
     [EVENTS.REVIEW_STALE]: () => {
       setIsStale(true);
@@ -132,7 +139,12 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   }, [enterReview, navigate, pendingReview]);
 
   useEffect(() => {
+    replayExpectedRef.current = true;
     emit(EVENTS.REQUEST_REVIEW);
+    const timer = globalThis.setTimeout(() => {
+      replayExpectedRef.current = false;
+    }, 500);
+    return () => globalThis.clearTimeout(timer);
   }, [emit]);
 
   // Tag every story in the active review so the sidebar shows reviewing status
@@ -227,25 +239,45 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   const isSummaryVisible = isReviewSummaryPath(path);
 
-  // Re-sync the persisted review-mode flag on every navigation. Enter/exit
-  // performed by the nav interceptor and shortcuts toggle it out of band before
-  // navigating, so a route change is the signal to re-read it.
+  // Keep review chrome/filters in sync with `full=1` and review routes in the URL.
   useEffect(() => {
-    setIsInReviewMode(isReviewModeActive());
-  }, [path, collectionParam]);
+    if (!isReviewRoute(path, collectionParam)) {
+      reviewStore.releaseUrlSyncSuppression();
+    }
+    if (reviewStore.isUrlSyncSuppressed()) {
+      return;
+    }
 
-  // First landing on the summary with a clean, newly available review enters
-  // review mode once. Deduplicated so reloads and post-exit returns don't re-enter.
-  useEffect(() => {
-    if (!state || !isSummaryVisible || isReviewModeActive()) {
+    const reviewRoute = isReviewRoute(path, collectionParam);
+    const fullActive = isReviewLayoutActive(location);
+
+    if (reviewRoute && !fullActive) {
+      if (isSummaryVisible) {
+        api.applyQueryParams({ full: '1' }, { replace: true });
+        return;
+      }
+      if (isReviewModeActive()) {
+        void exitReviewMode(api);
+        setIsInReviewMode(false);
+      }
       return;
     }
-    if (sessionStore.read(AUTO_ENTERED_SESSION_KEY) === '1') {
+
+    if (reviewRoute && fullActive) {
+      if (!isReviewModeActive()) {
+        void enterReviewMode(api, filtersRef.current);
+      }
+      setIsInReviewMode(true);
       return;
     }
-    sessionStore.write(AUTO_ENTERED_SESSION_KEY, '1');
-    enterReview();
-  }, [state, isSummaryVisible, enterReview]);
+
+    if (isReviewModeActive()) {
+      void exitReviewMode(api);
+      setIsInReviewMode(false);
+    } else {
+      setIsInReviewMode(false);
+    }
+  }, [api, collectionParam, filtersRef, isSummaryVisible, location, path]);
 
   // Remember the last canvas search outside review mode so leaving review can
   // return to the pre-review canvas (both summary back and dismiss).
@@ -309,5 +341,4 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   return children;
 };
 
-export const isReviewPath = (path: string): boolean =>
-  isReviewSummaryPath(path) || path.startsWith(REVIEW_CHANGES_URL);
+export const isReviewPath = (path: string): boolean => isReviewSummaryPath(path);

--- a/code/core/src/manager/components/review/ReviewProvider.tsx
+++ b/code/core/src/manager/components/review/ReviewProvider.tsx
@@ -250,13 +250,14 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
     const reviewRoute = isReviewRoute(path, collectionParam);
     const fullActive = isReviewLayoutActive(location);
+    const reviewModeActive = isReviewModeActive();
 
     if (reviewRoute && !fullActive) {
-      if (isSummaryVisible) {
+      if (isSummaryVisible && !reviewModeActive) {
         api.applyQueryParams({ full: '1' }, { replace: true });
         return;
       }
-      if (isReviewModeActive()) {
+      if (reviewModeActive) {
         void exitReviewMode(api);
         setIsInReviewMode(false);
       }

--- a/code/core/src/manager/components/review/ReviewToolbarHeader.stories.tsx
+++ b/code/core/src/manager/components/review/ReviewToolbarHeader.stories.tsx
@@ -2,18 +2,18 @@ import type { ReactNode } from 'react';
 
 import { expect, fn, within } from 'storybook/test';
 
+import { MemoryRouter } from 'storybook/internal/router';
 import {
   ManagerContext,
+  internal_fullStatusStore,
   type API,
   type State,
-  internal_fullStatusStore,
 } from 'storybook/manager-api';
-import { MemoryRouter } from 'storybook/internal/router';
 
 import preview from '../../../../../.storybook/preview.tsx';
-import { ADDON_ID, EVENTS } from './constants.ts';
 import { ReviewProvider } from './ReviewProvider.tsx';
 import { ReviewToolbarHeader } from './ReviewToolbarHeader.tsx';
+import { ADDON_ID, EVENTS } from './constants.ts';
 import { buildReviewChangesSummaryHref, buildReviewStoryHref } from './review-navigation.ts';
 import type { ReviewState } from './review-state.ts';
 import { useReviewShortcuts } from './useReviewShortcuts.ts';
@@ -102,9 +102,9 @@ const managerApi: API = {
   resetStatusFilters: fn().mockName('api::resetStatusFilters'),
   addStatusFilters: fn().mockName('api::addStatusFilters'),
   removeStatusFilters: fn().mockName('api::removeStatusFilters'),
-  getStoryHrefs: (storyId: string, options?: { freeze?: boolean }) => ({
+  getStoryHrefs: (storyId: string, options?: { embed?: boolean; freeze?: boolean }) => ({
     managerHref: `?path=/story/${storyId}`,
-    previewHref: `iframe.html?id=${storyId}&viewMode=story${options?.freeze ? '&freeze=finished' : ''}`,
+    previewHref: `iframe.html?id=${storyId}&viewMode=story${options?.embed ? '&embed=true' : ''}${options?.freeze ? '&freeze=finished' : ''}`,
   }),
 } as unknown as API;
 

--- a/code/core/src/manager/components/review/components/CollectionGrid.stories.tsx
+++ b/code/core/src/manager/components/review/components/CollectionGrid.stories.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { expect, within } from 'storybook/test';
+import { expect, waitFor, within } from 'storybook/test';
 
-import { IconSymbols } from '../../sidebar/IconSymbols.tsx';
 import preview from '../../../../../../.storybook/preview.tsx';
-import { CollectionGrid, type StoryInfo } from './CollectionGrid.tsx';
+import { IconSymbols } from '../../sidebar/IconSymbols.tsx';
+import type { StoryInfo } from '../review-types.ts';
+import { CollectionGrid } from './CollectionGrid.tsx';
 
 // 40 unique story IDs drawn from real internal stories.
 const fortyStoryIds = [
@@ -98,7 +99,7 @@ const meta = preview.meta({
     storyIds: demoStoryIds,
     storyInfo: demoStoryInfo,
     getStoryPreviewHref: (storyId: string) =>
-      `iframe.html?id=${encodeURIComponent(storyId)}&viewMode=story&freeze=finished`,
+      `iframe.html?id=${encodeURIComponent(storyId)}&viewMode=story&embed=true&freeze=finished`,
   },
 });
 
@@ -111,6 +112,13 @@ export const ManyStoriesOverflow = meta.story({
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByRole('button', { name: /Review all/i })).toBeInTheDocument();
+    const reviewAllFrame = canvasElement.querySelector('[data-review-all] > :first-child');
+    await expect(reviewAllFrame).toBeTruthy();
+    await waitFor(() => {
+      expect((reviewAllFrame as HTMLElement).getBoundingClientRect().height).toBeGreaterThanOrEqual(
+        50
+      );
+    });
   },
 });
 
@@ -125,6 +133,13 @@ export const FewStories = meta.story({
     await expect(
       canvasElement.querySelector<HTMLButtonElement>('[data-review-all] button')
     ).not.toBeVisible();
+
+    const frames = Array.from(cells).map((cell) => cell.firstElementChild as HTMLElement | null);
+    await waitFor(() => {
+      expect(frames.every((frame) => (frame?.clientHeight ?? 0) > 0)).toBe(true);
+    });
+    const [firstHeight, secondHeight] = frames.map((frame) => frame?.clientHeight ?? 0);
+    expect(firstHeight).toBe(secondHeight);
   },
 });
 

--- a/code/core/src/manager/components/review/components/CollectionGrid.stories.tsx
+++ b/code/core/src/manager/components/review/components/CollectionGrid.stories.tsx
@@ -32,8 +32,8 @@ const fortyStoryIds = [
   'overlay-popover--with-hide-button',
   'overlay-popover--with-chrome',
   'manager-main--default',
-  'manager-main--about-page',
-  'manager-main--guide-page',
+  'manager-main--connection-lost',
+  'manager-main--server-timed-out',
 
   'manager-settings-aboutscreen--default',
   'manager-settings-guidepage--default',

--- a/code/core/src/manager/components/review/components/CollectionGrid.tsx
+++ b/code/core/src/manager/components/review/components/CollectionGrid.tsx
@@ -1,122 +1,13 @@
-import React, { useCallback, useEffect, useRef, useState, type FC } from 'react';
+import React, { type FC } from 'react';
 
 import { Badge, Button } from 'storybook/internal/components';
 import { styled } from 'storybook/theming';
 
-const PREVIEW_SCALE = 0.5;
+import { fallbackStoryInfo, type StoryInfo } from '../review-types.ts';
+import { usePreviewThumbnail } from './usePreviewThumbnail.ts';
 
-/**
- * Each thumbnail is a full Storybook preview iframe, and booting one fires
- * dozens of module requests. Mounting every in-view thumbnail at once (wide
- * grids, or "Review all") floods the browser's connection pool and trips
- * `net::ERR_INSUFFICIENT_RESOURCES`, leaving some iframes permanently blank.
- *
- * The scheduler below caps how many previews boot concurrently across the
- * whole review page. A cell enqueues a task before it sets the iframe `src`;
- * the task starts when a slot is free and finishes once the iframe loads
- * (or errors / settles), so previews drain in waves instead of all at once.
- * Hovering a cell promotes its task to start immediately, bypassing the cap.
- */
-const MAX_CONCURRENT_PREVIEWS = 3;
-/**
- * A started preview frees its slot when its iframe fires `load`, or after this
- * delay — whichever comes first. The timeout guarantees the queue keeps
- * draining automatically even when `load` is slow or never fires (so previews
- * advance in steady waves rather than waiting on a single stuck frame), while
- * still rate-limiting how fast new iframes boot to avoid flooding the network.
- */
-const PREVIEW_SETTLE_TIMEOUT_MS = 1500;
-
-// IntersectionObserver `rootMargin`s for the preview lifecycle: mount a cell's
-// iframe within one root-height of the fold, evict it past two. The gap is
-// hysteresis so scrolling near a boundary doesn't thrash. These margins only
-// take effect when the observer's `root` is the real scroll container (see
-// `getScrollRoot`); `rootMargin` is not applied to intermediate scrollers, so
-// against the default viewport root they would be silently clipped to zero.
-const PREVIEW_MOUNT_ROOT_MARGIN = '100% 0px';
-const PREVIEW_EVICT_ROOT_MARGIN = '200% 0px';
-
-interface PreviewTask {
-  /** Assigns the iframe src, kicking off the actual load. */
-  start: () => void;
-  started: boolean;
-  finished: boolean;
-}
-
-let activePreviewLoads = 0;
-const previewQueue: PreviewTask[] = [];
-
-function startQueuedPreviews(): void {
-  while (activePreviewLoads < MAX_CONCURRENT_PREVIEWS) {
-    const task = previewQueue.shift();
-    if (!task) {
-      return;
-    }
-    if (task.started || task.finished) {
-      continue;
-    }
-    task.started = true;
-    activePreviewLoads += 1;
-    task.start();
-  }
-}
-
-function enqueuePreview(task: PreviewTask): void {
-  previewQueue.push(task);
-  startQueuedPreviews();
-}
-
-/** Mark a task done (load/error/settle/unmount) and let the next one start. */
-function finishPreview(task: PreviewTask): void {
-  if (task.finished) {
-    return;
-  }
-  task.finished = true;
-  if (task.started) {
-    activePreviewLoads = Math.max(0, activePreviewLoads - 1);
-  } else {
-    const index = previewQueue.indexOf(task);
-    if (index !== -1) {
-      previewQueue.splice(index, 1);
-    }
-  }
-  startQueuedPreviews();
-}
-
-/** Hover/focus: start a still-queued preview right away, bypassing the cap. */
-function forceStartPreview(task: PreviewTask): void {
-  if (task.started || task.finished) {
-    return;
-  }
-  const index = previewQueue.indexOf(task);
-  if (index !== -1) {
-    previewQueue.splice(index, 1);
-  }
-  task.started = true;
-  activePreviewLoads += 1;
-  task.start();
-}
-
-export type StoryChangeStatus = 'new' | 'modified';
-
-export interface StoryInfo {
-  title: string;
-  name: string;
-  isNewlyAdded?: boolean;
-  changeStatus?: StoryChangeStatus;
-}
-
-/** Best-effort labels when the Storybook index has not resolved a story yet. */
-export const fallbackStoryInfo = (storyId: string): StoryInfo => {
-  const separator = storyId.indexOf('--');
-  if (separator === -1) {
-    return { title: storyId, name: 'Story' };
-  }
-  return {
-    title: storyId.slice(0, separator),
-    name: storyId.slice(separator + 2) || 'Story',
-  };
-};
+/** Reference story width for thumbnail scale fit (matches typical story canvas). */
+const PREVIEW_CONTENT_WIDTH = 300;
 
 // Per-breakpoint grid: `cols` columns (each cell clamped to 400px) capped at
 // two rows. Overflow beyond the cap is hidden and a "Review all" cell takes the
@@ -144,12 +35,7 @@ const Grid = styled.div({
   display: 'grid',
   gap: 12,
   padding: 12,
-  // Fallback for browsers without container-query support: a single column and
-  // no two-row cap (every story is shown).
   gridTemplateColumns: 'minmax(0, 1fr)',
-  // Bands are mutually exclusive (ranged) so a narrower band's overflow rules
-  // never bleed into a wider one. The .98 upper bounds sit just below the next
-  // band's integer `min-width` so the two never both match at the boundary.
   '@container review-grid (max-width: 629.98px)': band(1),
   '@container review-grid (min-width: 630px) and (max-width: 844.98px)': band(2),
   '@container review-grid (min-width: 845px) and (max-width: 1259.98px)': band(3),
@@ -162,13 +48,14 @@ const Cell = styled.div({
   minWidth: 0,
 });
 
-// The bordered, clickable preview frame. Rendered as an <a> when a detail href
-// is provided, otherwise a plain <div>. Hover and keyboard focus are indicated
-// here (not on the surrounding cell) since the frame is the interactive target.
 const Frame = styled.a(({ theme }) => ({
   position: 'relative',
   display: 'block',
   width: '100%',
+  containerType: 'inline-size',
+  containerName: 'preview-frame',
+  '--fit': `min(1, calc(100cqw / ${PREVIEW_CONTENT_WIDTH}px))`,
+  '--scale': 'max(0.5, min(1, round(down, var(--fit), 0.25)))',
   aspectRatio: '3 / 2',
   borderRadius: 6,
   overflow: 'hidden',
@@ -189,18 +76,16 @@ const Frame = styled.a(({ theme }) => ({
 const Preview = styled.iframe(({ theme }) => ({
   position: 'absolute',
   inset: 0,
-  width: `${(1 / PREVIEW_SCALE) * 100}%`,
-  height: `${(1 / PREVIEW_SCALE) * 100}%`,
+  width: 'calc(100% / var(--scale))',
+  height: 'calc(100% / var(--scale))',
   background: theme.background.preview,
   border: 0,
   display: 'block',
-  transform: `scale(${PREVIEW_SCALE})`,
+  transform: 'scale(var(--scale))',
   transformOrigin: 'top left',
   pointerEvents: 'none',
 }));
 
-// The info/action bar below the preview: the component/story label stretches
-// and ellipsizes on the left; the action slot on the right never wraps.
 const ActionBar = styled.div({
   display: 'flex',
   alignItems: 'center',
@@ -244,8 +129,12 @@ const NewBadge = styled(Badge)({
   flexShrink: 0,
 });
 
-const ReviewAllCell = styled.div(({ theme }) => ({
+const ReviewAllCell = styled.div({
   display: 'none',
+});
+
+const ReviewAllFrame = styled.div(({ theme }) => ({
+  display: 'grid',
   placeItems: 'center',
   width: '100%',
   aspectRatio: '3 / 2',
@@ -254,58 +143,10 @@ const ReviewAllCell = styled.div(({ theme }) => ({
   border: `1px dashed ${theme.appBorderColor}`,
 }));
 
-// The cell lives inside a scrollable container (the review page keeps a single
-// Radix ScrollArea as its scroller), not the document viewport. The lifecycle
-// observers must use that container as their `root`, otherwise `rootMargin` is
-// ignored and cells evict the moment they leave the scroller. Falls back to the
-// viewport (null) when there is no scroll container, e.g. fullscreen stories.
-const getScrollRoot = (element: HTMLElement): HTMLElement | null => {
-  const radixViewport = element.closest<HTMLElement>('[data-radix-scroll-area-viewport]');
-  if (radixViewport) {
-    return radixViewport;
-  }
-  let current = element.parentElement;
-  while (current) {
-    const { overflowY } = window.getComputedStyle(current);
-    if (overflowY === 'auto' || overflowY === 'scroll') {
-      return current;
-    }
-    current = current.parentElement;
-  }
-  return null;
-};
-
-const isWithinPreloadRange = (
-  element: HTMLElement,
-  root: HTMLElement | null,
-  margin: number
-): boolean => {
-  const rect = element.getBoundingClientRect();
-  // Hidden cells (e.g. overflow beyond the two-row cap) have a zero-size box;
-  // don't seed them in-view or they'd boot iframes that never show.
-  if (rect.width === 0 && rect.height === 0) {
-    return false;
-  }
-  if (root) {
-    const rootRect = root.getBoundingClientRect();
-    return rect.bottom >= rootRect.top - margin && rect.top <= rootRect.bottom + margin;
-  }
-  const viewportHeight =
-    typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerHeight || 0;
-  return rect.bottom >= -margin && rect.top <= viewportHeight + margin;
-};
-
 const deriveStoryInfo = (info: StoryInfo): { component: string; name: string } => ({
   component: info.title.split('/').pop() ?? info.title,
   name: info.name,
 });
-
-const getPreloadMargin = (scrollRoot: HTMLElement | null): number => {
-  if (!scrollRoot) {
-    return typeof window === 'undefined' ? 0 : window.innerHeight;
-  }
-  return scrollRoot.clientHeight || window.innerHeight;
-};
 
 const StoryPreviewCell: FC<{
   storyId: string;
@@ -314,128 +155,19 @@ const StoryPreviewCell: FC<{
   getPreviewHref: (storyId: string) => string;
   previewsPaused?: boolean;
 }> = ({ storyId, href, info, getPreviewHref, previewsPaused = false }) => {
-  const hostRef = useRef<HTMLElement>(null);
-  const previewsPausedRef = useRef(previewsPaused);
-  previewsPausedRef.current = previewsPaused;
-  const [isInView, setIsInView] = useState(false);
-  // `src` stays unset until the scheduler starts this preview; the iframe only
-  // mounts (and starts requesting) once it does.
-  const [src, setSrc] = useState<string | undefined>(undefined);
-  const taskRef = useRef<PreviewTask | null>(null);
-
-  useEffect(() => {
-    const host = hostRef.current;
-    if (!host) {
-      return undefined;
-    }
-    if (typeof IntersectionObserver === 'undefined') {
-      setIsInView(true);
-      return undefined;
-    }
-    const scrollRoot = getScrollRoot(host);
-    const effectiveRoot = scrollRoot && scrollRoot.clientHeight > 0 ? scrollRoot : null;
-    const markInViewIfClose = () => {
-      if (isWithinPreloadRange(host, effectiveRoot, getPreloadMargin(scrollRoot))) {
-        setIsInView(true);
-      }
-    };
-    // Snappy first paint for above-the-fold cells: the observers' initial
-    // callbacks are deferred to the next frame, so seed the state synchronously.
-    markInViewIfClose();
-    const resizeObserver =
-      typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(() => markInViewIfClose())
-        : undefined;
-    resizeObserver?.observe(host);
-    // Mount when the cell comes within the mount margin of the scroll root.
-    const mountObserver = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsInView(true);
-        }
-      },
-      { root: effectiveRoot, rootMargin: PREVIEW_MOUNT_ROOT_MARGIN }
-    );
-    // Evict once the cell moves beyond the (larger) evict margin, unmounting
-    // its iframe to free the preview runtime. The margin gap is hysteresis.
-    const evictObserver = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry.isIntersecting && !previewsPausedRef.current) {
-          setIsInView(false);
-        }
-      },
-      { root: effectiveRoot, rootMargin: PREVIEW_EVICT_ROOT_MARGIN }
-    );
-    mountObserver.observe(host);
-    evictObserver.observe(host);
-    return () => {
-      resizeObserver?.disconnect();
-      mountObserver.disconnect();
-      evictObserver.disconnect();
-    };
-  }, []);
-
-  // Eviction: when the cell scrolls well out of range, drop the iframe so its
-  // preview runtime is reclaimed. It re-enqueues (below) if it scrolls back.
-  useEffect(() => {
-    if (!isInView && !previewsPaused) {
-      setSrc(undefined);
-    }
-  }, [isInView, previewsPaused]);
-
-  // Once in view, enqueue a scheduler task; it sets `src` when a slot frees.
-  useEffect(() => {
-    if (!isInView) {
-      return undefined;
-    }
-    const previewHref = getPreviewHref(storyId);
-    const task: PreviewTask = {
-      start: () => {
-        setSrc((current) => current ?? previewHref);
-      },
-      started: false,
-      finished: false,
-    };
-    taskRef.current = task;
-    enqueuePreview(task);
-    return () => {
-      // Unmounting / scrolling away before load frees the slot (or dequeues).
-      finishPreview(task);
-      taskRef.current = null;
-    };
-  }, [isInView, storyId, getPreviewHref]);
-
-  const finishCurrent = useCallback(() => {
-    if (taskRef.current) {
-      finishPreview(taskRef.current);
-    }
-  }, []);
-
-  // Hover or keyboard focus promotes this preview to start immediately.
-  const forceStartCurrent = useCallback(() => {
-    if (taskRef.current) {
-      forceStartPreview(taskRef.current);
-    }
-  }, []);
-
-  // Free this preview's slot a short time after it starts even if `load`
-  // hasn't fired, so the queue keeps draining automatically in steady waves.
-  useEffect(() => {
-    if (!src) {
-      return undefined;
-    }
-    const timer = setTimeout(finishCurrent, PREVIEW_SETTLE_TIMEOUT_MS);
-    return () => clearTimeout(timer);
-  }, [src, finishCurrent]);
+  const { cellRef, src, forceStartCurrent, finishCurrent } = usePreviewThumbnail({
+    storyId,
+    getPreviewHref,
+    previewsPaused,
+  });
 
   const { component, name } = deriveStoryInfo(info);
 
   return (
-    <Cell data-cell data-testid="review-collection-grid-cell">
+    <Cell ref={cellRef} data-cell data-testid="review-collection-grid-cell">
       <Frame
         as={href ? 'a' : 'div'}
-        href={href}
-        ref={hostRef as React.RefObject<HTMLAnchorElement>}
+        {...(href ? { href } : {})}
         aria-label={href ? `Review story ${storyId}` : undefined}
         onMouseEnter={forceStartCurrent}
         onFocus={forceStartCurrent}
@@ -507,9 +239,12 @@ export const CollectionGrid: FC<CollectionGridProps> = ({
         );
       })}
       <ReviewAllCell data-review-all>
-        <Button size="medium" onClick={() => onShowAll?.()}>
-          Review all {storyIds.length}
-        </Button>
+        <ReviewAllFrame>
+          <Button size="medium" onClick={() => onShowAll?.()}>
+            Review all {storyIds.length}
+          </Button>
+        </ReviewAllFrame>
+        <ActionBar aria-hidden="true" />
       </ReviewAllCell>
     </Grid>
   </GridContainer>

--- a/code/core/src/manager/components/review/components/previewScheduler.ts
+++ b/code/core/src/manager/components/review/components/previewScheduler.ts
@@ -1,0 +1,68 @@
+/**
+ * Caps concurrent preview iframe boots across the review grid. See CollectionGrid
+ * header comment for why this exists (`net::ERR_INSUFFICIENT_RESOURCES`).
+ */
+export const PREVIEW_SETTLE_TIMEOUT_MS = 1500;
+
+const MAX_CONCURRENT_PREVIEWS = 3;
+
+export interface PreviewTask {
+  /** Assigns the iframe src, kicking off the actual load. */
+  start: () => void;
+  started: boolean;
+  finished: boolean;
+}
+
+let activePreviewLoads = 0;
+const previewQueue: PreviewTask[] = [];
+
+function startQueuedPreviews(): void {
+  while (activePreviewLoads < MAX_CONCURRENT_PREVIEWS) {
+    const task = previewQueue.shift();
+    if (!task) {
+      return;
+    }
+    if (task.started || task.finished) {
+      continue;
+    }
+    task.started = true;
+    activePreviewLoads += 1;
+    task.start();
+  }
+}
+
+export function enqueuePreview(task: PreviewTask): void {
+  previewQueue.push(task);
+  startQueuedPreviews();
+}
+
+/** Mark a task done (load/error/settle/unmount) and let the next one start. */
+export function finishPreview(task: PreviewTask): void {
+  if (task.finished) {
+    return;
+  }
+  task.finished = true;
+  if (task.started) {
+    activePreviewLoads = Math.max(0, activePreviewLoads - 1);
+  } else {
+    const index = previewQueue.indexOf(task);
+    if (index !== -1) {
+      previewQueue.splice(index, 1);
+    }
+  }
+  startQueuedPreviews();
+}
+
+/** Hover/focus: start a still-queued preview right away, bypassing the cap. */
+export function forceStartPreview(task: PreviewTask): void {
+  if (task.started || task.finished) {
+    return;
+  }
+  const index = previewQueue.indexOf(task);
+  if (index !== -1) {
+    previewQueue.splice(index, 1);
+  }
+  task.started = true;
+  activePreviewLoads += 1;
+  task.start();
+}

--- a/code/core/src/manager/components/review/components/usePreviewThumbnail.ts
+++ b/code/core/src/manager/components/review/components/usePreviewThumbnail.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+
+import {
+  PREVIEW_SETTLE_TIMEOUT_MS,
+  enqueuePreview,
+  finishPreview,
+  forceStartPreview,
+  type PreviewTask,
+} from './previewScheduler.ts';
+
+// IntersectionObserver `rootMargin`s for the preview lifecycle: mount a cell's
+// iframe within half a root-height of the fold, evict it past one and a half.
+// The gap is hysteresis so scrolling near a boundary doesn't thrash.
+const PREVIEW_MOUNT_ROOT_MARGIN = '50% 0px';
+const PREVIEW_EVICT_ROOT_MARGIN = '150% 0px';
+
+const getScrollRoot = (element: HTMLElement): HTMLElement | null => {
+  const radixViewport = element.closest<HTMLElement>('[data-radix-scroll-area-viewport]');
+  if (radixViewport) {
+    return radixViewport;
+  }
+  let current = element.parentElement;
+  while (current) {
+    const { overflowY } = window.getComputedStyle(current);
+    if (overflowY === 'auto' || overflowY === 'scroll') {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+};
+
+const isWithinPreloadRange = (
+  element: HTMLElement,
+  root: HTMLElement | null,
+  margin: number
+): boolean => {
+  const rect = element.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) {
+    return false;
+  }
+  if (root) {
+    const rootRect = root.getBoundingClientRect();
+    return rect.bottom >= rootRect.top - margin && rect.top <= rootRect.bottom + margin;
+  }
+  const viewportHeight =
+    typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerHeight || 0;
+  return rect.bottom >= -margin && rect.top <= viewportHeight + margin;
+};
+
+const getPreloadMargin = (scrollRoot: HTMLElement | null): number => {
+  if (!scrollRoot) {
+    return typeof window === 'undefined' ? 0 : window.innerHeight;
+  }
+  return scrollRoot.clientHeight || window.innerHeight;
+};
+
+export type UsePreviewThumbnailOptions = {
+  storyId: string;
+  getPreviewHref: (storyId: string) => string;
+  previewsPaused?: boolean;
+};
+
+export type UsePreviewThumbnailResult = {
+  cellRef: RefObject<HTMLDivElement>;
+  src: string | undefined;
+  forceStartCurrent: () => void;
+  finishCurrent: () => void;
+};
+
+export const usePreviewThumbnail = ({
+  storyId,
+  getPreviewHref,
+  previewsPaused = false,
+}: UsePreviewThumbnailOptions): UsePreviewThumbnailResult => {
+  const cellRef = useRef<HTMLDivElement>(null);
+  const previewsPausedRef = useRef(previewsPaused);
+  previewsPausedRef.current = previewsPaused;
+  const [isInView, setIsInView] = useState(false);
+  const [src, setSrc] = useState<string | undefined>(undefined);
+  const taskRef = useRef<PreviewTask | null>(null);
+
+  useEffect(() => {
+    const host = cellRef.current;
+    if (!host) {
+      return undefined;
+    }
+    if (typeof IntersectionObserver === 'undefined') {
+      setIsInView(true);
+      return undefined;
+    }
+    const scrollRoot = getScrollRoot(host);
+    const effectiveRoot = scrollRoot && scrollRoot.clientHeight > 0 ? scrollRoot : null;
+    const markInViewIfClose = () => {
+      if (isWithinPreloadRange(host, effectiveRoot, getPreloadMargin(scrollRoot))) {
+        setIsInView(true);
+      }
+    };
+    markInViewIfClose();
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => markInViewIfClose())
+        : undefined;
+    resizeObserver?.observe(host);
+    const mountObserver = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true);
+        }
+      },
+      { root: effectiveRoot, rootMargin: PREVIEW_MOUNT_ROOT_MARGIN }
+    );
+    const evictObserver = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting && !previewsPausedRef.current) {
+          setIsInView(false);
+        }
+      },
+      { root: effectiveRoot, rootMargin: PREVIEW_EVICT_ROOT_MARGIN }
+    );
+    mountObserver.observe(host);
+    evictObserver.observe(host);
+    return () => {
+      resizeObserver?.disconnect();
+      mountObserver.disconnect();
+      evictObserver.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isInView && !previewsPaused) {
+      setSrc(undefined);
+    }
+  }, [isInView, previewsPaused]);
+
+  useEffect(() => {
+    if (!isInView) {
+      return undefined;
+    }
+    const previewHref = getPreviewHref(storyId);
+    const task: PreviewTask = {
+      start: () => {
+        setSrc((current) => (current === previewHref ? current : previewHref));
+      },
+      started: false,
+      finished: false,
+    };
+    taskRef.current = task;
+    enqueuePreview(task);
+    return () => {
+      finishPreview(task);
+      taskRef.current = null;
+    };
+  }, [isInView, storyId, getPreviewHref]);
+
+  const finishCurrent = useCallback(() => {
+    if (taskRef.current) {
+      finishPreview(taskRef.current);
+    }
+  }, []);
+
+  const forceStartCurrent = useCallback(() => {
+    if (taskRef.current) {
+      forceStartPreview(taskRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!src) {
+      return undefined;
+    }
+    const timer = setTimeout(finishCurrent, PREVIEW_SETTLE_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [src, finishCurrent]);
+
+  return {
+    cellRef,
+    src,
+    forceStartCurrent,
+    finishCurrent,
+  };
+};

--- a/code/core/src/manager/components/review/review-actions.ts
+++ b/code/core/src/manager/components/review/review-actions.ts
@@ -1,13 +1,13 @@
 import type { NavigateFunction } from 'storybook/internal/router';
 import { type API } from 'storybook/manager-api';
 
-import { REVIEW_CHANGES_URL } from './constants.ts';
-import { type ReviewModeFilters, enterReviewMode, exitReviewMode } from './review-mode.ts';
+import { enterReviewMode, exitReviewMode, type ReviewModeFilters } from './review-mode.ts';
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
-  type ReviewNavEntry,
-  buildReviewStoryTarget,
+  buildReviewChangesSummaryHref,
+  buildReviewStoryNavigateHref,
   isReviewReturnSearch,
+  type ReviewNavEntry,
 } from './review-navigation.ts';
 import { reviewStore } from './review-store.ts';
 
@@ -24,8 +24,7 @@ export const navigateToReviewEntry = (
 ): void => {
   void enterReviewMode(api, filters);
   reviewStore.suppressSummaryOverlay();
-  api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: String(entry.collectionIndex) });
-  navigate(buildReviewStoryTarget(entry));
+  navigate(buildReviewStoryNavigateHref(entry), { plain: true });
 };
 
 /** Navigate back to the review summary, entering (or staying in) review mode. */
@@ -36,7 +35,7 @@ export const navigateToReviewSummary = (
 ): void => {
   void enterReviewMode(api, filters);
   api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: null });
-  navigate(REVIEW_CHANGES_URL);
+  navigate(buildReviewChangesSummaryHref(), { plain: true });
 };
 
 /**
@@ -49,8 +48,9 @@ export const navigateOutOfReview = (
   navigate: NavigateFunction,
   returnSearch: string | null | undefined
 ): void => {
-  api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: null });
   reviewStore.releaseSummaryOverlaySuppression();
+  reviewStore.suppressUrlSync();
+  api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: null });
   void exitReviewMode(api);
 
   if (returnSearch && !isReviewReturnSearch(returnSearch)) {

--- a/code/core/src/manager/components/review/review-mode.ts
+++ b/code/core/src/manager/components/review/review-mode.ts
@@ -5,9 +5,8 @@ import { REVIEW_NAMESPACE } from '../../../shared/review/index.ts';
 import { REVIEWING_STATUS_VALUE } from './review-status.ts';
 import { sessionStore } from './session-store.ts';
 
-// Persisted flag marking the manager as being in review mode. Review mode is
-// interaction-driven (never inferred from the URL) and survives reloads via
-// this key.
+// Persisted flag marking filter snapshot while review mode is active. Chrome
+// collapse is driven by the `full=1` layout query param in the URL.
 const REVIEW_MODE_SESSION_KEY = `${REVIEW_NAMESPACE}/review-mode`;
 
 // Snapshot of the manager chrome (sidebar/addon panel visibility) taken when

--- a/code/core/src/manager/components/review/review-navigation.test.ts
+++ b/code/core/src/manager/components/review/review-navigation.test.ts
@@ -138,7 +138,9 @@ describe('path helpers', () => {
     expect(isReviewRoute('/review/', undefined)).toBe(true);
     expect(isReviewRoute('/story/foo', '0')).toBe(true);
     expect(isReviewRoute('/story/foo', undefined)).toBe(false);
+    expect(isReviewRoute('/story/foo', 'abc')).toBe(false);
     expect(isReviewStoryRoute('/story/foo', '0')).toBe(true);
+    expect(isReviewStoryRoute('/story/foo', 'abc')).toBe(false);
   });
 });
 

--- a/code/core/src/manager/components/review/review-navigation.test.ts
+++ b/code/core/src/manager/components/review/review-navigation.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ReviewState } from './review-state.ts';
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
+  REVIEW_FULL_QUERY_PARAM,
   buildFlattenedNavEntries,
   buildReviewChangesSummaryHref,
   buildReviewStoryHref,
@@ -10,6 +10,9 @@ import {
   buildSummaryBackHref,
   getAdjacentCollectionFirstStory,
   getAdjacentReviewEntries,
+  isReviewLayoutActive,
+  isReviewRoute,
+  isReviewStoryRoute,
   isReviewSummaryPath,
   parseCollectionIndex,
   parseReviewStoryHref,
@@ -17,6 +20,7 @@ import {
   resolveActiveNavEntry,
   resolveNavIndex,
 } from './review-navigation.ts';
+import type { ReviewState } from './review-state.ts';
 
 const reviewState: ReviewState = {
   title: 'Test review',
@@ -36,9 +40,9 @@ const reviewState: ReviewState = {
 };
 
 describe('buildReviewStoryHref', () => {
-  it('builds a story URL with collection query param', () => {
+  it('builds a story URL with full layout and collection query params', () => {
     expect(buildReviewStoryHref({ storyId: 'story-a', collectionIndex: 1 })).toBe(
-      `?path=/story/story-a&${REVIEW_COLLECTION_QUERY_PARAM}=1`
+      `?${REVIEW_FULL_QUERY_PARAM}=1&path=/story/story-a&${REVIEW_COLLECTION_QUERY_PARAM}=1`
     );
   });
 });
@@ -122,7 +126,19 @@ describe('path helpers', () => {
   });
 
   it('builds the summary href', () => {
-    expect(buildReviewChangesSummaryHref()).toBe('?path=/review/');
+    expect(buildReviewChangesSummaryHref()).toBe('?full=1&path=/review/');
+  });
+
+  it('detects review layout from the URL', () => {
+    expect(isReviewLayoutActive({ search: '?full=1&path=/review/' })).toBe(true);
+    expect(isReviewLayoutActive({ search: '?path=/story/foo' })).toBe(false);
+  });
+
+  it('detects review routes', () => {
+    expect(isReviewRoute('/review/', undefined)).toBe(true);
+    expect(isReviewRoute('/story/foo', '0')).toBe(true);
+    expect(isReviewRoute('/story/foo', undefined)).toBe(false);
+    expect(isReviewStoryRoute('/story/foo', '0')).toBe(true);
   });
 });
 

--- a/code/core/src/manager/components/review/review-navigation.ts
+++ b/code/core/src/manager/components/review/review-navigation.ts
@@ -1,5 +1,13 @@
+import { queryFromLocation } from 'storybook/internal/router';
+
 import { REVIEW_CHANGES_URL } from './constants.ts';
 import type { ReviewState } from './review-state.ts';
+
+/** Layout query param that collapses manager chrome during review. */
+export const REVIEW_FULL_QUERY_PARAM = 'full';
+
+const parseReviewLayoutFull = (value: unknown): boolean =>
+  value === '1' || value === 'true' || value === 1 || value === true;
 
 /** Fallback display name when the Storybook index has not resolved a title. */
 export const prettifyComponentId = (componentId: string) =>
@@ -17,7 +25,12 @@ export interface ReviewNavEntry {
 
 export const REVIEW_COLLECTION_QUERY_PARAM = 'collection';
 
-export const buildReviewChangesSummaryHref = () => `?path=${REVIEW_CHANGES_URL}`;
+export const buildReviewChangesSummaryHref = () =>
+  `?${REVIEW_FULL_QUERY_PARAM}=1&path=${REVIEW_CHANGES_URL}`;
+
+/** Plain manager href for navigating to a review story (includes `full=1`). */
+export const buildReviewStoryNavigateHref = (entry: ReviewNavEntry): string =>
+  `?${REVIEW_FULL_QUERY_PARAM}=1&path=/story/${entry.storyId}&${REVIEW_COLLECTION_QUERY_PARAM}=${entry.collectionIndex}`;
 
 /** Default back target when no story has been visited yet. */
 export const STORYBOOK_ROOT_HREF = '/';
@@ -34,12 +47,9 @@ export const buildReviewStoryTarget = (entry: ReviewNavEntry): string =>
 
 /** Full `?path=` href for a review story, derived from the router target. */
 export const buildReviewStoryHref = (entry: ReviewNavEntry): string =>
-  `?path=${buildReviewStoryTarget(entry)}`;
+  buildReviewStoryNavigateHref(entry);
 
 export const parseReviewStoryHref = (href: string): ReviewNavEntry | null => {
-  if (!href.startsWith('?path=/story/')) {
-    return null;
-  }
   const query = href.startsWith('?') ? href.slice(1) : href;
   const params = new URLSearchParams(query);
   const path = params.get('path');
@@ -69,6 +79,16 @@ export const buildFlattenedNavEntries = (state: ReviewState): ReviewNavEntry[] =
 
 export const isReviewSummaryPath = (path: string): boolean =>
   path === REVIEW_CHANGES_URL || path === '/review';
+
+export const isReviewLayoutActive = (location?: { search?: string }): boolean =>
+  parseReviewLayoutFull(queryFromLocation(location)[REVIEW_FULL_QUERY_PARAM]);
+
+export const isReviewStoryRoute = (path: string, collectionParam: string | undefined): boolean =>
+  parseStoryIdFromPath(path) !== null && collectionParam !== undefined;
+
+/** True when the route is part of the review flow (summary or curated story). */
+export const isReviewRoute = (path: string, collectionParam: string | undefined): boolean =>
+  isReviewSummaryPath(path) || isReviewStoryRoute(path, collectionParam);
 
 /** True when a manager search string points back at a review route (not a canvas). */
 export const isReviewReturnSearch = (search: string): boolean => {

--- a/code/core/src/manager/components/review/review-navigation.ts
+++ b/code/core/src/manager/components/review/review-navigation.ts
@@ -84,7 +84,7 @@ export const isReviewLayoutActive = (location?: { search?: string }): boolean =>
   parseReviewLayoutFull(queryFromLocation(location)[REVIEW_FULL_QUERY_PARAM]);
 
 export const isReviewStoryRoute = (path: string, collectionParam: string | undefined): boolean =>
-  parseStoryIdFromPath(path) !== null && collectionParam !== undefined;
+  parseStoryIdFromPath(path) !== null && parseCollectionIndex(collectionParam) !== undefined;
 
 /** True when the route is part of the review flow (summary or curated story). */
 export const isReviewRoute = (path: string, collectionParam: string | undefined): boolean =>

--- a/code/core/src/manager/components/review/review-store.ts
+++ b/code/core/src/manager/components/review/review-store.ts
@@ -1,8 +1,8 @@
 import { useSyncExternalStore } from 'react';
 
-import type { StoryInfo } from './components/CollectionGrid.tsx';
 import type { ReviewNavEntry } from './review-navigation.ts';
 import type { ReviewState } from './review-state.ts';
+import type { StoryInfo } from './review-types.ts';
 
 export interface ReviewStoreState {
   state: ReviewState | null;
@@ -41,6 +41,8 @@ const listeners = new Set<() => void>();
 
 /** Synchronously hide the summary overlay before SPA navigation to a story. */
 let summaryOverlaySuppressed = false;
+/** Skip URL-driven review enter/exit while an explicit leave is in flight. */
+let urlSyncSuppressed = false;
 
 const notify = () => {
   listeners.forEach((listener) => listener());
@@ -69,6 +71,13 @@ export const reviewStore = {
     }
   },
   isSummaryOverlayShown: () => currentStore.isSummaryVisible && !summaryOverlaySuppressed,
+  suppressUrlSync: () => {
+    urlSyncSuppressed = true;
+  },
+  releaseUrlSyncSuppression: () => {
+    urlSyncSuppressed = false;
+  },
+  isUrlSyncSuppressed: () => urlSyncSuppressed,
 };
 
 export const useReview = (): ReviewStoreState =>

--- a/code/core/src/manager/components/review/review-store.ts
+++ b/code/core/src/manager/components/review/review-store.ts
@@ -2,7 +2,7 @@ import { useSyncExternalStore } from 'react';
 
 import type { ReviewNavEntry } from './review-navigation.ts';
 import type { ReviewState } from './review-state.ts';
-import type { StoryInfo } from './components/CollectionGrid.tsx';
+import type { StoryInfo } from './review-types.ts';
 
 export interface ReviewStoreState {
   state: ReviewState | null;

--- a/code/core/src/manager/components/review/review-store.ts
+++ b/code/core/src/manager/components/review/review-store.ts
@@ -2,7 +2,7 @@ import { useSyncExternalStore } from 'react';
 
 import type { ReviewNavEntry } from './review-navigation.ts';
 import type { ReviewState } from './review-state.ts';
-import type { StoryInfo } from './review-types.ts';
+import type { StoryInfo } from './components/CollectionGrid.tsx';
 
 export interface ReviewStoreState {
   state: ReviewState | null;

--- a/code/core/src/manager/components/review/review-types.ts
+++ b/code/core/src/manager/components/review/review-types.ts
@@ -1,0 +1,20 @@
+export type StoryChangeStatus = 'new' | 'modified';
+
+export interface StoryInfo {
+  title: string;
+  name: string;
+  isNewlyAdded?: boolean;
+  changeStatus?: StoryChangeStatus;
+}
+
+/** Best-effort labels when the Storybook index has not resolved a story yet. */
+export const fallbackStoryInfo = (storyId: string): StoryInfo => {
+  const separator = storyId.indexOf('--');
+  if (separator === -1) {
+    return { title: storyId, name: 'Story' };
+  }
+  return {
+    title: storyId.slice(0, separator),
+    name: storyId.slice(separator + 2) || 'Story',
+  };
+};

--- a/code/core/src/manager/components/review/screens/SummaryScreen.stories.tsx
+++ b/code/core/src/manager/components/review/screens/SummaryScreen.stories.tsx
@@ -58,8 +58,8 @@ const largeCascade: ReviewState = {
         'Manager views consume shared typography, spacing, and theming tokens that can shift subtly.',
       storyIds: [
         'manager-main--default',
-        'manager-main--about-page',
-        'manager-main--guide-page',
+        'manager-settings-aboutscreen--default',
+        'manager-settings-guidepage--default',
         'manager-sidebar-sidebar--simple',
         'manager-sidebar-sidebar--with-refs',
         'manager-sidebar-sidebar--statuses-open',
@@ -123,7 +123,7 @@ const pagesAndBench: ReviewState = {
       storyIds: [
         'manager-settings-aboutscreen--default',
         'manager-settings-guidepage--default',
-        'manager-main--about-page',
+        'manager-main--default',
         'bench--es-build-analyzer',
       ],
     },
@@ -263,7 +263,11 @@ const manyCollections: ReviewState = {
     {
       title: 'Collection 09 — Manager main',
       rationale: 'Main manager page states.',
-      storyIds: ['manager-main--default', 'manager-main--about-page', 'manager-main--guide-page'],
+      storyIds: [
+        'manager-main--default',
+        'manager-settings-aboutscreen--default',
+        'manager-settings-guidepage--default',
+      ],
     },
     {
       title: 'Collection 10 — Manager settings',
@@ -424,8 +428,8 @@ const fortyStoryCollection: ReviewState = {
         'overlay-popover--with-hide-button',
         'overlay-popover--with-chrome',
         'manager-main--default',
-        'manager-main--about-page',
-        'manager-main--guide-page',
+        'manager-main--connection-lost',
+        'manager-main--server-timed-out',
         'manager-settings-aboutscreen--default',
         'manager-settings-guidepage--default',
         'manager-settings-shortcutsscreen--defaults',

--- a/code/core/src/manager/components/review/screens/SummaryScreen.stories.tsx
+++ b/code/core/src/manager/components/review/screens/SummaryScreen.stories.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 
 import { expect, within } from 'storybook/test';
 
-import { IconSymbols } from '../../sidebar/IconSymbols.tsx';
 import preview from '../../../../../../.storybook/preview.tsx';
-import type { StoryInfo } from '../components/CollectionGrid.tsx';
+import { IconSymbols } from '../../sidebar/IconSymbols.tsx';
 import type { ReviewState } from '../review-state.ts';
+import type { StoryInfo } from '../review-types.ts';
 import { SummaryScreen } from './SummaryScreen.tsx';
 
 const getStoryPreviewHref = (storyId: string) =>
-  `iframe.html?id=${encodeURIComponent(storyId)}&viewMode=story&freeze=finished`;
+  `iframe.html?id=${encodeURIComponent(storyId)}&viewMode=story&embed=true&freeze=finished`;
 
 const minimal: ReviewState = {
   title: 'Button prop rename',

--- a/code/core/src/manager/components/review/screens/SummaryScreen.tsx
+++ b/code/core/src/manager/components/review/screens/SummaryScreen.tsx
@@ -20,7 +20,8 @@ import {
   WandIcon,
 } from '@storybook/icons';
 
-import { CollectionGrid, type StoryInfo } from '../components/CollectionGrid.tsx';
+import { CollectionGrid } from '../components/CollectionGrid.tsx';
+import type { StoryInfo } from '../review-types.ts';
 import { Markdown } from '../components/Markdown.tsx';
 import { CopyButton } from '../components/CopyButton.tsx';
 import { AttentionBanner } from '../components/AttentionBanner.tsx';

--- a/code/core/src/manager/components/review/useReviewNavigationInterceptor.ts
+++ b/code/core/src/manager/components/review/useReviewNavigationInterceptor.ts
@@ -12,16 +12,30 @@ import {
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
   REVIEW_SUMMARY_BACK_ATTR,
-  buildReviewChangesSummaryHref,
+  isReviewSummaryPath,
   parseReviewStoryHref,
 } from './review-navigation.ts';
 import { sessionStore } from './session-store.ts';
 import { useReviewFiltersRef } from './useReviewFiltersRef.ts';
 
-const isReviewStoryHref = (href: string) =>
-  href.startsWith('?path=/story/') && href.includes(`${REVIEW_COLLECTION_QUERY_PARAM}=`);
+const parseHrefPath = (href: string): string | null => {
+  const query = href.startsWith('?') ? href.slice(1) : href;
+  return new URLSearchParams(query).get('path');
+};
 
-const isReviewSummaryHref = (href: string) => href === buildReviewChangesSummaryHref();
+const isReviewStoryHref = (href: string) => {
+  const path = parseHrefPath(href);
+  if (!path?.startsWith('/story/')) {
+    return false;
+  }
+  const query = href.startsWith('?') ? href.slice(1) : href;
+  return new URLSearchParams(query).has(REVIEW_COLLECTION_QUERY_PARAM);
+};
+
+const isReviewSummaryHref = (href: string) => {
+  const path = parseHrefPath(href);
+  return path !== null && isReviewSummaryPath(path);
+};
 
 /**
  * Intercepts primary clicks on in-page review navigation links for SPA

--- a/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
@@ -119,6 +119,7 @@ const makeManagerContext = (
       setAllTagFilters: options.setAllTagFilters ?? fn().mockName('api::setAllTagFilters'),
       setAllStatusFilters: options.setAllStatusFilters ?? fn().mockName('api::setAllStatusFilters'),
       navigate: options.navigate ?? fn().mockName('api::navigate'),
+      navigateUrl: options.navigate ?? fn().mockName('api::navigateUrl'),
     },
   };
 };
@@ -188,7 +189,7 @@ export const HiddenWhenZeroCounts: Story = {
   },
 };
 
-const navigateMock = fn().mockName('api::navigate');
+const navigateMock = fn().mockName('api::navigateUrl');
 const toggleNavMock = fn().mockName('api::toggleNav');
 const togglePanelMock = fn().mockName('api::togglePanel');
 const setAllTagFiltersMock = fn().mockName('api::setAllTagFilters');
@@ -200,6 +201,7 @@ export const OpenReview: Story = {
       storyIds: ['s1', 's2'],
       reviewTitle: 'Theme token cascade review',
       navigate: navigateMock,
+      navigateUrl: navigateMock,
       toggleNav: toggleNavMock,
       togglePanel: togglePanelMock,
       setAllTagFilters: setAllTagFiltersMock,
@@ -222,7 +224,7 @@ export const OpenReview: Story = {
     await expect(togglePanelMock).toHaveBeenCalledWith(false);
     await expect(setAllTagFiltersMock).toHaveBeenCalledWith([], []);
     await expect(setAllStatusFiltersMock).toHaveBeenCalledWith(['status-value:reviewing'], []);
-    await expect(navigateMock).toHaveBeenCalledWith('/review/');
+    await expect(navigateMock).toHaveBeenCalledWith('?full=1&path=/review/', {});
   },
 };
 

--- a/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
@@ -62,6 +62,7 @@ const makeManagerContext = (
     storyIds?: string[];
     reviewTitle?: string;
     navigate?: ReturnType<typeof fn>;
+    navigateUrl?: ReturnType<typeof fn>;
     toggleNav?: ReturnType<typeof fn>;
     togglePanel?: ReturnType<typeof fn>;
     setAllTagFilters?: ReturnType<typeof fn>;
@@ -119,7 +120,7 @@ const makeManagerContext = (
       setAllTagFilters: options.setAllTagFilters ?? fn().mockName('api::setAllTagFilters'),
       setAllStatusFilters: options.setAllStatusFilters ?? fn().mockName('api::setAllStatusFilters'),
       navigate: options.navigate ?? fn().mockName('api::navigate'),
-      navigateUrl: options.navigate ?? fn().mockName('api::navigateUrl'),
+      navigateUrl: options.navigateUrl ?? fn().mockName('api::navigateUrl'),
     },
   };
 };
@@ -189,7 +190,8 @@ export const HiddenWhenZeroCounts: Story = {
   },
 };
 
-const navigateMock = fn().mockName('api::navigateUrl');
+const navigateMock = fn().mockName('api::navigate');
+const navigateUrlMock = fn().mockName('api::navigateUrl');
 const toggleNavMock = fn().mockName('api::toggleNav');
 const togglePanelMock = fn().mockName('api::togglePanel');
 const setAllTagFiltersMock = fn().mockName('api::setAllTagFilters');
@@ -201,7 +203,7 @@ export const OpenReview: Story = {
       storyIds: ['s1', 's2'],
       reviewTitle: 'Theme token cascade review',
       navigate: navigateMock,
-      navigateUrl: navigateMock,
+      navigateUrl: navigateUrlMock,
       toggleNav: toggleNavMock,
       togglePanel: togglePanelMock,
       setAllTagFilters: setAllTagFiltersMock,
@@ -212,6 +214,7 @@ export const OpenReview: Story = {
     eventListeners.clear();
     sessionStorage.clear();
     navigateMock.mockClear();
+    navigateUrlMock.mockClear();
     toggleNavMock.mockClear();
     togglePanelMock.mockClear();
     setAllTagFiltersMock.mockClear();
@@ -224,7 +227,8 @@ export const OpenReview: Story = {
     await expect(togglePanelMock).toHaveBeenCalledWith(false);
     await expect(setAllTagFiltersMock).toHaveBeenCalledWith([], []);
     await expect(setAllStatusFiltersMock).toHaveBeenCalledWith(['status-value:reviewing'], []);
-    await expect(navigateMock).toHaveBeenCalledWith('?full=1&path=/review/', {});
+    await expect(navigateUrlMock).toHaveBeenCalledWith('?full=1&path=/review/', {});
+    await expect(navigateMock).not.toHaveBeenCalled();
   },
 };
 

--- a/code/core/src/manager/components/sidebar/ReviewWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.tsx
@@ -1,4 +1,4 @@
-import React, { type SyntheticEvent, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, type SyntheticEvent } from 'react';
 
 import { ActionList, Card } from 'storybook/internal/components';
 import type { StatusesByStoryIdAndTypeId, StoryIndex } from 'storybook/internal/types';
@@ -14,8 +14,8 @@ import {
 import { styled } from 'storybook/theming';
 
 import { REVIEW_EVENTS } from '../../../shared/review/index.ts';
-import { REVIEW_CHANGES_URL } from '../review/constants.ts';
 import { enterReviewMode } from '../review/review-mode.ts';
+import { buildReviewChangesSummaryHref } from '../review/review-navigation.ts';
 import { REVIEWING_STATUS_VALUE as REVIEWING } from '../review/review-status.ts';
 
 type ReviewPayload = {
@@ -119,7 +119,7 @@ export const ReviewWidget = () => {
       } catch {
         // Best-effort: still continue into the review route.
       }
-      api.navigate(REVIEW_CHANGES_URL);
+      api.navigateUrl(buildReviewChangesSummaryHref(), {});
     })();
   };
 

--- a/code/core/src/preview-api/modules/preview-web/setupStoryFreezer.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/setupStoryFreezer.test.ts
@@ -251,4 +251,21 @@ describe('setupStoryFreezer', () => {
       expect(pause).toHaveBeenCalledTimes(1);
     });
   });
+
+  it('calls onFrozen after freeze completes', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/iframe.html?id=example--story&viewMode=story&freeze=finished'
+    );
+
+    const channel = createChannel();
+    const onFrozen = vi.fn();
+    expect(setupStoryFreezer(channel, { onFrozen })).toBe(true);
+
+    channel.emit(STORY_RENDER_PHASE_CHANGED, { newPhase: 'finished', storyId: 'example--story' });
+    await Promise.resolve();
+
+    expect(onFrozen).toHaveBeenCalledTimes(1);
+  });
 });

--- a/code/core/src/preview-api/modules/preview-web/setupStoryFreezer.ts
+++ b/code/core/src/preview-api/modules/preview-web/setupStoryFreezer.ts
@@ -276,7 +276,15 @@ const createStoryFreezer = (windowRef: Window, documentRef: Document) => {
   return { freeze };
 };
 
-export const setupStoryFreezer = (channel: Pick<Channel, 'on'>) => {
+export type StoryFreezerOptions = {
+  /** Called once after the document has been frozen. */
+  onFrozen?: () => void;
+};
+
+export const setupStoryFreezer = (
+  channel: Pick<Channel, 'on'>,
+  options: StoryFreezerOptions = {}
+) => {
   const windowRef = global.window;
   const documentRef = global.document;
   if (!windowRef || !documentRef) {
@@ -291,10 +299,14 @@ export const setupStoryFreezer = (channel: Pick<Channel, 'on'>) => {
   const freezer = createStoryFreezer(windowRef, documentRef);
   channel.on(STORY_RENDER_PHASE_CHANGED, ({ newPhase }) => {
     if (newPhase === 'finished') {
+      const runFreeze = () => {
+        freezer.freeze();
+        options.onFrozen?.();
+      };
       if (typeof windowRef.queueMicrotask === 'function') {
-        windowRef.queueMicrotask(freezer.freeze);
+        windowRef.queueMicrotask(runFreeze);
       } else {
-        windowRef.setTimeout(freezer.freeze, 0);
+        windowRef.setTimeout(runFreeze, 0);
       }
     }
   });


### PR DESCRIPTION
## What I did

Ship review summary **live story thumbnails** (embed + freeze iframes, lazy load with a concurrency cap) alongside **URL-driven review layout** via the `full=1` query param.

### Thumbnails
- Render frozen embed previews in `CollectionGrid` with width-based CSS scaling (0.5–1.0 in 0.25 steps) inside fixed **3:2** frames.
- Add a preview scheduler and `usePreviewThumbnail` hook for mount/evict hysteresis and capped concurrent iframe loads.
- Wire `getStoryHrefs({ embed: true, freeze: true })` from the review provider.
- **Deferred:** dynamic iframe height / aspect-ratio resizing from content-dimension postMessage (removed for now).

### Review navigation (`full=1`)
- Auto-add `full=1` on first entry to `/?path=/review/` (replace, no extra history entry).
- Stop replaying a cached review on mount from redirecting logo/`/` navigation into the review summary.
- Exit review mode (restore sidebar + filters) when browser history leaves review routes or drops `full=1`.
- Apply persisted layout options from URL params on manager init so `full=1` survives reload.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Start the internal Storybook UI (`cd code && yarn storybook:ui`).
2. Push or open a review (MCP `display-review` or the sidebar Quick review widget).
3. Confirm the review summary shows scaled story thumbnails that load progressively (not all at once).
4. Click the Storybook logo or navigate to `/` — you should **not** be forced back into the review summary.
5. Enter review from the widget, then use the browser **Back** button — sidebar and filters should restore.
6. Open `/?path=/review/` directly (no prior history) — URL should gain `full=1` and review chrome should collapse.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:

  - `bug`

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `embed` option for Storybook preview links (including for frozen previews).
  * Introduced a `full layout` query flag for review navigation to keep review chrome consistent.
* **Bug Fixes**
  * Restores correct review navigation/layout state when reopening reviews and keeps UI synchronized with the current URL (including `full=1`).
  * Improved review update flow to use the correct “Update” action and navigate to the right destination.
  * More reliable interception of review link clicks across query-string variations.
* **Tests**
  * Added/updated coverage for `full`/route detection and `embed` preview URL behavior.
  * Added coverage to ensure the freeze “onFrozen” callback fires exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->