### PR TITLE
Angular: Re-add zone.js import to the preview in angular-to-angular-vite migration

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
@@ -928,6 +928,141 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         expect.anything()
       );
     });
+
+    const angularJsonWithPolyfills = (polyfills: unknown) =>
+      JSON.stringify({
+        projects: {
+          myApp: {
+            architect: {
+              build: {
+                builder: '@angular-devkit/build-angular:application',
+                options: { polyfills },
+              },
+              storybook: { builder: '@storybook/angular:start-storybook' },
+            },
+          },
+        },
+      });
+
+    const readFileForZoneJsTest =
+      (angularJson: string, previewContent: string) => (filePath: any) => {
+        const p = String(filePath);
+        if (p.endsWith('angular.json')) {
+          return Promise.resolve(angularJson) as any;
+        }
+        if (p.endsWith('preview.ts')) {
+          return Promise.resolve(previewContent) as any;
+        }
+        if (p.endsWith('package.json')) {
+          return Promise.resolve('{}') as any;
+        }
+        return Promise.resolve(`export default { framework: '${ANGULAR_PACKAGE}' };`) as any;
+      };
+
+    it("adds an `import 'zone.js';` to the preview when the build ships zone.js as a polyfill", async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      mockReadFile.mockImplementation(
+        readFileForZoneJsTest(
+          angularJsonWithPolyfills(['zone.js']),
+          `import { applicationConfig } from '${ANGULAR_PACKAGE}';\nexport const decorators = [];\n`
+        )
+      );
+
+      await angularToAngularVite.run!({
+        result: baseResult,
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        previewConfigPath: '/project/.storybook/preview.ts',
+        storiesPaths: [],
+        configDir: '/project/.storybook',
+        storybookVersion: '9.0.0',
+        addonsToPostinstall: [],
+      } as any);
+
+      const previewWrite = mockWriteFile.mock.calls.find(
+        ([p]) => p === '/project/.storybook/preview.ts'
+      );
+      expect(previewWrite).toBeDefined();
+      expect(String(previewWrite![1])).toMatch(/^import 'zone\.js';/);
+    });
+
+    it('does not touch the preview for a zoneless project (no zone.js polyfill)', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      mockReadFile.mockImplementation(
+        readFileForZoneJsTest(angularJsonWithPolyfills([]), `export const decorators = [];\n`)
+      );
+
+      await angularToAngularVite.run!({
+        result: baseResult,
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        previewConfigPath: '/project/.storybook/preview.ts',
+        storiesPaths: [],
+        configDir: '/project/.storybook',
+        storybookVersion: '9.0.0',
+        addonsToPostinstall: [],
+      } as any);
+
+      expect(mockWriteFile).not.toHaveBeenCalledWith(
+        '/project/.storybook/preview.ts',
+        expect.anything()
+      );
+    });
+
+    it('is idempotent when the preview already imports zone.js', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      mockReadFile.mockImplementation(
+        readFileForZoneJsTest(
+          angularJsonWithPolyfills(['zone.js']),
+          `import 'zone.js';\nexport const decorators = [];\n`
+        )
+      );
+
+      await angularToAngularVite.run!({
+        result: baseResult,
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        previewConfigPath: '/project/.storybook/preview.ts',
+        storiesPaths: [],
+        configDir: '/project/.storybook',
+        storybookVersion: '9.0.0',
+        addonsToPostinstall: [],
+      } as any);
+
+      expect(mockWriteFile).not.toHaveBeenCalledWith(
+        '/project/.storybook/preview.ts',
+        expect.anything()
+      );
+    });
+
+    it('does not modify the preview in dry-run mode even when zone.js is needed', async () => {
+      mockReadFile.mockImplementation(
+        readFileForZoneJsTest(
+          angularJsonWithPolyfills(['zone.js']),
+          `export const decorators = [];\n`
+        )
+      );
+
+      await angularToAngularVite.run!({
+        result: baseResult,
+        dryRun: true,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        previewConfigPath: '/project/.storybook/preview.ts',
+        storiesPaths: [],
+        configDir: '/project/.storybook',
+        storybookVersion: '9.0.0',
+        addonsToPostinstall: [],
+      } as any);
+
+      expect(mockWriteFile).not.toHaveBeenCalledWith(
+        '/project/.storybook/preview.ts',
+        expect.anything()
+      );
+    });
   });
 });
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -207,10 +207,49 @@ const detectDisabledCompodoc = (content: string): boolean => {
   );
 };
 
