### PR TITLE
Telemetry: Prevent pnpm paths from leaking into framework.name

### DIFF
--- a/code/core/src/common/utils/get-framework-name.test.ts
+++ b/code/core/src/common/utils/get-framework-name.test.ts
@@ -12,6 +12,19 @@ describe('get-framework-name', () => {
       );
     });
 
+    it('should extract the proper framework name from pnpm virtual-store paths', () => {
+      // pnpm resolves getAbsolutePath('@storybook/react-vite') to a path inside .pnpm
+      expect(
+        extractFrameworkPackageName(
+          '/repo/node_modules/.pnpm/@storybook+react-vite@9.0.0/node_modules/@storybook/react-vite'
+        )
+      ).toBe('@storybook/react-vite');
+      // ...or to the virtual-store dir itself, which does not end with the package name
+      expect(
+        extractFrameworkPackageName('/repo/node_modules/.pnpm/@storybook+react-vite@9.0.0')
+      ).toBe('@storybook/react-vite');
+    });
+
     it('should return the given framework name if it is a third-party framework', () => {
       expect(extractFrameworkPackageName('@third-party/framework')).toBe('@third-party/framework');
     });

--- a/code/core/src/common/utils/get-framework-name.ts
+++ b/code/core/src/common/utils/get-framework-name.ts
@@ -33,7 +33,14 @@ export async function getFrameworkName(options: Options) {
  */
 export const extractFrameworkPackageName = (framework: string) => {
   const normalizedPath = normalizePath(framework);
-  const frameworkName = Object.keys(frameworkPackages).find((pkg) => normalizedPath.endsWith(pkg));
+  const frameworkName = Object.keys(frameworkPackages).find(
+    (pkg) =>
+      normalizedPath.endsWith(pkg) ||
+      // pnpm virtual-store dirs encode the scope slash as '+' and append '@<version>',
+      // e.g. .../node_modules/.pnpm/@storybook+react-vite@9.0.0 — the trailing '@' keeps
+      // '@storybook/react' from matching '@storybook+react-vite@...'.
+      normalizedPath.includes(`/.pnpm/${pkg.replace('/', '+')}@`)
+  );
 
   return frameworkName ?? framework;
 };

--- a/code/core/src/telemetry/get-framework-info.test.ts
+++ b/code/core/src/telemetry/get-framework-info.test.ts
@@ -36,6 +36,21 @@ describe('getFrameworkInfo', () => {
     expect(getStorybookInfo).toHaveBeenCalledWith(configDir);
   });
 
+  it('decodes pnpm virtual-store paths so no version-bearing fragment leaks', async () => {
+    const { getStorybookInfo } = await import('storybook/internal/common');
+    vi.mocked(getStorybookInfo).mockResolvedValue({
+      frameworkPackage: '/repo/node_modules/.pnpm/@storybook+react-vite@9.0.0',
+      rendererPackage: '/repo/node_modules/.pnpm/@storybook+react@9.0.0_typescript@5.0.0',
+      builderPackage: '/repo/node_modules/.pnpm/@storybook+builder-vite@9.0.0',
+    } as any);
+
+    const result = await getFrameworkInfo({} as StorybookConfig, '/tmp/.storybook');
+
+    expect(result.framework.name).toBe('@storybook/react-vite');
+    expect(result.renderer).toBe('@storybook/react');
+    expect(result.builder).toBe('@storybook/builder-vite');
+  });
+
   it('returns provided framework options when object is passed', async () => {
     const options = { foo: 'bar' } as any;
     const result = await getFrameworkInfo(

--- a/code/core/src/telemetry/get-framework-info.ts
+++ b/code/core/src/telemetry/get-framework-info.ts
@@ -4,7 +4,13 @@ import type { StorybookConfig } from 'storybook/internal/types';
 import { cleanPaths } from './sanitize.ts';
 
 const cleanAndSanitizePath = (path: string) => {
-  return cleanPaths(path).replace(/.*node_modules[\\/]/, '');
+  const cleaned = cleanPaths(path).replace(/.*node_modules[\\/]/, '');
+  // A pnpm virtual-store dir leaks through when the resolved path points at
+  // `.pnpm/<name>@<version>` rather than its inner node_modules. Decode the real
+  // package name (scope slash is encoded as '+') so telemetry stays stable across
+  // versions and peer-dep suffixes (e.g. `@9.0.0_typescript@5.0.0`).
+  const pnpmDir = cleaned.match(/^\.pnpm\/(.+?)@[^/]+$/);
+  return pnpmDir ? pnpmDir[1].replace('+', '/') : cleaned;
 };
 
 export async function getFrameworkInfo(mainConfig: StorybookConfig, configDir: string) {


### PR DESCRIPTION
## What I did

`framework.name` telemetry was sometimes recorded as a pnpm virtual-store path rather than the package name.

Users commonly configure `framework: { name: getAbsolutePath('@storybook/react-vite') }`, so `framework.name` becomes an absolute resolved path. Under pnpm that path can be `.../node_modules/.pnpm/@storybook+react-vite@9.0.0` (ending at the virtual-store dir, without the inner `node_modules/@storybook/react-vite`). This polluted telemetry and, because the fragment embeds the version, made the value unstable across releases — which breaks Chromatic's reliance on a stable `framework.name` in `project.json`.

### Fix — two leak sites

1. `code/core/src/common/utils/get-framework-name.ts` — `extractFrameworkPackageName` previously only matched a known framework via `normalizedPath.endsWith(pkg)`, which misses the pnpm virtual-store dir and fell back to returning the raw path. It now also matches when the path contains `/.pnpm/<pkg-with-scope-slash-as-plus>@` (the trailing `@` prevents `@storybook/react` from matching `@storybook+react-vite@...`), mapping it back to the clean package name.
2. `code/core/src/telemetry/get-framework-info.ts` — `cleanAndSanitizePath`'s greedy `.*node_modules[\\/]` regex left the `.pnpm/@storybook+react-vite@<version>` tail intact. As defense-in-depth (this also covers third-party frameworks), it now decodes a leaked `.pnpm/<name>@<version>` tail back to the real package name.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Added unit tests to:

- `get-framework-name.test.ts` — both pnpm path shapes resolve to `@storybook/react-vite`, and the third-party fallback is preserved.
- `get-framework-info.test.ts` — end-to-end via the public `getFrameworkInfo`, including a peer-dep-suffixed path.

> [!NOTE]
> Local `yarn install` failed repeatedly due to registry network read errors in the execution environment, so vitest/typecheck/lint could not be run locally. Both functions' logic was verified with standalone Node probes replicating the exact implementation (all pnpm / scoped / unscoped / peer-suffixed / third-party cases pass). Please rely on CI to run the full suite.

#### Manual testing

1. Create a sandbox that resolves the framework through pnpm's virtual store, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`, with `framework: { name: getAbsolutePath('@storybook/react-vite') }` in `.storybook/main.ts`.
2. Enable telemetry debug logging (`STORYBOOK_TELEMETRY_DEBUG=1`) and start Storybook.
3. Inspect the emitted telemetry payload and confirm `framework.name` is the clean package name `@storybook/react-vite` rather than a `.pnpm/@storybook+react-vite@<version>` path.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update MIGRATION.MD

This is an internal bug fix with no user-facing documentation impact.

---

Slack thread: https://chromaticqa.slack.com/archives/C08702VG12T/p1782986954803969?thread_ts=1782960937.073919&cid=C08702VG12T