### PR TITLE
Init: Support pnpm catalogs when adding addon-vitest dependencies

### DIFF
--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -70,20 +70,14 @@ export default async function postInstall(options: PostinstallOptions) {
 
   const allDeps = packageManager.getAllDependencies();
 
-  // Determine Vitest version/range from installed or declared dependency to avoid pulling
-  // incompatible majors by default.
-  let vitestVersionSpecifier = await packageManager.getInstalledVersion('vitest');
-  if (!vitestVersionSpecifier && allDeps['vitest']) {
-    vitestVersionSpecifier = allDeps['vitest'];
-  }
+  const addonVitestService = new AddonVitestService(packageManager);
 
-  /**
-   * Coerce the version specifier to a version string
-   *
-   * This removed any version range specifiers like ^, ~, etc. which is needed to check with
-   * semver.satisfies.
-   */
-  vitestVersionSpecifier = coerce(vitestVersionSpecifier)?.version ?? null;
+  // Determine the Vitest version/range (catalog-aware, so a pnpm `catalog:` specifier resolves to
+  // the real version) to avoid pulling incompatible majors and to select the right config template.
+  // Coerce to a plain version string, dropping range specifiers like ^ or ~, so it can be checked
+  // with semver.satisfies below.
+  const vitestVersionSpecifier =
+    coerce(await addonVitestService.resolveVitestVersionSpecifier())?.version ?? null;
 
   logger.debug(`Vitest version specifier: ${vitestVersionSpecifier}`);
   const isVitest3_2To4 = vitestVersionSpecifier
@@ -99,8 +93,6 @@ export default async function postInstall(options: PostinstallOptions) {
   // framework/builder — causing the prerequisite check below to fail incorrectly.
   const info = await getStorybookInfo(options.configDir, undefined, { skipCache: true });
   // only install these dependencies if they are not already installed
-
-  const addonVitestService = new AddonVitestService(packageManager);
 
   // Use AddonVitestService for compatibility validation
   const compatibilityResult = await addonVitestService.validateCompatibility({

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -72,12 +72,12 @@ export default async function postInstall(options: PostinstallOptions) {
 
   const addonVitestService = new AddonVitestService(packageManager);
 
-  // Determine the Vitest version/range (catalog-aware, so a pnpm `catalog:` specifier resolves to
+  // Determine the Vitest version/range (the package manager resolves a pnpm `catalog:` reference to
   // the real version) to avoid pulling incompatible majors and to select the right config template.
   // Reduce to a plain comparable version via the same helper collectDependencies() uses, so template
   // selection and dependency collection agree on the major.
   const vitestVersionSpecifier = AddonVitestService.getComparableVersion(
-    await addonVitestService.resolveVitestVersionSpecifier()
+    await packageManager.getDeclaredVersionSpecifier('vitest')
   );
 
   logger.debug(`Vitest version specifier: ${vitestVersionSpecifier}`);

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -24,7 +24,7 @@ import { SupportedFramework } from 'storybook/internal/types';
 
 import * as find from 'empathic/find';
 import { dirname, relative, resolve } from 'pathe';
-import { coerce, satisfies } from 'semver';
+import { satisfies } from 'semver';
 import { dedent } from 'ts-dedent';
 
 import { type PostinstallOptions } from '../../../lib/cli-storybook/src/add.ts';
@@ -74,10 +74,11 @@ export default async function postInstall(options: PostinstallOptions) {
 
   // Determine the Vitest version/range (catalog-aware, so a pnpm `catalog:` specifier resolves to
   // the real version) to avoid pulling incompatible majors and to select the right config template.
-  // Coerce to a plain version string, dropping range specifiers like ^ or ~, so it can be checked
-  // with semver.satisfies below.
-  const vitestVersionSpecifier =
-    coerce(await addonVitestService.resolveVitestVersionSpecifier())?.version ?? null;
+  // Reduce to a plain comparable version via the same helper collectDependencies() uses, so template
+  // selection and dependency collection agree on the major.
+  const vitestVersionSpecifier = AddonVitestService.getComparableVersion(
+    await addonVitestService.resolveVitestVersionSpecifier()
+  );
 
   logger.debug(`Vitest version specifier: ${vitestVersionSpecifier}`);
   const isVitest3_2To4 = vitestVersionSpecifier

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -403,6 +403,7 @@
     "valibot": "^1.4.0",
     "watchpack": "^2.5.0",
     "wrap-ansi": "^9.0.2",
+    "yaml": "^2.8.2",
     "zod": "^3.25.76"
   },
   "peerDependencies": {

--- a/code/core/src/cli/AddonVitestService.test.ts
+++ b/code/core/src/cli/AddonVitestService.test.ts
@@ -225,6 +225,42 @@ describe('AddonVitestService', () => {
     });
   });
 
+  describe('resolveVitestVersionSpecifier', () => {
+    it('prefers the installed version', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({ vitest: 'catalog:' });
+      vi.mocked(mockPackageManager.getInstalledVersion).mockResolvedValue('3.2.1');
+
+      await expect(service.resolveVitestVersionSpecifier()).resolves.toBe('3.2.1');
+      // Installed version short-circuits — the catalog is not consulted.
+      expect(mockPackageManager.getCatalogVersion).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the catalog entry when not installed', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
+        vitest: 'catalog:testing',
+      });
+      vi.mocked(mockPackageManager.getInstalledVersion).mockResolvedValue(null);
+      vi.mocked(mockPackageManager.getCatalogVersion).mockReturnValue('^3.2.0');
+
+      await expect(service.resolveVitestVersionSpecifier()).resolves.toBe('^3.2.0');
+      expect(mockPackageManager.getCatalogVersion).toHaveBeenCalledWith('vitest', 'testing');
+    });
+
+    it('falls back to a plain declared semver range when not installed', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({ vitest: '^3.2.0' });
+      vi.mocked(mockPackageManager.getInstalledVersion).mockResolvedValue(null);
+
+      await expect(service.resolveVitestVersionSpecifier()).resolves.toBe('^3.2.0');
+    });
+
+    it('returns null for a non-semver protocol specifier', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({ vitest: 'workspace:*' });
+      vi.mocked(mockPackageManager.getInstalledVersion).mockResolvedValue(null);
+
+      await expect(service.resolveVitestVersionSpecifier()).resolves.toBeNull();
+    });
+  });
+
   describe('validatePackageVersions', () => {
     it('should return compatible when vitest >=3.0.0', async () => {
       vi.mocked(mockPackageManager.getInstalledVersion)

--- a/code/core/src/cli/AddonVitestService.test.ts
+++ b/code/core/src/cli/AddonVitestService.test.ts
@@ -31,8 +31,11 @@ describe('AddonVitestService', () => {
       getInstalledVersion: vi.fn(),
       runPackageCommand: vi.fn(),
       getPackageCommand: vi.fn(),
-      getCatalogVersion: vi.fn().mockReturnValue(null),
-      syncWorkspaceCatalog: vi.fn(),
+      getDeclaredVersionSpecifier: vi.fn().mockResolvedValue(null),
+      // Default to the base-class behavior (pin each package directly).
+      applyVersionToRelatedPackages: vi.fn((packages: string[], version: string) =>
+        packages.map((pkg) => `${pkg}@${version}`)
+      ),
     } as Partial<JsPackageManager> as JsPackageManager;
 
     service = new AddonVitestService(mockPackageManager);
@@ -50,16 +53,12 @@ describe('AddonVitestService', () => {
   describe('collectDeps', () => {
     beforeEach(() => {
       vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
+      // getInstalledVersion is only used here for the coverage reporters (v8 / istanbul).
       vi.mocked(mockPackageManager.getInstalledVersion).mockResolvedValue(null);
+      vi.mocked(mockPackageManager.getDeclaredVersionSpecifier).mockResolvedValue(null);
     });
 
     it('should collect base packages when not installed', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
-      vi.mocked(mockPackageManager.getInstalledVersion)
-        .mockResolvedValueOnce(null) // vitest version check
-        .mockResolvedValueOnce(null) // @vitest/coverage-v8
-        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
-
       const deps = await service.collectDependencies();
 
       expect(deps).toContain('vitest');
@@ -75,8 +74,8 @@ describe('AddonVitestService', () => {
         '@vitest/browser': '3.0.0',
         playwright: '1.0.0',
       });
+      vi.mocked(mockPackageManager.getDeclaredVersionSpecifier).mockResolvedValue('3.0.0');
       vi.mocked(mockPackageManager.getInstalledVersion)
-        .mockResolvedValueOnce('3.0.0') // vitest version
         .mockResolvedValueOnce('3.0.0') // @vitest/coverage-v8
         .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
 
@@ -90,12 +89,6 @@ describe('AddonVitestService', () => {
     // Note: collectDependencies doesn't add framework-specific packages
     // It only collects base vitest packages
     it('should collect base packages without framework-specific additions', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
-      vi.mocked(mockPackageManager.getInstalledVersion)
-        .mockResolvedValueOnce(null) // vitest version check
-        .mockResolvedValueOnce(null) // @vitest/coverage-v8
-        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
-
       const deps = await service.collectDependencies();
 
       // Should only contain base packages, not framework-specific ones
@@ -108,21 +101,13 @@ describe('AddonVitestService', () => {
     });
 
     it('should not add @storybook/nextjs-vite for non-Next.js frameworks', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
-      vi.mocked(mockPackageManager.getInstalledVersion)
-        .mockResolvedValueOnce(null) // vitest version
-        .mockResolvedValueOnce(null) // @vitest/coverage-v8
-        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
-
       const deps = await service.collectDependencies();
 
       expect(deps.every((d) => !d.includes('nextjs-vite'))).toBe(true);
     });
 
     it('should not add coverage reporter if v8 already installed', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
       vi.mocked(mockPackageManager.getInstalledVersion)
-        .mockResolvedValueOnce(null) // vitest version
         .mockResolvedValueOnce('3.0.0') // @vitest/coverage-v8
         .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
 
@@ -132,96 +117,41 @@ describe('AddonVitestService', () => {
     });
 
     it('skips coverage if istanbul', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
       vi.mocked(mockPackageManager.getInstalledVersion)
         .mockResolvedValueOnce(null) // @vitest/coverage-v8
-        .mockResolvedValueOnce('3.0.0') // @vitest/coverage-istanbul
-        .mockResolvedValueOnce(null); // vitest version
+        .mockResolvedValueOnce('3.0.0'); // @vitest/coverage-istanbul
 
       const deps = await service.collectDependencies();
 
       expect(deps.every((d) => !d.includes('coverage'))).toBe(true);
     });
 
-    it('applies version', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
-      vi.mocked(mockPackageManager.getInstalledVersion)
-        .mockResolvedValueOnce('3.2.0') // vitest version check
-        .mockResolvedValueOnce(null) // @vitest/coverage-v8
-        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
+    it('pins vitest-related packages to the resolved version via the package manager', async () => {
+      vi.mocked(mockPackageManager.getDeclaredVersionSpecifier).mockResolvedValue('3.2.0');
 
       const deps = await service.collectDependencies();
 
-      expect(deps).toContain('vitest@3.2.0');
       // Version 3.2.0 < 4.0.0, so uses @vitest/browser
+      expect(deps).toContain('vitest@3.2.0');
       expect(deps).toContain('@vitest/browser@3.2.0');
       expect(deps).toContain('@vitest/coverage-v8@3.2.0');
-      expect(deps).toContain('playwright'); // no version for playwright
-    });
-
-    it('references the default catalog and registers entries for a "catalog:" vitest dependency', async () => {
-      // In a pnpm catalog workspace, vitest is declared as "catalog:" and node_modules may not be
-      // materialized yet, so getInstalledVersion returns null. The derived @vitest/* packages must
-      // reuse the catalog convention and get registered in pnpm-workspace.yaml so install succeeds.
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
-        vitest: 'catalog:',
-      });
-      vi.mocked(mockPackageManager.getInstalledVersion)
-        .mockResolvedValueOnce(null) // vitest version check
-        .mockResolvedValueOnce(null) // @vitest/coverage-v8
-        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
-      vi.mocked(mockPackageManager.getCatalogVersion).mockReturnValue('^3.2.0');
-
-      const deps = await service.collectDependencies();
-
-      // Version < 4.0.0, so uses @vitest/browser
-      expect(deps).toContain('@vitest/browser@catalog:');
-      expect(deps).toContain('@vitest/coverage-v8@catalog:');
-      expect(mockPackageManager.getCatalogVersion).toHaveBeenCalledWith('vitest', undefined);
-      expect(mockPackageManager.syncWorkspaceCatalog).toHaveBeenCalledWith(
-        expect.objectContaining({
-          '@vitest/browser': '^3.2.0',
-          '@vitest/coverage-v8': '^3.2.0',
-        }),
-        undefined
+      expect(deps).toContain('playwright'); // playwright is versioned independently
+      // Only the vitest-related packages are handed to the package manager for version pinning.
+      expect(mockPackageManager.applyVersionToRelatedPackages).toHaveBeenCalledWith(
+        ['vitest', '@vitest/browser', '@vitest/coverage-v8'],
+        '3.2.0',
+        'vitest'
       );
     });
 
-    it('references a named catalog for a "catalog:<name>" vitest dependency', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
-        vitest: 'catalog:testing',
-      });
-      vi.mocked(mockPackageManager.getInstalledVersion)
-        .mockResolvedValueOnce(null) // vitest version check
-        .mockResolvedValueOnce(null) // @vitest/coverage-v8
-        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
-      vi.mocked(mockPackageManager.getCatalogVersion).mockReturnValue('^3.2.0');
-
-      const deps = await service.collectDependencies();
-
-      expect(deps).toContain('@vitest/coverage-v8@catalog:testing');
-      expect(mockPackageManager.getCatalogVersion).toHaveBeenCalledWith('vitest', 'testing');
-      expect(mockPackageManager.syncWorkspaceCatalog).toHaveBeenCalledWith(
-        expect.objectContaining({ '@vitest/coverage-v8': '^3.2.0' }),
-        'testing'
-      );
-    });
-
-    it('falls back to bare packages when a catalog vitest version cannot be resolved', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
-        vitest: 'catalog:',
-      });
-      vi.mocked(mockPackageManager.getInstalledVersion)
-        .mockResolvedValueOnce(null) // vitest version check
-        .mockResolvedValueOnce(null) // @vitest/coverage-v8
-        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
-      vi.mocked(mockPackageManager.getCatalogVersion).mockReturnValue(null);
+    it('does not pin anything when the vitest version cannot be resolved', async () => {
+      vi.mocked(mockPackageManager.getDeclaredVersionSpecifier).mockResolvedValue(null);
 
       const deps = await service.collectDependencies();
 
       expect(deps).toContain('@vitest/coverage-v8');
-      expect(deps.every((d) => !d.includes('catalog:'))).toBe(true);
-      expect(mockPackageManager.syncWorkspaceCatalog).not.toHaveBeenCalled();
+      expect(deps.every((d) => !d.includes('@catalog:') && !d.includes('@3.'))).toBe(true);
+      expect(mockPackageManager.applyVersionToRelatedPackages).not.toHaveBeenCalled();
     });
   });
 
@@ -244,42 +174,6 @@ describe('AddonVitestService', () => {
       // minVersion() alone keeps `4.0.0-beta.1`, which fails `>=4.0.0`; coercing to `4.0.0` fixes the
       // major check and keeps it consistent with the postinstall template selection.
       expect(AddonVitestService.getComparableVersion('4.0.0-beta.1')).toBe('4.0.0');
-    });
-  });
-
-  describe('resolveVitestVersionSpecifier', () => {
-    it('prefers the installed version', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({ vitest: 'catalog:' });
-      vi.mocked(mockPackageManager.getInstalledVersion).mockResolvedValue('3.2.1');
-
-      await expect(service.resolveVitestVersionSpecifier()).resolves.toBe('3.2.1');
-      // Installed version short-circuits — the catalog is not consulted.
-      expect(mockPackageManager.getCatalogVersion).not.toHaveBeenCalled();
-    });
-
-    it('falls back to the catalog entry when not installed', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
-        vitest: 'catalog:testing',
-      });
-      vi.mocked(mockPackageManager.getInstalledVersion).mockResolvedValue(null);
-      vi.mocked(mockPackageManager.getCatalogVersion).mockReturnValue('^3.2.0');
-
-      await expect(service.resolveVitestVersionSpecifier()).resolves.toBe('^3.2.0');
-      expect(mockPackageManager.getCatalogVersion).toHaveBeenCalledWith('vitest', 'testing');
-    });
-
-    it('falls back to a plain declared semver range when not installed', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({ vitest: '^3.2.0' });
-      vi.mocked(mockPackageManager.getInstalledVersion).mockResolvedValue(null);
-
-      await expect(service.resolveVitestVersionSpecifier()).resolves.toBe('^3.2.0');
-    });
-
-    it('returns null for a non-semver protocol specifier', async () => {
-      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({ vitest: 'workspace:*' });
-      vi.mocked(mockPackageManager.getInstalledVersion).mockResolvedValue(null);
-
-      await expect(service.resolveVitestVersionSpecifier()).resolves.toBeNull();
     });
   });
 

