### PR TITLE
CLI: Use detected package manager instead of npx for remote commands

### DIFF
--- a/code/core/src/bin/dispatcher.ts
+++ b/code/core/src/bin/dispatcher.ts
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 import { pathToFileURL } from 'node:url';
 
-import { executeNodeCommand } from 'storybook/internal/common';
+import {
+  JsPackageManagerFactory,
+  executeNodeCommand,
+  getRemotePackageRunnerArgs,
+} from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
 import { join } from 'pathe';
 import { dedent } from 'ts-dedent';
 
-import { JsPackageManagerFactory } from '../common/js-package-manager/JsPackageManagerFactory.ts';
-import { getRemotePackageRunnerArgs } from '../common/js-package-manager/util.ts';
 import { MIN_SUPPORTED_NODE_DESCRIPTION, isNodeVersionSupported } from '../common/node-version.ts';
 import versions from '../common/versions.ts';
 import { resolvePackageDir } from '../shared/utils/module.ts';

--- a/code/core/src/bin/dispatcher.ts
+++ b/code/core/src/bin/dispatcher.ts
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 import { pathToFileURL } from 'node:url';
 
-import { executeCommand, executeNodeCommand } from 'storybook/internal/common';
+import { executeNodeCommand } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
 import { join } from 'pathe';
 import { dedent } from 'ts-dedent';
 
+import { JsPackageManagerFactory } from '../common/js-package-manager/JsPackageManagerFactory.ts';
+import { getRemotePackageRunnerArgs } from '../common/js-package-manager/util.ts';
 import { MIN_SUPPORTED_NODE_DESCRIPTION, isNodeVersionSupported } from '../common/node-version.ts';
 import versions from '../common/versions.ts';
 import { resolvePackageDir } from '../shared/utils/module.ts';
@@ -19,8 +21,8 @@ import { resolvePackageDir } from '../shared/utils/module.ts';
  * - Core Storybook commands (dev, build, index, ai) are routed to the core binary at
  *   storybook/dist/bin/core.js — `ai` is bundled because agent skills invoke it repeatedly and
  *   must never wait on an npx download
- * - Init is routed to the create-storybook package via npx
- * - External CLI tools (upgrade, doctor, etc.) are routed to @storybook/cli via npx
+ * - Init is routed to the create-storybook package via the detected package manager
+ * - External CLI tools (upgrade, doctor, etc.) are routed to @storybook/cli the same way
  */
 const [major, minor, patch] = process.versions.node.split('.').map(Number);
 if (!isNodeVersionSupported(major, minor, patch)) {
@@ -69,12 +71,18 @@ async function run() {
       return;
     }
   } catch {
-    // the package couldn't be imported, use npx to install and run it instead
+    // the package couldn't be imported, download and run it with the detected package manager
   }
 
