### PR TITLE
feat: add useRaw option for object controls

### DIFF
--- a/code/addons/docs/src/blocks/controls/Object.stories.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.stories.tsx
@@ -30,6 +30,17 @@ export const Object: Story = {
   },
 };
 
+export const RawByDefault: Story = {
+  args: {
+    value: {
+      name: 'Michael',
+      someDate: new Date('2022-10-30T12:31:11'),
+      nested: { someBool: true, someNumber: 22 },
+    },
+    useRaw: true,
+  },
+};
+
 export const Array: Story = {
   args: {
     value: [

--- a/code/addons/docs/src/blocks/controls/Object.stories.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.stories.tsx
@@ -30,14 +30,14 @@ export const Object: Story = {
   },
 };
 
-export const RawByDefault: Story = {
+export const JsonByDefault: Story = {
   args: {
     value: {
       name: 'Michael',
       someDate: new Date('2022-10-30T12:31:11'),
       nested: { someBool: true, someNumber: 22 },
     },
-    useRaw: true,
+    defaultEditor: 'json',
   },
 };
 

--- a/code/addons/docs/src/blocks/controls/Object.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.tsx
@@ -171,11 +171,11 @@ export const ObjectControl: FC<ObjectProps> = ({
   onChange,
   argType,
   required,
-  useRaw,
+  defaultEditor,
 }) => {
   const data = useMemo(() => value && cloneDeep(value), [value]);
   const hasData = data !== null && data !== undefined;
-  const [showRaw, setShowRaw] = useState(() => useRaw === true || !hasData);
+  const [showRaw, setShowRaw] = useState(() => defaultEditor === 'json' || !hasData);
   const hadDataRef = useRef(hasData);
 
   const [parseError, setParseError] = useState<Error | null>(null);

--- a/code/addons/docs/src/blocks/controls/Object.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.tsx
@@ -171,10 +171,11 @@ export const ObjectControl: FC<ObjectProps> = ({
   onChange,
   argType,
   required,
+  useRaw,
 }) => {
   const data = useMemo(() => value && cloneDeep(value), [value]);
   const hasData = data !== null && data !== undefined;
-  const [showRaw, setShowRaw] = useState(!hasData);
+  const [showRaw, setShowRaw] = useState(() => useRaw === true || !hasData);
   const hadDataRef = useRef(hasData);
 
   const [parseError, setParseError] = useState<Error | null>(null);

--- a/code/addons/docs/src/blocks/controls/types.ts
+++ b/code/addons/docs/src/blocks/controls/types.ts
@@ -50,7 +50,10 @@ export interface NumberConfig {
 export type RangeConfig = NumberConfig;
 
 export type ObjectValue = any;
-export interface ObjectConfig {}
+export interface ObjectConfig {
+  /** Show the raw JSON editor by default for object controls. */
+  useRaw?: boolean;
+}
 
 export type OptionsSingleSelection = any;
 export type OptionsMultiSelection = any[];

--- a/code/addons/docs/src/blocks/controls/types.ts
+++ b/code/addons/docs/src/blocks/controls/types.ts
@@ -51,8 +51,8 @@ export type RangeConfig = NumberConfig;
 
 export type ObjectValue = any;
 export interface ObjectConfig {
-  /** Show the raw JSON editor by default for object controls. */
-  useRaw?: boolean;
+  /** Show the JSON editor by default for object controls. */
+  defaultEditor?: 'object' | 'json';
 }
 
 export type OptionsSingleSelection = any;

--- a/docs/api/arg-types.mdx
+++ b/docs/api/arg-types.mdx
@@ -84,6 +84,7 @@ Type:
     max?: number;
     min?: number;
     presetColors?: string[];
+    useRaw?: boolean;
     step?: number;
   }
 | false
@@ -120,7 +121,7 @@ Specifies the type of control used to change the arg value with the [controls pa
 | **number**  | `'number'`       | Provides a numeric input to include the range of all possible values.<br /> `{ control: { type: 'number', min:1, max:30, step: 2 } }`                                                   |
 |             | `'range'`        | Provides a range slider to include all possible values.<br /> `{ control: { type: 'range', min: 1, max: 30, step: 3 } }`                                                                |
 | **object**  | `'file'`         | Provides a file input that returns an array of URLs. Can be further customized to accept specific file types.<br /> `{ control: { type: 'file', accept: '.png' } }`                     |
-|             | `'object'`       | Provides a JSON-based editor to handle the object's values. Also allows editing in raw mode.<br /> `{ control: 'object' }`                                                              |
+|             | `'object'`       | Provides a JSON-based editor to handle the object's values. Also allows editing in raw mode.<br /> `{ control: { type: 'object', useRaw: true } }`                                      |
 | **string**  | `'color'`        | Provides a color picker to choose color values. Can be additionally configured to include a set of color presets.<br /> `{ control: { type: 'color', presetColors: ['red', 'green']} }` |
 |             | `'date'`         | Provides a datepicker to choose a date.<br /> `{ control: 'date' }`                                                                                                                     |
 |             | `'text'`         | Provides a freeform text input.<br /> `{ control: 'text' }`                                                                                                                             |
@@ -160,6 +161,12 @@ When `type` is `'number'` or `'range'`, sets the minimum allowed value.
 Type: `string[]`
 
 When `type` is `'color'`, defines the set of colors that are available in addition to the general color picker. The values in the array should be valid CSS color values.
+
+#### `control.useRaw`
+
+Type: `boolean`
+
+When `type` is `'object'`, set to `true` to show the raw JSON editor by default.
 
 #### `control.step`
 

--- a/docs/api/arg-types.mdx
+++ b/docs/api/arg-types.mdx
@@ -84,7 +84,7 @@ Type:
     max?: number;
     min?: number;
     presetColors?: string[];
-    useRaw?: boolean;
+    defaultEditor?: 'object' | 'json';
     step?: number;
   }
 | false
@@ -110,7 +110,7 @@ Specifies the type of control used to change the arg value with the [controls pa
 
 | Data type   | ControlType      | Description                                                                                                                                                                             |
 | ----------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **array**   | `'object'`       | Provides a JSON-based editor to handle the values of the array. Also allows editing in raw mode.<br /> `{ control: 'object' }`                                                          |
+| **array**   | `'object'`       | Provides a JSON-based editor to handle the values of the array. Also allows editing in the JSON editor by default.<br /> `{ control: 'object' }`                                        |
 | **boolean** | `'boolean'`      | Provides a toggle for switching between possible states.<br /> `{ control: 'boolean' }`                                                                                                 |
 | **enum**    | `'check'`        | Provides a set of stacked checkboxes for selecting multiple options.<br /> `{ control: 'check', options: ['email', 'phone', 'mail'] }`                                                  |
 |             | `'inline-check'` | Provides a set of inlined checkboxes for selecting multiple options.<br /> `{ control: 'inline-check', options: ['email', 'phone', 'mail'] }`                                           |
@@ -121,7 +121,7 @@ Specifies the type of control used to change the arg value with the [controls pa
 | **number**  | `'number'`       | Provides a numeric input to include the range of all possible values.<br /> `{ control: { type: 'number', min:1, max:30, step: 2 } }`                                                   |
 |             | `'range'`        | Provides a range slider to include all possible values.<br /> `{ control: { type: 'range', min: 1, max: 30, step: 3 } }`                                                                |
 | **object**  | `'file'`         | Provides a file input that returns an array of URLs. Can be further customized to accept specific file types.<br /> `{ control: { type: 'file', accept: '.png' } }`                     |
-|             | `'object'`       | Provides a JSON-based editor to handle the object's values. Also allows editing in raw mode.<br /> `{ control: { type: 'object', useRaw: true } }`                                      |
+|             | `'object'`       | Provides a JSON-based editor to handle the object's values. Also allows editing in the JSON editor by default.<br /> `{ control: { type: 'object', defaultEditor: 'json' } }`           |
 | **string**  | `'color'`        | Provides a color picker to choose color values. Can be additionally configured to include a set of color presets.<br /> `{ control: { type: 'color', presetColors: ['red', 'green']} }` |
 |             | `'date'`         | Provides a datepicker to choose a date.<br /> `{ control: 'date' }`                                                                                                                     |
 |             | `'text'`         | Provides a freeform text input.<br /> `{ control: 'text' }`                                                                                                                             |
@@ -162,11 +162,11 @@ Type: `string[]`
 
 When `type` is `'color'`, defines the set of colors that are available in addition to the general color picker. The values in the array should be valid CSS color values.
 
-#### `control.useRaw`
+#### `control.defaultEditor`
 
-Type: `boolean`
+Type: `'object' | 'json'`
 
-When `type` is `'object'`, set to `true` to show the raw JSON editor by default.
+When `type` is `'object'`, set to `'json'` to show the JSON editor by default.
 
 #### `control.step`
 


### PR DESCRIPTION
Closes #15900

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added a `defaultEditor` option for object controls so users can configure which editor opens by default through `argTypes`.

This enables the following API:

```ts
argTypes: {
  data: {
    control: {
      type: 'object',
      defaultEditor: 'json',
    },
  },
}
```

The default behavior is preserved unless `defaultEditor: 'json'` is explicitly provided. By default, object controls continue to open in the object editor.

This PR also adds a story demonstrating the new behavior and updates the `argTypes.control` documentation.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

To manually verify this change:

1. Start Storybook locally:

   ```sh
   yarn start
   ```

2. Open the local Storybook URL printed in the terminal.

3. In the sidebar, open the object control stories from `Object.stories.tsx`.

4. Select the default object control story and open the Controls panel.

5. Verify that the object control opens in the object editor by default.

6. Select the story that uses `defaultEditor: 'json'`.

7. Open the Controls panel and verify that the object control opens directly in the JSON editor.

8. Toggle back to the object editor and verify that both editor modes remain available.

9. Edit a value in the JSON editor, blur the textarea, and verify that the control value updates.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
  [[[MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:

   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading dependencies).
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team [[here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml)](https://github.com/storybookjs/storybook/actions/workflows/publish.yml).

*core team members can create a canary release [[here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml)](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`*

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

<!-- BENCHMARK_SECTION -->