--- a/code/core/src/cli/AddonVitestService.test.ts
+++ b/code/core/src/cli/AddonVitestService.test.ts
@@ -31,6 +31,8 @@ describe('AddonVitestService', () => {
       getInstalledVersion: vi.fn(),
       runPackageCommand: vi.fn(),
       getPackageCommand: vi.fn(),
+      getCatalogVersion: vi.fn().mockReturnValue(null),
+      syncWorkspaceCatalog: vi.fn(),
     } as Partial<JsPackageManager> as JsPackageManager;
 
     service = new AddonVitestService(mockPackageManager);
@@ -155,6 +157,71 @@ describe('AddonVitestService', () => {
       expect(deps).toContain('@vitest/browser@3.2.0');
       expect(deps).toContain('@vitest/coverage-v8@3.2.0');
       expect(deps).toContain('playwright'); // no version for playwright
+    });
+
+    it('references the default catalog and registers entries for a "catalog:" vitest dependency', async () => {
+      // In a pnpm catalog workspace, vitest is declared as "catalog:" and node_modules may not be
+      // materialized yet, so getInstalledVersion returns null. The derived @vitest/* packages must
+      // reuse the catalog convention and get registered in pnpm-workspace.yaml so install succeeds.
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
+        vitest: 'catalog:',
+      });
+      vi.mocked(mockPackageManager.getInstalledVersion)
+        .mockResolvedValueOnce(null) // vitest version check
+        .mockResolvedValueOnce(null) // @vitest/coverage-v8
+        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
+      vi.mocked(mockPackageManager.getCatalogVersion).mockReturnValue('^3.2.0');
+
+      const deps = await service.collectDependencies();
+
+      // Version < 4.0.0, so uses @vitest/browser
+      expect(deps).toContain('@vitest/browser@catalog:');
+      expect(deps).toContain('@vitest/coverage-v8@catalog:');
+      expect(mockPackageManager.getCatalogVersion).toHaveBeenCalledWith('vitest', undefined);
+      expect(mockPackageManager.syncWorkspaceCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          '@vitest/browser': '^3.2.0',
+          '@vitest/coverage-v8': '^3.2.0',
+        }),
+        undefined
+      );
+    });
+
+    it('references a named catalog for a "catalog:<name>" vitest dependency', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
+        vitest: 'catalog:testing',
+      });
+      vi.mocked(mockPackageManager.getInstalledVersion)
+        .mockResolvedValueOnce(null) // vitest version check
+        .mockResolvedValueOnce(null) // @vitest/coverage-v8
+        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
+      vi.mocked(mockPackageManager.getCatalogVersion).mockReturnValue('^3.2.0');
+
+      const deps = await service.collectDependencies();
+
+      expect(deps).toContain('@vitest/coverage-v8@catalog:testing');
+      expect(mockPackageManager.getCatalogVersion).toHaveBeenCalledWith('vitest', 'testing');
+      expect(mockPackageManager.syncWorkspaceCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({ '@vitest/coverage-v8': '^3.2.0' }),
+        'testing'
+      );
+    });
+
+    it('falls back to bare packages when a catalog vitest version cannot be resolved', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
+        vitest: 'catalog:',
+      });
+      vi.mocked(mockPackageManager.getInstalledVersion)
+        .mockResolvedValueOnce(null) // vitest version check
+        .mockResolvedValueOnce(null) // @vitest/coverage-v8
+        .mockResolvedValueOnce(null); // @vitest/coverage-istanbul
+      vi.mocked(mockPackageManager.getCatalogVersion).mockReturnValue(null);
+
+      const deps = await service.collectDependencies();
+
+      expect(deps).toContain('@vitest/coverage-v8');
+      expect(deps.every((d) => !d.includes('catalog:'))).toBe(true);
+      expect(mockPackageManager.syncWorkspaceCatalog).not.toHaveBeenCalled();
     });
   });
 

