### PR TITLE
Feature: Support function-based conditions in conditional args

### DIFF
--- a/code/core/src/csf/includeConditionalArg.test.ts
+++ b/code/core/src/csf/includeConditionalArg.test.ts
@@ -160,4 +160,56 @@ describe('includeConditionalArg', () => {
       });
     });
   });
+
+  describe('function', () => {
+    it('should return true when function returns true', () => {
+      expect(
+        includeConditionalArg(
+          { if: (args) => args.a === 1 },
+          { a: 1 },
+          {}
+        )
+      ).toBe(true);
+    });
+
+    it('should return false when function returns false', () => {
+      expect(
+        includeConditionalArg(
+          { if: (args) => args.a === 1 },
+          { a: 2 },
+          {}
+        )
+      ).toBe(false);
+    });
+
+    it('should support multiple conditions via function', () => {
+      expect(
+        includeConditionalArg(
+          { if: (args) => args.type === 'pessoaFisica' && args.pais === 'Brasil' },
+          { type: 'pessoaFisica', pais: 'Brasil' },
+          {}
+        )
+      ).toBe(true);
+    });
+
+    it('should support multiple conditions via function returning false', () => {
+      expect(
+        includeConditionalArg(
+          { if: (args) => args.type === 'pessoaFisica' && args.pais === 'Brasil' },
+          { type: 'pessoaFisica', pais: 'Alemanha' },
+          {}
+        )
+      ).toBe(false);
+    });
+
+    it('should pass globals to the function', () => {
+      expect(
+        includeConditionalArg(
+          { if: (_args, globals) => globals.theme === 'dark' },
+          {},
+          { theme: 'dark' }
+        )
+      ).toBe(true);
+    });
+  });
 });

--- a/code/core/src/csf/includeConditionalArg.ts
+++ b/code/core/src/csf/includeConditionalArg.ts
@@ -1,7 +1,7 @@
 /* @ts-expect-error (has no typings) */
 import { isEqual } from '@ngard/tiny-isequal';
 
-import type { Args, Conditional, Globals, InputType } from './story.ts';
+import type { Args, ConditionalFunction, Conditional, Globals, InputType } from './story.ts';
 
 const count = (vals: any[]) => vals.map((v) => typeof v !== 'undefined').filter(Boolean).length;
 
@@ -25,20 +25,23 @@ export const testValue = (cond: Omit<Conditional, 'arg' | 'global'>, value: any)
 };
 
 /**
- * Helper function to include/exclude an arg based on the value of other other args aka "conditional
- * args"
+ * Helper function to include/exclude an arg based on the value of other args aka "conditional
+ * args". Supports both object-based conditions and function-based conditions.
  */
 export const includeConditionalArg = (argType: InputType, args: Args, globals: Globals) => {
   if (!argType.if) {
     return true;
   }
 
+  // Support function-based conditions
+  if (typeof argType.if === 'function') {
+    return (argType.if as ConditionalFunction)(args, globals);
+  }
+
   const { arg, global } = argType.if as any;
   if (count([arg, global]) !== 1) {
     throw new Error(`Invalid conditional value ${JSON.stringify({ arg, global })}`);
   }
-
   const value = arg ? args[arg] : globals[global];
-
   return testValue(argType.if!, value);
 };

--- a/code/core/src/csf/story.ts
+++ b/code/core/src/csf/story.ts
@@ -58,7 +58,8 @@ type ControlType =
 
 type ConditionalTest = { truthy?: boolean } | { exists: boolean } | { eq: any } | { neq: any };
 type ConditionalValue = { arg: string } | { global: string };
-export type Conditional = ConditionalValue & ConditionalTest;
+export type ConditionalFunction = (args: Args, globals: Globals) => boolean;
+export type Conditional = (ConditionalValue & ConditionalTest) | ConditionalFunction;
 
 interface ControlBase {
   [key: string]: any;


### PR DESCRIPTION
Closes #19135

## What I did

Extended the conditional args system to accept a function as a condition, in addition to the existing object based syntax.

Previously, conditional args only supported simple single condition checks via an object (`if: { arg: 'type', eq: 'button' }`). Complex scenarios that depend on multiple args simultaneously were impossible to express. This change allows passing a function that receives the current `args` and `globals` and returns a boolean

The existing object based syntax continues to work exactly as before, the function check is added before the existing logic, and falls through to the original behavior when the condition is not a function.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual testing is strictly required, since this is a backward compatible addition fully covered by unit tests. To verify manually:

1. Run a sandbox: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. In a story, add an argType with a function condition, e.g. `if: (args) => args.a && args.b`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conditional logic now supports function-based rules, allowing more flexible show/hide behavior based on both current values and global settings.
  * Function-based conditions can evaluate multiple checks and receive global context for more advanced decisions.

* **Tests**
  * Added coverage for function-based conditional behavior, including matching, non-matching, multiple conditions, and global argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->