### PR TITLE
Docs: Clarify Build Watch Workflow

### DIFF
--- a/docs/api/cli-options.mdx
+++ b/docs/api/cli-options.mdx
@@ -103,6 +103,23 @@ Options include:
 | `--enable-crash-reports`        | Enables sending crash reports to Storybook's telemetry. Learn more about it [here](../configure/telemetry.mdx#crash-reports-disabled-by-default).<br />`storybook build --enable-crash-reports`                                                |
 | `--preview-only`                | Skips Storybook's manager from building and produces a "preview only" app, which is designed to be used in [unsupported browsers](../sharing/publish-storybook.mdx#build-storybook-for-older-browsers). <br />`storybook build --preview-only` |
 
+<Callout variant="info">
+
+`storybook build` does not include a built-in watch mode. For normal development, use
+`storybook dev` so Storybook updates in the browser as your source files change. If your workflow
+must repeatedly rebuild static output, run `storybook build` from a file watcher such as
+[`nodemon`](https://www.npmjs.com/package/nodemon):
+
+```json
+{
+  "scripts": {
+    "build-storybook:watch": "nodemon --watch src --exec 'storybook build'"
+  }
+}
+```
+
+</Callout>
+
 ### `init`
 
 <Callout variant="info">


### PR DESCRIPTION
Refs #15946

## Summary
- Document that `storybook build` does not include a built-in watch mode.
- Point normal development workflows to `storybook dev` for browser updates while source files change.
- Add a `nodemon` wrapper example for workflows that need repeated static rebuilds.

## Validation
- `git diff --check -- docs/api/cli-options.mdx`
- `npm_config_cache=../../.cache/npm npm exec --yes --package oxfmt@0.41.0 -- oxfmt --check docs/api/cli-options.mdx`

#### Manual testing

Docs-only change. I did not run Storybook manually; the changed page was checked for formatting and whitespace issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note to the CLI options guide clarifying that `storybook build` does not support watch mode.
  * Included guidance on using `storybook dev` for live updates or pairing `storybook build` with a file watcher for repeated static rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->