### PR TITLE
CI: Prevent pushes from cancelling in-progress canary publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,6 @@ on:
         description: '⚠️ CANARY RELEASES ONLY - Enter the pull request number to create a canary release for'
         required: true
         type: number
-  pull_request:
-    # Automated canary releases on PRs with the "with-canary-release"-suffix in the branch name
-    types: [opened, synchronize, reopened]
 
 env:
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -26,17 +23,12 @@ permissions: {}
 
 concurrency:
   # Group concurrent runs to control cancellation per release type:
-  # - Canary releases (manual `workflow_dispatch`, or `pull_request` events on a
-  #   branch whose name ends with `with-canary-release`) are grouped by PR number,
-  #   so a newer canary supersedes an older one for the same PR. Only runs that
-  #   actually publish a canary join this group.
-  # - A `pull_request` event on any other branch publishes nothing (the
-  #   `publish-canary` job is skipped), so it gets its own group and never cancels
-  #   an in-progress canary — e.g. one triggered manually then followed by an
-  #   unrelated push to the same PR.
+  # - Canary releases (manual `workflow_dispatch`) are grouped by PR number,
+  #   so a newer canary supersedes an older one for the same PR. Only runs
+  #   that actually publish a canary join this group.
   # - Pushes to release branches are grouped by branch name and never cancelled.
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && endsWith(github.head_ref, 'with-canary-release'))) && format('{0}-canary-{1}', github.workflow, github.event_name == 'workflow_dispatch' && inputs.pr || github.event.pull_request.number) || github.event_name == 'pull_request' && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.ref_name) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
+  group: ${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.workflow, inputs.pr) || format('{0}-{1}', github.workflow, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch'}}
 
 jobs:
   publish-normal:
@@ -218,10 +210,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.repository_owner == 'storybookjs' &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' && endsWith(github.head_ref, 'with-canary-release'))
-      ) &&
+      github.event_name == 'workflow_dispatch' &&
       contains(github.event.head_commit.message, '[skip ci]') != true
     environment: Release
     permissions:
@@ -238,7 +227,7 @@ jobs:
         id: info
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr || github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr }}
           REPOSITORY: ${{ github.repository }}
         run: |
           PR_INFO=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json isCrossRepository,headRefOid,headRefName,headRepository,headRepositoryOwner --jq '{isFork: .isCrossRepository, owner: .headRepositoryOwner.login, repoName: .headRepository.name, branch: .headRefName, sha: .headRefOid}')
@@ -270,7 +259,7 @@ jobs:
         id: version
         working-directory: scripts
         env:
-          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr || github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr }}
           SHORT_SHA: ${{ steps.info.outputs.shortSha }}
         run: |
           yarn release:version --exact "0.0.0-pr-$PR_NUMBER-sha-$SHORT_SHA" --verbose
@@ -305,14 +294,14 @@ jobs:
 
             To request a new release of this pull request, mention the `@storybookjs/core` team.
 
-            _core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=${{ github.event_name == 'workflow_dispatch' && inputs.pr || github.event.pull_request.number }}`_
+            _core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=${{ github.event_name == 'workflow_dispatch' && inputs.pr }}`_
             </details>
 
       - name: Create failing comment on PR
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr || github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr }}
           REPOSITORY: ${{ github.repository }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
           RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,17 @@ env:
 permissions: {}
 
 concurrency:
-  # Group concurrent runs based on the event type:
-  # - For workflow_dispatch and pull_request: group by PR number to allow only one canary release per PR
-  # - For push events: group by branch name to prevent multiple releases on the same branch
-  group: ${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.workflow, inputs.pr) || github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.ref_name) }}
+  # Group concurrent runs to control cancellation per release type:
+  # - Canary releases (manual `workflow_dispatch`, or `pull_request` events on a
+  #   branch whose name ends with `with-canary-release`) are grouped by PR number,
+  #   so a newer canary supersedes an older one for the same PR. Only runs that
+  #   actually publish a canary join this group.
+  # - A `pull_request` event on any other branch publishes nothing (the
+  #   `publish-canary` job is skipped), so it gets its own group and never cancels
+  #   an in-progress canary — e.g. one triggered manually then followed by an
+  #   unrelated push to the same PR.
+  # - Pushes to release branches are grouped by branch name and never cancelled.
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && endsWith(github.head_ref, 'with-canary-release'))) && format('{0}-canary-{1}', github.workflow, github.event_name == 'workflow_dispatch' && inputs.pr || github.event.pull_request.number) || github.event_name == 'pull_request' && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.ref_name) }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Closes #

## What I did

Fixes an issue where triggering a canary publish and then pushing a commit to the PR would cancel the in-progress canary publish workflow.

### Root cause

In `.github/workflows/publish.yml`, the `concurrency` group resolved to the same value (`Publish-<PR-number>`) for both `workflow_dispatch` (manual canary) and `pull_request` events, with `cancel-in-progress: true`. Pushing a commit fires a `pull_request: synchronize` event whose Publish run lands in that same concurrency group and cancels the in-flight canary — even though that run publishes nothing, because the `publish-canary` job is skipped unless the head branch ends in `with-canary-release`. Concurrency cancellation happens at the workflow level, before job-level `if:` conditions are evaluated, so a no-op run ends up killing the real canary.

This is the publish-workflow analogue of the CircleCI trigger cancellation fixed in #35320.

### The fix

Only runs that actually produce a canary join the per-PR canary concurrency group (`Publish-canary-<PR>`):
- Manual canaries (`workflow_dispatch`) and automated canaries (`pull_request` on a `with-canary-release` branch) share `Publish-canary-<PR>`, preserving the documented "one canary per PR, newest supersedes older" behavior.
- A `pull_request` event on any other branch — which publishes nothing — gets its own `Publish-pr-<PR>` group, so it can no longer cancel an in-progress canary.
- Pushes to release branches are unchanged (grouped by branch name, never cancelled).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Trigger a manual canary on a PR (non-`with-canary-release` branch), then push a new commit to that PR. The canary publish run should continue rather than being cancelled.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

Slack thread: https://chromaticqa.slack.com/archives/D0BEADVU5RS/p1782831076776409?thread_ts=1782831039.290389&cid=D0BEADVU5RS

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6r8DkymZJMsVKmHsUwor1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow so canary releases run only on manual triggers, rather than automatically on pull request events.
  * Refined concurrency behavior to better separate canary, pull request, and push runs, reducing unintended cancellations of active canary work.
  * Simplified canary PR-number handling to rely on the manual input for subsequent steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->