### PR TITLE
Controls: Fix regression test for optional union types in select controls

### DIFF
--- a/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/optional-unions.tsx
+++ b/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/optional-unions.tsx
@@ -1,0 +1,37 @@
+import type { FC } from 'react';
+import React from 'react';
+
+type LargeUnion =
+  | 'k1'
+  | 'k2'
+  | 'k3'
+  | 'k4'
+  | 'k5'
+  | 'k6'
+  | 'k7'
+  | 'k8'
+  | 'k9'
+  | 'k10'
+  | 'k11'
+  | 'k12'
+  | 'k13'
+  | 'k14'
+  | 'k15'
+  | 'k16'
+  | 'k17'
+  | 'k18'
+  | 'k19'
+  | 'k20'
+  | 'k21'
+  | 'k22'
+  | 'k23'
+  | 'k24'
+  | 'k25'
+  | 'k26'
+  | 'k27'
+  | 'k28'
+  | 'k29';
+interface Props {
+  largeOptionalUnion?: LargeUnion;
+}
+export const Component: FC<Props> = (props: Props) => <>JSON.stringify(props)</>;

--- a/code/core/src/docs-tools/argTypes/convert/convert.test.ts
+++ b/code/core/src/docs-tools/argTypes/convert/convert.test.ts
@@ -220,7 +220,36 @@ describe('storybook type system', () => {
         "import type { FC } from 'react';
         import React from 'react';
 
-        type LargeUnion = 'k1' | 'k2' | 'k3' | 'k4' | 'k5' | 'k6' | 'k7' | 'k8' | 'k9' | 'k10' | 'k11' | 'k12' | 'k13' | 'k14' | 'k15' | 'k16' | 'k17' | 'k18' | 'k19' | 'k20' | 'k21' | 'k22' | 'k23' | 'k24' | 'k25' | 'k26' | 'k27' | 'k28' | 'k29';
+        type LargeUnion =
+          | 'k1'
+          | 'k2'
+          | 'k3'
+          | 'k4'
+          | 'k5'
+          | 'k6'
+          | 'k7'
+          | 'k8'
+          | 'k9'
+          | 'k10'
+          | 'k11'
+          | 'k12'
+          | 'k13'
+          | 'k14'
+          | 'k15'
+          | 'k16'
+          | 'k17'
+          | 'k18'
+          | 'k19'
+          | 'k20'
+          | 'k21'
+          | 'k22'
+          | 'k23'
+          | 'k24'
+          | 'k25'
+          | 'k26'
+          | 'k27'
+          | 'k28'
+          | 'k29';
         interface Props {
           largeOptionalUnion?: LargeUnion;
         }

--- a/code/core/src/docs-tools/argTypes/convert/convert.test.ts
+++ b/code/core/src/docs-tools/argTypes/convert/convert.test.ts
@@ -214,6 +214,60 @@ describe('storybook type system', () => {
         }
       `);
     });
+    it('optional unions', () => {
+      const input = readFixture('typescript/optional-unions.tsx');
+      expect(input).toMatchInlineSnapshot(`
+        "import type { FC } from 'react';
+        import React from 'react';
+
+        type LargeUnion = 'k1' | 'k2' | 'k3' | 'k4' | 'k5' | 'k6' | 'k7' | 'k8' | 'k9' | 'k10' | 'k11' | 'k12' | 'k13' | 'k14' | 'k15' | 'k16' | 'k17' | 'k18' | 'k19' | 'k20' | 'k21' | 'k22' | 'k23' | 'k24' | 'k25' | 'k26' | 'k27' | 'k28' | 'k29';
+        interface Props {
+          largeOptionalUnion?: LargeUnion;
+        }
+        export const Component: FC<Props> = (props: Props) => <>JSON.stringify(props)</>;
+        "
+      `);
+      expect(convertTs(input)).toMatchInlineSnapshot(`
+        {
+          "largeOptionalUnion": {
+            "raw": "LargeUnion",
+            "name": "enum",
+            "value": [
+              "k1",
+              "k2",
+              "k3",
+              "k4",
+              "k5",
+              "k6",
+              "k7",
+              "k8",
+              "k9",
+              "k10",
+              "k11",
+              "k12",
+              "k13",
+              "k14",
+              "k15",
+              "k16",
+              "k17",
+              "k18",
+              "k19",
+              "k20",
+              "k21",
+              "k22",
+              "k23",
+              "k24",
+              "k25",
+              "k26",
+              "k27",
+              "k28",
+              "k29"
+            ]
+          }
+        }
+      `);
+    });
+
     it('intersections', () => {
       const input = readFixture('typescript/intersections.tsx');
       expect(input).toMatchInlineSnapshot(`


### PR DESCRIPTION
Resolves #12641

The issue describes a problem with the `select` control falling back to an `object` control for optional union types because the TS parser included `undefined` in the union types.
This issue was technically fixed by PR #33200 but lacked an explicit regression test to ensure it does not break again.
This PR adds a robust regression test for `convert.ts` to explicitly verify that optional unions correctly map to an `enum` rather than an `object` control, finalizing the fix for #12641.

#### What I did

Added a regression test fixture (`optional-unions.tsx`) and a corresponding test case in `convert.test.ts` to verify that optional union props correctly produce `enum`-typed controls with all expected literal values.

#### Manual testing

This is a pure test addition — no runtime behavior changes. To verify:
1. Run `yarn test` inside `code/core/src/docs-tools/argTypes/convert/`
2. Confirm the new `optional-unions` test case passes and the control type is `enum`, not `object`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for TypeScript props with large optional string-union values.
  * Verified that these values are correctly represented as enumerated options in generated output, improving consistency for documented component props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->