### PR TITLE
CI: Prevent concurrent merges from cancelling CircleCI trigger

### DIFF
--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -44,8 +44,13 @@ on:
       - next
       - main
 
+# For PR events, group per-PR (github.ref is refs/pull/<n>/merge) so redundant
+# re-triggers on the same PR cancel each other. For pushes to a shared branch
+# (next/main), key on the commit SHA instead: otherwise two merges landing close
+# together share the refs/heads/<branch> group and the earlier merge's trigger is
+# cancelled before it can POST to CircleCI, silently skipping its `merged` workflow.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -50,7 +50,7 @@ on:
 # together share the refs/heads/<branch> group and the earlier merge's trigger is
 # cancelled before it can POST to CircleCI, silently skipping its `merged` workflow.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What I did

The **Trigger CircleCI workflow** sets its concurrency group to `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`.

- For `pull_request_target` events, `github.ref` is per-PR (`refs/pull/<n>/merge`), so this correctly cancels only redundant re-triggers on the *same* PR. Two different open PRs never collide.
- For `push` events (merges to `next`/`main`), `github.ref` is the **shared** `refs/heads/<branch>`. So two merges landing close together share one concurrency group, and the earlier merge's trigger job is cancelled **before it POSTs to CircleCI** — silently skipping that commit's `merged` workflow.

This PR keys the group on `github.sha` for `push` events, while preserving per-PR grouping (and redundant-retrigger cancellation) for PR events:

```yaml
group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
```

## Evidence

I queried GitHub Actions history for cancelled runs of this workflow (sampled the 500 most recent; 5,228 cancelled all-time):

- **494/500 were `pull_request_target`** — all same-PR self-cancellations (identical branch + timestamp clusters from burst `labeled`/`synchronize` events). Bucketing by timestamp showed **zero** causal cross-PR cancellations, confirming open PRs are already isolated.
- **6/500 were `push`, all on `next`** — these are the genuine cross-PR interference this PR fixes. Examples:
  - https://github.com/storybookjs/storybook/actions/runs/27743483936
  - https://github.com/storybookjs/storybook/actions/runs/27711930203
  - https://github.com/storybookjs/storybook/actions/runs/27704473688
  - https://github.com/storybookjs/storybook/actions/runs/27692688143
  - https://github.com/storybookjs/storybook/actions/runs/27647293307
  - https://github.com/storybookjs/storybook/actions/runs/27199682355

## Impact

Each cancelled push-trigger meant a merged commit on `next` never fired its CircleCI `merged` (post-merge validation) workflow. Low frequency (~1.2% of cancellations) but a silent gap in CI coverage. PR-event behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow run grouping to reduce unintended cancellations during closely timed merges on shared branches.
  * Separate grouping is now used for pull requests and branch pushes, helping keep CI runs more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


#### Manual testing

* Merge two PRs at the same time on `next`
* Notice `ci:merged` trigger can get cancelled
* Merge this PR, and re-merge two PRs
* Notice we now get a `ci:merged` per commit