### PR TITLE
CI: re-enable the NX cache for CI compiles

### DIFF
--- a/scripts/tasks/compile.ts
+++ b/scripts/tasks/compile.ts
@@ -36,10 +36,7 @@ export const compile: Task = {
     const command = link && !prod ? linkCommand : noLinkCommand;
     await rm(join(codeDir, 'bench/esbuild-metafiles'), { recursive: true, force: true });
     return exec(
-      // NX cache is disabled in Circle CI during the NX Cloud experiment so we can
-      // measure the true cost of NX Cloud agents without local cache hits.
-      // This will be reverted once the experiment concludes.
-      `${command} ${skipCache || process.env.CI ? '--skip-nx-cache' : ''}`,
+      `${command} ${skipCache ? '--skip-nx-cache' : ''}`,
       { cwd: ROOT_DIRECTORY },
       {
         startMessage: '🥾 Bootstrapping',


### PR DESCRIPTION
Follow-up to #35343 (Lead: re-enable NX remote cache). The `--skip-nx-cache` flag on CI was a leftover of the concluded NX Cloud agents experiment - its own comment said it "will be reverted once the experiment concludes". The build--linux Compile log confirms the flag fully disconnects Nx Cloud: *"--skip-nx-cache disables the connection to Nx Cloud for the current run. The remote cache will not be read from or written to."*

## What

`yarn task compile` no longer forces `--skip-nx-cache` on CI; the explicit `--skip-cache` task flag still works (and the #35341 determinism verification keeps using it).

## Safety

- **Correctness**: cache inputs cover the whole build toolchain (`sharedGlobals` = `scripts/**/*` + `code/tsconfig.json`; `production` = project sources minus tests/stories), and #35341 made d.ts emission byte-identical across clean runs, so a cache restore is equivalent to a rebuild. To verify by measurement here: a lockfile-only change must produce a cache miss.
- **Fork PRs**: forks get no Nx Cloud token from CircleCI, so the client degrades to a warning + uncached compile. Will confirm the exact behavior from an untrusted pipeline before undrafting.
- The determinism gate from #35341 is untouched (that script passes `--skip-cache` explicitly).

## Measurement plan (before undraft)

| Scenario | Compile step | 
| --- | --- |
| Baseline (skip-nx-cache), job 1697302 | 59s |
| Cache-miss run (first pipeline on this PR) | _pending_ |
| Cache-hit run (re-run / follow-up push) | _pending_ |

If Nx Cloud turns out to have no usable token on CI (no read access), this PR gets closed with that measurement noted.