### PR TITLE
CI: fold format check and Knip into one static-checks job

### DIFF
--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -274,8 +274,15 @@ export const check = defineJob(
   [commonJobsNoOpJob]
 );
 
+/**
+ * ESLint, format check and Knip in one job: each is cheap next to the ~50s of
+ * spin-up + checkout + workspace restore a dedicated job pays, and none of
+ * them is anywhere near the workflow critical path. The standalone `fmt` job
+ * remains for the docs workflow, which has no build job to restore a
+ * workspace from.
+ */
 export const lint = defineJob(
-  'ESLint',
+  'Static checks',
   () => ({
     executor: {
       name: 'sb_node_22_classic',
@@ -283,6 +290,12 @@ export const lint = defineJob(
     },
     steps: [
       ...workflow.restoreLinux(),
+      {
+        run: {
+          name: 'Format check',
+          command: 'yarn fmt:check',
+        },
+      },
       {
         run: {
           name: 'Lint code JS',
@@ -297,20 +310,6 @@ export const lint = defineJob(
           command: 'yarn lint',
         },
       },
-    ],
-  }),
-  [commonJobsNoOpJob]
-);
-
-export const knip = defineJob(
-  'Knip validation',
-  () => ({
-    executor: {
-      name: 'sb_node_22_classic',
-      class: 'medium',
-    },
-    steps: [
-      ...workflow.restoreLinux(),
       {
         run: {
           name: 'Run Knip',

--- a/scripts/ci/main.ts
+++ b/scripts/ci/main.ts
@@ -12,7 +12,6 @@ import {
   commonJobsNoOpJob,
   defineCircleciCompletion,
   docgenMemoryGate,
-  knip,
   lint,
   fmt,
   internalStorybookBuildE2e,
@@ -65,9 +64,7 @@ function generateConfig(workflow: Workflow) {
 
       commonJobsNoOpJob,
       lint,
-      fmt,
       check,
-      knip,
 
       storybookChromatic,
       internalStorybookE2e,


### PR DESCRIPTION
Follow-up to #35343, part of the per-job fixed-overhead lead (~50s spin-up + checkout + workspace restore per job).

## What

ESLint (177s), Knip validation (109s) and format check (79s) each paid the fixed setup cost per pipeline; format-check additionally ran its own 46s `yarn install` because it never attached the workspace. They merge into one **Static checks** job (large executor, workspace-restored), ordered format → eslint → knip for the fastest failure signal. Knip keeps `--no-exit-code` (it was already informational-only).

The standalone `format-check` job remains in the **docs** workflow, which has no build job to restore a workspace from.

## Expected effect (baseline workflow `a65d3769-97c8-479f-aaae-39f92a2cb874`)

| | Before | After |
| --- | --- | --- |
| Jobs | 3 (eslint 177s + knip 109s + format-check 79s = 365s summed) | 1 (~240s expected) |
| Wall impact | none (all three end well before the sandbox tail) | none |

No check is removed or weakened; all three commands run unchanged.

_Measured numbers will be updated from the CI run on this PR._