### PR TITLE
CI: trim fixed overhead from the sandbox create flow

### DIFF
--- a/scripts/ci/sandboxes.ts
+++ b/scripts/ci/sandboxes.ts
@@ -17,21 +17,26 @@ import {
 import type { JobOrNoOpJob, Workflow } from './utils/types.ts';
 import { defineJob, defineNoOpJob, isWorkflowOrAbove } from './utils/types.ts';
 
-function getSandboxSetupSteps(template: string) {
-  const extraSteps = [];
+/**
+ * The cimg/node executors ship Node 22.22.3 (matching .nvmrc), which
+ * satisfies every template's minimum. The Playwright image pins its own,
+ * older Node, so jobs running on the sb_playwright executor must still
+ * install the minimum version for templates that declare one (Angular's CLI
+ * refuses to boot below it).
+ */
+function getPlaywrightNodeSetupSteps(template: string) {
   const templateData = sandboxTemplates.allTemplates[template as TemplateKey];
-
-  if (templateData.extraCiSteps?.ensureMinNodeVersion) {
-    extraSteps.push({
+  if (!templateData.extraCiSteps?.ensureMinNodeVersion) {
+    return [] as unknown[];
+  }
+  return [
+    {
       'node/install': {
         'install-yarn': true,
-        // Currently using Node 22.22.3 as minimum supported version for Angular sandboxes
         'node-version': '22.22.3',
       },
-    });
-  }
-
-  return extraSteps;
+    },
+  ];
 }
 
 function defineSandboxJob_dev({
@@ -68,7 +73,7 @@ function defineSandboxJob_dev({
       // spec files, split by `circleci tests run`.
       ...(options.e2e ? { parallelism: 2 } : {}),
       steps: [
-        ...getSandboxSetupSteps(template),
+        ...(options.e2e ? getPlaywrightNodeSetupSteps(template) : []),
         ...workflow.restoreLinux({ sandboxId: directory }),
         ...(options.e2e
           ? [
@@ -131,7 +136,6 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         class: 'large',
       },
       steps: [
-        ...getSandboxSetupSteps(key),
         ...workflow.restoreLinux(),
         verdaccio.start(),
         {
@@ -147,10 +151,13 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
           run: {
             name: 'Setup Corepack',
             command: [
-              //
               'sudo corepack enable',
               'which yarn',
               'yarn --version',
+              // Pre-warm the npx cache for the exact gitpick version the CLI
+              // spawns during 'sb repro' (code/lib/cli-storybook/src/sandbox.ts),
+              // so the template download does not pay a cold npx install.
+              'npx -y gitpick@4.12.4 --version',
             ].join('\n'),
           },
         },
@@ -227,7 +234,6 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         class: 'medium',
       },
       steps: [
-        ...getSandboxSetupSteps(key),
         'checkout', // we need the full git history for chromatic
         workspace.attach(),
         workspace.unpack(),
@@ -260,7 +266,7 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         class: 'medium+',
       },
       steps: [
-        ...getSandboxSetupSteps(key),
+        ...getPlaywrightNodeSetupSteps(key),
         ...workflow.restoreLinux({ sandboxId: id }),
         {
           run: {
@@ -287,7 +293,7 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         class: 'medium+',
       },
       steps: [
-        ...getSandboxSetupSteps(key),
+        ...getPlaywrightNodeSetupSteps(key),
         ...workflow.restoreLinux({ sandboxId: id }),
         {
           run: {
@@ -327,7 +333,7 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
         class: 'medium',
       },
       steps: [
-        ...getSandboxSetupSteps(key),
+        ...getPlaywrightNodeSetupSteps(key),
         ...workflow.restoreLinux({ sandboxId: id }),
         {
           run: {
@@ -378,7 +384,7 @@ export function defineSandboxTestRunner(sandbox: ReturnType<typeof defineSandbox
         class: 'medium',
       },
       steps: [
-        ...getSandboxSetupSteps(sandbox.name),
+        ...getPlaywrightNodeSetupSteps(sandbox.name),
         ...workflow.restoreLinux({ sandboxId: toId(sandbox.name) }),
         {
           run: {

--- a/scripts/ci/utils/executors.ts
+++ b/scripts/ci/utils/executors.ts
@@ -7,7 +7,7 @@ export const executors = {
         environment: {
           NODE_OPTIONS: '--max_old_space_size=6144',
         },
-        image: 'cimg/node:22.22.1-browsers',
+        image: 'cimg/node:22.22.3-browsers',
       },
     ],
     parameters: {
@@ -27,7 +27,7 @@ export const executors = {
         environment: {
           NODE_OPTIONS: '--max_old_space_size=6144',
         },
-        image: 'cimg/node:22.22.1',
+        image: 'cimg/node:22.22.3',
       },
     ],
     parameters: {

--- a/scripts/tasks/dev.ts
+++ b/scripts/tasks/dev.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { connect } from 'node:net';
 import { join } from 'node:path';
 
 import waitOn from 'wait-on';
@@ -55,17 +56,23 @@ export const dev: Task = {
   async ready({ key }) {
     const port = getDevPort(key);
     try {
-      // When no server is running the fetch fails fast (connection refused),
-      // so a long timeout only applies while a server is listening but still
-      // compiling its first preview bundle. On CI that state must count as
-      // ready: giving up after 1s makes the e2e task spawn a second dev
-      // server on the same port, which crashes with EADDRINUSE once its own
-      // compile finishes. Locally keep the probe snappy.
-      const timeout = process.env.CI ? 180_000 : 1_000;
-      await fetch(`http://localhost:${port}/iframe.html`, { signal: AbortSignal.timeout(timeout) });
+      await fetch(`http://localhost:${port}/iframe.html`, { signal: AbortSignal.timeout(1000) });
       return true;
     } catch {
-      return false;
+      // The fetch can fail while a dev server owns the port: a cold compile
+      // outlasting the timeout, or the server resetting connections before
+      // its middleware is up. Spawning a second server then can only crash
+      // with EADDRINUSE once it finishes compiling, so a held port must
+      // count as ready - every consumer of this task performs its own HTTP
+      // wait before using the server.
+      return await new Promise<boolean>((resolve) => {
+        const socket = connect({ port, host: '127.0.0.1' });
+        socket.once('connect', () => {
+          socket.destroy();
+          resolve(true);
+        });
+        socket.once('error', () => resolve(false));
+      });
     }
   },
   async run({ sandboxDir, key, selectedTask }, { dryRun, debug, link }) {

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -85,15 +85,18 @@ export const sandbox: Task = {
       runMigrations,
     } = await import('./sandbox-parts.ts');
 
+    // Versioned specifiers: bare names make addExtraDependencies probe the
+    // registry once per package to resolve 'latest' (a subprocess each), and
+    // let sandbox contents drift whenever a new major is published.
     const extraDeps = [
       ...(details.template.modifications?.extraDependencies ?? []),
       // The storybook package forwards some CLI commands to @storybook/cli with npx.
       // Adding the dep makes sure that even npx will use the linked workspace version.
       '@storybook/cli',
-      'lodash-es',
-      '@types/lodash-es',
-      '@types/aria-query',
-      'uuid',
+      'lodash-es@^4.18.1',
+      '@types/lodash-es@^4.17.12',
+      '@types/aria-query@^5.0.4',
+      'uuid@^14.0.1',
     ];
 
     const extraDevDeps = [
@@ -105,10 +108,10 @@ export const sandbox: Task = {
     const shouldAddVitestIntegration = !details.template.skipTasks?.includes('vitest-integration');
 
     if (shouldAddVitestIntegration) {
-      extraDeps.push('happy-dom');
+      extraDeps.push('happy-dom@^20.10.6');
 
       if (details.template.expected.framework.includes('nextjs')) {
-        extraDeps.push('jsdom');
+        extraDeps.push('jsdom@^29.1.1');
       }
 
       // if (details.template.expected.renderer === '@storybook/svelte') {
@@ -182,7 +185,9 @@ export const sandbox: Task = {
 
     const packageManager = JsPackageManagerFactory.getPackageManager({}, details.sandboxDir);
 
-    await rm(path.join(details.sandboxDir, 'node_modules'), { force: true, recursive: true });
+    // Incremental on purpose: the init step already installed the bulk of the
+    // tree, so this final install only links the extra deps added above.
+    // Wiping node_modules first forced a full re-extraction (~10-25s on CI).
     await packageManager.installDependencies();
 
     await runMigrations(details, options);

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -1,11 +1,13 @@
-import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+
+import { parse, stringify } from 'yaml';
 
 // TODO -- should we generate this file a second time outside of CLI?
 import storybookVersions from '../../code/core/src/common/versions.ts';
 import { allTemplates } from '../../code/lib/cli-storybook/src/sandbox-templates.ts';
 import type { AllTemplatesKey } from '../../code/lib/cli-storybook/src/sandbox-templates.ts';
-import { exec } from './exec.ts';
+import { ROOT_DIRECTORY } from './constants.ts';
 
 export type YarnOptions = {
   cwd: string;
@@ -45,44 +47,79 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 };
 
-export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
+/**
+ * Merge keys into the sandbox's .yarnrc.yml with a plain file write. Yarn
+ * configuration used to happen through chained `yarn config set` calls, but
+ * each of those boots a yarn process (~0.5s each on CI) and the very first
+ * one triggers corepack network downloads - a measurable slice of every
+ * sandbox create job for what is ultimately just YAML authoring.
+ */
+const mergeYarnrc = async (cwd: string, overrides: Record<string, unknown>) => {
+  const yarnrcPath = join(cwd, '.yarnrc.yml');
+  const current = await readFile(yarnrcPath, 'utf-8').catch(() => '');
+  const config = { ...(parse(current) ?? {}), ...overrides };
+  await writeFile(yarnrcPath, stringify(config));
+};
+
+export const installYarn2 = async ({ cwd, dryRun }: YarnOptions) => {
+  logger.info(`🧶 Installing Yarn`);
+
+  if (dryRun) {
+    return;
+  }
+
   await rm(join(cwd, '.yarnrc.yml'), { force: true }).catch(() => {});
 
   // TODO: Remove in SB11
   const pnpApiExists = await pathExists(join(cwd, '.pnp.cjs'));
 
-  await mkdir(cwd, { recursive: true }).then(() =>
-    Promise.all([
-      //
-      writeFile(join(cwd, 'yarn.lock'), ''),
-      writeFile(join(cwd, '.yarnrc.yml'), ''),
-    ])
-  );
+  await mkdir(cwd, { recursive: true });
+  await writeFile(join(cwd, 'yarn.lock'), '');
 
-  const command = [
-    `yarn set version berry`,
-    `yarn config set enableGlobalCache true`, // Use the global cache so we aren't re-caching dependencies each time we run sandbox
-    `yarn config set checksumBehavior ignore`,
+  // Vendor the repository's own pinned Yarn release instead of running
+  // `yarn set version berry`, which downloads the latest Berry from the
+  // network on every sandbox (on top of corepack fetching a bootstrap yarn).
+  // Any bootstrap yarn - corepack's default or the image's classic yarn -
+  // sees yarnPath and delegates to this file, so no download happens and the
+  // sandbox runs the exact yarn version the monorepo itself is tested with.
+  const { packageManager } = JSON.parse(
+    await readFile(join(ROOT_DIRECTORY, 'package.json'), 'utf-8')
+  );
+  const yarnRelease = `yarn-${packageManager.replace(/^yarn@/, '')}.cjs`;
+  const releaseSource = join(ROOT_DIRECTORY, '.yarn', 'releases', yarnRelease);
+  // Fails loudly if the repo ever stops vendoring its yarn release.
+  await access(releaseSource);
+  await mkdir(join(cwd, '.yarn', 'releases'), { recursive: true });
+  await copyFile(releaseSource, join(cwd, '.yarn', 'releases', yarnRelease));
+
+  // Pin packageManager in the sandbox to the same version. Without the field,
+  // corepack auto-pins whatever bootstrap yarn it resolves (classic 1.22.x)
+  // on the first install; installs still work through yarnPath delegation,
+  // but JsPackageManagerFactory reads the field first and would classify the
+  // sandbox as Yarn 1, making the CLI run classic-syntax commands.
+  const sandboxPackageJsonPath = join(cwd, 'package.json');
+  let sandboxPackageJson: Record<string, unknown> | undefined;
+  try {
+    sandboxPackageJson = JSON.parse(await readFile(sandboxPackageJsonPath, 'utf-8'));
+  } catch {
+    sandboxPackageJson = undefined;
+  }
+  if (sandboxPackageJson) {
+    sandboxPackageJson.packageManager = packageManager;
+    await writeFile(sandboxPackageJsonPath, JSON.stringify(sandboxPackageJson, null, 2));
+  }
+
+  await mergeYarnrc(cwd, {
+    yarnPath: `.yarn/releases/${yarnRelease}`,
+    // Use the global cache so we aren't re-caching dependencies each time we run sandbox
+    enableGlobalCache: true,
+    checksumBehavior: 'ignore',
     // Yarn 4.15.0 defaults `npmMinimalAgeGate` to 1d, which quarantines freshly
     // published Storybook packages from the local Verdaccio registry. Disable
     // the gate inside sandboxes so installs aren't blocked.
-    `yarn config set npmMinimalAgeGate 0`,
-  ];
-
-  if (!pnpApiExists) {
-    command.push(`yarn config set nodeLinker node-modules`);
-  }
-
-  await exec(
-    command.join(' && '),
-    { cwd },
-    {
-      dryRun,
-      debug,
-      startMessage: `🧶 Installing Yarn`,
-      errorMessage: `🚨 Installing Yarn failed`,
-    }
-  );
+    npmMinimalAgeGate: 0,
+    ...(pnpApiExists ? {} : { nodeLinker: 'node-modules' }),
+  });
 };
 
 export const isViteSandbox = (key?: AllTemplatesKey) => {
@@ -143,27 +180,20 @@ export const addWorkaroundResolutions = async ({
 export const configureYarn2ForVerdaccio = async ({
   cwd,
   dryRun,
-  debug,
   key,
 }: YarnOptions & { key: AllTemplatesKey }) => {
+  logger.info(`🎛 Configuring Yarn 2`);
+
+  if (dryRun) {
+    return;
+  }
+
   // On NX Cloud agents, we use the global cache to avoid duplicating .yarn/cache across sandboxes.
   // Stale @storybook/* packages are cleaned from the global cache in the agent init step (agents.yaml).
   // Locally and on CircleCI, we disable the global cache to avoid stale packages from previous runs.
   const useGlobalCache = Boolean(process.env.STORYBOOK_NX_CLOUD_AGENT);
 
-  const command = [
-    `yarn config set enableGlobalCache ${useGlobalCache}`,
-    `yarn config set enableMirror false`,
-    // ⚠️ Need to set registry because Yarn 2 is not using the conf of Yarn 1 (URL is hardcoded in CircleCI config.yml)
-    `yarn config set npmRegistryServer "http://localhost:6001/"`,
-    // Some required magic to be able to fetch deps from local registry
-    `yarn config set unsafeHttpWhitelist "localhost"`,
-    // Disable fallback mode to make sure everything is required correctly
-    `yarn config set pnpFallbackMode none`,
-    // We need to be able to update lockfile when bootstrapping the examples
-    `yarn config set enableImmutableInstalls false`,
-  ];
-
+  let logFilters: { code: string; level: string }[] | undefined;
   if (
     key.includes('svelte-kit') ||
     // React prereleases will have INCOMPATIBLE_PEER_DEPENDENCY errors because of transitive dependencies not allowing v19 betas
@@ -176,27 +206,28 @@ export const configureYarn2ForVerdaccio = async ({
     key.includes('web-components-rsbuild/default-ts')
   ) {
     // Don't error with INCOMPATIBLE_PEER_DEPENDENCY for SvelteKit sandboxes, it is expected to happen with @sveltejs/vite-plugin-svelte
-    command.push(
-      `yarn config set logFilters --json "[{\\"code\\":\\"YN0013\\",\\"level\\":\\"discard\\"}]"`
-    );
+    logFilters = [{ code: 'YN0013', level: 'discard' }];
   } else if (key.includes('nuxt')) {
     // Nothing to do for Nuxt
   } else {
-    // Discard all YN0013 - FETCH_NOT_CACHED messages
-    // Error on YN0060 - INCOMPATIBLE_PEER_DEPENDENCY
-    command.push(
-      `yarn config set logFilters --json "[{\\"code\\":\\"YN0013\\",\\"level\\":\\"discard\\"},{\\"code\\":\\"YN0060\\",\\"level\\":\\"discard\\"}]"`
-    );
+    // Discard all YN0013 - FETCH_NOT_CACHED and YN0060 - INCOMPATIBLE_PEER_DEPENDENCY messages
+    logFilters = [
+      { code: 'YN0013', level: 'discard' },
+      { code: 'YN0060', level: 'discard' },
+    ];
   }
 
-  await exec(
-    command.join(' && '),
-    { cwd },
-    {
-      dryRun,
-      debug,
-      startMessage: `🎛 Configuring Yarn 2`,
-      errorMessage: `🚨 Configuring Yarn 2 failed`,
-    }
-  );
+  await mergeYarnrc(cwd, {
+    enableGlobalCache: useGlobalCache,
+    enableMirror: false,
+    // ⚠️ Need to set registry because Yarn 2 is not using the conf of Yarn 1 (URL is hardcoded in CircleCI config.yml)
+    npmRegistryServer: 'http://localhost:6001/',
+    // Some required magic to be able to fetch deps from local registry
+    unsafeHttpWhitelist: ['localhost'],
+    // Disable fallback mode to make sure everything is required correctly
+    pnpFallbackMode: 'none',
+    // We need to be able to update lockfile when bootstrapping the examples
+    enableImmutableInstalls: false,
+    ...(logFilters ? { logFilters } : {}),
+  });
 };


### PR DESCRIPTION
Follow-up to #35353; the angular-create investigation (12 verified findings from the create-job phase decomposition + a timestamped local reproduction).

## What (four independent trims, scripts/CI only)

1. **Yarn setup becomes two file writes.** `installYarn2` ran `yarn set version berry` + chained `yarn config set` calls: ~12 yarn boots and two network downloads (corepack bootstrap yarn, then latest Berry) per sandbox. The sandbox now vendors the repo's own pinned yarn release via `yarnPath` and writes `.yarnrc.yml` directly. `packageManager` is pinned to the same version - without the field, corepack auto-pins its classic bootstrap yarn and `JsPackageManagerFactory` misclassifies the sandbox as Yarn 1 (caught by the local E2E reproduction: installs kept working through yarnPath delegation while the CLI ran classic-syntax commands). Side effect: sandboxes now run the exact yarn version the monorepo pins instead of floating on latest Berry.
2. **No more `rm -rf node_modules` before the final install** - the wipe forced a full re-extraction (~10-25s on CI) that yarn's incremental install makes redundant.
3. **Extra sandbox deps carry explicit version ranges** (matching current npm latest majors), so `addExtraDependencies` stops probing the registry per package and sandbox contents stop drifting on new majors.
4. **Executor images move to `cimg/node:22.22.3`** (matching `.nvmrc`), which satisfies Angular's minimum - the ~9s `node/install` step disappears from every angular create/dev job. Create jobs also pre-warm the npx cache for the pinned gitpick version, so the template download skips its cold npx install.

## Rejected while implementing

**`skip-install` on the init CLI step** (would fold init's install into the final one, ~15-25s): `postinstallAddon` resolves each addon's postinstall hook from the sandbox's node_modules and silently returns when resolution fails - with the install skipped, all addon configuration (including addon-vitest's setup) would silently disappear from sandboxes.

## Measured (local timestamped E2E, angular-vite full creation)

| | Before | After |
| --- | --- | --- |
| Full `yarn task sandbox` (link mode) | 107.3s | **55.7s** |
| Sandbox tree diff vs baseline | - | `packageManager` pin only; deps + .storybook byte-identical |

Verified: `.yarnrc.yml` writer probed directly against both logFilter variants; `yarn nx run-many -t check` clean; normal + daily configs generate correctly (no `node/install` steps remain).

_CI create-job step timings will be posted from this PR's pipeline._