### PR TITLE
Channel: Ensure every runtime installs the real channel and stop the mock fallback from poisoning it

### DIFF
--- a/code/.storybook/ensure-channel.ts
+++ b/code/.storybook/ensure-channel.ts
@@ -1,0 +1,12 @@
+import { Channel, getChannel, setChannel } from 'storybook/internal/channels';
+
+// The Storybook Vitest runtime (browser mode) has no builder preamble to install an addons channel,
+// yet preview side-effect modules (open services) call `registerService()` at import time. Install a
+// channel here so those registrations have one to bind to.
+//
+// This lives in its own module and is imported before `./preview.tsx` in the setup file: ES modules
+// evaluate their imports in source order, so an inline statement would run *after* the preview import
+// (and its service registrations), too late to help.
+if (!getChannel()) {
+  setChannel(new Channel({}));
+}

--- a/code/.storybook/storybook.setup.ts
+++ b/code/.storybook/storybook.setup.ts
@@ -6,6 +6,9 @@ import { userEvent as storybookEvent, expect as storybookExpect } from 'storyboo
 
 import '../core/src/shared/utils/toHaveLiveRegion.ts';
 
+// Must be imported before `./preview.tsx` so a channel exists when preview open-services register.
+import './ensure-channel.ts';
+
 import preview from './preview.tsx';
 
 vi.spyOn(console, 'warn').mockImplementation((...args) => console.log(...args));

--- a/code/core/src/manager-api/lib/addons.test.ts
+++ b/code/core/src/manager-api/lib/addons.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { Channel } from 'storybook/internal/channels';
+
 import { clearChannel, getChannel as readInstalledChannel } from '../../channels/channel-slot.ts';
