### PR TITLE
fix: infer select/radio controls for large union types misclassified by docgen

### DIFF
--- a/code/core/src/preview-api/modules/store/inferControls.ts
+++ b/code/core/src/preview-api/modules/store/inferControls.ts
@@ -65,8 +65,21 @@ const inferControl = (argType: StrictInputType, name: string, matchers: Controls
     case 'function':
     case 'symbol':
       return null;
-    default:
+    default: {
+      const enumValues = (type as SBEnumType).value;
+      if (enumValues && Array.isArray(enumValues) && enumValues.length > 0) {
+        const allPrimitives = enumValues.every(
+          (v: any) => typeof v === 'string' || typeof v === 'number'
+        );
+        if (allPrimitives) {
+          return {
+            control: { type: enumValues.length <= 5 ? 'radio' : 'select' },
+            options: enumValues,
+          };
+        }
+      }
       return { control: { type: options ? 'select' : 'object' } };
+    }
   }
 };
 


### PR DESCRIPTION
## Problem

When a component prop is typed as `keyof typeof customObject` and the object has **29 or more key-value pairs**, Storybook incorrectly renders an `object` control (JSON editor) instead of a `select` dropdown.

### Root Cause

`react-docgen-typescript` fails to classify `keyof typeof` unions with many members as `enum`. Instead, it reports the type as `other`, `intersection`, or similar non-enum names. However, the type metadata still contains a `value` array with all string literals.

## Fix

Added a defensive guard in the `default` case of `inferControl()` that checks if the type value property is an array of primitive literals (strings/numbers). When detected, it treats the type as an enum and infers `select` (>5 options) or `radio` (≤5 options).

## Impact

Fixes #12641

## Backwards Compatibility

Zero breaking changes. The fix only activates for types that were previously incorrectly rendered as `object`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic control selection for enum-like values, now choosing more suitable input types based on the available values.
  * Added support for passing enum options directly into the inferred control when the values are valid primitives.
* **Bug Fixes**
  * Fallback behavior remains in place for invalid or unsupported enum values, preserving previous control inference for non-enum cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->