### PR TITLE
Addon-Vitest: Bound per-flush test-status payload to prevent manager "Server timed out"

### DIFF
--- a/code/addons/vitest/src/node/test-manager.test.ts
+++ b/code/addons/vitest/src/node/test-manager.test.ts
@@ -350,6 +350,56 @@ describe('TestManager', () => {
     ]);
   });
 
+  it('keeps per-flush synced state bounded and materializes full results at run end', async () => {
+    const testManager = await TestManager.start(options);
+    const passedResult = {
+      state: 'passed',
+      errors: [],
+    } as unknown as TestResult;
+
+    await testManager.runTestsWithState({
+      storyIds: ['story--one', 'story--two'],
+      triggeredBy: 'global',
+      callback: async () => {
+        testManager.onTestCaseResult({
+          storyId: 'story--one',
+          testResult: passedResult,
+          reports: [{ type: 'a11y', status: 'passed', result: { id: 'a11y-1' } } as Report],
+        });
+        testManager.throttledFlushTestCaseResults.flush();
+
+        // During the run the heavy per-run arrays must NOT be synced into the store - only counts
+        // advance. Syncing them every flush is the O(N^2) re-serialization that trips the heartbeat.
+        expect(mockStore.getState().currentRun.componentTestStatuses).toHaveLength(0);
+        expect(mockStore.getState().currentRun.a11yStatuses).toHaveLength(0);
+        expect(mockStore.getState().currentRun.reports).toEqual({});
+        expect(mockStore.getState().currentRun.a11yReports).toEqual({});
+        expect(mockStore.getState().currentRun.componentTestCount.success).toBe(1);
+
+        testManager.onTestCaseResult({
+          storyId: 'story--two',
+          testResult: passedResult,
+        });
+        testManager.throttledFlushTestCaseResults.flush();
+
+        expect(mockStore.getState().currentRun.componentTestStatuses).toHaveLength(0);
+        expect(mockStore.getState().currentRun.componentTestCount.success).toBe(2);
+
+        testManager.onTestRunEnd({ totalTestCount: 2, unhandledErrors: [] });
+      },
+    });
+
+    // Materialized exactly once, at run end.
+    const { currentRun } = mockStore.getState();
+    expect(currentRun.componentTestStatuses.map((status) => status.storyId)).toEqual([
+      'story--one',
+      'story--two',
+    ]);
+    expect(currentRun.a11yStatuses).toHaveLength(1);
+    expect(currentRun.reports['story--one']).toHaveLength(1);
+    expect(currentRun.a11yReports['story--one']).toHaveLength(1);
+  });
+
   it('should filter tests', async () => {
     vitest.globTestSpecifications.mockImplementation(() => tests);
     const testManager = await TestManager.start(options);

--- a/code/addons/vitest/src/node/test-manager.ts
+++ b/code/addons/vitest/src/node/test-manager.ts
@@ -68,6 +68,23 @@ export class TestManager {
     reports?: Report[];
   }[] = [];
 
+  /**
+   * Full-run results are accumulated here, on the node side, instead of in the synced store. The
+   * store broadcasts its entire state on every `setState`, so accumulating these arrays in
+   * `currentRun` and flushing every 500ms re-serializes and re-broadcasts the whole run each time -
+   * O(N²) work across a run. Late in a large run (thousands of stories) a single flush can block the
+   * manager main thread past the WebSocket heartbeat window, dropping the connection with code 3008.
+   * Keeping them local bounds the per-flush payload to counts only; they are materialized into
+   * `currentRun` once, at run end, for the `TEST_RUN_COMPLETED` payload.
+   */
+  private runComponentTestStatuses: CurrentRun['componentTestStatuses'] = [];
+
+  private runA11yStatuses: CurrentRun['a11yStatuses'] = [];
+
+  private runReports: CurrentRun['reports'] = {};
+
+  private runA11yReports: CurrentRun['a11yReports'] = {};
+
   constructor(options: TestManagerOptions) {
     this.store = options.store;
     this.componentTestStatusStore = options.componentTestStatusStore;
@@ -142,6 +159,11 @@ export class TestManager {
     this.componentTestStatusStore.unset(storyIds);
     this.a11yStatusStore.unset(storyIds);
 
+    this.runComponentTestStatuses = [];
+    this.runA11yStatuses = [];
+    this.runReports = {};
+    this.runA11yReports = {};
+
     const runConfig = configOverride ?? this.store.getState().config;
 
     this.store.setState((s) => ({
@@ -208,13 +230,14 @@ export class TestManager {
    * This function:
    *
    * 1. Takes all batched test case results and clears the batch
-   * 2. Updates the store state with new test counts (component tests and a11y tests)
-   * 3. Adjusts the totalTestCount if more tests were run than initially anticipated
-   * 4. Creates status objects for component tests and updates the component test status store
-   * 5. Creates status objects for a11y tests (if any) and updates the a11y status store
+   * 2. Updates the status stores (the live, per-story source of truth for the sidebar) with the
+   *    just-processed batch
+   * 3. Accumulates the full-run statuses/reports locally (not in the synced store - see the
+   *    `runComponentTestStatuses` field) so the per-flush channel payload stays bounded
+   * 4. Updates the synced store with the new counts only (and an adjusted totalTestCount)
    *
-   * The throttling (500ms) is necessary as the channel would otherwise get overwhelmed with events,
-   * eventually causing the manager and dev server to lose connection.
+   * The throttling (500ms) still batches channel traffic, but the payload no longer grows with the
+   * run, so a busy channel can't starve the WebSocket heartbeat late in a large run.
    */
   throttledFlushTestCaseResults = throttle(() => {
     const testCaseResultsToFlush = this.batchedTestCaseResults;
@@ -261,6 +284,16 @@ export class TestManager {
       this.a11yStatusStore.set(a11yStatuses);
     }
 
+    // Accumulate the full run locally; materialized into `currentRun` once, at run end.
+    if (componentTestStatuses.length > 0) {
+      this.runComponentTestStatuses.push(...componentTestStatuses);
+    }
+    if (a11yStatuses.length > 0) {
+      this.runA11yStatuses.push(...a11yStatuses);
+    }
+    Object.assign(this.runReports, reportsByStoryId);
+    Object.assign(this.runA11yReports, a11yReportsByStoryId);
+
     this.store.setState((s) => {
       let { success: ctSuccess, error: ctError } = s.currentRun.componentTestCount;
       let { success: a11ySuccess, warning: a11yWarning, error: a11yError } = s.currentRun.a11yCount;
@@ -294,20 +327,6 @@ export class TestManager {
             warning: a11yWarning,
             error: a11yError,
           },
-          componentTestStatuses: s.currentRun.componentTestStatuses.concat(componentTestStatuses),
-          a11yStatuses: s.currentRun.a11yStatuses.concat(a11yStatuses),
-          /*
-            TODO: a11yReports is just here for backwards compatibility with older versions of addon-mcp.
-            They are also part of the more generic reports property, so we can remove this in a future major release when we can break compatibility.
-          */
-          a11yReports: {
-            ...s.currentRun.a11yReports,
-            ...a11yReportsByStoryId,
-          },
-          reports: {
-            ...s.currentRun.reports,
-            ...reportsByStoryId,
-          },
           // in some cases successes and errors can exceed the anticipated totalTestCount
           // e.g. when testing more tests than the stories we know about upfront
           // in those cases, we set the totalTestCount to the sum of successes and errors
@@ -335,6 +354,17 @@ export class TestManager {
           totalTestCount: s.currentRun.storyIds ? focusedRunTotal : endResult.totalTestCount,
           unhandledErrors: endResult.unhandledErrors,
           finishedAt: Date.now(),
+          // Materialize the full-run results (accumulated locally during the run) into the store
+          // exactly once, so the TEST_RUN_COMPLETED payload and post-run state stay complete
+          // without paying the per-flush re-serialization cost.
+          componentTestStatuses: this.runComponentTestStatuses,
+          a11yStatuses: this.runA11yStatuses,
+          /*
+            TODO: a11yReports is just here for backwards compatibility with older versions of addon-mcp.
+            They are also part of the more generic reports property, so we can remove this in a future major release when we can break compatibility.
+          */
+          a11yReports: this.runA11yReports,
+          reports: this.runReports,
         },
       };
     });


### PR DESCRIPTION
Related to #35422 (merged). Supersedes the `@storybook/addon-vitest` part of the now-closed #35400 / #35419.

## What I did

**The problem.** On large Storybooks, running the full component-test suite via `@storybook/addon-vitest` pops a **"Server timed out"** toast partway through the run and disconnects the manager — even though the dev server is perfectly healthy. Under the hood, the manager's WebSocket is closing with code `3008` ("timeout").

**Why #35422 wasn't enough.** #35422 already fixed part of this by resetting the WebSocket heartbeat on every message. But at scale (~3579 stories) the manager *still* disconnects around test ~2100 — so that PR was necessary but not sufficient. This PR removes the remaining cause.

**Root cause.** While tests run, addon-vitest flushes results every 500ms into a `UniversalStore`, accumulating the **entire run so far** (`componentTestStatuses`, `a11yStatuses`, `reports`, `a11yReports`). Because `UniversalStore.setState` broadcasts the **whole** state on every change, each flush re-serialized and re-sent the ever-growing run over the channel — **O(N²)** work across a run. Late in a big run, a single flush blocks the manager's main thread for longer than the 20s heartbeat window, so nothing resets the watchdog and it closes the socket (`3008`).

**The fix — keep the growing data out of the per-flush broadcast:**

- Accumulate the four full-run arrays **locally on the Node side**, not in the synced store.
- Each 500ms flush now syncs **only the counts** → a small, constant-size payload no matter how long the run gets.
- Materialize the full results into the store **once, at the end of the run**, so the `TEST_RUN_COMPLETED` payload (external test API, telemetry, addon-mcp) is unchanged.

```diff
  // on every 500ms flush, into the synced store:
- componentTestStatuses: [...entire run so far]   // re-broadcast every flush → O(N²)
- reports:               { ...entire run so far }
+ componentTestCount:    { success, error }        // counts only → bounded, constant size
  // the full arrays are written to the store once, at run end
```

**No user-visible change.** The live sidebar / per-story statuses come from the separate status stores, not from this run state, so live progress keeps updating exactly as before.

### Result (Chromatic, ~3579 tests — DevTools → Network → WS)

| Config | Outcome |
|--------|---------|
| before #35422, 500ms flush | ❌ disconnects (`3008`) at ~200–400 tests |
| #35422 only, 500ms flush | ❌ disconnects (`3008`) at ~2100–2200 tests |
| #35422 + **this PR**, 500ms flush | ✅ full run completes, socket stays open |

All three rows are measured. The last was verified on a canary of this PR (`0.0.0-pr-35425-sha-76189a02`) at the stock 500ms flush interval — i.e. with the temporary 2s-throttle workaround removed.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests

<!-- `test-manager.test.ts` asserts the heavy per-run arrays stay out of the synced store during the run (only counts advance) and are materialized exactly once at run end. -->

#### Manual testing

Reproducing requires a large Storybook (1000+ test-tagged stories; most reliable at several thousand).

1. Point a large Storybook that uses `@storybook/addon-vitest` at this branch (or a canary of it), leave the addon-vitest flush at its stock 500ms, and run `storybook dev`.
2. Open the manager → DevTools → **Network → WS** → select `storybook-server-channel`, and enable **Disable cache**.
3. In the Test widget, enable **Interactions + Coverage**, then **Run all component tests**.
4. (Optional, to force the failure faster on smaller projects) DevTools → Performance → **CPU throttling 6×** on the manager tab.
5. **Expected:** the run completes with the manager staying connected — no "Server timed out" toast and **no `3008` close frame** on the WS. On `next` without this PR, the socket closes with `3008` partway through a large run.

### Documentation

- [ ] Add or update documentation reflecting your changes

<!-- No docs change: this is an internal performance fix with no API/behavior change. -->

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below: `bug`
- [x] Suggested extra label: `upgrade:10.5.0`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test run performance by reducing how much result data is updated during intermediate progress.
  * Kept live progress counts accurate while delaying heavier result details until the run finishes.
  * Ensured full component and accessibility results, including per-story reports, appear reliably at the end of a run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
