### PR TITLE
fix(addon-vitest): subscribe to store before triggering run to preven…

### DIFF
--- a/code/addons/vitest/src/preset.test.ts
+++ b/code/addons/vitest/src/preset.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Channel } from 'storybook/internal/channels';
+import type { Options } from 'storybook/internal/types';
+
+import { TRIGGER_TEST_RUN_REQUEST, TRIGGER_TEST_RUN_RESPONSE } from './constants.ts';
+import { experimental_serverChannel } from './preset.ts';
+
+const mockApply = vi.fn().mockImplementation((key) => {
+  if (key === 'core') {
+    return Promise.resolve({ builder: 'builder-vite' });
+  }
+  if (key === 'previewAnnotations') {
+    return Promise.resolve([]);
+  }
+  if (key === 'storyIndexGenerator') {
+    return Promise.resolve({
+      getIndex: vi.fn().mockResolvedValue({ v: 5, entries: {} }),
+      onInvalidated: vi.fn(),
+    });
+  }
+  return Promise.resolve(undefined);
+});
+
+const mockOptions = {
+  configDir: '.storybook',
+  presets: {
+    apply: mockApply,
+  },
+} as unknown as Options;
+
+vi.mock('storybook/internal/common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('storybook/internal/common')>();
+  return {
+    ...actual,
+    createFileSystemCache: vi.fn(() => ({
+      get: vi.fn().mockImplementation((key, defaultValue) => Promise.resolve(defaultValue ?? {})),
+      set: vi.fn().mockResolvedValue(undefined),
+    })),
+    getFrameworkName: vi.fn().mockResolvedValue('react-vite'),
+    loadPreviewOrConfigFile: vi.fn().mockReturnValue(undefined),
+    resolvePathInStorybookCache: vi.fn().mockReturnValue('/tmp/storybook-cache'),
+  };
+});
+
+const mockUnsubscribe = vi.fn();
+const mockStore = {
+  untilReady: vi.fn().mockResolvedValue(undefined),
+  getState: vi.fn().mockReturnValue({
+    currentRun: { startedAt: undefined, finishedAt: undefined },
+    config: {},
+  }),
+  setState: vi.fn(),
+  send: vi.fn(),
+  subscribe: vi.fn().mockReturnValue(mockUnsubscribe),
+  onStateChange: vi.fn(() => () => {}),
+};
+
+vi.mock('storybook/internal/core-server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('storybook/internal/core-server')>();
+  return {
+    ...actual,
+    experimental_UniversalStore: {
+      create: vi.fn(() => mockStore),
+    },
+    experimental_getTestProviderStore: vi.fn(() => ({
+      setState: vi.fn(),
+      onClearAll: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('./node/boot-test-runner.ts', () => ({
+  runTestRunner: vi.fn(),
+}));
+
+vi.mock('storybook/internal/node-logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('storybook/internal/telemetry', () => ({
+  cleanPaths: vi.fn((x) => x),
+  oneWayHash: vi.fn((x) => x),
+  sanitizeError: vi.fn((x) => x),
+  telemetry: vi.fn(),
+}));
+
+describe('preset experimental_serverChannel', () => {
+  let channel: Channel;
+  let emitSpy: ReturnType<typeof vi.spyOn<Channel, 'emit'>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    channel = new Channel({
+      transport: {
+        setHandler: vi.fn(),
+        send: vi.fn(),
+      },
+    });
+    emitSpy = vi.spyOn(channel, 'emit');
+  });
+
+  it('should register TRIGGER_TEST_RUN_REQUEST listener', async () => {
+    const onSpy = vi.spyOn(channel, 'on');
+    await experimental_serverChannel(channel, mockOptions);
+
+    expect(onSpy).toHaveBeenCalledWith(TRIGGER_TEST_RUN_REQUEST, expect.any(Function));
+  });
+
+  it('should successfully subscribe and send TRIGGER_RUN', async () => {
+    await experimental_serverChannel(channel, mockOptions);
+
+    const handler = channel.listeners(TRIGGER_TEST_RUN_REQUEST)[0] as (
+      ...args: unknown[]
+    ) => unknown;
+    expect(handler).toBeDefined();
+
+    const payload = {
+      requestId: 'test-id',
+      actor: 'test-actor',
+      storyIds: ['story-1'],
+    };
+
+    mockStore.send.mockImplementationOnce(() => {
+      const calls = mockStore.subscribe.mock.calls;
+      const callbackCall = calls.find((call) => typeof call[0] === 'function');
+      const callback = callbackCall ? callbackCall[0] : null;
+      if (callback) {
+        callback({
+          type: 'TEST_RUN_COMPLETED',
+          payload: {
+            startedAt: 100,
+            finishedAt: 200,
+            unhandledErrors: [],
+          },
+        });
+      }
+    });
+
+    await handler(payload);
+
+    const calls = mockStore.subscribe.mock.calls;
+    const subscriptionIndex = calls.findIndex((call) => typeof call[0] === 'function');
+    expect(subscriptionIndex).toBeGreaterThanOrEqual(0);
+
+    const subscribeCallOrder = mockStore.subscribe.mock.invocationCallOrder[subscriptionIndex];
+    const sendCallOrder = mockStore.send.mock.invocationCallOrder[0];
+    expect(subscribeCallOrder).toBeLessThan(sendCallOrder);
+
+    expect(emitSpy).toHaveBeenCalledWith(TRIGGER_TEST_RUN_RESPONSE, {
+      requestId: 'test-id',
+      status: 'completed',
+      result: {
+        startedAt: 100,
+        finishedAt: 200,
+        unhandledErrors: [],
+      },
+    });
+
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+});

--- a/code/addons/vitest/src/preset.test.ts
+++ b/code/addons/vitest/src/preset.test.ts
@@ -1,101 +1,103 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Channel } from 'storybook/internal/channels';
+import {
+  createFileSystemCache,
+  getFrameworkName,
+  loadPreviewOrConfigFile,
+  resolvePathInStorybookCache,
+} from 'storybook/internal/common';
+import {
+  experimental_UniversalStore,
+  experimental_getTestProviderStore,
+} from 'storybook/internal/core-server';
+import { cleanPaths, oneWayHash, sanitizeError, telemetry } from 'storybook/internal/telemetry';
 import type { Options } from 'storybook/internal/types';
 
 import { TRIGGER_TEST_RUN_REQUEST, TRIGGER_TEST_RUN_RESPONSE } from './constants.ts';
 import { experimental_serverChannel } from './preset.ts';
 
-const mockApply = vi.fn().mockImplementation((key) => {
-  if (key === 'core') {
-    return Promise.resolve({ builder: 'builder-vite' });
-  }
-  if (key === 'previewAnnotations') {
-    return Promise.resolve([]);
-  }
-  if (key === 'storyIndexGenerator') {
-    return Promise.resolve({
-      getIndex: vi.fn().mockResolvedValue({ v: 5, entries: {} }),
-      onInvalidated: vi.fn(),
-    });
-  }
-  return Promise.resolve(undefined);
-});
-
-const mockOptions = {
-  configDir: '.storybook',
-  presets: {
-    apply: mockApply,
-  },
-} as unknown as Options;
-
-vi.mock('storybook/internal/common', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('storybook/internal/common')>();
-  return {
-    ...actual,
-    createFileSystemCache: vi.fn(() => ({
-      get: vi.fn().mockImplementation((key, defaultValue) => Promise.resolve(defaultValue ?? {})),
-      set: vi.fn().mockResolvedValue(undefined),
-    })),
-    getFrameworkName: vi.fn().mockResolvedValue('react-vite'),
-    loadPreviewOrConfigFile: vi.fn().mockReturnValue(undefined),
-    resolvePathInStorybookCache: vi.fn().mockReturnValue('/tmp/storybook-cache'),
-  };
-});
-
-const mockUnsubscribe = vi.fn();
-const mockStore = {
-  untilReady: vi.fn().mockResolvedValue(undefined),
-  getState: vi.fn().mockReturnValue({
-    currentRun: { startedAt: undefined, finishedAt: undefined },
-    config: {},
-  }),
-  setState: vi.fn(),
-  send: vi.fn(),
-  subscribe: vi.fn().mockReturnValue(mockUnsubscribe),
-  onStateChange: vi.fn(() => () => {}),
-};
-
-vi.mock('storybook/internal/core-server', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('storybook/internal/core-server')>();
-  return {
-    ...actual,
-    experimental_UniversalStore: {
-      create: vi.fn(() => mockStore),
-    },
-    experimental_getTestProviderStore: vi.fn(() => ({
-      setState: vi.fn(),
-      onClearAll: vi.fn(),
-    })),
-  };
-});
-
-vi.mock('./node/boot-test-runner.ts', () => ({
-  runTestRunner: vi.fn(),
-}));
-
-vi.mock('storybook/internal/node-logger', () => ({
-  logger: {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-}));
-
-vi.mock('storybook/internal/telemetry', () => ({
-  cleanPaths: vi.fn((x) => x),
-  oneWayHash: vi.fn((x) => x),
-  sanitizeError: vi.fn((x) => x),
-  telemetry: vi.fn(),
-}));
+vi.mock('storybook/internal/common', { spy: true });
+vi.mock('storybook/internal/core-server', { spy: true });
+vi.mock('./node/boot-test-runner.ts', { spy: true });
+vi.mock('storybook/internal/node-logger', { spy: true });
+vi.mock('storybook/internal/telemetry', { spy: true });
 
 describe('preset experimental_serverChannel', () => {
   let channel: Channel;
   let emitSpy: ReturnType<typeof vi.spyOn<Channel, 'emit'>>;
+  let mockApply: ReturnType<typeof vi.fn>;
+  let mockOptions: Options;
+  let mockUnsubscribe: ReturnType<typeof vi.fn>;
+  let mockStore: {
+    untilReady: ReturnType<typeof vi.fn>;
+    getState: ReturnType<typeof vi.fn>;
+    setState: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+    subscribe: ReturnType<typeof vi.fn>;
+    onStateChange: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    mockApply = vi.fn().mockImplementation((key) => {
+      if (key === 'core') {
+        return Promise.resolve({ builder: 'builder-vite' });
+      }
+      if (key === 'previewAnnotations') {
+        return Promise.resolve([]);
+      }
+      if (key === 'storyIndexGenerator') {
+        return Promise.resolve({
+          getIndex: vi.fn().mockResolvedValue({ v: 5, entries: {} }),
+          onInvalidated: vi.fn(),
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    mockOptions = {
+      configDir: '.storybook',
+      presets: {
+        apply: mockApply,
+      },
+    } as unknown as Options;
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    vi.mocked(createFileSystemCache).mockReturnValue({
+      get: vi.fn().mockImplementation((key, defaultValue) => Promise.resolve(defaultValue ?? {})),
+      set: vi.fn().mockResolvedValue(undefined),
+    } as any);
+    vi.mocked(getFrameworkName).mockResolvedValue('react-vite');
+    vi.mocked(loadPreviewOrConfigFile).mockReturnValue(undefined);
+    vi.mocked(resolvePathInStorybookCache).mockReturnValue('/tmp/storybook-cache');
+
+    mockUnsubscribe = vi.fn();
+    mockStore = {
+      untilReady: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockReturnValue({
+        currentRun: { startedAt: undefined, finishedAt: undefined },
+        config: {},
+      }),
+      setState: vi.fn(),
+      send: vi.fn(),
+      subscribe: vi.fn().mockReturnValue(mockUnsubscribe),
+      onStateChange: vi.fn(() => () => {}),
+    };
+
+    vi.mocked(experimental_UniversalStore.create).mockReturnValue(mockStore as any);
+    vi.mocked(experimental_getTestProviderStore).mockReturnValue({
+      setState: vi.fn(),
+      onClearAll: vi.fn(),
+    } as any);
+
+    vi.mocked(cleanPaths).mockImplementation((x) => x);
+    vi.mocked(oneWayHash).mockImplementation((x) => x);
+    vi.mocked(sanitizeError).mockImplementation((x) => x);
+    vi.mocked(telemetry).mockResolvedValue(undefined as any);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
     channel = new Channel({
       transport: {
         setHandler: vi.fn(),

--- a/code/addons/vitest/src/preset.ts
+++ b/code/addons/vitest/src/preset.ts
@@ -233,17 +233,6 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
       return;
     }
 
-    store.send({
-      type: 'TRIGGER_RUN',
-      payload: {
-        storyIds,
-        triggeredBy: `external:${actor}`,
-        ...(configOverride && {
-          configOverride: { ...config, ...configOverride },
-        }),
-      },
-    });
-
     const unsubscribe = store.subscribe((event) => {
       switch (event.type) {
         case 'TEST_RUN_COMPLETED': {
@@ -262,6 +251,17 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
           return;
         }
       }
+    });
+
+    store.send({
+      type: 'TRIGGER_RUN',
+      payload: {
+        storyIds,
+        triggeredBy: `external:${actor}`,
+        ...(configOverride && {
+          configOverride: { ...config, ...configOverride },
+        }),
+      },
     });
   });
 


### PR DESCRIPTION
Closes #35289

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->
Swapped the execution order in the programmatic test triggering logic so that `store.subscribe` is registered before `store.send` is called. This prevents race conditions where extremely fast or synchronous test runs complete before the listener is registered, causing the execution to hang or time out.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->
No manual testing is needed as the fix is covered by the newly added unit tests in `preset.test.ts` (which test the race condition under immediate/synchronous resolution).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of server-side test run handling by ensuring completion listeners are set up before a run is triggered.
  * Preserved run metadata and result details when returning completed test run responses.
  * Added coverage for the server channel flow to verify event handling and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->