### PR TITLE
UI: Allow hiding tags from sidebar filters

### DIFF
--- a/code/addons/docs/src/preview.ts
+++ b/code/addons/docs/src/preview.ts
@@ -1,9 +1,9 @@
-import type { PreparedStory, TagOptions } from "storybook/internal/types";
+import type { PreparedStory, TagOptions } from 'storybook/internal/types';
 
 const excludeTags = Object.fromEntries(
   Object.entries<Partial<TagOptions>>(globalThis.TAGS_OPTIONS ?? {})
     .filter(([, { excludeFromDocsStories }]) => excludeFromDocsStories)
-    .map(([tag, { excludeFromDocsStories }]) => [tag, excludeFromDocsStories]),
+    .map(([tag, { excludeFromDocsStories }]) => [tag, excludeFromDocsStories])
 );
 
 export const parameters: any = {

--- a/code/addons/docs/src/preview.ts
+++ b/code/addons/docs/src/preview.ts
@@ -1,14 +1,9 @@
-import type { PreparedStory } from 'storybook/internal/types';
+import type { PreparedStory, TagOptions } from "storybook/internal/types";
 
-const excludeTags = Object.entries(globalThis.TAGS_OPTIONS ?? {}).reduce(
-  (acc, entry) => {
-    const [tag, option] = entry;
-    if ((option as any).excludeFromDocsStories) {
-      acc[tag] = true;
-    }
-    return acc;
-  },
-  {} as Record<string, boolean>
+const excludeTags = Object.fromEntries(
+  Object.entries<Partial<TagOptions>>(globalThis.TAGS_OPTIONS ?? {})
+    .filter(([, { excludeFromDocsStories }]) => excludeFromDocsStories)
+    .map(([tag, { excludeFromDocsStories }]) => [tag, excludeFromDocsStories]),
 );
 
 export const parameters: any = {

--- a/code/core/src/manager-api/modules/tags.ts
+++ b/code/core/src/manager-api/modules/tags.ts
@@ -2,6 +2,7 @@ import type {
   API_PreparedIndexEntry,
   FilterFunction,
   Tag,
+  TagOptions,
   TagsOptions,
 } from 'storybook/internal/types';
 
@@ -56,16 +57,10 @@ export const getDefaultTagsFromPreset = memoize(1)((
 });
 
 export const computeStaticFilterFn = (tagPresets: TagsOptions) => {
-  const staticExcludeTags = Object.entries(tagPresets).reduce(
-    (acc, entry) => {
-      const [tag, option] = entry;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ((option as any).excludeFromSidebar) {
-        acc[tag] = true;
-      }
-      return acc;
-    },
-    {} as Record<string, boolean>
+  const staticExcludeTags = Object.fromEntries(
+    Object.entries<Partial<TagOptions>>(tagPresets)
+      .filter(([, { excludeFromSidebar }]) => excludeFromSidebar)
+      .map(([tag, { excludeFromSidebar }]) => [tag, excludeFromSidebar])
   );
 
   return (item: API_PreparedIndexEntry) => {

--- a/code/core/src/manager/components/sidebar/Filter.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Filter.stories.tsx
@@ -215,6 +215,63 @@ export const ClosedWithSelection: Story = {
   },
 };
 
+export const HiddenTagSelection: Story = {
+  ...ClosedWithSelection,
+  beforeEach: () => {
+    const originalTagsOptions = global.TAGS_OPTIONS;
+    global.TAGS_OPTIONS = {
+      ...originalTagsOptions,
+      hidden: {
+        excludeFromFilterPanel: true,
+      },
+    };
+
+    return () => {
+      global.TAGS_OPTIONS = originalTagsOptions;
+    };
+  },
+  parameters: {
+    initialStoryState: {
+      internal_index: {
+        v: 6,
+        entries: {
+          'c1-s1': {
+            tags: ['hidden', 'visible', 'dev', 'play-fn'],
+            type: 'story',
+          } as StoryIndexEntry,
+          'c1-test': {
+            tags: ['test-fn'],
+            type: 'story',
+            subtype: 'test',
+          } as StoryIndexEntry,
+          'c1-doc': { tags: [], type: 'docs' } as unknown as DocsIndexEntry,
+        },
+      } as StoryIndex,
+      includedTagFilters: ['hidden'],
+    },
+  },
+  play: async ({ canvas }) => {
+    const button = await canvas.findByRole('button', { name: /1 active tag filter/i });
+
+    button.click();
+
+    const visibleTag = await screen.findByRole('checkbox', { name: /visible/i });
+    await expect(visibleTag).toBeInTheDocument();
+    await expect(screen.queryByRole('checkbox', { name: /hidden/i })).not.toBeInTheDocument();
+
+    const clearButton = await screen.findByRole('button', {
+      name: 'Clear filters',
+    });
+    clearButton.click();
+
+    await expect(await canvas.findByRole('button', { name: /tag filters/i })).toBeInTheDocument();
+
+    await expect(
+      canvas.queryByRole('button', { name: /1 active tag filter/i })
+    ).not.toBeInTheDocument();
+  },
+} satisfies Story;
+
 export const Clear = {
   ...ClosedWithSelection,
   beforeEach: () => {

--- a/code/core/src/manager/components/sidebar/useFilterData.tsx
+++ b/code/core/src/manager/components/sidebar/useFilterData.tsx
@@ -9,6 +9,7 @@ import type {
 } from 'storybook/internal/types';
 
 import { BeakerIcon, DocumentIcon, PlayHollowIcon } from '@storybook/icons';
+import { global } from '@storybook/global';
 
 import { color } from 'storybook/theming';
 
@@ -51,9 +52,11 @@ export function useTagFilterEntries(indexJson: StoryIndex) {
   return useMemo(() => {
     const entries = Object.values(indexJson.entries);
 
+    const tagOptions = global.TAGS_OPTIONS ?? {};
+
     const userTagsCounts = entries.reduce<Record<Tag, number>>((acc, entry) => {
       entry.tags?.forEach((tag: Tag) => {
-        if (!BUILT_IN_TAGS.has(tag)) {
+        if (!BUILT_IN_TAGS.has(tag) && !tagOptions[tag]?.excludeFromFilterPanel) {
           acc[tag] = (acc[tag] || 0) + 1;
         }
       });

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -409,9 +409,11 @@ type Tag = string;
 
 export interface TagOptions {
   /** Visually include or exclude stories with this tag in the sidebar by default */
-  defaultFilterSelection?: 'include' | 'exclude' | undefined;
-  excludeFromSidebar: boolean;
-  excludeFromDocsStories: boolean;
+  defaultFilterSelection?: "include" | "exclude" | undefined;
+  /** Exclude stories with this tag from appearing in the sidebar */
+  excludeFromSidebar?: boolean;
+  /** Exclude stories with this tag from appearing in docs */
+  excludeFromDocsStories?: boolean;
 }
 
 export type TagsOptions = Record<Tag, Partial<TagOptions>>;

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -409,7 +409,9 @@ type Tag = string;
 
 export interface TagOptions {
   /** Visually include or exclude stories with this tag in the sidebar by default */
-  defaultFilterSelection?: "include" | "exclude" | undefined;
+  defaultFilterSelection?: 'include' | 'exclude' | undefined;
+  /** Exclude this tag from the sidebar filtering UI */
+  excludeFromFilterPanel?: boolean;
   /** Exclude stories with this tag from appearing in the sidebar */
   excludeFromSidebar?: boolean;
   /** Exclude stories with this tag from appearing in docs */

--- a/docs/api/main-config/main-config-tags.mdx
+++ b/docs/api/main-config/main-config-tags.mdx
@@ -24,4 +24,11 @@ Type: `'include' | 'exclude'`
 
 Set the default filter selection state for a tag in the Storybook sidebar. If set to `include`, stories with this tag are selected as included. If set to `exclude`, stories with this tag are selected as excluded, and must be explicitly included by selecting the tag in the sidebar filter menu. If not set, the tag has no default selection.
 
+### `[tagName].excludeFromFilterPanel`
+
+Type: `boolean`
+
+Exclude a tag from the sidebar filter UI by setting this to `true`. Using a hidden tag with the built-in tag filter (for instance,
+via `addTagFilters`) is strongly discouraged as it will result in an inconsistent UI.
+
 ![Filtering by tags](../../_assets/writing-stories/tag-filter.png)


### PR DESCRIPTION
Closes #34186


## What I did

Follow-up from #35113 with some minor modifications - only user tags are included (rather than system tags), and a note is added to the docs to discourage using hidden tags within the built-in tag filter.

This is because this will present an inconsistent and confusing UI to the user:

<img width="270" height="345" alt="image" src="https://github.com/user-attachments/assets/b393d016-8e10-4b0a-a80a-b6abfcdfe11a" />

Here we see a notification that there is an active filter, but no evidence of it (as the tag in question is hidden).

Whilst it _may_ be possible to dig through the various code paths and add further exclusions (including url persistence) it is hard to see a use case for hiding a tag _and_ using it in the built-in tag filters.

It is more likely that the hidden tag will be used for, for example, static filters like `excludeFromSidebar` , `excludeFromDocsStories` or a user-provided custom filter function.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

The new story added describes an undesirable use case of a hidden tag being used as a filter, but exercises the UI logic.

To give it a more thorough spin:

1. Create a new tag that has the option `excludeFromFilterPanel` set
2. Also set `excludeFromSidebar` and `excludeFromDocsStories`
3. Set that tag on a story
4. Observe that the tag does not appear in the UI, but does still affect visibility of the story in the sidebar and autodocs


### Documentation


- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `excludeFromFilterPanel` to tag options to hide specific tags from the sidebar tag filter UI while keeping them usable for internal tag-based filtering.
* **Bug Fixes**
  * Tag filter counts and selectable tag checkboxes now respect the new tag visibility setting.
  * Sidebar and docs story filtering follow consistent tag exclusion rules.
* **Documentation**
  * Documented `excludeFromFilterPanel` in the main configuration reference, including guidance on recommended usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->