### PR TITLE
CLI: Fix silent hang in deferred addon configuration during upgrade

### DIFF
--- a/code/addons/a11y/src/postinstall.ts
+++ b/code/addons/a11y/src/postinstall.ts
@@ -29,5 +29,11 @@ export default async function postinstall(options: PostinstallOptions) {
     configDir: options.configDir,
   });
 
-  await jsPackageManager.runPackageCommand({ args, useRemotePkg: !!options.skipInstall });
+  // stdio must not be left as open pipes: the nested CLI (and the npm exec layers in between)
+  // can block on them forever, which freezes the outer upgrade/add command without any output.
+  await jsPackageManager.runPackageCommand({
+    args,
+    stdio: 'ignore',
+    useRemotePkg: !!options.skipInstall,
+  });
 }

--- a/code/addons/a11y/src/postinstall.ts
+++ b/code/addons/a11y/src/postinstall.ts
@@ -29,11 +29,12 @@ export default async function postinstall(options: PostinstallOptions) {
     configDir: options.configDir,
   });
 
-  // stdio must not be left as open pipes: the nested CLI (and the npm exec layers in between)
-  // can block on them forever, which freezes the outer upgrade/add command without any output.
+  // stdin must not be left as an open pipe: the nested CLI (and the npm exec layers in between)
+  // never receive EOF on it and block forever, which freezes the outer upgrade/add command
+  // without any output. stdout/stderr stay piped so a failure still carries the child's output.
   await jsPackageManager.runPackageCommand({
     args,
-    stdio: 'ignore',
+    stdio: ['ignore', 'pipe', 'pipe'],
     useRemotePkg: !!options.skipInstall,
   });
 }

--- a/code/lib/cli-storybook/src/postinstallAddon.ts
+++ b/code/lib/cli-storybook/src/postinstallAddon.ts
@@ -1,40 +1,73 @@
+import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { importModule } from '../../../core/src/shared/utils/module.ts';
 import type { PostinstallOptions } from './add.ts';
 
 const DIR_CWD = process.cwd();
