### PR TITLE
Controls: Load controls for composed-ref stories on direct deep-link

### DIFF
--- a/code/core/src/manager-api/modules/refs.ts
+++ b/code/core/src/manager-api/modules/refs.ts
@@ -2,6 +2,7 @@ import type {
   API_ComposedRef,
   API_ComposedRefUpdate,
   API_IndexHash,
+  API_RefStoryRuntimeData,
   API_Refs,
   API_SetRefData,
   API_StoryMapper,
@@ -101,6 +102,27 @@ const addRefIds = (input: API_IndexHash, ref: API_ComposedRef): API_IndexHash =>
   return Object.entries(input).reduce((acc, [id, item]) => {
     return { ...acc, [id]: { ...item!, refId: ref.id } };
   }, {} as API_IndexHash);
+};
+
+// A composed ref's story/docs entries are enriched at runtime from the preview's STORY_PREPARED /
+// DOCS_PREPARED events (args, argTypes, parameters, prepared) — data that is NOT in the ref's static
+// story index. That enrichment is cached per ref (`ref.storyUpdates`) and re-applied here whenever
+// `setRef` rebuilds the hash from the static index, so it is not wiped by re-composition and is
+// applied even when it arrives before the index is first composed (the deep-link race in #34553).
+const applyRefStoryUpdates = (
+  index: API_IndexHash,
+  storyUpdates: API_RefStoryRuntimeData | undefined
+): API_IndexHash => {
+  if (!storyUpdates) {
+    return index;
+  }
+  Object.entries(storyUpdates).forEach(([id, update]) => {
+    const entry = index[id];
+    if (entry && (entry.type === 'story' || entry.type === 'docs')) {
+      index[id] = { ...entry, ...update } as API_IndexHash[string];
+    }
+  });
+  return index;
 };
 
 async function handleRequest(
@@ -339,9 +361,11 @@ export const init: ModuleFn<SubAPI, SubState> = (
 
       if (index) {
         index = addRefIds(index, ref);
+        index = applyRefStoryUpdates(index, ref?.storyUpdates);
       }
       if (filteredIndex) {
         filteredIndex = addRefIds(filteredIndex, ref);
+        filteredIndex = applyRefStoryUpdates(filteredIndex, ref?.storyUpdates);
       }
       await api.updateRef(id, { ...ref, ...rest, index, filteredIndex, internal_index });
     },

--- a/code/core/src/manager-api/modules/stories.ts
+++ b/code/core/src/manager-api/modules/stories.ts
@@ -832,6 +832,13 @@ export const init: ModuleFn<SubAPI, SubState> = ({
         }
       } else {
         const { id: refId, index, filteredIndex }: any = ref;
+        // Cache the runtime enrichment on the ref so it survives index (re)builds in `setRef` and is
+        // applied even when it arrives before the ref index is first composed (the deep-link race in
+        // #34553, where the preview sends STORY_PREPARED once, before the index has been composed).
+        const storyUpdates = {
+          ...ref.storyUpdates,
+          [storyId]: { ...ref.storyUpdates?.[storyId], ...update },
+        };
         if (index && index[storyId]) {
           index[storyId] = {
             ...index[storyId],
@@ -844,7 +851,7 @@ export const init: ModuleFn<SubAPI, SubState> = ({
             ...update,
           } as API_StoryEntry;
         }
-        await fullAPI.updateRef(refId, { index, filteredIndex });
+        await fullAPI.updateRef(refId, { index, filteredIndex, storyUpdates });
       }
     },
     updateDocs: async (
@@ -871,15 +878,23 @@ export const init: ModuleFn<SubAPI, SubState> = ({
         }
       } else {
         const { id: refId, index, filteredIndex }: any = ref;
-        index[docsId] = {
-          ...index[docsId],
-          ...update,
-        } as API_DocsEntry;
-        filteredIndex[docsId] = {
-          ...filteredIndex[docsId],
-          ...update,
-        } as API_DocsEntry;
-        await fullAPI.updateRef(refId, { index, filteredIndex });
+        const storyUpdates = {
+          ...ref.storyUpdates,
+          [docsId]: { ...ref.storyUpdates?.[docsId], ...update },
+        };
+        if (index && index[docsId]) {
+          index[docsId] = {
+            ...index[docsId],
+            ...update,
+          } as API_DocsEntry;
+        }
+        if (filteredIndex && filteredIndex[docsId]) {
+          filteredIndex[docsId] = {
+            ...filteredIndex[docsId],
+            ...update,
+          } as API_DocsEntry;
+        }
+        await fullAPI.updateRef(refId, { index, filteredIndex, storyUpdates });
       }
     },
     setPreviewInitialized: async (ref) => {

--- a/code/core/src/manager-api/tests/refs.test.ts
+++ b/code/core/src/manager-api/tests/refs.test.ts
@@ -1331,6 +1331,48 @@ describe('Refs API', () => {
         expect.objectContaining({ 'a--2': expect.anything() })
       );
     });
+
+    it('re-applies cached runtime story enrichment when rebuilding the index (#34553)', async () => {
+      const index: StoryIndex = {
+        v: 5,
+        entries: {
+          'a--1': {
+            id: 'a--1',
+            title: 'A',
+            name: '1',
+            importPath: './path/to/a1.ts',
+            type: 'story',
+            subtype: 'story',
+          },
+        },
+      };
+
+      // Simulate a ref whose story got enriched at runtime (via STORY_PREPARED) before/independent of
+      // its static index being (re)composed. The enrichment is cached on `storyUpdates`.
+      const initialState: Partial<State> = {
+        filters: {},
+        refs: {
+          fake: {
+            id: 'fake',
+            url: 'https://example.com',
+            previewInitialized: true,
+            storyUpdates: {
+              'a--1': { prepared: true, argTypes: { label: { name: 'label' } } as any },
+            },
+          },
+        },
+      };
+
+      const store = createMockStore(initialState);
+      const { api } = initRefs({ provider, store } as any, { runCheck: false });
+
+      // The incoming static index has no argTypes; the cached enrichment must survive the rebuild.
+      await api.setRef('fake', { storyIndex: index });
+
+      const rebuilt = api.getRefs().fake.index?.['a--1'] as any;
+      expect(rebuilt.argTypes).toEqual({ label: { name: 'label' } });
+      expect(rebuilt.prepared).toBe(true);
+    });
   });
 
   it('errors on unknown version', async () => {

--- a/code/core/src/manager-api/tests/stories.test.ts
+++ b/code/core/src/manager-api/tests/stories.test.ts
@@ -825,6 +825,8 @@ describe('stories API', () => {
       expect(fullAPI.updateRef).toHaveBeenCalledWith('refId', {
         filteredIndex: { 'a--1': { args: { foo: 'bar' } } },
         index: { 'a--1': { args: { foo: 'bar' } } },
+        // Runtime enrichment is also cached on the ref so it survives index rebuilds (#34553).
+        storyUpdates: { 'a--1': { args: { foo: 'bar' } } },
       });
     });
     it('updateStoryArgs emits UPDATE_STORY_ARGS to the local frame and does not change anything', () => {

--- a/code/core/src/types/modules/api-stories.ts
+++ b/code/core/src/types/modules/api-stories.ts
@@ -64,6 +64,16 @@ export interface API_TestEntry extends Omit<API_StoryEntry, 'subtype' | 'childre
 }
 
 export type API_LeafEntry = API_DocsEntry | API_StoryEntry | API_TestEntry;
+
+/**
+ * Runtime enrichment for a composed ref's stories/docs, keyed by entry id. These fields come from
+ * the ref preview's STORY_PREPARED / DOCS_PREPARED events and are not part of the ref's static story
+ * index, so they are cached per ref and re-applied whenever the ref index is (re)built.
+ */
+export type API_RefStoryRuntimeData = Record<
+  StoryId,
+  Partial<Pick<API_StoryEntry, 'prepared' | 'parameters' | 'args' | 'argTypes' | 'initialArgs'>>
+>;
 export type API_HashEntry =
   | API_RootEntry
   | API_GroupEntry

--- a/code/core/src/types/modules/api.ts
+++ b/code/core/src/types/modules/api.ts
@@ -152,8 +152,8 @@ export interface API_LoadedRefData {
   indexError?: Error;
   previewInitialized: boolean;
   /**
-   * Runtime story enrichment (args, argTypes, parameters, prepared) received from the ref preview
-   * via STORY_PREPARED / DOCS_PREPARED, cached so it survives ref index (re)builds. See
+   * Runtime story enrichment (args, argTypes, parameters, initialArgs, prepared) received from the
+   * ref preview via STORY_PREPARED / DOCS_PREPARED, cached so it survives ref index (re)builds. See
    * `API_RefStoryRuntimeData`.
    */
   storyUpdates?: API_RefStoryRuntimeData;

--- a/code/core/src/types/modules/api.ts
+++ b/code/core/src/types/modules/api.ts
@@ -10,6 +10,7 @@ import type {
   API_HashEntry,
   API_IndexHash,
   API_PreparedIndexEntry,
+  API_RefStoryRuntimeData,
 } from './api-stories.ts';
 import type { SetStoriesStory, SetStoriesStoryData } from './channelApi.ts';
 import type { DocsOptions } from './core-common.ts';
@@ -150,6 +151,12 @@ export interface API_LoadedRefData {
   filteredIndex?: API_IndexHash;
   indexError?: Error;
   previewInitialized: boolean;
+  /**
+   * Runtime story enrichment (args, argTypes, parameters, prepared) received from the ref preview
+   * via STORY_PREPARED / DOCS_PREPARED, cached so it survives ref index (re)builds. See
+   * `API_RefStoryRuntimeData`.
+   */
+  storyUpdates?: API_RefStoryRuntimeData;
 }
 
 export interface API_ComposedRef extends API_LoadedRefData {
@@ -181,6 +188,7 @@ export type API_ComposedRefUpdate = Partial<
     | 'previewInitialized'
     | 'sourceUrl'
     | 'internal_index'
+    | 'storyUpdates'
   >
 >;
 


### PR DESCRIPTION
Closes #34553

## What I did

Composed-ref Controls still didn't work when a ref story is opened via a **direct deep-link** (the exact way it gets QA'd): the panel shows _"This story has no controls"_ even for stories that clearly have args.

### Background / history

`#34553` reported that Controls never load for a story served from a composed Storybook ref. It went through a couple of rounds:

- **#35050** ("Controls: Load controls for stories from a composed ref") fixed the *loading gate*: `ControlsPanel` only watched the host's global `previewInitialized`, which stays `false` for ref stories, so the args table was stuck on the loading skeleton forever. Shipped in `v10.5.0-alpha.5`.
- **#35078** ("Manager: Keep local preview iframe on host URL when a ref story loads first") fixed a separate side effect surfaced by #35050 (host preview stuck after a ref-first load). Shipped in `v10.5.0-alpha.6`.

During a secondary QA pass on `v10.5.0-alpha.11`, composed-ref Controls **still failed** — but with a different symptom. #35050 correctly cleared the loading skeleton, so instead of "loading forever" the panel now renders the **"No controls"** empty state. Because the user still never sees controls, it read as "the same bug" and didn't pass QA. This was never a regression — it's a second, independent bug that was masked by the loading-skeleton bug and is present in `10.4.x` too.

### Root cause

A composed ref's story entries are enriched at runtime from the ref preview's `STORY_PREPARED` event (`args`, `argTypes`, `parameters`, `prepared`). That enrichment is **not** part of the ref's static story index. Two things then conspire:

1. `setRef` rebuilds the ref's `index` from the static story index (which has no `argTypes`), **wiping** any runtime enrichment on every (re)composition.
2. On a direct deep-link, the ref preview emits `STORY_PREPARED` **before** the ref index has been composed, so `updateStory`'s `if (index && index[storyId])` guard fails and the enrichment is **dropped** outright.

Since the ref preview already rendered the story, it doesn't re-emit `STORY_PREPARED`, so the enrichment never comes back → `useArgTypes()` returns `{}` → "No controls". (In-app navigation happened to work because the ref index was already composed before opening the story.)

### The fix

Cache the runtime enrichment on the ref itself (`ref.storyUpdates`) and re-apply it whenever the ref index is (re)built, so it survives index rebuilds and works regardless of whether it arrives before or after the index is composed:

- `updateStory` / `updateDocs` (ref branch) merge each update into `ref.storyUpdates` (in addition to the live index entry when present).
- `setRef` re-applies `ref.storyUpdates` onto the freshly built `index`/`filteredIndex`.
- New type `API_RefStoryRuntimeData` + `API_LoadedRefData.storyUpdates`.

The `ControlsPanel` fix from #35050 is left intact — it correctly handles the loading half. This change completes the other half.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Added a regression test in `refs.test.ts` (cached runtime enrichment is re-applied when `setRef` rebuilds the index) and updated the `STORY_ARGS_UPDATED` assertion in `stories.test.ts`.

#### Manual testing

1. Serve a Storybook that composes another Storybook via `refs` (e.g. the composed-ref repro from #34553, or point the internal Storybook UI — which composes the `Icons` ref — at these changes).
2. Open the host Storybook and **deep-link directly** to a composed-ref story that has args, e.g. `http://localhost:6006/?path=/story/icons_icons-arrowtoplefticon--default` (hard reload).
3. Open the **Controls** tab: it should show the story's controls instead of "This story has no controls".
4. Navigate to a host story and back to confirm both keep working.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved runtime “prepared” story/docs details (including args/argTypes) when ref indexes are rebuilt, keeping metadata consistent after updates.
  * Fixed scenarios where enriched story information could be lost during refreshes or when runtime updates arrived before the initial index composition.
* **New Features**
  * Added caching and propagation of runtime story/docs enrichment for composed refs, ensuring consistent story/docs presentation across ref changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->