### PR TITLE
CLI: Make automigration import rewrites monorepo-safe

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { transformImportFiles } from 'storybook/internal/common';
 import type { JsPackageManager } from 'storybook/internal/common';
 import { loadConfig, printConfig } from 'storybook/internal/csf-tools';
 
@@ -61,6 +62,7 @@ vi.mock('../helpers/mainConfigFile.ts', () => ({
 
 const mockReadFile = vi.mocked(readFile);
 const mockWriteFile = vi.mocked(writeFile);
+const mockTransformImportFiles = vi.mocked(transformImportFiles);
 const mockPromptConfirm = vi.mocked(prompt.confirm);
 const mockAdd = vi.mocked(add);
 const mockUpdateMainConfig = vi.mocked(updateMainConfig);
@@ -326,6 +328,32 @@ describe('angular-to-angular-vite', () => {
       expect(mockPackageManager.addDependencies).toHaveBeenCalledWith(
         { type: 'devDependencies', skipInstall: true },
         [`${ANGULAR_VITE_PACKAGE}@9.0.0`]
+      );
+    });
+
+    it('rewrites imports only in story files, main config, and preview config', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      mockReadFile.mockResolvedValue(`export default { framework: '${ANGULAR_PACKAGE}' };`);
+
+      await angularToAngularVite.run!({
+        result: baseResult,
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        previewConfigPath: '/project/.storybook/preview.ts',
+        storiesPaths: ['/project/src/Button.stories.tsx'],
+        configDir: '.storybook',
+        storybookVersion: '9.0.0',
+      } as any);
+
+      expect(mockTransformImportFiles).toHaveBeenCalledWith(
+        [
+          '/project/src/Button.stories.tsx',
+          '/project/.storybook/main.ts',
+          '/project/.storybook/preview.ts',
+        ],
+        { [ANGULAR_PACKAGE]: ANGULAR_VITE_PACKAGE },
+        false
       );
     });
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -318,6 +318,7 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
     result,
     dryRun = false,
     mainConfigPath,
+    previewConfigPath,
     storiesPaths,
     configDir,
     packageManager,
@@ -460,8 +461,9 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
 
     // 5. Update import statements across config and story files.
     logger.debug('Scanning and updating import statements...');
-    const configFiles = configDir ? await globby([`${configDir}/**/*`]) : [];
-    const allFiles = [...storiesPaths, ...configFiles].filter(Boolean) as string[];
+    const allFiles = [...storiesPaths, mainConfigPath, previewConfigPath].filter(
+      Boolean
+    ) as string[];
 
     const transformErrors = await transformImportFiles(
       allFiles,

--- a/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.test.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { JsPackageManager, versions } from 'storybook/internal/common';
+import { JsPackageManager, transformImportFiles, versions } from 'storybook/internal/common';
 
 import { consolidatedImports, transformPackageJsonFiles } from './consolidated-imports.ts';
 
@@ -20,6 +20,12 @@ vi.mock('node:fs/promises');
 vi.mock('globby', () => ({
   globby: vi.fn(),
 }));
+vi.mock('storybook/internal/common', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('storybook/internal/common')>()),
+    transformImportFiles: vi.fn().mockResolvedValue([]),
+  };
+});
 
 const mockPackageJson = {
   dependencies: {
@@ -35,6 +41,7 @@ const mockPackageJson = {
 };
 
 const mockPackageManager = vi.mocked(JsPackageManager.prototype);
+const mockTransformImportFiles = vi.mocked(transformImportFiles);
 
 const mockRunOptions = {
   packageManager: mockPackageManager,
@@ -232,5 +239,65 @@ describe('transformPackageJsonFiles', () => {
       file: filePath,
       error: expect.any(Error),
     });
+  });
+});
+
+describe('run', () => {
+  it('rewrites imports only across the files that belong to the current project', async () => {
+    Object.defineProperty(mockPackageManager, 'packageJsonPaths', {
+      value: [],
+      writable: true,
+      configurable: true,
+    });
+
+    const storiesPaths = ['./src/Button.stories.tsx', './src/Card.stories.tsx'];
+    const mainConfigPath = '.storybook/main.ts';
+    const previewConfigPath = '.storybook/preview.ts';
+
+    await consolidatedImports.run!({
+      result: { consolidatedDeps: new Set() },
+      dryRun: false,
+      packageManager: mockPackageManager,
+      storiesPaths,
+      mainConfigPath,
+      previewConfigPath,
+      configDir: '.storybook',
+      mainConfig: {} as any,
+      storybookVersion: '8.0.0',
+    });
+
+    expect(mockTransformImportFiles).toHaveBeenCalledWith(
+      [...storiesPaths, mainConfigPath, previewConfigPath],
+      expect.any(Object),
+      false
+    );
+  });
+
+  it('omits previewConfigPath from the rewrite set when it is not present', async () => {
+    Object.defineProperty(mockPackageManager, 'packageJsonPaths', {
+      value: [],
+      writable: true,
+      configurable: true,
+    });
+
+    const storiesPaths = ['./src/Button.stories.tsx'];
+    const mainConfigPath = '.storybook/main.ts';
+
+    await consolidatedImports.run!({
+      result: { consolidatedDeps: new Set() },
+      dryRun: false,
+      packageManager: mockPackageManager,
+      storiesPaths,
+      mainConfigPath,
+      configDir: '.storybook',
+      mainConfig: {} as any,
+      storybookVersion: '8.0.0',
+    });
+
+    expect(mockTransformImportFiles).toHaveBeenCalledWith(
+      [...storiesPaths, mainConfigPath],
+      expect.any(Object),
+      false
+    );
   });
 });

