### PR TITLE
VSCode: Do not reference removed config files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,8 +60,6 @@
   "typescript.preferences.quoteStyle": "single",
   "typescript.preferGoToSourceDefinition": true,
   "typescript.tsdk": "./node_modules/typescript/lib",
-  "vitest.workspaceConfig": "./code/vitest.workspace.ts",
-  "vitest.rootConfig": "./code/vitest.workspace.ts",
   "oxc.fmt.configPath": ".oxfmtrc.json",
   "oxc.enable.oxlint": false
 }


### PR DESCRIPTION
## What I did

Removed broken references to old Vitest config files in VSCode settings

## Checklist for Contributors

### Testing
#### Manual testing

Open VSCode with Vitest IDE. It should now work again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up workspace settings by removing two obsolete test configuration entries.
  * No functional behavior or user-facing features were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->