### PR TITLE
CLI: Prompt for framework when project type cannot be detected

### DIFF
--- a/code/lib/create-storybook/src/commands/ProjectDetectionCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/ProjectDetectionCommand.test.ts
@@ -96,6 +96,59 @@ describe('ProjectDetectionCommand', () => {
       expect(mockProjectTypeService.autoDetectProjectType).not.toHaveBeenCalled();
     });
 
+    describe('undetected project type (#35045)', () => {
+      it('should install HTML framework when user selects it', async () => {
+        vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(
+          ProjectType.UNDETECTED
+        );
+        vi.mocked(prompt.select).mockResolvedValueOnce('html');
+
+        const command = new ProjectDetectionCommand({} as CommandOptions, mockPackageManager);
+        const result = await command.execute();
+
+        expect(result.projectType).toBe(ProjectType.HTML);
+      });
+
+      it('should let the user choose another framework', async () => {
+        vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(
+          ProjectType.UNDETECTED
+        );
+        vi.mocked(prompt.select)
+          .mockResolvedValueOnce('select')
+          .mockResolvedValueOnce(ProjectType.VUE3);
+
+        const command = new ProjectDetectionCommand({} as CommandOptions, mockPackageManager);
+        const result = await command.execute();
+
+        expect(result.projectType).toBe(ProjectType.VUE3);
+      });
+
+      it('should fail when the user cancels the installation', async () => {
+        vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(
+          ProjectType.UNDETECTED
+        );
+        vi.mocked(prompt.select).mockResolvedValueOnce('cancel');
+
+        const command = new ProjectDetectionCommand({} as CommandOptions, mockPackageManager);
+
+        await expect(command.execute()).rejects.toThrow();
+      });
+
+      it('should fail without prompting in non-interactive mode', async () => {
+        vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(
+          ProjectType.UNDETECTED
+        );
+
+        const command = new ProjectDetectionCommand(
+          { yes: true } as CommandOptions,
+          mockPackageManager
+        );
+
+        await expect(command.execute()).rejects.toThrow();
+        expect(prompt.select).not.toHaveBeenCalled();
+      });
+    });
+
     it('should auto-detect project type when not provided', async () => {
       options.type = undefined;
       vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(ProjectType.VUE3);

--- a/code/lib/create-storybook/src/commands/ProjectDetectionCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/ProjectDetectionCommand.test.ts
@@ -123,6 +123,21 @@ describe('ProjectDetectionCommand', () => {
         expect(result.projectType).toBe(ProjectType.VUE3);
       });
 
+      it('should chain into the React Native variant prompt when RN is selected', async () => {
+        vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(
+          ProjectType.UNDETECTED
+        );
+        vi.mocked(prompt.select)
+          .mockResolvedValueOnce('select')
+          .mockResolvedValueOnce(ProjectType.REACT_NATIVE)
+          .mockResolvedValueOnce(ProjectType.REACT_NATIVE_WEB);
+
+        const command = new ProjectDetectionCommand({} as CommandOptions, mockPackageManager);
+        const result = await command.execute();
+
+        expect(result.projectType).toBe(ProjectType.REACT_NATIVE_WEB);
+      });
+
       it('should fail when the user cancels the installation', async () => {
         vi.mocked(mockProjectTypeService.autoDetectProjectType).mockResolvedValue(
           ProjectType.UNDETECTED

--- a/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
+++ b/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
@@ -83,48 +83,44 @@ export class ProjectDetectionCommand {
    */
   private async promptUndetectedProjectType(): Promise<ProjectType> {
     logger.error(dedent`
-      Unable to detect a supported framework in this directory.
+      Storybook couldn't detect a supported framework in this directory. Make sure you're inside your project's root folder and that its dependencies are installed. Vanilla Web Components projects cannot be automatically detected.
 
-      Storybook couldn't detect a supported framework or configuration for your project. Make sure you're inside a framework project (e.g., React, Vue, Svelte, Angular, Next.js) and that its dependencies are installed.
-
-      You can tell Storybook which framework to use with the ${picocolors.bold('--type')} flag, e.g. ${picocolors.bold('--type html')} for projects without a framework.
+      To tell Storybook which framework to use, pass the ${picocolors.bold('--type')} flag, e.g. ${picocolors.bold('--type html')} for Web Components and vanilla HTML projects.
     `);
 
-    if (this.options.yes) {
-      throw new HandledError('Storybook failed to detect your project type');
-    }
-
-    const choice = await prompt.select(
-      {
-        message: 'How would you like to proceed?',
-        options: [
-          {
-            label: `Install the ${picocolors.bold('HTML')} framework (for projects without a framework)`,
-            value: 'html',
-          },
-          { label: 'Choose a framework to install', value: 'select' },
-          { label: 'Cancel the installation', value: 'cancel' },
-        ],
-      },
-      createPromptCancelOptions(this.telemetryService, 'undetected-project-type')
-    );
-
-    if (choice === 'html') {
-      return ProjectType.HTML;
-    }
-
-    if (choice === 'select') {
-      const installable = Object.values(ProjectType).filter(
-        (t) => !['undetected', 'unsupported', 'nx'].includes(String(t))
-      );
-      const manualType = await prompt.select(
+    if (!this.options.yes) {
+      const choice = await prompt.select(
         {
-          message: 'Which framework would you like to install?',
-          options: installable.map((t) => ({ label: String(t), value: t })),
+          message: 'How would you like to proceed?',
+          options: [
+            {
+              label: `Install the ${picocolors.bold('HTML')} framework (for Web Components and HTML projects)`,
+              value: 'html',
+            },
+            { label: 'Choose a framework to install', value: 'select' },
+            { label: 'Abort', value: 'cancel' },
+          ],
         },
-        createPromptCancelOptions(this.telemetryService, 'undetected-project-type-framework')
+        createPromptCancelOptions(this.telemetryService, 'undetected-project-type')
       );
-      return manualType as ProjectType;
+
+      if (choice === 'html') {
+        return ProjectType.HTML;
+      }
+
+      if (choice === 'select') {
+        const installable = Object.values(ProjectType).filter(
+          (t) => !['undetected', 'unsupported', 'nx'].includes(String(t))
+        );
+        const manualType = await prompt.select(
+          {
+            message: 'Which framework would you like to install?',
+            options: installable.map((t) => ({ label: String(t), value: t })),
+          },
+          createPromptCancelOptions(this.telemetryService, 'undetected-project-type-framework')
+        );
+        return manualType as ProjectType;
+      }
     }
 
     throw new HandledError('Storybook failed to detect your project type');

--- a/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
+++ b/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
@@ -46,7 +46,7 @@ export class ProjectDetectionCommand {
       if (detected === ProjectType.UNDETECTED) {
         projectType = await this.promptUndetectedProjectType();
       }
-      if (detected === ProjectType.REACT_NATIVE && !this.options.yes) {
+      if (projectType === ProjectType.REACT_NATIVE && !this.options.yes) {
         projectType = await this.promptReactNativeVariant();
       }
       logger.debug(`Project type detected: ${projectType}`);

--- a/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
+++ b/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
@@ -1,4 +1,5 @@
 import { ProjectType } from 'storybook/internal/cli';
+import { HandledError } from 'storybook/internal/common';
 import type { JsPackageManager } from 'storybook/internal/common';
 import { logger, prompt } from 'storybook/internal/node-logger';
 import { telemetry } from 'storybook/internal/telemetry';
@@ -42,6 +43,9 @@ export class ProjectDetectionCommand {
     } else {
       const detected = await this.projectTypeService.autoDetectProjectType(this.options);
       projectType = detected;
+      if (detected === ProjectType.UNDETECTED) {
+        projectType = await this.promptUndetectedProjectType();
+      }
       if (detected === ProjectType.REACT_NATIVE && !this.options.yes) {
         projectType = await this.promptReactNativeVariant();
       }
@@ -70,6 +74,60 @@ export class ProjectDetectionCommand {
     }
 
     return language;
+  }
+
+  /**
+   * Handle the case where no supported framework could be detected: educate about the `--type`
+   * flag and, when interactive, offer to install the HTML framework, pick another framework, or
+   * cancel. Non-interactive runs keep the previous fail-with-error behavior.
+   */
+  private async promptUndetectedProjectType(): Promise<ProjectType> {
+    logger.error(dedent`
+      Unable to detect a supported framework in this directory.
+
+      Storybook couldn't detect a supported framework or configuration for your project. Make sure you're inside a framework project (e.g., React, Vue, Svelte, Angular, Next.js) and that its dependencies are installed.
+
+      You can tell Storybook which framework to use with the ${picocolors.bold('--type')} flag, e.g. ${picocolors.bold('--type html')} for projects without a framework.
+    `);
+
+    if (this.options.yes) {
+      throw new HandledError('Storybook failed to detect your project type');
+    }
+
+    const choice = await prompt.select(
+      {
+        message: 'How would you like to proceed?',
+        options: [
+          {
+            label: `Install the ${picocolors.bold('HTML')} framework (for projects without a framework)`,
+            value: 'html',
+          },
+          { label: 'Choose a framework to install', value: 'select' },
+          { label: 'Cancel the installation', value: 'cancel' },
+        ],
+      },
+      createPromptCancelOptions(this.telemetryService, 'undetected-project-type')
+    );
+
+    if (choice === 'html') {
+      return ProjectType.HTML;
+    }
+
+    if (choice === 'select') {
+      const installable = Object.values(ProjectType).filter(
+        (t) => !['undetected', 'unsupported', 'nx'].includes(String(t))
+      );
+      const manualType = await prompt.select(
+        {
+          message: 'Which framework would you like to install?',
+          options: installable.map((t) => ({ label: String(t), value: t })),
+        },
+        createPromptCancelOptions(this.telemetryService, 'undetected-project-type-framework')
+      );
+      return manualType as ProjectType;
+    }
+
+    throw new HandledError('Storybook failed to detect your project type');
   }
 
   /** Prompt user to select React Native variant */

--- a/code/lib/create-storybook/src/services/ProjectTypeService.test.ts
+++ b/code/lib/create-storybook/src/services/ProjectTypeService.test.ts
@@ -26,18 +26,15 @@ describe('ProjectTypeService', () => {
   });
 
   describe('autoDetectProjectType', () => {
-    it('logs a helpful message when framework cannot be detected', async () => {
+    it('returns UNDETECTED when framework cannot be detected', async () => {
       const service = new ProjectTypeService(pm);
       const options = { html: false } as unknown as CommandOptions;
       // @ts-expect-error accessing private for test
       vi.spyOn(service, 'detectProjectType').mockResolvedValue(ProjectType.UNDETECTED);
 
-      await expect(service.autoDetectProjectType(options)).rejects.toThrowError(
-        'Storybook failed to detect your project type'
-      );
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Unable to initialize Storybook in this directory.')
-      );
+      // messaging and prompting for undetected projects is handled by the command layer
+      await expect(service.autoDetectProjectType(options)).resolves.toBe(ProjectType.UNDETECTED);
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('throws NxProjectDetectedError when NX project is detected', async () => {
@@ -277,7 +274,7 @@ describe('ProjectTypeService', () => {
 
       await expect(
         service.autoDetectProjectType({ html: false } as CommandOptions)
-      ).rejects.toThrowError('Storybook failed to detect your project type');
+      ).resolves.toBe(ProjectType.UNDETECTED);
     });
   });
 

--- a/code/lib/create-storybook/src/services/ProjectTypeService.ts
+++ b/code/lib/create-storybook/src/services/ProjectTypeService.ts
@@ -181,19 +181,9 @@ export class ProjectTypeService {
     try {
       const detectedType = await this.detectProjectType(options);
 
-      // prompting handled by command layer
-
+      // messaging and prompting for undetected projects is handled by the command layer
       if (detectedType === ProjectType.UNDETECTED || detectedType === null) {
-        logger.error(dedent`
-          Unable to initialize Storybook in this directory.
-
-          Storybook couldn't detect a supported framework or configuration for your project. Make sure you're inside a framework project (e.g., React, Vue, Svelte, Angular, Next.js) and that its dependencies are installed.
-
-          Tips:
-          - Run init in an empty directory or create a new framework app first.
-          - If this directory contains unrelated files, try a new directory for Storybook.
-        `);
-        throw new HandledError('Storybook failed to detect your project type');
+        return ProjectType.UNDETECTED;
       }
 
       if (detectedType === ProjectType.NX) {

--- a/docs/get-started/frameworks/web-components-vite.mdx
+++ b/docs/get-started/frameworks/web-components-vite.mdx
@@ -14,6 +14,12 @@ To install Storybook in an existing project, run this command in your project's 
 
 <CodeSnippets path="create-command.md" variant="new-users" copyEvent="CreateCommandCopy" />
 
+<Callout variant="info">
+
+The installer detects Web components projects through a library dependency like [Lit](https://lit.dev/). If your project doesn't use one (for example, vanilla Web components), detection fails and you need to pass the project type explicitly: use `--type web_components` to install this framework, or `--type html` for plain HTML projects, e.g. `pnpm create storybook --type html`. See [the full list of project types](../install.mdx#the-cli-doesnt-detect-my-framework).
+
+</Callout>
+
 You can then get started [writing stories](../whats-a-story.mdx), [running tests](../../writing-tests/index.mdx) and [documenting your components](../../writing-docs/index.mdx). For more control over the installation process, refer to the [installation guide](../install.mdx).
 
 ### Requirements


### PR DESCRIPTION
Partially addresses #35045

## What I did

When `create storybook` can't detect a supported framework it previously hard-failed with an error that never mentioned the `--type` flag — leaving vanilla-HTML / Web Components users (and monorepo users in the wrong folder) stuck.

Following the fix shape prescribed by @Sidnioulz in the issue:

- `ProjectTypeService.autoDetectProjectType` now returns `ProjectType.UNDETECTED` instead of logging + throwing (its "prompting handled by command layer" comment is now actually true; the NX error path is unchanged).
- `ProjectDetectionCommand` handles `UNDETECTED`: it prints the education message (now mentioning `--type`, e.g. `--type html`) and, when interactive, prompts:
  1. Install the **HTML** framework (for projects without a framework)
  2. Choose a framework to install (second select over all installable project types)
  3. Cancel the installation (fails with a non-zero exit as before)
- Non-interactive runs (`--yes`) keep the previous fail-with-error behavior, without prompting.
- If the user picks **React Native** from the framework select, the existing React Native variant prompt (native / web / both) runs as it does for auto-detected RN projects.

The prompt mirrors the existing `promptReactNativeVariant` pattern, including `createPromptCancelOptions` telemetry.

## Checklist for reviewers

- [x] Make sure to add/update tests for your changes
- [ ] (n/a) Documentation — behavior change is CLI-interactive; docs update for `--type html` is tracked separately per the issue

#### Manual testing

1. `mkdir empty-dir && cd empty-dir && npm init -y`
2. Run this branch's CLI: `node <repo>/code/lib/create-storybook/bin/index.cjs` (or `yarn task --task sandbox` equivalent)
3. Observe the error now mentions `--type`, followed by the "How would you like to proceed?" prompt:
   - selecting **HTML** proceeds with the HTML framework install
   - selecting **Choose a framework** shows the full framework list; picking **React Native** additionally shows the native/web/both variant prompt
   - selecting **Cancel** exits with a non-zero code
4. `node <repo>/code/lib/create-storybook/bin/index.cjs --yes` in the same directory still fails immediately with a non-zero exit and no prompt.

Automated: 5 cases in `ProjectDetectionCommand.test.ts` (HTML selection, framework selection, RN-variant chaining, cancel, non-interactive fail) + updated `ProjectTypeService.test.ts` expectations. All create-storybook package tests pass; the new tests fail without the source change.