### PR TITLE
fix: infer select/radio controls for large union types misclassified by docgen

### DIFF
--- a/code/core/src/preview-api/modules/store/inferControls.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.ts
@@ -65,8 +65,26 @@ const inferControl = (argType: StrictInputType, name: string, matchers: Controls
     case 'function':
     case 'symbol':
       return null;
-    default:
+    default: {
+      // When type parsers (e.g. react-docgen-typescript) encounter large union types
+      // such as  with many keys, they may fail to classify the type
+      // as 'enum' and instead report it as 'other', 'intersection', etc.
+      // However, the type metadata often still contains a  array with the
+      // individual union members. Detect this case and infer a select/radio control.
+      const enumValues = (type as SBEnumType).value;
+      if (
+        !options &&
+        Array.isArray(enumValues) &&
+        enumValues.length > 0 &&
+        enumValues.every((v) => typeof v === 'string' || typeof v === 'number')
+      ) {
+        return {
+          control: { type: enumValues.length <= 5 ? 'radio' : 'select' },
+          options: enumValues,
+        };
+      }
       return { control: { type: options ? 'select' : 'object' } };
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #12641

When docgen parsers (react-docgen-typescript) encounter large union types such as `keyof typeof obj` with 29+ keys, they may fail to classify the type as `enum`. The type metadata still contains a `value` array with string literals, but the type name may be `other` or `intersection`.

This fix checks if `type.value` is an array of strings/numbers and infers `select` (or `radio` for ≤5 items) control, matching the `enum` case behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic control selection for enum-like values, making props and args easier to edit in the UI.
  * Small value sets now appear as radio controls, while larger sets use a select control.
* **Bug Fixes**
  * Better fallback behavior when control type details are incomplete, helping preserve previous control handling where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->