### PR TITLE
Fix zone.js drop in angular-to-angular-vite migration + schema sync + transform widening

### DIFF
--- a/code/frameworks/angular-vite/build-schema.json
+++ b/code/frameworks/angular-vite/build-schema.json
@@ -114,9 +114,10 @@
       "description": "Configure sourcemaps. See: https://angular.io/guide/workspace-config#source-map-configuration",
       "default": false
     },
-    "experimentalZoneless": {
+    "zoneless": {
       "type": "boolean",
-      "description": "Experimental: Use zoneless change detection."
+      "description": "Use zoneless change detection.",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { findConfigFile } from 'storybook/internal/common';
+
+import { angularOptionsPlugin } from './preset.ts';
+import type { StandaloneOptions } from './builders/utils/standalone-options.ts';
+
+vi.mock('storybook/internal/common', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('storybook/internal/common')>()),
+  findConfigFile: vi.fn(),
+}));
+
+const mockFindConfigFile = vi.mocked(findConfigFile);
+const normalizePath = (p: string) => p.replace(/\\/g, '/');
+
+const baseOptions = { configDir: '.storybook' } as unknown as StandaloneOptions;
+
+describe('angularOptionsPlugin', () => {
+  // Core's own preview-file resolution list (`validConfigExtensions` in
+  // code/core/src/common/utils/get-storybook-info.ts) — the transform must match every one of
+  // these via `findConfigFile`, not a hardcoded/duplicated array.
+  const extensions = ['ts', 'js', 'tsx', 'jsx', 'mjs', 'cjs'];
+
+  it.each(extensions)(
+    "injects `import 'zone.js';` for a resolved preview.%s when zoneless is false",
+    async (ext) => {
+      const resolvedPreviewPath = `.storybook/preview.${ext}`;
+      mockFindConfigFile.mockReturnValue(resolvedPreviewPath);
+
+      const plugin = angularOptionsPlugin(baseOptions, { normalizePath, zoneless: false });
+      (plugin.config as any)({});
+
+      const result: any = await (plugin.transform as any)('code-here', resolvedPreviewPath);
+
+      expect(result.code).toContain("import 'zone.js';");
+      expect(result.code).toContain('code-here');
+    }
+  );
+
+  it('does not inject zone.js when zoneless is true', async () => {
+    const resolvedPreviewPath = '.storybook/preview.ts';
+    mockFindConfigFile.mockReturnValue(resolvedPreviewPath);
+
+    const plugin = angularOptionsPlugin(baseOptions, { normalizePath, zoneless: true });
+    (plugin.config as any)({});
+
+    const result: any = await (plugin.transform as any)('code-here', resolvedPreviewPath);
+
+    expect(result.code).not.toContain('zone.js');
+  });
+
+  it('no-ops for an id that does not match the resolved preview path', async () => {
+    mockFindConfigFile.mockReturnValue('.storybook/preview.ts');
+
+    const plugin = angularOptionsPlugin(baseOptions, { normalizePath, zoneless: false });
+    (plugin.config as any)({});
+
+    const result = await (plugin.transform as any)('code-here', '.storybook/preview.vue');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('no-ops without throwing when no preview file resolves', async () => {
+    mockFindConfigFile.mockReturnValue(null);
+
+    const plugin = angularOptionsPlugin(baseOptions, { normalizePath, zoneless: false });
+    (plugin.config as any)({});
+
+    const result = await (plugin.transform as any)('code-here', '.storybook/preview.ts');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('resolves the preview path once in config() and reuses it across multiple transform() calls', async () => {
+    mockFindConfigFile.mockReturnValue('.storybook/preview.ts');
+
+    const plugin = angularOptionsPlugin(baseOptions, { normalizePath, zoneless: false });
+    (plugin.config as any)({});
+    await (plugin.transform as any)('a', '.storybook/preview.ts');
+    await (plugin.transform as any)('b', 'unrelated.ts');
+    await (plugin.transform as any)('c', '.storybook/preview.ts');
+
+    expect(mockFindConfigFile).toHaveBeenCalledTimes(1);
+    expect(mockFindConfigFile).toHaveBeenCalledWith('preview', '.storybook');
+  });
+});

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -227,15 +227,20 @@ export const viteFinal = async (config: UserConfig, options?: StandaloneOptions)
   });
 };
 
-function angularOptionsPlugin(
+export function angularOptionsPlugin(
   options: StandaloneOptions,
   { normalizePath, zoneless }: any
 ): Plugin {
   let resolvedConfig: UserConfig;
+  // Resolved once in `config()` (below) rather than per-`transform` call: `findConfigFile` performs
+  // up to several synchronous `existsSync` disk checks, and `transform` has no `id`-pattern
+  // pre-filter, so it runs for every module Vite processes through this plugin.
+  let resolvedPreviewPath: string | undefined;
   return {
     name: 'storybook-angular-vite-options-plugin',
     config(userConfig: UserConfig) {
       resolvedConfig = userConfig;
+      resolvedPreviewPath = findConfigFile('preview', options.configDir) ?? undefined;
       const loadPaths = options?.angularBuilderOptions?.stylePreprocessorOptions?.loadPaths;
       const sassOptions = options?.angularBuilderOptions?.stylePreprocessorOptions?.sass;
 
@@ -257,7 +262,7 @@ function angularOptionsPlugin(
       return;
     },
     async transform(code, id) {
-      if (normalizePath(id).endsWith(normalizePath(`${options.configDir}/preview.ts`))) {
+      if (resolvedPreviewPath && normalizePath(id).endsWith(normalizePath(resolvedPreviewPath))) {
         const imports = [];
         const styles = options?.angularBuilderOptions?.styles;
 

--- a/code/frameworks/angular-vite/src/schema-consistency.test.ts
+++ b/code/frameworks/angular-vite/src/schema-consistency.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Guards Bug A: `builders.json` points at these published top-level schemas (not the unpublished
+// `src/builders/*/schema.json` copies), so they must declare `zoneless` and no longer declare the
+// stale `experimentalZoneless` key.
+const packageRoot = resolve(import.meta.dirname, '..');
+
+describe('published builder schemas declare `zoneless`, not `experimentalZoneless`', () => {
+  it.each(['start-schema.json', 'build-schema.json'])('%s', (schemaFile) => {
+    const schema = JSON.parse(readFileSync(resolve(packageRoot, schemaFile), 'utf-8'));
+
+    expect(schema.properties.zoneless).toEqual(
+      expect.objectContaining({ type: 'boolean', default: true })
+    );
+    expect(schema.properties.experimentalZoneless).toBeUndefined();
+  });
+});

--- a/code/frameworks/angular-vite/start-schema.json
+++ b/code/frameworks/angular-vite/start-schema.json
@@ -149,9 +149,10 @@
       "description": "Configure sourcemaps. See: https://angular.io/guide/workspace-config#source-map-configuration",
       "default": false
     },
-    "experimentalZoneless": {
+    "zoneless": {
       "type": "boolean",
-      "description": "Experimental: Use zoneless change detection."
+      "description": "Use zoneless change detection.",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { JsPackageManager } from 'storybook/internal/common';
 import { loadConfig, printConfig } from 'storybook/internal/csf-tools';
 
-import { prompt } from 'storybook/internal/node-logger';
+import { logger, prompt } from 'storybook/internal/node-logger';
 
 import { add } from '../../add.ts';
 import { updateMainConfig } from '../helpers/mainConfigFile.ts';
@@ -768,6 +768,384 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         '/project/vitest.config.ts',
         expect.anything()
       );
+    });
+
+    describe('zone.js detection and preview injection', () => {
+      const previewConfigPath = '/project/.storybook/preview.ts';
+
+      const angularJsonWithFlag = (flag: boolean | undefined) =>
+        JSON.stringify({
+          projects: {
+            myApp: {
+              architect: {
+                storybook: {
+                  builder: '@storybook/angular:start-storybook',
+                  options: flag === undefined ? {} : { experimentalZoneless: flag },
+                },
+              },
+            },
+          },
+        });
+
+      const mockFilesFor = (angularJsonContent: string, previewContent: string) => {
+        mockReadFile.mockImplementation((filePath: any) => {
+          const p = String(filePath);
+          if (p.endsWith('angular.json')) {
+            return Promise.resolve(angularJsonContent) as any;
+          }
+          if (p === previewConfigPath) {
+            return Promise.resolve(previewContent) as any;
+          }
+          if (p.endsWith('package.json')) {
+            return Promise.resolve('{}') as any;
+          }
+          return Promise.resolve(`export default { framework: '${ANGULAR_PACKAGE}' };`) as any;
+        });
+      };
+
+      it("prepends `import 'zone.js';` and logs a step when the flag is unset", async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        mockFilesFor(angularJsonWithFlag(undefined), 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).toHaveBeenCalledWith(
+          previewConfigPath,
+          "import 'zone.js';\nexport default {};"
+        );
+        expect(logger.step).toHaveBeenCalledWith(expect.stringContaining(previewConfigPath));
+      });
+
+      it('does not modify the preview when every storybook target sets experimentalZoneless: true', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        mockFilesFor(angularJsonWithFlag(true), 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).not.toHaveBeenCalledWith(previewConfigPath, expect.anything());
+      });
+
+      it('behaves like unset when experimentalZoneless is explicitly false: injection happens', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        mockFilesFor(angularJsonWithFlag(false), 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).toHaveBeenCalledWith(
+          previewConfigPath,
+          expect.stringContaining("import 'zone.js';")
+        );
+      });
+
+      it('is idempotent: leaves a preview that already imports zone.js (incl. deep imports) untouched', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        mockFilesFor(
+          angularJsonWithFlag(undefined),
+          "import 'zone.js/testing';\nexport default {};"
+        );
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).not.toHaveBeenCalledWith(previewConfigPath, expect.anything());
+      });
+
+      it('performs no file writes in --dry-run while still reporting the planned change', async () => {
+        mockFilesFor(angularJsonWithFlag(undefined), 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: true,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).not.toHaveBeenCalled();
+      });
+
+      it('works with a .tsx preview file', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        const tsxPreviewPath = '/project/.storybook/preview.tsx';
+        mockReadFile.mockImplementation((filePath: any) => {
+          const p = String(filePath);
+          if (p.endsWith('angular.json')) {
+            return Promise.resolve(angularJsonWithFlag(undefined)) as any;
+          }
+          if (p === tsxPreviewPath) {
+            return Promise.resolve('export default {};') as any;
+          }
+          if (p.endsWith('package.json')) {
+            return Promise.resolve('{}') as any;
+          }
+          return Promise.resolve(`export default { framework: '${ANGULAR_PACKAGE}' };`) as any;
+        });
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath: tsxPreviewPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).toHaveBeenCalledWith(
+          tsxPreviewPath,
+          expect.stringContaining("import 'zone.js';")
+        );
+      });
+
+      it('warns with manual-import guidance when no preview file was found, without throwing', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        mockFilesFor(angularJsonWithFlag(undefined), 'export default {};');
+
+        await expect(
+          angularToAngularVite.run!({
+            result: baseResult,
+            dryRun: false,
+            packageManager: mockPackageManager,
+            mainConfigPath: '/project/.storybook/main.ts',
+            previewConfigPath: undefined,
+            storiesPaths: [],
+            configDir: '.storybook',
+            storybookVersion: '9.0.0',
+          } as any)
+        ).resolves.toBeUndefined();
+
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('manually'));
+        expect(mockWriteFile).not.toHaveBeenCalledWith(previewConfigPath, expect.anything());
+      });
+
+      it('renames a leftover experimentalZoneless key to zoneless with the same boolean value', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        mockFilesFor(angularJsonWithFlag(true), 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        const angularJsonWrite = mockWriteFile.mock.calls.find(
+          ([p]) => p === '/project/angular.json'
+        );
+        expect(angularJsonWrite).toBeDefined();
+        const written = String(angularJsonWrite![1]);
+        expect(written).toContain('"zoneless":true');
+        expect(written).not.toContain('experimentalZoneless');
+      });
+
+      it('handles Nx project.json storybook targets identically to angular.json targets', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        // eslint-disable-next-line depend/ban-dependencies
+        const { globby } = await import('globby');
+        vi.mocked(globby).mockResolvedValueOnce(['/project/libs/soba/project.json']);
+
+        const projectJsonContent = JSON.stringify({
+          name: 'soba',
+          targets: {
+            storybook: {
+              executor: '@storybook/angular:start-storybook',
+              options: {},
+            },
+          },
+        });
+
+        mockReadFile.mockImplementation((filePath: any) => {
+          const p = String(filePath);
+          if (p.endsWith('project.json')) {
+            return Promise.resolve(projectJsonContent) as any;
+          }
+          if (p === previewConfigPath) {
+            return Promise.resolve('export default {};') as any;
+          }
+          return Promise.resolve(`export default { framework: '${ANGULAR_PACKAGE}' };`) as any;
+        });
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).toHaveBeenCalledWith(
+          previewConfigPath,
+          expect.stringContaining("import 'zone.js';")
+        );
+      });
+
+      it('injects when one of multiple storybook targets leaves the flag unset (multi-target rule)', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        const angularJsonContent = JSON.stringify({
+          projects: {
+            myApp: {
+              architect: {
+                storybook: {
+                  builder: '@storybook/angular:start-storybook',
+                  options: { experimentalZoneless: true },
+                },
+                'build-storybook': {
+                  builder: '@storybook/angular:build-storybook',
+                  options: {},
+                },
+              },
+            },
+          },
+        });
+        mockFilesFor(angularJsonContent, 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).toHaveBeenCalledWith(
+          previewConfigPath,
+          expect.stringContaining("import 'zone.js';")
+        );
+      });
+
+      it('skips injection when every one of multiple storybook targets sets the flag true', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        const angularJsonContent = JSON.stringify({
+          projects: {
+            myApp: {
+              architect: {
+                storybook: {
+                  builder: '@storybook/angular:start-storybook',
+                  options: { experimentalZoneless: true },
+                },
+                'build-storybook': {
+                  builder: '@storybook/angular:build-storybook',
+                  options: { experimentalZoneless: true },
+                },
+              },
+            },
+          },
+        });
+        mockFilesFor(angularJsonContent, 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).not.toHaveBeenCalledWith(previewConfigPath, expect.anything());
+      });
+
+      it('only renames/detects the correct project when two projects name their storybook target identically', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        const angularJsonContent = JSON.stringify({
+          projects: {
+            appA: {
+              architect: {
+                storybook: {
+                  builder: '@storybook/angular:start-storybook',
+                  options: { experimentalZoneless: true },
+                },
+              },
+            },
+            appB: {
+              architect: {
+                storybook: {
+                  builder: '@storybook/angular:start-storybook',
+                  options: {},
+                },
+              },
+            },
+          },
+        });
+        mockFilesFor(angularJsonContent, 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        // Injection fires because appB's target is unset (multi-target rule).
+        expect(mockWriteFile).toHaveBeenCalledWith(
+          previewConfigPath,
+          expect.stringContaining("import 'zone.js';")
+        );
+
+        const angularJsonWrite = mockWriteFile.mock.calls.find(
+          ([p]) => p === '/project/angular.json'
+        );
+        expect(angularJsonWrite).toBeDefined();
+        const written = JSON.parse(String(angularJsonWrite![1]));
+        // Only appA's target (which explicitly carried the old key) is renamed.
+        expect(written.projects.appA.architect.storybook.options).toEqual({ zoneless: true });
+        expect(written.projects.appB.architect.storybook.options).toEqual({});
+      });
     });
   });
 });

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -184,22 +184,247 @@ const detectDisabledCompodoc = (content: string): boolean => {
   );
 };
 
