### PR TITLE
Build: Run repository type checks on the TypeScript 7 native compiler

### DIFF
--- a/code/core/src/components/components/Select/Select.stories.tsx
+++ b/code/core/src/components/components/Select/Select.stories.tsx
@@ -4,7 +4,7 @@ import { Button, Toolbar } from 'storybook/internal/components';
 
 import { LinuxIcon } from '@storybook/icons';
 
-import type { StoryAnnotations } from 'core/src/types';
+import type { StoryAnnotations } from '../../../types/index.ts';
 import { expect, fn, screen, userEvent, within } from 'storybook/test';
 import { styled } from 'storybook/theming';
 

--- a/code/core/src/csf/csf-factories.test.ts
+++ b/code/core/src/csf/csf-factories.test.ts
@@ -37,12 +37,13 @@ test('addon parameters are inferred', () => {
     },
   });
   const MyStory2 = meta.story({
-    // @ts-expect-error can not assign numbers to strings
     parameters: {
       foo: {
+        // @ts-expect-error can not assign numbers to strings
         value: 1,
       },
       bar: {
+        // @ts-expect-error can not assign numbers to strings
         value: 1,
       },
     },

--- a/code/core/src/manager/components/sidebar/Search.tsx
+++ b/code/core/src/manager/components/sidebar/Search.tsx
@@ -324,13 +324,14 @@ export const Search = React.memo<SearchProps>(function Search({
   const { landmarkProps } = useLandmark({ role: 'search' }, searchLandmarkRef);
 
   return (
-    // @ts-expect-error (non strict)
     <Downshift<DownshiftItem>
       initialInputValue={initialQuery}
+      // @ts-expect-error (non strict)
       stateReducer={stateReducer}
       // @ts-expect-error (Converted from ts-ignore)
       itemToString={(result) => result?.item?.name || ''}
       scrollIntoView={(e) => scrollIntoView(e)}
+      // @ts-expect-error (non strict)
       onSelect={onSelect}
       onInputValueChange={onInputValueChange}
     >

--- a/code/frameworks/html-vite/tsconfig.json
+++ b/code/frameworks/html-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/preact-vite/tsconfig.json
+++ b/code/frameworks/preact-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/react-native-web-vite/tsconfig.json
+++ b/code/frameworks/react-native-web-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/react-vite/tsconfig.json
+++ b/code/frameworks/react-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/svelte-vite/tsconfig.json
+++ b/code/frameworks/svelte-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/sveltekit/tsconfig.json
+++ b/code/frameworks/sveltekit/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     }

--- a/code/frameworks/tanstack-react/tsconfig.json
+++ b/code/frameworks/tanstack-react/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/vue3-vite/tsconfig.json
+++ b/code/frameworks/vue3-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/web-components-vite/tsconfig.json
+++ b/code/frameworks/web-components-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/renderers/react/tsconfig.json
+++ b/code/renderers/react/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@storybook/react": ["./src"]
     }

--- a/code/renderers/web-components/tsconfig.json
+++ b/code/renderers/web-components/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "resolveJsonModule": true,
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]

--- a/code/tsconfig.json
+++ b/code/tsconfig.json
@@ -2,7 +2,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "customConditions": ["code"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -28,7 +28,7 @@ const checkDependencies = async () => {
         if (code !== 0) {
           rej();
         } else {
-          res();
+          res(undefined);
         }
       });
     }).catch(() => {

--- a/scripts/check/check-package.ts
+++ b/scripts/check/check-package.ts
@@ -1,11 +1,12 @@
+import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { isAbsolute } from 'node:path';
+import { createRequire } from 'node:module';
+import { dirname, isAbsolute } from 'node:path';
 import { parseArgs } from 'node:util';
 
 import { join } from 'pathe';
 
 import { ROOT_DIRECTORY } from '../utils/constants.ts';
-import { getTSDiagnostics, getTSFilesAndConfig, getTSProgramAndHost } from './utils/typescript.ts';
 
 const {
   values: { cwd },
@@ -21,16 +22,69 @@ const normalizedCwd = cwd ? (isAbsolute(cwd) ? cwd : join(ROOT_DIRECTORY, cwd)) 
 const tsconfigPath = join(normalizedCwd, 'tsconfig.json');
 
 if (existsSync(tsconfigPath)) {
-  const { options, fileNames } = getTSFilesAndConfig(tsconfigPath, normalizedCwd);
-  const { program, host } = getTSProgramAndHost(fileNames, options);
+  const require = createRequire(import.meta.url);
+  // `typescript-native` is an npm alias for typescript@7 (the native compiler). Its `exports`
+  // map only exposes the new API entry points, so resolve the package root via package.json and
+  // spawn its tsc launcher directly.
+  const tscPath = join(dirname(require.resolve('typescript-native/package.json')), 'bin/tsc');
 
-  const tsDiagnostics = getTSDiagnostics(program, normalizedCwd, host);
-  if (tsDiagnostics.length > 0) {
-    console.log(tsDiagnostics);
+  const result = spawnSync(
+    process.execPath,
+    [tscPath, '--project', tsconfigPath, '--noEmit', '--target', 'es2022', '--pretty', 'false'],
+    { cwd: normalizedCwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  const diagnostics = filterDiagnosticsToCwd(output, normalizedCwd);
+
+  if (diagnostics.length > 0) {
+    console.log(diagnostics.join('\n'));
     process.exit(1);
+  } else if (result.status !== 0 && !/: error TS\d+: /.test(output)) {
+    // tsc failed without reporting any diagnostics (e.g. it crashed or rejected the CLI usage),
+    // so surface its raw output instead of silently passing.
+    console.log(output);
+    process.exit(result.status ?? 1);
   } else if (!process.env.CI) {
     console.log('✅ No type errors');
   }
+}
+
+/**
+ * Keeps only diagnostics for files inside `cwd` (plus file-less global errors), mirroring the
+ * previous behavior of filtering `getPreEmitDiagnostics` down to the checked package. Diagnostics
+ * for files outside the package (e.g. sibling workspaces pulled in through imports) are reported
+ * by the owning package's own check instead.
+ */
+function filterDiagnosticsToCwd(output: string, cwd: string): string[] {
+  const kept: string[] = [];
+  let keepBlock = false;
+
+  for (const line of output.split(/\r?\n/)) {
+    const fileHeader = line.match(/^(.+?)\(\d+,\d+\): (?:error|warning) TS\d+: /);
+    const globalHeader = fileHeader ? null : line.match(/^(?:error|warning) TS\d+: /);
+
+    if (fileHeader) {
+      const file = fileHeader[1];
+      keepBlock = isAbsolute(file) ? file.startsWith(cwd) : !file.startsWith('..');
+    } else if (globalHeader) {
+      keepBlock = true;
+    } else if (line !== '' && !/^\s/.test(line)) {
+      // unrecognized non-indented line: not part of a diagnostic block
+      keepBlock = false;
+    }
+    // indented lines are continuations (e.g. related-information) of the current diagnostic
+
+    if (keepBlock && line !== '') {
+      kept.push(line);
+    }
+  }
+
+  return kept;
 }
 
 // TODO, add more package checks here, like:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -160,6 +160,7 @@
     "ts-dedent": "^2.2.0",
     "type-fest": "^5.6.0",
     "typescript": "^6.0.3",
+    "typescript-native": "npm:typescript@^7.0.2",
     "uuid": "^9.0.1",
     "vitest": "^4.1.5",
     "wait-on": "^8.0.3",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -2,7 +2,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "customConditions": ["code"],
-    "baseUrl": ".",
     "noEmit": true,
     "incremental": false,
     "noImplicitAny": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10213,6 +10213,7 @@ __metadata:
     ts-dedent: "npm:^2.2.0"
     type-fest: "npm:^5.6.0"
     typescript: "npm:^6.0.3"
+    typescript-native: "npm:typescript@^7.0.2"
     uuid: "npm:^9.0.1"
     verdaccio: "npm:^5.33.0"
     verdaccio-auth-memory: "npm:^10.3.1"
@@ -12047,6 +12048,146 @@ __metadata:
     "@typescript-eslint/types": "npm:8.60.0"
     eslint-visitor-keys: "npm:^5.0.0"
   checksum: 10c0/5ff775fe5352d359e25ed47ce27d8d61dea7aa9aa4d21a3556a9ee02957673e8d4787ad1d0c325977f47cca56ecdce401417864de0c773b6167053fe36bf9e65
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-aix-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-aix-ppc64@npm:7.0.2"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-arm64@npm:7.0.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-x64@npm:7.0.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-arm64@npm:7.0.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-x64@npm:7.0.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm64@npm:7.0.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm@npm:7.0.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-loong64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-loong64@npm:7.0.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-mips64el@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-mips64el@npm:7.0.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-ppc64@npm:7.0.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-riscv64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-riscv64@npm:7.0.2"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-s390x@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-s390x@npm:7.0.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-x64@npm:7.0.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-arm64@npm:7.0.2"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-x64@npm:7.0.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-arm64@npm:7.0.2"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-x64@npm:7.0.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-sunos-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-sunos-x64@npm:7.0.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-arm64@npm:7.0.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-x64@npm:7.0.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -32790,6 +32931,77 @@ __metadata:
   version: 0.0.6
   resolution: "typedarray@npm:0.0.6"
   checksum: 10c0/6005cb31df50eef8b1f3c780eb71a17925f3038a100d82f9406ac2ad1de5eb59f8e6decbdc145b3a1f8e5836e17b0c0002fb698b9fe2516b8f9f9ff602d36412
+  languageName: node
+  linkType: hard
+
+"typescript-native@npm:typescript@^7.0.2":
+  version: 7.0.2
+  resolution: "typescript@npm:7.0.2"
+  dependencies:
+    "@typescript/typescript-aix-ppc64": "npm:7.0.2"
+    "@typescript/typescript-darwin-arm64": "npm:7.0.2"
+    "@typescript/typescript-darwin-x64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-x64": "npm:7.0.2"
+    "@typescript/typescript-linux-arm": "npm:7.0.2"
+    "@typescript/typescript-linux-arm64": "npm:7.0.2"
+    "@typescript/typescript-linux-loong64": "npm:7.0.2"
+    "@typescript/typescript-linux-mips64el": "npm:7.0.2"
+    "@typescript/typescript-linux-ppc64": "npm:7.0.2"
+    "@typescript/typescript-linux-riscv64": "npm:7.0.2"
+    "@typescript/typescript-linux-s390x": "npm:7.0.2"
+    "@typescript/typescript-linux-x64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-sunos-x64": "npm:7.0.2"
+    "@typescript/typescript-win32-arm64": "npm:7.0.2"
+    "@typescript/typescript-win32-x64": "npm:7.0.2"
+  dependenciesMeta:
+    "@typescript/typescript-aix-ppc64":
+      optional: true
+    "@typescript/typescript-darwin-arm64":
+      optional: true
+    "@typescript/typescript-darwin-x64":
+      optional: true
+    "@typescript/typescript-freebsd-arm64":
+      optional: true
+    "@typescript/typescript-freebsd-x64":
+      optional: true
+    "@typescript/typescript-linux-arm":
+      optional: true
+    "@typescript/typescript-linux-arm64":
+      optional: true
+    "@typescript/typescript-linux-loong64":
+      optional: true
+    "@typescript/typescript-linux-mips64el":
+      optional: true
+    "@typescript/typescript-linux-ppc64":
+      optional: true
+    "@typescript/typescript-linux-riscv64":
+      optional: true
+    "@typescript/typescript-linux-s390x":
+      optional: true
+    "@typescript/typescript-linux-x64":
+      optional: true
+    "@typescript/typescript-netbsd-arm64":
+      optional: true
+    "@typescript/typescript-netbsd-x64":
+      optional: true
+    "@typescript/typescript-openbsd-arm64":
+      optional: true
+    "@typescript/typescript-openbsd-x64":
+      optional: true
+    "@typescript/typescript-sunos-x64":
+      optional: true
+    "@typescript/typescript-win32-arm64":
+      optional: true
+    "@typescript/typescript-win32-x64":
+      optional: true
+  bin:
+    tsc: bin/tsc
+  checksum: 10c0/3dcee51ec8c332492325bcdbf7df48b66668751f127e622ae7d41b6c716eb19184424a45e14f7750f50f340232388b69e6287859155f06a5ce2df76f12cb31cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

Experiment requested on top of #34971: use the newly released TypeScript 7 (the native Go compiler) for this repo.

TS 7 is not a drop-in replacement: the npm package ships only the native binary plus a new JSON-RPC API under `typescript/unstable/*`. The legacy JS compiler API (`import ts from 'typescript'`) is gone, and typescript-eslint (supports `<6.1.0` only), vue-tsc, svelte-check, and rollup-plugin-dts all still embed that API. So this PR moves what can move today:

- `scripts/check/check-package.ts` (the `check` task / `typescript-validation` CI job) now spawns `tsc` from `typescript@7.0.2`, added as the `typescript-native` npm alias in `scripts/package.json`. It keeps the previous behavior of only failing on diagnostics inside the checked package. Per-package checks now run in ~1-5s.
- Removed the `baseUrl` compiler option (removed in TS 7, error TS5102) from all 13 toolchain tsconfigs. Every value was `"."`, so `paths` resolution is unchanged for the TS 6-based tools that still read these configs.
- Fixed the four diagnostics TS 7 surfaces that TS 6 did not: a `baseUrl`-dependent bare import in `Select.stories.tsx`, stale `@ts-expect-error` placements in `csf-factories.test.ts` and `Search.tsx` (TS 7 attributes the same errors to different lines), and an argument-less `resolve()` call in `check-dependencies.js` (new TS2810 checkJs rule).
- `typescript@6.0.3` remains the `typescript` dependency for everything that embeds the legacy JS API (eslint, vue-tsc, svelte-check, dts bundling, docgen type imports).

Validation: all 44 projects pass `nx run-many -t check` (including vue-tsc and svelte-check on TS 6 against the edited tsconfigs), `yarn dedupe --check` is clean, and the negative path (a real in-package type error) still fails the check.

Known follow-up outside this PR's scope: the react/svelte docgen integrations `import('typescript')` from the user's project at runtime, so user projects on TypeScript 7 will need a migration to the new API there.

## Checklist for Contributors

### Testing

- All 44 projects green on `yarn nx run-many -t check`
- `yarn vitest run code/core/src/csf/csf-factories.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)