### PR TITLE
Angular: Rewrite @storybook/angular imports outside stories in angular-to-angular-vite migration

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { JsPackageManager } from 'storybook/internal/common';
+import { type JsPackageManager, transformImportFiles } from 'storybook/internal/common';
 import { loadConfig, printConfig } from 'storybook/internal/csf-tools';
 
 import { prompt } from 'storybook/internal/node-logger';
@@ -64,6 +64,7 @@ const mockWriteFile = vi.mocked(writeFile);
 const mockPromptConfirm = vi.mocked(prompt.confirm);
 const mockAdd = vi.mocked(add);
 const mockUpdateMainConfig = vi.mocked(updateMainConfig);
+const mockTransformImportFiles = vi.mocked(transformImportFiles);
 
 describe('angular-to-angular-vite', () => {
   const mockPackageManager = {
@@ -768,6 +769,65 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         '/project/vitest.config.ts',
         expect.anything()
       );
+    });
+
+    it('rewrites @storybook/angular imports in non-story project source files', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      mockReadFile.mockResolvedValue(`export default { framework: '${ANGULAR_PACKAGE}' };`);
+
+      const helper = '/project/src/shared/with-angular-decorator.ts';
+      // globby is called for (1) Nx project.json, (2) the configDir files, and
+      // (3) the project source files. Only the third returns our non-story helper.
+      // eslint-disable-next-line depend/ban-dependencies
+      const { globby } = await import('globby');
+      vi.mocked(globby)
+        .mockResolvedValueOnce([]) // project.json
+        .mockResolvedValueOnce([]) // configDir/**/*
+        .mockResolvedValueOnce([helper]); // project source files
+
+      await angularToAngularVite.run!({
+        result: baseResult,
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        storiesPaths: ['/project/src/Button.stories.ts'],
+        configDir: '/project/.storybook',
+        storybookVersion: '9.0.0',
+        addonsToPostinstall: [],
+      } as any);
+
+      expect(mockTransformImportFiles).toHaveBeenCalledWith(
+        expect.arrayContaining(['/project/src/Button.stories.ts', helper]),
+        { [ANGULAR_PACKAGE]: ANGULAR_VITE_PACKAGE },
+        false
+      );
+    });
+
+    it('dedupes files that appear in both storiesPaths and the project source scan', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      mockReadFile.mockResolvedValue(`export default { framework: '${ANGULAR_PACKAGE}' };`);
+
+      const story = '/project/src/Button.stories.ts';
+      // eslint-disable-next-line depend/ban-dependencies
+      const { globby } = await import('globby');
+      vi.mocked(globby)
+        .mockResolvedValueOnce([]) // project.json
+        .mockResolvedValueOnce([]) // configDir/**/*
+        .mockResolvedValueOnce([story]); // project source glob also returns the story
+
+      await angularToAngularVite.run!({
+        result: baseResult,
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        storiesPaths: [story],
+        configDir: '/project/.storybook',
+        storybookVersion: '9.0.0',
+        addonsToPostinstall: [],
+      } as any);
+
+      const passedFiles = mockTransformImportFiles.mock.calls[0][0] as string[];
+      expect(passedFiles.filter((f) => f === story)).toHaveLength(1);
     });
   });
 });

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -458,10 +458,35 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
       }
     }
 
-    // 5. Update import statements across config and story files.
+    // 5. Update import statements across config, story, and project source files.
+    // `storiesPaths` only ever contains *.stories.* files and `configFiles` only the
+    // Storybook config dir, so non-story modules that import from @storybook/angular
+    // (shared decorators, moduleMetadata/applicationConfig helpers, mocks, test setup,
+    // …) would keep importing the now-removed package. Also scan the project directory
+    // (the folder that holds the Storybook config) so those files are rewritten too.
+    // Scoped to the project rather than the repo root, so sibling projects in a
+    // monorepo that were not migrated are left untouched. transformImportFiles only
+    // rewrites quoted @storybook/angular specifiers (and leaves @storybook/angular-vite
+    // alone), so over-including files is safe - at worst a wasted read.
     logger.debug('Scanning and updating import statements...');
     const configFiles = configDir ? await globby([`${configDir}/**/*`]) : [];
-    const allFiles = [...storiesPaths, ...configFiles].filter(Boolean) as string[];
+    const projectSourceFiles = configDir
+      ? await globby(['**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}'], {
+          cwd: dirname(configDir),
+          absolute: true,
+          gitignore: true,
+          ignore: [
+            '**/node_modules/**',
+            '**/dist/**',
+            '**/.storybook-static/**',
+            '**/.angular/**',
+            '**/coverage/**',
+          ],
+        })
+      : [];
+    const allFiles = [
+      ...new Set([...storiesPaths, ...configFiles, ...projectSourceFiles].filter(Boolean)),
+    ] as string[];
 
     const transformErrors = await transformImportFiles(
       allFiles,


### PR DESCRIPTION
Follow-up bug fix for the `@storybook/angular-vite` work (#34202). Found during QA on the Bitwarden clients repo.

## What I did

`:ladybug:` **The issue**

After automigrating an Angular 21 project from `@storybook/angular` to `@storybook/angular-vite`, some files still import from `@storybook/angular` - which no longer exists once the migration removes it from `package.json`. The build/typecheck then breaks for any story that pulls one of those files in.

**Root cause**

The import-rewrite step only fed two things into `transformImportFiles`:

```ts
const configFiles = configDir ? await globby([`${configDir}/**/*`]) : [];
const allFiles = [...storiesPaths, ...configFiles].filter(Boolean);
```

`storiesPaths` is strictly `*.stories.*` files (it comes from the `stories` glob), and `configFiles` is only the `.storybook` config dir. Angular projects import from `@storybook/angular` in a lot of **non-story** modules though - shared decorators, `moduleMetadata`/`applicationConfig` helpers, `*.mock.ts`, test setup, per-component helpers. None of those are in either set, so they were silently skipped.

**The fix**

Also scan the **project directory** (the folder that holds the Storybook config) for source files and run them through the same rewrite, deduped with the existing sets:

```ts
const projectSourceFiles = await globby(['**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}'], {
  cwd: dirname(configDir),
  absolute: true,
  gitignore: true,
  ignore: ['**/node_modules/**', '**/dist/**', '**/.storybook-static/**', '**/.angular/**', '**/coverage/**'],
});
const allFiles = [...new Set([...storiesPaths, ...configFiles, ...projectSourceFiles].filter(Boolean))];
```

Two deliberate choices:

- **Scoped to the project, not the repo root.** In a partially-migrated monorepo we must not rewrite `@storybook/angular` imports in sibling projects that stayed on the Webpack framework, so I glob `dirname(configDir)` rather than `getProjectRoot()`.
- **Over-including is safe.** `transformImportFiles` only rewrites quoted `@storybook/angular` specifiers and correctly leaves `@storybook/angular-vite` alone, so the worst case for an unrelated file is a wasted read.

> Heads-up: the same `storiesPaths + configDir` scanning shape exists in `nextjs-to-nextjs-vite.ts`, `consolidated-imports.ts`, and `renderer-to-framework.ts`. I kept this PR scoped to the Angular fix, but we may want to align the others in a follow-up. WDYT?

## How to test

- New unit tests in `angular-to-angular-vite.test.ts`:
  - a non-story helper importing `@storybook/angular` is now included in the rewrite scan
  - a file present in both `storiesPaths` and the project scan is deduped to a single entry
- `yarn vitest run code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts`

Draft while I land the sibling QA fixes.
