### PR TITLE
Docs: Clarify TanStack Query client tradeoffs

### DIFF
--- a/docs/get-started/frameworks/tanstack-react.mdx
+++ b/docs/get-started/frameworks/tanstack-react.mdx
@@ -183,6 +183,10 @@ TanStack Query is not automatically set up. The recommended approach is to creat
 
 <CodeSnippets path="tanstack-react-query-setup.md" />
 
+This setup keeps the router context and React provider pointed at the same `QueryClient` no matter how Storybook renders the story: in the sidebar, in the Docs page, through portable stories, or in a test run. Clearing the cache before each story gives every story fresh query state while preserving one predictable integration point for loaders, route context, decorators, and story-level setup.
+
+You can create a separate `QueryClient` for each story when you need stronger isolation, such as rendering several stories with the same query keys on one Docs page and keeping their cached responses independent. The tradeoff is that you must make the per-story client available to both the router context and the `QueryClientProvider` for that story. If those two places receive different clients, route loaders and components can read different caches, and story setup that calls `setQueryData` may not affect the component being rendered. Per-story clients also require explicit cleanup of timers, subscriptions, and cached data owned by each client.
+
 #### Seeding query data per story
 
 In individual stories, use [`beforeEach`](../../writing-tests/interaction-testing.mdx#beforeeach) to call [`setQueryData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetquerydata) on the shared `QueryClient` before the component renders. Access it from `parameters.tanstack.router.context`:


### PR DESCRIPTION
## Summary

Closes #35283.

Adds clarification to the TanStack React framework docs explaining why the recommended TanStack Query setup uses one shared `QueryClient` that is cleared between stories.

The new note also documents when a per-story `QueryClient` can be useful, especially for multiple stories rendered on the same Docs page with the same query keys, and calls out the tradeoffs around keeping the router context and `QueryClientProvider` wired to the same client.

## What changed

- Clarified that the shared client keeps router context, decorators, loaders, portable stories, Docs, and test runs using one predictable integration point.
- Documented the stronger isolation provided by per-story clients.
- Documented the risks of mismatched router/provider clients and the need to clean up per-story client-owned state.

## Testing

- `corepack yarn install --immutable --mode=skip-build`
- `corepack yarn fmt:write`
- `corepack yarn docs:check`

#### Manual testing

Docs-only change. Manually reviewed the rendered Markdown source around the TanStack Query section to confirm the new guidance appears after the setup snippet and before the per-story seeding example.
