### PR TITLE
Core: Include Null In TypeScript Union Arg Types

### DIFF
--- a/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/unions.tsx
+++ b/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/unions.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import React from 'react';
 
 type Kind = 'default' | 'action';
+type NullableKind = 'default' | 'action' | null;
 enum DefaultEnum {
   TopLeft,
   TopRight,
@@ -15,6 +16,8 @@ enum NumericEnum {
 type EnumUnion = DefaultEnum | NumericEnum;
 interface Props {
   kind?: Kind;
+  nullableKind: NullableKind;
+  inlinedNullableUnion: 'default' | 'action' | null;
   inlinedNumericLiteralUnion: 0 | 1;
   enumUnion: EnumUnion;
 }

--- a/code/core/src/docs-tools/argTypes/convert/convert.test.ts
+++ b/code/core/src/docs-tools/argTypes/convert/convert.test.ts
@@ -160,6 +160,7 @@ describe('storybook type system', () => {
         import React from 'react';
 
         type Kind = 'default' | 'action';
+        type NullableKind = 'default' | 'action' | null;
         enum DefaultEnum {
           TopLeft,
           TopRight,
@@ -173,6 +174,8 @@ describe('storybook type system', () => {
         type EnumUnion = DefaultEnum | NumericEnum;
         interface Props {
           kind?: Kind;
+          nullableKind: NullableKind;
+          inlinedNullableUnion: 'default' | 'action' | null;
           inlinedNumericLiteralUnion: 0 | 1;
           enumUnion: EnumUnion;
         }
@@ -187,6 +190,24 @@ describe('storybook type system', () => {
             "value": [
               "default",
               "action"
+            ]
+          },
+          "nullableKind": {
+            "raw": "'default' | 'action' | null",
+            "name": "enum",
+            "value": [
+              "default",
+              "action",
+              null
+            ]
+          },
+          "inlinedNullableUnion": {
+            "raw": "'default' | 'action' | null",
+            "name": "enum",
+            "value": [
+              "default",
+              "action",
+              null
             ]
           },
           "inlinedNumericLiteralUnion": {

--- a/code/core/src/docs-tools/argTypes/convert/typescript/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/typescript/convert.ts
@@ -6,9 +6,12 @@ import type { TSSigType, TSType } from './types.ts';
 
 // Type guards for narrowing TSType discriminant unions
 type TSLiteralType = Extract<TSType, { name: 'literal' }>;
+type TSNullType = Extract<TSType, { name: 'null' }>;
 type TSUndefinedType = Extract<TSType, { name: 'undefined' }>;
 
 const isLiteral = (type: TSType): type is TSLiteralType => type.name === 'literal';
+const isLiteralOrNull = (type: TSType): type is TSLiteralType | TSNullType =>
+  isLiteral(type) || type.name === 'null';
 const isUndefined = (type: TSType): type is TSUndefinedType => type.name === 'undefined';
 
 const convertSig = (type: TSSigType) => {
@@ -50,15 +53,18 @@ export const convert = (type: TSType): SBType | void => {
       return { ...base, ...convertSig(type) };
     case 'union': {
       const nonUndefinedElements = type.elements.filter((element) => !isUndefined(element));
-      const allLiterals = nonUndefinedElements.length > 0 && nonUndefinedElements.every(isLiteral);
+      const allLiterals =
+        nonUndefinedElements.length > 0 && nonUndefinedElements.every(isLiteralOrNull);
 
       if (allLiterals) {
-        // TypeScript can't infer from .every(), so we filter again with the type guard
-        const literalElements = nonUndefinedElements.filter(isLiteral);
+        // TypeScript can't infer from .every(), so we filter again with the type guard.
+        const literalElements = nonUndefinedElements.filter(isLiteralOrNull);
         return {
           ...base,
           name: 'enum',
-          value: literalElements.map((element) => parseLiteral(element.value)),
+          value: literalElements.map((element) =>
+            element.name === 'null' ? null : parseLiteral(element.value)
+          ),
         };
       }
       return { ...base, name, value: type.elements.map(convert) };

--- a/code/core/src/docs-tools/argTypes/convert/typescript/types.ts
+++ b/code/core/src/docs-tools/argTypes/convert/typescript/types.ts
@@ -33,7 +33,7 @@ type TSObjectSigType = TSBaseType & {
 };
 
 type TSScalarType = TSBaseType & {
-  name: 'any' | 'boolean' | 'number' | 'void' | 'string' | 'symbol' | 'undefined';
+  name: 'any' | 'boolean' | 'number' | 'void' | 'string' | 'symbol' | 'undefined' | 'null';
 };
 
 type TSLiteralType = TSBaseType & {


### PR DESCRIPTION
## Summary
- Preserve `null` entries when converting TypeScript literal unions into enum arg types.
- Add regression coverage for both named and inline nullable union props.

Closes #32106

## Testing
- `yarn install --immutable`
- `yarn nx compile core`
- `yarn nx compile eslint-plugin`
- `yarn vitest run --config code/core/vitest.config.ts code/core/src/docs-tools/argTypes/convert/convert.test.ts`
- `yarn --cwd code lint:js:cmd core/src/docs-tools/argTypes/convert/typescript/convert.ts core/src/docs-tools/argTypes/convert/typescript/types.ts core/src/docs-tools/argTypes/convert/convert.test.ts core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/unions.tsx --fix`
- `git diff --check`

#### Manual testing
- Verified through the TypeScript argTypes converter regression fixture; no browser-only behavior is involved.