+interface StorybookTargetRef {
+  projectName: string | null;
+  targetName: string;
+}
+
+/**
+ * Locate the object-value span of a top-level `"key": { ... }` entry in a raw JSON string,
+ * starting the search at `fromIndex`. Used to relocate a target/project's span in the raw
+ * string (for a scoped string-level replace) after it has already been identified structurally
+ * via `JSON.parse`. The brace-matching walk is string-literal-aware (tracks an `inString` flag
+ * toggled by unescaped `"`) so brace characters inside string values (glob patterns, paths, …)
+ * don't desync the depth count.
+ */
+const findKeyObjectSpan = (
+  haystack: string,
+  key: string,
+  fromIndex: number
+): { start: number; end: number } | null => {
+  const re = new RegExp(`"${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"\\s*:`, 'g');
+  re.lastIndex = fromIndex;
+  const match = re.exec(haystack);
+  if (!match) {
+    return null;
+  }
+
+  let i = match.index + match[0].length;
+  while (i < haystack.length && /\s/.test(haystack[i])) {
+    i++;
+  }
+  if (haystack[i] !== '{') {
+    return null;
+  }
+
+  const start = i;
+  let depth = 0;
+  let inString = false;
+  for (; i < haystack.length; i++) {
+    const ch = haystack[i];
+    if (inString) {
+      if (ch === '\\') {
+        i++;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return { start, end: i + 1 };
+      }
+    }
+  }
+  return null;
+};
+
+/**
+ * Rename `experimentalZoneless` -> `zoneless` (same boolean value) inside each given storybook
+ * target's own span, applied one target at a time against a progressively-updated working
+ * string. A project's span is located first (by its unique project name) so that two different
+ * projects naming their storybook target identically (e.g. both `"storybook"`) never collide —
+ * the target search is scoped to its own project's already-isolated substring.
+ */
+const renameExperimentalZonelessKey = (content: string, targets: StorybookTargetRef[]): string => {
+  let result = content;
+
+  for (const { projectName, targetName } of targets) {
+    let searchBase = result;
+    let baseOffset = 0;
+
+    if (projectName !== null) {
+      const projectSpan = findKeyObjectSpan(result, projectName, 0);
+      if (!projectSpan) {
+        continue;
+      }
+      searchBase = result.slice(projectSpan.start, projectSpan.end);
+      baseOffset = projectSpan.start;
+    }
+
+    const targetSpan = findKeyObjectSpan(searchBase, targetName, 0);
+    if (!targetSpan) {
+      continue;
+    }
+
+    const absStart = baseOffset + targetSpan.start;
+    const absEnd = baseOffset + targetSpan.end;
+    const targetText = result.slice(absStart, absEnd);
+    const renamed = targetText.replace(
+      /"experimentalZoneless"(\s*:\s*)(true|false)/,
+      '"zoneless"$1$2'
+    );
+
+    if (renamed !== targetText) {
+      result = result.slice(0, absStart) + renamed + result.slice(absEnd);
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Read the flag-only zone.js detection signal from a Storybook builder target's
+ * `options.experimentalZoneless`, across every `:start-storybook`/`:build-storybook` target in an
+ * `angular.json` or Nx `project.json`. Also collects the `(project, target)` refs whose options
+ * still carry the old key, so it can be renamed to `zoneless` (map & drop).
+ */
+const detectZoneJsAndTargetsToRename = (
+  content: string
+): {
+  hasStorybookTarget: boolean;
+  allStorybookTargetsZonelessTrue: boolean;
+  targets: StorybookTargetRef[];
+} => {
+  let json: any;
+  try {
+    json = JSON.parse(content);
+  } catch {
+    return { hasStorybookTarget: false, allStorybookTargetsZonelessTrue: true, targets: [] };
+  }
+
+  const isStorybookTarget = (target: any): boolean => {
+    const ref: unknown = target?.builder ?? target?.executor;
+    return (
+      typeof ref === 'string' &&
+      (ref.endsWith(':start-storybook') || ref.endsWith(':build-storybook'))
+    );
+  };
+
+  let hasStorybookTarget = false;
+  let allZonelessTrue = true;
+  const targets: StorybookTargetRef[] = [];
+
+  const processTargetGroup = (group: any, projectName: string | null) => {
+    if (!group || typeof group !== 'object') {
+      return;
+    }
+    for (const [targetName, target] of Object.entries<any>(group)) {
+      if (!isStorybookTarget(target)) {
+        continue;
+      }
+      hasStorybookTarget = true;
+      if (target?.options?.experimentalZoneless !== true) {
+        allZonelessTrue = false;
+      }
+      if (target?.options && 'experimentalZoneless' in target.options) {
+        targets.push({ projectName, targetName });
+      }
+    }
+  };
+
+  if (json?.projects && typeof json.projects === 'object') {
+    for (const [projectName, project] of Object.entries<any>(json.projects)) {
+      processTargetGroup(project?.architect, projectName);
+      processTargetGroup(project?.targets, projectName);
+    }
+  }
+  processTargetGroup(json?.targets, null);
+
+  return { hasStorybookTarget, allStorybookTargetsZonelessTrue: allZonelessTrue, targets };
+};
+
 const transformJsonFile = async (
   filePath: string,
   dryRun: boolean
-): Promise<{ changed: boolean; disablesCompodoc: boolean }> => {
+): Promise<{
+  changed: boolean;
+  disablesCompodoc: boolean;
+  hasStorybookTarget: boolean;
+  allStorybookTargetsZonelessTrue: boolean;
+}> => {
   try {
     const content = await readFile(filePath, 'utf-8');
-    const transformed = rewriteBuilderRefs(content);
+    let transformed = rewriteBuilderRefs(content);
+
+    const { hasStorybookTarget, allStorybookTargetsZonelessTrue, targets } =
+      detectZoneJsAndTargetsToRename(content);
+
+    if (targets.length > 0) {
+      transformed = renameExperimentalZonelessKey(transformed, targets);
+    }
+
     const changed = transformed !== content;
 
     if (changed && !dryRun) {
       await writeFile(filePath, transformed);
     }
 
-    return { changed, disablesCompodoc: detectDisabledCompodoc(content) };
+    return {
+      changed,
+      disablesCompodoc: detectDisabledCompodoc(content),
+      hasStorybookTarget,
+      allStorybookTargetsZonelessTrue,
+    };
   } catch {
-    return { changed: false, disablesCompodoc: false };
+    return {
+      changed: false,
+      disablesCompodoc: false,
+      hasStorybookTarget: false,
+      allStorybookTargetsZonelessTrue: true,
+    };
+  }
+};
+
+/**
+ * Prepend `import 'zone.js';` to the Storybook preview when the migrated project needs zone-based
+ * change detection (see `needsZoneJs` in `run()`). @storybook/angular-vite defaults to zoneless
+ * outside `ng run`, so without this the polyfill is dropped for `storybook dev`, `storybook build`,
+ * and standalone Vitest, breaking `NgZone`-dependent stories. Idempotent, and a no-op in dry runs.
+ */
+const addZoneJsPreviewImport = async (
+  previewConfigPath: string,
+  dryRun: boolean
+): Promise<void> => {
+  try {
+    const content = await readFile(previewConfigPath, 'utf-8');
+
+    // Leave an existing zone.js import (any quote style, incl. subpaths) alone.
+    if (/import\s+['"]zone\.js(\/[^'"]*)?['"]/.test(content)) {
+      return;
+    }
+
+    if (dryRun) {
+      return;
+    }
+
+    // zone.js must be imported before Angular loads, so it goes at the very top.
+    await writeFile(previewConfigPath, `import 'zone.js';\n${content}`);
+    logger.step(`Added a \`zone.js\` import to ${previewConfigPath}`);
+  } catch (error) {
+    logger.warn(
+      `Could not add a \`zone.js\` import to ${previewConfigPath} automatically: ${error}. ` +
+        "If your app uses zone-based change detection, add `import 'zone.js';` at the top of your preview."
+    );
   }
 };
 
@@ -318,6 +543,7 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
     result,
     dryRun = false,
     mainConfigPath,
+    previewConfigPath,
     storiesPaths,
     configDir,
     packageManager,
@@ -389,14 +615,24 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
     // Track whether any migrated builder config disabled Compodoc, so the
     // intent can be carried into framework.options (step 4b).
     let disableCompodoc = false;
+    // Track the flag-only zone.js detection signal across every storybook target seen in
+    // angular.json/project.json (steps 3/3b): injection fires unless EVERY storybook target
+    // explicitly sets `experimentalZoneless: true`.
+    let anyStorybookTarget = false;
+    let allZonelessTrue = true;
 
     // 3. Rewrite Angular CLI builder references in angular.json.
     // Search for angular.json beside every package.json we know about.
     for (const pkgJsonPath of packageManager.packageJsonPaths) {
       const dir = pkgJsonPath.replace(/[/\\]package\.json$/, '');
       const angularJsonPath = `${dir}/angular.json`;
-      const { changed, disablesCompodoc } = await transformJsonFile(angularJsonPath, dryRun);
+      const { changed, disablesCompodoc, hasStorybookTarget, allStorybookTargetsZonelessTrue } =
+        await transformJsonFile(angularJsonPath, dryRun);
       disableCompodoc ||= disablesCompodoc;
+      if (hasStorybookTarget) {
+        anyStorybookTarget = true;
+        allZonelessTrue = allZonelessTrue && allStorybookTargetsZonelessTrue;
+      }
       if (changed) {
         logger.debug(`Updated Angular CLI builder references in ${angularJsonPath}`);
       }
@@ -415,8 +651,13 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
       absolute: true,
     });
     for (const projectJsonPath of projectJsonFiles) {
-      const { changed, disablesCompodoc } = await transformJsonFile(projectJsonPath, dryRun);
+      const { changed, disablesCompodoc, hasStorybookTarget, allStorybookTargetsZonelessTrue } =
+        await transformJsonFile(projectJsonPath, dryRun);
       disableCompodoc ||= disablesCompodoc;
+      if (hasStorybookTarget) {
+        anyStorybookTarget = true;
+        allZonelessTrue = allZonelessTrue && allStorybookTargetsZonelessTrue;
+      }
       if (changed) {
         logger.debug(`Updated Nx builder references in ${projectJsonPath}`);
       }
@@ -456,6 +697,17 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
             "Set `compodoc: false` in your main config's framework.options manually."
         );
       }
+    }
+
+    // 4c. Add a `zone.js` import to the preview when any migrated storybook target needs it
+    // (flag unset, or explicitly `false`) and not every storybook target opted into zoneless.
+    const needsZoneJs = anyStorybookTarget && !allZonelessTrue;
+    if (needsZoneJs && previewConfigPath) {
+      await addZoneJsPreviewImport(previewConfigPath, dryRun);
+    } else if (needsZoneJs && !previewConfigPath) {
+      logger.warn(
+        "Could not find a Storybook preview file to add the zone.js import to. If your app uses zone-based change detection, add `import 'zone.js';` at the top of your preview file manually."
+      );
     }
 
     // 5. Update import statements across config and story files.