-import { Channel } from '../../channels/main.ts';
 import { AddonStore } from './addons.ts';
 
 describe('AddonStore channel', () => {

--- a/code/core/src/manager-api/lib/addons.test.ts
+++ b/code/core/src/manager-api/lib/addons.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { clearChannel, getChannel as readInstalledChannel } from '../../channels/channel-slot.ts';
+import { Channel } from '../../channels/main.ts';
+import { AddonStore } from './addons.ts';
+
+describe('AddonStore channel', () => {
+  beforeEach(() => {
+    clearChannel();
+  });
+
+  afterEach(() => {
+    clearChannel();
+  });
+
+  it('returns a throwaway mock before a channel is installed, without poisoning the shared slot', () => {
+    const store = new AddonStore();
+
+    // Reading early must not crash...
+    expect(store.getChannel()).toBeDefined();
+
+    // ...but it must not install anything into the shared slot, so the real channel installed later
+    // at the runtime entry point can still take over.
+    expect(readInstalledChannel()).toBeNull();
+    expect(store.hasChannel()).toBe(false);
+  });
+
+  it('lets a real setChannel() take over after an early getChannel() fallback', async () => {
+    const store = new AddonStore();
+
+    // Simulate an errant early read (e.g. at manager module-eval before the channel is installed).
+    store.getChannel();
+
+    const real = new Channel({});
+    store.setChannel(real);
+
+    expect(store.getChannel()).toBe(real);
+    expect(readInstalledChannel()).toBe(real);
+    await expect(store.ready()).resolves.toBe(real);
+  });
+});

--- a/code/core/src/manager-api/lib/addons.ts
+++ b/code/core/src/manager-api/lib/addons.ts
@@ -50,18 +50,22 @@ export class AddonStore {
   private resolve: any;
 
   getChannel = (): Channel => {
-    if (!this.channel) {
-      const installed = readInstalledChannel();
-      if (installed) {
-        this.channel = installed as Channel;
-        this.resolve();
-        return this.channel;
-      }
-
-      this.setChannel(mockChannel() as unknown as Channel);
+    if (this.channel) {
+      return this.channel;
     }
 
-    return this.channel!;
+    const installed = readInstalledChannel();
+    if (installed) {
+      this.channel = installed as Channel;
+      this.resolve();
+      return this.channel;
+    }
+
+    // No channel has been installed in this runtime yet. Return a throwaway mock so callers do not
+    // crash, but do NOT cache it, mirror it to the shared channel slot, or resolve `ready()` with
+    // it. Otherwise a single early read would poison the whole runtime, and the real channel
+    // installed later (at the runtime entry point) would never take over.
+    return mockChannel() as unknown as Channel;
   };
 
   ready = (): Promise<Channel> => this.promise;

--- a/code/core/src/manager/runtime.tsx
+++ b/code/core/src/manager/runtime.tsx
@@ -29,25 +29,19 @@ addons.register(TOOLBAR_ID, () =>
   })
 );
 
-class ReactProvider extends Provider {
-  addons: AddonStore;
+// Install the manager channel at module load, before the deferred render below and before any
+// manager entry can read it. This guarantees `addons.getChannel()` returns the real channel in the
+// manager runtime instead of falling back to a throwaway mock.
+const channel = createBrowserChannel({ page: 'manager' });
+addons.setChannel(channel);
+channel.emit(CHANNEL_CREATED);
 
-  channel: Channel;
+class ReactProvider extends Provider {
+  addons: AddonStore = addons;
+
+  channel: Channel = channel;
 
   wsDisconnected = false;
-
-  constructor() {
-    super();
-
-    const channel = createBrowserChannel({ page: 'manager' });
-
-    addons.setChannel(channel);
-
-    channel.emit(CHANNEL_CREATED);
-
-    this.addons = addons;
-    this.channel = channel;
-  }
 
   getElements(type: Addon_Types) {
     return this.addons.getElements(type);

--- a/code/core/src/preview-api/modules/addons/main.ts
+++ b/code/core/src/preview-api/modules/addons/main.ts
@@ -19,20 +19,22 @@ export class AddonStore {
   private resolve: any;
 
   getChannel = (): Channel => {
-    if (!this.channel) {
-      const installed = readInstalledChannel();
-      if (installed) {
-        this.channel = installed as Channel;
-        this.resolve();
-        return this.channel;
-      }
-
-      const channel = mockChannel() as unknown as Channel;
-      this.setChannel(channel);
-      return channel;
+    if (this.channel) {
+      return this.channel;
     }
 
-    return this.channel;
+    const installed = readInstalledChannel();
+    if (installed) {
+      this.channel = installed as Channel;
+      this.resolve();
+      return this.channel;
+    }
+
+    // No channel has been installed in this runtime yet. Return a throwaway mock so callers do not
+    // crash, but do NOT cache it, mirror it to the shared channel slot, or resolve `ready()` with
+    // it. Otherwise a single early read would poison the whole runtime, and the real channel
+    // installed later (at the runtime entry point) would never take over.
+    return mockChannel() as unknown as Channel;
   };
 
   ready = (): Promise<Channel> => this.promise;


### PR DESCRIPTION
Closes #

> Stacked on top of #35408 (`norbert/fix-root-initial-setstate`) — please review/merge that one first.

## What I did

### The symptom

`addons.getChannel()` started returning a **dummy (mock) channel** instead of the real one. Any addon that grabbed the channel — directly, via `getService(...)`, or by awaiting `addons.ready()` — silently ended up talking to a dead channel, so its events never reached the preview. It was reported as a regression between `10.5.0-alpha.5` and `alpha.6`.

### Why it happened

`getChannel()` has always had a safety net: if no channel is installed yet, it hands back a throwaway `mockChannel()` so callers don't crash. Historically that mock lived only on the local addon store and was quietly replaced the moment the real channel arrived — no harm done.

The alpha.5 → alpha.6 channel-management refactor introduced a **single shared channel slot** (`globalThis.__STORYBOOK_ADDONS_CHANNEL__`) as the source of truth. As a side effect, the safety net changed: the throwaway mock now gets

- **written into the shared slot**, and
- **used to resolve the `ready()` promise**.

Both are permanent. So a single early `getChannel()` call — one that happens before the runtime finishes installing its real channel — now **poisons the entire runtime**: the real channel that arrives later is ignored, and every `ready()` consumer stays bound to the mock forever.

The **manager** made this easy to trigger because it created and installed its channel inside a deferred `setTimeout(…, 0)`, leaving a window during startup where a read could fall into the safety net. (The preview installs its channel in the builder preamble, and Node/server installs a no-op channel on import, so those runtimes were far less exposed.)

### The fix

Two complementary changes so that calling `getChannel()` in any runtime always returns the right channel:

1. **Install the manager's real channel eagerly** — at module load in `manager/runtime.tsx`, before the deferred render — so there is no startup window left to fall into.
2. **Make the safety net harmless** — in both the manager-api and preview-api addon stores, when no channel exists yet, still return a throwaway mock, but **don't** cache it, **don't** write it into the shared slot, and **don't** resolve `ready()` with it. The real channel installed at the runtime's entry point stays authoritative.

### Alternative considered

Doing only change 1 (close the manager timing window) would fix the reported case, but it leaves the sticky-mock foot-gun in place for any other early caller. Doing both removes the window *and* neutralizes the safety net, which matches the intended contract: "call `getChannel()`, always get the right thing".

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Added `code/core/src/manager-api/lib/addons.test.ts`, which asserts the contract directly: an early `getChannel()` returns a mock **without** touching the shared slot or flipping `hasChannel()`, and a later real `setChannel()` takes over and resolves `ready()` with the real channel.

#### Manual testing

1. Run a sandbox: `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. Open Storybook in the browser.
3. Confirm addons that rely on the channel work on **first load** (not just after navigating) — e.g. `storybook-addon-tag-badges`, and any `experimental_setFilter`-based filtering applied to the initial story index.
4. From an addon `register` callback (or a manager entry), call `addons.getChannel()` and verify events actually reach the preview, i.e. it is the real browser channel rather than a dummy.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Storybook startup reliability so the preview and manager communicate correctly during initial load.
  * Fixed an issue where an early placeholder connection could interfere with the real Storybook connection later on.
  * Reduced the chance of addons or preview features failing to initialize when the app loads in a deferred order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->