### PR TITLE
A11y: Surface required args and keyboard-reachable Setup controls in ArgsTable

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgControl.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgControl.tsx
@@ -3,8 +3,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { Link } from 'storybook/internal/components';
 
-import { styled } from 'storybook/theming';
-
 import {
   BooleanControl,
   ColorControl,
@@ -26,15 +24,6 @@ export interface ArgControlProps {
   storyId?: string;
   controlsId?: string;
 }
-
-/** Parent row toggles visibility purely with CSS (see `StyledTr` in `ArgRow`).  */
-const SetupControlsLink = styled.span({
-  display: 'none',
-});
-
-const NoControlPlaceholder = styled.span({
-  display: 'inline',
-});
 
 const Controls: Record<string, FC<any>> = {
   array: ObjectControl,
@@ -97,7 +86,7 @@ export const ArgControl: FC<ArgControlProps> = ({
     // :hover and :focus-within, so the link stays reachable for keyboard users.
     return (
       <>
-        <span className="sbdocs sbdocs-argcontrol-placeholder">
+        <span className="sbdocs sbdocs-argcontrol-setup">
           <Link
             href="https://storybook.js.org/docs/essentials/controls?ref=ui"
             target="_blank"
@@ -106,7 +95,7 @@ export const ArgControl: FC<ArgControlProps> = ({
             Setup controls
           </Link>
         </span>
-        <span>
+        <span className="sbdocs sbdocs-argcontrol-placeholder">
           <NoControl />
         </span>
       </>

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgControl.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgControl.tsx
@@ -3,6 +3,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { Link } from 'storybook/internal/components';
 
+import { styled } from 'storybook/theming';
+
 import {
   BooleanControl,
   ColorControl,
@@ -20,10 +22,19 @@ export interface ArgControlProps {
   row: ArgType;
   arg: any;
   updateArgs: (args: Args) => void;
-  isHovered: boolean;
+  isRequired: boolean;
   storyId?: string;
   controlsId?: string;
 }
+
+/** Parent row toggles visibility purely with CSS (see `StyledTr` in `ArgRow`).  */
+export const SetupControlsLink = styled.span({
+  display: 'none',
+});
+
+export const NoControlPlaceholder = styled.span({
+  display: 'inline',
+});
 
 const Controls: Record<string, FC<any>> = {
   array: ObjectControl,
@@ -49,7 +60,7 @@ export const ArgControl: FC<ArgControlProps> = ({
   row,
   arg,
   updateArgs,
-  isHovered,
+  isRequired,
   storyId,
   controlsId,
 }) => {
@@ -79,16 +90,26 @@ export const ArgControl: FC<ArgControlProps> = ({
 
   if (!control || control.disable) {
     const canBeSetup = control?.disable !== true && row?.type?.name !== 'function';
-    return isHovered && canBeSetup ? (
-      <Link
-        href="https://storybook.js.org/docs/essentials/controls?ref=ui"
-        target="_blank"
-        withArrow
-      >
-        Setup controls
-      </Link>
-    ) : (
-      <NoControl />
+    if (!canBeSetup) {
+      return <NoControl />;
+    }
+    // Both nodes are always rendered; the parent row toggles their visibility with CSS on
+    // :hover and :focus-within, so the link stays reachable for keyboard users.
+    return (
+      <>
+        <SetupControlsLink>
+          <Link
+            href="https://storybook.js.org/docs/essentials/controls?ref=ui"
+            target="_blank"
+            withArrow
+          >
+            Setup controls
+          </Link>
+        </SetupControlsLink>
+        <NoControlPlaceholder>
+          <NoControl />
+        </NoControlPlaceholder>
+      </>
     );
   }
   // row.name is a display name and not a suitable DOM input id or name - i might contain whitespace etc.
@@ -99,6 +120,7 @@ export const ArgControl: FC<ArgControlProps> = ({
     controlsId,
     argType: row,
     value: boxedValue.value,
+    required: isRequired,
     onChange,
     onBlur,
     onFocus,

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgControl.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgControl.tsx
@@ -28,11 +28,11 @@ export interface ArgControlProps {
 }
 
 /** Parent row toggles visibility purely with CSS (see `StyledTr` in `ArgRow`).  */
-export const SetupControlsLink = styled.span({
+const SetupControlsLink = styled.span({
   display: 'none',
 });
 
-export const NoControlPlaceholder = styled.span({
+const NoControlPlaceholder = styled.span({
   display: 'inline',
 });
 
@@ -97,7 +97,7 @@ export const ArgControl: FC<ArgControlProps> = ({
     // :hover and :focus-within, so the link stays reachable for keyboard users.
     return (
       <>
-        <SetupControlsLink>
+        <span className="sbdocs sbdocs-argcontrol-placeholder">
           <Link
             href="https://storybook.js.org/docs/essentials/controls?ref=ui"
             target="_blank"
@@ -105,10 +105,10 @@ export const ArgControl: FC<ArgControlProps> = ({
           >
             Setup controls
           </Link>
-        </SetupControlsLink>
-        <NoControlPlaceholder>
+        </span>
+        <span>
           <NoControl />
-        </NoControlPlaceholder>
+        </span>
       </>
     );
   }

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.tsx
@@ -9,7 +9,7 @@ import type { CSSObject } from 'storybook/theming';
 import { styled } from 'storybook/theming';
 
 import type { ArgControlProps } from './ArgControl';
-import { ArgControl, NoControlPlaceholder, SetupControlsLink } from './ArgControl';
+import { ArgControl } from './ArgControl';
 import { ArgJsDoc } from './ArgJsDoc';
 import { ArgValue } from './ArgValue';
 import type { ArgType, Args, TableAnnotation } from './types';
@@ -83,11 +83,14 @@ const StyledTd = styled.td<{ expandable: boolean }>(({ expandable }) => ({
 // When a row has no usable control, the "Setup controls" link is hidden and a placeholder dash is
 // shown. Hovering or focusing within the row swaps them, so keyboard users reach the link too.
 const StyledTr = styled.tr({
+  [`span.sbdocs-argcontrol-placeholder`]: {
+    display: 'none',
+  },
   '&:hover, &:focus-within': {
-    [`${SetupControlsLink}`]: {
+    [`span.sbdocs-argcontrol-placeholder`]: {
       display: 'inline',
     },
-    [`${NoControlPlaceholder}`]: {
+    [`span:not(.sbdocs-argcontrol-placeholder)`]: {
       display: 'none',
     },
   },

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.tsx
@@ -6,7 +6,7 @@ import { codeCommon } from 'storybook/internal/components';
 import Markdown from 'markdown-to-jsx';
 import { transparentize } from 'polished';
 import type { CSSObject } from 'storybook/theming';
-import { styled } from 'storybook/theming';
+import { srOnlyStyles, srOnlyUnsetStyles, styled } from 'storybook/theming';
 
 import type { ArgControlProps } from './ArgControl';
 import { ArgControl } from './ArgControl';
@@ -83,15 +83,15 @@ const StyledTd = styled.td<{ expandable: boolean }>(({ expandable }) => ({
 // When a row has no usable control, the "Setup controls" link is hidden and a placeholder dash is
 // shown. Hovering or focusing within the row swaps them, so keyboard users reach the link too.
 const StyledTr = styled.tr({
-  [`span.sbdocs-argcontrol-placeholder`]: {
-    display: 'none',
+  [`span.sbdocs-argcontrol-setup`]: {
+    ...srOnlyStyles,
   },
   '&:hover, &:focus-within': {
-    [`span.sbdocs-argcontrol-placeholder`]: {
-      display: 'inline',
+    [`span.sbdocs-argcontrol-setup`]: {
+      ...srOnlyUnsetStyles,
     },
-    [`span:not(.sbdocs-argcontrol-placeholder)`]: {
-      display: 'none',
+    [`span.sbdocs-argcontrol-placeholder`]: {
+      ...srOnlyStyles,
     },
   },
 });
@@ -151,7 +151,7 @@ export const ArgRow: FC<ArgRowProps> = (props) => {
       )}
       {updateArgs ? (
         <td>
-          <ArgControl {...(props as ArgControlProps)} isRequired={required} />
+          <ArgControl {...(props as ArgControlProps)} isRequired={!!required} />
         </td>
       ) : null}
     </StyledTr>

--- a/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/ArgRow.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { codeCommon } from 'storybook/internal/components';
 
@@ -9,7 +9,7 @@ import type { CSSObject } from 'storybook/theming';
 import { styled } from 'storybook/theming';
 
 import type { ArgControlProps } from './ArgControl';
-import { ArgControl } from './ArgControl';
+import { ArgControl, NoControlPlaceholder, SetupControlsLink } from './ArgControl';
 import { ArgJsDoc } from './ArgJsDoc';
 import { ArgValue } from './ArgValue';
 import type { ArgType, Args, TableAnnotation } from './types';
@@ -80,6 +80,19 @@ const StyledTd = styled.td<{ expandable: boolean }>(({ expandable }) => ({
   paddingLeft: expandable ? '40px !important' : '20px !important',
 }));
 
+// When a row has no usable control, the "Setup controls" link is hidden and a placeholder dash is
+// shown. Hovering or focusing within the row swaps them, so keyboard users reach the link too.
+const StyledTr = styled.tr({
+  '&:hover, &:focus-within': {
+    [`${SetupControlsLink}`]: {
+      display: 'inline',
+    },
+    [`${NoControlPlaceholder}`]: {
+      display: 'none',
+    },
+  },
+});
+
 const toSummary = (value: any) => {
   if (!value) {
     return value;
@@ -89,7 +102,6 @@ const toSummary = (value: any) => {
 };
 
 export const ArgRow: FC<ArgRowProps> = (props) => {
-  const [isHovered, setIsHovered] = useState(false);
   const { row, updateArgs, compact, expandable, initialExpandedArgs } = props;
   const { name, description } = row;
   const table = (row.table || {}) as TableAnnotation;
@@ -99,10 +111,14 @@ export const ArgRow: FC<ArgRowProps> = (props) => {
   const hasDescription = description != null && description !== '';
 
   return (
-    <tr onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+    <StyledTr>
       <StyledTd expandable={expandable ?? false}>
         <Name>{name}</Name>
-        {required ? <Required title="Required">*</Required> : null}
+        {required ? (
+          <Required aria-hidden title="Required">
+            *
+          </Required>
+        ) : null}
       </StyledTd>
       {compact ? null : (
         <td>
@@ -132,9 +148,9 @@ export const ArgRow: FC<ArgRowProps> = (props) => {
       )}
       {updateArgs ? (
         <td>
-          <ArgControl {...(props as ArgControlProps)} isHovered={isHovered} />
+          <ArgControl {...(props as ArgControlProps)} isRequired={required} />
         </td>
       ) : null}
-    </tr>
+    </StyledTr>
   );
 };

--- a/code/addons/docs/src/blocks/controls/Boolean.tsx
+++ b/code/addons/docs/src/blocks/controls/Boolean.tsx
@@ -129,6 +129,7 @@ export const BooleanControl: FC<BooleanProps> = ({
   onBlur,
   onFocus,
   argType,
+  required,
 }) => {
   const onSetFalse = useCallback(() => onChange(false), [onChange]);
   const readonly = !!argType?.table?.readonly;
@@ -159,6 +160,7 @@ export const BooleanControl: FC<BooleanProps> = ({
         checked={parsedValue}
         role="switch"
         disabled={readonly}
+        aria-required={required || undefined}
         {...{ name, onBlur, onFocus }}
       />
       <span aria-hidden="true">False</span>

--- a/code/addons/docs/src/blocks/controls/Color.tsx
+++ b/code/addons/docs/src/blocks/controls/Color.tsx
@@ -376,6 +376,7 @@ export const ColorControl: FC<ColorControlProps> = ({
   maxPresetColors,
   startOpen = false,
   argType,
+  required,
 }) => {
   const debouncedOnChange = useCallback(debounce(onChange, 200), [onChange]);
   const { value, realValue, updateValue, color, colorSpace, cycleColorSpace } = useColorInput(
@@ -399,6 +400,7 @@ export const ColorControl: FC<ColorControlProps> = ({
         onChange={(e: ChangeEvent<HTMLInputElement>) => updateValue(e.target.value)}
         onFocus={(e: FocusEvent<HTMLInputElement>) => e.target.select()}
         readOnly={readOnly}
+        aria-required={required || undefined}
         placeholder="Choose color..."
       />
       <PopoverProvider

--- a/code/addons/docs/src/blocks/controls/Date.tsx
+++ b/code/addons/docs/src/blocks/controls/Date.tsx
@@ -75,6 +75,7 @@ export const DateControl: FC<DateProps> = ({
   onFocus,
   onBlur,
   argType,
+  required,
 }) => {
   const [valid, setValid] = useState(true);
   const dateRef = useRef<HTMLInputElement>();
@@ -138,6 +139,7 @@ export const DateControl: FC<DateProps> = ({
         id={`${controlId}-date`}
         name={`${controlId}-date`}
         readOnly={readonly}
+        aria-required={required || undefined}
         onChange={onDateChange}
         {...{ onFocus, onBlur }}
       />
@@ -151,6 +153,7 @@ export const DateControl: FC<DateProps> = ({
         ref={timeRef as RefObject<HTMLInputElement>}
         onChange={onTimeChange}
         readOnly={readonly}
+        aria-required={required || undefined}
         {...{ onFocus, onBlur }}
       />
       {!valid ? <div>invalid</div> : null}

--- a/code/addons/docs/src/blocks/controls/Files.tsx
+++ b/code/addons/docs/src/blocks/controls/Files.tsx
@@ -45,6 +45,7 @@ export const FilesControl: FC<FilesControlProps> = ({
   accept = 'image/*',
   value,
   argType,
+  required,
 }) => {
   const inputElement = useRef<HTMLInputElement>(null);
   const readonly = argType?.control?.readOnly;
@@ -81,6 +82,7 @@ export const FilesControl: FC<FilesControlProps> = ({
         disabled={readonly}
         onChange={handleFileChange}
         accept={accept}
+        aria-required={required || undefined}
         size="flex"
       />
     </>

--- a/code/addons/docs/src/blocks/controls/Number.tsx
+++ b/code/addons/docs/src/blocks/controls/Number.tsx
@@ -37,6 +37,7 @@ export const NumberControl: FC<NumberProps> = ({
   onBlur,
   onFocus,
   argType,
+  required,
 }) => {
   const [inputValue, setInputValue] = useState(typeof value === 'number' ? value : '');
   const [forceVisible, setForceVisible] = useState(false);
@@ -125,6 +126,7 @@ export const NumberControl: FC<NumberProps> = ({
         value={inputValue}
         valid={parseError ? 'error' : undefined}
         autoFocus={forceVisible}
+        aria-required={required || undefined}
         readOnly={readonly}
         {...{ name, min, max, step, onFocus, onBlur }}
       />

--- a/code/addons/docs/src/blocks/controls/Object.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.tsx
@@ -170,6 +170,7 @@ export const ObjectControl: FC<ObjectProps> = ({
   value,
   onChange,
   argType,
+  required,
 }) => {
   const data = useMemo(() => value && cloneDeep(value), [value]);
   const hasData = data !== null && data !== undefined;
@@ -248,6 +249,7 @@ export const ObjectControl: FC<ObjectProps> = ({
         autoFocus={forceVisible}
         valid={parseError ? 'error' : undefined}
         readOnly={readonly}
+        aria-required={required || undefined}
       />
     </>
   );

--- a/code/addons/docs/src/blocks/controls/Range.tsx
+++ b/code/addons/docs/src/blocks/controls/Range.tsx
@@ -187,6 +187,7 @@ export const RangeControl: FC<RangeProps> = ({
   onBlur,
   onFocus,
   argType,
+  required,
 }) => {
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChange(parse(event.target.value));
@@ -209,6 +210,7 @@ export const RangeControl: FC<RangeProps> = ({
         type="range"
         disabled={readonly}
         onChange={handleChange}
+        aria-required={required || undefined}
         {...{ name, min, max, step, onFocus, onBlur }}
         value={value ?? min}
       />

--- a/code/addons/docs/src/blocks/controls/Text.tsx
+++ b/code/addons/docs/src/blocks/controls/Text.tsx
@@ -30,6 +30,7 @@ export const TextControl: FC<TextProps> = ({
   onBlur,
   maxLength,
   argType,
+  required,
 }) => {
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     onChange(event.target.value);
@@ -71,6 +72,7 @@ export const TextControl: FC<TextProps> = ({
         size="flex"
         placeholder="Edit string..."
         autoFocus={forceVisible}
+        aria-required={required || undefined}
         valid={isValid ? undefined : 'error'}
         {...{ name, value: isValid ? value : '', onFocus, onBlur }}
       />

--- a/code/addons/docs/src/blocks/controls/options/Checkbox.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Checkbox.tsx
@@ -94,8 +94,11 @@ export const CheckboxControl: FC<CheckboxProps> = ({
   const controlId = getControlId(name, storyId, controlsId);
 
   return (
-    <Wrapper $isInline={isInline} aria-required={required || undefined}>
-      <legend className="sb-sr-only">{name}</legend>
+    <Wrapper $isInline={isInline}>
+      <legend className="sb-sr-only">
+        {name}
+        {required ? ' (required)' : ''}
+      </legend>
       {Object.keys(options).map((key, index) => {
         const id = `${controlId}-${index}`;
         return (

--- a/code/addons/docs/src/blocks/controls/options/Checkbox.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Checkbox.tsx
@@ -63,6 +63,7 @@ export const CheckboxControl: FC<CheckboxProps> = ({
   onChange,
   isInline,
   argType,
+  required,
 }) => {
   if (!options) {
     logger.warn(`Checkbox with no options: ${name}`);
@@ -93,7 +94,7 @@ export const CheckboxControl: FC<CheckboxProps> = ({
   const controlId = getControlId(name, storyId, controlsId);
 
   return (
-    <Wrapper $isInline={isInline}>
+    <Wrapper $isInline={isInline} aria-required={required || undefined}>
       <legend className="sb-sr-only">{name}</legend>
       {Object.keys(options).map((key, index) => {
         const id = `${controlId}-${index}`;

--- a/code/addons/docs/src/blocks/controls/options/Radio.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Radio.tsx
@@ -63,6 +63,7 @@ export const RadioControl: FC<RadioProps> = ({
   onChange,
   isInline,
   argType,
+  required,
 }) => {
   if (!options) {
     logger.warn(`Radio with no options: ${name}`);
@@ -74,7 +75,7 @@ export const RadioControl: FC<RadioProps> = ({
   const readonly = !!argType?.table?.readonly;
 
   return (
-    <Wrapper isInline={isInline}>
+    <Wrapper isInline={isInline} aria-required={required || undefined}>
       <legend className="sb-sr-only">{name}</legend>
       {Object.keys(options).map((key, index) => {
         const id = `${controlId}-${index}`;

--- a/code/addons/docs/src/blocks/controls/options/Radio.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Radio.tsx
@@ -75,8 +75,11 @@ export const RadioControl: FC<RadioProps> = ({
   const readonly = !!argType?.table?.readonly;
 
   return (
-    <Wrapper isInline={isInline} aria-required={required || undefined}>
-      <legend className="sb-sr-only">{name}</legend>
+    <Wrapper isInline={isInline}>
+      <legend className="sb-sr-only">
+        {name}
+        {required ? ' (required)' : ''}
+      </legend>
       {Object.keys(options).map((key, index) => {
         const id = `${controlId}-${index}`;
         return (

--- a/code/addons/docs/src/blocks/controls/options/Select.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Select.tsx
@@ -112,6 +112,7 @@ const SingleSelect: FC<SelectProps> = ({
   options,
   onChange,
   argType,
+  required,
 }) => {
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     onChange(options[e.currentTarget.value]);
@@ -127,7 +128,13 @@ const SingleSelect: FC<SelectProps> = ({
       <label htmlFor={controlId} className="sb-sr-only">
         {name}
       </label>
-      <OptionsSelect disabled={readonly} id={controlId} value={selection} onChange={handleChange}>
+      <OptionsSelect
+        disabled={readonly}
+        id={controlId}
+        value={selection}
+        onChange={handleChange}
+        aria-required={required || undefined}
+      >
         <option disabled={selection === NO_SELECTION} key="no-selection">
           {NO_SELECTION}
         </option>
@@ -149,6 +156,7 @@ const MultiSelect: FC<SelectProps> = ({
   options,
   onChange,
   argType,
+  required,
 }) => {
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const selection = Array.from(e.currentTarget.options)
@@ -172,6 +180,7 @@ const MultiSelect: FC<SelectProps> = ({
         multiple
         value={selection}
         onChange={handleChange}
+        aria-required={required || undefined}
       >
         {Object.keys(options).map((key) => (
           <option key={key} value={key}>

--- a/code/addons/docs/src/blocks/controls/types.ts
+++ b/code/addons/docs/src/blocks/controls/types.ts
@@ -7,6 +7,8 @@ export interface ControlProps<T> {
   value?: T;
   defaultValue?: T;
   argType?: ArgType;
+  /** Whether the underlying arg is required; surfaced as `aria-required` on the control's input. */
+  required?: boolean;
   onChange: (value?: T) => T | void;
   onFocus?: (evt: any) => void;
   onBlur?: (evt: any) => void;

--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -389,6 +389,7 @@ export default {
     'keyframes',
     'lighten',
     'srOnlyStyles',
+    'srOnlyUnsetStyles',
     'styled',
     'themes',
     'tokens',

--- a/code/core/src/theming/global.ts
+++ b/code/core/src/theming/global.ts
@@ -22,6 +22,19 @@ export const srOnlyStyles = {
   border: 0,
 };
 
+export const srOnlyUnsetStyles = {
+  position: 'unset' as const,
+  width: 'unset' as const,
+  height: 'unset' as const,
+  padding: 'unset' as const,
+  margin: 'unset' as const,
+  overflow: 'unset' as const,
+  whiteSpace: 'unset' as const,
+  clip: 'unset' as const,
+  clipPath: 'unset' as const,
+  border: 'unset' as const,
+};
+
 export const createReset = memoize(1)(
   ({ typography }: { typography: Typography }): Return => ({
     body: {

--- a/code/core/src/theming/index.ts
+++ b/code/core/src/theming/index.ts
@@ -33,7 +33,7 @@ export * from './types.ts';
 export { default as createCache } from '@emotion/cache';
 export { default as isPropValid } from '@emotion/is-prop-valid';
 
-export { createGlobal, createReset, srOnlyStyles } from './global.ts';
+export { createGlobal, createReset, srOnlyStyles, srOnlyUnsetStyles } from './global.ts';
 export * from './create.ts';
 export * from './convert.ts';
 export * from './ensure.ts';


### PR DESCRIPTION
## What I did

These two changes were originally developed alongside the `lang`-attribute work in #35207 but are unrelated, so they have been split out into this dedicated PR (and reverted on #35207).

Both are accessibility improvements to the docs `ArgsTable` controls:

- **Expose `required` args to assistive tech.** The `required` flag from an arg's type is now threaded from `ArgRow` → `ArgControl` → each control, which renders `aria-required` on its underlying input (`Boolean`, `Color`, `Date`, `Files`, `Number`, `Object`, `Range`, `Text`, `Select` single/multi, and the `Checkbox`/`Radio` fieldsets). The `required` prop is added to the shared `ControlProps` type.
- **Keep the "Setup controls" link reachable for keyboard users.** Previously the link for args without a usable control only appeared on mouse `:hover` (driven by JS `onMouseEnter`/`isHovered`). It now renders both the link and a placeholder dash at all times, and the row toggles their visibility purely via CSS on `:hover, :focus-within` (`StyledTr`), so keyboard focus reveals the link too. The `aria-hidden` attribute is added to the decorative required `*` marker.

> [!NOTE]
> This was mostly hand-coded, but split from another branch by AI. PR description is AI.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook and view a story with a Controls/ArgsTable panel where some args are marked required and some args have no usable control.
3. Required args: inspect the control inputs and confirm `aria-required="true"` is present on the input/fieldset.
4. Keyboard reachability: with the mouse away, Tab through an arg row that has no control and confirm the "Setup controls" link becomes visible and focusable (it should also still appear on mouse hover).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved required-field support across form controls: required state is now reflected via `aria-required` and clearer screen-reader labeling (including required markers in option legends).
* **Bug Fixes**
  * Improved the “Setup controls” vs placeholder behavior for both hover and keyboard focus by switching to CSS-based visibility.
  * Updated required indicator rendering in the args table to stay consistent, including when controls are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->