-const require = createRequire(DIR_CWD);
+// createRequire treats a bare directory as a file path and resolves from its parent,
+// so anchor it to a file inside the project instead.
+const require = createRequire(join(DIR_CWD, 'package.json'));
 
 export const postinstallAddon = async (addonName: string, options: PostinstallOptions) => {
   const hookPath = `${addonName}/postinstall`;
-  let modulePath: string;
+  const logger = options.logger;
+  let modulePath: string | undefined;
   try {
-    modulePath = import.meta.resolve(hookPath, DIR_CWD);
+    // Resolve from the user's project: import.meta.resolve would resolve relative to THIS file,
+    // which points at the wrong copy (or none at all) when the CLI runs from a different tree
+    // than the project, e.g. via npx or in a monorepo.
+    modulePath = require.resolve(hookPath, { paths: [DIR_CWD] });
   } catch (e) {
+    // When the addon was installed while this process was already running (the upgrade command
+    // installs dependencies mid-run), Node's module resolution has cached the earlier negative
+    // lookup and keeps failing. A fresh child process resolves from a clean cache.
+    const result = spawnSync(
+      process.execPath,
+      ['-p', `require.resolve(${JSON.stringify(hookPath)}, { paths: [process.cwd()] })`],
+      { cwd: DIR_CWD, encoding: 'utf8', timeout: 30_000 }
+    );
+    if (result.status === 0 && result.stdout.trim()) {
+      modulePath = result.stdout.trim();
+    }
+  }
+
+  if (!modulePath) {
     try {
-      modulePath = require.resolve(hookPath, { paths: [DIR_CWD] });
+      modulePath = import.meta.resolve(hookPath);
     } catch (e) {
+      logger.warn(
+        `Could not resolve the postinstall hook of ${addonName}, skipping its configuration. Run \`npx storybook add ${addonName}\` to set it up manually.`
+      );
       return;
     }
   }
 
+  // Prefer the module resolved from the user's project (modulePath): a bare `import(hookPath)`
+  // resolves relative to THIS file, which points at the wrong copy (or none at all) when the CLI
+  // runs from a different tree than the project, e.g. via npx or in a monorepo.
+  const moduleFilePath = modulePath.startsWith('file:') ? fileURLToPath(modulePath) : modulePath;
+
   let moduledLoaded: any;
   try {
-    moduledLoaded = await import(hookPath)
+    moduledLoaded = await import(pathToFileURL(moduleFilePath).href)
+      .catch(() => importModule(moduleFilePath))
+      .catch(() => require(moduleFilePath))
+      .catch(() => import(hookPath))
       .catch(() => importModule(hookPath))
-      .catch(() => importModule(modulePath))
-      .catch(() => importModule(fileURLToPath(modulePath)))
-      .catch(() => require(hookPath))
-      .catch(() => require(modulePath))
-      .catch(() => require(fileURLToPath(modulePath)));
+      .catch(() => require(hookPath));
   } catch (e) {
+    logger.warn(
+      `Could not load the postinstall hook of ${addonName} (${String(
+        e
+      )}), skipping its configuration. Run \`npx storybook add ${addonName}\` to set it up manually.`
+    );
     return;
   }
 
   const postinstall = moduledLoaded?.default || moduledLoaded?.postinstall || moduledLoaded;
-  const logger = options.logger;
 
   if (!postinstall || typeof postinstall !== 'function') {
     logger.error(`Error finding postinstall function for ${addonName}`);

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -500,13 +500,23 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
       for (const project of storybookProjects) {
         const addonsToPostinstall = automigrationResults[project.configDir]?.addonsToPostinstall;
         if (addonsToPostinstall?.length) {
-          await configureDeferredAddons(addonsToPostinstall, {
-            packageManager: project.packageManager.type,
-            configDir: project.configDir,
-            yes: options.yes,
-            logger,
-            prompt,
-          });
+          logger.step(`Configuring addons: ${addonsToPostinstall.join(', ')}..`);
+          try {
+            await configureDeferredAddons(addonsToPostinstall, {
+              packageManager: project.packageManager.type,
+              configDir: project.configDir,
+              yes: options.yes,
+              logger,
+              prompt,
+            });
+          } catch (error) {
+            logger.warn(
+              `Configuring ${addonsToPostinstall.join(', ')} failed: ${String(
+                error
+              )}. Run "npx storybook add <addon>" manually for each addon to finish the setup.`
+            );
+            logger.debug(error instanceof Error ? (error.stack ?? error.message) : String(error));
+          }
         }
       }
     }


### PR DESCRIPTION
Closes #

## What I did

`storybook upgrade` could hang forever right after the dedupe prompt, without any output. Additionally, addon setup failures in that phase were invisible. Both problems live in the deferred addon configuration introduced in #34202 (e.g. addon-vitest/addon-a11y from the `angular-to-angular-vite` migration).

The issue:

- The a11y postinstall spawns a nested `storybook automigrate addon-a11y-addon-test` command with open stdio pipes. The `npm exec` layers in between wait for an EOF on stdin that never comes, because the parent never writes to or closes the pipe. When the nested run fails (in the reproduction: an npm ERESOLVE peer conflict), the whole process tree blocks forever, and the pipes swallow all output.
- The postinstall hooks were resolved relative to the CLI bundle instead of the user's project. When the CLI runs from a different tree (npx, monorepo), resolution failed and the addon was silently skipped.

Solution:

- The nested command now runs with `stdio: ['ignore', 'pipe', 'pipe']`. Stdin is `/dev/null`, so it returns EOF immediately and the deadlock is gone. Stdout/stderr stay captured, so a failure still reports the full npm error.
- Postinstall hooks are resolved from the user's project first. Since the upgrade installs the addon mid-run and Node caches the earlier failed lookup, a short-lived child process is used as a resolution fallback. Failures now warn with the error and a `npx storybook add <addon>` hint instead of silently returning.
- The upgrade logs a visible `Configuring addons: ...` step and warns when that phase fails.

Verified against a real reproduction (bitwarden/clients): before, the identical flow hung every time. With the canary `0.0.0-pr-35423-sha-43213e67`, the hooks resolve and run, the vitest setup failure is reported with the full npm error, and the upgrade completes.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Clone an Angular project using `@storybook/angular` (e.g. bitwarden/clients) and install dependencies.
2. Run `npx storybook@0.0.0-pr-35423-sha-43213e67 upgrade`, select the `angular-to-angular-vite` automigration, and accept the addon-vitest/addon-a11y setup prompts.
3. After the dedupe prompt, a `Configuring addons: ...` step should appear, the postinstall hooks should run, and any failure should be printed as a warning with the underlying error, instead of hanging silently.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35423-sha-43213e67`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35423-sha-43213e67 sandbox` or in an existing project with `npx storybook@0.0.0-pr-35423-sha-43213e67 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35423-sha-43213e67`](https://npmjs.com/package/storybook/v/0.0.0-pr-35423-sha-43213e67) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`task/c1adc443-regression-bug--upgrade--CLI`](https://github.com/storybookjs/storybook/tree/task/c1adc443-regression-bug--upgrade--CLI) |
| **Commit** | [`43213e67`](https://github.com/storybookjs/storybook/commit/43213e67a015c66b465861870fa6c01f811bca6f) |
| **Datetime** | Thu Jul  9 20:07:46 UTC 2026 (`1783627666`) |
| **Workflow run** | [29046777834](https://github.com/storybookjs/storybook/actions/runs/29046777834) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35423`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a post-install step that could hang in some environments by ensuring command input is handled safely.
  * Improved the upgrade experience to better report partial failures and provide clearer guidance when some steps do not complete.
  * Added more reliable handling for installation and deduplication issues during upgrades, with better error summaries and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->