### PR TITLE
CLI: skip redundant registry probes during sandbox creation

### DIFF
--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -15,6 +15,7 @@ import invariant from 'tiny-invariant';
 
 import { HandledError } from '../utils/HandledError.ts';
 import type { ExecuteCommandOptions } from '../utils/command.ts';
+import { optionalEnvToBoolean } from '../utils/envs.ts';
 import { findFilesUp, getProjectRoot } from '../utils/paths.ts';
 import storybookPackagesVersions from '../versions.ts';
 import type { PackageJson, PackageJsonWithDepsAndDevDeps } from './PackageJson.ts';
@@ -366,10 +367,17 @@ export abstract class JsPackageManager {
       const { operationDir, packageJson } = packageJsonInfo;
       const dependenciesMap: Record<string, string> = {};
 
-      for (const dep of dependencies) {
-        const [packageName, packageVersion] = getPackageDetails(dep);
-        const latestVersion = await this.getVersion(packageName);
-        dependenciesMap[packageName] = packageVersion ?? latestVersion;
+      // Versions resolve concurrently (each lookup may spawn the package
+      // manager), and only for dependencies that don't carry one already.
+      // The entries array keeps package.json key order deterministic.
+      const entries = await Promise.all(
+        dependencies.map(async (dep) => {
+          const [packageName, packageVersion] = getPackageDetails(dep);
+          return [packageName, packageVersion ?? (await this.getVersion(packageName))] as const;
+        })
+      );
+      for (const [packageName, version] of entries) {
+        dependenciesMap[packageName] = version;
       }
 
       const targetDeps = packageJson[options.type] as Record<string, string>;
@@ -547,6 +555,21 @@ export abstract class JsPackageManager {
       return cachedVersion;
     }
 
+    // In monorepo sandbox creation every storybook package is published to
+    // the local registry at exactly the version this CLI was built with, so
+    // the registry probe (a package-manager subprocess per package) is a
+    // foregone conclusion. Real user installs never have this variable set.
+    if (
+      optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX) &&
+      packageName in storybookPackagesVersions
+    ) {
+      const version = storybookPackagesVersions[packageName as StorybookPackage];
+      if (!constraint || satisfies(version, constraint)) {
+        JsPackageManager.latestVersionCache.set(cacheKey, version);
+        return version;
+      }
+    }
+
     let result: string;
 
     logger.debug(`Getting CLI versions from NPM for ${packageName}...`);
@@ -719,7 +742,17 @@ export abstract class JsPackageManager {
         version = vitePlusVersions[packageName]!;
       }
 
+      // Resolving the module's own package.json is a plain fs read (PnP
+      // included) and covers the common cases - installed-and-resolvable, or
+      // not installed at all. findInstallations spawns the package manager
+      // for a full dependency-graph walk, so it stays as the fallback for
+      // declared dependencies that don't resolve directly (e.g. pnpm's
+      // virtual store layouts).
       if (!version) {
+        version = (await this.getModulePackageJSON(packageName))?.version ?? null;
+      }
+
+      if (!version && this.isDependencyInstalled(packageName)) {
         const installations = await this.findInstallations([packageName]);
         if (installations) {
           version = Object.entries(installations.dependencies)[0]?.[1]?.[0].version || null;

--- a/code/core/src/common/js-package-manager/NPMProxy.test.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { prompt } from 'storybook/internal/node-logger';
 import { MinimumReleaseAgeHandledError } from 'storybook/internal/server-errors';
 
 import { executeCommand } from '../utils/command.ts';
 import { JsPackageManager } from './JsPackageManager.ts';
+import storybookPackagesVersions from '../versions.ts';
 import { NPMProxy } from './NPMProxy.ts';
 
 vi.mock('storybook/internal/node-logger', () => ({
@@ -30,7 +31,14 @@ describe('NPM Proxy', () => {
     vi.useRealTimers();
     npmProxy = new NPMProxy();
     JsPackageManager.clearLatestVersionCache();
+    // The repo-level .env marks test runs as sandbox context; these tests
+    // assert user-facing registry-probe behavior, so run them without it.
+    vi.stubEnv('IN_STORYBOOK_SANDBOX', 'false');
     vi.spyOn(npmProxy, 'writePackageJson').mockImplementation(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('type should be npm', () => {
@@ -310,6 +318,16 @@ describe('NPM Proxy', () => {
   });
 
   describe('latestVersion', () => {
+    it('returns the monorepo version without spawning inside a sandbox task', async () => {
+      vi.stubEnv('IN_STORYBOOK_SANDBOX', 'true');
+      const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '5.3.19' } as any);
+
+      const version = await npmProxy.latestVersion('storybook');
+
+      expect(executeCommandSpy).not.toHaveBeenCalled();
+      expect(version).toEqual(storybookPackagesVersions.storybook);
+    });
+
     it('without constraint it returns the latest version', async () => {
       const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '5.3.19' } as any);
 

--- a/code/core/src/common/js-package-manager/PNPMProxy.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.test.ts
@@ -38,7 +38,14 @@ describe('PNPM Proxy', () => {
   beforeEach(() => {
     pnpmProxy = new PNPMProxy();
     JsPackageManager.clearLatestVersionCache();
+    // The repo-level .env marks test runs as sandbox context; these tests
+    // assert user-facing registry-probe behavior, so run them without it.
+    vi.stubEnv('IN_STORYBOOK_SANDBOX', 'false');
     vi.spyOn(pnpmProxy, 'writePackageJson').mockImplementation(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('type should be pnpm', () => {

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { prompt } from 'storybook/internal/node-logger';
 
@@ -41,7 +41,14 @@ describe('Yarn 1 Proxy', () => {
   beforeEach(() => {
     yarn1Proxy = new Yarn1Proxy();
     JsPackageManager.clearLatestVersionCache();
+    // The repo-level .env marks test runs as sandbox context; these tests
+    // assert user-facing registry-probe behavior, so run them without it.
+    vi.stubEnv('IN_STORYBOOK_SANDBOX', 'false');
     vi.spyOn(yarn1Proxy, 'writePackageJson').mockImplementation(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('type should be yarn1', () => {

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
@@ -40,7 +40,14 @@ describe('Yarn 2 Proxy', () => {
   beforeEach(() => {
     yarn2Proxy = new Yarn2Proxy();
     JsPackageManager.clearLatestVersionCache();
+    // The repo-level .env marks test runs as sandbox context; these tests
+    // assert user-facing registry-probe behavior, so run them without it.
+    vi.stubEnv('IN_STORYBOOK_SANDBOX', 'false');
     vi.spyOn(yarn2Proxy, 'writePackageJson').mockImplementation(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('type should be yarn2', () => {

--- a/code/lib/cli-storybook/src/sandbox.ts
+++ b/code/lib/cli-storybook/src/sandbox.ts
@@ -42,14 +42,23 @@ export const sandbox = async ({
   let selectedConfig: Template | undefined = TEMPLATES[filterValue as TemplateKey];
   let templateId: Choice | null = selectedConfig ? (filterValue as TemplateKey) : null;
 
+  const currentVersion = versions.storybook;
+  // In monorepo sandbox creation the CLI is freshly built from the local
+  // branch, so the latest/next registry probes can only ever produce the
+  // "you are behind" warning copy - at the cost of two npm roundtrips before
+  // the template download starts. Treat the local version as current there.
+  const insideSandboxTask = optionalEnvToBoolean(process.env.IN_STORYBOOK_SANDBOX);
   // Always use npm to fetch versions, as other package manager commands may fail when running in
   // non-project directories (e.g. parent sandbox directory). We just need to use npm info for this use case.
   const packageManager = JsPackageManagerFactory.getPackageManager({
     force: PackageManagerName.NPM,
   });
-  const latestVersion = (await packageManager.latestVersion('storybook'))!;
-  const nextVersion = (await packageManager.latestVersion('storybook@next')) ?? '0.0.0';
-  const currentVersion = versions.storybook;
+  const latestVersion = insideSandboxTask
+    ? currentVersion
+    : (await packageManager.latestVersion('storybook'))!;
+  const nextVersion = insideSandboxTask
+    ? currentVersion
+    : ((await packageManager.latestVersion('storybook@next')) ?? '0.0.0');
   const isPrerelease = prerelease(currentVersion);
   const isOutdated = lt(currentVersion, isPrerelease ? nextVersion : latestVersion);
 


### PR DESCRIPTION
Follow-up to #35355 - the product-code half of the angular-create investigation. Sandbox creation spawned ~24 package-manager subprocesses just to resolve versions; most were foregone conclusions.

## What

1. **`latestVersion()` short-circuits to the CLI's own `versions.ts` inside sandbox creation** (`IN_STORYBOOK_SANDBOX`, set by the monorepo task runner, never by real user installs). Verdaccio serves exactly those versions and `addPackageResolutions` pins them in resolutions regardless, so the per-package registry probe answered a question the CLI already knew. CI specifiers are byte-identical; link-mode local sandboxes get `^version` instead of an exact pin (where the linked workspace overrides resolution anyway).
2. **`addDependencies(skipInstall)` stops resolving versions it throws away**: it probed the registry serially for every dependency, including ones whose specifier already carried a version (result discarded). Lookups now happen only for unversioned specifiers and run concurrently with deterministic package.json key order. **This speeds up real `storybook init` runs too.**
3. **`getInstalledVersion()` reads `node_modules/<pkg>/package.json` first** (plain fs, PnP included) instead of spawning a full dependency-graph walk per package - a walk that exits 1 with clipanion usage output for packages that aren't installed at all (addon-vitest probes vitest/msw/coverage this way on every sandbox). The graph walk remains as fallback for declared dependencies that don't resolve directly (pnpm virtual stores).
4. **`sb repro` skips its latest/next npm probes inside sandbox creation** - they only feed the "you are behind" warning copy there and cost two public-registry roundtrips before the template download starts.

## Tests

- The four package-manager proxy test suites asserting registry-probe behavior now stub `IN_STORYBOOK_SANDBOX` off explicitly - the repo-level `.env` marks every vitest run as sandbox context, which is exactly the environment leak that made these tests catch the change.
- New contract test: inside a sandbox task, `latestVersion('storybook')` returns the versions.ts version without spawning.
- Full sweep: 1053 tests green across `core/common`, `create-storybook`, `cli-storybook`.

## Measured (local timestamped E2E, angular-vite full creation)

| | #35355 alone | + this PR |
| --- | --- | --- |
| Version-probe subprocess spawns | 24 | **8** (all non-storybook packages) |
| Full `yarn task sandbox` | 55.7s | **47.5s** (baseline before both PRs: 107.3s) |
| Sandbox tree diff | - | deps + .storybook config identical on the CI path |

_CI create-job step timings will be posted from this PR's pipeline._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Storybook sandbox workflows by using the locally built Storybook version without registry lookups.
  - Dependency additions now resolve unspecified versions concurrently for faster processing.
  - Improved installed-version detection across supported package environments.

- **Bug Fixes**
  - Sandbox version checks now consistently use the current local version.

- **Tests**
  - Added coverage for sandbox version resolution and improved environment cleanup across package manager tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->