### PR TITLE
Generic heartbeat hardening on top of the Vitest addon timeout fix

### DIFF
--- a/code/addons/vitest/src/constants.ts
+++ b/code/addons/vitest/src/constants.ts
@@ -33,6 +33,14 @@ export const DEFAULT_TEST_STATUS_FLUSH_INTERVAL = 500;
  */
 export const TEST_STATUS_FLUSH_INTERVAL_ENV_VAR = 'STORYBOOK_TEST_STATUS_FLUSH_INTERVAL';
 
+/**
+ * Maximum number of batched test-case results applied per flush. Bounds how large a single flush's
+ * status-store update (and the resulting outgoing channel message) can grow, so a run that produces
+ * results faster than they're flushed can't turn into one oversized synchronous burst - the backlog
+ * is drained in bounded slices across subsequent flushes instead.
+ */
+export const DEFAULT_MAX_TEST_CASE_RESULTS_PER_FLUSH = 200;
+
 export const storeOptions = {
   id: ADDON_ID,
   initialState: {

--- a/code/addons/vitest/src/node/reporter.ts
+++ b/code/addons/vitest/src/node/reporter.ts
@@ -46,7 +46,7 @@ export class StorybookReporter implements Reporter {
         cause: e.cause,
       };
     });
-    this.testManager.onTestRunEnd({
+    await this.testManager.onTestRunEnd({
       totalTestCount,
       unhandledErrors: serializedErrors as unknown as VitestError[],
     });

--- a/code/addons/vitest/src/node/test-manager.test.ts
+++ b/code/addons/vitest/src/node/test-manager.test.ts
@@ -545,6 +545,118 @@ describe('TestManager', () => {
     }
   });
 
+  it('drains at most one bounded chunk per elapsed interval, never cascading through a backlog in one synchronous burst', () => {
+    vi.useFakeTimers();
+    try {
+      const testManager = new TestManager({
+        ...options,
+        flushTestCaseResultsInterval: 500,
+        maxTestCaseResultsPerFlush: 2,
+      });
+      const passedResult = { state: 'passed', errors: [] } as unknown as TestResult;
+      // 3x the cap, pushed synchronously in a burst - enough that a reentrant continuation (e.g. one
+      // that re-arms via the throttle instead of a real event-loop tick) would drain more than one
+      // extra chunk here.
+      const storyIds = [
+        'story--one',
+        'story--two',
+        'another--one',
+        'another--two',
+        'parent--story',
+        'parent--story:test',
+      ];
+      storyIds.forEach((storyId) => {
+        testManager.onTestCaseResult({ storyId, testResult: passedResult });
+      });
+
+      const setMock = vi.mocked(mockComponentTestStatusStore.set);
+      // Leading edge: only the first pushed result was in the batch at the moment the throttle fired.
+      expect(setMock).toHaveBeenCalledTimes(1);
+
+      // A single elapsed interval must drain exactly one more bounded chunk, not the rest of the
+      // backlog in the same synchronous callback.
+      vi.advanceTimersByTime(500);
+      expect(setMock).toHaveBeenCalledTimes(2);
+      expect(setMock.mock.calls[1][0].length).toBeLessThanOrEqual(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should cap test case results per flush and drain the remainder across subsequent throttle ticks', () => {
+    vi.useFakeTimers();
+    try {
+      const testManager = new TestManager({
+        ...options,
+        flushTestCaseResultsInterval: 500,
+        maxTestCaseResultsPerFlush: 2,
+      });
+      const passedResult = { state: 'passed', errors: [] } as unknown as TestResult;
+      const storyIds = ['story--one', 'story--two', 'another--one', 'another--two'];
+
+      storyIds.forEach((storyId) => {
+        testManager.onTestCaseResult({ storyId, testResult: passedResult });
+      });
+
+      // Give the throttle plenty of ticks to drain the backlog.
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(500);
+      }
+
+      // The full backlog was eventually applied, but every individual flush was capped instead of
+      // being applied as one unbounded burst.
+      const setCalls = vi.mocked(mockComponentTestStatusStore.set).mock.calls;
+      expect(setCalls.length).toBeGreaterThan(1);
+      for (const [statuses] of setCalls) {
+        expect(statuses.length).toBeLessThanOrEqual(2);
+      }
+      const flushedStoryIds = setCalls.flatMap(([statuses]) =>
+        statuses.map((status) => status.storyId)
+      );
+      expect(flushedStoryIds).toEqual(storyIds);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should drain the full backlog across multiple bounded flushes when a run ends', async () => {
+    vi.useFakeTimers();
+    try {
+      const testManager = new TestManager({
+        ...options,
+        flushTestCaseResultsInterval: 500,
+        maxTestCaseResultsPerFlush: 2,
+      });
+      const passedResult = { state: 'passed', errors: [] } as unknown as TestResult;
+      const storyIds = ['story--one', 'story--two', 'another--one', 'another--two'];
+
+      storyIds.forEach((storyId) => {
+        testManager.onTestCaseResult({ storyId, testResult: passedResult });
+      });
+
+      const onTestRunEndPromise = testManager.onTestRunEnd({
+        totalTestCount: storyIds.length,
+        unhandledErrors: [],
+      });
+
+      await vi.runAllTimersAsync();
+      await onTestRunEndPromise;
+
+      const setCalls = vi.mocked(mockComponentTestStatusStore.set).mock.calls;
+      expect(setCalls.length).toBeGreaterThan(1);
+      for (const [statuses] of setCalls) {
+        expect(statuses.length).toBeLessThanOrEqual(2);
+      }
+      const flushedStoryIds = setCalls.flatMap(([statuses]) =>
+        statuses.map((status) => status.storyId)
+      );
+      expect(flushedStoryIds).toEqual(storyIds);
+      expect(mockStore.getState().currentRun.totalTestCount).toBe(storyIds.length);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('should restart Vitest before a test run if coverage is enabled', async () => {
     const testManager = await TestManager.start(options);
     expect(createVitest).toHaveBeenCalledTimes(1);

--- a/code/addons/vitest/src/node/test-manager.ts
+++ b/code/addons/vitest/src/node/test-manager.ts
@@ -14,6 +14,7 @@ import { type ThrottledFunction, throttle } from 'es-toolkit/function';
 import type { Report } from 'storybook/preview-api';
 
 import {
+  DEFAULT_MAX_TEST_CASE_RESULTS_PER_FLUSH,
   DEFAULT_TEST_STATUS_FLUSH_INTERVAL,
   STATUS_TYPE_ID_A11Y,
   STATUS_TYPE_ID_COMPONENT_TEST,
@@ -46,6 +47,12 @@ export type TestManagerOptions = {
    * large storybooks at the cost of less frequent sidebar/status updates.
    */
   flushTestCaseResultsInterval?: number;
+  /**
+   * Maximum number of batched test-case results applied per flush. Defaults to
+   * {@link DEFAULT_MAX_TEST_CASE_RESULTS_PER_FLUSH}, which is safe for any project size and isn't
+   * meant to be tuned - this option exists so tests can shrink it to exercise chunking directly.
+   */
+  maxTestCaseResultsPerFlush?: number;
 };
 
 const testStateToStatusValueMap: Record<TestState | 'warning', StatusValue> = {
@@ -79,6 +86,8 @@ export class TestManager {
     reports?: Report[];
   }[] = [];
 
+  private maxTestCaseResultsPerFlush: number;
+
   constructor(options: TestManagerOptions) {
     this.store = options.store;
     this.componentTestStatusStore = options.componentTestStatusStore;
@@ -87,6 +96,10 @@ export class TestManager {
     this.onReady = options.onReady;
     this.storybookOptions = options.storybookOptions;
     this.configLoader = options.configLoader;
+    this.maxTestCaseResultsPerFlush = Math.max(
+      1,
+      options.maxTestCaseResultsPerFlush ?? DEFAULT_MAX_TEST_CASE_RESULTS_PER_FLUSH
+    );
 
     this.throttledFlushTestCaseResults = throttle(
       this.flushTestCaseResults,
@@ -235,15 +248,25 @@ export class TestManager {
    *
    * This function:
    *
-   * 1. Takes all batched test case results and clears the batch
+   * 1. Takes up to {@link TestManagerOptions.maxTestCaseResultsPerFlush} batched test case results
+   *    and removes them from the batch. Any remainder is drained via `setImmediate` rather than by
+   *    re-arming the throttle: the throttle could synchronously re-enter this function when its
+   *    interval has already elapsed, draining an unbounded number of chunks in one burst instead of
+   *    yielding between them
    * 2. Updates the store state with new test counts (component tests and a11y tests)
    * 3. Adjusts the totalTestCount if more tests were run than initially anticipated
    * 4. Creates status objects for component tests and updates the component test status store
    * 5. Creates status objects for a11y tests (if any) and updates the a11y status store
    */
   private flushTestCaseResults = () => {
-    const testCaseResultsToFlush = this.batchedTestCaseResults;
-    this.batchedTestCaseResults = [];
+    const testCaseResultsToFlush = this.batchedTestCaseResults.splice(
+      0,
+      this.maxTestCaseResultsPerFlush
+    );
+
+    if (testCaseResultsToFlush.length === 0) {
+      return;
+    }
 
     const componentTestStatuses = testCaseResultsToFlush.map(({ storyId, testResult }) => ({
       storyId,
@@ -343,10 +366,23 @@ export class TestManager {
         },
       };
     });
+
+    if (this.batchedTestCaseResults.length > 0) {
+      setImmediate(this.flushTestCaseResults);
+    }
   };
 
-  onTestRunEnd(endResult: { totalTestCount: number; unhandledErrors: VitestError[] }) {
-    this.throttledFlushTestCaseResults.flush();
+  async onTestRunEnd(endResult: { totalTestCount: number; unhandledErrors: VitestError[] }) {
+    this.throttledFlushTestCaseResults.cancel();
+    // Kick off (or continue) draining in the same bounded slices used during the run, then wait for
+    // it to finish rather than flushing everything in one go - so a run that produces a lot of
+    // results right before finishing can't turn the final flush into one oversized synchronous burst
+    // either. flushTestCaseResults re-schedules itself via setImmediate while a backlog remains, so
+    // this loop only needs to wait for that chain to catch up.
+    this.flushTestCaseResults();
+    while (this.batchedTestCaseResults.length > 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
     this.store.setState((s) => {
       const focusedRunTotal =
         s.currentRun.componentTestCount.success + s.currentRun.componentTestCount.error;

--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Channel } from 'storybook/internal/channels';
+import { Channel, HEARTBEAT_INTERVAL } from 'storybook/internal/channels';
 
 import { EventEmitter } from 'events';
 import type { Server } from 'http';
-import { stringify } from 'telejson';
+import { parse, stringify } from 'telejson';
+import WebSocket from 'ws';
 
 import { ServerChannelTransport, getServerChannel } from '../get-server-channel.ts';
 
@@ -363,5 +364,66 @@ describe('ServerChannelTransport', () => {
     expect(socket.write).not.toHaveBeenCalled();
     expect(destroySpy).not.toHaveBeenCalled();
     expect(handleUpgradeSpy).toHaveBeenCalled();
+  });
+});
+
+describe('ServerChannelTransport heartbeat priority', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const connectFakeClient = (transport: ServerChannelTransport) => {
+    const client = { readyState: WebSocket.OPEN, send: vi.fn() };
+    // @ts-expect-error (an internal API; mirrors how WebSocketServer itself populates `clients`)
+    transport.socket.clients.add(client);
+    return client;
+  };
+
+  const sentTypes = (client: { send: (data: string) => void }) =>
+    (client.send as any).mock.calls.map(([data]: [string]) => parse(data).type);
+
+  it('proactively sends a ping from send() once the heartbeat is overdue, without waiting for the scheduled interval', () => {
+    const server = new EventEmitter() as any as Server;
+    const transport = new ServerChannelTransport(server, options);
+    const client = connectFakeClient(transport);
+
+    transport.send({ type: 'STORY_RENDERED' });
+
+    // Jump the clock past HEARTBEAT_INTERVAL without advancing any timers, so the scheduled
+    // `setInterval` callback never runs. Only the opportunistic check inside send() can be
+    // responsible for the ping that follows.
+    vi.setSystemTime(new Date(Date.now() + HEARTBEAT_INTERVAL));
+
+    transport.send({ type: 'STORY_RENDERED' });
+
+    expect(sentTypes(client)).toEqual(['STORY_RENDERED', 'ping', 'STORY_RENDERED']);
+  });
+
+  it('does not send a redundant ping from send() when the heartbeat is not yet overdue', () => {
+    const server = new EventEmitter() as any as Server;
+    const transport = new ServerChannelTransport(server, options);
+    const client = connectFakeClient(transport);
+
+    transport.send({ type: 'STORY_RENDERED' });
+    vi.setSystemTime(new Date(Date.now() + HEARTBEAT_INTERVAL - 1));
+    transport.send({ type: 'STORY_RENDERED' });
+
+    expect(sentTypes(client)).toEqual(['STORY_RENDERED', 'STORY_RENDERED']);
+  });
+
+  it('does not double up when send() is asked to broadcast a ping directly', () => {
+    const server = new EventEmitter() as any as Server;
+    const transport = new ServerChannelTransport(server, options);
+    const client = connectFakeClient(transport);
+
+    vi.setSystemTime(new Date(Date.now() + HEARTBEAT_INTERVAL));
+    transport.send({ type: 'ping' });
+
+    expect(sentTypes(client)).toEqual(['ping']);
   });
 });

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -29,6 +29,8 @@ export class ServerChannelTransport {
 
   private handler?: ChannelHandler;
 
+  private lastPingSentAt = Date.now();
+
   constructor(server: Server, options: ServerChannelTransportOptions) {
     this.socket = new WebSocketServer({ noServer: true });
 
@@ -92,6 +94,22 @@ export class ServerChannelTransport {
   }
 
   send(event: any) {
+    if (event.type === 'ping') {
+      this.lastPingSentAt = Date.now();
+    } else if (Date.now() - this.lastPingSentAt >= HEARTBEAT_INTERVAL) {
+      // Any outgoing broadcast is an opportunity to top up the heartbeat. A provider that floods
+      // this channel with events (e.g. addon-vitest relaying status updates for a large test run)
+      // calls send() far more often than the ping `setInterval` ticks, so piggybacking the ping here
+      // means clients keep getting one within HEARTBEAT_INTERVAL regardless of whether the event
+      // loop is otherwise busy enough to delay that interval's own callback.
+      this.lastPingSentAt = Date.now();
+      this.broadcast({ type: 'ping' });
+    }
+
+    this.broadcast(event);
+  }
+
+  private broadcast(event: any) {
     const data = stringify(event, { maxDepth: 15 });
 
     Array.from(this.socket.clients)


### PR DESCRIPTION
## What I did

Stacked on top of #35400 (`norbert/fix-timeout-vitest-addon`), which fixed the "Server timed out" disconnect on large `@storybook/addon-vitest` runs by reordering `WebsocketTransport.onmessage` to handle `ping` before the channel handler. That fix, plus a `STORYBOOK_TEST_STATUS_FLUSH_INTERVAL` env var to reduce flush frequency, is a solid, low-risk improvement on its own.

This PR adds two more generic changes on top, so the heartbeat is resilient to *any* provider flooding the channel, not just addon-vitest, and without needing per-project tuning:

**1. Bound how many test-case results are applied per flush (`code/addons/vitest/src/node/test-manager.ts`, `constants.ts`)**

Previously a single flush applied the *entire* accumulated batch. `flushTestCaseResults` now takes at most `maxTestCaseResultsPerFlush` (default 200) per call, draining any remainder via `setImmediate` in bounded slices instead of one unbounded burst. `onTestRunEnd` is now `async` and waits for the drain to fully complete (also in bounded slices) before the run is considered finished, instead of flushing everything synchronously at the end.

This makes `STORYBOOK_TEST_STATUS_FLUSH_INTERVAL` optional rather than load-bearing: raising the interval no longer trades "queue depth risk" for "bigger single-burst risk," because no single flush can grow unbounded regardless of how much backlog accumulates.

**2. Give the dev-server's heartbeat ping priority over relay traffic (`code/core/src/core-server/utils/get-server-channel.ts`)**

`ServerChannelTransport` sends its keep-alive ping via a bare `setInterval`, in the same Node process that relays every event from a Vitest child process (or any other provider) to connected clients. If that relay work is heavy enough for long enough, the scheduled ping can slip on the server side too - the mirror image of the client-side bug #35400 fixes, just unaddressed until now.

`send()` now opportunistically broadcasts a ping first (and updates its own "last ping sent" bookkeeping) whenever it's asked to relay a non-ping event and a full `HEARTBEAT_INTERVAL` has elapsed since the last one. Since `send()` is called far more often than the interval ticks during a busy relay, heartbeat delivery no longer depends on that interval callback getting a turn on a busy event loop - it piggybacks on whatever traffic is already flowing. The existing `setInterval` is left untouched as the baseline driver for idle periods.

## Notes for reviewers

- Both changes are purely additive on top of #35400's diff; nothing there was modified.
- The bounded-flush re-arm intentionally does **not** go through the throttle wrapper (`this.throttledFlushTestCaseResults()`) - doing so can synchronously re-enter `flushTestCaseResults` when the throttle's interval has already elapsed, draining multiple chunks in one burst instead of yielding between them. Caught this empirically during development; there's a dedicated regression test for it (`test-manager.test.ts`: "drains at most one bounded chunk per elapsed interval...").
- New/updated tests: `code/addons/vitest/src/node/test-manager.test.ts` (bounded flush + run-end drain), `code/core/src/core-server/utils/__tests__/server-channel.test.ts` (opportunistic heartbeat priority, 3 new tests using `vi.setSystemTime()` to jump the clock without advancing timers, isolating the new code path from the pre-existing `setInterval`).
- `maxTestCaseResultsPerFlush` is a constructor option (for testability) but deliberately has no env var - the point is it shouldn't need tuning.

## Testing

- [x] unit tests (21 tests in `test-manager.test.ts`, 3 new tests in `server-channel.test.ts`, all passing)
- [ ] manual verification against a large storybook (same repro as #35400)

`yarn nx run addon-vitest:check` and `yarn nx run core:check` both pass with no type errors. Formatted with `oxfmt`; lint has no new warnings beyond what already existed on these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved test result updates by sending them in smaller batches, making long runs more responsive and predictable.
  * Heartbeat pings can now be sent alongside normal outgoing messages when needed, helping keep connections active during busy periods.

* **Bug Fixes**
  * Test runs now wait for all pending result updates to finish before fully ending.
  * Added coverage to verify heartbeat and batched update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->