### PR TITLE
Core: Fix symlinked stories directory misclassified as a file

### DIFF
--- a/code/core/src/common/utils/__tests__/normalize-stories-symlinks.test.ts
+++ b/code/core/src/common/utils/__tests__/normalize-stories-symlinks.test.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { normalizeStoriesEntry } from '../normalize-stories.ts';
+
+// Unlike normalize-stories.test.ts, this file deliberately does NOT mock
+// node:fs - it exercises normalizeStoriesEntry against a real symlink on
+// disk, which is the only way to catch a regression in how isDirectory()
+// resolves symlinked entries.
+describe('normalizeStoriesEntry with a real symlinked stories directory', () => {
+  let root: string;
+  let configDir: string;
+
+  beforeEach(() => {
+    // A `stories` folder that's a symlink to another package's folder is
+    // exactly what pnpm/yarn workspaces produce when two packages share a
+    // set of stories, or what a monorepo author wires up by hand.
+    root = mkdtempSync(join(tmpdir(), 'normalize-stories-symlinks-'));
+    configDir = join(root, '.storybook');
+    mkdirSync(configDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('treats a symlink to a real directory as a directory', () => {
+    const targetDir = join(root, 'shared-stories');
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(targetDir, 'Button.stories.tsx'), '');
+
+    symlinkSync(targetDir, join(configDir, 'stories-link'), 'dir');
+
+    const specifier = normalizeStoriesEntry('stories-link', {
+      configDir,
+      workingDir: configDir,
+    });
+
+    expect(specifier.files).toBe('**/*.@(mdx|stories.@(js|jsx|mjs|ts|tsx))');
+    expect(specifier.importPathMatcher.test('./stories-link/Button.stories.tsx')).toBe(true);
+  });
+
+  it('still treats a symlink to a file as a file', () => {
+    const targetFile = join(root, 'Button.stories.tsx');
+    writeFileSync(targetFile, '');
+
+    symlinkSync(targetFile, join(configDir, 'file-link.stories.tsx'), 'file');
+
+    const specifier = normalizeStoriesEntry('file-link.stories.tsx', {
+      configDir,
+      workingDir: configDir,
+    });
+
+    expect(specifier.files).toBe('file-link.stories.tsx');
+  });
+
+  it('does not throw on a dangling symlink, and treats it as a non-directory', () => {
+    symlinkSync(join(root, 'does-not-exist'), join(configDir, 'dangling-link'), 'dir');
+
+    const specifier = normalizeStoriesEntry('dangling-link', {
+      configDir,
+      workingDir: configDir,
+    });
+
+    expect(specifier.files).toBe('dangling-link');
+  });
+});

--- a/code/core/src/common/utils/normalize-stories.ts
+++ b/code/core/src/common/utils/normalize-stories.ts
@@ -1,4 +1,4 @@
-import { lstatSync } from 'node:fs';
+import { statSync } from 'node:fs';
 import { basename, dirname, relative, resolve } from 'node:path';
 
 import { InvalidStoriesEntryError } from 'storybook/internal/server-errors';
@@ -16,7 +16,12 @@ export const DEFAULT_FILES_PATTERN = '**/*.@(mdx|stories.@(js|jsx|mjs|ts|tsx))';
 
 const isDirectory = (configDir: string, entry: string) => {
   try {
-    return lstatSync(resolve(configDir, entry)).isDirectory();
+    // statSync (not lstatSync) follows symlinks, so a `stories` entry that's
+    // a symlink to a directory - e.g. a stories folder shared between
+    // packages in a pnpm/yarn workspace - is correctly recognized as a
+    // directory instead of being misclassified as a single file. A dangling
+    // symlink still throws (ENOENT) and is caught below, same as before.
+    return statSync(resolve(configDir, entry)).isDirectory();
   } catch (err) {
     return false;
   }


### PR DESCRIPTION
isDirectory() in normalize-stories.ts uses lstatSync, which inspects the symlink itself rather than what it points to. So if a `stories` entry is a symlink to a directory - the classic case being a shared stories folder in a pnpm/yarn workspace, symlinked into each package that needs it - it gets misclassified as a single file. The indexer then looks for a file with that name instead of globbing the directory, and quietly ends up with zero story files.

Swapped it for statSync, which follows symlinks to their target. Dangling symlinks still throw ENOENT and get caught the same way they did before, so that behavior is unchanged. Added a test that builds a real symlink on disk and runs it through normalizeStoriesEntry, plus checks the file/dangling-link cases so the fix doesn't regress anything nearby.

#### Manual testing

1. In a pnpm/yarn workspace, put a real stories folder in one package, e.g. `packages/shared/stories/Button.stories.tsx`.
2. In another package, symlink it in and reference that symlink from `stories` in `.storybook/main.ts`: `ln -s ../shared/stories packages/app/shared-stories`, then `stories: ['../app/shared-stories/**/*.stories.@(js|ts|tsx)']`.
3. Run Storybook. On `main`, the symlinked folder silently indexes zero stories. With this fix, the stories inside it show up normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved story path handling so symlinked directories are recognized correctly.
  * Symlinked story files now resolve as files as expected.
  * Dangling symlinks are handled safely without causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->