### PR TITLE
Angular-Vite: Drop @angular/platform-browser-dynamic peer dependency

### DIFF
--- a/code/frameworks/angular-vite/package.json
+++ b/code/frameworks/angular-vite/package.json
@@ -99,7 +99,6 @@
     "@angular/compiler-cli": ">=21.0.0 < 23.0.0",
     "@angular/core": ">=21.0.0 < 23.0.0",
     "@angular/platform-browser": ">=21.0.0 < 23.0.0",
-    "@angular/platform-browser-dynamic": ">=21.0.0 < 23.0.0",
     "rxjs": "^7.4.0",
     "storybook": "workspace:^",
     "typescript": "^5.9.0",

--- a/code/lib/create-storybook/src/generators/ANGULAR/index.ts
+++ b/code/lib/create-storybook/src/generators/ANGULAR/index.ts
@@ -146,9 +146,15 @@ export default defineGeneratorModule({
         : '@angular-devkit/build-angular',
       devkitVersion ? `@angular-devkit/architect@${devkitVersion}` : '@angular-devkit/architect',
       angularVersion ? `@angular-devkit/core@${angularVersion}` : '@angular-devkit/core',
-      angularVersion
-        ? `@angular/platform-browser-dynamic@${angularVersion}`
-        : '@angular/platform-browser-dynamic',
+      // @storybook/angular-vite renders via bootstrapApplication from @angular/platform-browser,
+      // so platform-browser-dynamic is only a peer requirement of the webpack framework.
+      ...(isVite
+        ? []
+        : [
+            angularVersion
+              ? `@angular/platform-browser-dynamic@${angularVersion}`
+              : '@angular/platform-browser-dynamic',
+          ]),
     ];
 
     // pnpm's strict isolation hides transitively-installed `@types/node`, so a fresh Angular

--- a/yarn.lock
+++ b/yarn.lock
@@ -9340,7 +9340,6 @@ __metadata:
     "@angular/compiler-cli": ">=21.0.0 < 23.0.0"
     "@angular/core": ">=21.0.0 < 23.0.0"
     "@angular/platform-browser": ">=21.0.0 < 23.0.0"
-    "@angular/platform-browser-dynamic": ">=21.0.0 < 23.0.0"
     rxjs: ^7.4.0
     storybook: "workspace:^"
     typescript: ^5.9.0


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Removed `@angular/platform-browser-dynamic` from the `peerDependencies` of `@storybook/angular-vite`:

- The framework renders via `bootstrapApplication` from `@angular/platform-browser` (`src/client/renderer/AbstractRenderer.ts`); nothing in the shipped code imports `@angular/platform-browser-dynamic`. Its only usages are internal test files and the vitest setup, which are covered by the existing `devDependencies` entry.
- Modern standalone-API Angular apps don't include `@angular/platform-browser-dynamic` by default anymore, so requiring it as a peer forces users to install a package the framework never touches.
- Also updated the `create-storybook` Angular generator so it no longer installs `@angular/platform-browser-dynamic` when setting up an Angular + Vite project. It is still installed for the webpack-based `@storybook/angular`, which continues to declare it as a peer dependency.
- Updated `yarn.lock` via `yarn install`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Run `npx storybook init` (canary of this PR) in a fresh Angular CLI project using the Vite builder
2. Confirm the install completes without peer dependency warnings and that `@angular/platform-browser-dynamic` is NOT added to the project's `package.json`
3. Run Storybook and verify stories render correctly
4. Repeat with a webpack-based Angular project and confirm `@angular/platform-browser-dynamic` IS still installed there

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-35457-sha-526b992f`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-35457-sha-526b992f sandbox` or in an existing project with `npx storybook@0.0.0-pr-35457-sha-526b992f upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-35457-sha-526b992f`](https://npmjs.com/package/storybook/v/0.0.0-pr-35457-sha-526b992f) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/angular-vite-drop-platform-browser-dynamic-peer`](https://github.com/storybookjs/storybook/tree/valentin/angular-vite-drop-platform-browser-dynamic-peer) |
| **Commit** | [`526b992f`](https://github.com/storybookjs/storybook/commit/526b992fe6912b4bc5be6533b449d0e1b2c87fec) |
| **Datetime** | Fri Jul 10 12:57:49 UTC 2026 (`1783688269`) |
| **Workflow run** | [29094320771](https://github.com/storybookjs/storybook/actions/runs/29094320771) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=35457`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->