### PR TITLE
CI: Build sandbox static output inside the create job

### DIFF
--- a/scripts/ci/sandboxes.ts
+++ b/scripts/ci/sandboxes.ts
@@ -34,39 +34,6 @@ function getSandboxSetupSteps(template: string) {
   return extraSteps;
 }
 
-function defineSandboxJob_build({
-  directory,
-  name,
-  template,
-  requires,
-}: {
-  directory: string;
-  name: string;
-  requires: JobOrNoOpJob[];
-  template: string;
-}) {
-  return defineJob(
-    name,
-    () => ({
-      executor: {
-        name: 'sb_node_22_classic',
-        class: 'medium+',
-      },
-      steps: [
-        ...getSandboxSetupSteps(template),
-        ...workflow.restoreLinux({ sandboxId: directory }),
-        {
-          run: {
-            name: 'Build storybook',
-            command: `yarn task build --template ${template} --no-link -s build`,
-          },
-        },
-        workspace.persist([`${SANDBOX_DIR}/${directory}/storybook-static`]),
-      ],
-    }),
-    requires
-  );
-}
 function defineSandboxJob_dev({
   directory,
   name,
@@ -224,6 +191,16 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
               },
             ]
           : []),
+        {
+          // Built here rather than in a dedicated job: a separate build job
+          // paid ~55s of fixed setup plus a workspace round-trip, and it sat
+          // between create and the e2e/chromatic/vitest jobs on the critical
+          // path. The static build lands inside the sandbox tarball below.
+          run: {
+            name: 'Build storybook',
+            command: `yarn task build --template ${key} --no-link -s build`,
+          },
+        },
         artifact.persist(`${LINUX_ROOT_DIR}/${SANDBOX_DIR}/${id}/debug-storybook.log`, 'logs'),
         workspace.packSandbox(id),
         workspace.persist([sandboxArchive(id)]),
@@ -231,12 +208,6 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
     }),
     [sandboxesNoOpJob]
   );
-  const buildJob = defineSandboxJob_build({
-    name: `${name} (build)`,
-    template: key,
-    directory: id,
-    requires: [createJob],
-  });
   const devJob = defineSandboxJob_dev({
     name: `${name} (dev)`,
     template: key,
@@ -275,7 +246,7 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         },
       ],
     }),
-    [buildJob]
+    [createJob]
   );
   const vitestJob = defineJob(
     `${name} (vitest)`,
@@ -302,7 +273,7 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         testResults.persist(join(LINUX_ROOT_DIR, WORKING_DIR, 'test-results')),
       ],
     }),
-    [buildJob]
+    [createJob]
   );
   const e2eJob = defineJob(
     `${name} (e2e)`,
@@ -342,7 +313,7 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         testResults.persist(join(LINUX_ROOT_DIR, WORKING_DIR, 'test-results')),
       ],
     }),
-    [buildJob]
+    [createJob]
   );
   const testRunnerJob = defineJob(
     `${name} (test-runner)`,
@@ -363,12 +334,11 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         testResults.persist(join(LINUX_ROOT_DIR, WORKING_DIR, 'test-results')),
       ],
     }),
