### PR TITLE
ESLint: Recognize storybook/test imports in await-interactions

### DIFF
--- a/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
@@ -216,8 +216,38 @@ ruleTester.run('await-interactions', rule, {
         }
       `,
       errors: [
-        { messageId: 'interactionShouldBeAwaited', data: { method: 'toHaveBeenCalled' } },
-        { messageId: 'interactionShouldBeAwaited', data: { method: 'findByText' } },
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'toHaveBeenCalled' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { expect, findByText } from 'storybook/test'
+                WithModalOpen.play = async ({ args }) => {
+                  await expect(args.onClick).toHaveBeenCalled()
+                  const element = findByText(canvasElement, 'asdf')
+                }
+              `,
+            },
+          ],
+        },
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'findByText' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { expect, findByText } from 'storybook/test'
+                WithModalOpen.play = async ({ args }) => {
+                  expect(args.onClick).toHaveBeenCalled()
+                  const element = await findByText(canvasElement, 'asdf')
+                }
+              `,
+            },
+          ],
+        },
       ],
     },
     {

--- a/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
@@ -199,6 +199,28 @@ ruleTester.run('await-interactions', rule, {
       ],
     },
     {
+      // Storybook v10 exposes these from the bare `storybook/test` entry point,
+      // so the rule must apply to that import too.
+      code: dedent`
+        import { expect, findByText } from 'storybook/test'
+        WithModalOpen.play = async ({ args }) => {
+          expect(args.onClick).toHaveBeenCalled()
+          const element = findByText(canvasElement, 'asdf')
+        }
+      `,
+      output: dedent`
+        import { expect, findByText } from 'storybook/test'
+        WithModalOpen.play = async ({ args }) => {
+          await expect(args.onClick).toHaveBeenCalled()
+          const element = await findByText(canvasElement, 'asdf')
+        }
+      `,
+      errors: [
+        { messageId: 'interactionShouldBeAwaited', data: { method: 'toHaveBeenCalled' } },
+        { messageId: 'interactionShouldBeAwaited', data: { method: 'findByText' } },
+      ],
+    },
+    {
       code: dedent`
         WithModalOpen.play = ({ canvasElement }) => {
           const canvas = within(canvasElement)

--- a/code/lib/eslint-plugin/src/rules/await-interactions.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.ts
@@ -135,7 +135,8 @@ export default createStorybookRule({
     const isUserEventFromStorybookImported = (node: TSESTree.ImportDeclaration) => {
       return (
         (node.source.value === '@storybook/testing-library' ||
-          node.source.value === '@storybook/test') &&
+          node.source.value === '@storybook/test' ||
+          node.source.value === 'storybook/test') &&
         node.specifiers.find(
           (spec) =>
             isImportSpecifier(spec) &&
@@ -148,7 +149,9 @@ export default createStorybookRule({
 
     const isExpectFromStorybookImported = (node: TSESTree.ImportDeclaration) => {
       return (
-        (node.source.value === '@storybook/jest' || node.source.value === '@storybook/test') &&
+        (node.source.value === '@storybook/jest' ||
+          node.source.value === '@storybook/test' ||
+          node.source.value === 'storybook/test') &&
         node.specifiers.find(
           (spec) =>
             isImportSpecifier(spec) && 'name' in spec.imported && spec.imported.name === 'expect'


### PR DESCRIPTION
Closes #35456

## What I did

`eslint-plugin-storybook`'s `await-interactions` rule only fired when `userEvent`/`expect` were imported from `@storybook/testing-library`, `@storybook/jest`, or `@storybook/test`. Storybook v10 exposes these from the bare `storybook/test` entry point, so play functions importing from `storybook/test` were never linted.

Added `storybook/test` to both `isUserEventFromStorybookImported` and `isExpectFromStorybookImported`, so v10 imports are treated exactly like `@storybook/test`, plus an `invalid` test case covering the new import path.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. In the eslint-plugin package, add a story/play function that imports `userEvent`/`expect` from `storybook/test` (not `@storybook/test`) and calls `userEvent.click(...)` or `expect(...).toHaveBeenCalled()` without `await`.
2. Run the plugin's `await-interactions` rule against that file (e.g. via the rule's own RuleTester, or `eslint` configured with `plugin:storybook/recommended` against a `.storybook` project using v10's `storybook/test` import).
3. On `next` (before this fix) the un-awaited call is not flagged. With this change it is flagged the same way an un-awaited `@storybook/test` import already is.

I verified the rule logic directly with ESLint's `Linter` API: a `storybook/test` import produces the two expected `interactionShouldBeAwaited` errors, `@storybook/test` still produces one, and an unrelated `chai` import produces none. I couldn't run the eslint-plugin's own `vitest` suite in an isolated container (the monorepo's TS/build tooling doesn't install standalone), so CI's eslint-plugin test job is the authoritative check for the added test case.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes.
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the `bug`/`maintenance`/`dependencies`/`build`/`cleanup`/`documentation`/`feature request`/`BREAKING CHANGE`/`other` labels


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Storybook interactions imported from supported test entry points.
  * The linting rule now correctly flags missing `await` usage for `expect`, `findByText`, and related interactions.
  * Fix suggestions now add `await` where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->