### PR TITLE
Core: Respect toJSON for Cyclic Arg Type Inference

### DIFF
--- a/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
@@ -144,6 +144,31 @@ describe('inferArgTypes', () => {
     });
   });
 
+  it('uses toJSON() result for cyclic objects that define a valid toJSON()', () => {
+    const cyclic: any = { a: 1 };
+    cyclic.self = cyclic;
+    Object.defineProperty(cyclic, 'toJSON', {
+      value: () => ({ a: 1, self: 'cyclic reference' }),
+      enumerable: false,
+    });
+
+    vi.mocked(logger.warn).mockClear();
+    expect(
+      inferArgTypes({
+        initialArgs: { a: cyclic },
+      } as any)
+    ).toEqual({
+      a: {
+        name: 'a',
+        type: {
+          name: 'object',
+          value: { a: { name: 'number' }, self: { name: 'string' } },
+        },
+      },
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it('does not infer types for args that already have an argType', () => {
     expect(
       inferArgTypes({

--- a/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.test.ts
@@ -191,4 +191,56 @@ describe('inferArgTypes', () => {
       },
     });
   });
+  it('uses JSON serialization semantics for key-aware toJSON on cyclic args', () => {
+    const cyclic: any = { a: 1 };
+    cyclic.self = cyclic;
+    Object.defineProperty(cyclic, 'toJSON', {
+      value: (key: string) => (key === 'a' ? { a: 1, self: 'cyclic reference' } : cyclic),
+      enumerable: false,
+    });
+
+    vi.mocked(logger.warn).mockClear();
+    expect(inferArgTypes({ initialArgs: { a: cyclic } } as any)).toEqual({
+      a: {
+        name: 'a',
+        type: {
+          name: 'object',
+          value: { a: { name: 'number' }, self: { name: 'string' } },
+        },
+      },
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('uses JSON serialization semantics for nested toJSON in cyclic args', () => {
+    const child: any = { value: 'child' };
+    child.self = child;
+    Object.defineProperty(child, 'toJSON', {
+      value: (key: string) =>
+        key === 'child' ? { value: 'child', self: 'cyclic reference' } : child,
+      enumerable: false,
+    });
+
+    const wrapper = { child };
+
+    vi.mocked(logger.warn).mockClear();
+    expect(inferArgTypes({ initialArgs: { wrapper } } as any)).toEqual({
+      wrapper: {
+        name: 'wrapper',
+        type: {
+          name: 'object',
+          value: {
+            child: {
+              name: 'object',
+              value: {
+                value: { name: 'string' },
+                self: { name: 'string' },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });

--- a/code/core/src/preview-api/modules/store/inferArgTypes.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.ts
@@ -96,17 +96,18 @@ export const inferArgTypes: ((context: InferArgTypesContext) => StrictArgTypes) 
         const argName = `${id}.${key}`;
         const type = inferType(arg, argName, new Set(), cache);
 
-        if (isCyclicType(type) && typeof arg?.toJSON === 'function') {
+        if (isCyclicType(type)) {
           try {
-            const jsonValue = arg.toJSON();
-            if (jsonValue !== arg) {
+            const json = JSON.stringify({ [key]: arg });
+            if (json !== undefined) {
+              const jsonValue = JSON.parse(json)[key];
               const serializedType = inferType(jsonValue, argName, new Set(), new Map());
               if (!isCyclicType(serializedType)) {
                 return [key, { name: key, type: serializedType }];
               }
             }
           } catch {
-            // toJSON() threw; fall through to the cycle warning below
+            // JSON serialization failed; fall through to the cycle warning below
           }
         }
 

--- a/code/core/src/preview-api/modules/store/inferArgTypes.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.ts
@@ -17,6 +17,19 @@ export type InferArgTypesContext<TRenderer extends Renderer = Renderer> = Pick<
   'id' | 'argTypes' | 'initialArgs'
 >;
 
+const isCyclicType = (type: SBType): boolean => {
+  if (type.name === 'other' && type.value === 'cyclic object') {
+    return true;
+  }
+  if (type.name === 'object' && type.value) {
+    return Object.values(type.value).some((t) => isCyclicType(t));
+  }
+  if (type.name === 'array' && type.value) {
+    return isCyclicType(type.value);
+  }
+  return false;
+};
+
 const inferType = (
   value: any,
   name: string,
@@ -42,13 +55,6 @@ const inferType = (
 
     // Check for cycles (currently being processed in this path)
     if (visited.has(value)) {
-      logger.warn(dedent`
-        We've detected a cycle in arg '${name}'. Args should be JSON-serializable.
-
-        Consider using the mapping feature or fully custom args:
-        - Mapping: https://storybook.js.org/docs/writing-stories/args#mapping-to-complex-arg-values
-        - Custom args: https://storybook.js.org/docs/essentials/controls#fully-custom-args
-      `);
       return { name: 'other', value: 'cyclic object' };
     }
 
@@ -86,13 +92,36 @@ export const inferArgTypes: ((context: InferArgTypesContext) => StrictArgTypes) 
   const argTypes = Object.fromEntries(
     Object.entries(initialArgs)
       .filter(([key]) => !userArgTypes[key]?.type)
-      .map(([key, arg]) => [
-        key,
-        {
-          name: key,
-          type: inferType(arg, `${id}.${key}`, new Set(), cache),
-        },
-      ])
+      .map(([key, arg]) => {
+        const argName = `${id}.${key}`;
+        const type = inferType(arg, argName, new Set(), cache);
+
+        if (isCyclicType(type) && typeof arg?.toJSON === 'function') {
+          try {
+            const jsonValue = arg.toJSON();
+            if (jsonValue !== arg) {
+              const serializedType = inferType(jsonValue, argName, new Set(), new Map());
+              if (!isCyclicType(serializedType)) {
+                return [key, { name: key, type: serializedType }];
+              }
+            }
+          } catch {
+            // toJSON() threw; fall through to the cycle warning below
+          }
+        }
+
+        if (isCyclicType(type)) {
+          logger.warn(dedent`
+            We've detected a cycle in arg '${argName}'. Args should be JSON-serializable.
+
+            Consider using the mapping feature or fully custom args:
+            - Mapping: https://storybook.js.org/docs/writing-stories/args#mapping-to-complex-arg-values
+            - Custom args: https://storybook.js.org/docs/essentials/controls#fully-custom-args
+          `);
+        }
+
+        return [key, { name: key, type }];
+      })
   );
   const userArgTypesNames = mapValues(userArgTypes, (argType, key) => ({
     name: key,


### PR DESCRIPTION
## What I did

Fixes misleading cyclic-arg warnings when an arg contains an internal cycle but provides a valid `toJSON()` representation.

Previously, `inferArgTypes` always treated detected cycles as non-serializable and emitted:

> We've detected a cycle in arg ...

That is correct for plain cyclic objects, but misleading when `JSON.stringify()` can serialize the arg through `toJSON()`.

## Changes

- Added a regression test for a cyclic arg with a valid `toJSON()` method.
- Preserved the existing warning behavior for plain cyclic objects.
- Updated arg type inference to use the clean `toJSON()` result when the original inferred type only fails because of a cycle.

Fixes #35239

## Testing

- `node node_modules/vitest/vitest.mjs run --config code/core/vitest.config.ts code/core/src/preview-api/modules/store/inferArgTypes.test.ts`
  - Result: 9 tests passed, 0 type errors.

- `node node_modules/vitest/vitest.mjs run --config code/core/vitest.config.ts code/core/src/preview-api/modules/store`
  - Result: 21 test files passed, 309 tests passed, 0 type errors.

- `yarn --cwd code lint:js:cmd core/src/preview-api/modules/store/inferArgTypes.ts core/src/preview-api/modules/store/inferArgTypes.test.ts --quiet`
  - Result: passed.

#### Manual testing

No manual UI testing was performed. This change is covered by a focused regression test for `inferArgTypes`, and the related store test suite passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference for cyclic values, including cases where `toJSON()` (including `toJSON(key)`) provides a non-cyclic serialization shape.
  * Cycle warnings are now emitted only if a value remains cyclic after considering serialization behavior, reducing false alarms.
* **Tests**
  * Expanded tests to cover cyclic objects with `toJSON()`, key-aware `toJSON(key)`, and nested cyclic structures, verifying inferred types match serialized output and that no warning is triggered for supported cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->