### PR TITLE
Review: Serialize preview boots to fix blank review thumbnails

### DIFF
--- a/code/core/src/manager/components/review/components/CollectionGrid.tsx
+++ b/code/core/src/manager/components/review/components/CollectionGrid.tsx
@@ -256,7 +256,6 @@ const StoryPreviewCell: FC<{
         data-content-height={rememberedDimensions?.height}
         tabIndex={-1}
         scrolling="no"
-        onLoad={finishCurrent}
         onError={finishCurrent}
       />
     </div>

--- a/code/core/src/manager/components/review/components/previewScheduler.test.ts
+++ b/code/core/src/manager/components/review/components/previewScheduler.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The scheduler keeps module-level state (active count, queue), so each test loads a fresh copy
+// under fake timers.
+const loadScheduler = async () => import('./previewScheduler.ts');
+
+describe('previewScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts the first preview immediately', async () => {
+    const { enqueuePreview } = await loadScheduler();
+    const start = vi.fn();
+    enqueuePreview(start);
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('boots one preview at a time', async () => {
+    const { enqueuePreview } = await loadScheduler();
+    const a = vi.fn();
+    const b = vi.fn();
+    const c = vi.fn();
+    enqueuePreview(a);
+    enqueuePreview(b);
+    enqueuePreview(c);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).not.toHaveBeenCalled();
+    expect(c).not.toHaveBeenCalled();
+  });
+
+  it('starts the next queued preview only when the current slot is released', async () => {
+    const { enqueuePreview } = await loadScheduler();
+    const a = vi.fn();
+    const b = vi.fn();
+    const handleA = enqueuePreview(a);
+    enqueuePreview(b);
+
+    expect(b).not.toHaveBeenCalled();
+    handleA.release();
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('releasing is idempotent and does not over-start the queue', async () => {
+    const { enqueuePreview } = await loadScheduler();
+    const a = vi.fn();
+    const b = vi.fn();
+    const c = vi.fn();
+    const handleA = enqueuePreview(a);
+    enqueuePreview(b);
+    enqueuePreview(c);
+
+    handleA.release();
+    handleA.release();
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(c).not.toHaveBeenCalled();
+  });
+
+  it('auto-releases a wedged slot after the backstop deadline', async () => {
+    const { enqueuePreview, PREVIEW_SETTLE_TIMEOUT_MS } = await loadScheduler();
+    const a = vi.fn();
+    const b = vi.fn();
+    enqueuePreview(a);
+    enqueuePreview(b);
+
+    expect(b).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(PREVIEW_SETTLE_TIMEOUT_MS);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('forceStart bypasses the cap for a still-queued preview', async () => {
+    const { enqueuePreview } = await loadScheduler();
+    const a = vi.fn();
+    const b = vi.fn();
+    enqueuePreview(a);
+    const handleB = enqueuePreview(b);
+
+    expect(b).not.toHaveBeenCalled();
+    handleB.forceStart();
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/code/core/src/manager/components/review/components/previewScheduler.ts
+++ b/code/core/src/manager/components/review/components/previewScheduler.ts
@@ -1,18 +1,23 @@
-// Caps concurrent preview iframe boots across the review grid: booting many
-// embed iframes at once can fail with `net::ERR_INSUFFICIENT_RESOURCES`.
-const MAX_CONCURRENT_PREVIEWS = 3;
+// Serializes preview iframe boots across the review grid. Several same-origin embeds that boot at
+// the same time race each other during the preview runtime's top-level initialization and some lose
+// and never construct their preview runtime, leaving a blank thumbnail. Booting one at a time avoids
+// the race entirely; a lone boot always succeeds. The slot is held until the consumer signals the
+// preview actually booted (or the backstop deadline fires), NOT when the iframe document loads, so
+// the next boot never overlaps one still coming up.
+const MAX_CONCURRENT_PREVIEWS = 1;
 
 /**
- * How long a started preview may hold its concurrency slot. The iframe's load/error events release
- * the slot earlier; this deadline keeps the queue draining when neither fires.
+ * How long a started preview may hold its concurrency slot before it is released regardless. The
+ * consumer releases earlier once the preview runtime boots; this backstop keeps the queue draining
+ * if a preview never comes up. Generous enough to cover a cold boot.
  */
-export const PREVIEW_SETTLE_TIMEOUT_MS = 1500;
+export const PREVIEW_SETTLE_TIMEOUT_MS = 10000;
 
 /** Handle for a scheduled preview boot, returned by `enqueuePreview`. */
 export interface PreviewHandle {
   /** Hover/focus: start a still-queued preview right away, bypassing the cap. */
   forceStart: () => void;
-  /** Release the concurrency slot (iframe loaded/errored/unmounted). Idempotent. */
+  /** Release the concurrency slot (preview booted, gave up, errored, or unmounted). Idempotent. */
   release: () => void;
 }
 
@@ -54,7 +59,9 @@ function releaseTask(task: Task): void {
 
 /**
  * Queue a preview boot. `start` runs (synchronously or later) once a concurrency slot frees up. The
- * slot is held until `release()` or the settle deadline, whichever comes first.
+ * slot is held until `release()` or the settle deadline, whichever comes first. Because only one
+ * preview boots at a time, the consumer must call `release()` when the preview has booted so the
+ * next queued preview can begin.
  */
 export function enqueuePreview(start: () => void): PreviewHandle {
   const task: Task = { start, state: 'queued' };

--- a/code/core/src/manager/components/review/components/usePreviewThumbnail.ts
+++ b/code/core/src/manager/components/review/components/usePreviewThumbnail.ts
@@ -14,8 +14,8 @@ import {
   type IframeResizeDimensions,
 } from '../../../../shared/constants/iframe-resize.ts';
 import {
-  PREVIEW_SETTLE_TIMEOUT_MS,
   enqueuePreview,
+  PREVIEW_SETTLE_TIMEOUT_MS,
   type PreviewHandle,
 } from './previewScheduler.ts';
 import {
@@ -24,11 +24,25 @@ import {
   thumbnailReducer,
 } from './previewThumbnailState.ts';
 
+/** If iframe.resize never arrives, clear the spinner anyway. */
+const PREVIEW_SCALE_SETTLE_FALLBACK_MS = 4500;
+
+/** How often to poll a booting frame so its scheduler slot is released the moment it comes up. */
+const PREVIEW_BOOT_POLL_MS = 150;
+
 /**
- * If iframe.resize never arrives, clear the spinner anyway. 3× the scheduler slot deadline so even
- * a boot that spent a full queue round waiting still gets time to report.
+ * A booted preview constructs `__STORYBOOK_PREVIEW__` on its window early (before the story renders),
+ * so its presence marks the boot as complete. Same-origin embeds can be inspected; a cross-origin
+ * embed throws, in which case we assume booted so the scheduler slot is never held indefinitely.
  */
-const PREVIEW_SCALE_SETTLE_FALLBACK_MS = PREVIEW_SETTLE_TIMEOUT_MS * 3;
+const previewRuntimeBooted = (iframe: HTMLIFrameElement | null): boolean => {
+  try {
+    return !!(iframe?.contentWindow as unknown as { __STORYBOOK_PREVIEW__?: unknown })
+      ?.__STORYBOOK_PREVIEW__;
+  } catch {
+    return true;
+  }
+};
 
 // IntersectionObserver `rootMargin`s for the preview lifecycle: mount a cell's
 // iframe well before it scrolls into view, evict it only much further out.
@@ -143,12 +157,48 @@ export const usePreviewThumbnail = ({
     };
   }, [isInView, storyId, getPreviewHref]);
 
+  // Boots are serialized (one scheduler slot), so this frame is the only one coming up. Hold the
+  // slot until the preview runtime is constructed, then release it so the next queued preview
+  // begins; the scheduler's own deadline is the backstop if the runtime never comes up. The
+  // fallback only clears the spinner so a frame that renders without reporting its size still shows.
   useEffect(() => {
     if (!src) {
       return undefined;
     }
-    const timer = setTimeout(() => dispatch({ type: 'settled' }), PREVIEW_SCALE_SETTLE_FALLBACK_MS);
-    return () => clearTimeout(timer);
+    let pollTimer = 0;
+    let released = false;
+    // Stop polling once the scheduler's own deadline would have released the slot anyway.
+    let pollsLeft = Math.ceil(PREVIEW_SETTLE_TIMEOUT_MS / PREVIEW_BOOT_POLL_MS);
+
+    const releaseSlot = () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      handleRef.current?.release();
+    };
+
+    const pollBoot = () => {
+      if (previewRuntimeBooted(iframeRef.current)) {
+        releaseSlot();
+        return;
+      }
+      if (pollsLeft-- <= 0) {
+        return;
+      }
+      pollTimer = window.setTimeout(pollBoot, PREVIEW_BOOT_POLL_MS);
+    };
+
+    const fallbackTimer = window.setTimeout(
+      () => dispatch({ type: 'settled' }),
+      PREVIEW_SCALE_SETTLE_FALLBACK_MS
+    );
+    pollBoot();
+
+    return () => {
+      window.clearTimeout(pollTimer);
+      window.clearTimeout(fallbackTimer);
+    };
   }, [bootId, src]);
 
   const handleResize = useCallback((dimensions: IframeResizeDimensions) => {


### PR DESCRIPTION
Closes #35442

## What I did

Fixes **blank thumbnails on the review page**. When the review grid mounts several preview embeds at once, some iframes stay white; visiting the story directly always works, and collapsing/reopening the group makes some render.

**Root cause** (bisected on a blanked iframe): a **concurrency race in the preview boot**. All modules fetch successfully, but a losing iframe stalls during **evaluation of its first import**, `storybook/internal/preview/runtime` — none of the `__STORYBOOK_MODULE_*` globals that module installs are present (a booted iframe has all of them), and no error is thrown. So the core preview runtime's top-level init never completes under concurrent same-origin boots, `PreviewWeb` is never constructed, and the frame stays blank. A lone boot always succeeds. (Not dep optimization, a network failure, a service worker, a Web Lock, or the open-service `sync-start` handshake — that runs from `beforeAll`, after `PreviewWeb` exists.)

**Fix: boot previews one at a time.**
- `previewScheduler.ts` — `MAX_CONCURRENT_PREVIEWS = 1`; the slot is held until the consumer signals the preview actually booted (or a backstop deadline), so the next boot never overlaps one still initializing.
- `usePreviewThumbnail.ts` — the consumer polls `__STORYBOOK_PREVIEW__` and releases the slot the moment the runtime is constructed (so the next boot starts without waiting for this story to finish rendering).
- `CollectionGrid.tsx` — removed the `onLoad` slot release; freeing the slot on document load was premature and let the next boot overlap.

Because serialization removes the race entirely, no reload/retry recovery is needed — a single in-flight boot always comes up.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`previewScheduler.test.ts` covers serialized start, release-driven queue draining, the backstop deadline, and `forceStart`.

#### Manual testing

1. Run a sandbox with several stories, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`.
2. Clear the Vite cache for a cold start: `rm -rf node_modules/.cache/storybook node_modules/.vite` in the sandbox.
3. Open Storybook and start a review that includes 3+ stories so the grid mounts several embeds at once.
4. Every thumbnail should render; none should stay blank.
5. Reload the review page a few times (cold and warm): all thumbnails come up on each load.

### Documentation

- [ ] Add or update documentation reflecting your changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview thumbnails now load more reliably and avoid getting stuck during startup.
  * Preview rendering is now processed one at a time, reducing race conditions and inconsistent thumbnail states.
  * If a preview iframe fails to load or never finishes initializing, the UI now recovers more gracefully and clears the loading state sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->