### PR TITLE
Manager: Apply addon-registered filters to the initial story index

### DIFF
--- a/code/core/src/manager-api/root.tsx
+++ b/code/core/src/manager-api/root.tsx
@@ -132,6 +132,11 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
 
   modules: ReturnType<ModuleFn>[];
 
+  // Addon register callbacks run in the constructor (before mount) so manager-side listeners exist
+  // before the preview iframe emits its first events. React's this.setState is a no-op before mount,
+  // so store writes during registration are applied directly to this.state until this flips true.
+  mounted = false;
+
   static displayName = 'Manager';
 
   constructor(props: ManagerProviderProps) {
@@ -150,6 +155,20 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
     const store = new Store({
       getState: () => this.state,
       setState: (stateChange: Partial<State>, callback) => {
+        if (!this.mounted) {
+          // Before mount (e.g. during addon registration in the constructor) React's setState is a
+          // no-op, so apply the patch directly to this.state and resolve synchronously. This ensures
+          // register-time writes (like experimental_setFilter) land in the first render.
+          const patch =
+            typeof stateChange === 'function'
+              ? (stateChange as (s: State) => Partial<State>)(this.state)
+              : stateChange;
+          this.state = { ...this.state, ...patch };
+          callback?.(this.state);
+
+          return this.state;
+        }
+
         this.setState(stateChange, () => callback(this.state));
 
         return this.state;
@@ -198,6 +217,10 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
     // Run addon register callbacks before the first render mounts the preview iframe, so manager-side
     // listeners (e.g. open-service) exist before preview JS can emit sync-start.
     props.provider.handleAPI(this.api);
+  }
+
+  componentDidMount() {
+    this.mounted = true;
   }
 
   static getDerivedStateFromProps(props: ManagerProviderProps, state: State): State {

--- a/code/core/src/manager-api/tests/root.test.tsx
+++ b/code/core/src/manager-api/tests/root.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import React from 'react';
+
+import type { API_PreparedStoryIndex } from 'storybook/internal/types';
+
+import type { API, Combo, State } from '../root.tsx';
+import { Provider as ManagerProvider, mockChannel } from '../root.tsx';
+
+// The stories module destructures `fetch` from `@storybook/global` at import time to fetch the
+// index on init. Reject it so the init no-ops (into indexError) instead of hitting the network,
+// while preserving the real global (document, etc.) that other manager modules rely on.
+vi.mock('@storybook/global', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@storybook/global')>();
+  mod.global.fetch = vi.fn().mockRejectedValue(new Error('network disabled in test')) as any;
+  return mod;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const mockIndex: API_PreparedStoryIndex = {
+  v: 5,
+  entries: {
+    'a--visible': {
+      type: 'story',
+      id: 'a--visible',
+      title: 'A',
+      name: 'Visible',
+      importPath: './a.stories.tsx',
+      // "dev" is auto-added at real index time and is required by the built-in static filter.
+      tags: ['dev'],
+    },
+    'a--hidden': {
+      type: 'story',
+      id: 'a--hidden',
+      title: 'A',
+      name: 'Hidden',
+      importPath: './a.stories.tsx',
+      tags: ['dev'],
+    },
+  } as any,
+};
+
+describe('ManagerProvider', () => {
+  it('applies a filter set during addon registration (before mount) to the initial index', async () => {
+    let api: API | undefined;
+    let latestState: State | undefined;
+
+    // Simulate an addon that calls experimental_setFilter synchronously from its register callback.
+    // handleAPI runs in the constructor, before the component mounts.
+    const provider = {
+      channel: mockChannel(),
+      getConfig: () => ({}),
+      getElements: () => ({}),
+      handleAPI: (a: API) => {
+        api = a;
+        a.experimental_setFilter('addon-filter', (item) => !item.id.includes('hidden'));
+      },
+    };
+
+    render(
+      <ManagerProvider
+        provider={provider as any}
+        docsOptions={{}}
+        location={{ search: '' } as any}
+        path="/"
+        viewMode="story"
+        storyId="a--visible"
+        refId={undefined}
+        navigate={vi.fn() as any}
+      >
+        {(combo: Combo) => {
+          latestState = combo.state;
+          return null;
+        }}
+      </ManagerProvider>
+    );
+
+    // The filter registered during (pre-mount) addon registration must have landed in state.
+    expect(latestState?.filters).toHaveProperty('addon-filter');
+
+    // The preview would emit SET_INDEX after mount; setIndex reads state.filters, which already
+    // contains the filter registered during addon registration.
+    act(() => {
+      void api!.setIndex(mockIndex);
+    });
+
+    await waitFor(() => {
+      expect(latestState?.filteredIndex).toHaveProperty(['a--visible']);
+    });
+
+    // The unfiltered index keeps every entry, the filtered index drops the "hidden" story.
+    expect(latestState?.index).toHaveProperty(['a--hidden']);
+    expect(latestState?.filteredIndex).not.toHaveProperty(['a--hidden']);
+  });
+});

--- a/code/core/src/manager-api/tests/root.test.tsx
+++ b/code/core/src/manager-api/tests/root.test.tsx
@@ -10,12 +10,19 @@ import type { API, Combo, State } from '../root.tsx';
 import { Provider as ManagerProvider, mockChannel } from '../root.tsx';
 
 // The stories module destructures `fetch` from `@storybook/global` at import time to fetch the
-// index on init. Reject it so the init no-ops (into indexError) instead of hitting the network,
-// while preserving the real global (document, etc.) that other manager modules rely on.
+// index on init. Reject it so the init no-ops (into indexError) instead of hitting the network.
+// Return a fresh `global` object rather than mutating the shared global in place, so the mocked
+// `fetch` cannot leak into other test files. We copy all own property descriptors (a plain spread
+// drops non-enumerable globals like happy-dom's `document`) and keep the prototype, so the other
+// globals that manager modules rely on are preserved.
 vi.mock('@storybook/global', async (importOriginal) => {
   const mod = await importOriginal<typeof import('@storybook/global')>();
-  mod.global.fetch = vi.fn().mockRejectedValue(new Error('network disabled in test')) as any;
-  return mod;
+  const global = Object.create(
+    Object.getPrototypeOf(mod.global),
+    Object.getOwnPropertyDescriptors(mod.global)
+  );
+  global.fetch = vi.fn().mockRejectedValue(new Error('network disabled in test'));
+  return { ...mod, global };
 });
 
 afterEach(() => {
@@ -84,7 +91,9 @@ describe('ManagerProvider', () => {
     expect(latestState?.filters).toHaveProperty('addon-filter');
 
     // The preview would emit SET_INDEX after mount; setIndex reads state.filters, which already
-    // contains the filter registered during addon registration.
+    // contains the filter registered during addon registration. setIndex's returned promise
+    // resolves via React's class-component setState callback, which does not settle within an
+    // async act() here, so trigger it inside act() and assert on the resulting state via waitFor.
     act(() => {
       void api!.setIndex(mockIndex);
     });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### The bug

Addons that call `api.experimental_setFilter(...)` from their `register` callback (e.g. `storybook-addon-tag-badges`) stopped filtering the **initial** set of stories. The sidebar rendered unfiltered on first load, and the filter only kicked in after navigating to another story. This was a regression introduced between `10.5.0-alpha.5` and `alpha.6`.

### Root cause

In [abf5677](https://github.com/storybookjs/storybook/commit/abf5677235d809824e2a81e1f0ff8c8e9fd7bee4), addon registration (`provider.handleAPI` -> `addons.loadAddons`, which runs every addon `register` callback) was intentionally moved into the `ManagerProvider` **constructor**. This was needed so that manager-side channel listeners (notably open-service, which registers via `addons.register`) exist before the preview iframe mounts and starts emitting events.

The side effect: the manager store's `setState` is wired to the React component's `this.setState`. Calling `this.setState` **before the component mounts is a no-op** in React. So when an addon called `experimental_setFilter` during registration, the write to `state.filters` was silently dropped (and its callback never fired). When the initial `SET_INDEX` later arrived, `setIndex` read `state.filters` without the addon's filter, producing an unfiltered index. A subsequent navigation (or any post-mount event) re-ran `setState` successfully, which is why filtering appeared to "start working" after navigating.

Internal callers were unaffected because they call `experimental_setFilter` from a post-mount `useEffect` (e.g. `SidebarBottom`), not from a `register` callback.

```mermaid
sequenceDiagram
    participant Ctor as ManagerProvider ctor
    participant Addon as addon register
    participant Store as store.setState
    participant React as React this.setState
    participant Ch as channel SET_INDEX
    Ctor->>Addon: handleAPI -> loadAddons
    Addon->>Store: experimental_setFilter
    Store->>React: this.setState(filters)
    Note over React: not mounted yet -> no-op, filter dropped
    Note over Ctor: first render + mount (unfiltered index)
    Ch->>Store: setIndex reads state.filters (addon filter missing)
```

### The fix

Make the store resilient to writes that happen before mount. The `ManagerProvider` now tracks a `mounted` flag: while not mounted (i.e. during constructor-time addon registration) store writes are applied **directly to `this.state`** and resolve synchronously; once `componentDidMount` runs, writes delegate to React's `this.setState` as before.

This keeps addon registration in the constructor (so the open-service ordering fix stays intact) while ensuring register-time filters — and any other register-time store write — land in the very first render, so the initial `SET_INDEX` is filtered correctly.

### Alternative considered (not taken)

A more thorough fix would be to **decouple the manager `Store` from React component state entirely**: let `Store` own the canonical state object and push snapshots into React (e.g. via `useSyncExternalStore` or a subscription). Writes would then never depend on the component's mount status, eliminating this whole class of "setState before/around mount" timing bugs at the source.

We opted against it here because it is a substantial refactor of `ManagerProvider`/`Store` and every consumer of manager state, with a much larger blast radius than is appropriate for a targeted regression fix. It is worth considering as a separate, dedicated follow-up.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

<!-- Added code/core/src/manager-api/tests/root.test.tsx: renders ManagerProvider with an addon that calls experimental_setFilter during registration and asserts the filter is applied to the initial index. Confirmed it fails without the fix. -->

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Create a sandbox: `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. Add an addon (or a `.storybook/manager.ts` snippet) that registers a filter at registration time:
   ```ts
   import { addons } from 'storybook/manager-api';
   addons.register('demo/filter', (api) => {
     // hide every story whose name contains "Secondary"
     api.experimental_setFilter('demo/filter', (item) => !/secondary/i.test(item.name ?? ''));
   });
   ```
3. Start the sandbox and open Storybook **on a fresh load** (do not navigate yet).
4. Expected: the sidebar is already filtered on first paint (the "Secondary" stories are hidden) — not only after clicking another story.
5. Regression focus: also confirm normal navigation, the tag/status sidebar filters, and refs/composition still filter as before.

<!-- The reported case can also be reproduced with the QA project chromatic / storybook-addon-tag-badges. -->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manager state updates during startup so updates registered before initial mount are applied immediately and remain accurate once rendering begins.
  * Ensured filters registered early are included from the start and correctly affect the visible story list after the index is set.
* **Tests**
  * Added coverage to verify early filter registration and its effect on `filteredIndex`, including scenarios with hidden stories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->