### PR TITLE
Controls: Fix select control for single-quoted and large union types

### DIFF
--- a/code/core/src/docs-tools/argTypes/convert/proptypes/convert.test.ts
+++ b/code/core/src/docs-tools/argTypes/convert/proptypes/convert.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { convert } from './convert.ts';
+
+describe('convert (proptypes)', () => {
+  describe('union flattening for large union types', () => {
+    it('flattens a union of single-value enums into one enum', () => {
+      // react-docgen-typescript emits each literal as a separate single-value enum
+      // when the union exceeds its internal member limit (around 28 values).
+      const largeLiteralUnion = {
+        name: 'union',
+        value: ['k1', 'k2', 'k3', 'k4', 'k5'].map((k) => ({
+          name: 'enum',
+          value: [{ value: `'${k}'` }],
+        })),
+      };
+
+      expect(convert(largeLiteralUnion as any)).toEqual({
+        name: 'enum',
+        value: ['k1', 'k2', 'k3', 'k4', 'k5'],
+      });
+    });
+
+    it('does not flatten a union of mixed types', () => {
+      const mixedUnion = {
+        name: 'union',
+        value: [
+          { name: 'string' },
+          { name: 'number' },
+        ],
+      };
+
+      expect(convert(mixedUnion as any)).toEqual({
+        name: 'union',
+        value: [{ name: 'string' }, { name: 'number' }],
+      });
+    });
+  });
+
+  describe('pipe-separated name fallback', () => {
+    it('parses single-quoted string literals from pipe-separated type names', () => {
+      // react-docgen-typescript-plugin puts the raw union string in `name`
+      // when shouldExtractValuesFromUnion is off.  Single quotes are valid TS
+      // but JSON.parse rejects them — parseLiteral handles both.
+      const singleQuotedUnion = { name: `'foo'|'bar'|'baz'` };
+
+      expect(convert(singleQuotedUnion as any)).toEqual({
+        name: 'enum',
+        value: ['foo', 'bar', 'baz'],
+      });
+    });
+
+    it('parses double-quoted string literals from pipe-separated type names', () => {
+      const doubleQuotedUnion = { name: `"foo"|"bar"` };
+
+      expect(convert(doubleQuotedUnion as any)).toEqual({
+        name: 'enum',
+        value: ['foo', 'bar'],
+      });
+    });
+
+    it('parses numeric literals from pipe-separated type names', () => {
+      const numericUnion = { name: `1|2|3` };
+
+      expect(convert(numericUnion as any)).toEqual({
+        name: 'enum',
+        value: [1, 2, 3],
+      });
+    });
+  });
+});

--- a/code/core/src/docs-tools/argTypes/convert/proptypes/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/proptypes/convert.ts
@@ -64,12 +64,8 @@ export const convert = (type: PTType): SBType | any => {
         // (like if a user has turned off shouldExtractValuesFromUnion) so here we
         // try to recover and construct one.  parseLiteral handles both single-
         // and double-quoted strings, unlike JSON.parse which rejects single quotes.
-        try {
-          const literalValues = name.split('|').map((v: string) => parseLiteral(v.trim()));
-          return { ...base, name: 'enum', value: literalValues };
-        } catch (err) {
-          // fall through
-        }
+        const literalValues = name.split('|').map((v: string) => parseLiteral(v.trim()));
+        return { ...base, name: 'enum', value: literalValues };
       }
       const otherVal = value ? `${name}(${value})` : name;
       const otherName = SIGNATURE_REGEXP.test(name) ? 'function' : 'other';

--- a/code/core/src/docs-tools/argTypes/convert/proptypes/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/proptypes/convert.ts
@@ -40,8 +40,21 @@ export const convert = (type: PTType): SBType | any => {
     case 'exact':
       const values = mapValues(value, (field) => convert(field));
       return { ...base, name: 'object', value: values };
-    case 'union':
-      return { ...base, name: 'union', value: value.map((v: PTType) => convert(v)) };
+    case 'union': {
+      const convertedValues = value.map((v: PTType) => convert(v));
+      // When react-docgen-typescript exceeds its union-member limit it emits each
+      // literal as a separate single-value enum inside a union.  Flatten those
+      // into one enum so inferControls can render a select/radio control.
+      if (
+        convertedValues.length > 0 &&
+        convertedValues.every(
+          (v: any) => v?.name === 'enum' && Array.isArray(v.value) && v.value.length === 1
+        )
+      ) {
+        return { ...base, name: 'enum', value: convertedValues.map((v: any) => v.value[0]) };
+      }
+      return { ...base, name: 'union', value: convertedValues };
+    }
     case 'instanceOf':
     case 'element':
     case 'elementType':
@@ -49,9 +62,10 @@ export const convert = (type: PTType): SBType | any => {
       if (name?.indexOf('|') > 0) {
         // react-docgen-typescript-plugin doesn't always produce enum-like unions
         // (like if a user has turned off shouldExtractValuesFromUnion) so here we
-        // try to recover and construct one.
+        // try to recover and construct one.  parseLiteral handles both single-
+        // and double-quoted strings, unlike JSON.parse which rejects single quotes.
         try {
-          const literalValues = name.split('|').map((v: string) => JSON.parse(v));
+          const literalValues = name.split('|').map((v: string) => parseLiteral(v.trim()));
           return { ...base, name: 'enum', value: literalValues };
         } catch (err) {
           // fall through


### PR DESCRIPTION
#### What changed and why

Fixes #35236 — two bugs in `code/core/src/docs-tools/argTypes/convert/proptypes/convert.ts` caused large or single-quoted TypeScript union types to silently fall back to an object control instead of rendering a `select`/`radio` dropdown.

**Bug 1 — `JSON.parse` rejects single-quoted string literals**

The pipe-separated name fallback used `JSON.parse(v)`, which throws on TypeScript single-quoted string literals like `'foo' | 'bar'`. `parseLiteral` (already imported) handles both quote styles and cannot throw, so the try/catch is also removed.

**Bug 2 — union of single-value enums not flattened**

When `react-docgen-typescript` exceeds its union-member limit it emits each literal as a separate single-value enum inside a `union` node. The `union` case now detects this and flattens it into a single `enum` so `inferControls` renders a `select`/`radio` control.

#### Manual testing

1. Create a component with a prop typed as a large union (30+ string literals):
```tsx
type BigUnion = 'a1'|'a2'|'a3'| ... |'c10';
export const MyComp = ({ value }: { value: BigUnion }) => <div>{value}</div>;
```
2. Write a story and open Storybook Controls panel
3. **Before fix:** the `value` control renders as an object editor
4. **After fix:** the `value` control renders as a `select` dropdown with all options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of complex union types by flattening large unions of single-value enum options into a combined enum when safe.
  * Kept mixed-type unions unflattened to preserve correct output shape.
  * Enhanced fallback parsing for pipe-separated values, improving recognition of single-quoted strings, double-quoted strings, and numeric literals.
* **Tests**
  * Added coverage for union flattening behavior and fallback parsing across quoted and numeric value formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->