+/**
+ * Detect whether an Angular build target in an `angular.json` or Nx `project.json`
+ * ships `zone.js` as a polyfill, i.e. the project uses zone-based change detection.
+ * @storybook/angular-vite defaults to zoneless outside `ng run`, so this signal is
+ * used to re-add the `zone.js` import to the Storybook preview (see step 4c).
+ */
+const detectUsesZoneJs = (content: string): boolean => {
+  let json: any;
+  try {
+    json = JSON.parse(content);
+  } catch {
+    return false;
+  }
+
+  const isZoneJsPolyfill = (entry: unknown): boolean =>
+    typeof entry === 'string' && (entry === 'zone.js' || entry.startsWith('zone.js/'));
+
+  const targetUsesZoneJs = (target: any): boolean => {
+    const polyfills = target?.options?.polyfills;
+    return Array.isArray(polyfills)
+      ? polyfills.some(isZoneJsPolyfill)
+      : isZoneJsPolyfill(polyfills);
+  };
+
+  // angular.json: projects.<name>.architect.<target>; project.json: targets.<target>
+  const targetGroups: any[] = [];
+  if (json?.projects && typeof json.projects === 'object') {
+    for (const project of Object.values<any>(json.projects)) {
+      targetGroups.push(project?.architect, project?.targets);
+    }
+  }
+  targetGroups.push(json?.targets);
+
+  return targetGroups.some(
+    (group) =>
+      group && typeof group === 'object' && Object.values<any>(group).some(targetUsesZoneJs)
+  );
+};
+
 const transformJsonFile = async (
   filePath: string,
   dryRun: boolean
-): Promise<{ changed: boolean; disablesCompodoc: boolean }> => {
+): Promise<{ changed: boolean; disablesCompodoc: boolean; usesZoneJs: boolean }> => {
   try {
     const content = await readFile(filePath, 'utf-8');
     const transformed = rewriteBuilderRefs(content);
@@ -220,9 +259,48 @@ const transformJsonFile = async (
       await writeFile(filePath, transformed);
     }
 
-    return { changed, disablesCompodoc: detectDisabledCompodoc(content) };
+    return {
+      changed,
+      disablesCompodoc: detectDisabledCompodoc(content),
+      usesZoneJs: detectUsesZoneJs(content),
+    };
   } catch {
-    return { changed: false, disablesCompodoc: false };
+    return { changed: false, disablesCompodoc: false, usesZoneJs: false };
+  }
+};
+
+/**
+ * Prepend `import 'zone.js';` to the Storybook preview when the migrated project uses
+ * zone-based change detection. The Webpack `@storybook/angular` builder loaded zone.js
+ * from the Angular build `polyfills`; @storybook/angular-vite defaults to zoneless
+ * outside `ng run`, so without this the polyfill is dropped for `storybook dev`,
+ * `storybook build`, and standalone Vitest, breaking `NgZone`-dependent stories.
+ * Idempotent, and a no-op in dry runs.
+ */
+const addZoneJsPreviewImport = async (
+  previewConfigPath: string,
+  dryRun: boolean
+): Promise<void> => {
+  try {
+    const content = await readFile(previewConfigPath, 'utf-8');
+
+    // Leave an existing zone.js import (any quote style, incl. subpaths) alone.
+    if (/import\s+['"]zone\.js(\/[^'"]*)?['"]/.test(content)) {
+      return;
+    }
+
+    if (dryRun) {
+      return;
+    }
+
+    // zone.js must be imported before Angular loads, so it goes at the very top.
+    await writeFile(previewConfigPath, `import 'zone.js';\n${content}`);
+    logger.step(`Added a \`zone.js\` import to ${previewConfigPath}`);
+  } catch (error) {
+    logger.warn(
+      `Could not add a \`zone.js\` import to ${previewConfigPath} automatically: ${error}. ` +
+        "If your app uses zone-based change detection, add `import 'zone.js';` at the top of your preview."
+    );
   }
 };
 
@@ -459,14 +537,21 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
     // Track whether any migrated builder config disabled Compodoc, so the
     // intent can be carried into framework.options (step 4b).
     let disableCompodoc = false;
