### PR TITLE
CLI: Do not auto-open the browser in storybook dev under AI agents

### DIFF
--- a/code/core/src/bin/dev-options.test.ts
+++ b/code/core/src/bin/dev-options.test.ts
@@ -120,7 +120,6 @@ describe('resolveDevCommandOptions', () => {
     ['CODEX_SANDBOX', '1'],
     ['CODEX_THREAD_ID', '1'],
     ['CURSOR_AGENT', '1'],
-    // AI_AGENT is std-env's explicit override: any agent can self-identify with it.
     ['AI_AGENT', 'my-custom-agent'],
   ])('suppresses browser opening when %s marks an AI agent environment', (name, value) => {
     vi.stubEnv(name, value);

--- a/code/core/src/bin/dev-options.test.ts
+++ b/code/core/src/bin/dev-options.test.ts
@@ -120,7 +120,8 @@ describe('resolveDevCommandOptions', () => {
     ['CODEX_SANDBOX', '1'],
     ['CODEX_THREAD_ID', '1'],
     ['CURSOR_AGENT', '1'],
-    ['AI_AGENT', 'copilot'],
+    // AI_AGENT is std-env's explicit override: any agent can self-identify with it.
+    ['AI_AGENT', 'my-custom-agent'],
   ])('suppresses browser opening when %s marks an AI agent environment', (name, value) => {
     vi.stubEnv(name, value);
 

--- a/code/core/src/bin/dev-options.test.ts
+++ b/code/core/src/bin/dev-options.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resolveDevCommandOptions } from './dev-options.ts';
 
@@ -11,7 +11,34 @@ const getErrorMessage = (callback: () => unknown) => {
   throw new Error('Expected callback to throw');
 };
 
+// detectAgent() reads the live process.env via std-env, so ambient agent
+// variables (e.g. when this suite itself runs under an AI agent) must be
+// cleared for the non-agent expectations below to hold.
+const agentEnvVars = [
+  'AI_AGENT',
+  'AUGMENT_AGENT',
+  'CLAUDECODE',
+  'CLAUDE_CODE',
+  'CODEX_SANDBOX',
+  'CODEX_THREAD_ID',
+  'CURSOR_AGENT',
+  'GEMINI_CLI',
+  'GOOSE_PROVIDER',
+  'OPENCODE',
+  'REPL_ID',
+];
+
 describe('resolveDevCommandOptions', () => {
+  beforeEach(() => {
+    for (const key of agentEnvVars) {
+      vi.stubEnv(key, undefined);
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('preserves truthy getEnvConfig-style env overrides for existing dev options', () => {
     expect(
       resolveDevCommandOptions(
@@ -105,6 +132,29 @@ describe('resolveDevCommandOptions', () => {
   it('keeps the browser opening default outside Claude preview', () => {
     expect(resolveDevCommandOptions({ open: true }, { env: {} })).toMatchObject({
       open: true,
+    });
+  });
+
+  it.each([
+    ['CLAUDECODE', '1'],
+    ['CODEX_SANDBOX', '1'],
+    ['CODEX_THREAD_ID', '1'],
+    ['CURSOR_AGENT', '1'],
+    ['AI_AGENT', 'copilot'],
+  ])('suppresses browser opening when %s marks an AI agent environment', (name, value) => {
+    vi.stubEnv(name, value);
+
+    expect(resolveDevCommandOptions({ open: true }, { env: {} })).toMatchObject({
+      open: false,
+    });
+  });
+
+  it('keeps explicit --port precedence over PORT in agent shells outside Claude preview', () => {
+    vi.stubEnv('CLAUDECODE', '1');
+
+    expect(resolveDevCommandOptions({ port: '7007' }, { env: { PORT: '6123' } })).toMatchObject({
+      open: false,
+      port: 7007,
     });
   });
 

--- a/code/core/src/bin/dev-options.test.ts
+++ b/code/core/src/bin/dev-options.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { resolveDevCommandOptions } from './dev-options.ts';
 
@@ -11,30 +11,7 @@ const getErrorMessage = (callback: () => unknown) => {
   throw new Error('Expected callback to throw');
 };
 
-// detectAgent() reads the live process.env via std-env, so ambient agent
-// variables (e.g. when this suite itself runs under an AI agent) must be
-// cleared for the non-agent expectations below to hold.
-const agentEnvVars = [
-  'AI_AGENT',
-  'AUGMENT_AGENT',
-  'CLAUDECODE',
-  'CLAUDE_CODE',
-  'CODEX_SANDBOX',
-  'CODEX_THREAD_ID',
-  'CURSOR_AGENT',
-  'GEMINI_CLI',
-  'GOOSE_PROVIDER',
-  'OPENCODE',
-  'REPL_ID',
-];
-
 describe('resolveDevCommandOptions', () => {
-  beforeEach(() => {
-    for (const key of agentEnvVars) {
-      vi.stubEnv(key, undefined);
-    }
-  });
-
   afterEach(() => {
     vi.unstubAllEnvs();
   });
@@ -123,14 +100,17 @@ describe('resolveDevCommandOptions', () => {
 
   it('defaults browser opening to false for Claude preview launches', () => {
     expect(
-      resolveDevCommandOptions({ open: true }, { env: { CLAUDE_AGENT_SDK_VERSION: '0.1.0' } })
+      resolveDevCommandOptions(
+        { open: true },
+        { env: { CLAUDE_AGENT_SDK_VERSION: '0.1.0' }, agent: null }
+      )
     ).toMatchObject({
       open: false,
     });
   });
 
   it('keeps the browser opening default outside Claude preview', () => {
-    expect(resolveDevCommandOptions({ open: true }, { env: {} })).toMatchObject({
+    expect(resolveDevCommandOptions({ open: true }, { env: {}, agent: null })).toMatchObject({
       open: true,
     });
   });
@@ -149,12 +129,34 @@ describe('resolveDevCommandOptions', () => {
     });
   });
 
+  it('lets callers opt out of ambient agent detection with agent: null', () => {
+    vi.stubEnv('CLAUDECODE', '1');
+
+    expect(resolveDevCommandOptions({ open: true }, { env: {}, agent: null })).toMatchObject({
+      open: true,
+    });
+  });
+
   it('keeps explicit --port precedence over PORT in agent shells outside Claude preview', () => {
     vi.stubEnv('CLAUDECODE', '1');
 
     expect(resolveDevCommandOptions({ port: '7007' }, { env: { PORT: '6123' } })).toMatchObject({
       open: false,
       port: 7007,
+    });
+  });
+
+  it('keeps Claude preview PORT precedence when an agent environment is also detected', () => {
+    vi.stubEnv('CLAUDECODE', '1');
+
+    expect(
+      resolveDevCommandOptions(
+        { port: '7007' },
+        { env: { CLAUDE_AGENT_SDK_VERSION: '0.1.0', PORT: '6123' } }
+      )
+    ).toMatchObject({
+      open: false,
+      port: 6123,
     });
   });
 

--- a/code/core/src/bin/dev-options.ts
+++ b/code/core/src/bin/dev-options.ts
@@ -2,7 +2,7 @@ import * as v from 'valibot';
 import { HandledError } from 'storybook/internal/common';
 
 import { isClaudePreviewLaunch, type AgentEnvironment } from '../shared/utils/agent-environment.ts';
-import { detectAgent } from '../telemetry/detect-agent.ts';
+import { detectAgent, type AgentInfo } from '../telemetry/detect-agent.ts';
 
 type DevCommandEnvironment = AgentEnvironment & {
   CI?: string;
@@ -43,12 +43,17 @@ const DevOptionsSchema = v.looseObject({
 
 export function resolveDevCommandOptions<TOptions extends DevCommandOptions>(
   options: TOptions,
-  { env = process.env }: { env?: DevCommandEnvironment } = {}
+  {
+    env = process.env,
+    // std-env can only detect agents from the live process.env, not from the injected `env`.
+    // Tests pass `null` to force non-agent behavior instead of scrubbing the real environment.
+    agent = detectAgent(),
+  }: { env?: DevCommandEnvironment; agent?: AgentInfo | null } = {}
 ) {
   const isClaudePreview = isClaudePreviewLaunch(env);
   // AI agents usually start Storybook to verify changes; auto-opening the system
   // browser next to their own preview is pure noise, so suppress it silently.
-  const isAgentSession = isClaudePreview || detectAgent() !== undefined;
+  const isAgentSession = isClaudePreview || !!agent;
   const PORT = env.PORT ?? undefined;
   const SBCONFIG_PORT = env.SBCONFIG_PORT ?? undefined;
 

--- a/code/core/src/bin/dev-options.ts
+++ b/code/core/src/bin/dev-options.ts
@@ -2,6 +2,7 @@ import * as v from 'valibot';
 import { HandledError } from 'storybook/internal/common';
 
 import { isClaudePreviewLaunch, type AgentEnvironment } from '../shared/utils/agent-environment.ts';
+import { detectAgent } from '../telemetry/detect-agent.ts';
 
 type DevCommandEnvironment = AgentEnvironment & {
   CI?: string;
@@ -45,6 +46,9 @@ export function resolveDevCommandOptions<TOptions extends DevCommandOptions>(
   { env = process.env }: { env?: DevCommandEnvironment } = {}
 ) {
   const isClaudePreview = isClaudePreviewLaunch(env);
+  // AI agents usually start Storybook to verify changes; auto-opening the system
+  // browser next to their own preview is pure noise, so suppress it silently.
+  const isAgentSession = isClaudePreview || detectAgent() !== undefined;
   const PORT = env.PORT ?? undefined;
   const SBCONFIG_PORT = env.SBCONFIG_PORT ?? undefined;
 
@@ -57,7 +61,7 @@ export function resolveDevCommandOptions<TOptions extends DevCommandOptions>(
     port: isClaudePreview
       ? (PORT ?? options.port ?? SBCONFIG_PORT)
       : (options.port ?? SBCONFIG_PORT ?? PORT),
-    open: isClaudePreview ? false : options.open,
+    open: isAgentSession ? false : options.open,
   });
 
   if (!result.success) {

--- a/code/core/src/bin/dev-options.ts
+++ b/code/core/src/bin/dev-options.ts
@@ -45,14 +45,10 @@ export function resolveDevCommandOptions<TOptions extends DevCommandOptions>(
   options: TOptions,
   {
     env = process.env,
-    // std-env can only detect agents from the live process.env, not from the injected `env`.
-    // Tests pass `null` to force non-agent behavior instead of scrubbing the real environment.
     agent = detectAgent(),
   }: { env?: DevCommandEnvironment; agent?: AgentInfo | null } = {}
 ) {
   const isClaudePreview = isClaudePreviewLaunch(env);
-  // AI agents usually start Storybook to verify changes; auto-opening the system
-  // browser next to their own preview is pure noise, so suppress it silently.
   const isAgentSession = isClaudePreview || !!agent;
   const PORT = env.PORT ?? undefined;
   const SBCONFIG_PORT = env.SBCONFIG_PORT ?? undefined;


### PR DESCRIPTION
Part 1 of #35411 (the SB11 default flip and the storybookjs/mcp changes are tracked separately in that issue).

## What I did

When `storybook dev` is launched from an AI agent environment (Claude Code, Codex, Cursor, Gemini CLI, opencode, Devin, Kiro, or an explicit `AI_AGENT` env var), the system browser is no longer auto-opened. Agents usually start Storybook to verify changes — often next to their own in-app preview browser — so the extra Chrome tab is pure noise.

- `resolveDevCommandOptions` now resolves `open: false` whenever the existing `detectAgent()` (backed by `std-env` v4, already used for telemetry and onboarding-skip) reports an agent. The suppression is silent: no log line and no new CLI flag.
- The existing `isClaudePreviewLaunch` handling (including its `PORT` precedence behavior) is fully unchanged; agent detection is a superset for the open gate only.
- Humans in non-agent shells are unaffected.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

New cases in `code/core/src/bin/dev-options.test.ts` cover suppression via `CLAUDECODE`, `CODEX_SANDBOX`, `CODEX_THREAD_ID`, `CURSOR_AGENT`, and explicit `AI_AGENT` (using `vi.stubEnv`), plus no-regression coverage for the Claude-preview port precedence logic.

#### Manual testing

1. Run a sandbox, e.g. `yarn task sandbox --start-from auto --template react-vite/default-ts`
2. In the sandbox, run `CLAUDECODE=1 yarn storybook` — Storybook starts but no browser opens.
3. Run `yarn storybook` from a regular shell (no agent env vars) — the browser still opens automatically.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The dev command now respects agent-aware sessions when deciding whether to auto-open the browser.
  * Port selection behavior was refined to keep command-line port settings higher priority than environment-based defaults in these sessions.
  * Updated test coverage for browser-opening behavior and environment cleanup to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->