### PR TITLE
CLI: Skip a11y addon automigration prompting when not applicable

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
@@ -159,7 +159,7 @@ describe('addonA11yAddonTest', () => {
       });
     });
 
-    it.skip('should return previewFile and transformedPreviewCode if preview file exists', async () => {
+    it('should return previewFile and transformedPreviewCode if preview file exists', async () => {
       vi.mocked(getAddonNames).mockReturnValue([
         '@storybook/addon-a11y',
         '@storybook/addon-vitest',
@@ -191,8 +191,45 @@ describe('addonA11yAddonTest', () => {
         transformedPreviewCode: expect.any(String),
         transformedSetupCode: null,
         skipPreviewTransformation: false,
-        skipVitestSetupTransformation: false,
+        skipVitestSetupTransformation: true,
       });
+    });
+
+    it('should return null if vitest.setup file does not exist and preview file has the necessary transformations', async () => {
+      vi.mocked(getAddonNames).mockReturnValue([
+        '@storybook/addon-a11y',
+        '@storybook/addon-vitest',
+      ]);
+      vi.mocked(existsSync).mockImplementation((p) => {
+        if (p.toString().includes('preview')) {
+          return true;
+        } else {
+          return false;
+        }
+      });
+      vi.mocked(readFileSync).mockImplementation((p) => {
+        if (p.toString().includes('preview')) {
+          return `
+            export default {
+              parameters: {
+                a11y: {
+                  test: 'todo'
+                }
+              }
+            }
+          `;
+        } else {
+          return '';
+        }
+      });
+
+      const result = await addonA11yAddonTest.check({
+        mainConfig: {
+          framework: '@storybook/react-vite',
+        },
+        configDir,
+      } as any);
+      expect(result).toBeNull();
     });
 
     it('should return setupFile and null transformedSetupCode if transformation fails', async () => {
@@ -265,7 +302,7 @@ describe('addonA11yAddonTest', () => {
         transformedPreviewCode: null,
         transformedSetupCode: null,
         skipPreviewTransformation: false,
-        skipVitestSetupTransformation: false,
+        skipVitestSetupTransformation: true,
       });
     });
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
@@ -72,19 +72,31 @@ export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
         .map((ext) => path.join(configDir, `preview${ext}`))
         .find((filePath) => existsSync(filePath)) ?? null;
 
-    let skipVitestSetupTransformation = hasCsfFactoryPreview;
+    // Without a setup file there is nothing to transform: since Storybook 10.3
+    // the vitest plugin auto-provisions preview annotations (including addon-a11y's).
+    let skipVitestSetupTransformation = hasCsfFactoryPreview || !vitestSetupFile;
     let skipPreviewTransformation = false;
 
-    if (vitestSetupFile && previewFile) {
-      const vitestSetupSource = readFileSync(vitestSetupFile, 'utf8');
-      const previewSetupSource = readFileSync(previewFile, 'utf8');
-
-      skipVitestSetupTransformation ||= vitestSetupSource.includes('@storybook/addon-a11y');
-      skipPreviewTransformation ||= !shouldPreviewFileBeTransformed(previewSetupSource);
-
-      if (skipVitestSetupTransformation && skipPreviewTransformation) {
-        return null;
+    if (vitestSetupFile && !skipVitestSetupTransformation) {
+      try {
+        const vitestSetupSource = readFileSync(vitestSetupFile, 'utf8');
+        skipVitestSetupTransformation = vitestSetupSource.includes('@storybook/addon-a11y');
+      } catch {
+        // leave the flag as-is; getTransformedSetupCode handles unreadable files
       }
+    }
+
+    if (previewFile) {
+      try {
+        const previewSetupSource = readFileSync(previewFile, 'utf8');
+        skipPreviewTransformation = !shouldPreviewFileBeTransformed(previewSetupSource);
+      } catch {
+        // leave the flag as-is; getTransformedPreviewCode handles unreadable files
+      }
+    }
+
+    if (skipVitestSetupTransformation && skipPreviewTransformation) {
+      return null;
     }
 
     const getTransformedSetupCode = () => {
@@ -95,7 +107,7 @@ export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
       try {
         const vitestSetupSource = readFileSync(vitestSetupFile, 'utf8');
         return transformSetupFile(vitestSetupSource);
-      } catch (e) {
+      } catch {
         return null;
       }
     };
@@ -108,7 +120,7 @@ export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
       try {
         const previewSetupSource = readFileSync(previewFile, 'utf8');
         return transformPreviewFile(previewSetupSource, previewFile);
-      } catch (e) {
+      } catch {
         return null;
       }
     };


### PR DESCRIPTION
Closes #

## What I did

The `addon-a11y-addon-test` automigration was prompted for projects where it had nothing to do. Its `check()` only evaluated the "already migrated" skip conditions when **both** `.storybook/vitest.setup.*` and `.storybook/preview.*` existed:

```ts
if (vitestSetupFile && previewFile) {
  ...
  if (skipVitestSetupTransformation && skipPreviewTransformation) {
    return null; // the only "don't prompt" exit
  }
}
```

Projects without a `vitest.setup` file — the norm since the vitest plugin auto-provisions preview annotations (10.3+) — skipped that block entirely, so the migration was always prompted even when `preview` already had `parameters.a11y.test` configured. Selecting it was a complete no-op (it rewrote `preview` with identical content).

This PR computes the two skip flags independently per file:

- No `vitest.setup` file → nothing to transform on the setup side (the plugin auto-provisions annotations, including addon-a11y's). Projects that keep the optional setup file are still checked and transformed exactly as before.
- The preview file is checked on its own, regardless of whether a setup file exists.
- The early `return null` now runs whenever both flags are set.

This also fixes a second latent bug the old gating had: a project with an already-migrated setup file but **no preview file** skipped the "already has `@storybook/addon-a11y`" detection and re-transformed the setup file, injecting a duplicate `a11yAddonAnnotations` import.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Includes a regression test for the false-positive scenario (no setup file + preview already configured → `check()` returns `null`), and un-skips the previously skipped "preview file only" test with a corrected expectation.

#### Manual testing

1. Take a project with `@storybook/addon-a11y` and `@storybook/addon-vitest` in `main.ts`, **no** `.storybook/vitest.setup.*` file, and `parameters: { a11y: { test: 'todo' } }` already set in `.storybook/preview.*` (e.g. https://github.com/yannbf/mealdrop).
2. Run `npx storybook@next upgrade` (or `yarn automigrate` from a linked CLI build).
3. Before this fix: the `addon-a11y-addon-test` automigration is prompted and does nothing when run. After: it is not prompted.
4. Also verify a legacy project **with** a `.storybook/vitest.setup.ts` lacking the a11y annotations still gets prompted and transformed as before.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automigration checks for Storybook preview and Vitest setup files so updates are only suggested when needed.
  * Better handles cases where the preview file already includes the required changes, avoiding unnecessary transformations.
  * More accurately skips setup changes when transformation isn’t possible or no longer required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->