### PR TITLE
Angular: Switch framework in angular-to-angular-vite migration when configured indirectly

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
@@ -6,7 +6,7 @@ import { transformImportFiles } from 'storybook/internal/common';
 import type { JsPackageManager } from 'storybook/internal/common';
 import { loadConfig, printConfig } from 'storybook/internal/csf-tools';
 
-import { prompt } from 'storybook/internal/node-logger';
+import { logger, prompt } from 'storybook/internal/node-logger';
 
 import { add } from '../../add.ts';
 import { updateMainConfig } from '../helpers/mainConfigFile.ts';
@@ -66,6 +66,7 @@ const mockTransformImportFiles = vi.mocked(transformImportFiles);
 const mockPromptConfirm = vi.mocked(prompt.confirm);
 const mockAdd = vi.mocked(add);
 const mockUpdateMainConfig = vi.mocked(updateMainConfig);
+const mockLoggerWarn = vi.mocked(logger.warn);
 
 describe('angular-to-angular-vite', () => {
   const mockPackageManager = {
@@ -399,6 +400,88 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
       expect(mockWriteFile).not.toHaveBeenCalledWith(
         '/project/.storybook/main.ts',
         expect.anything()
+      );
+    });
+
+    it('forces the framework to @storybook/angular-vite (and warns) when it is configured indirectly', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+
+      // A main config whose framework comes from a spread of an imported base config
+      // (common in Nx workspaces). The literal '@storybook/angular' never appears, so
+      // the text rewrite no-ops and, without this fix, the config keeps resolving to
+      // @storybook/angular — later breaking the deferred addon-vitest install.
+      const indirectMain = `import { base } from './base';\nexport default { ...base, stories: [] };`;
+      mockReadFile.mockResolvedValue(indirectMain);
+
+      // Drive the AST callback with a real ConfigFile so the assertion reflects the
+      // actual transform rather than a mocked field-setter.
+      let printed: string | undefined;
+      mockUpdateMainConfig.mockImplementation((async (_opts: any, cb: any) => {
+        const main = loadConfig(indirectMain).parse();
+        await cb(main);
+        printed = printConfig(main).code;
+      }) as any);
+
+      await angularToAngularVite.run!({
+        result: baseResult,
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        storiesPaths: [],
+        configDir: '.storybook',
+        storybookVersion: '9.0.0',
+      } as any);
+
+      expect(mockUpdateMainConfig).toHaveBeenCalled();
+      expect(printed).toMatch(/framework:\s*['"]@storybook\/angular-vite['"]/);
+      expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('configured indirectly'));
+    });
+
+    it('does not force the framework when it is a resolvable literal', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      // Literal object-form framework: the text rewrite handles it, so the AST
+      // safety net must not touch the config or warn about indirect configuration.
+      mockReadFile.mockResolvedValue(
+        `export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
+      );
+
+      await angularToAngularVite.run!({
+        result: { ...baseResult, packageJsonFiles: [] },
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        storiesPaths: [],
+        configDir: '.storybook',
+        storybookVersion: '9.0.0',
+      } as any);
+
+      expect(mockUpdateMainConfig).not.toHaveBeenCalled();
+      expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+        expect.stringContaining('configured indirectly')
+      );
+    });
+
+    it('does not false-positive on a defineMain()-wrapped framework', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      // CSF-factory form: csf-tools unwraps the call wrapper, so the framework name
+      // resolves and the AST safety net must stay out of the way.
+      mockReadFile.mockResolvedValue(
+        `import { defineMain } from '${ANGULAR_VITE_PACKAGE}/node';\nexport default defineMain({ framework: '${ANGULAR_VITE_PACKAGE}' });`
+      );
+
+      await angularToAngularVite.run!({
+        result: { ...baseResult, packageJsonFiles: [] },
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        storiesPaths: [],
+        configDir: '.storybook',
+        storybookVersion: '9.0.0',
+      } as any);
+
+      expect(mockUpdateMainConfig).not.toHaveBeenCalled();
+      expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+        expect.stringContaining('configured indirectly')
       );
     });
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
@@ -485,6 +485,54 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
       );
     });
 
+    it('warns when a spread after the framework property could override it at runtime', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      // The literal resolves (so the force-set is skipped), but at runtime the trailing
+      // spread wins over the earlier key - if `base` also sets `framework`, it silently
+      // undoes the migration. The spread contents are unknown here, so the fix must warn.
+      mockReadFile.mockResolvedValue(
+        `import { base } from './base';\nexport default { framework: '${ANGULAR_VITE_PACKAGE}', ...base };`
+      );
+
+      await angularToAngularVite.run!({
+        result: { ...baseResult, packageJsonFiles: [] },
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        storiesPaths: [],
+        configDir: '.storybook',
+        storybookVersion: '9.0.0',
+      } as any);
+
+      expect(mockUpdateMainConfig).not.toHaveBeenCalled();
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('spreads another object after its')
+      );
+    });
+
+    it('does not warn about spread override when the spread comes before the framework property', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      // A leading spread cannot override the later literal - no warning needed.
+      mockReadFile.mockResolvedValue(
+        `import { base } from './base';\nexport default { ...base, framework: '${ANGULAR_VITE_PACKAGE}' };`
+      );
+
+      await angularToAngularVite.run!({
+        result: { ...baseResult, packageJsonFiles: [] },
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        storiesPaths: [],
+        configDir: '.storybook',
+        storybookVersion: '9.0.0',
+      } as any);
+
+      expect(mockUpdateMainConfig).not.toHaveBeenCalled();
+      expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+        expect.stringContaining('spreads another object after its')
+      );
+    });
+
     it('rewrites angular.json builder entries', async () => {
       mockPromptConfirm.mockResolvedValue(false);
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -122,6 +122,29 @@ export default defineConfig({
 });
 `;
 
+/**
+ * True when the main config's export object has a literal `framework` property followed by an
+ * object spread. ConfigFile's `_exports` bookkeeping skips SpreadElement nodes, so
+ * `getNameFromPath(['framework'])` resolves the literal even though, per object-literal runtime
+ * semantics, a later spread that also sets `framework` silently overrides it.
+ */
+const hasSpreadAfterFrameworkProperty = (main: ConfigFile): boolean => {
+  const properties = main._exportsObject?.properties;
+  if (!properties) {
+    return false;
+  }
+  const frameworkIndex = properties.findIndex(
+    (property) =>
+      t.isObjectProperty(property) &&
+      ((t.isIdentifier(property.key) && property.key.name === 'framework') ||
+        (t.isStringLiteral(property.key) && property.key.value === 'framework'))
+  );
+  if (frameworkIndex === -1) {
+    return false;
+  }
+  return properties.slice(frameworkIndex + 1).some((property) => t.isSpreadElement(property));
+};
+
 const transformMainConfig = async (mainConfigPath: string, dryRun: boolean): Promise<boolean> => {
   try {
     const content = await readFile(mainConfigPath, 'utf-8');
@@ -408,6 +431,19 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
                 value in ${mainConfigPath}), so it could not be switched automatically.
                 We set \`framework: '${ANGULAR_VITE_PACKAGE}'\` for you - please re-apply any framework
                 options (e.g. \`compodoc\`) that were previously defined in your shared config.
+              `
+            );
+          } else if (hasSpreadAfterFrameworkProperty(main)) {
+            // The literal was rewritten above, but at runtime a later `...spread` wins over an
+            // earlier key - so a spread source that also sets `framework` silently undoes the
+            // migration. The spread's contents are unknown here, and appending a duplicate
+            // literal key is a TypeScript error, so warn instead of force-setting.
+            logger.warn(
+              dedent`
+                The main config at ${mainConfigPath} spreads another object after its \`framework\`
+                property. If that spread source also sets \`framework\`, it overrides the migrated
+                value at runtime. Verify the shared config does not set \`framework\`, or move the
+                \`framework\` property after the spread.
               `
             );
           }

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 
 import { types as t } from 'storybook/internal/babel';
 import { formatFileContent, getProjectRoot, transformImportFiles } from 'storybook/internal/common';
-import type { ConfigFile } from 'storybook/internal/csf-tools';
+import { type ConfigFile, readConfig } from 'storybook/internal/csf-tools';
 import { logger, prompt } from 'storybook/internal/node-logger';
 
 import * as find from 'empathic/find';
@@ -385,6 +385,39 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
     if (mainConfigPath) {
       logger.debug('Updating main config...');
       await transformMainConfig(mainConfigPath, dryRun);
+
+      // 2b. Guarantee the framework field actually points at @storybook/angular-vite.
+      // The text rewrite above only touches frameworks spelled out literally in the
+      // main config. When the framework is configured indirectly (e.g. spread from a
+      // shared base config in an Nx workspace) the literal `@storybook/angular` string
+      // is absent, so nothing is rewritten and the config still resolves to
+      // @storybook/angular. That later makes the deferred @storybook/addon-vitest
+      // postinstall fail with a confusing "cannot yet be used with angular" error.
+      // Read the framework back via AST and, when it doesn't resolve to a literal name,
+      // set it explicitly so the migrated project is unambiguously on angular-vite.
+      if (!dryRun) {
+        try {
+          const main = await readConfig(mainConfigPath);
+          if (!main.getNameFromPath(['framework'])) {
+            await updateMainConfig({ mainConfigPath, dryRun: false }, async (config) => {
+              config.setFieldValue(['framework'], ANGULAR_VITE_PACKAGE);
+            });
+            logger.warn(
+              dedent`
+                Your Storybook framework looks like it is configured indirectly (not as a literal
+                value in ${mainConfigPath}), so it could not be switched automatically.
+                We set \`framework: '${ANGULAR_VITE_PACKAGE}'\` for you - please re-apply any framework
+                options (e.g. \`compodoc\`) that were previously defined in your shared config.
+              `
+            );
+          }
+        } catch (error) {
+          logger.warn(
+            `Could not verify the framework in ${mainConfigPath} automatically: ${error}. ` +
+              `Make sure \`framework\` is set to '${ANGULAR_VITE_PACKAGE}'.`
+          );
+        }
+      }
     }
 
     // Track whether any migrated builder config disabled Compodoc, so the


### PR DESCRIPTION
> [!NOTE]
> Rebased onto #35375 (the monorepo-safe import-rewrite fix) - both touch `angular-to-angular-vite.ts`, so please review #35375 first. This PR now only adds the two Angular commits on top. #35366 (zone.js) stacks on top of this one, and #35365 is superseded by #35375.

Follow-up bug fix for the `@storybook/angular-vite` work (#34202). Found during QA on the Bitwarden clients repo.

## What I did

**The issue**

When automigrating an Angular 21 project from `@storybook/angular` to `@storybook/angular-vite`, the deferred `@storybook/addon-vitest` install fails at the very end with:

```
Non-Vite builder is not supported
Test feature cannot yet be used with angular
```

The `angular` (not `angular-vite`) in that second line is the smoking gun: at postinstall time `getStorybookInfo` still resolved the project to `@storybook/angular` + Webpack, so the addon-vitest compatibility check correctly rejected it.

**Root cause**

The migration switched the framework only via a whole-file **text** replace of the literal `@storybook/angular` string in `main.ts` (`transformMainConfig`). That works for the common case, but Bitwarden (like a lot of Nx workspaces) configures the framework **indirectly** - e.g. spread from a shared base config:

```ts
// .storybook/main.ts
import { base } from '../../storybook-shared/main-base';
export default { ...base, stories: ['../src/**/*.stories.ts'] };
```

Here the literal `@storybook/angular` never appears in `main.ts`, so the rewrite silently no-ops. `main.ts` keeps resolving to `@storybook/angular`, and a few steps later the deferred addon-vitest postinstall (which re-reads the config with `skipCache: true`) sees the old framework and blows up with the confusing error above.

**The fix**

After the text rewrite, read the framework back via AST (`readConfig(...).getNameFromPath(['framework'])`). When it does **not** resolve to a literal name, set `framework: '@storybook/angular-vite'` explicitly and warn the user to re-apply any framework options (e.g. `compodoc`) that lived in their shared config.

A couple of things that keep this safe and lean:

- The csf-tools reader already unwraps `defineMain({...})`, `satisfies StorybookConfig`, and `const config = {...}; export default config`, so **resolvable literals are left completely untouched** - no spurious rewrites or warnings on modern configs.
- I only round-trip `main.ts` through the AST writer when there is genuinely something to fix, so the common path keeps its minimal text diff.

There is one more edge the AST reader alone misses: a literal `framework` **followed by** a spread (`{ framework: '...', ...base }`). `getNameFromPath` resolves the literal, so the force-set is skipped - but at runtime the trailing spread wins, so if `base` also sets `framework` it silently clobbers the migrated value. The spread's contents are unknown here and appending a duplicate key is not valid, so the second commit detects that shape via the raw export-object property order and warns instead.

## How to test

- New unit tests in `angular-to-angular-vite.test.ts`:
  - indirect (spread) framework -> framework is forced to `@storybook/angular-vite` and the user is warned
  - literal object-form framework -> untouched, no warning
  - `defineMain()`-wrapped framework -> untouched, no warning (regression guard against false positives)
  - literal `framework` followed by a spread -> warns about the possible runtime override; a leading spread (before the literal) does not warn
- `yarn vitest run code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts`