--- a/code/core/src/cli/AddonVitestService.test.ts
+++ b/code/core/src/cli/AddonVitestService.test.ts
@@ -225,6 +225,28 @@ describe('AddonVitestService', () => {
     });
   });
 
+  describe('getComparableVersion', () => {
+    it('returns undefined for empty input', () => {
+      expect(AddonVitestService.getComparableVersion(null)).toBeUndefined();
+      expect(AddonVitestService.getComparableVersion(undefined)).toBeUndefined();
+    });
+
+    it('passes through an exact version', () => {
+      expect(AddonVitestService.getComparableVersion('3.2.1')).toBe('3.2.1');
+    });
+
+    it('reduces a range to its lower bound', () => {
+      expect(AddonVitestService.getComparableVersion('^3.2.0')).toBe('3.2.0');
+      expect(AddonVitestService.getComparableVersion('>=4.1.0 <5.0.0')).toBe('4.1.0');
+    });
+
+    it('strips the prerelease tag so a beta compares by its release major', () => {
+      // minVersion() alone keeps `4.0.0-beta.1`, which fails `>=4.0.0`; coercing to `4.0.0` fixes the
+      // major check and keeps it consistent with the postinstall template selection.
+      expect(AddonVitestService.getComparableVersion('4.0.0-beta.1')).toBe('4.0.0');
+    });
+  });
+
   describe('resolveVitestVersionSpecifier', () => {
     it('prefers the installed version', async () => {
       vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({ vitest: 'catalog:' });

--- a/code/core/src/cli/AddonVitestService.ts
+++ b/code/core/src/cli/AddonVitestService.ts
@@ -54,29 +54,6 @@ export class AddonVitestService {
   }
 
   /**
-   * Resolve the Vitest version/range used both to keep the derived `@vitest/*` packages on a
-   * compatible major and to select the right config template. Prefers the resolved installed
-   * version, then a pnpm catalog entry when vitest is declared as `catalog:` / `catalog:<name>`,
-   * then a plain declared semver range. Non-semver protocol specifiers (`workspace:`, an
-   * unregistered `catalog:`, ...) resolve to null so they are never copied onto other packages.
-   */
-  async resolveVitestVersionSpecifier(): Promise<string | null> {
-    const declared = this.packageManager.getAllDependencies()['vitest'];
-
-    let specifier = await this.packageManager.getInstalledVersion('vitest');
-    if (!specifier && declared) {
-      const catalogMatch = declared.match(/^catalog:(.*)$/);
-      if (catalogMatch) {
-        const catalogName = catalogMatch[1].trim() || undefined;
-        specifier = this.packageManager.getCatalogVersion('vitest', catalogName);
-      } else if (validRange(declared)) {
-        specifier = declared;
-      }
-    }
-    return specifier;
-  }
-
-  /**
    * Collect all dependencies needed for @storybook/addon-vitest
    *
    * Returns versioned package strings ready for installation:
@@ -89,16 +66,9 @@ export class AddonVitestService {
     const allDeps = this.packageManager.getAllDependencies();
     const dependencies: string[] = [];
 
-    // Vitest may be declared through a pnpm catalog (`catalog:` or `catalog:<name>`). When it is, the
-    // derived `@vitest/*` packages we add must also become catalog entries — copying the raw
-    // `catalog:` specifier onto them produces e.g. `@vitest/coverage-v8@catalog:`, which fails
-    // install because no such catalog entry exists.
-    const catalogMatch = allDeps['vitest']?.match(/^catalog:(.*)$/);
-    const catalogName = catalogMatch?.[1]?.trim() || undefined;
-
-    // Resolve the Vitest version/range (catalog-aware) to keep the derived `@vitest/*` packages on a
-    // compatible major.
-    const vitestVersionSpecifier = await this.resolveVitestVersionSpecifier();
+    // Resolve the Vitest version/range to keep the derived `@vitest/*` packages on a compatible
+    // major. The package manager owns the resolution (e.g. reading a pnpm `catalog:` reference).
+    const vitestVersionSpecifier = await this.packageManager.getDeclaredVersionSpecifier('vitest');
 
     const versionToCheck = AddonVitestService.getComparableVersion(vitestVersionSpecifier);
     const isVitest4OrNewer = versionToCheck ? satisfies(versionToCheck, '>=4.0.0') : true;
@@ -127,26 +97,23 @@ export class AddonVitestService {
       dependencies.push('@vitest/coverage-v8');
     }
 
-    // Apply version specifiers to vitest-related packages.
-    const catalogEntries: Record<string, string> = {};
-    const versionedDependencies = dependencies.map((pkg) => {
-      if (!pkg.includes('vitest') || !vitestVersionSpecifier) {
-        return pkg;
-      }
-      if (catalogMatch) {
-        // Mirror the project's catalog convention: reference the catalog from package.json and
-        // register the resolved version in pnpm-workspace.yaml below.
-        catalogEntries[pkg] = vitestVersionSpecifier;
-        return `${pkg}@catalog:${catalogName ?? ''}`;
-      }
-      return `${pkg}@${vitestVersionSpecifier}`;
-    });
-
-    if (Object.keys(catalogEntries).length > 0) {
-      this.packageManager.syncWorkspaceCatalog(catalogEntries, catalogName);
+    if (!vitestVersionSpecifier) {
+      return dependencies;
     }
 
-    return versionedDependencies;
+    // Pin the vitest-related packages to the resolved vitest version, letting the package manager
+    // apply its own convention (e.g. registering pnpm catalog entries). Playwright is versioned
+    // independently, so it is left untouched.
+    const related = dependencies.filter((pkg) => pkg.includes('vitest'));
+    const rest = dependencies.filter((pkg) => !pkg.includes('vitest'));
+    return [
+      ...this.packageManager.applyVersionToRelatedPackages(
+        related,
+        vitestVersionSpecifier,
+        'vitest'
+      ),
+      ...rest,
+    ];
   }
 
   /**

--- a/code/core/src/cli/AddonVitestService.ts
+++ b/code/core/src/cli/AddonVitestService.ts
@@ -52,11 +52,24 @@ export class AddonVitestService {
     const allDeps = this.packageManager.getAllDependencies();
     const dependencies: string[] = [];
 
-    // Determine Vitest version/range from installed or declared dependency to avoid pulling
-    // incompatible majors by default.
+    // Vitest may be declared through a pnpm catalog (`catalog:` or `catalog:<name>`). When it is, the
+    // derived `@vitest/*` packages we add must also become catalog entries — copying the raw
+    // `catalog:` specifier onto them produces e.g. `@vitest/coverage-v8@catalog:`, which fails
+    // install because no such catalog entry exists.
+    const catalogMatch = allDeps['vitest']?.match(/^catalog:(.*)$/);
+    const catalogName = catalogMatch?.[1] || undefined;
+
+    // Determine the Vitest version/range used to keep the derived `@vitest/*` packages on a
+    // compatible major. Prefer the resolved installed version, then the catalog entry, then a plain
+    // declared semver range. Protocol specifiers like `catalog:`/`workspace:` are never copied
+    // verbatim onto the derived packages.
     let vitestVersionSpecifier = await this.packageManager.getInstalledVersion('vitest');
-    if (!vitestVersionSpecifier && allDeps['vitest']) {
-      vitestVersionSpecifier = allDeps['vitest'];
+    if (!vitestVersionSpecifier) {
+      if (catalogMatch) {
+        vitestVersionSpecifier = this.packageManager.getCatalogVersion('vitest', catalogName);
+      } else if (allDeps['vitest'] && validRange(allDeps['vitest'])) {
+        vitestVersionSpecifier = allDeps['vitest'];
+      }
     }
 
     let isVitest4OrNewer = true;
@@ -92,13 +105,24 @@ export class AddonVitestService {
       dependencies.push('@vitest/coverage-v8');
     }
 
-    // Apply version specifiers to vitest-related packages
+    // Apply version specifiers to vitest-related packages.
+    const catalogEntries: Record<string, string> = {};
     const versionedDependencies = dependencies.map((pkg) => {
-      if (pkg.includes('vitest') && vitestVersionSpecifier) {
-        return `${pkg}@${vitestVersionSpecifier}`;
+      if (!pkg.includes('vitest') || !vitestVersionSpecifier) {
+        return pkg;
       }
-      return pkg;
+      if (catalogMatch) {
+        // Mirror the project's catalog convention: reference the catalog from package.json and
+        // register the resolved version in pnpm-workspace.yaml below.
+        catalogEntries[pkg] = vitestVersionSpecifier;
+        return `${pkg}@catalog:${catalogName ?? ''}`;
+      }
+      return `${pkg}@${vitestVersionSpecifier}`;
     });
+
+    if (Object.keys(catalogEntries).length > 0) {
+      this.packageManager.syncWorkspaceCatalog(catalogEntries, catalogName);
+    }
 
     return versionedDependencies;
   }

--- a/code/core/src/cli/AddonVitestService.ts
+++ b/code/core/src/cli/AddonVitestService.ts
@@ -40,6 +40,29 @@ export class AddonVitestService {
   constructor(private readonly packageManager: JsPackageManager) {}
 
   /**
+   * Resolve the Vitest version/range used both to keep the derived `@vitest/*` packages on a
+   * compatible major and to select the right config template. Prefers the resolved installed
+   * version, then a pnpm catalog entry when vitest is declared as `catalog:` / `catalog:<name>`,
+   * then a plain declared semver range. Non-semver protocol specifiers (`workspace:`, an
+   * unregistered `catalog:`, ...) resolve to null so they are never copied onto other packages.
+   */
+  async resolveVitestVersionSpecifier(): Promise<string | null> {
+    const declared = this.packageManager.getAllDependencies()['vitest'];
+
+    let specifier = await this.packageManager.getInstalledVersion('vitest');
+    if (!specifier && declared) {
+      const catalogMatch = declared.match(/^catalog:(.*)$/);
+      if (catalogMatch) {
+        const catalogName = catalogMatch[1].trim() || undefined;
+        specifier = this.packageManager.getCatalogVersion('vitest', catalogName);
+      } else if (validRange(declared)) {
+        specifier = declared;
+      }
+    }
+    return specifier;
+  }
+
+  /**
    * Collect all dependencies needed for @storybook/addon-vitest
    *
    * Returns versioned package strings ready for installation:
@@ -57,20 +80,11 @@ export class AddonVitestService {
     // `catalog:` specifier onto them produces e.g. `@vitest/coverage-v8@catalog:`, which fails
     // install because no such catalog entry exists.
     const catalogMatch = allDeps['vitest']?.match(/^catalog:(.*)$/);
-    const catalogName = catalogMatch?.[1] || undefined;
+    const catalogName = catalogMatch?.[1]?.trim() || undefined;
 
-    // Determine the Vitest version/range used to keep the derived `@vitest/*` packages on a
-    // compatible major. Prefer the resolved installed version, then the catalog entry, then a plain
-    // declared semver range. Protocol specifiers like `catalog:`/`workspace:` are never copied
-    // verbatim onto the derived packages.
-    let vitestVersionSpecifier = await this.packageManager.getInstalledVersion('vitest');
-    if (!vitestVersionSpecifier) {
-      if (catalogMatch) {
-        vitestVersionSpecifier = this.packageManager.getCatalogVersion('vitest', catalogName);
-      } else if (allDeps['vitest'] && validRange(allDeps['vitest'])) {
-        vitestVersionSpecifier = allDeps['vitest'];
-      }
-    }
+    // Resolve the Vitest version/range (catalog-aware) to keep the derived `@vitest/*` packages on a
+    // compatible major.
+    const vitestVersionSpecifier = await this.resolveVitestVersionSpecifier();
 
     let isVitest4OrNewer = true;
     if (vitestVersionSpecifier) {

--- a/code/core/src/cli/AddonVitestService.ts
+++ b/code/core/src/cli/AddonVitestService.ts
@@ -40,6 +40,20 @@ export class AddonVitestService {
   constructor(private readonly packageManager: JsPackageManager) {}
 
   /**
+   * Reduce a Vitest version specifier (exact or range) to a single concrete version for
+   * `semver.satisfies` comparisons, so dependency collection and postinstall template selection make
+   * the same major/minor decision. Uses the lower bound of a valid range, then coerces so a
+   * prerelease like `4.0.0-beta.1` is treated as `4.0.0` rather than failing `>=4.0.0`.
+   */
+  static getComparableVersion(specifier: string | null | undefined): string | undefined {
+    if (!specifier) {
+      return undefined;
+    }
+    const range = validRange(specifier);
+    return coerce(range ? minVersion(range)?.version : specifier)?.version;
+  }
+
+  /**
    * Resolve the Vitest version/range used both to keep the derived `@vitest/*` packages on a
    * compatible major and to select the right config template. Prefers the resolved installed
    * version, then a pnpm catalog entry when vitest is declared as `catalog:` / `catalog:<name>`,
@@ -86,14 +100,8 @@ export class AddonVitestService {
     // compatible major.
     const vitestVersionSpecifier = await this.resolveVitestVersionSpecifier();
 
-    let isVitest4OrNewer = true;
-    if (vitestVersionSpecifier) {
-      const range = validRange(vitestVersionSpecifier);
-      const versionToCheck = range
-        ? minVersion(range)?.version
-        : coerce(vitestVersionSpecifier)?.version;
-      isVitest4OrNewer = versionToCheck ? satisfies(versionToCheck, '>=4.0.0') : true;
-    }
+    const versionToCheck = AddonVitestService.getComparableVersion(vitestVersionSpecifier);
+    const isVitest4OrNewer = versionToCheck ? satisfies(versionToCheck, '>=4.0.0') : true;
 
     // only install these dependencies if they are not already installed
     const basePackages = [

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -297,6 +297,24 @@ export abstract class JsPackageManager {
   }
 
   /**
+   * Returns the version declared for a package in a workspace catalog (the default catalog when no
+   * name is given), or null when there is no such entry. Catalogs are a pnpm-only feature, so every
+   * other package manager returns null.
+   */
+  public getCatalogVersion(_packageName: string, _catalogName?: string): string | null {
+    return null;
+  }
+
+  /**
+   * Registers `entries` (package name -> version range) in a workspace catalog, creating the entries
+   * that don't exist yet. Catalogs are a pnpm-only feature, so this is a no-op for every other
+   * package manager.
+   */
+  public syncWorkspaceCatalog(_entries: Record<string, string>, _catalogName?: string): void {
+    // no-op — overridden by PNPMProxy
+  }
+
+  /**
    * Add dependencies to a project using `yarn add` or `npm install`.
    *
    * @example

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -10,7 +10,7 @@ import { type ResultPromise } from 'execa';
 // eslint-disable-next-line depend/ban-dependencies
 import { globSync } from 'glob';
 import picocolors from 'picocolors';
-import { coerce, gt, satisfies } from 'semver';
+import { coerce, gt, satisfies, validRange } from 'semver';
 import invariant from 'tiny-invariant';
 
 import { HandledError } from '../utils/HandledError.ts';
@@ -297,21 +297,31 @@ export abstract class JsPackageManager {
   }
 
   /**
-   * Returns the version declared for a package in a workspace catalog (the default catalog when no
-   * name is given), or null when there is no such entry. Catalogs are a pnpm-only feature, so every
-   * other package manager returns null.
+   * Resolve the effective version/range of a declared dependency: the installed version if present,
+   * otherwise the declared semver range. Returns null when the package is not declared or only a
+   * non-semver specifier is declared. PNPMProxy additionally resolves pnpm `catalog:` references.
    */
-  public getCatalogVersion(_packageName: string, _catalogName?: string): string | null {
-    return null;
+  public async getDeclaredVersionSpecifier(packageName: string): Promise<string | null> {
+    const installed = await this.getInstalledVersion(packageName);
+    if (installed) {
+      return installed;
+    }
+    const declared = this.getAllDependencies()[packageName];
+    return declared && validRange(declared) ? declared : null;
   }
 
   /**
-   * Registers `entries` (package name -> version range) in a workspace catalog, creating the entries
-   * that don't exist yet. Catalogs are a pnpm-only feature, so this is a no-op for every other
-   * package manager.
+   * Pin `packages` to `version`, mirroring how `anchorPackage` is declared. The base implementation
+   * pins each directly (`pkg@version`). PNPMProxy overrides this to honor pnpm catalogs: when
+   * `anchorPackage` is declared through a catalog, the packages are registered in that catalog and
+   * referenced as `catalog:` instead. Returns the install specifiers to write to package.json.
    */
-  public syncWorkspaceCatalog(_entries: Record<string, string>, _catalogName?: string): void {
-    // no-op — overridden by PNPMProxy
+  public applyVersionToRelatedPackages(
+    packages: string[],
+    version: string,
+    _anchorPackage: string
+  ): string[] {
+    return packages.map((pkg) => `${pkg}@${version}`);
   }
 
   /**

--- a/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as find from 'empathic/find';
+import { fs as memfs, vol } from 'memfs';
 
 import { getProjectRoot } from '../utils/paths.ts';
 import { PNPMProxy } from './PNPMProxy.ts';
@@ -17,17 +18,20 @@ vi.mock('storybook/internal/node-logger', () => ({
 
 const WORKSPACE_YAML = '/root/pnpm-workspace.yaml';
 
+const writtenYaml = () => vol.toJSON()[WORKSPACE_YAML] as string;
+
 describe('PNPMProxy catalogs', () => {
   let pnpmProxy: PNPMProxy;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    // Construct against the real fs before overriding fs/find in individual tests.
+    // Restore the real fs so the proxy can be constructed, then redirect fs to memfs.
+    vi.resetAllMocks();
     pnpmProxy = new PNPMProxy();
+    vol.reset();
+    vi.mocked(readFileSync).mockImplementation(memfs.readFileSync as typeof readFileSync);
+    vi.mocked(writeFileSync).mockImplementation(memfs.writeFileSync as typeof writeFileSync);
     vi.mocked(getProjectRoot).mockReturnValue('/root');
     vi.mocked(find.up).mockReturnValue(WORKSPACE_YAML);
-    // Never touch the real disk when writing.
-    vi.mocked(writeFileSync).mockImplementation(() => {});
     // Drive the version resolution through controllable inputs.
     vi.spyOn(pnpmProxy, 'getInstalledVersion').mockResolvedValue(null);
     vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({});
@@ -44,21 +48,28 @@ describe('PNPMProxy catalogs', () => {
 
     it('reads the default catalog when declared as "catalog:" and not installed', async () => {
       vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
-      vi.mocked(readFileSync).mockReturnValue('catalog:\n  vitest: ^3.2.0\n' as any);
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalog:\n  vitest: ^3.2.0\n' });
+
+      await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBe('^3.2.0');
+    });
+
+    it('reads a default catalog defined under `catalogs.default`', async () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalogs:\n  default:\n    vitest: ^3.2.0\n' });
 
       await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBe('^3.2.0');
     });
 
     it('reads a named catalog for "catalog:<name>"', async () => {
       vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:testing' });
-      vi.mocked(readFileSync).mockReturnValue('catalogs:\n  testing:\n    vitest: ^3.2.0\n' as any);
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalogs:\n  testing:\n    vitest: ^3.2.0\n' });
 
       await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBe('^3.2.0');
     });
 
     it('reads a bare numeric catalog pin that YAML parses as a number', async () => {
       vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
-      vi.mocked(readFileSync).mockReturnValue('catalog:\n  vitest: 4\n' as any);
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalog:\n  vitest: 4\n' });
 
       await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBe('4');
     });
@@ -77,7 +88,7 @@ describe('PNPMProxy catalogs', () => {
 
     it('returns null when the catalog entry is missing', async () => {
       vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
-      vi.mocked(readFileSync).mockReturnValue('catalog:\n  react: ^18.0.0\n' as any);
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalog:\n  react: ^18.0.0\n' });
 
       await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBeNull();
     });
@@ -106,9 +117,7 @@ describe('PNPMProxy catalogs', () => {
 
     it('registers entries and returns catalog references for a default-catalog anchor', () => {
       vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
-      vi.mocked(readFileSync).mockReturnValue(
-        '# my workspace\ncatalog:\n  vitest: ^3.2.0 # pinned\n' as any
-      );
+      vol.fromJSON({ [WORKSPACE_YAML]: '# my workspace\ncatalog:\n  vitest: ^3.2.0 # pinned\n' });
 
       const result = pnpmProxy.applyVersionToRelatedPackages(
         ['@vitest/coverage-v8', '@vitest/browser'],
@@ -117,17 +126,31 @@ describe('PNPMProxy catalogs', () => {
       );
 
       expect(result).toEqual(['@vitest/coverage-v8@catalog:', '@vitest/browser@catalog:']);
-      expect(writeFileSync).toHaveBeenCalledTimes(1);
-      const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
-      expect(written).toContain('# my workspace');
-      expect(written).toContain('vitest: ^3.2.0 # pinned');
-      expect(written).toContain('"@vitest/coverage-v8": ^3.2.0');
-      expect(written).toContain('"@vitest/browser": ^3.2.0');
+      expect(writtenYaml()).toContain('# my workspace');
+      expect(writtenYaml()).toContain('vitest: ^3.2.0 # pinned');
+      expect(writtenYaml()).toContain('"@vitest/coverage-v8": ^3.2.0');
+      expect(writtenYaml()).toContain('"@vitest/browser": ^3.2.0');
+    });
+
+    it('writes into `catalogs.default` when the default catalog is defined there', () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalogs:\n  default:\n    vitest: ^3.2.0\n' });
+
+      const result = pnpmProxy.applyVersionToRelatedPackages(
+        ['@vitest/coverage-v8'],
+        '^3.2.0',
+        'vitest'
+      );
+
+      expect(result).toEqual(['@vitest/coverage-v8@catalog:']);
+      expect(writtenYaml()).toContain('"@vitest/coverage-v8": ^3.2.0');
+      // Defining both `catalog` and `catalogs.default` is a pnpm config error.
+      expect(writtenYaml()).not.toMatch(/^catalog:/m);
     });
 
     it('writes into a named catalog', () => {
       vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:testing' });
-      vi.mocked(readFileSync).mockReturnValue('packages:\n  - packages/*\n' as any);
+      vol.fromJSON({ [WORKSPACE_YAML]: 'packages:\n  - packages/*\n' });
 
       const result = pnpmProxy.applyVersionToRelatedPackages(
         ['@vitest/coverage-v8'],
@@ -136,23 +159,37 @@ describe('PNPMProxy catalogs', () => {
       );
 
       expect(result).toEqual(['@vitest/coverage-v8@catalog:testing']);
-      const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
-      expect(written).toContain('catalogs:');
-      expect(written).toContain('testing:');
-      expect(written).toContain('"@vitest/coverage-v8": ^3.2.0');
+      expect(writtenYaml()).toContain('catalogs:');
+      expect(writtenYaml()).toContain('testing:');
+      expect(writtenYaml()).toContain('"@vitest/coverage-v8": ^3.2.0');
+    });
+
+    it('reuses the anchor catalog entry format instead of the resolved exact version', () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalog:\n  vitest: ^3.2.0\n' });
+
+      // 3.2.4 is the installed version; the catalog entry should keep the user's range style.
+      pnpmProxy.applyVersionToRelatedPackages(['@vitest/coverage-v8'], '3.2.4', 'vitest');
+
+      expect(writtenYaml()).toContain('"@vitest/coverage-v8": ^3.2.0');
     });
 
     it('does not override an entry the user already pinned', () => {
       vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
-      vi.mocked(readFileSync).mockReturnValue('catalog:\n  "@vitest/coverage-v8": ^3.0.0\n' as any);
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalog:\n  "@vitest/coverage-v8": ^3.0.0\n' });
 
-      pnpmProxy.applyVersionToRelatedPackages(['@vitest/coverage-v8'], '^3.2.0', 'vitest');
+      const result = pnpmProxy.applyVersionToRelatedPackages(
+        ['@vitest/coverage-v8'],
+        '^3.2.0',
+        'vitest'
+      );
 
-      // Nothing changed, so nothing is written.
+      // The entry already resolves, so nothing is written and the reference is still used.
+      expect(result).toEqual(['@vitest/coverage-v8@catalog:']);
       expect(writeFileSync).not.toHaveBeenCalled();
     });
 
-    it('does not write when there is no workspace file, but still returns catalog references', () => {
+    it('falls back to direct pins when there is no workspace file', () => {
       vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -162,8 +199,39 @@ describe('PNPMProxy catalogs', () => {
         'vitest'
       );
 
-      expect(result).toEqual(['@vitest/coverage-v8@catalog:']);
+      // An unregistered `catalog:` reference would fail install, so pin directly instead.
+      expect(result).toEqual(['@vitest/coverage-v8@^3.2.0']);
       expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('falls back to direct pins when the workspace file is malformed', () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalog: [\n' });
+
+      const result = pnpmProxy.applyVersionToRelatedPackages(
+        ['@vitest/coverage-v8'],
+        '^3.2.0',
+        'vitest'
+      );
+
+      expect(result).toEqual(['@vitest/coverage-v8@^3.2.0']);
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('falls back to direct pins when the workspace file cannot be written', () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalog:\n  vitest: ^3.2.0\n' });
+      vi.mocked(writeFileSync).mockImplementation(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+      const result = pnpmProxy.applyVersionToRelatedPackages(
+        ['@vitest/coverage-v8'],
+        '^3.2.0',
+        'vitest'
+      );
+
+      expect(result).toEqual(['@vitest/coverage-v8@^3.2.0']);
     });
   });
 });

--- a/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
@@ -56,6 +56,13 @@ describe('PNPMProxy catalogs', () => {
 
       expect(pnpmProxy.getCatalogVersion('vitest')).toBeNull();
     });
+
+    it('reads a bare numeric pin that YAML parses as a number', () => {
+      // `vitest: 4` parses as the number 4; it must not be silently dropped.
+      vi.mocked(readFileSync).mockReturnValue('catalog:\n  vitest: 4\n' as any);
+
+      expect(pnpmProxy.getCatalogVersion('vitest')).toBe('4');
+    });
   });
 
   describe('syncWorkspaceCatalog', () => {

--- a/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
@@ -28,83 +28,141 @@ describe('PNPMProxy catalogs', () => {
     vi.mocked(find.up).mockReturnValue(WORKSPACE_YAML);
     // Never touch the real disk when writing.
     vi.mocked(writeFileSync).mockImplementation(() => {});
+    // Drive the version resolution through controllable inputs.
+    vi.spyOn(pnpmProxy, 'getInstalledVersion').mockResolvedValue(null);
+    vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({});
   });
 
-  describe('getCatalogVersion', () => {
-    it('reads a package version from the default catalog', () => {
+  describe('getDeclaredVersionSpecifier', () => {
+    it('prefers the installed version and does not read the catalog', async () => {
+      vi.spyOn(pnpmProxy, 'getInstalledVersion').mockResolvedValue('4.1.9');
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
+
+      await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBe('4.1.9');
+      expect(readFileSync).not.toHaveBeenCalledWith(WORKSPACE_YAML, expect.anything());
+    });
+
+    it('reads the default catalog when declared as "catalog:" and not installed', async () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
       vi.mocked(readFileSync).mockReturnValue('catalog:\n  vitest: ^3.2.0\n' as any);
 
-      expect(pnpmProxy.getCatalogVersion('vitest')).toBe('^3.2.0');
+      await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBe('^3.2.0');
     });
 
-    it('reads a package version from a named catalog', () => {
+    it('reads a named catalog for "catalog:<name>"', async () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:testing' });
       vi.mocked(readFileSync).mockReturnValue('catalogs:\n  testing:\n    vitest: ^3.2.0\n' as any);
 
-      expect(pnpmProxy.getCatalogVersion('vitest', 'testing')).toBe('^3.2.0');
-      // The default catalog does not have the entry.
-      expect(pnpmProxy.getCatalogVersion('vitest')).toBeNull();
+      await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBe('^3.2.0');
     });
 
-    it('returns null when there is no workspace file', () => {
-      vi.mocked(find.up).mockReturnValue(undefined);
-
-      expect(pnpmProxy.getCatalogVersion('vitest')).toBeNull();
-    });
-
-    it('returns null when the entry does not exist', () => {
-      vi.mocked(readFileSync).mockReturnValue('catalog:\n  react: ^18.0.0\n' as any);
-
-      expect(pnpmProxy.getCatalogVersion('vitest')).toBeNull();
-    });
-
-    it('reads a bare numeric pin that YAML parses as a number', () => {
-      // `vitest: 4` parses as the number 4; it must not be silently dropped.
+    it('reads a bare numeric catalog pin that YAML parses as a number', async () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
       vi.mocked(readFileSync).mockReturnValue('catalog:\n  vitest: 4\n' as any);
 
-      expect(pnpmProxy.getCatalogVersion('vitest')).toBe('4');
+      await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBe('4');
+    });
+
+    it('falls back to a plain declared semver range when not a catalog and not installed', async () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: '^3.2.0' });
+
+      await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBe('^3.2.0');
+    });
+
+    it('returns null for a non-semver, non-catalog specifier', async () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'workspace:*' });
+
+      await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBeNull();
+    });
+
+    it('returns null when the catalog entry is missing', async () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
+      vi.mocked(readFileSync).mockReturnValue('catalog:\n  react: ^18.0.0\n' as any);
+
+      await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBeNull();
+    });
+
+    it('returns null when there is no workspace file', async () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
+      vi.mocked(find.up).mockReturnValue(undefined);
+
+      await expect(pnpmProxy.getDeclaredVersionSpecifier('vitest')).resolves.toBeNull();
     });
   });
 
-  describe('syncWorkspaceCatalog', () => {
-    it('adds missing entries to the default catalog and preserves comments', () => {
+  describe('applyVersionToRelatedPackages', () => {
+    it('pins directly when the anchor is not declared through a catalog', () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: '^3.2.0' });
+
+      const result = pnpmProxy.applyVersionToRelatedPackages(
+        ['@vitest/coverage-v8', '@vitest/browser'],
+        '3.2.0',
+        'vitest'
+      );
+
+      expect(result).toEqual(['@vitest/coverage-v8@3.2.0', '@vitest/browser@3.2.0']);
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('registers entries and returns catalog references for a default-catalog anchor', () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
       vi.mocked(readFileSync).mockReturnValue(
         '# my workspace\ncatalog:\n  vitest: ^3.2.0 # pinned\n' as any
       );
 
-      pnpmProxy.syncWorkspaceCatalog({ '@vitest/coverage-v8': '^3.2.0' });
+      const result = pnpmProxy.applyVersionToRelatedPackages(
+        ['@vitest/coverage-v8', '@vitest/browser'],
+        '^3.2.0',
+        'vitest'
+      );
 
+      expect(result).toEqual(['@vitest/coverage-v8@catalog:', '@vitest/browser@catalog:']);
       expect(writeFileSync).toHaveBeenCalledTimes(1);
       const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
       expect(written).toContain('# my workspace');
       expect(written).toContain('vitest: ^3.2.0 # pinned');
       expect(written).toContain('"@vitest/coverage-v8": ^3.2.0');
+      expect(written).toContain('"@vitest/browser": ^3.2.0');
     });
 
-    it('does not override an entry the user already pinned', () => {
-      vi.mocked(readFileSync).mockReturnValue('catalog:\n  "@vitest/coverage-v8": ^3.0.0\n' as any);
-
-      pnpmProxy.syncWorkspaceCatalog({ '@vitest/coverage-v8': '^3.2.0' });
-
-      // Nothing changed, so nothing is written.
-      expect(writeFileSync).not.toHaveBeenCalled();
-    });
-
-    it('writes entries into a named catalog', () => {
+    it('writes into a named catalog', () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:testing' });
       vi.mocked(readFileSync).mockReturnValue('packages:\n  - packages/*\n' as any);
 
-      pnpmProxy.syncWorkspaceCatalog({ '@vitest/coverage-v8': '^3.2.0' }, 'testing');
+      const result = pnpmProxy.applyVersionToRelatedPackages(
+        ['@vitest/coverage-v8'],
+        '^3.2.0',
+        'vitest'
+      );
 
+      expect(result).toEqual(['@vitest/coverage-v8@catalog:testing']);
       const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
       expect(written).toContain('catalogs:');
       expect(written).toContain('testing:');
       expect(written).toContain('"@vitest/coverage-v8": ^3.2.0');
     });
 
-    it('warns and does not write when there is no workspace file', () => {
+    it('does not override an entry the user already pinned', () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
+      vi.mocked(readFileSync).mockReturnValue('catalog:\n  "@vitest/coverage-v8": ^3.0.0\n' as any);
+
+      pnpmProxy.applyVersionToRelatedPackages(['@vitest/coverage-v8'], '^3.2.0', 'vitest');
+
+      // Nothing changed, so nothing is written.
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('does not write when there is no workspace file, but still returns catalog references', () => {
+      vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: 'catalog:' });
       vi.mocked(find.up).mockReturnValue(undefined);
 
-      pnpmProxy.syncWorkspaceCatalog({ '@vitest/coverage-v8': '^3.2.0' });
+      const result = pnpmProxy.applyVersionToRelatedPackages(
+        ['@vitest/coverage-v8'],
+        '^3.2.0',
+        'vitest'
+      );
 
+      expect(result).toEqual(['@vitest/coverage-v8@catalog:']);
       expect(writeFileSync).not.toHaveBeenCalled();
     });
   });

--- a/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as find from 'empathic/find';
+
+import { getProjectRoot } from '../utils/paths.ts';
+import { PNPMProxy } from './PNPMProxy.ts';
+
+vi.mock('node:fs', { spy: true });
+vi.mock('empathic/find', { spy: true });
+vi.mock('../utils/paths.ts', { spy: true });
+vi.mock('storybook/internal/node-logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  prompt: { getPreferredStdio: vi.fn(() => 'inherit') },
+}));
+
+const WORKSPACE_YAML = '/root/pnpm-workspace.yaml';
+
+describe('PNPMProxy catalogs', () => {
+  let pnpmProxy: PNPMProxy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Construct against the real fs before overriding fs/find in individual tests.
+    pnpmProxy = new PNPMProxy();
+    vi.mocked(getProjectRoot).mockReturnValue('/root');
+    vi.mocked(find.up).mockReturnValue(WORKSPACE_YAML);
+    // Never touch the real disk when writing.
+    vi.mocked(writeFileSync).mockImplementation(() => {});
+  });
+
+  describe('getCatalogVersion', () => {
+    it('reads a package version from the default catalog', () => {
+      vi.mocked(readFileSync).mockReturnValue('catalog:\n  vitest: ^3.2.0\n' as any);
+
+      expect(pnpmProxy.getCatalogVersion('vitest')).toBe('^3.2.0');
+    });
+
+    it('reads a package version from a named catalog', () => {
+      vi.mocked(readFileSync).mockReturnValue('catalogs:\n  testing:\n    vitest: ^3.2.0\n' as any);
+
+      expect(pnpmProxy.getCatalogVersion('vitest', 'testing')).toBe('^3.2.0');
+      // The default catalog does not have the entry.
+      expect(pnpmProxy.getCatalogVersion('vitest')).toBeNull();
+    });
+
+    it('returns null when there is no workspace file', () => {
+      vi.mocked(find.up).mockReturnValue(undefined);
+
+      expect(pnpmProxy.getCatalogVersion('vitest')).toBeNull();
+    });
+
+    it('returns null when the entry does not exist', () => {
+      vi.mocked(readFileSync).mockReturnValue('catalog:\n  react: ^18.0.0\n' as any);
+
+      expect(pnpmProxy.getCatalogVersion('vitest')).toBeNull();
+    });
+  });
+
+  describe('syncWorkspaceCatalog', () => {
+    it('adds missing entries to the default catalog and preserves comments', () => {
+      vi.mocked(readFileSync).mockReturnValue(
+        '# my workspace\ncatalog:\n  vitest: ^3.2.0 # pinned\n' as any
+      );
+
+      pnpmProxy.syncWorkspaceCatalog({ '@vitest/coverage-v8': '^3.2.0' });
+
+      expect(writeFileSync).toHaveBeenCalledTimes(1);
+      const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+      expect(written).toContain('# my workspace');
+      expect(written).toContain('vitest: ^3.2.0 # pinned');
+      expect(written).toContain('"@vitest/coverage-v8": ^3.2.0');
+    });
+
+    it('does not override an entry the user already pinned', () => {
+      vi.mocked(readFileSync).mockReturnValue('catalog:\n  "@vitest/coverage-v8": ^3.0.0\n' as any);
+
+      pnpmProxy.syncWorkspaceCatalog({ '@vitest/coverage-v8': '^3.2.0' });
+
+      // Nothing changed, so nothing is written.
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('writes entries into a named catalog', () => {
+      vi.mocked(readFileSync).mockReturnValue('packages:\n  - packages/*\n' as any);
+
+      pnpmProxy.syncWorkspaceCatalog({ '@vitest/coverage-v8': '^3.2.0' }, 'testing');
+
+      const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+      expect(written).toContain('catalogs:');
+      expect(written).toContain('testing:');
+      expect(written).toContain('"@vitest/coverage-v8": ^3.2.0');
+    });
+
+    it('warns and does not write when there is no workspace file', () => {
+      vi.mocked(find.up).mockReturnValue(undefined);
+
+      pnpmProxy.syncWorkspaceCatalog({ '@vitest/coverage-v8': '^3.2.0' });
+
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -12,6 +12,7 @@ import * as find from 'empathic/find';
 // eslint-disable-next-line depend/ban-dependencies
 import type { ResultPromise } from 'execa';
 import { dedent } from 'ts-dedent';
+import { parseDocument } from 'yaml';
 
 import type { ExecuteCommandOptions } from '../utils/command.ts';
 import { executeCommand } from '../utils/command.ts';
@@ -217,6 +218,74 @@ export class PNPMProxy extends JsPackageManager {
         ...versions,
       },
     };
+  }
+
+  /**
+   * Locate the `pnpm-workspace.yaml` that governs this project's catalogs, walking up from the
+   * package.json we operate on. Catalogs are only valid inside a pnpm workspace, so a `catalog:`
+   * specifier implies this file exists somewhere up the tree.
+   */
+  #findWorkspaceYaml(): string | undefined {
+    return find.up('pnpm-workspace.yaml', {
+      cwd: this.primaryPackageJson.operationDir,
+      last: getProjectRoot(),
+    });
+  }
+
+  /**
+   * The key path within a parsed `pnpm-workspace.yaml` for a catalog. The default catalog (referenced
+   * as `catalog:` or `catalog:default`) lives under the top-level `catalog` key; named catalogs live
+   * under `catalogs.<name>`.
+   */
+  #catalogKeyPath(catalogName?: string): string[] {
+    return !catalogName || catalogName === 'default' ? ['catalog'] : ['catalogs', catalogName];
+  }
+
+  override getCatalogVersion(packageName: string, catalogName?: string): string | null {
+    const workspaceYamlPath = this.#findWorkspaceYaml();
+    if (!workspaceYamlPath) {
+      return null;
+    }
+    try {
+      const doc = parseDocument(readFileSync(workspaceYamlPath, 'utf8'));
+      const version = doc.getIn([...this.#catalogKeyPath(catalogName), packageName]);
+      return typeof version === 'string' ? version : null;
+    } catch (e) {
+      logger.debug(`Could not read pnpm catalog from ${workspaceYamlPath}: ${String(e)}`);
+      return null;
+    }
+  }
+
+  override syncWorkspaceCatalog(entries: Record<string, string>, catalogName?: string): void {
+    const workspaceYamlPath = this.#findWorkspaceYaml();
+    if (!workspaceYamlPath) {
+      logger.warn(
+        `Could not find pnpm-workspace.yaml to register catalog entries for: ${Object.keys(entries).join(', ')}`
+      );
+      return;
+    }
+
+    try {
+      // Edit the document (rather than re-serializing a parsed object) so existing formatting and
+      // comments in the user's workspace file are preserved.
+      const doc = parseDocument(readFileSync(workspaceYamlPath, 'utf8'));
+      const keyPath = this.#catalogKeyPath(catalogName);
+      let changed = false;
+
+      for (const [packageName, version] of Object.entries(entries)) {
+        // Never override an entry the user already pinned themselves.
+        if (doc.getIn([...keyPath, packageName]) === undefined) {
+          doc.setIn([...keyPath, packageName], version);
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        writeFileSync(workspaceYamlPath, doc.toString(), 'utf8');
+      }
+    } catch (e) {
+      logger.warn(`Could not update pnpm catalog in ${workspaceYamlPath}: ${String(e)}`);
+    }
   }
 
   protected runInstall(options?: { force?: boolean }) {

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -11,9 +11,8 @@ import {
 import * as find from 'empathic/find';
 // eslint-disable-next-line depend/ban-dependencies
 import type { ResultPromise } from 'execa';
-import { validRange } from 'semver';
 import { dedent } from 'ts-dedent';
-import { parseDocument } from 'yaml';
+import { type Document, parseDocument } from 'yaml';
 
 import type { ExecuteCommandOptions } from '../utils/command.ts';
 import { executeCommand } from '../utils/command.ts';
@@ -222,16 +221,25 @@ export class PNPMProxy extends JsPackageManager {
   }
 
   override async getDeclaredVersionSpecifier(packageName: string): Promise<string | null> {
-    const installed = await this.getInstalledVersion(packageName);
-    if (installed) {
-      return installed;
+    const specifier = await super.getDeclaredVersionSpecifier(packageName);
+    if (specifier) {
+      return specifier;
     }
-    const declared = this.getAllDependencies()[packageName];
-    const catalogName = this.#getCatalogName(declared);
-    if (catalogName !== null) {
-      return this.#getCatalogVersion(packageName, catalogName);
+    const catalogName = this.#getCatalogName(this.getAllDependencies()[packageName]);
+    if (catalogName === null) {
+      return null;
     }
-    return declared && validRange(declared) ? declared : null;
+    const workspace = this.#readWorkspaceYaml();
+    if (!workspace) {
+      return null;
+    }
+    const version = workspace.doc.getIn([
+      ...this.#catalogKeyPath(workspace.doc, catalogName),
+      packageName,
+    ]);
+    // Catalog pins are strings, but YAML parses a bare numeric range like `vitest: 4` as a number.
+    // Accept those too rather than silently dropping the pin.
+    return typeof version === 'string' || typeof version === 'number' ? String(version) : null;
   }
 
   override applyVersionToRelatedPackages(
@@ -240,28 +248,18 @@ export class PNPMProxy extends JsPackageManager {
     anchorPackage: string
   ): string[] {
     const catalogName = this.#getCatalogName(this.getAllDependencies()[anchorPackage]);
-    if (catalogName === null) {
-      return super.applyVersionToRelatedPackages(packages, version, anchorPackage);
+    // When the anchor (e.g. vitest) is declared through a catalog, mirror that: register the
+    // packages in the same catalog and reference it from package.json. Copying the raw `catalog:`
+    // specifier without registering would fail install, since no such catalog entry exists. If the
+    // catalog cannot be updated, fall back to direct pins, which always install.
+    if (
+      catalogName !== null &&
+      this.#registerCatalogEntries(packages, version, anchorPackage, catalogName)
+    ) {
+      return packages.map((pkg) => `${pkg}@catalog:${catalogName}`);
     }
-    // The anchor (e.g. vitest) is declared through a catalog, so mirror that: register the packages
-    // in the same catalog and reference it from package.json. Copying the raw `catalog:` specifier
-    // without registering would fail install, since no such catalog entry exists.
-    this.#syncWorkspaceCatalog(
-      Object.fromEntries(packages.map((pkg) => [pkg, version])),
-      catalogName
-    );
-    return packages.map((pkg) => `${pkg}@catalog:${catalogName}`);
+    return super.applyVersionToRelatedPackages(packages, version, anchorPackage);
   }
-
-  /**
-   * Catalog helpers edit `pnpm-workspace.yaml` directly via the `yaml` document API, unlike the
-   * `minimumReleaseAge*` settings above which go through `pnpm config get/set`. This is deliberate:
-   * `pnpm config` rejects scoped keys (`pnpm config set catalog.@vitest/coverage-v8 …` →
-   * `ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH`), and `pnpm add --save-catalog` writes a resolved
-   * direct version instead of `catalog:` whenever the requested range doesn't match an existing
-   * entry — so neither CLI path can deterministically register a scoped `catalog:` reference.
-   * Editing the parsed document keeps it deterministic, offline, and preserves the user's comments.
-   */
 
   /**
    * If `specifier` is a pnpm catalog reference (`catalog:` / `catalog:<name>`), return the catalog
@@ -273,72 +271,89 @@ export class PNPMProxy extends JsPackageManager {
   }
 
   /**
-   * Locate the `pnpm-workspace.yaml` that governs this project's catalogs, walking up from the
-   * package.json we operate on. Catalogs are only valid inside a pnpm workspace, so a `catalog:`
-   * specifier implies this file exists somewhere up the tree.
+   * Locate and parse the `pnpm-workspace.yaml` that governs this project's catalogs, walking up
+   * from the package.json we operate on. Returns null when the file is missing or malformed.
    */
-  #findWorkspaceYaml(): string | undefined {
-    return find.up('pnpm-workspace.yaml', {
+  #readWorkspaceYaml(): { path: string; doc: Document } | null {
+    const path = find.up('pnpm-workspace.yaml', {
       cwd: this.primaryPackageJson.operationDir,
       last: getProjectRoot(),
     });
+    if (!path) {
+      return null;
+    }
+    try {
+      const doc = parseDocument(readFileSync(path, 'utf8'));
+      if (doc.errors.length > 0) {
+        throw doc.errors[0];
+      }
+      return { path, doc };
+    } catch (e) {
+      logger.debug(`Could not read pnpm workspace file ${path}: ${String(e)}`);
+      return null;
+    }
   }
 
   /**
-   * The key path within a parsed `pnpm-workspace.yaml` for a catalog. The default catalog (referenced
-   * as `catalog:` or `catalog:default`) lives under the top-level `catalog` key; named catalogs live
-   * under `catalogs.<name>`.
+   * The key path within a parsed `pnpm-workspace.yaml` for a catalog. Named catalogs live under
+   * `catalogs.<name>`. The default catalog (referenced as `catalog:` or `catalog:default`) may be
+   * defined either as top-level `catalog` or as `catalogs.default` — defining both is a pnpm config
+   * error, so follow whichever form the workspace already uses.
    */
-  #catalogKeyPath(catalogName?: string): string[] {
-    return !catalogName || catalogName === 'default' ? ['catalog'] : ['catalogs', catalogName];
+  #catalogKeyPath(doc: Document, catalogName: string): string[] {
+    if (catalogName && catalogName !== 'default') {
+      return ['catalogs', catalogName];
+    }
+    return doc.hasIn(['catalogs', 'default']) ? ['catalogs', 'default'] : ['catalog'];
   }
 
-  #getCatalogVersion(packageName: string, catalogName?: string): string | null {
-    const workspaceYamlPath = this.#findWorkspaceYaml();
-    if (!workspaceYamlPath) {
-      return null;
-    }
-    try {
-      const doc = parseDocument(readFileSync(workspaceYamlPath, 'utf8'));
-      const version = doc.getIn([...this.#catalogKeyPath(catalogName), packageName]);
-      // Catalog pins are strings, but YAML parses a bare numeric range like `vitest: 4` as a number.
-      // Accept those too rather than silently dropping the pin.
-      return typeof version === 'string' || typeof version === 'number' ? String(version) : null;
-    } catch (e) {
-      logger.debug(`Could not read pnpm catalog from ${workspaceYamlPath}: ${String(e)}`);
-      return null;
-    }
-  }
-
-  #syncWorkspaceCatalog(entries: Record<string, string>, catalogName?: string): void {
-    const workspaceYamlPath = this.#findWorkspaceYaml();
-    if (!workspaceYamlPath) {
+  /**
+   * Register `packages` in the same catalog as `anchorPackage`, editing `pnpm-workspace.yaml` via
+   * the `yaml` document API so the user's comments and formatting are preserved. The pnpm CLI can't
+   * do this: `pnpm config set` rejects scoped keys and `pnpm add --save-catalog` writes a resolved
+   * direct version whenever the requested range doesn't match an existing entry. Entries the user
+   * already pinned are never overridden. Returns whether the entries are now present, i.e. whether
+   * `catalog:` references to them will resolve.
+   */
+  #registerCatalogEntries(
+    packages: string[],
+    version: string,
+    anchorPackage: string,
+    catalogName: string
+  ): boolean {
+    const workspace = this.#readWorkspaceYaml();
+    if (!workspace) {
       logger.warn(
-        `Could not find pnpm-workspace.yaml to register catalog entries for: ${Object.keys(entries).join(', ')}`
+        `Could not read pnpm-workspace.yaml to register catalog entries for: ${packages.join(', ')}`
       );
-      return;
+      return false;
     }
-
     try {
-      // Edit the document (rather than re-serializing a parsed object) so existing formatting and
-      // comments in the user's workspace file are preserved.
-      const doc = parseDocument(readFileSync(workspaceYamlPath, 'utf8'));
-      const keyPath = this.#catalogKeyPath(catalogName);
+      const keyPath = this.#catalogKeyPath(workspace.doc, catalogName);
+      // Reuse the anchor's own catalog entry when present (e.g. `^3.2.0`) so the new entries match
+      // the format the user chose, rather than an exact installed version.
+      const anchorVersion = workspace.doc.getIn([...keyPath, anchorPackage]);
+      const entryVersion =
+        typeof anchorVersion === 'string' || typeof anchorVersion === 'number'
+          ? String(anchorVersion)
+          : version;
       let changed = false;
 
-      for (const [packageName, version] of Object.entries(entries)) {
+      for (const pkg of packages) {
         // Never override an entry the user already pinned themselves.
-        if (doc.getIn([...keyPath, packageName]) === undefined) {
-          doc.setIn([...keyPath, packageName], version);
+        if (workspace.doc.getIn([...keyPath, pkg]) === undefined) {
+          workspace.doc.setIn([...keyPath, pkg], entryVersion);
           changed = true;
         }
       }
 
       if (changed) {
-        writeFileSync(workspaceYamlPath, doc.toString(), 'utf8');
+        writeFileSync(workspace.path, workspace.doc.toString(), 'utf8');
       }
+      return true;
     } catch (e) {
-      logger.warn(`Could not update pnpm catalog in ${workspaceYamlPath}: ${String(e)}`);
+      logger.warn(`Could not update pnpm catalog in ${workspace.path}: ${String(e)}`);
+      return false;
     }
   }
 

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -249,7 +249,9 @@ export class PNPMProxy extends JsPackageManager {
     try {
       const doc = parseDocument(readFileSync(workspaceYamlPath, 'utf8'));
       const version = doc.getIn([...this.#catalogKeyPath(catalogName), packageName]);
-      return typeof version === 'string' ? version : null;
+      // Catalog pins are strings, but YAML parses a bare numeric range like `vitest: 4` as a number.
+      // Accept those too rather than silently dropping the pin.
+      return typeof version === 'string' || typeof version === 'number' ? String(version) : null;
     } catch (e) {
       logger.debug(`Could not read pnpm catalog from ${workspaceYamlPath}: ${String(e)}`);
       return null;

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -221,6 +221,16 @@ export class PNPMProxy extends JsPackageManager {
   }
 
   /**
+   * Catalog helpers edit `pnpm-workspace.yaml` directly via the `yaml` document API, unlike the
+   * `minimumReleaseAge*` settings above which go through `pnpm config get/set`. This is deliberate:
+   * `pnpm config` rejects scoped keys (`pnpm config set catalog.@vitest/coverage-v8 …` →
+   * `ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH`), and `pnpm add --save-catalog` writes a resolved
+   * direct version instead of `catalog:` whenever the requested range doesn't match an existing
+   * entry — so neither CLI path can deterministically register a scoped `catalog:` reference.
+   * Editing the parsed document keeps it deterministic, offline, and preserves the user's comments.
+   */
+
+  /**
    * Locate the `pnpm-workspace.yaml` that governs this project's catalogs, walking up from the
    * package.json we operate on. Catalogs are only valid inside a pnpm workspace, so a `catalog:`
    * specifier implies this file exists somewhere up the tree.

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -11,6 +11,7 @@ import {
 import * as find from 'empathic/find';
 // eslint-disable-next-line depend/ban-dependencies
 import type { ResultPromise } from 'execa';
+import { validRange } from 'semver';
 import { dedent } from 'ts-dedent';
 import { parseDocument } from 'yaml';
 
@@ -220,6 +221,38 @@ export class PNPMProxy extends JsPackageManager {
     };
   }
 
+  override async getDeclaredVersionSpecifier(packageName: string): Promise<string | null> {
+    const installed = await this.getInstalledVersion(packageName);
+    if (installed) {
+      return installed;
+    }
+    const declared = this.getAllDependencies()[packageName];
+    const catalogName = this.#getCatalogName(declared);
+    if (catalogName !== null) {
+      return this.#getCatalogVersion(packageName, catalogName);
+    }
+    return declared && validRange(declared) ? declared : null;
+  }
+
+  override applyVersionToRelatedPackages(
+    packages: string[],
+    version: string,
+    anchorPackage: string
+  ): string[] {
+    const catalogName = this.#getCatalogName(this.getAllDependencies()[anchorPackage]);
+    if (catalogName === null) {
+      return super.applyVersionToRelatedPackages(packages, version, anchorPackage);
+    }
+    // The anchor (e.g. vitest) is declared through a catalog, so mirror that: register the packages
+    // in the same catalog and reference it from package.json. Copying the raw `catalog:` specifier
+    // without registering would fail install, since no such catalog entry exists.
+    this.#syncWorkspaceCatalog(
+      Object.fromEntries(packages.map((pkg) => [pkg, version])),
+      catalogName
+    );
+    return packages.map((pkg) => `${pkg}@catalog:${catalogName}`);
+  }
+
   /**
    * Catalog helpers edit `pnpm-workspace.yaml` directly via the `yaml` document API, unlike the
    * `minimumReleaseAge*` settings above which go through `pnpm config get/set`. This is deliberate:
@@ -229,6 +262,15 @@ export class PNPMProxy extends JsPackageManager {
    * entry — so neither CLI path can deterministically register a scoped `catalog:` reference.
    * Editing the parsed document keeps it deterministic, offline, and preserves the user's comments.
    */
+
+  /**
+   * If `specifier` is a pnpm catalog reference (`catalog:` / `catalog:<name>`), return the catalog
+   * name (`''` for the default catalog); otherwise return null.
+   */
+  #getCatalogName(specifier: string | undefined): string | null {
+    const match = specifier?.match(/^catalog:(.*)$/);
+    return match ? match[1].trim() : null;
+  }
 
   /**
    * Locate the `pnpm-workspace.yaml` that governs this project's catalogs, walking up from the
@@ -251,7 +293,7 @@ export class PNPMProxy extends JsPackageManager {
     return !catalogName || catalogName === 'default' ? ['catalog'] : ['catalogs', catalogName];
   }
 
-  override getCatalogVersion(packageName: string, catalogName?: string): string | null {
+  #getCatalogVersion(packageName: string, catalogName?: string): string | null {
     const workspaceYamlPath = this.#findWorkspaceYaml();
     if (!workspaceYamlPath) {
       return null;
@@ -268,7 +310,7 @@ export class PNPMProxy extends JsPackageManager {
     }
   }
 
-  override syncWorkspaceCatalog(entries: Record<string, string>, catalogName?: string): void {
+  #syncWorkspaceCatalog(entries: Record<string, string>, catalogName?: string): void {
     const workspaceYamlPath = this.#findWorkspaceYaml();
     if (!workspaceYamlPath) {
       logger.warn(

--- a/code/lib/create-storybook/src/commands/DependencyInstallationCommand.ts
+++ b/code/lib/create-storybook/src/commands/DependencyInstallationCommand.ts
@@ -83,7 +83,11 @@ export class DependencyInstallationCommand {
     return { status: 'success' };
   }
 
-  /** Collect addon dependencies without installing them */
+  /**
+   * Collect addon dependencies (the caller adds them to package.json and installs them afterwards).
+   * For pnpm catalog workspaces this also registers the derived entries in pnpm-workspace.yaml so
+   * the subsequent install can resolve their `catalog:` specifiers.
+   */
   private async collectAddonDependencies(selectedFeatures: Set<Feature>): Promise<void> {
     try {
       if (selectedFeatures.has(Feature.TEST)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -31401,6 +31401,7 @@ __metadata:
     watchpack: "npm:^2.5.0"
     wrap-ansi: "npm:^9.0.2"
     ws: "npm:^8.18.0"
+    yaml: "npm:^2.8.2"
     zod: "npm:^3.25.76"
   peerDependencies:
     "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed `storybook init` breaking pnpm **catalog** workspaces. When `vitest` was declared via a pnpm catalog (`"vitest": "catalog:"`), the addon-vitest setup copied the raw `catalog:` specifier onto derived packages like `@vitest/coverage-v8`, writing `"@vitest/coverage-v8": "catalog:"` into `package.json`. Because no such catalog entry exists, `pnpm install` failed with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC`, which in turn made `@storybook/addon-vitest` and `@storybook/addon-a11y` setup fail.

Now the initializer honors the project's catalog convention end-to-end:

- Detects when `vitest` is declared as `catalog:` / `catalog:<name>` and resolves its concrete version from the installed version or the catalog entry itself (this also fixes a secondary bug where a catalog spec silently defaulted to the "Vitest 4" branch and picked the wrong browser package).
- Writes a `catalog:` reference in `package.json` for the derived `@vitest/*` packages (matching the project's convention).
- Registers those packages in `pnpm-workspace.yaml`, preserving existing comments and formatting via the `yaml` document API, and **never** overrides a version the user already pinned. New entries reuse the format of the user's own `vitest` entry (e.g. `^3.2.0` rather than an exact installed version). Both forms of the default catalog are supported (top-level `catalog` and `catalogs.default` — pnpm forbids defining both, so the existing form is followed).
- Falls back to direct version pins (or bare package names when no version can be resolved) whenever the catalog can't be used — workspace file missing, malformed, or unwritable — so install always succeeds.

New surface area:

- `JsPackageManager.getDeclaredVersionSpecifier()` — installed version, else the declared semver range. `PNPMProxy` overrides it to also resolve `catalog:` references from `pnpm-workspace.yaml`.
- `JsPackageManager.applyVersionToRelatedPackages()` — pins each package directly (`pkg@version`). `PNPMProxy` overrides it to register the packages in the anchor's catalog and return `catalog:` references instead.
- `AddonVitestService.getComparableVersion()` — shared Vitest major-version detection between postinstall template selection and dependency collection.
- Added `yaml` as a bundled devDependency of `storybook` (core).

### Repro (before this PR)

1. In a pnpm workspace using catalogs (`vitest` declared as `catalog:` in `pnpm-workspace.yaml`), run `pnpm create storybook@latest` inside a package (e.g. `packages/react`).
2. It writes `"@vitest/coverage-v8": "catalog:"` into the package's `package.json`.
3. `pnpm install` fails with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC`.
4. addon-vitest and addon-a11y are reported as "Failed to configure addons".

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Create a pnpm workspace that uses catalogs. In `pnpm-workspace.yaml`:
   ```yaml
   packages:
     - packages/*
   catalog:
     vitest: ^3.2.0
   ```
   and a package (e.g. `packages/react/package.json`) that declares `"vitest": "catalog:"` in `devDependencies`. Run `pnpm install`.
2. From that package directory, run `storybook init` (using this branch's canary, e.g. `pnpm create storybook@<canary>` or `npx storybook@<canary> init`), enabling `@storybook/addon-vitest`.
3. Verify the package's `package.json` gets `"@vitest/coverage-v8": "catalog:"` (and `@vitest/browser`) — **not** a broken value.
4. Verify `pnpm-workspace.yaml` now has `@vitest/coverage-v8` (and `@vitest/browser`) under the `catalog:` section, with a version matching vitest — and that existing comments/formatting are preserved.
5. Verify `pnpm install` succeeds (no `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC`) and addon-vitest / addon-a11y configure successfully.
6. Optionally repeat with the default catalog defined under `catalogs.default` instead of top-level `catalog:` — the new entries should land under `catalogs.default` (no top-level `catalog` key should be created).
7. Sanity check the non-catalog path is unchanged: repeat in a plain (non-catalog) pnpm/npm/yarn project and confirm the `@vitest/*` packages are still pinned to vitest's version as before.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35415-sha-4034979a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35415-sha-4034979a sandbox` or in an existing project with `npx storybook@0.0.0-pr-35415-sha-4034979a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35415-sha-4034979a`](https://npmjs.com/package/storybook/v/0.0.0-pr-35415-sha-4034979a) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`fix/init-pnpm-catalog-vitest`](https://github.com/storybookjs/storybook/tree/fix/init-pnpm-catalog-vitest) |
| **Commit** | [`4034979a`](https://github.com/storybookjs/storybook/commit/4034979af64a810ec711696963cb6f4bedc11bea) |
| **Datetime** | Thu Jul  9 10:27:50 UTC 2026 (`1783592870`) |
| **Workflow run** | [29011641666](https://github.com/storybookjs/storybook/actions/runs/29011641666) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35415`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pnpm workspace catalog support for Vitest dependency management, including catalog-aware Vitest version resolution and registration of related `@vitest/*` packages into the appropriate catalog.
* **Bug Fixes**
  * Improved Vitest compatibility selection and version pinning by deriving from the declared Vitest specifier, normalizing version/range comparisons, and safely falling back when the specifier can’t be resolved.
* **Tests**
  * Expanded coverage for declared-version resolution (including numeric YAML pins), catalog syncing without overwriting existing user pins, and version comparison edge cases.
* **Documentation**
  * Clarified addon dependency collection behavior alongside installation and catalog registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
