### PR TITLE
Core: Add experimentalReview feature flag and make the features type augmentable

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -162,6 +162,7 @@ const config = defineMain({
     experimentalDocgenServer: process.env.STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER === 'true',
     experimentalReactComponentMeta: true,
     changeDetection: true,
+    experimentalReview: true,
   },
   staticDirs: [{ from: './bench/bundle-analyzer', to: '/bundle-analyzer' }],
   viteFinal: async (viteConfig: InlineConfig, { configType }: Options) => {

--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -45,6 +45,7 @@ import { initCreateNewStoryChannel } from '../server-channel/create-new-story-ch
 import { initFileSearchChannel } from '../server-channel/file-search-channel.ts';
 import { initGhostStoriesChannel } from '../server-channel/ghost-stories-channel.ts';
 import { initOpenInEditorChannel } from '../server-channel/open-in-editor-channel.ts';
+import { isReviewFeatureEnabled } from '../../shared/review/features.ts';
 import { initReviewChannel } from '../server-channel/review-channel.ts';
 import { initTelemetryChannel } from '../server-channel/telemetry-channel.ts';
 import { initializeChecklist } from '../utils/checklist.ts';
@@ -230,6 +231,7 @@ export const features: PresetProperty<'features'> = async (existing) => ({
   componentsManifest: false,
   controls: true,
   disallowImplicitActionsInRenderV8: true,
+  experimentalReview: false,
   highlight: true,
   interactions: true,
   legacyDecoratorFileOrder: false,
@@ -300,7 +302,9 @@ export const experimental_serverChannel = async (
   initCreateNewStoryChannel(channel, options);
   initGhostStoriesChannel(channel, options);
   initOpenInEditorChannel(channel);
-  initReviewChannel(channel);
+  if (isReviewFeatureEnabled(await options.presets.apply('features'))) {
+    initReviewChannel(channel);
+  }
   initTelemetryChannel(channel);
 
   return channel;

--- a/code/core/src/manager/App.tsx
+++ b/code/core/src/manager/App.tsx
@@ -7,6 +7,9 @@ import type { Addon_PageType } from 'storybook/internal/types';
 import { addons } from 'storybook/manager-api';
 import { Global, createGlobal } from 'storybook/theming';
 
+import { global } from '@storybook/global';
+
+import { isReviewFeatureEnabled } from '../shared/review/features.ts';
 import { ManagerErrorBoundary } from './components/error-boundary/ManagerErrorBoundary.tsx';
 import { Layout } from './components/layout/Layout.tsx';
 import { useLayout } from './components/layout/LayoutProvider.tsx';
@@ -80,7 +83,9 @@ export const App = ({ managerLayoutState, setManagerLayoutState, pages, hasTab }
           hasTab={hasTab}
           managerLayoutState={managerLayoutState}
           setManagerLayoutState={setManagerLayoutState}
-          slotOverlay={<ReviewPersistentLayer />}
+          slotOverlay={
+            isReviewFeatureEnabled(global.FEATURES) ? <ReviewPersistentLayer /> : undefined
+          }
           slotMain={<MainPreview />}
           slotSidebar={<Sidebar onMenuClick={() => setMobileAboutOpen((state) => !state)} />}
           slotPanel={<Panel />}

--- a/code/core/src/manager/components/preview/Preview.tsx
+++ b/code/core/src/manager/components/preview/Preview.tsx
@@ -13,6 +13,7 @@ import { Helmet } from 'react-helmet-async';
 import { Consumer, addons, merge, types, type Combo } from 'storybook/manager-api';
 
 import { useLandmark } from '../../hooks/useLandmark.ts';
+import { isReviewFeatureEnabled } from '../../../shared/review/features.ts';
 import { isReviewCollectionStoryRoute } from '../../../shared/review/routes.ts';
 import { ReviewToolbarHeader } from '../review/components/ReviewToolbarHeader.tsx';
 import { FramesRenderer } from './FramesRenderer.tsx';
@@ -93,7 +94,8 @@ const Preview = React.memo<PreviewProps>(function Preview(props) {
   const shouldScale = viewMode === 'story';
   const { showToolbar } = options;
   const customisedShowToolbar = api.getShowToolbarWithCustomisations(showToolbar);
-  const isReviewCollectionStory = isReviewCollectionStoryRoute(path, queryParams);
+  const isReviewCollectionStory =
+    isReviewFeatureEnabled(global.FEATURES) && isReviewCollectionStoryRoute(path, queryParams);
 
   const previousStoryId = useRef(storyId);
 

--- a/code/core/src/shared/review/features.ts
+++ b/code/core/src/shared/review/features.ts
@@ -1,0 +1,9 @@
+import type { StorybookFeatures } from '../../types/modules/core-common.ts';
+
+/**
+ * Whether the agentic review feature is enabled. Review is opt-in via the
+ * `experimentalReview` feature flag and builds on the change-detection pipeline, so it needs both
+ * flags. Mirrors the availability check MCP tooling uses to register review tools.
+ */
+export const isReviewFeatureEnabled = (features: StorybookFeatures | undefined): boolean =>
+  !!features?.experimentalReview && !!features?.changeDetection;

--- a/code/core/src/shared/review/index.ts
+++ b/code/core/src/shared/review/index.ts
@@ -1,4 +1,5 @@
 export { REVIEW_EVENTS, REVIEW_NAMESPACE } from './events.ts';
+export { isReviewFeatureEnabled } from './features.ts';
 export type { ReviewPage, ReviewPageviewPayload } from './events.ts';
 export type { ReviewCollection, ReviewState } from './review-state.ts';
 export {

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -456,6 +456,177 @@ export type Manifests = { components?: ComponentsManifest } & Record<ManifestNam
 
 export type CsfEnricher = (csf: CsfFile, csfSource: CsfFile) => Promise<void>;
 
+/**
+ * The feature flags configured under the `features` key in `.storybook/main.ts`.
+ *
+ * Addons can declare their own feature flags through TypeScript module augmentation:
+ *
+ * ```ts
+ * declare module 'storybook/internal/types' {
+ *   interface StorybookFeatures {
+ *     myAddonFeature?: boolean;
+ *   }
+ * }
+ * ```
+ */
+export interface StorybookFeatures {
+  /**
+   * Enable the integrated viewport addon
+   *
+   * @default true
+   */
+  viewport?: boolean;
+
+  /**
+   * Enable the integrated highlight addon
+   *
+   * @default true
+   */
+  highlight?: boolean;
+
+  /**
+   * Enable the integrated backgrounds addon
+   *
+   * @default true
+   */
+  backgrounds?: boolean;
+
+  /**
+   * Enable the integrated measure addon
+   *
+   * @default true
+   */
+  measure?: boolean;
+
+  /**
+   * Enable the integrated outline addon
+   *
+   * @default true
+   */
+  outline?: boolean;
+
+  /**
+   * Enable the integrated controls addon
+   *
+   * @default true
+   */
+  controls?: boolean;
+
+  /**
+   * Enable the integrated interactions addon
+   *
+   * @default true
+   */
+  interactions?: boolean;
+
+  /**
+   * Enable the integrated actions addon
+   *
+   * @default true
+   */
+  actions?: boolean;
+
+  /**
+   * Enable the onboarding checklist sidebar widget
+   *
+   * @default true
+   */
+  sidebarOnboardingChecklist?: boolean;
+
+  /**
+   * Enable the onboarding guide page in the menu
+   *
+   * @default true
+   */
+  menuOnboardingChecklist?: boolean;
+
+  /**
+   * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
+   *
+   * Filter args with a "target" on the type from the render function (EXPERIMENTAL)
+   */
+  argTypeTargetsV7?: boolean;
+
+  /**
+   * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
+   *
+   * Apply decorators from preview.js before decorators from addons or frameworks
+   */
+  legacyDecoratorFileOrder?: boolean;
+
+  /**
+   * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
+   *
+   * Disallow implicit actions during rendering. This will be the default in Storybook 8.
+   *
+   * This will make sure that your story renders the same no matter if docgen is enabled or not.
+   */
+  disallowImplicitActionsInRenderV8?: boolean;
+
+  /**
+   * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
+   *
+   * Enable asynchronous component rendering in React renderer
+   */
+  experimentalRSC?: boolean;
+
+  /**
+   * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
+   *
+   * Set NODE_ENV to development in built Storybooks for better testability and debuggability
+   */
+  developmentModeForBuild?: boolean;
+  /** Only show input controls in Angular */
+  angularFilterNonInputControls?: boolean;
+
+  /**
+   * Enable component manifest generation for MCP and other tooling integrations.
+   *
+   * @default false
+   */
+  componentsManifest?: boolean;
+
+  /**
+   * Use TypeScript LanguageService (react-component-meta) for extracting React component props
+   * instead of react-docgen / react-docgen-typescript.
+   *
+   * @default false
+   * @experimental
+   */
+  experimentalReactComponentMeta?: boolean;
+
+  /**
+   * Enables the new code example generation for React components. You can see those examples when
+   * clicking on the "Show code" button in the Storybook UI.
+   *
+   * We refactored the code examples by reading the actual source file. This should make the code
+   * examples a lot faster, more readable and more accurate. They are not dynamic though, it won't
+   * change if you change when using the control panel.
+   *
+   * @default false
+   * @experimental This feature is in early development and may change significantly in future releases.
+   */
+  experimentalCodeExamples?: boolean;
+
+  /**
+   * Enable the experimental docgen open service.
+   *
+   * When true, Storybook registers the `core/docgen` service in the open-service registry and
+   * generates per-component docgen JSON snapshots during static builds. Renderer and addon
+   * providers contribute through the `experimental_docgenProvider` preset.
+   *
+   * @default false
+   * @experimental This feature is in early development and may change significantly in future releases.
+   */
+  experimentalDocgenServer?: boolean;
+
+  /**
+   * Enable change detection
+   * @default true
+   */
+  changeDetection?: boolean;
+}
+
 export interface StorybookConfigRaw {
   /**
    * Sets the addons you want to use with Storybook.
@@ -475,163 +646,7 @@ export interface StorybookConfigRaw {
   experimental_storyDocsProvider?: StoryDocsProvider;
   staticDirs?: (DirectoryMapping | string)[];
   logLevel?: string;
-  features?: {
-    /**
-     * Enable the integrated viewport addon
-     *
-     * @default true
-     */
-    viewport?: boolean;
-
-    /**
-     * Enable the integrated highlight addon
-     *
-     * @default true
-     */
-    highlight?: boolean;
-
-    /**
-     * Enable the integrated backgrounds addon
-     *
-     * @default true
-     */
-    backgrounds?: boolean;
-
-    /**
-     * Enable the integrated measure addon
-     *
-     * @default true
-     */
-    measure?: boolean;
-
-    /**
-     * Enable the integrated outline addon
-     *
-     * @default true
-     */
-    outline?: boolean;
-
-    /**
-     * Enable the integrated controls addon
-     *
-     * @default true
-     */
-    controls?: boolean;
-
-    /**
-     * Enable the integrated interactions addon
-     *
-     * @default true
-     */
-    interactions?: boolean;
-
-    /**
-     * Enable the integrated actions addon
-     *
-     * @default true
-     */
-    actions?: boolean;
-
-    /**
-     * Enable the onboarding checklist sidebar widget
-     *
-     * @default true
-     */
-    sidebarOnboardingChecklist?: boolean;
-
-    /**
-     * Enable the onboarding guide page in the menu
-     *
-     * @default true
-     */
-    menuOnboardingChecklist?: boolean;
-
-    /**
-     * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
-     *
-     * Filter args with a "target" on the type from the render function (EXPERIMENTAL)
-     */
-    argTypeTargetsV7?: boolean;
-
-    /**
-     * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
-     *
-     * Apply decorators from preview.js before decorators from addons or frameworks
-     */
-    legacyDecoratorFileOrder?: boolean;
-
-    /**
-     * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
-     *
-     * Disallow implicit actions during rendering. This will be the default in Storybook 8.
-     *
-     * This will make sure that your story renders the same no matter if docgen is enabled or not.
-     */
-    disallowImplicitActionsInRenderV8?: boolean;
-
-    /**
-     * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
-     *
-     * Enable asynchronous component rendering in React renderer
-     */
-    experimentalRSC?: boolean;
-
-    /**
-     * @temporary This feature flag is a migration assistant, and is scheduled to be removed.
-     *
-     * Set NODE_ENV to development in built Storybooks for better testability and debuggability
-     */
-    developmentModeForBuild?: boolean;
-    /** Only show input controls in Angular */
-    angularFilterNonInputControls?: boolean;
-
-    /**
-     * Enable component manifest generation for MCP and other tooling integrations.
-     *
-     * @default false
-     */
-    componentsManifest?: boolean;
-
-    /**
-     * Use TypeScript LanguageService (react-component-meta) for extracting React component props
-     * instead of react-docgen / react-docgen-typescript.
-     *
-     * @default false
-     * @experimental
-     */
-    experimentalReactComponentMeta?: boolean;
-
-    /**
-     * Enables the new code example generation for React components. You can see those examples when
-     * clicking on the "Show code" button in the Storybook UI.
-     *
-     * We refactored the code examples by reading the actual source file. This should make the code
-     * examples a lot faster, more readable and more accurate. They are not dynamic though, it won't
-     * change if you change when using the control panel.
-     *
-     * @default false
-     * @experimental This feature is in early development and may change significantly in future releases.
-     */
-    experimentalCodeExamples?: boolean;
-
-    /**
-     * Enable the experimental docgen open service.
-     *
-     * When true, Storybook registers the `core/docgen` service in the open-service registry and
-     * generates per-component docgen JSON snapshots during static builds. Renderer and addon
-     * providers contribute through the `experimental_docgenProvider` preset.
-     *
-     * @default false
-     * @experimental This feature is in early development and may change significantly in future releases.
-     */
-    experimentalDocgenServer?: boolean;
-
-    /**
-     * Enable change detection
-     * @default true
-     */
-    changeDetection?: boolean;
-  };
+  features?: StorybookFeatures;
 
   build?: TestBuildConfig;
 

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -625,6 +625,16 @@ export interface StorybookFeatures {
    * @default true
    */
   changeDetection?: boolean;
+
+  /**
+   * Enable the agentic review workflow: the review UI in the manager and the server-side review
+   * channel that MCP tooling (e.g. `@storybook/addon-mcp`) uses to push curated reviews of code
+   * changes. Builds on change detection, so `changeDetection` must also be enabled.
+   *
+   * @default false
+   * @experimental This feature is in early development and may change significantly in future releases.
+   */
+  experimentalReview?: boolean;
 }
 
 export interface StorybookConfigRaw {

--- a/docs/_snippets/main-config-features-experimental-review.md
+++ b/docs/_snippets/main-config-features-experimental-review.md
@@ -1,0 +1,53 @@
+```js filename=".storybook/main.js" renderer="react" language="js" tabTitle="CSF 3"
+export default {
+  // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  features: {
+    experimentalReview: true,
+  },
+};
+```
+
+```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF 3"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+import type { StorybookConfig } from '@storybook/your-framework';
+
+const config: StorybookConfig = {
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  features: {
+    experimentalReview: true,
+  },
+};
+
+export default config;
+```
+
+```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { defineMain } from '@storybook/your-framework/node';
+
+export default defineMain({
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  features: {
+    experimentalReview: true,
+  },
+});
+```
+
+<!-- JS snippets still needed while providing both CSF 3 & Next -->
+
+```js filename=".storybook/main.js" renderer="react" language="js" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { defineMain } from '@storybook/your-framework/node';
+
+export default defineMain({
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  features: {
+    experimentalReview: true,
+  },
+});
+```

--- a/docs/api/main-config/main-config-features.mdx
+++ b/docs/api/main-config/main-config-features.mdx
@@ -22,6 +22,7 @@ Type:
   developmentModeForBuild?: boolean;
   experimentalCodeExamples?: boolean;
   experimentalDocgenServer?: boolean;
+  experimentalReview?: boolean;
   experimentalTestSyntax?: boolean;
   highlight?: boolean;
   interactions?: boolean;
@@ -215,6 +216,18 @@ Snippets are static: they won't update if you change values in the Controls tabl
 This feature is currently only supported for React projects. We [welcome feedback](https://github.com/storybookjs/storybook/discussions/35333) on the RFC.
 
 <CodeSnippets path="main-config-features-experimental-docgen-server.md" />
+
+## `experimentalReview`
+
+(⚠️ **Experimental**)
+
+Type: `boolean`
+
+Default: `false`
+
+Enable the agentic review workflow: the review UI in the Storybook manager and the server-side review channel that AI agents (via the [MCP server](../../ai/mcp/overview.mdx)) use to push a curated review of their code changes. Builds on [`changeDetection`](#changedetection), which must also be enabled (it is, by default).
+
+<CodeSnippets path="main-config-features-experimental-review.md" />
 
 ## `experimentalTestSyntax`
 


### PR DESCRIPTION
## What I did

Two related changes to make the agentic review feature properly opt-in:

1. **Extracted the inline `features` type on `StorybookConfigRaw` into an exported `StorybookFeatures` interface** (`code/core/src/types/modules/core-common.ts`). Addons can now declare their own feature flags via TypeScript module augmentation instead of forcing users to `@ts-expect-error` unknown flags in `main.ts`:

   ```ts
   declare module 'storybook/internal/types' {
     interface StorybookFeatures {
       myAddonFeature?: boolean;
     }
   }
   ```

   Verified against the production d.ts bundle: the interface survives the rollup un-renamed, augmentation merges, and a config using an augmented flag typechecks (and fails without the augmentation).

2. **Declared `features.experimentalReview` in core (default `false`) and gated the review feature on it.** The review feature (manager UI layer + server review channel) previously mounted unconditionally; the only gate lived in the external `@storybook/addon-mcp`. Core now gates both sides on `experimentalReview && changeDetection` (mirroring the addon's availability check) via a shared `isReviewFeatureEnabled` helper:
   - server: `initReviewChannel` in `common-preset.ts` only runs when enabled
   - manager: `ReviewPersistentLayer` (App.tsx) and `ReviewToolbarHeader` (Preview.tsx) only mount when enabled, read from `global.FEATURES`

   The internal Storybook (`code/.storybook/main.ts`) enables the flag since it registers `@storybook/addon-mcp` and uses the review workflow. Docs entry added to `main-config-features.mdx`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. `cd code && yarn storybook:ui` — the internal Storybook has `experimentalReview: true`, so the review workflow should behave exactly as before (push a review via addon-mcp's `display-review`; the review notification/summary appears).
2. Remove `experimentalReview: true` from `code/.storybook/main.ts` and restart — the review layer no longer mounts (no review notification/summary, review routes render as plain stories) and the server does not respond to review channel events.
3. Type check: in a sandbox `main.ts`, `features: { experimentalReview: true }` typechecks without `@ts-expect-error`. Adding an unknown flag still errors, unless an addon augments `StorybookFeatures` with it (see example above).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in review feature setting to Storybook configuration.
  * Review-related UI and server behavior now only appear when the feature is enabled.
* **Documentation**
  * Added setup examples showing how to turn on the new review feature in different configuration styles.
  * Updated configuration docs to include the new option and its requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->