### PR TITLE
Review: URL-driven `full=1` layout navigation

### DIFF
--- a/code/core/src/manager-api/modules/layout.ts
+++ b/code/core/src/manager-api/modules/layout.ts
@@ -1,4 +1,5 @@
 import { SET_CONFIG } from 'storybook/internal/core-events';
+import { queryFromLocation } from 'storybook/internal/router';
 import type {
   API_Layout,
   API_LayoutCustomisations,
@@ -621,9 +622,12 @@ export const init: ModuleFn<SubAPI, SubState> = ({ store, provider, singleStory 
   const persisted = pick(store.getState(), ['layout', 'selectedPanel']);
   const initialOptions = api.getInitialOptions();
   const merged = merge(initialOptions, persisted);
+  const { full } = queryFromLocation(store.getState().location);
   const layout = applyLayoutOptions(
     merged.layout,
-    { layout: { showNav: merged.layout.showNav, showPanel: merged.layout.showPanel } },
+    full === '1' || full === 'true'
+      ? {}
+      : { layout: { showNav: merged.layout.showNav, showPanel: merged.layout.showPanel } },
     !!singleStory
   );
   const state = { ...merged, layout };

--- a/code/core/src/manager-api/modules/layout.ts
+++ b/code/core/src/manager-api/modules/layout.ts
@@ -10,8 +10,8 @@ import { global } from '@storybook/global';
 
 import { pick, toMerged } from 'es-toolkit/object';
 import { isEqual as deepEqual } from 'es-toolkit/predicate';
-import type { ThemeVars } from 'storybook/theming';
 import { deprecate } from 'storybook/internal/client-logger';
+import type { ThemeVars } from 'storybook/theming';
 import { create } from 'storybook/theming/create';
 
 import merge from '../lib/merge.ts';
@@ -619,6 +619,14 @@ export const init: ModuleFn<SubAPI, SubState> = ({ store, provider, singleStory 
   };
 
   const persisted = pick(store.getState(), ['layout', 'selectedPanel']);
+  const initialOptions = api.getInitialOptions();
+  const merged = merge(initialOptions, persisted);
+  const layout = applyLayoutOptions(
+    merged.layout,
+    { layout: { showNav: merged.layout.showNav, showPanel: merged.layout.showPanel } },
+    !!singleStory
+  );
+  const state = { ...merged, layout };
 
   provider.channel?.on(SET_CONFIG, () => {
     api.setOptions(merge(api.getInitialOptions(), persisted));
@@ -626,6 +634,6 @@ export const init: ModuleFn<SubAPI, SubState> = ({ store, provider, singleStory 
 
   return {
     api,
-    state: merge(api.getInitialOptions(), persisted),
+    state,
   };
 };

--- a/code/core/src/manager-api/modules/stories.ts
+++ b/code/core/src/manager-api/modules/stories.ts
@@ -51,6 +51,8 @@ import type {
 
 import { global } from '@storybook/global';
 
+import { BUILT_IN_FILTERS } from '../../shared/constants/tags.ts';
+import { countStatusesByValue } from '../../shared/status-store/index.ts';
 import { getEventMetadata } from '../lib/events.ts';
 import {
   addPreparedStories,
@@ -63,8 +65,6 @@ import type { ModuleFn } from '../lib/types.tsx';
 import { buildNavigationUrl } from '../lib/url.ts';
 import type { ComposedRef } from '../root.tsx';
 import { fullStatusStore } from '../stores/status.ts';
-import { BUILT_IN_FILTERS } from '../../shared/constants/tags.ts';
-import { countStatusesByValue } from '../../shared/status-store/index.ts';
 import { computeStatusFilterFn, parseStatusesParam, serializeStatusesParam } from './statuses.ts';
 import {
   computeStaticFilterFn,
@@ -73,6 +73,7 @@ import {
   parseTagsParam,
   serializeTagsParam,
 } from './tags.ts';
+import { mergeNavigationQueryParams } from './url.ts';
 
 const { fetch } = global;
 const STORY_INDEX_PATH = './index.json';
@@ -412,8 +413,11 @@ export const init: ModuleFn<SubAPI, SubState> = ({
   docsOptions = {},
 }) => {
   const navigateWithQueryParams = (path: string, options?: NavigateOptions) => {
-    const { customQueryParams } = store.getState();
-    navigate(buildNavigationUrl(path, customQueryParams ?? {}), options);
+    const { customQueryParams, location } = store.getState();
+    navigate(
+      buildNavigationUrl(path, mergeNavigationQueryParams(customQueryParams ?? {}, location)),
+      options
+    );
   };
 
   const persistFilters = (inputPatch: Parameters<typeof store.setState>[0]) => {

--- a/code/core/src/manager-api/modules/url.ts
+++ b/code/core/src/manager-api/modules/url.ts
@@ -5,14 +5,14 @@ import {
   STORY_ARGS_UPDATED,
   UPDATE_QUERY_PARAMS,
 } from 'storybook/internal/core-events';
-import { buildArgsParam, queryFromLocation } from 'storybook/internal/router';
 import type { NavigateOptions } from 'storybook/internal/router';
+import { buildArgsParam, queryFromLocation } from 'storybook/internal/router';
 import type { API_Layout, API_UI, API_ViewMode, Args } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
 
 import { dequal as deepEqual } from 'dequal';
-import { omit } from 'es-toolkit/object';
+import { omit, pick } from 'es-toolkit/object';
 import { stringify } from 'picoquery';
 
 import merge from '../lib/merge.ts';
@@ -66,6 +66,19 @@ const LAYOUT_QUERY_PARAM_KEYS = ['full', 'panel', 'nav', 'shortcuts', 'addonPane
 export const getCustomQueryParams = (
   location: Parameters<typeof queryFromLocation>[0]
 ): QueryParams => omit(queryFromLocation(location), LAYOUT_QUERY_PARAM_KEYS);
+
+/** Merge custom params with layout params from the current URL for manager navigation. */
+export const mergeNavigationQueryParams = (
+  customQueryParams: QueryParams,
+  location: Parameters<typeof queryFromLocation>[0],
+  patch: QueryParamInput = {}
+): QueryParams => {
+  const layoutParams = pick(
+    queryFromLocation(location),
+    LAYOUT_QUERY_PARAM_KEYS.filter((key) => key !== 'path')
+  );
+  return { ...customQueryParams, ...layoutParams, ...patch } as QueryParams;
+};
 
 // Initialize the state based on the URL.
 // NOTE:
@@ -327,9 +340,14 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
       }
     },
     applyQueryParams(input, options) {
-      const { path, hash = '', queryParams } = api.getUrlState();
+      const { path, customQueryParams, location } = store.getState();
+      const hash = location?.hash ?? '';
 
-      navigateTo(`${path}${hash}`, { ...queryParams, ...input } as any, options);
+      navigateTo(
+        `${path}${hash}`,
+        mergeNavigationQueryParams(customQueryParams, location, input) as any,
+        options
+      );
       api.setQueryParams(input);
     },
     navigateUrl(url, options) {
@@ -342,7 +360,8 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
    * unserialized safely.
    */
   const updateArgsParam = () => {
-    const { path, hash = '', queryParams, viewMode } = api.getUrlState();
+    const { path, customQueryParams, location, viewMode } = store.getState();
+    const hash = location?.hash ?? '';
 
     if (viewMode !== 'story') {
       return;
@@ -356,7 +375,13 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
 
     const { args, initialArgs } = currentStory;
     const argsString = buildArgsParam(initialArgs, args as Args);
-    navigateTo(`${path}${hash}`, { ...queryParams, args: argsString || null }, { replace: true });
+    navigateTo(
+      `${path}${hash}`,
+      mergeNavigationQueryParams(customQueryParams, location, {
+        args: argsString || null,
+      }) as any,
+      { replace: true }
+    );
     api.setQueryParams({ args: argsString || null });
   };
 
@@ -378,11 +403,14 @@ export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
   });
 
   provider.channel?.on(GLOBALS_UPDATED, ({ userGlobals, initialGlobals }: any) => {
-    const { path, hash = '', queryParams } = api.getUrlState();
+    const { path, customQueryParams, location } = store.getState();
+    const hash = location?.hash ?? '';
     const globalsString = buildArgsParam(initialGlobals, merge(initialGlobals, userGlobals));
     navigateTo(
       `${path}${hash}`,
-      { ...queryParams, globals: globalsString || null },
+      mergeNavigationQueryParams(customQueryParams, location, {
+        globals: globalsString || null,
+      }) as any,
       { replace: true }
     );
     api.setQueryParams({ globals: globalsString || null });

--- a/code/core/src/manager-api/tests/layout.test.ts
+++ b/code/core/src/manager-api/tests/layout.test.ts
@@ -1,8 +1,8 @@
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { API_Provider } from 'storybook/internal/types';
 import * as clientLogger from 'storybook/internal/client-logger';
+import type { API_Provider } from 'storybook/internal/types';
 
 import EventEmitter from 'events';
 import { themes } from 'storybook/theming';
@@ -626,6 +626,30 @@ describe('layout API', () => {
 
       expect(state.layout.navSize).toBe(0);
       expect(state.layout.recentVisibleSizes.navSize).toBe(300);
+    });
+
+    it('should restore navSize from recentVisibleSizes when persisted showNav is true but navSize is 0', () => {
+      const storeWithCollapsedNav = {
+        ...store,
+        getState: () =>
+          ({
+            selectedPanel: currentState.selectedPanel,
+            layout: {
+              ...getDefaultLayoutState().layout,
+              navSize: 0,
+              showNav: true,
+            },
+          }) as unknown as State,
+      } as unknown as Store;
+
+      const { state } = initLayout({
+        store: storeWithCollapsedNav,
+        provider,
+        singleStory: false,
+      } as unknown as ModuleArgs);
+
+      expect(state.layout.showNav).toBe(true);
+      expect(state.layout.navSize).toBe(300);
     });
 
     it('should prioritize layout over top-level config keys', () => {

--- a/code/core/src/manager-api/tests/url.test.js
+++ b/code/core/src/manager-api/tests/url.test.js
@@ -184,6 +184,70 @@ describe('queryParams', () => {
     expect(state.customQueryParams).not.toHaveProperty('tags');
   });
 
+  it('preserves layout params from the current URL when updating custom params', () => {
+    let state = {
+      path: '/review/',
+      customQueryParams: { tags: 'a11y' },
+      location: { search: '?full=1&path=/review/&tags=a11y', hash: '' },
+    };
+    const store = {
+      setState: (change) => {
+        state = { ...state, ...change };
+      },
+      getState: () => state,
+    };
+    const navigate = vi.fn();
+    const { api } = initURL({
+      state,
+      navigate,
+      store,
+      provider: { channel: new EventEmitter() },
+    });
+
+    api.applyQueryParams({ tags: null, statuses: 'reviewing' }, { replace: true });
+
+    expect(navigate).toHaveBeenLastCalledWith(expect.stringContaining('full=1'), expect.anything());
+    expect(state.customQueryParams).toEqual({ statuses: 'reviewing' });
+  });
+
+  it('preserves layout params when args are synced to the URL', () => {
+    let state = {
+      path: '/story/test--story',
+      storyId: 'test--story',
+      viewMode: 'story',
+      customQueryParams: {},
+      location: {
+        search: '?full=1&path=/story/test--story&collection=0',
+        hash: '',
+      },
+    };
+    const store = {
+      setState: (change) => {
+        state = { ...state, ...change };
+      },
+      getState: () => state,
+    };
+    const channel = new EventEmitter();
+    const navigate = vi.fn();
+    initURL({
+      state,
+      navigate,
+      store,
+      provider: { channel },
+      fullAPI: {
+        getCurrentStoryData: () => ({
+          type: 'story',
+          args: {},
+          initialArgs: {},
+        }),
+      },
+    });
+
+    channel.emit(SET_CURRENT_STORY);
+
+    expect(navigate).toHaveBeenCalledWith(expect.stringContaining('full=1'), expect.anything());
+  });
+
   it('lets your read out parameters you set previously', () => {
     let state = {};
     const store = {

--- a/code/core/src/manager/components/review/ReviewPage.stories.tsx
+++ b/code/core/src/manager/components/review/ReviewPage.stories.tsx
@@ -2,19 +2,19 @@ import React, { type ReactNode } from 'react';
 
 import { expect, fn, userEvent, within } from 'storybook/test';
 
+import { Location, MemoryRouter, parsePath, queryFromLocation } from 'storybook/internal/router';
 import {
   ManagerContext,
+  internal_fullStatusStore,
   type API,
   type State,
-  internal_fullStatusStore,
 } from 'storybook/manager-api';
-import { Location, MemoryRouter, parsePath, queryFromLocation } from 'storybook/internal/router';
 
 import preview from '../../../../../.storybook/preview.tsx';
-import { EVENTS } from './constants.ts';
 import { ReviewProvider } from './ReviewProvider.tsx';
 import { ReviewSummaryPortal } from './ReviewSummaryPortal.tsx';
 import { ReviewToolbarHeader } from './ReviewToolbarHeader.tsx';
+import { EVENTS } from './constants.ts';
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
   buildReviewStoryHref,
@@ -68,6 +68,7 @@ const managerState: State = {
   path: '/review/',
   viewMode: 'review',
   customQueryParams: {},
+  location: { search: '?full=1&path=/review/', pathname: '/', hash: '' },
 } as unknown as State;
 const managerApi: API = {
   on: onMock,
@@ -82,6 +83,8 @@ const managerApi: API = {
   resetStatusFilters: fn().mockName('api::resetStatusFilters'),
   addStatusFilters: fn().mockName('api::addStatusFilters'),
   removeStatusFilters: fn().mockName('api::removeStatusFilters'),
+  applyQueryParams: fn().mockName('api::applyQueryParams'),
+  setQueryParams: fn().mockName('api::setQueryParams'),
   getStoryHrefs: (storyId: string, options?: { freeze?: boolean }) => ({
     managerHref: `?path=/story/${storyId}`,
     previewHref: `iframe.html?id=${storyId}&viewMode=story${options?.freeze ? '&freeze=finished' : ''}`,
@@ -156,6 +159,7 @@ const ManagerStateSync = ({
         ...managerState,
         ...(parameters?.managerState ?? {}),
         path,
+        location,
         viewMode: deriveViewMode(path),
         customQueryParams,
       } as State;
@@ -179,7 +183,7 @@ const meta = preview.meta({
   },
   decorators: [
     (Story, { parameters }) => (
-      <MemoryRouter initialEntries={parameters?.routerInitialEntries ?? ['/?path=/review/']}>
+      <MemoryRouter initialEntries={parameters?.routerInitialEntries ?? ['/?full=1&path=/review/']}>
         <ManagerStateSync parameters={parameters}>
           <div
             id="main-content-wrapper"
@@ -286,11 +290,16 @@ export const PendingUpdateAccept = meta.story({
 
 export const PendingUpdateFromStoryNavigatesToSummary = meta.story({
   parameters: {
-    routerInitialEntries: ['/?path=/story/manager-settings-guidepage--default&collection=0'],
+    routerInitialEntries: ['/?full=1&path=/story/manager-settings-guidepage--default&collection=0'],
     managerState: {
       path: '/story/manager-settings-guidepage--default',
       viewMode: 'story',
       customQueryParams: { collection: '0' },
+      location: {
+        search: '?full=1&path=/story/manager-settings-guidepage--default&collection=0',
+        pathname: '/',
+        hash: '',
+      },
     },
   },
   play: async ({ canvasElement }) => {

--- a/code/core/src/manager/components/review/ReviewPersistentLayer.tsx
+++ b/code/core/src/manager/components/review/ReviewPersistentLayer.tsx
@@ -1,27 +1,13 @@
 import React, { type FC } from 'react';
 
-import { useChannel, useStorybookApi } from 'storybook/manager-api';
-
-import { ReviewProvider, isReviewPath } from './ReviewProvider.tsx';
+import { ReviewProvider } from './ReviewProvider.tsx';
 import { ReviewSummaryPortal } from './ReviewSummaryPortal.tsx';
-import { EVENTS, REVIEW_CHANGES_URL } from './constants.ts';
 import { useReviewNavigationInterceptor } from './useReviewNavigationInterceptor.ts';
 import { useReviewShortcuts } from './useReviewShortcuts.ts';
 
 const ReviewNavigationLayer: FC = () => {
-  const api = useStorybookApi();
   useReviewNavigationInterceptor();
   useReviewShortcuts();
-
-  // Surface the summary when a review is pushed while the user is elsewhere.
-  useChannel({
-    [EVENTS.DISPLAY_REVIEW]: () => {
-      const currentPath = new URLSearchParams(window.location.search).get('path') ?? '';
-      if (!isReviewPath(currentPath)) {
-        api.navigate(REVIEW_CHANGES_URL);
-      }
-    },
-  });
 
   return <ReviewSummaryPortal />;
 };

--- a/code/core/src/manager/components/review/ReviewProvider.tsx
+++ b/code/core/src/manager/components/review/ReviewProvider.tsx
@@ -9,6 +9,9 @@ import {
   type ReactNode,
 } from 'react';
 
+import { useNavigate } from 'storybook/internal/router';
+import type { StatusesByStoryIdAndTypeId } from 'storybook/internal/types';
+import { CHANGE_DETECTION_STATUS_TYPE_ID, REVIEW_STATUS_TYPE_ID } from 'storybook/internal/types';
 import {
   experimental_getStatusStore,
   experimental_useStatusStore,
@@ -16,9 +19,6 @@ import {
   useStorybookApi,
   useStorybookState,
 } from 'storybook/manager-api';
-import { useNavigate } from 'storybook/internal/router';
-import type { StatusesByStoryIdAndTypeId } from 'storybook/internal/types';
-import { CHANGE_DETECTION_STATUS_TYPE_ID, REVIEW_STATUS_TYPE_ID } from 'storybook/internal/types';
 
 import {
   fallbackStoryInfo,
@@ -29,9 +29,9 @@ import { AUTO_ENTERED_SESSION_KEY, EVENTS, PRE_REVIEW_RETURN_KEY } from './const
 import { navigateOutOfReview } from './review-actions.ts';
 import { enterReviewMode, exitReviewMode, isReviewModeActive } from './review-mode.ts';
 import {
-  REVIEW_COLLECTION_QUERY_PARAM,
   buildFlattenedNavEntries,
   buildReviewChangesSummaryHref,
+  buildReviewStoryNavigateHref,
   isReviewLayoutActive,
   isReviewReturnSearch,
   isReviewRoute,
@@ -40,10 +40,11 @@ import {
   parseStoryIdFromPath,
   resolveActiveNavEntry,
   resolveNavIndex,
+  REVIEW_COLLECTION_QUERY_PARAM,
 } from './review-navigation.ts';
 import type { ReviewState } from './review-state.ts';
-import { reviewStore, type ReviewStoreState } from './review-store.ts';
 import { clearReviewStatuses, collectReviewStoryIds, syncReviewStatuses } from './review-status.ts';
+import { reviewStore, type ReviewStoreState } from './review-store.ts';
 import { sessionStore } from './session-store.ts';
 import { useReviewFiltersRef } from './useReviewFiltersRef.ts';
 
@@ -241,19 +242,23 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   // Keep review chrome/filters in sync with `full=1` and review routes in the URL.
   useEffect(() => {
+    const reviewRoute = isReviewRoute(path, collectionParam);
+    const fullActive = isReviewLayoutActive(location);
+    const reviewModeActive = isReviewModeActive();
+
     if (reviewStore.isUrlSyncSuppressed()) {
       const navigationSettled =
-        isReviewRoute(path, collectionParam) ||
-        (!isReviewModeActive() && !isReviewLayoutActive(location));
+        (isReviewModeActive() &&
+          isReviewRoute(path, collectionParam) &&
+          isReviewLayoutActive(location)) ||
+        (!isReviewModeActive() &&
+          !isReviewLayoutActive(location) &&
+          !isReviewRoute(path, collectionParam));
       if (!navigationSettled) {
         return;
       }
       reviewStore.releaseUrlSyncSuppression();
     }
-
-    const reviewRoute = isReviewRoute(path, collectionParam);
-    const fullActive = isReviewLayoutActive(location);
-    const reviewModeActive = isReviewModeActive();
 
     if (reviewRoute && !fullActive) {
       if (isSummaryVisible && !reviewModeActive) {
@@ -261,8 +266,17 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
         return;
       }
       if (reviewModeActive) {
-        void exitReviewMode(api);
-        setIsInReviewMode(false);
+        if (isSummaryVisible) {
+          api.navigateUrl(buildReviewChangesSummaryHref(), { replace: true });
+        } else {
+          const storyId = parseStoryIdFromPath(path);
+          const collectionIndex = parseCollectionIndex(collectionParam);
+          if (storyId && collectionIndex !== undefined) {
+            api.navigateUrl(buildReviewStoryNavigateHref({ storyId, collectionIndex }), {
+              replace: true,
+            });
+          }
+        }
       }
       return;
     }
@@ -275,11 +289,11 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
       return;
     }
 
-    if (isReviewModeActive()) {
+    if (!isReviewRoute(path, collectionParam) && !fullActive && isReviewModeActive()) {
       void exitReviewMode(api);
       setIsInReviewMode(false);
     } else {
-      setIsInReviewMode(false);
+      setIsInReviewMode(isReviewModeActive());
     }
   }, [api, collectionParam, filtersRef, isSummaryVisible, location, path]);
 

--- a/code/core/src/manager/components/review/ReviewProvider.tsx
+++ b/code/core/src/manager/components/review/ReviewProvider.tsx
@@ -25,7 +25,7 @@ import {
   type StoryChangeStatus,
   type StoryInfo,
 } from './components/CollectionGrid.tsx';
-import { AUTO_ENTERED_SESSION_KEY, EVENTS, PRE_REVIEW_RETURN_KEY } from './constants.ts';
+import { EVENTS, PRE_REVIEW_RETURN_KEY } from './constants.ts';
 import { navigateOutOfReview } from './review-actions.ts';
 import { enterReviewMode, exitReviewMode, isReviewModeActive } from './review-mode.ts';
 import {
@@ -95,8 +95,6 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
         return;
       }
       setPendingReview(null);
-      // A fresh payload re-arms the one-time auto-enter.
-      sessionStore.remove(AUTO_ENTERED_SESSION_KEY);
       setState(next);
       setIsStale(!!next.stale);
 
@@ -113,7 +111,6 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
     [EVENTS.REVIEW_DISMISSED]: (returnSearch?: string | null) => {
       clearReviewStatuses(reviewStatusStore);
       previousReviewStoryIdsRef.current = new Set();
-      sessionStore.remove(AUTO_ENTERED_SESSION_KEY);
       setState(null);
       setPendingReview(null);
       setIsStale(false);
@@ -134,7 +131,6 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
     setState(pendingReview);
     setIsStale(!!pendingReview.stale);
     setPendingReview(null);
-    sessionStore.remove(AUTO_ENTERED_SESSION_KEY);
     enterReview();
     navigate(buildReviewChangesSummaryHref(), { plain: true });
   }, [enterReview, navigate, pendingReview]);
@@ -358,5 +354,3 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   return children;
 };
-
-export const isReviewPath = (path: string): boolean => isReviewSummaryPath(path);

--- a/code/core/src/manager/components/review/ReviewProvider.tsx
+++ b/code/core/src/manager/components/review/ReviewProvider.tsx
@@ -241,11 +241,14 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   // Keep review chrome/filters in sync with `full=1` and review routes in the URL.
   useEffect(() => {
-    if (!isReviewRoute(path, collectionParam)) {
-      reviewStore.releaseUrlSyncSuppression();
-    }
     if (reviewStore.isUrlSyncSuppressed()) {
-      return;
+      const navigationSettled =
+        isReviewRoute(path, collectionParam) ||
+        (!isReviewModeActive() && !isReviewLayoutActive(location));
+      if (!navigationSettled) {
+        return;
+      }
+      reviewStore.releaseUrlSyncSuppression();
     }
 
     const reviewRoute = isReviewRoute(path, collectionParam);
@@ -254,7 +257,7 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
     if (reviewRoute && !fullActive) {
       if (isSummaryVisible && !reviewModeActive) {
-        api.applyQueryParams({ full: '1' }, { replace: true });
+        api.navigateUrl(buildReviewChangesSummaryHref(), { replace: true });
         return;
       }
       if (reviewModeActive) {

--- a/code/core/src/manager/components/review/ReviewProvider.tsx
+++ b/code/core/src/manager/components/review/ReviewProvider.tsx
@@ -25,19 +25,16 @@ import {
   type StoryChangeStatus,
   type StoryInfo,
 } from './components/CollectionGrid.tsx';
-import {
-  AUTO_ENTERED_SESSION_KEY,
-  EVENTS,
-  PRE_REVIEW_RETURN_KEY,
-  REVIEW_CHANGES_URL,
-} from './constants.ts';
-import { enterReviewMode, isReviewModeActive } from './review-mode.ts';
+import { AUTO_ENTERED_SESSION_KEY, EVENTS, PRE_REVIEW_RETURN_KEY } from './constants.ts';
 import { navigateOutOfReview } from './review-actions.ts';
+import { enterReviewMode, exitReviewMode, isReviewModeActive } from './review-mode.ts';
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
   buildFlattenedNavEntries,
   buildReviewChangesSummaryHref,
+  isReviewLayoutActive,
   isReviewReturnSearch,
+  isReviewRoute,
   isReviewSummaryPath,
   parseCollectionIndex,
   parseStoryIdFromPath,
@@ -65,6 +62,8 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [isInReviewMode, setIsInReviewMode] = useState(() => isReviewModeActive());
   const previousReviewStoryIdsRef = useRef<Set<string>>(new Set());
   const displayedReviewRef = useRef<ReviewState | null>(null);
+  const replayExpectedRef = useRef(true);
+  const routeRef = useRef({ path: '/', collectionParam: undefined as string | undefined });
   displayedReviewRef.current = state;
 
   const api = useStorybookApi();
@@ -72,6 +71,7 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { index, path, viewMode, customQueryParams, location } = useStorybookState();
 
   const collectionParam = customQueryParams?.[REVIEW_COLLECTION_QUERY_PARAM] as string | undefined;
+  routeRef.current = { path, collectionParam };
 
   // Current sidebar filters, snapshotted by enterReviewMode and restored on exit.
   const filtersRef = useReviewFiltersRef();
@@ -98,6 +98,13 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
       sessionStore.remove(AUTO_ENTERED_SESSION_KEY);
       setState(next);
       setIsStale(!!next.stale);
+
+      const isReplay = replayExpectedRef.current;
+      replayExpectedRef.current = false;
+      const { path: currentPath, collectionParam: currentCollection } = routeRef.current;
+      if (!isReplay && !isReviewRoute(currentPath, currentCollection)) {
+        navigate(buildReviewChangesSummaryHref(), { plain: true });
+      }
     },
     [EVENTS.REVIEW_STALE]: () => {
       setIsStale(true);
@@ -132,7 +139,12 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   }, [enterReview, navigate, pendingReview]);
 
   useEffect(() => {
+    replayExpectedRef.current = true;
     emit(EVENTS.REQUEST_REVIEW);
+    const timer = globalThis.setTimeout(() => {
+      replayExpectedRef.current = false;
+    }, 500);
+    return () => globalThis.clearTimeout(timer);
   }, [emit]);
 
   // Tag every story in the active review so the sidebar shows reviewing status
@@ -227,25 +239,45 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   const isSummaryVisible = isReviewSummaryPath(path);
 
-  // Re-sync the persisted review-mode flag on every navigation. Enter/exit
-  // performed by the nav interceptor and shortcuts toggle it out of band before
-  // navigating, so a route change is the signal to re-read it.
+  // Keep review chrome/filters in sync with `full=1` and review routes in the URL.
   useEffect(() => {
-    setIsInReviewMode(isReviewModeActive());
-  }, [path, collectionParam]);
+    if (!isReviewRoute(path, collectionParam)) {
+      reviewStore.releaseUrlSyncSuppression();
+    }
+    if (reviewStore.isUrlSyncSuppressed()) {
+      return;
+    }
 
-  // First landing on the summary with a clean, newly available review enters
-  // review mode once. Deduplicated so reloads and post-exit returns don't re-enter.
-  useEffect(() => {
-    if (!state || !isSummaryVisible || isReviewModeActive()) {
+    const reviewRoute = isReviewRoute(path, collectionParam);
+    const fullActive = isReviewLayoutActive(location);
+
+    if (reviewRoute && !fullActive) {
+      if (isSummaryVisible) {
+        api.applyQueryParams({ full: '1' }, { replace: true });
+        return;
+      }
+      if (isReviewModeActive()) {
+        void exitReviewMode(api);
+        setIsInReviewMode(false);
+      }
       return;
     }
-    if (sessionStore.read(AUTO_ENTERED_SESSION_KEY) === '1') {
+
+    if (reviewRoute && fullActive) {
+      if (!isReviewModeActive()) {
+        void enterReviewMode(api, filtersRef.current);
+      }
+      setIsInReviewMode(true);
       return;
     }
-    sessionStore.write(AUTO_ENTERED_SESSION_KEY, '1');
-    enterReview();
-  }, [state, isSummaryVisible, enterReview]);
+
+    if (isReviewModeActive()) {
+      void exitReviewMode(api);
+      setIsInReviewMode(false);
+    } else {
+      setIsInReviewMode(false);
+    }
+  }, [api, collectionParam, filtersRef, isSummaryVisible, location, path]);
 
   // Remember the last canvas search outside review mode so leaving review can
   // return to the pre-review canvas (both summary back and dismiss).
@@ -309,5 +341,4 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
   return children;
 };
 
-export const isReviewPath = (path: string): boolean =>
-  isReviewSummaryPath(path) || path.startsWith(REVIEW_CHANGES_URL);
+export const isReviewPath = (path: string): boolean => isReviewSummaryPath(path);

--- a/code/core/src/manager/components/review/ReviewProvider.tsx
+++ b/code/core/src/manager/components/review/ReviewProvider.tsx
@@ -250,13 +250,14 @@ export const ReviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
     const reviewRoute = isReviewRoute(path, collectionParam);
     const fullActive = isReviewLayoutActive(location);
+    const reviewModeActive = isReviewModeActive();
 
     if (reviewRoute && !fullActive) {
-      if (isSummaryVisible) {
+      if (isSummaryVisible && !reviewModeActive) {
         api.applyQueryParams({ full: '1' }, { replace: true });
         return;
       }
-      if (isReviewModeActive()) {
+      if (reviewModeActive) {
         void exitReviewMode(api);
         setIsInReviewMode(false);
       }

--- a/code/core/src/manager/components/review/constants.ts
+++ b/code/core/src/manager/components/review/constants.ts
@@ -4,7 +4,7 @@
 // manager and the external `@storybook/addon-mcp` producer agree on the names.
 import { REVIEW_EVENTS, REVIEW_NAMESPACE } from '../../../shared/review/index.ts';
 
-export { REVIEW_EVENTS as EVENTS, REVIEW_NAMESPACE as ADDON_ID };
+export { REVIEW_NAMESPACE as ADDON_ID, REVIEW_EVENTS as EVENTS };
 
 export const PAGE_ID = `${REVIEW_NAMESPACE}/page`;
 export const REVIEW_CHANGES_URL = '/review/';
@@ -13,7 +13,3 @@ export const REVIEW_CHANGES_URL = '/review/';
 // mode (both summary back-to-Storybook and dismiss). Captured while browsing
 // stories/docs outside review mode, so it points at the pre-review canvas.
 export const PRE_REVIEW_RETURN_KEY = `${REVIEW_NAMESPACE}/pre-review-return`;
-
-// sessionStorage marker deduplicating the one-time auto-enter on first landing
-// on the review summary. Reset on dismiss and when a new review payload arrives.
-export const AUTO_ENTERED_SESSION_KEY = `${REVIEW_NAMESPACE}/auto-entered`;

--- a/code/core/src/manager/components/review/review-actions.ts
+++ b/code/core/src/manager/components/review/review-actions.ts
@@ -34,6 +34,7 @@ export const navigateToReviewSummary = (
   filters: ReviewModeFilters
 ): void => {
   void enterReviewMode(api, filters);
+  reviewStore.suppressUrlSync();
   api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: null });
   navigate(buildReviewChangesSummaryHref(), { plain: true });
 };

--- a/code/core/src/manager/components/review/review-actions.ts
+++ b/code/core/src/manager/components/review/review-actions.ts
@@ -1,13 +1,13 @@
 import type { NavigateFunction } from 'storybook/internal/router';
 import { type API } from 'storybook/manager-api';
 
-import { REVIEW_CHANGES_URL } from './constants.ts';
-import { type ReviewModeFilters, enterReviewMode, exitReviewMode } from './review-mode.ts';
+import { enterReviewMode, exitReviewMode, type ReviewModeFilters } from './review-mode.ts';
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
-  type ReviewNavEntry,
-  buildReviewStoryTarget,
+  buildReviewChangesSummaryHref,
+  buildReviewStoryNavigateHref,
   isReviewReturnSearch,
+  type ReviewNavEntry,
 } from './review-navigation.ts';
 import { reviewStore } from './review-store.ts';
 
@@ -24,8 +24,7 @@ export const navigateToReviewEntry = (
 ): void => {
   void enterReviewMode(api, filters);
   reviewStore.suppressSummaryOverlay();
-  api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: String(entry.collectionIndex) });
-  navigate(buildReviewStoryTarget(entry));
+  navigate(buildReviewStoryNavigateHref(entry), { plain: true });
 };
 
 /** Navigate back to the review summary, entering (or staying in) review mode. */
@@ -36,7 +35,7 @@ export const navigateToReviewSummary = (
 ): void => {
   void enterReviewMode(api, filters);
   api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: null });
-  navigate(REVIEW_CHANGES_URL);
+  navigate(buildReviewChangesSummaryHref(), { plain: true });
 };
 
 /**
@@ -49,8 +48,9 @@ export const navigateOutOfReview = (
   navigate: NavigateFunction,
   returnSearch: string | null | undefined
 ): void => {
-  api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: null });
   reviewStore.releaseSummaryOverlaySuppression();
+  reviewStore.suppressUrlSync();
+  api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: null });
   void exitReviewMode(api);
 
   if (returnSearch && !isReviewReturnSearch(returnSearch)) {

--- a/code/core/src/manager/components/review/review-actions.ts
+++ b/code/core/src/manager/components/review/review-actions.ts
@@ -3,10 +3,11 @@ import { type API } from 'storybook/manager-api';
 
 import { enterReviewMode, exitReviewMode, type ReviewModeFilters } from './review-mode.ts';
 import {
-  REVIEW_COLLECTION_QUERY_PARAM,
   buildReviewChangesSummaryHref,
   buildReviewStoryNavigateHref,
   isReviewReturnSearch,
+  REVIEW_COLLECTION_QUERY_PARAM,
+  stripReviewLayoutFromSearch,
   type ReviewNavEntry,
 } from './review-navigation.ts';
 import { reviewStore } from './review-store.ts';
@@ -51,13 +52,14 @@ export const navigateOutOfReview = (
 ): void => {
   reviewStore.releaseSummaryOverlaySuppression();
   reviewStore.suppressUrlSync();
-  api.setQueryParams({ [REVIEW_COLLECTION_QUERY_PARAM]: null });
-  void exitReviewMode(api);
 
   if (returnSearch && !isReviewReturnSearch(returnSearch)) {
-    navigate(returnSearch.startsWith('?') ? returnSearch : `?${returnSearch}`, { plain: true });
+    const normalized = returnSearch.startsWith('?') ? returnSearch : `?${returnSearch}`;
+    navigate(stripReviewLayoutFromSearch(normalized), { plain: true });
+    void exitReviewMode(api);
     return;
   }
 
+  void exitReviewMode(api);
   api.selectFirstStory();
 };

--- a/code/core/src/manager/components/review/review-mode.test.ts
+++ b/code/core/src/manager/components/review/review-mode.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { StatusValue } from 'storybook/internal/types';
 
+import { REVIEW_NAMESPACE } from '../../../shared/review/index.ts';
 import {
-  type ReviewModeFilters,
   enterReviewMode,
   exitReviewMode,
   isReviewModeActive,
+  type ReviewModeFilters,
 } from './review-mode.ts';
+import { sessionStore } from './session-store.ts';
 
 const emptyFilters: ReviewModeFilters = {
   includedStatusFilters: [],
@@ -31,6 +33,7 @@ const makeApi = (
 
 beforeEach(() => {
   sessionStorage.clear();
+  globalThis.history.replaceState({}, '', '/');
 });
 
 describe('enterReviewMode', () => {
@@ -61,6 +64,17 @@ describe('enterReviewMode', () => {
     expect(api.setAllTagFilters).toHaveBeenCalledWith(['play-fn'], []);
     expect(api.setAllStatusFilters).toHaveBeenCalledWith(['status-value:error'], []);
   });
+
+  it('snapshots nav as shown when chrome is collapsed by review layout in the URL', async () => {
+    globalThis.history.replaceState({}, '', '?full=1&path=/review/');
+    const api = makeApi({ getIsNavShown: () => false, getIsPanelShown: () => false });
+    await enterReviewMode(api, emptyFilters);
+
+    const restoreApi = makeApi();
+    await exitReviewMode(restoreApi);
+    expect(restoreApi.toggleNav).toHaveBeenCalledWith(true);
+    expect(restoreApi.togglePanel).toHaveBeenCalledWith(true);
+  });
 });
 
 describe('exitReviewMode', () => {
@@ -81,6 +95,24 @@ describe('exitReviewMode', () => {
     const api = makeApi();
     await exitReviewMode(api);
     expect(api.toggleNav).not.toHaveBeenCalled();
+    expect(isReviewModeActive()).toBe(false);
+  });
+
+  it('restores collapsed chrome when the snapshot was already consumed', async () => {
+    sessionStore.write(`${REVIEW_NAMESPACE}/review-mode`, '1');
+    const api = makeApi({ getIsNavShown: () => false, getIsPanelShown: () => false });
+    await exitReviewMode(api);
+    expect(api.toggleNav).toHaveBeenCalledWith(true);
+    expect(api.togglePanel).toHaveBeenCalledWith(true);
+    expect(isReviewModeActive()).toBe(false);
+  });
+
+  it('is idempotent when exit runs twice during history navigation', async () => {
+    await enterReviewMode(makeApi(), emptyFilters);
+    const api = makeApi();
+    await exitReviewMode(api);
+    await exitReviewMode(api);
+    expect(api.toggleNav).toHaveBeenCalledTimes(1);
     expect(isReviewModeActive()).toBe(false);
   });
 });

--- a/code/core/src/manager/components/review/review-mode.ts
+++ b/code/core/src/manager/components/review/review-mode.ts
@@ -2,6 +2,7 @@ import type { StatusValue } from 'storybook/internal/types';
 import type { API } from 'storybook/manager-api';
 
 import { REVIEW_NAMESPACE } from '../../../shared/review/index.ts';
+import { isReviewLayoutActive } from './review-navigation.ts';
 import { REVIEWING_STATUS_VALUE } from './review-status.ts';
 import { sessionStore } from './session-store.ts';
 
@@ -61,11 +62,13 @@ export const enterReviewMode = async (
   filters: ReviewModeFilters
 ): Promise<void> => {
   if (!isReviewModeActive()) {
+    // URL-driven `full=1` collapse is not the user's pre-review preference.
+    const layoutCollapsed = isReviewLayoutActive({ search: globalThis.location?.search });
     sessionStore.write(
       CHROME_SNAPSHOT_SESSION_KEY,
       JSON.stringify({
-        nav: api.getIsNavShown(),
-        panel: api.getIsPanelShown(),
+        nav: layoutCollapsed || api.getIsNavShown(),
+        panel: layoutCollapsed || api.getIsPanelShown(),
       })
     );
     sessionStore.write(FILTERS_SNAPSHOT_SESSION_KEY, JSON.stringify(filters));
@@ -83,15 +86,24 @@ export const enterReviewMode = async (
  * the persisted review-mode flag. Always restores the pre-review snapshot.
  */
 export const exitReviewMode = async (api: ReviewModeApi): Promise<void> => {
+  if (!isReviewModeActive()) {
+    return;
+  }
+
   const chrome = readJson<{ nav: boolean; panel: boolean }>(CHROME_SNAPSHOT_SESSION_KEY);
+  const filters = readJson<ReviewModeFilters>(FILTERS_SNAPSHOT_SESSION_KEY);
+  sessionStore.remove(REVIEW_MODE_SESSION_KEY);
   if (chrome?.nav) {
+    api.toggleNav(true);
+  } else if (chrome === null && !api.getIsNavShown()) {
     api.toggleNav(true);
   }
   if (chrome?.panel) {
     api.togglePanel(true);
+  } else if (chrome === null && !api.getIsPanelShown()) {
+    api.togglePanel(true);
   }
 
-  const filters = readJson<ReviewModeFilters>(FILTERS_SNAPSHOT_SESSION_KEY);
   if (filters) {
     await api.setAllTagFilters(filters.includedTagFilters, filters.excludedTagFilters);
     await api.setAllStatusFilters(filters.includedStatusFilters, filters.excludedStatusFilters);
@@ -99,5 +111,4 @@ export const exitReviewMode = async (api: ReviewModeApi): Promise<void> => {
 
   sessionStore.remove(CHROME_SNAPSHOT_SESSION_KEY);
   sessionStore.remove(FILTERS_SNAPSHOT_SESSION_KEY);
-  sessionStore.remove(REVIEW_MODE_SESSION_KEY);
 };

--- a/code/core/src/manager/components/review/review-mode.ts
+++ b/code/core/src/manager/components/review/review-mode.ts
@@ -5,9 +5,8 @@ import { REVIEW_NAMESPACE } from '../../../shared/review/index.ts';
 import { REVIEWING_STATUS_VALUE } from './review-status.ts';
 import { sessionStore } from './session-store.ts';
 
-// Persisted flag marking the manager as being in review mode. Review mode is
-// interaction-driven (never inferred from the URL) and survives reloads via
-// this key.
+// Persisted flag marking filter snapshot while review mode is active. Chrome
+// collapse is driven by the `full=1` layout query param in the URL.
 const REVIEW_MODE_SESSION_KEY = `${REVIEW_NAMESPACE}/review-mode`;
 
 // Snapshot of the manager chrome (sidebar/addon panel visibility) taken when

--- a/code/core/src/manager/components/review/review-navigation.test.ts
+++ b/code/core/src/manager/components/review/review-navigation.test.ts
@@ -138,7 +138,9 @@ describe('path helpers', () => {
     expect(isReviewRoute('/review/', undefined)).toBe(true);
     expect(isReviewRoute('/story/foo', '0')).toBe(true);
     expect(isReviewRoute('/story/foo', undefined)).toBe(false);
+    expect(isReviewRoute('/story/foo', 'abc')).toBe(false);
     expect(isReviewStoryRoute('/story/foo', '0')).toBe(true);
+    expect(isReviewStoryRoute('/story/foo', 'abc')).toBe(false);
   });
 });
 

--- a/code/core/src/manager/components/review/review-navigation.test.ts
+++ b/code/core/src/manager/components/review/review-navigation.test.ts
@@ -6,7 +6,6 @@ import {
   buildFlattenedNavEntries,
   buildReviewChangesSummaryHref,
   buildReviewStoryHref,
-  buildReviewStoryTarget,
   buildSummaryBackHref,
   getAdjacentCollectionFirstStory,
   getAdjacentReviewEntries,
@@ -43,14 +42,6 @@ describe('buildReviewStoryHref', () => {
   it('builds a story URL with full layout and collection query params', () => {
     expect(buildReviewStoryHref({ storyId: 'story-a', collectionIndex: 1 })).toBe(
       `?${REVIEW_FULL_QUERY_PARAM}=1&path=/story/story-a&${REVIEW_COLLECTION_QUERY_PARAM}=1`
-    );
-  });
-});
-
-describe('buildReviewStoryTarget', () => {
-  it('builds a router navigate target without the query wrapper', () => {
-    expect(buildReviewStoryTarget({ storyId: 'story-a', collectionIndex: 1 })).toBe(
-      `/story/story-a&${REVIEW_COLLECTION_QUERY_PARAM}=1`
     );
   });
 });

--- a/code/core/src/manager/components/review/review-navigation.test.ts
+++ b/code/core/src/manager/components/review/review-navigation.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ReviewState } from './review-state.ts';
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
+  REVIEW_FULL_QUERY_PARAM,
   buildFlattenedNavEntries,
   buildReviewChangesSummaryHref,
   buildReviewStoryHref,
@@ -10,6 +10,9 @@ import {
   buildSummaryBackHref,
   getAdjacentCollectionFirstStory,
   getAdjacentReviewEntries,
+  isReviewLayoutActive,
+  isReviewRoute,
+  isReviewStoryRoute,
   isReviewSummaryPath,
   parseCollectionIndex,
   parseReviewStoryHref,
@@ -17,6 +20,7 @@ import {
   resolveActiveNavEntry,
   resolveNavIndex,
 } from './review-navigation.ts';
+import type { ReviewState } from './review-state.ts';
 
 const reviewState: ReviewState = {
   title: 'Test review',
@@ -36,9 +40,9 @@ const reviewState: ReviewState = {
 };
 
 describe('buildReviewStoryHref', () => {
-  it('builds a story URL with collection query param', () => {
+  it('builds a story URL with full layout and collection query params', () => {
     expect(buildReviewStoryHref({ storyId: 'story-a', collectionIndex: 1 })).toBe(
-      `?path=/story/story-a&${REVIEW_COLLECTION_QUERY_PARAM}=1`
+      `?${REVIEW_FULL_QUERY_PARAM}=1&path=/story/story-a&${REVIEW_COLLECTION_QUERY_PARAM}=1`
     );
   });
 });
@@ -122,7 +126,19 @@ describe('path helpers', () => {
   });
 
   it('builds the summary href', () => {
-    expect(buildReviewChangesSummaryHref()).toBe('?path=/review/');
+    expect(buildReviewChangesSummaryHref()).toBe('?full=1&path=/review/');
+  });
+
+  it('detects review layout from the URL', () => {
+    expect(isReviewLayoutActive({ search: '?full=1&path=/review/' })).toBe(true);
+    expect(isReviewLayoutActive({ search: '?path=/story/foo' })).toBe(false);
+  });
+
+  it('detects review routes', () => {
+    expect(isReviewRoute('/review/', undefined)).toBe(true);
+    expect(isReviewRoute('/story/foo', '0')).toBe(true);
+    expect(isReviewRoute('/story/foo', undefined)).toBe(false);
+    expect(isReviewStoryRoute('/story/foo', '0')).toBe(true);
   });
 });
 

--- a/code/core/src/manager/components/review/review-navigation.ts
+++ b/code/core/src/manager/components/review/review-navigation.ts
@@ -1,5 +1,13 @@
+import { queryFromLocation } from 'storybook/internal/router';
+
 import { REVIEW_CHANGES_URL } from './constants.ts';
 import type { ReviewState } from './review-state.ts';
+
+/** Layout query param that collapses manager chrome during review. */
+export const REVIEW_FULL_QUERY_PARAM = 'full';
+
+const parseReviewLayoutFull = (value: unknown): boolean =>
+  value === '1' || value === 'true' || value === 1 || value === true;
 
 /** Fallback display name when the Storybook index has not resolved a title. */
 export const prettifyComponentId = (componentId: string) =>
@@ -17,7 +25,12 @@ export interface ReviewNavEntry {
 
 export const REVIEW_COLLECTION_QUERY_PARAM = 'collection';
 
-export const buildReviewChangesSummaryHref = () => `?path=${REVIEW_CHANGES_URL}`;
+export const buildReviewChangesSummaryHref = () =>
+  `?${REVIEW_FULL_QUERY_PARAM}=1&path=${REVIEW_CHANGES_URL}`;
+
+/** Plain manager href for navigating to a review story (includes `full=1`). */
+export const buildReviewStoryNavigateHref = (entry: ReviewNavEntry): string =>
+  `?${REVIEW_FULL_QUERY_PARAM}=1&path=/story/${entry.storyId}&${REVIEW_COLLECTION_QUERY_PARAM}=${entry.collectionIndex}`;
 
 /** Default back target when no story has been visited yet. */
 export const STORYBOOK_ROOT_HREF = '/';
@@ -34,12 +47,9 @@ export const buildReviewStoryTarget = (entry: ReviewNavEntry): string =>
 
 /** Full `?path=` href for a review story, derived from the router target. */
 export const buildReviewStoryHref = (entry: ReviewNavEntry): string =>
-  `?path=${buildReviewStoryTarget(entry)}`;
+  buildReviewStoryNavigateHref(entry);
 
 export const parseReviewStoryHref = (href: string): ReviewNavEntry | null => {
-  if (!href.startsWith('?path=/story/')) {
-    return null;
-  }
   const query = href.startsWith('?') ? href.slice(1) : href;
   const params = new URLSearchParams(query);
   const path = params.get('path');
@@ -69,6 +79,16 @@ export const buildFlattenedNavEntries = (state: ReviewState): ReviewNavEntry[] =
 
 export const isReviewSummaryPath = (path: string): boolean =>
   path === REVIEW_CHANGES_URL || path === '/review';
+
+export const isReviewLayoutActive = (location?: { search?: string }): boolean =>
+  parseReviewLayoutFull(queryFromLocation(location)[REVIEW_FULL_QUERY_PARAM]);
+
+export const isReviewStoryRoute = (path: string, collectionParam: string | undefined): boolean =>
+  parseStoryIdFromPath(path) !== null && collectionParam !== undefined;
+
+/** True when the route is part of the review flow (summary or curated story). */
+export const isReviewRoute = (path: string, collectionParam: string | undefined): boolean =>
+  isReviewSummaryPath(path) || isReviewStoryRoute(path, collectionParam);
 
 /** True when a manager search string points back at a review route (not a canvas). */
 export const isReviewReturnSearch = (search: string): boolean => {

--- a/code/core/src/manager/components/review/review-navigation.ts
+++ b/code/core/src/manager/components/review/review-navigation.ts
@@ -84,7 +84,7 @@ export const isReviewLayoutActive = (location?: { search?: string }): boolean =>
   parseReviewLayoutFull(queryFromLocation(location)[REVIEW_FULL_QUERY_PARAM]);
 
 export const isReviewStoryRoute = (path: string, collectionParam: string | undefined): boolean =>
-  parseStoryIdFromPath(path) !== null && collectionParam !== undefined;
+  parseStoryIdFromPath(path) !== null && parseCollectionIndex(collectionParam) !== undefined;
 
 /** True when the route is part of the review flow (summary or curated story). */
 export const isReviewRoute = (path: string, collectionParam: string | undefined): boolean =>

--- a/code/core/src/manager/components/review/review-navigation.ts
+++ b/code/core/src/manager/components/review/review-navigation.ts
@@ -38,6 +38,15 @@ export const STORYBOOK_ROOT_HREF = '/';
 export const buildSummaryBackHref = (returnSearch: string | null | undefined): string =>
   returnSearch || STORYBOOK_ROOT_HREF;
 
+/** Strip review layout params so exit/history navigation restores normal chrome. */
+export const stripReviewLayoutFromSearch = (search: string): string => {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  params.delete(REVIEW_FULL_QUERY_PARAM);
+  params.delete(REVIEW_COLLECTION_QUERY_PARAM);
+  const query = params.toString();
+  return query ? `?${query}` : '';
+};
+
 /** Marks summary-header back links for SPA navigation in useReviewNavigationInterceptor. */
 export const REVIEW_SUMMARY_BACK_ATTR = 'data-review-summary-back';
 

--- a/code/core/src/manager/components/review/review-navigation.ts
+++ b/code/core/src/manager/components/review/review-navigation.ts
@@ -50,11 +50,7 @@ export const stripReviewLayoutFromSearch = (search: string): string => {
 /** Marks summary-header back links for SPA navigation in useReviewNavigationInterceptor. */
 export const REVIEW_SUMMARY_BACK_ATTR = 'data-review-summary-back';
 
-/** Storybook router navigate target for a review story (no `?path=` wrapper). */
-export const buildReviewStoryTarget = (entry: ReviewNavEntry): string =>
-  `/story/${entry.storyId}&${REVIEW_COLLECTION_QUERY_PARAM}=${entry.collectionIndex}`;
-
-/** Full `?path=` href for a review story, derived from the router target. */
+/** Full `?path=` href for a review story. */
 export const buildReviewStoryHref = (entry: ReviewNavEntry): string =>
   buildReviewStoryNavigateHref(entry);
 

--- a/code/core/src/manager/components/review/review-store.ts
+++ b/code/core/src/manager/components/review/review-store.ts
@@ -1,8 +1,8 @@
 import { useSyncExternalStore } from 'react';
 
-import type { StoryInfo } from './components/CollectionGrid.tsx';
 import type { ReviewNavEntry } from './review-navigation.ts';
 import type { ReviewState } from './review-state.ts';
+import type { StoryInfo } from './review-types.ts';
 
 export interface ReviewStoreState {
   state: ReviewState | null;
@@ -41,6 +41,8 @@ const listeners = new Set<() => void>();
 
 /** Synchronously hide the summary overlay before SPA navigation to a story. */
 let summaryOverlaySuppressed = false;
+/** Skip URL-driven review enter/exit while an explicit leave is in flight. */
+let urlSyncSuppressed = false;
 
 const notify = () => {
   listeners.forEach((listener) => listener());
@@ -69,6 +71,13 @@ export const reviewStore = {
     }
   },
   isSummaryOverlayShown: () => currentStore.isSummaryVisible && !summaryOverlaySuppressed,
+  suppressUrlSync: () => {
+    urlSyncSuppressed = true;
+  },
+  releaseUrlSyncSuppression: () => {
+    urlSyncSuppressed = false;
+  },
+  isUrlSyncSuppressed: () => urlSyncSuppressed,
 };
 
 export const useReview = (): ReviewStoreState =>

--- a/code/core/src/manager/components/review/review-store.ts
+++ b/code/core/src/manager/components/review/review-store.ts
@@ -2,7 +2,7 @@ import { useSyncExternalStore } from 'react';
 
 import type { ReviewNavEntry } from './review-navigation.ts';
 import type { ReviewState } from './review-state.ts';
-import type { StoryInfo } from './review-types.ts';
+import type { StoryInfo } from './components/CollectionGrid.tsx';
 
 export interface ReviewStoreState {
   state: ReviewState | null;

--- a/code/core/src/manager/components/review/useReviewNavigationInterceptor.ts
+++ b/code/core/src/manager/components/review/useReviewNavigationInterceptor.ts
@@ -10,7 +10,6 @@ import {
   navigateToReviewSummary,
 } from './review-actions.ts';
 import {
-  REVIEW_COLLECTION_QUERY_PARAM,
   REVIEW_SUMMARY_BACK_ATTR,
   isReviewSummaryPath,
   parseReviewStoryHref,
@@ -23,14 +22,7 @@ const parseHrefPath = (href: string): string | null => {
   return new URLSearchParams(query).get('path');
 };
 
-const isReviewStoryHref = (href: string) => {
-  const path = parseHrefPath(href);
-  if (!path?.startsWith('/story/')) {
-    return false;
-  }
-  const query = href.startsWith('?') ? href.slice(1) : href;
-  return new URLSearchParams(query).has(REVIEW_COLLECTION_QUERY_PARAM);
-};
+const isReviewStoryHref = (href: string) => parseReviewStoryHref(href) !== null;
 
 const isReviewSummaryHref = (href: string) => {
   const path = parseHrefPath(href);

--- a/code/core/src/manager/components/review/useReviewNavigationInterceptor.ts
+++ b/code/core/src/manager/components/review/useReviewNavigationInterceptor.ts
@@ -12,16 +12,30 @@ import {
 import {
   REVIEW_COLLECTION_QUERY_PARAM,
   REVIEW_SUMMARY_BACK_ATTR,
-  buildReviewChangesSummaryHref,
+  isReviewSummaryPath,
   parseReviewStoryHref,
 } from './review-navigation.ts';
 import { sessionStore } from './session-store.ts';
 import { useReviewFiltersRef } from './useReviewFiltersRef.ts';
 
-const isReviewStoryHref = (href: string) =>
-  href.startsWith('?path=/story/') && href.includes(`${REVIEW_COLLECTION_QUERY_PARAM}=`);
+const parseHrefPath = (href: string): string | null => {
+  const query = href.startsWith('?') ? href.slice(1) : href;
+  return new URLSearchParams(query).get('path');
+};
 
-const isReviewSummaryHref = (href: string) => href === buildReviewChangesSummaryHref();
+const isReviewStoryHref = (href: string) => {
+  const path = parseHrefPath(href);
+  if (!path?.startsWith('/story/')) {
+    return false;
+  }
+  const query = href.startsWith('?') ? href.slice(1) : href;
+  return new URLSearchParams(query).has(REVIEW_COLLECTION_QUERY_PARAM);
+};
+
+const isReviewSummaryHref = (href: string) => {
+  const path = parseHrefPath(href);
+  return path !== null && isReviewSummaryPath(path);
+};
 
 /**
  * Intercepts primary clicks on in-page review navigation links for SPA

--- a/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
@@ -119,6 +119,7 @@ const makeManagerContext = (
       setAllTagFilters: options.setAllTagFilters ?? fn().mockName('api::setAllTagFilters'),
       setAllStatusFilters: options.setAllStatusFilters ?? fn().mockName('api::setAllStatusFilters'),
       navigate: options.navigate ?? fn().mockName('api::navigate'),
+      navigateUrl: options.navigate ?? fn().mockName('api::navigateUrl'),
     },
   };
 };
@@ -188,7 +189,7 @@ export const HiddenWhenZeroCounts: Story = {
   },
 };
 
-const navigateMock = fn().mockName('api::navigate');
+const navigateMock = fn().mockName('api::navigateUrl');
 const toggleNavMock = fn().mockName('api::toggleNav');
 const togglePanelMock = fn().mockName('api::togglePanel');
 const setAllTagFiltersMock = fn().mockName('api::setAllTagFilters');
@@ -200,6 +201,7 @@ export const OpenReview: Story = {
       storyIds: ['s1', 's2'],
       reviewTitle: 'Theme token cascade review',
       navigate: navigateMock,
+      navigateUrl: navigateMock,
       toggleNav: toggleNavMock,
       togglePanel: togglePanelMock,
       setAllTagFilters: setAllTagFiltersMock,
@@ -222,7 +224,7 @@ export const OpenReview: Story = {
     await expect(togglePanelMock).toHaveBeenCalledWith(false);
     await expect(setAllTagFiltersMock).toHaveBeenCalledWith([], []);
     await expect(setAllStatusFiltersMock).toHaveBeenCalledWith(['status-value:reviewing'], []);
-    await expect(navigateMock).toHaveBeenCalledWith('/review/');
+    await expect(navigateMock).toHaveBeenCalledWith('?full=1&path=/review/', {});
   },
 };
 

--- a/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.stories.tsx
@@ -62,6 +62,7 @@ const makeManagerContext = (
     storyIds?: string[];
     reviewTitle?: string;
     navigate?: ReturnType<typeof fn>;
+    navigateUrl?: ReturnType<typeof fn>;
     toggleNav?: ReturnType<typeof fn>;
     togglePanel?: ReturnType<typeof fn>;
     setAllTagFilters?: ReturnType<typeof fn>;
@@ -119,7 +120,7 @@ const makeManagerContext = (
       setAllTagFilters: options.setAllTagFilters ?? fn().mockName('api::setAllTagFilters'),
       setAllStatusFilters: options.setAllStatusFilters ?? fn().mockName('api::setAllStatusFilters'),
       navigate: options.navigate ?? fn().mockName('api::navigate'),
-      navigateUrl: options.navigate ?? fn().mockName('api::navigateUrl'),
+      navigateUrl: options.navigateUrl ?? fn().mockName('api::navigateUrl'),
     },
   };
 };
@@ -189,7 +190,8 @@ export const HiddenWhenZeroCounts: Story = {
   },
 };
 
-const navigateMock = fn().mockName('api::navigateUrl');
+const navigateMock = fn().mockName('api::navigate');
+const navigateUrlMock = fn().mockName('api::navigateUrl');
 const toggleNavMock = fn().mockName('api::toggleNav');
 const togglePanelMock = fn().mockName('api::togglePanel');
 const setAllTagFiltersMock = fn().mockName('api::setAllTagFilters');
@@ -201,7 +203,7 @@ export const OpenReview: Story = {
       storyIds: ['s1', 's2'],
       reviewTitle: 'Theme token cascade review',
       navigate: navigateMock,
-      navigateUrl: navigateMock,
+      navigateUrl: navigateUrlMock,
       toggleNav: toggleNavMock,
       togglePanel: togglePanelMock,
       setAllTagFilters: setAllTagFiltersMock,
@@ -212,6 +214,7 @@ export const OpenReview: Story = {
     eventListeners.clear();
     sessionStorage.clear();
     navigateMock.mockClear();
+    navigateUrlMock.mockClear();
     toggleNavMock.mockClear();
     togglePanelMock.mockClear();
     setAllTagFiltersMock.mockClear();
@@ -224,7 +227,8 @@ export const OpenReview: Story = {
     await expect(togglePanelMock).toHaveBeenCalledWith(false);
     await expect(setAllTagFiltersMock).toHaveBeenCalledWith([], []);
     await expect(setAllStatusFiltersMock).toHaveBeenCalledWith(['status-value:reviewing'], []);
-    await expect(navigateMock).toHaveBeenCalledWith('?full=1&path=/review/', {});
+    await expect(navigateUrlMock).toHaveBeenCalledWith('?full=1&path=/review/', {});
+    await expect(navigateMock).not.toHaveBeenCalled();
   },
 };
 

--- a/code/core/src/manager/components/sidebar/ReviewWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ReviewWidget.tsx
@@ -1,4 +1,4 @@
-import React, { type SyntheticEvent, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, type SyntheticEvent } from 'react';
 
 import { ActionList, Card } from 'storybook/internal/components';
 import type { StatusesByStoryIdAndTypeId, StoryIndex } from 'storybook/internal/types';
@@ -14,8 +14,8 @@ import {
 import { styled } from 'storybook/theming';
 
 import { REVIEW_EVENTS } from '../../../shared/review/index.ts';
-import { REVIEW_CHANGES_URL } from '../review/constants.ts';
 import { enterReviewMode } from '../review/review-mode.ts';
+import { buildReviewChangesSummaryHref } from '../review/review-navigation.ts';
 import { REVIEWING_STATUS_VALUE as REVIEWING } from '../review/review-status.ts';
 
 type ReviewPayload = {
@@ -119,7 +119,7 @@ export const ReviewWidget = () => {
       } catch {
         // Best-effort: still continue into the review route.
       }
-      api.navigate(REVIEW_CHANGES_URL);
+      api.navigateUrl(buildReviewChangesSummaryHref(), {});
     })();
   };
 


### PR DESCRIPTION
## What I did

Drive review mode from the `full=1` URL param so logo/home navigation is not hijacked by cached review replay, browser back restores sidebar, and landing on `/review/` auto-enters full layout.

- Auto-add `full=1` on first entry to `/?path=/review/` (replace, no extra history entry).
- Stop replaying a cached review on mount from redirecting logo/`/` navigation into the review summary.
- Exit review mode (restore sidebar + filters) when browser history leaves review routes or drops `full=1`.
- Apply persisted layout options from URL params on manager init so `full=1` survives reload.
- Reject non-numeric `collection` params in review story routes (aligned with `parseCollectionIndex`).

Split from #35304 — this PR excludes embed/thumbnail iframe work and targets `next` directly.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Start the internal Storybook UI (`cd code && yarn storybook:ui`).
2. Push or open a review (MCP `display-review` or the sidebar Quick review widget).
3. Click the Storybook logo or navigate to `/` — you should **not** be forced back into the review summary.
4. Enter review from the widget, then use the browser **Back** button — sidebar and filters should restore.
5. Open `/?path=/review/` directly (no prior history) — URL should gain `full=1` and review chrome should collapse.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:

  - `bug`

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35312-sha-bffa81f4`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35312-sha-bffa81f4 sandbox` or in an existing project with `npx storybook@0.0.0-pr-35312-sha-bffa81f4 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35312-sha-bffa81f4`](https://npmjs.com/package/storybook/v/0.0.0-pr-35312-sha-bffa81f4) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`ghengeveld/review-full-mode-navigation`](https://github.com/storybookjs/storybook/tree/ghengeveld/review-full-mode-navigation) |
| **Commit** | [`bffa81f4`](https://github.com/storybookjs/storybook/commit/bffa81f40e42d912f3cd5c768d4244d4111fd6c0) |
| **Datetime** | Mon Jun 29 10:44:23 UTC 2026 (`1782729863`) |
| **Workflow run** | [28366371240](https://github.com/storybookjs/storybook/actions/runs/28366371240) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35312`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review pages now use `full=1` in the URL and generate review links (including the review widget’s “review changes” navigation).

* **Bug Fixes**
  * Improved review routing so summary vs. story routes are detected more reliably.
  * Enhanced restoration of review chrome (nav/panel) when returning from review, including when the layout is collapsed via `full=1`.
  * URL updates now preserve layout-related query params (like `full=1`) more consistently.

* **Tests**
  * Updated and expanded coverage for layout, URL, review navigation, review mode, and Storybook routing in full mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->