### PR DESCRIPTION
## Summary
- The `angular-to-angular-vite` automigration never re-added `zone.js` after moving projects off the webpack builder's implicit polyfill loading, breaking zone-based Angular apps (e.g. Bitwarden clients) after migrating to `@storybook/angular-vite`. Detection is flag-only (`options.experimentalZoneless !== true` on every `:start-storybook`/`:build-storybook` target in `angular.json`/Nx `project.json`), injects `import 'zone.js';` into the preview when needed, and renames any leftover `experimentalZoneless` key to `zoneless`.
- Bug A: `@storybook/angular-vite`'s published `start-schema.json`/`build-schema.json` still declared the stale `experimentalZoneless` option instead of `zoneless`, so the correct `zoneless: false` setting failed schema validation while the stale key passed silently.
- Bug B: `preset.ts`'s transform hook only matched a literal `preview.ts`, so `.tsx` (and other) preview files never received the runtime `zone.js` injection. It now resolves the preview path once via `findConfigFile` (core's own preview-resolution list), cached in the plugin's `config()` hook to avoid extra disk I/O per transformed module.

## Test plan
- [x] `yarn vitest run` on the migration suite (`angular-to-angular-vite.test.ts`, 43 tests, including multi-target, multi-project same-key-name, Nx `project.json`, dry-run, `.tsx`, and missing-preview cases)
- [x] `yarn vitest run` on the new schema-consistency and preset unit tests (12 tests)
- [x] `yarn lint` / typecheck on all changed packages (`cli`, `angular-vite`) — clean
- [x] Repro-first E2E against a real `bitwarden/clients` checkout: reproduced the bug with the currently-published (pre-fix) automigration (zone.js import missing from `preview.tsx` after migration), then confirmed this branch's local build correctly injects `import 'zone.js';` as the first line against the same checkout