-  const child = executeCommand({
-    command: 'npx',
-    args: ['--yes', `${targetCli.pkg}@${versions[targetCli.pkg]}`, ...targetCli.args],
+  const packageManager = JsPackageManagerFactory.getPackageManager();
+  const child = packageManager.runPackageCommand({
+    args: getRemotePackageRunnerArgs(
+      packageManager.type,
+      targetCli.pkg,
+      versions[targetCli.pkg],
+      targetCli.args
+    ),
+    useRemotePkg: true,
     stdio: 'inherit',
   });
   child.on('exit', (code) => {

--- a/code/core/src/cli/ai/setup-prompts/partials/dod.ts
+++ b/code/core/src/cli/ai/setup-prompts/partials/dod.ts
@@ -1,5 +1,7 @@
+import { getVitestStorybookRunCommand } from 'storybook/internal/common';
+
 import { dedent } from 'ts-dedent';
-import { getVitestStorybookRunCommand } from '../../../../common/js-package-manager/util.ts';
+
 import type { SetupInstructionsContext } from '../../types.ts';
 
 export function cssCheckDOD(ctx: SetupInstructionsContext): string {

--- a/code/core/src/cli/ai/setup-prompts/partials/dod.ts
+++ b/code/core/src/cli/ai/setup-prompts/partials/dod.ts
@@ -1,4 +1,5 @@
 import { dedent } from 'ts-dedent';
+import { getVitestStorybookRunCommand } from '../../../../common/js-package-manager/util.ts';
 import type { SetupInstructionsContext } from '../../types.ts';
 
 export function cssCheckDOD(ctx: SetupInstructionsContext): string {
@@ -13,12 +14,12 @@ export function storyTagsV2DOD(ctx: SetupInstructionsContext): string {
   return dedent`Every story file that passes vitest tests has had \`'needs-work'\` stripped, leaving \`tags: ['ai-generated']\`. Story files with vitest failures keep \`['ai-generated', 'needs-work']\`.`;
 }
 
-export function vitestPassesStrictDOD(ctx: SetupInstructionsContext): string {
-  return dedent`\`npx vitest --project storybook run\` passes for the new files.`;
+export function vitestPassesStrictDOD({ packageManager }: SetupInstructionsContext): string {
+  return dedent`\`${getVitestStorybookRunCommand(packageManager)}\` passes for the new files.`;
 }
 
-export function vitestPassesWhenExpectedDOD(ctx: SetupInstructionsContext): string {
-  return dedent`\`npx vitest --project storybook run\` passes for the new files that don't have \`'needs-work'\` in their tags. Files with \`'needs-work'\` may still fail.`;
+export function vitestPassesWhenExpectedDOD({ packageManager }: SetupInstructionsContext): string {
+  return dedent`\`${getVitestStorybookRunCommand(packageManager)}\` passes for the new files that don't have \`'needs-work'\` in their tags. Files with \`'needs-work'\` may still fail.`;
 }
 
 export function typeCheckPassesStrictDOD(ctx: SetupInstructionsContext): string {

--- a/code/core/src/cli/ai/setup-prompts/partials/rules.ts
+++ b/code/core/src/cli/ai/setup-prompts/partials/rules.ts
@@ -1,6 +1,6 @@
 import { dedent } from 'ts-dedent';
-import type { SetupInstructionsContext } from '../../types.ts';
 import { getMonorepoType } from '../../../../shared/utils/get-monorepo-type.ts';
+import type { SetupInstructionsContext } from '../../types.ts';
 
 export function toolsVsShellRule(ctx: SetupInstructionsContext): string {
   return dedent`**Discover with Glob/Grep/Read, not shell.** Never use \`ls\`, \`find\`, \`cat\`, \`head\`, \`tail\`, shell \`grep\`, \`sed\`, or \`node -e\` for discovery or for editing files in bulk — these are slower per call and violate caching. Substitute bash commands for the specific tool names listed below, or available tools with the closest semantics:
@@ -21,11 +21,15 @@ export function monorepoRule(ctx: SetupInstructionsContext): string | undefined 
   }
 }
 
-export function packageManagerRule({ packageManagerName }: SetupInstructionsContext): string {
+export function packageManagerRule({
+  packageManager,
+  packageManagerName,
+}: SetupInstructionsContext): string {
+  const storybookCmd = packageManager.getPackageCommand(['storybook']);
   if (packageManagerName) {
-    return dedent`**Use \`${packageManagerName}\` for every install** (detected from this project's lockfile).`;
+    return dedent`**Use \`${packageManagerName}\` for installs and \`${storybookCmd}\` for Storybook/Vitest CLI commands** (detected from this project's lockfile). Do not use \`npx\` — it invokes npm and fails when the repo enforces a different package manager.`;
   }
-  return '**Detect the package manager once** from the lockfile (`pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `bun.lockb` → bun, otherwise npm) and use it for every install in this trial.';
+  return dedent`**Detect the package manager once** from the lockfile (\`pnpm-lock.yaml\` → pnpm, \`yarn.lock\` → yarn, \`bun.lockb\` → bun, otherwise npm) and use it for every install and CLI command in this trial. Do not use \`npx\` when the project uses pnpm, yarn, or bun.`;
 }
 
 export function editOverWriteRule({ configDir, tsx }: SetupInstructionsContext): string {

--- a/code/core/src/cli/ai/setup-prompts/partials/steps.ts
+++ b/code/core/src/cli/ai/setup-prompts/partials/steps.ts
@@ -1,5 +1,9 @@
 import { dedent } from 'ts-dedent';
-import type { ProjectInfo, SetupInstructionsContext as InstructionsContext } from '../../types.ts';
+import {
+  getMswInitCommand,
+  getVitestStorybookRunCommand,
+} from '../../../../common/js-package-manager/util.ts';
+import type { SetupInstructionsContext as InstructionsContext, ProjectInfo } from '../../types.ts';
 import {
   getInteractionPlayExample,
   getMainConfigExample,
@@ -60,12 +64,15 @@ export function verifyStep(
   projectInfo: ProjectInfo,
   { packageManager, tsx }: InstructionsContext
 ): { title: string; body: string } {
+  const vitestRunAll = getVitestStorybookRunCommand(packageManager);
+  const vitestRunFile = getVitestStorybookRunCommand(packageManager, `path/to/Foo.stories.${tsx}`);
+
   return {
     title: `Verify in one batch, then iterate only on failures`,
     body: dedent`**Read this rule once before running anything:** the first vitest invocation must run **all** the new stories together. No single-file runs before the batch.
 
     \`\`\`bash
-    npx vitest --project storybook run
+    ${vitestRunAll}
     \`\`\`
 
     Then run the project's TypeScript check (use the script from \`package.json\` — typically \`tsc --noEmit\` or \`${packageManager.getRunCommand('typecheck')}\`). Read the raw output once; don't pipe it through repeated \`grep\`/\`head\` invocations to slice it.
@@ -74,7 +81,7 @@ export function verifyStep(
 
     1. Read the error.
     2. If multiple stories share the failure, fix the shared preview setup, not the stories.
-    3. Re-run vitest **only for the affected file(s)**: \`npx vitest --project storybook run path/to/Foo.stories.${tsx}\`.
+    3. Re-run vitest **only for the affected file(s)**: \`${vitestRunFile}\`.
     4. Repeat until the file passes, then move on. Cap retries at ~5 per file — if it still fails, leave \`'needs-work'\` tag to inform the user.
     5. When you keep failing on a story, play function, etc., do not substitute it for easier content that contributes less to codebase understanding.
 
@@ -86,12 +93,15 @@ export function verifyWithAllowedFailureStep(
   projectInfo: ProjectInfo,
   { packageManager, tsx }: InstructionsContext
 ): { title: string; body: string } {
+  const vitestRunAll = getVitestStorybookRunCommand(packageManager);
+  const vitestRunFile = getVitestStorybookRunCommand(packageManager, `path/to/Foo.stories.${tsx}`);
+
   return {
     title: `Verify in one batch, then iterate only on failures`,
     body: dedent`**Read this rule once before running anything:** the first vitest invocation must run **all** the new stories together. No single-file runs before the batch.
 
     \`\`\`bash
-    npx vitest --project storybook run
+    ${vitestRunAll}
     \`\`\`
 
     Then run the project's TypeScript check (use the script from \`package.json\` — typically \`tsc --noEmit\` or \`${packageManager.getRunCommand('typecheck')}\`). Read the raw output once; don't pipe it through repeated \`grep\`/\`head\` invocations to slice it.
@@ -100,7 +110,7 @@ export function verifyWithAllowedFailureStep(
 
     1. Read the error.
     2. If multiple stories share the failure, fix the shared preview setup, not the stories.
-    3. In subsequent runs, re-run Vitest **only for the affected file(s)**: \`npx vitest --project storybook run path/to/Foo.stories.${tsx}\`.
+    3. In subsequent runs, re-run Vitest **only for the affected file(s)**: \`${vitestRunFile}\`.
     4. Fix any TypeScript issues needed for story files to pass, then re-run TS and Vitest only for those files. Repeat until files pass, or until you have tried 5 times.
     5. If a story file still fails after those retries, leave the file tagged \`'needs-work'\` and move on — do not keep chasing project-wide TS errors caused by preserved \`'needs-work'\` files.
     6. When you keep failing on a story, play function, etc., do not substitute it for easier content that contributes less to codebase understanding.
@@ -171,15 +181,17 @@ export function buildPortalStep(
 
 export function mswStep(
   projectInfo: ProjectInfo,
-  { configDir, mswInstall, ts }: InstructionsContext
+  { configDir, mswInstall, packageManager, ts }: InstructionsContext
 ): { title: string; body: string } {
+  const mswInit = getMswInitCommand(packageManager);
+
   return {
     title: 'MSW handlers (only what stories will hit)',
     body: `Use \`msw-storybook-addon\`. Install with:
 
     \`\`\`bash
     ${mswInstall}
-    npx msw init ./public --save
+    ${mswInit}
     \`\`\`
 
     Make sure \`${configDir}/main.${ts}\` serves \`./public\`:

--- a/code/core/src/cli/ai/setup-prompts/partials/steps.ts
+++ b/code/core/src/cli/ai/setup-prompts/partials/steps.ts
@@ -1,8 +1,7 @@
+import { getMswInitCommand, getVitestStorybookRunCommand } from 'storybook/internal/common';
+
 import { dedent } from 'ts-dedent';
-import {
-  getMswInitCommand,
-  getVitestStorybookRunCommand,
-} from '../../../../common/js-package-manager/util.ts';
+
 import type { SetupInstructionsContext as InstructionsContext, ProjectInfo } from '../../types.ts';
 import {
   getInteractionPlayExample,

--- a/code/core/src/cli/ai/setup-prompts/pattern-copy-play.ts
+++ b/code/core/src/cli/ai/setup-prompts/pattern-copy-play.ts
@@ -10,12 +10,10 @@
  * Update this header when iterating: bump the iteration number and link the
  * latest eval run so reviewers can compare variants without spelunking git.
  */
+import { getMswInitCommand, getVitestStorybookRunCommand } from 'storybook/internal/common';
+
 import { dedent } from 'ts-dedent';
 
-import {
-  getMswInitCommand,
-  getVitestStorybookRunCommand,
-} from '../../../common/js-package-manager/util.ts';
 import type { ProjectInfo } from '../types.ts';
 import { getDocsMarkdownUrl } from '../utils/docs-markdown-url.ts';
 import { getTypeImportSource } from '../utils/type-import-source.ts';

--- a/code/core/src/cli/ai/setup-prompts/pattern-copy-play.ts
+++ b/code/core/src/cli/ai/setup-prompts/pattern-copy-play.ts
@@ -12,6 +12,10 @@
  */
 import { dedent } from 'ts-dedent';
 
+import {
+  getMswInitCommand,
+  getVitestStorybookRunCommand,
+} from '../../../common/js-package-manager/util.ts';
 import type { ProjectInfo } from '../types.ts';
 import { getDocsMarkdownUrl } from '../utils/docs-markdown-url.ts';
 import { getTypeImportSource } from '../utils/type-import-source.ts';
@@ -450,6 +454,11 @@ function getPageStoryExample(projectInfo: ProjectInfo): string {
 export function instructions(projectInfo: ProjectInfo): string {
   const configDir = projectInfo.configDir;
   const typeImport = getTypeImportSource(projectInfo);
+  const mswInit = getMswInitCommand(projectInfo.packageManager);
+  const vitestRunFile = getVitestStorybookRunCommand(
+    projectInfo.packageManager,
+    '<path-to-story-file>'
+  );
 
   return dedent`
     Attention: The following instructions must be followed in order to successfully set up Storybook in this project. Do not skip steps or attempt to do them out of order.
@@ -602,7 +611,7 @@ export function instructions(projectInfo: ProjectInfo): string {
     All network/data queries should be handled by the default Storybook environment.
 
     - Always use \`msw-storybook-addon\` for query mocking.
-    - If you introduce MSW, run \`npx msw init ./public --save\` to create the worker file.
+    - If you introduce MSW, run \`${mswInit}\` to create the worker file.
     - Make sure Storybook serves \`./public\` as a static dir so \`mockServiceWorker.js\` is available.
     - Do not mock \`fetch\` directly.
     - Network/data queries should return deterministic mock data.
@@ -824,7 +833,7 @@ export function instructions(projectInfo: ProjectInfo): string {
     As you work, verify the stories with Vitest:
 
     \`\`\`bash
-    npx vitest --project storybook <path-to-story-file>
+    ${vitestRunFile}
     \`\`\`
 
     Also verify types so you catch missing required props, broken imports, and preview typing issues. Run the same TypeScript command the project itself uses.

--- a/code/core/src/cli/ai/setup-prompts/setup.ts
+++ b/code/core/src/cli/ai/setup-prompts/setup.ts
@@ -10,9 +10,10 @@
  * Update this header when iterating: bump the iteration number and link the
  * latest eval run so reviewers can compare variants without spelunking git.
  */
+import { getVitestStorybookRunCommand } from 'storybook/internal/common';
+
 import { dedent } from 'ts-dedent';
 
-import { getVitestStorybookRunCommand } from '../../../common/js-package-manager/util.ts';
 import type { ProjectInfo } from '../types.ts';
 import { getTypeImportSource } from '../utils/type-import-source.ts';
 

--- a/code/core/src/cli/ai/setup-prompts/setup.ts
+++ b/code/core/src/cli/ai/setup-prompts/setup.ts
@@ -12,6 +12,7 @@
  */
 import { dedent } from 'ts-dedent';
 
+import { getVitestStorybookRunCommand } from '../../../common/js-package-manager/util.ts';
 import type { ProjectInfo } from '../types.ts';
 import { getTypeImportSource } from '../utils/type-import-source.ts';
 
@@ -153,6 +154,11 @@ function getNeedsWorkTagExample(projectInfo: ProjectInfo): string {
 
 export function instructions(projectInfo: ProjectInfo): string {
   const configDir = projectInfo.configDir;
+  const { packageManager } = projectInfo;
+  const vitestRunFile = getVitestStorybookRunCommand(packageManager, '<path-to-story-file>');
+  const vitestRunAll = getVitestStorybookRunCommand(packageManager);
+  const storybookBuild = packageManager.getPackageCommand(['storybook', 'build']);
+  const storybookDoctor = packageManager.getPackageCommand(['storybook', 'doctor']);
 
   return dedent`
     Attention: The following instructions must be followed in order to successfully set up Storybook in this project. Do not skip steps or attempt to do them out of order.
@@ -237,13 +243,13 @@ export function instructions(projectInfo: ProjectInfo): string {
     After writing each story file, immediately verify it:
 
     \`\`\`bash
-    npx vitest --project storybook <path-to-story-file>
+    ${vitestRunFile}
     \`\`\`
 
     **Self-healing loop — repeat for every story file:**
 
     1. Write/update the story file
-    2. Run \`npx vitest --project storybook <path-to-story-file>\`
+    2. Run \`${vitestRunFile}\`
     3. If it fails: read the error output carefully
        - Missing provider → add a decorator in \`${configDir}/preview.tsx\` or in the story meta
        - Missing prop → add the required prop to \`args\`
@@ -255,18 +261,18 @@ export function instructions(projectInfo: ProjectInfo): string {
     After all 9 story files pass individually, run the full suite:
 
     \`\`\`bash
-    npx vitest --project storybook
+    ${vitestRunAll}
     \`\`\`
 
     Once all stories pass, run a full Storybook build as a final check:
 
     \`\`\`bash
-    npx storybook build
+    ${storybookBuild}
     \`\`\`
 
     If the build fails, fix the issue before finishing.
 
-    Finally, run \`npx storybook doctor\` to check for common issues
+    Finally, run \`${storybookDoctor}\` to check for common issues
     (version mismatches, duplicated deps, etc.) and fix anything it reports.
 
     ### Checklist
@@ -283,9 +289,9 @@ export function instructions(projectInfo: ProjectInfo): string {
     - [ ] Complex component 1: story written and passing
     - [ ] Complex component 2: story written and passing
     - [ ] Complex component 3: story written and passing
-    - [ ] Full Vitest suite passes: \`npx vitest --project storybook\`
-    - [ ] \`npx storybook build\` succeeds
-    - [ ] \`npx storybook doctor\` reports no remaining issues
+    - [ ] Full Vitest suite passes: \`${vitestRunAll}\`
+    - [ ] \`${storybookBuild}\` succeeds
+    - [ ] \`${storybookDoctor}\` reports no remaining issues
     - [ ] All passing stories have \`tags: ['ai-generated']\` in their meta
     - [ ] Any stories that still need work have \`tags: ['ai-generated', 'needs-work']\` in their meta
   `;

--- a/code/core/src/common/js-package-manager/index.ts
+++ b/code/core/src/common/js-package-manager/index.ts
@@ -2,4 +2,5 @@ export * from './JsPackageManagerFactory.ts';
 export * from './JsPackageManager.ts';
 export * from './PackageJson.ts';
 export * from './types.ts';
+export * from './util.ts';
 export * from './vite-plus-versions.ts';

--- a/code/core/src/common/js-package-manager/util.test.ts
+++ b/code/core/src/common/js-package-manager/util.test.ts
@@ -96,11 +96,22 @@ describe('js package manager util', () => {
   });
 
   it('builds remote package runner args for the active package manager', () => {
+    // npm and Yarn Classic run through npx, which needs --yes to skip the install prompt
     expect(
       getRemotePackageRunnerArgs(PackageManagerName.NPM, '@storybook/cli', '10.3.2', ['upgrade'])
     ).toEqual(['--yes', '@storybook/cli@10.3.2', 'upgrade']);
     expect(
+      getRemotePackageRunnerArgs(PackageManagerName.YARN1, '@storybook/cli', '10.3.2', ['upgrade'])
+    ).toEqual(['--yes', '@storybook/cli@10.3.2', 'upgrade']);
+    // dlx/bunx-based managers download without prompting, so no --yes
+    expect(
       getRemotePackageRunnerArgs(PackageManagerName.PNPM, '@storybook/cli', '10.3.2', ['upgrade'])
+    ).toEqual(['@storybook/cli@10.3.2', 'upgrade']);
+    expect(
+      getRemotePackageRunnerArgs(PackageManagerName.YARN2, '@storybook/cli', '10.3.2', ['upgrade'])
+    ).toEqual(['@storybook/cli@10.3.2', 'upgrade']);
+    expect(
+      getRemotePackageRunnerArgs(PackageManagerName.BUN, '@storybook/cli', '10.3.2', ['upgrade'])
     ).toEqual(['@storybook/cli@10.3.2', 'upgrade']);
   });
 

--- a/code/core/src/common/js-package-manager/util.test.ts
+++ b/code/core/src/common/js-package-manager/util.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
+import { PackageManagerName } from './JsPackageManager.ts';
+import { NPMProxy } from './NPMProxy.ts';
+import { PNPMProxy } from './PNPMProxy.ts';
 import {
   getAgeInMinutes,
   getErrorLogs,
   getLatestStableVersionAdheringToMinimumAgeGate,
+  getMswInitCommand,
+  getRemotePackageRunnerArgs,
   getStorybookRerunCommand,
   getStorybookRerunInstruction,
+  getVitestStorybookRunCommand,
   hasStorybookMinimumAgeExclusions,
   parsePackageData,
   parsePackageTimeMap,
@@ -87,6 +93,24 @@ describe('js package manager util', () => {
     );
     expect(getStorybookRerunCommand('create', '10.3.2')).toBe('npx create-storybook@10.3.2');
     expect(getStorybookRerunCommand('upgrade', '10.3.2')).toBe('npx storybook@10.3.2 upgrade');
+  });
+
+  it('builds remote package runner args for the active package manager', () => {
+    expect(
+      getRemotePackageRunnerArgs(PackageManagerName.NPM, '@storybook/cli', '10.3.2', ['upgrade'])
+    ).toEqual(['--yes', '@storybook/cli@10.3.2', 'upgrade']);
+    expect(
+      getRemotePackageRunnerArgs(PackageManagerName.PNPM, '@storybook/cli', '10.3.2', ['upgrade'])
+    ).toEqual(['@storybook/cli@10.3.2', 'upgrade']);
+  });
+
+  it('builds package-manager-aware setup commands', () => {
+    const npm = new NPMProxy({ cwd: process.cwd(), configDir: '.storybook' });
+    const pnpm = new PNPMProxy({ cwd: process.cwd(), configDir: '.storybook' });
+
+    expect(getVitestStorybookRunCommand(npm)).toBe('npx vitest --project storybook run');
+    expect(getVitestStorybookRunCommand(pnpm)).toBe('pnpm exec vitest --project storybook run');
+    expect(getMswInitCommand(pnpm)).toBe('pnpm exec msw init ./public --save');
   });
 
   it('extracts structured error logs', () => {

--- a/code/core/src/common/js-package-manager/util.ts
+++ b/code/core/src/common/js-package-manager/util.ts
@@ -1,5 +1,8 @@
 import { gt, prerelease, valid } from 'semver';
 
+import type { JsPackageManager } from './JsPackageManager.ts';
+import { PackageManagerName } from './JsPackageManager.ts';
+
 export type StorybookInstallContext = 'create' | 'upgrade';
 
 export const STORYBOOK_PACKAGE_PATTERNS = [
@@ -109,6 +112,31 @@ export const getLatestStableVersionAdheringToMinimumAgeGate = (
 
   return latestStableVersion;
 };
+
+/** Args for `runPackageCommand({ useRemotePkg: true })` when bootstrapping a Storybook CLI package. */
+export function getRemotePackageRunnerArgs(
+  packageManagerType: PackageManagerName,
+  pkg: string,
+  version: string,
+  args: string[]
+): string[] {
+  const pkgWithVersion = `${pkg}@${version}`;
+  return packageManagerType === PackageManagerName.NPM
+    ? ['--yes', pkgWithVersion, ...args]
+    : [pkgWithVersion, ...args];
+}
+
+export function getVitestStorybookRunCommand(packageManager: JsPackageManager, file?: string) {
+  const args = ['vitest', '--project', 'storybook', 'run'];
+  if (file) {
+    args.push(file);
+  }
+  return packageManager.getPackageCommand(args);
+}
+
+export function getMswInitCommand(packageManager: JsPackageManager) {
+  return packageManager.getPackageCommand(['msw', 'init', './public', '--save']);
+}
 
 export const getStorybookRerunCommand = (
   installContext: StorybookInstallContext,

--- a/code/core/src/common/js-package-manager/util.ts
+++ b/code/core/src/common/js-package-manager/util.ts
@@ -113,7 +113,15 @@ export const getLatestStableVersionAdheringToMinimumAgeGate = (
   return latestStableVersion;
 };
 
-/** Args for `runPackageCommand({ useRemotePkg: true })` when bootstrapping a Storybook CLI package. */
+/**
+ * Args for `runPackageCommand({ useRemotePkg: true })` when bootstrapping a Storybook CLI package
+ * that isn't installed locally.
+ *
+ * npm and Yarn Classic both execute the remote package through `npx`, which prompts "Ok to
+ * proceed?" before downloading and hangs in non-interactive/CI environments. `--yes` auto-confirms
+ * that install. pnpm (`dlx`), Yarn Berry (`dlx`) and Bun (`bunx`) download without prompting, so
+ * they must not receive the npx-only `--yes` flag.
+ */
 export function getRemotePackageRunnerArgs(
   packageManagerType: PackageManagerName,
   pkg: string,
@@ -121,9 +129,10 @@ export function getRemotePackageRunnerArgs(
   args: string[]
 ): string[] {
   const pkgWithVersion = `${pkg}@${version}`;
-  return packageManagerType === PackageManagerName.NPM
-    ? ['--yes', pkgWithVersion, ...args]
-    : [pkgWithVersion, ...args];
+  const usesNpx =
+    packageManagerType === PackageManagerName.NPM ||
+    packageManagerType === PackageManagerName.YARN1;
+  return usesNpx ? ['--yes', pkgWithVersion, ...args] : [pkgWithVersion, ...args];
 }
 
 export function getVitestStorybookRunCommand(packageManager: JsPackageManager, file?: string) {

--- a/code/core/src/shared/utils/ai-prompts.ts
+++ b/code/core/src/shared/utils/ai-prompts.ts
@@ -2,13 +2,7 @@
  * Source of truth for AI prompts throughout the application.
  */
 
-import type { JsPackageManager } from '../../common/js-package-manager/JsPackageManager.ts';
-
 const DEFAULT_STORYBOOK_EXECUTOR = 'npx storybook';
-
-export function getStorybookAiSetupCommand(packageManager: JsPackageManager) {
-  return packageManager.getPackageCommand(['storybook', 'ai', 'setup']);
-}
 
 export function getAiSetupPrompt(executor = DEFAULT_STORYBOOK_EXECUTOR) {
   return `Run \`${executor} ai setup\` and follow its instructions precisely.`;

--- a/code/core/src/shared/utils/ai-prompts.ts
+++ b/code/core/src/shared/utils/ai-prompts.ts
@@ -2,6 +2,14 @@
  * Source of truth for AI prompts throughout the application.
  */
 
-export function getAiSetupPrompt(executor = 'npx storybook') {
+import type { JsPackageManager } from '../../common/js-package-manager/JsPackageManager.ts';
+
+const DEFAULT_STORYBOOK_EXECUTOR = 'npx storybook';
+
+export function getStorybookAiSetupCommand(packageManager: JsPackageManager) {
+  return packageManager.getPackageCommand(['storybook', 'ai', 'setup']);
+}
+
+export function getAiSetupPrompt(executor = DEFAULT_STORYBOOK_EXECUTOR) {
   return `Run \`${executor} ai setup\` and follow its instructions precisely.`;
 }

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
@@ -22,6 +22,7 @@ describe('FinalizationCommand', () => {
       logfile: undefined,
       showAgentFollowUp: false,
       showAiInstructions: false,
+      aiSetupCommand: 'npx storybook ai setup',
     });
 
     vi.mocked(getProjectRoot).mockReturnValue('/test/project');
@@ -140,6 +141,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: true,
+        aiSetupCommand: 'npx storybook ai setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -158,6 +160,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
+        aiSetupCommand: 'npx storybook ai setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -182,6 +185,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: true,
+        aiSetupCommand: 'npx storybook ai setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -198,6 +202,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
+        aiSetupCommand: 'npx storybook ai setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -212,6 +217,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: true,
         showAiInstructions: true,
+        aiSetupCommand: 'npx storybook ai setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -232,6 +238,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
+        aiSetupCommand: 'npx storybook ai setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -246,6 +253,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
+        aiSetupCommand: 'npx storybook ai setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -264,6 +272,7 @@ describe('FinalizationCommand', () => {
         showAgentFollowUp: true,
         showAiInstructions: false,
         logfile: undefined,
+        aiSetupCommand: 'npx storybook ai setup',
       });
 
       // Agent mode should show agent-specific message
@@ -279,6 +288,7 @@ describe('FinalizationCommand', () => {
         showAgentFollowUp: false,
         showAiInstructions: true,
         logfile: undefined,
+        aiSetupCommand: 'npx storybook ai setup',
       });
 
       expect(logger.step).toHaveBeenCalledWith(
@@ -294,6 +304,7 @@ describe('FinalizationCommand', () => {
         showAiInstructions: false,
         logfile: undefined,
         storybookCommand: 'yarn storybook',
+        aiSetupCommand: 'npx storybook ai setup',
       });
 
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('yarn storybook'));

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
@@ -118,6 +118,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: true,
         showAiInstructions: true,
+        aiSetupCommand: 'pnpm exec storybook ai setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -126,7 +127,9 @@ describe('FinalizationCommand', () => {
       expect(logger.step).toHaveBeenCalledWith(
         expect.stringContaining('is not entirely set up yet')
       );
-      expect(logger.step).toHaveBeenCalledWith(expect.stringContaining('npx storybook ai setup'));
+      expect(logger.step).toHaveBeenCalledWith(
+        expect.stringContaining('pnpm exec storybook ai setup')
+      );
       const logCalls = vi.mocked(logger.log).mock.calls.map((c) => String(c[0]));
       expect(logCalls.some((msg) => msg.includes('https://storybook.js.org/llms.txt'))).toBe(true);
       expect(logCalls.some((msg) => msg.includes('https://discord.gg/storybook/'))).toBe(false);

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.ts
@@ -9,10 +9,12 @@ import { dedent } from 'ts-dedent';
 
 export type FinalizationCommandOptions = {
   logfile: string | boolean | undefined;
-  /** When true, show the agent follow-up message ("run npx storybook ai setup") instead of the normal success message */
+  /** When true, show the agent follow-up message instead of the normal success message */
   showAgentFollowUp: boolean;
   /** When true, show the "paste this prompt to your AI agent" instructions */
   showAiInstructions: boolean;
+  /** Package-manager-aware `storybook ai setup` command shown to agents */
+  aiSetupCommand?: string;
 };
 
 type ExecuteFinalizationParams = {
@@ -84,12 +86,20 @@ export class FinalizationCommand {
   }
 
   /** Print success message with feature summary */
+  private getAiSetupCommandText(): string {
+    return this.options.aiSetupCommand ?? 'npx storybook ai setup';
+  }
+
+  private getAiSetupPromptText(): string {
+    return `Run \`${this.getAiSetupCommandText()}\` and follow its instructions precisely.`;
+  }
+
   private printSuccessMessage(storybookCommand?: string | null): void {
     if (this.options.showAgentFollowUp) {
       logger.step(
         CLI_COLORS.storybook(
           dedent`Storybook is installed but is not entirely set up yet.
-          To finish setting up, now run \`npx storybook ai setup\` and follow its instructions precisely.`
+          To finish setting up, now run \`${this.getAiSetupCommandText()}\` and follow its instructions precisely.`
         )
       );
     } else {
@@ -118,7 +128,7 @@ export class FinalizationCommand {
     if (this.options.showAiInstructions) {
       logger.step(dedent`To finalize setting up with AI, paste this prompt to your AI agent:
 
-        ${CLI_COLORS.storybook(`Run \`npx storybook ai setup\` and follow its instructions precisely.`)}
+        ${CLI_COLORS.storybook(this.getAiSetupPromptText())}
       `);
     }
   }
@@ -128,9 +138,13 @@ export const executeFinalization = ({
   logfile,
   showAgentFollowUp,
   showAiInstructions,
+  aiSetupCommand,
   ...params
 }: ExecuteFinalizationParams & FinalizationCommandOptions) => {
-  return new FinalizationCommand({ logfile, showAgentFollowUp, showAiInstructions }).execute(
-    params
-  );
+  return new FinalizationCommand({
+    logfile,
+    showAgentFollowUp,
+    showAiInstructions,
+    aiSetupCommand,
+  }).execute(params);
 };

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.ts
@@ -14,7 +14,7 @@ export type FinalizationCommandOptions = {
   /** When true, show the "paste this prompt to your AI agent" instructions */
   showAiInstructions: boolean;
   /** Package-manager-aware `storybook ai setup` command shown to agents */
-  aiSetupCommand?: string;
+  aiSetupCommand: string;
 };
 
 type ExecuteFinalizationParams = {
@@ -85,13 +85,8 @@ export class FinalizationCommand {
     } catch {}
   }
 
-  /** Print success message with feature summary */
-  private getAiSetupCommandText(): string {
-    return this.options.aiSetupCommand ?? 'npx storybook ai setup';
-  }
-
   private getAiSetupPromptText(): string {
-    return `Run \`${this.getAiSetupCommandText()}\` and follow its instructions precisely.`;
+    return `Run \`${this.options.aiSetupCommand}\` and follow its instructions precisely.`;
   }
 
   private printSuccessMessage(storybookCommand?: string | null): void {
@@ -99,7 +94,7 @@ export class FinalizationCommand {
       logger.step(
         CLI_COLORS.storybook(
           dedent`Storybook is installed but is not entirely set up yet.
-          To finish setting up, now run \`${this.getAiSetupCommandText()}\` and follow its instructions precisely.`
+          To finish setting up, now run \`${this.options.aiSetupCommand}\` and follow its instructions precisely.`
         )
       );
     } else {

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -3,20 +3,20 @@ import { resolve } from 'node:path';
 import { ProjectType } from 'storybook/internal/cli';
 import {
   HandledError,
-  type JsPackageManager,
   PackageManagerName,
   cache,
   executeCommand,
+  type JsPackageManager,
 } from 'storybook/internal/common';
 import { getServerPort, withTelemetry } from 'storybook/internal/core-server';
 import { logTracker, logger } from 'storybook/internal/node-logger';
-import { telemetry, setTelemetryEnabled } from 'storybook/internal/telemetry';
-import { Feature } from 'storybook/internal/types';
+import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
 import type {
   SupportedBuilder,
   SupportedFramework,
   SupportedRenderer,
 } from 'storybook/internal/types';
+import { Feature } from 'storybook/internal/types';
 
 import {
   executeAddonConfiguration,
@@ -190,6 +190,7 @@ export async function doInitiate(options: CommandOptions): Promise<
     showAiInstructions: hasAiFeature,
     logfile: options.logfile,
     storybookCommand,
+    aiSetupCommand: packageManager.getPackageCommand(['storybook', 'ai', 'setup']),
   });
 
   // Step 9: Track telemetry


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Storybook's CLI dispatcher always fell back to `npx` when `@storybook/cli` / `create-storybook` was not available locally. That invokes npm, which fails in pnpm-only repos that enforce `devEngines.packageManager` (reported in Chromatic Slack while running `pnpm dlx storybook@next upgrade` and `npx storybook ai setup`).

- Route remote CLI packages through the detected package manager (`pnpm dlx`, `bunx`, etc.) instead of hardcoded `npx`
- Emit package-manager-aware Vitest/MSW/Storybook commands in `storybook ai setup` prompts
- Pass a package-manager-aware `storybook ai setup` command from `storybook init` finalization

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual testing required beyond automated coverage: the regression is in CLI dispatch and prompt string generation, both covered by unit tests. A maintainer can optionally verify in a pnpm monorepo with `devEngines.packageManager` set to `pnpm` by running `pnpm dlx storybook@next upgrade --package-manager pnpm --yes` and confirming it no longer invokes npm.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup and verification instructions now generate Storybook, Vitest, and MSW commands using your detected package manager.
  * AI setup flows now display the correct “run Storybook AI setup” command for your environment.

* **Bug Fixes**
  * CLI fallback execution no longer relies on a fixed `npx` approach; external tool routing now respects the detected package manager, reducing incorrect copy/paste instructions.

* **Tests**
  * Added unit tests covering package-manager-specific command and runner argument generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->