-    [buildJob]
+    [createJob]
   );
 
   const jobs = [
     createJob,
-    buildJob,
     devJob,
     !skipTasks?.includes('chromatic') ? chromaticJob : undefined,
     !skipTasks?.includes('vitest-integration') ? vitestJob : undefined,
@@ -391,12 +361,14 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
     name: key,
     path,
     jobs,
+    createJob,
+    devJob,
   };
 }
 
 export function defineSandboxTestRunner(sandbox: ReturnType<typeof defineSandboxFlow>) {
   return defineJob(
-    `${sandbox.jobs[1].id}-test-runner`,
+    `${sandbox.id}--test-runner`,
     () => ({
       executor: {
         name: 'sb_playwright',
@@ -414,13 +386,13 @@ export function defineSandboxTestRunner(sandbox: ReturnType<typeof defineSandbox
         testResults.persist(join(LINUX_ROOT_DIR, WORKING_DIR, 'test-results')),
       ],
     }),
-    [sandbox.jobs[1]]
+    [sandbox.createJob]
   );
 }
 
 export function defineWindowsSandboxDev(sandbox: ReturnType<typeof defineSandboxFlow>) {
   return defineJob(
-    `${sandbox.jobs[2].id}-windows`,
+    `${sandbox.devJob.id}-windows`,
     () => ({
       executor: {
         name: 'win/default',
@@ -464,13 +436,13 @@ export function defineWindowsSandboxDev(sandbox: ReturnType<typeof defineSandbox
         testResults.persist(`${WINDOWS_ROOT_DIR}\\${WORKING_DIR}\\test-results`),
       ],
     }),
-    [sandbox.jobs[0]]
+    [sandbox.createJob]
   );
 }
 
 export function defineWindowsSandboxBuild(sandbox: ReturnType<typeof defineSandboxFlow>) {
   return defineJob(
-    `${sandbox.jobs[1].id}-windows`,
+    `${sandbox.id}--build-windows`,
     () => ({
       executor: {
         name: 'win/default',

--- a/scripts/ci/sandboxes.ts
+++ b/scripts/ci/sandboxes.ts
@@ -192,10 +192,6 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
             ]
           : []),
         {
-          // Built here rather than in a dedicated job: a separate build job
-          // paid ~55s of fixed setup plus a workspace round-trip, and it sat
-          // between create and the e2e/chromatic/vitest jobs on the critical
-          // path. The static build lands inside the sandbox tarball below.
           run: {
             name: 'Build storybook',
             command: `yarn task build --template ${key} --no-link -s build`,


### PR DESCRIPTION
Follow-up to #35343. Was stacked on #35350; now rebased directly onto `next` (#35347 and #35348 have merged), so the diff is the single build-in-create commit. Removes one full job level from every sandbox template's static chain.

## Why

After the Playwright-workers win (#35347), the workflow tail shifts to the four-level chain **build-linux → create → build → {e2e, chromatic, vitest}**. The standalone `(build)` job averages ~74s, of which ~50s is fixed setup (spin-up, checkout, attach, unpack) around a ~25-45s actual build - and every downstream job waits for it plus another workspace round-trip. Measured on the baseline below: 25 build jobs, 1,843s summed, of which 1,243s is non-build overhead.

## What

- `yarn task build` runs at the end of the `(create)` job, before the sandbox is packed, so `storybook-static` travels inside the existing per-template sandbox tarball (#35348).
- `(e2e)`, `(chromatic)`, `(vitest)` and `(test-runner)` depend on `(create)` directly.
- The standalone build jobs disappear: 17 from the normal workflow, 25 from merged, 42 from daily.
- Windows sandbox jobs / daily test-runner referenced flow jobs by array index; they use named references now (`sandbox.createJob` / `sandbox.devJob` / `sandbox.id`).

Coverage unchanged: the same `yarn task build` runs with the same inputs and assertions, one job earlier. `saveBench('build')` records identical data (it runs inside the task, not the job), and no generated workflow consumed the bench task output.

### Benchmark (measured)

Both sides are `ci:merged` runs on the same code state: baseline is `next` at the #35348 merge ([workflow `cfc64fdc`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127446/workflows/cfc64fdc-7d7b-4d27-98d7-fccecab36f75)), this PR is that plus the build-in-create commit ([workflow `fdfc525e`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127449/workflows/fdfc525e-4cc1-4e5a-9f6e-2d394285a92a)). Both fully green.

| Metric | `next` baseline | This PR |
| --- | --- | --- |
| Workflow jobs | 144 | 119 (25 standalone build jobs removed) |
| Standalone build jobs, durations summed | 1,843s | 0s (jobs removed) |
| "Build storybook" steps inside create, summed | - | 422s |
| create jobs, durations summed | 4,043s | 4,172s (+3%) |
| e2e/chromatic/vitest start offset, avg of 44 jobs | 456s | 377s (-79s avg, up to -195s) |
| e2e "Running E2E Tests" summed | 970s | 977s (1.01x) |
| dev-family "Running E2E Tests" summed | 3,011s | 3,088s (1.03x) |
| Sandbox-family job time summed | 17,955s | 15,760s (-12%) |
| **Workflow wall** | **820s** | **758s** (independent rerun: 771s) |

The in-create builds sum to 422s where the standalone jobs spent ~600s building - the sandbox is already warm on disk and the create executor is larger - and the ~1,243s of per-job fixed overhead disappears outright. Downstream jobs start 79s earlier on average because the chain is one level shorter. The flat e2e/dev numbers (and vitest: 668s -> 716s over 12 jobs, within noise) confirm nothing regressed functionally. Wall clock is contention-noisy across runs, but both PR runs came in ~50-60s faster than the same-tree baseline (758s and 771s vs 820s).

### Cost

Per fully-executed run: the removed build jobs are ~460 credits of medium+ on `ci:merged` (25 jobs, measured 1,843s) against ~140 credits of added large-class create time (~420s), so ≈ **-320 credits per merged run**; normal (17 build jobs) nets ≈ -255 and daily (42) ≈ -540. Fleet-wide, CircleCI Insights (last 30 days, all branches): the standalone `---build` job class ran 21,580 times for ~421k credits - 8.4% of the total ~5.0M credits of CI spend - and is removed entirely, while ~126k credits/30d get added back inside the create jobs (22,530 create runs × ~17s of large). Net ≈ **-295k credits/30d ≈ -3.6M credits/yr (~$2,150/yr)**. Workspace storage improves slightly as well: per merged run, 95 MiB of raw `storybook-static` layers disappear while the sandbox tarballs grow only 78 MiB (the static ships zstd-compressed inside them), so total persisted bytes drop ~17 MiB.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [x] integration tests
- [x] end-to-end tests

Every sandbox job on this PR's CI run exercises the new path: the e2e/chromatic/vitest/test-runner jobs consume `storybook-static` exclusively from the create-time sandbox tarball, so a missing or broken static build fails the whole downstream family.

#### Manual testing

1. ~On this PR's `ci:merged` run: every `(create)` job must show "Build storybook" between "Create Sandbox" and "Pack sandbox for workspace", and the workflow must contain no standalone `(build)` jobs.~ Done: [workflow `fdfc525e`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127449/workflows/fdfc525e-4cc1-4e5a-9f6e-2d394285a92a), 119/119 jobs green.
2. ~Verify e2e, chromatic and vitest jobs stay green with no extra restore step (they get `storybook-static` from the sandbox tarball).~ Done, same run.
3. ~Before merge: run `ci:daily` once to exercise the renamed daily-only jobs (`react-vite-default-ts--build-windows`, `react-vite-default-ts--test-runner`) and the Windows unpack of the now-larger sandbox tarball.~ Done: [workflow `196a3e91`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127493/workflows/196a3e91-e8eb-44be-bf99-c5fd288e83ec), **189/189 jobs green** - `react-vite-default-ts--build-windows` 637s and `react-latest--vite---typescript---dev-windows` 845s match their pre-rename baselines (639s/850s), `react-vite-default-ts--test-runner` 204s.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined sandbox CI workflows by building Storybook during sandbox creation.
  * Improved job sequencing and artifact handling across Linux and Windows sandbox workflows.
  * Updated dependent test and development jobs to run from the sandbox creation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->