--- a/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
@@ -132,7 +132,13 @@ export const consolidatedImports: Fix<ConsolidatedOptions> = {
   prompt: () => {
     return "We've detected Storybook packages that have been renamed or consolidated. We'll update these packages by scanning your codebase and updating any imports from these packages.";
   },
-  run: async ({ dryRun = false, packageManager, storiesPaths, configDir }) => {
+  run: async ({
+    dryRun = false,
+    packageManager,
+    storiesPaths,
+    mainConfigPath,
+    previewConfigPath,
+  }) => {
     const errors: Array<{ file: string; error: Error }> = [];
 
     const packageJsonErrors = await transformPackageJsonFiles(
@@ -141,12 +147,8 @@ export const consolidatedImports: Fix<ConsolidatedOptions> = {
     );
     errors.push(...packageJsonErrors);
 
-    // eslint-disable-next-line depend/ban-dependencies
-    const { globby } = await import('globby');
-    const configFiles = await globby([`${configDir}/**/*`]);
-
     const importErrors = await transformImportFiles(
-      [...storiesPaths, ...configFiles].filter(Boolean) as string[],
+      [...storiesPaths, mainConfigPath, previewConfigPath].filter(Boolean) as string[],
       {
         ...consolidatedPackages,
         'storybook/internal/manager-api': 'storybook/manager-api',

--- a/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.test.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { transformImportFiles } from 'storybook/internal/common';
 import type { JsPackageManager } from 'storybook/internal/common';
 
 import type { CheckOptions } from './index.ts';
@@ -27,12 +28,9 @@ vi.mock('storybook/internal/common', () => ({
   transformImportFiles: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock('globby', () => ({
-  globby: vi.fn().mockResolvedValue([]),
-}));
-
 const mockReadFile = vi.mocked(readFile);
 const mockWriteFile = vi.mocked(writeFile);
+const mockTransformImportFiles = vi.mocked(transformImportFiles);
 
 describe('nextjs-to-nextjs-vite', () => {
   const mockPackageManager = {
@@ -147,6 +145,7 @@ describe('nextjs-to-nextjs-vite', () => {
         dryRun: false,
         packageManager: mockPackageManager,
         mainConfigPath: '/project/.storybook/main.js',
+        previewConfigPath: '/project/.storybook/preview.js',
         storiesPaths: ['**/*.stories.*'],
         configDir: '.storybook',
         storybookVersion: '9.0.0',
@@ -156,6 +155,11 @@ describe('nextjs-to-nextjs-vite', () => {
       expect(mockPackageManager.addDependencies).toHaveBeenCalledWith(
         { type: 'devDependencies', skipInstall: true },
         [`@storybook/nextjs-vite@9.0.0`, `vite@${VITE_DEFAULT_VERSION}`]
+      );
+      expect(mockTransformImportFiles).toHaveBeenCalledWith(
+        ['**/*.stories.*', '/project/.storybook/main.js', '/project/.storybook/preview.js'],
+        { '@storybook/nextjs': '@storybook/nextjs-vite' },
+        false
       );
     });
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/nextjs-to-nextjs-vite.ts
@@ -88,8 +88,8 @@ export const nextjsToNextjsVite: Fix<NextjsToNextjsViteOptions> = {
     result,
     dryRun = false,
     mainConfigPath,
+    previewConfigPath,
     storiesPaths,
-    configDir,
     packageManager,
     storybookVersion,
   }) {
@@ -121,10 +121,9 @@ export const nextjsToNextjsVite: Fix<NextjsToNextjsViteOptions> = {
     // Scan and transform import statements in source files
     logger.debug('Scanning and updating import statements...');
 
-    // eslint-disable-next-line depend/ban-dependencies
-    const { globby } = await import('globby');
-    const configFiles = await globby([`${configDir}/**/*`]);
-    const allFiles = [...storiesPaths, ...configFiles].filter(Boolean) as string[];
+    const allFiles = [...storiesPaths, mainConfigPath, previewConfigPath].filter(
+      Boolean
+    ) as string[];
 
     const transformErrors = await transformImportFiles(
       allFiles,

--- a/code/lib/cli-storybook/src/automigrate/fixes/react-vite-to-tanstack-react.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/react-vite-to-tanstack-react.test.ts
@@ -180,7 +180,7 @@ describe('react-vite-to-tanstack-react', () => {
         packageManager: mockPackageManager,
         mainConfigPath: '/project/.storybook/main.ts',
         previewConfigPath: '/project/.storybook/preview.tsx',
-        storiesPaths: [],
+        storiesPaths: ['/project/src/Button.stories.tsx'],
         configDir: '.storybook',
         storybookVersion: '10.1.0',
       } as any);
@@ -198,6 +198,19 @@ describe('react-vite-to-tanstack-react', () => {
       const writtenContent = mockWriteFile.mock.calls[0]?.[1] as string;
       expect(writtenContent).not.toContain(REACT_VITE_PACKAGE);
       expect(writtenContent).toContain(`${TANSTACK_REACT_PACKAGE}/node`);
+      // The import rewrite must target only files provably belonging to the current
+      // Storybook project — stories, main config, and preview config — never a glob of
+      // the config directory, which can reach into sibling packages in a monorepo.
+      expect(transformImportFiles).toHaveBeenCalledWith(
+        [
+          '/project/src/Button.stories.tsx',
+          '/project/.storybook/main.ts',
+          '/project/.storybook/preview.tsx',
+        ],
+        { [REACT_VITE_PACKAGE]: TANSTACK_REACT_PACKAGE },
+        false
+      );
+      expect(globby).not.toHaveBeenCalled();
     });
 
     it('skips writes in dry run mode', async () => {

--- a/code/lib/cli-storybook/src/automigrate/fixes/react-vite-to-tanstack-react.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/react-vite-to-tanstack-react.ts
@@ -309,7 +309,6 @@ export const reactViteToTanstackReact: Fix<ReactViteToTanstackReactOptions> = {
     mainConfigPath,
     previewConfigPath,
     storiesPaths,
-    configDir,
     packageManager,
     storybookVersion,
     yes,
@@ -337,14 +336,7 @@ export const reactViteToTanstackReact: Fix<ReactViteToTanstackReactOptions> = {
 
     logger.debug('Scanning and updating import statements...');
 
-    // eslint-disable-next-line depend/ban-dependencies
-    const { globby } = await import('globby');
-    const configFiles = configDir
-      ? await globby([`${configDir}/**/*.{ts,tsx,js,jsx,mjs,cjs}`], {
-          ignore: ['**/node_modules/**', '**/dist/**'],
-        })
-      : [];
-    const allFiles = [...storiesPaths, ...configFiles, previewConfigPath].filter(
+    const allFiles = [...storiesPaths, mainConfigPath, previewConfigPath].filter(
       Boolean
     ) as string[];
 


### PR DESCRIPTION
Closes #

## What I did

TL;DR: the import-rewriting automigrations decided which files to rewrite by globbing the whole config directory, which is not monorepo-safe. This scopes them to the files we can be sure belong to a single Storybook project - the main config, the preview, and the story files we resolve from that project's main config - which is exactly what `remove-essentials` already does.

Just for context: this came out of QA on the Bitwarden clients repo. When a fix runs `transformImportFiles` over `globby(`${configDir}/**/*`)`, the file selection is the only safety control - `transformImportFiles` is a pure quoted-string rewrite with no project awareness of its own. So an over-broad glob is the whole problem.

**The failure modes**

- Single project with a repo-root config: `configDir = /repo/.storybook` -> the glob is effectively `/repo/**/*`, so it rewrites sibling packages that still depend on `@storybook/angular` and breaks them.
- Monorepo: the same glob reaches into files that belong to other projects in the workspace.

**The fix**

Rewrite only the files we can actually attribute to this project:

- the main config
- the preview file
- the story files resolved from this project's `stories` globs

No directory glob. `remove-essentials` already selects exactly this set (`[...storiesPaths, mainConfigPath, previewConfigPath]`), so this just brings `angular-to-angular-vite`, `nextjs-to-nextjs-vite`, `consolidated-imports`, and `react-vite-to-tanstack-react` in line with it.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Each of the four fixes has a unit test asserting `transformImportFiles` is now called with exactly `[...storiesPaths, mainConfigPath, previewConfigPath].filter(Boolean)`.

#### Manual testing

To confirm the original corruption is gone, a maintainer can build a small monorepo with a repo-root config plus two projects:

```text
repo/
  .storybook/main.ts                    # shared base config
  package.json                          # single, shared package.json
  apps/angular-app/.storybook/main.ts   # framework: '@storybook/angular'
  apps/angular-app/src/*.stories.ts
  apps/react-app/.storybook/main.ts     # framework: '@storybook/react-vite'
  apps/react-app/src/*.stories.ts
```

1. Run the Angular automigration for the Angular project, e.g. `yarn storybook automigrate angular-to-angular-vite --config-dir apps/angular-app/.storybook`.
2. Confirm the React app's source is **not** rewritten to `@storybook/angular-vite` - only the Angular project's own `main`, `preview`, and story files are touched.

Before this change the same run rewrites files outside the Angular project (the whole repo in the single-config case).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
