### PR TITLE
CI: shard sandbox dev E2E across two containers

### DIFF
--- a/code/playwright.config.ts
+++ b/code/playwright.config.ts
@@ -80,10 +80,15 @@ export default defineConfig({
     {
       // Specs that write to the sandbox's source files trigger dev-server
       // invalidations (HMR, index refresh) that can reload other tests' pages
-      // mid-assertion. They run here, serially, after the parallel pass.
+      // mid-assertion. They run serially, after the parallel pass - ordered by
+      // the task runner via two sequential invocations (see
+      // scripts/tasks/e2e-tests-build.ts), NOT via a dependency on 'chromium':
+      // Playwright runs dependency projects unfiltered, which made CI shards
+      // whose file subset contained a mutating spec re-run the entire
+      // chromium suite.
       name: 'chromium-mutating',
       testMatch: MUTATING_SPECS,
-      dependencies: ['chromium'],
+      dependencies: ['setup'],
       fullyParallel: false,
       use: {
         ...devices['Desktop Chrome'],

--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -274,8 +274,15 @@ export const check = defineJob(
   [commonJobsNoOpJob]
 );
 
+/**
+ * ESLint, format check and Knip in one job: each is cheap next to the ~50s of
+ * spin-up + checkout + workspace restore a dedicated job pays, and none of
+ * them is anywhere near the workflow critical path. The standalone `fmt` job
+ * remains for the docs workflow, which has no build job to restore a
+ * workspace from.
+ */
 export const lint = defineJob(
-  'ESLint',
+  'Static checks',
   () => ({
     executor: {
       name: 'sb_node_22_classic',
@@ -283,6 +290,12 @@ export const lint = defineJob(
     },
     steps: [
       ...workflow.restoreLinux(),
+      {
+        run: {
+          name: 'Format check',
+          command: 'yarn fmt:check',
+        },
+      },
       {
         run: {
           name: 'Lint code JS',
@@ -297,20 +310,6 @@ export const lint = defineJob(
           command: 'yarn lint',
         },
       },
-    ],
-  }),
-  [commonJobsNoOpJob]
-);
-
-export const knip = defineJob(
-  'Knip validation',
-  () => ({
-    executor: {
-      name: 'sb_node_22_classic',
-      class: 'medium',
-    },
-    steps: [
-      ...workflow.restoreLinux(),
       {
         run: {
           name: 'Run Knip',

--- a/scripts/ci/main.ts
+++ b/scripts/ci/main.ts
@@ -12,7 +12,6 @@ import {
   commonJobsNoOpJob,
   defineCircleciCompletion,
   docgenMemoryGate,
-  knip,
   lint,
   fmt,
   internalStorybookBuildE2e,
@@ -65,9 +64,7 @@ function generateConfig(workflow: Workflow) {
 
       commonJobsNoOpJob,
       lint,
-      fmt,
       check,
-      knip,
 
       storybookChromatic,
       internalStorybookE2e,

--- a/scripts/ci/sandboxes.ts
+++ b/scripts/ci/sandboxes.ts
@@ -63,6 +63,10 @@ function defineSandboxJob_dev({
             name: 'sb_node_22_classic',
             class: 'medium',
           },
+      // Dev-mode E2E is the workflow's wall-clock tail even with parallel
+      // Playwright workers: each shard runs its own dev server and half the
+      // spec files, split by `circleci tests run`.
+      ...(options.e2e ? { parallelism: 2 } : {}),
       steps: [
         ...getSandboxSetupSteps(template),
         ...workflow.restoreLinux({ sandboxId: directory }),
@@ -85,7 +89,7 @@ function defineSandboxJob_dev({
                   },
                   command: [
                     'TEST_FILES=$(circleci tests glob "code/e2e-sandbox/*.{test,spec}.{ts,js,mjs}")',
-                    `echo "$TEST_FILES" | circleci tests run --command="xargs yarn task e2e-tests-dev --template ${template} --no-link -s e2e-tests-dev --junit" --verbose --index=0 --total=1`,
+                    `echo "$TEST_FILES" | circleci tests run --command="xargs yarn task e2e-tests-dev --template ${template} --no-link -s e2e-tests-dev --junit" --verbose --index=$CIRCLE_NODE_INDEX --total=$CIRCLE_NODE_TOTAL`,
                   ].join('\n'),
                 },
               },

--- a/scripts/ci/sandboxes.ts
+++ b/scripts/ci/sandboxes.ts
@@ -34,39 +34,6 @@ function getSandboxSetupSteps(template: string) {
   return extraSteps;
 }
 
-function defineSandboxJob_build({
-  directory,
-  name,
-  template,
-  requires,
-}: {
-  directory: string;
-  name: string;
-  requires: JobOrNoOpJob[];
-  template: string;
-}) {
-  return defineJob(
-    name,
-    () => ({
-      executor: {
-        name: 'sb_node_22_classic',
-        class: 'medium+',
-      },
-      steps: [
-        ...getSandboxSetupSteps(template),
-        ...workflow.restoreLinux({ sandboxId: directory }),
-        {
-          run: {
-            name: 'Build storybook',
-            command: `yarn task build --template ${template} --no-link -s build`,
-          },
-        },
-        workspace.persist([`${SANDBOX_DIR}/${directory}/storybook-static`]),
-      ],
-    }),
-    requires
-  );
-}
 function defineSandboxJob_dev({
   directory,
   name,
@@ -224,6 +191,16 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
               },
             ]
           : []),
+        {
+          // Built here rather than in a dedicated job: a separate build job
+          // paid ~55s of fixed setup plus a workspace round-trip, and it sat
+          // between create and the e2e/chromatic/vitest jobs on the critical
+          // path. The static build lands inside the sandbox tarball below.
+          run: {
+            name: 'Build storybook',
+            command: `yarn task build --template ${key} --no-link -s build`,
+          },
+        },
         artifact.persist(`${LINUX_ROOT_DIR}/${SANDBOX_DIR}/${id}/debug-storybook.log`, 'logs'),
         workspace.packSandbox(id),
         workspace.persist([sandboxArchive(id)]),
@@ -231,12 +208,6 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
     }),
     [sandboxesNoOpJob]
   );
-  const buildJob = defineSandboxJob_build({
-    name: `${name} (build)`,
-    template: key,
-    directory: id,
-    requires: [createJob],
-  });
   const devJob = defineSandboxJob_dev({
     name: `${name} (dev)`,
     template: key,
@@ -275,7 +246,7 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         },
       ],
     }),
-    [buildJob]
+    [createJob]
   );
   const vitestJob = defineJob(
     `${name} (vitest)`,
@@ -302,7 +273,7 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         testResults.persist(join(LINUX_ROOT_DIR, WORKING_DIR, 'test-results')),
       ],
     }),
-    [buildJob]
+    [createJob]
   );
   const e2eJob = defineJob(
     `${name} (e2e)`,
@@ -342,7 +313,7 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         testResults.persist(join(LINUX_ROOT_DIR, WORKING_DIR, 'test-results')),
       ],
     }),
-    [buildJob]
+    [createJob]
   );
   const testRunnerJob = defineJob(
     `${name} (test-runner)`,
@@ -363,12 +334,11 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         testResults.persist(join(LINUX_ROOT_DIR, WORKING_DIR, 'test-results')),
       ],
     }),