+    // Track whether the project ships zone.js as a build polyfill, so the zone.js
+    // import can be re-added to the preview (step 4c).
+    let zoneJsNeeded = false;
 
     // 3. Rewrite Angular CLI builder references in angular.json.
     // Search for angular.json beside every package.json we know about.
     for (const pkgJsonPath of packageManager.packageJsonPaths) {
       const dir = pkgJsonPath.replace(/[/\\]package\.json$/, '');
       const angularJsonPath = `${dir}/angular.json`;
-      const { changed, disablesCompodoc } = await transformJsonFile(angularJsonPath, dryRun);
+      const { changed, disablesCompodoc, usesZoneJs } = await transformJsonFile(
+        angularJsonPath,
+        dryRun
+      );
       disableCompodoc ||= disablesCompodoc;
+      zoneJsNeeded ||= usesZoneJs;
       if (changed) {
         logger.debug(`Updated Angular CLI builder references in ${angularJsonPath}`);
       }
@@ -485,8 +570,12 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
       absolute: true,
     });
     for (const projectJsonPath of projectJsonFiles) {
-      const { changed, disablesCompodoc } = await transformJsonFile(projectJsonPath, dryRun);
+      const { changed, disablesCompodoc, usesZoneJs } = await transformJsonFile(
+        projectJsonPath,
+        dryRun
+      );
       disableCompodoc ||= disablesCompodoc;
+      zoneJsNeeded ||= usesZoneJs;
       if (changed) {
         logger.debug(`Updated Nx builder references in ${projectJsonPath}`);
       }
@@ -526,6 +615,14 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
             "Set `compodoc: false` in your main config's framework.options manually."
         );
       }
+    }
+
+    // 4c. Re-add the zone.js import to the preview for zone-based projects. The
+    // Webpack builder loaded zone.js from the Angular build `polyfills`, but
+    // @storybook/angular-vite defaults to zoneless outside `ng run`, so the polyfill
+    // would otherwise be dropped for `storybook dev`, `storybook build`, and Vitest.
+    if (zoneJsNeeded && previewConfigPath) {
+      await addZoneJsPreviewImport(previewConfigPath, dryRun);
     }
 
     // 5. Update import statements across config and story files.


### PR DESCRIPTION
> [!NOTE]
> Bottom of the stack: this sits on top of #35364, which sits on top of #35375. Please review those two first - this PR only adds the zone.js commit.

Follow-up bug fix for the `@storybook/angular-vite` work (#34202). Found during QA on the Bitwarden clients repo.

## What I did

`:ladybug:` **The issue**

After automigrating a zone-based Angular 21 project from `@storybook/angular` to `@storybook/angular-vite`, `preview.ts(x)` is missing an `import 'zone.js';`. Stories/tests that rely on `NgZone` change detection then break, because zone.js is never loaded.

**Root cause**

The Webpack `@storybook/angular` builder pulled `zone.js` in via the Angular build `polyfills`. `@storybook/angular-vite` defaults to **zoneless** (`resolveZoneless` returns `angularBuilderOptions?.zoneless ?? true`, and the builders default `zoneless = true`), and the framework only injects `zone.js` into the preview transform when it runs through `ng run` with `angularBuilderOptions.zoneless === false`.

That means for `storybook dev`, `storybook build`, and standalone Vitest, a migrated zone-based project silently loses zone.js. The migration itself never touched the preview, so nothing carried the polyfill over.

**The fix**

- Detect zone usage from the `zone.js` entry in the Angular build target `polyfills` (`angular.json` or Nx `project.json`), reusing the same target-walking shape as the existing `compodoc` detection.
- When the project is **not** zoneless, prepend `import 'zone.js';` to the Storybook preview (`previewConfigPath`, which the runner already provides).

Kept safe and boring:

- **Idempotent** - an existing `zone.js` import (any quote style, including subpaths like `zone.js/testing`) is left alone.
- **Dry-run aware** - no writes when `--dry-run`.
- Placed at the very top of the preview, since zone.js must be imported before Angular loads.

## How to test

- New unit tests in `angular-to-angular-vite.test.ts`:
  - `polyfills: ['zone.js']` -> preview gets `import 'zone.js';` prepended
  - zoneless project (`polyfills: []`) -> preview untouched
  - preview already imports zone.js -> untouched (idempotent)
  - dry-run -> preview untouched
- `yarn vitest run code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts`

Draft - part of the same QA batch as the indirect-framework and import-rewrite fixes.

