### PR TITLE
Core: Recognise .extend() calls as CSF factory stories in enrichCsfStory

### DIFF
--- a/code/core/src/csf-tools/enrichCsf.test.ts
+++ b/code/core/src/csf-tools/enrichCsf.test.ts
@@ -191,6 +191,64 @@ describe('enrichCsf', () => {
         };
       `);
     });
+    it('csf factories with .extend()', async () => {
+      expect(
+        await enrich(
+          dedent`
+          // compiled code
+          import {config} from "/.storybook/preview.ts";
+          const meta = config.meta({
+              args: {
+                label: "Hello world!"
+              }
+          });
+          export const Story = meta.story({});
+          export const Extended = Story.extend({});
+        `,
+          dedent`
+          // original code
+          import {config} from "#.storybook/preview.ts";
+          const meta = config.meta({
+              args: {
+                label: "Hello world!"
+              }
+          });
+          export const Story = meta.story({});
+          export const Extended = Story.extend({});
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        // compiled code
+        import { config } from "/.storybook/preview.ts";
+        const meta = config.meta({
+          args: {
+            label: "Hello world!"
+          }
+        });
+        export const Story = meta.story({});
+        export const Extended = Story.extend({});
+        Story.input.parameters = {
+          ...Story.input.parameters,
+          docs: {
+            ...Story.input.parameters?.docs,
+            source: {
+              originalSource: "meta.story({})",
+              ...Story.input.parameters?.docs?.source
+            }
+          }
+        };
+        Extended.input.parameters = {
+          ...Extended.input.parameters,
+          docs: {
+            ...Extended.input.parameters?.docs,
+            source: {
+              originalSource: "Story.extend({})",
+              ...Extended.input.parameters?.docs?.source
+            }
+          }
+        };
+      `);
+    });
     it('multiple stories', async () => {
       expect(
         await enrich(

--- a/code/core/src/csf-tools/enrichCsf.ts
+++ b/code/core/src/csf-tools/enrichCsf.ts
@@ -9,6 +9,26 @@ export interface EnrichCsfOptions {
   enrichCsf?: CsfEnricher;
 }
 
+const isMetaStoryFactory = (storyExport: t.Node) =>
+  t.isCallExpression(storyExport) &&
+  t.isMemberExpression(storyExport.callee) &&
+  t.isIdentifier(storyExport.callee.object) &&
+  storyExport.callee.object.name === 'meta';
+
+// A base declared in this same file (e.g. `Primary` in `Primary.extend(...)`) is only
+// trusted as a CSF factory if `CsfFile` itself recognized it as one; bases we can't
+// resolve locally (e.g. imported from another file) default to trusting `.extend()`.
+const isLocalNonFactoryStory = (csfSource: CsfFile, name: string) =>
+  name in csfSource._stories && !csfSource._stories[name].__stats?.factory;
+
+const isStoryExtendFactory = (storyExport: t.Node, csfSource: CsfFile) =>
+  t.isCallExpression(storyExport) &&
+  t.isMemberExpression(storyExport.callee) &&
+  t.isIdentifier(storyExport.callee.property) &&
+  storyExport.callee.property.name === 'extend' &&
+  t.isIdentifier(storyExport.callee.object) &&
+  !isLocalNonFactoryStory(csfSource, storyExport.callee.object.name);
+
 export const enrichCsfStory = (
   csf: CsfFile,
   csfSource: CsfFile,
@@ -17,11 +37,7 @@ export const enrichCsfStory = (
 ) => {
   const storyExport = csfSource.getStoryExport(key);
   const isCsfFactory =
-    t.isCallExpression(storyExport) &&
-    t.isMemberExpression(storyExport.callee) &&
-    ((t.isIdentifier(storyExport.callee.object) && storyExport.callee.object.name === 'meta') ||
-      (t.isIdentifier(storyExport.callee.property) &&
-        storyExport.callee.property.name === 'extend'));
+    isMetaStoryFactory(storyExport) || isStoryExtendFactory(storyExport, csfSource);
   const source = !options?.disableSource && extractSource(storyExport);
   const description =
     !options?.disableDescription && extractDescription(csfSource._storyStatements[key]);

--- a/code/core/src/csf-tools/enrichCsf.ts
+++ b/code/core/src/csf-tools/enrichCsf.ts
@@ -19,8 +19,9 @@ export const enrichCsfStory = (
   const isCsfFactory =
     t.isCallExpression(storyExport) &&
     t.isMemberExpression(storyExport.callee) &&
-    t.isIdentifier(storyExport.callee.object) &&
-    storyExport.callee.object.name === 'meta';
+    ((t.isIdentifier(storyExport.callee.object) && storyExport.callee.object.name === 'meta') ||
+      (t.isIdentifier(storyExport.callee.property) &&
+        storyExport.callee.property.name === 'extend'));
   const source = !options?.disableSource && extractSource(storyExport);
   const description =
     !options?.disableDescription && extractDescription(csfSource._storyStatements[key]);

--- a/code/core/src/csf-tools/enrichCsf.ts
+++ b/code/core/src/csf-tools/enrichCsf.ts
@@ -9,11 +9,11 @@ export interface EnrichCsfOptions {
   enrichCsf?: CsfEnricher;
 }
 
-const isMetaStoryFactory = (storyExport: t.Node) =>
+const isMetaStoryFactory = (storyExport: t.Node, csfSource: CsfFile) =>
   t.isCallExpression(storyExport) &&
   t.isMemberExpression(storyExport.callee) &&
   t.isIdentifier(storyExport.callee.object) &&
-  storyExport.callee.object.name === 'meta';
+  storyExport.callee.object.name === csfSource._metaVariableName;
 
 // A base declared in this same file (e.g. `Primary` in `Primary.extend(...)`) is only
 // trusted as a CSF factory if `CsfFile` itself recognized it as one; bases we can't
@@ -37,7 +37,7 @@ export const enrichCsfStory = (
 ) => {
   const storyExport = csfSource.getStoryExport(key);
   const isCsfFactory =
-    isMetaStoryFactory(storyExport) || isStoryExtendFactory(storyExport, csfSource);
+    isMetaStoryFactory(storyExport, csfSource) || isStoryExtendFactory(storyExport, csfSource);
   const source = !options?.disableSource && extractSource(storyExport);
   const description =
     !options?.disableDescription && extractDescription(csfSource._storyStatements[key]);


### PR DESCRIPTION
Closes #35338

## What I did

The `isCsfFactory` check in `enrichCsfStory` only matched `meta.story()` calls by testing `callee.object.name === 'meta'`. For `.extend()` calls, the callee object is the base story (e.g. Primary), so `isCsfFactory` was always false.

This caused `enrichCsfStory` to write docs parameters to `story.parameters` instead of `story.input.parameters`. Since Storybook reads the latter for CSF factory stories, the JSDoc descriptions  never appear one the Docs page `.extend()` stories.

Extends the check to also match any `.extend()` call expression.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Clone https://github.com/kurtdoherty/urban-memory
2. Run `yarn install` and `yarn storybook`
4. Navigate to the Docs page for the Button component and observe the absence of JS doc for MyButton's Secondary story.
5. Manually apply the fix to Storybook's source (I used `yarn patch`)
6. Rerun `yarn storybook` and observe the presence of JS doc for MyButton's Secondary story.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->