-    [buildJob]
+    [createJob]
   );
 
   const jobs = [
     createJob,
-    buildJob,
     devJob,
     !skipTasks?.includes('chromatic') ? chromaticJob : undefined,
     !skipTasks?.includes('vitest-integration') ? vitestJob : undefined,
@@ -390,12 +360,14 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
     name: key,
     path,
     jobs,
+    createJob,
+    devJob,
   };
 }
 
 export function defineSandboxTestRunner(sandbox: ReturnType<typeof defineSandboxFlow>) {
   return defineJob(
-    `${sandbox.jobs[1].id}-test-runner`,
+    `${toId(sandbox.name)}--test-runner`,
     () => ({
       executor: {
         name: 'sb_playwright',
@@ -413,13 +385,13 @@ export function defineSandboxTestRunner(sandbox: ReturnType<typeof defineSandbox
         testResults.persist(join(LINUX_ROOT_DIR, WORKING_DIR, 'test-results')),
       ],
     }),
-    [sandbox.jobs[1]]
+    [sandbox.createJob]
   );
 }
 
 export function defineWindowsSandboxDev(sandbox: ReturnType<typeof defineSandboxFlow>) {
   return defineJob(
-    `${sandbox.jobs[2].id}-windows`,
+    `${sandbox.devJob.id}-windows`,
     () => ({
       executor: {
         name: 'win/default',
@@ -463,13 +435,13 @@ export function defineWindowsSandboxDev(sandbox: ReturnType<typeof defineSandbox
         testResults.persist(`${WINDOWS_ROOT_DIR}\\${WORKING_DIR}\\test-results`),
       ],
     }),
-    [sandbox.jobs[0]]
+    [sandbox.createJob]
   );
 }
 
 export function defineWindowsSandboxBuild(sandbox: ReturnType<typeof defineSandboxFlow>) {
   return defineJob(
-    `${sandbox.jobs[1].id}-windows`,
+    `${toId(sandbox.name)}--build-windows`,
     () => ({
       executor: {
         name: 'win/default',
@@ -517,7 +489,7 @@ export function defineWindowsSandboxBuild(sandbox: ReturnType<typeof defineSandb
         },
       ],
     }),
-    [sandbox.jobs[0]]
+    [sandbox.createJob]
   );
 }
 

--- a/scripts/tasks/compile.ts
+++ b/scripts/tasks/compile.ts
@@ -36,10 +36,7 @@ export const compile: Task = {
     const command = link && !prod ? linkCommand : noLinkCommand;
     await rm(join(codeDir, 'bench/esbuild-metafiles'), { recursive: true, force: true });
     return exec(
-      // NX cache is disabled in Circle CI during the NX Cloud experiment so we can
-      // measure the true cost of NX Cloud agents without local cache hits.
-      // This will be reverted once the experiment concludes.
-      `${command} ${skipCache || process.env.CI ? '--skip-nx-cache' : ''}`,
+      `${command} ${skipCache ? '--skip-nx-cache' : ''}`,
       { cwd: ROOT_DIRECTORY },
       {
         startMessage: '🥾 Bootstrapping',

--- a/scripts/tasks/e2e-tests-build.ts
+++ b/scripts/tasks/e2e-tests-build.ts
@@ -33,29 +33,48 @@ export const e2eTestsBuild: Task & { port: number; type: 'build' | 'dev' } = {
     const firstTestFileArgIndex = process.argv.findIndex((arg) => testFileRegex.test(arg));
     const testFiles = firstTestFileArgIndex === -1 ? [] : process.argv.slice(firstTestFileArgIndex);
 
-    // chromium-mutating holds the specs that write to sandbox files; it runs
-    // after the parallel chromium pass (see code/playwright.config.ts).
-    const projects = '--project=chromium --project=chromium-mutating';
-    const playwrightCommand = process.env.DEBUG
-      ? `yarn playwright test ${projects} --ui ${testFiles.join(' ')}`
-      : `yarn playwright test ${projects} ${testFiles.join(' ')}`;
+    const baseEnv = {
+      STORYBOOK_URL: `http://localhost:${port}`,
+      STORYBOOK_TYPE: this.type,
+      STORYBOOK_TEMPLATE_NAME: key,
+      STORYBOOK_SANDBOX_DIR: sandboxDir,
+    };
 
     await waitOn({ resources: [`http://localhost:${port}`], interval: 16, timeout: 200000 });
-    await exec(
-      playwrightCommand,
-      {
-        env: {
-          STORYBOOK_URL: `http://localhost:${port}`,
-          STORYBOOK_TYPE: this.type,
-          STORYBOOK_TEMPLATE_NAME: key,
-          STORYBOOK_SANDBOX_DIR: sandboxDir,
-          ...(junitFilename && {
-            PLAYWRIGHT_JUNIT_OUTPUT_NAME: junitFilename,
-          }),
+
+    if (process.env.DEBUG) {
+      await exec(
+        `yarn playwright test --project=chromium --project=chromium-mutating --ui ${testFiles.join(' ')}`,
+        { env: baseEnv, cwd: codeDir },
+        { dryRun, debug }
+      );
+      return;
+    }
+
+    // The sandbox-mutating specs run in a second, serial invocation so their
+    // dev-server invalidations cannot reload the parallel pass's pages. Two
+    // invocations instead of a Playwright project dependency: dependency
+    // projects run unfiltered, which would re-run the whole chromium suite on
+    // any CI shard whose file subset contains a mutating spec.
+    // --pass-with-no-tests covers shards whose subset has no match for one of
+    // the projects.
+    for (const [project, junitSuffix] of [
+      ['chromium', ''],
+      ['chromium-mutating', '-mutating'],
+    ]) {
+      await exec(
+        `yarn playwright test --project=${project} --pass-with-no-tests ${testFiles.join(' ')}`,
+        {
+          env: {
+            ...baseEnv,
+            ...(junitFilename && {
+              PLAYWRIGHT_JUNIT_OUTPUT_NAME: junitFilename.replace(/\.xml$/, `${junitSuffix}.xml`),
+            }),
+          },
+          cwd: codeDir,
         },
-        cwd: codeDir,
-      },
-      { dryRun, debug }
-    );
+        { dryRun, debug }
+      );
+    }
   },
 };


### PR DESCRIPTION
Follow-up to #35343; stacked on #35352. Takes the last piece of the wall-clock tail.

## Why

After parallel Playwright workers (#35347), the dev-mode E2E jobs still run 300-377s each and start only after their template's create job - they gate the workflow finish. In-job worker scaling is exhausted (the large executor's 4 vCPUs are shared with the dev server), so the remaining lever is CircleCI `parallelism`.

## What

- `parallelism: 2` on every e2e dev job. The `circleci tests run` scaffolding already carried `--index/--total` flags hardcoded to one node; they now use `$CIRCLE_NODE_INDEX/$CIRCLE_NODE_TOTAL`, splitting the 22 spec files per container.
- Each shard runs its own dev server; `change-detection.spec.ts` lands on exactly one shard, where the serial `chromium-mutating` isolation (#35347) still applies.
- Smoke-test dev jobs (bench templates) stay unsharded - no Playwright pass to split.

Coverage unchanged: same files, same assertions, split across two containers whose junit results CircleCI merges.

## Cost/benefit (estimates, to be replaced by this PR's pipeline numbers)

| | Before | After |
| --- | --- | --- |
| slowest dev job (angular/next-js vite) | 374-377s | ~230-260s expected |
| summed job-time | - | +~11 × 110s setup ≈ +20 min (against the -78 min from #35346/#35347) |

_Measured tables will be updated from the CI run on this PR._