### PR TITLE
ESLint: Recognize storybook/test in await-interactions

### DIFF
--- a/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
@@ -198,6 +198,94 @@ ruleTester.run('await-interactions', rule, {
         },
       ],
     },
+    // v10 serves userEvent/expect from the bare `storybook/test` entry point. The next
+    // two cases gate through one helper each (expect-only, then userEvent-only) so both
+    // import checks are covered independently.
+    {
+      code: dedent`
+        import { expect, findByText } from 'storybook/test'
+        WithModalOpen.play = async ({ args }) => {
+          // should complain
+          expect(args.onClick).toHaveBeenCalled()
+          const element = findByText(canvasElement, 'asdf')
+        }
+      `,
+      output: dedent`
+        import { expect, findByText } from 'storybook/test'
+        WithModalOpen.play = async ({ args }) => {
+          // should complain
+          await expect(args.onClick).toHaveBeenCalled()
+          const element = await findByText(canvasElement, 'asdf')
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'toHaveBeenCalled' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { expect, findByText } from 'storybook/test'
+                WithModalOpen.play = async ({ args }) => {
+                  // should complain
+                  await expect(args.onClick).toHaveBeenCalled()
+                  const element = findByText(canvasElement, 'asdf')
+                }
+              `,
+            },
+          ],
+        },
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'findByText' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { expect, findByText } from 'storybook/test'
+                WithModalOpen.play = async ({ args }) => {
+                  // should complain
+                  expect(args.onClick).toHaveBeenCalled()
+                  const element = await findByText(canvasElement, 'asdf')
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { userEvent } from 'storybook/test'
+        Basic.play = async () => {
+          userEvent.click(button)
+        }
+      `,
+      output: dedent`
+        import { userEvent } from 'storybook/test'
+        Basic.play = async () => {
+          await userEvent.click(button)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'userEvent' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { userEvent } from 'storybook/test'
+                Basic.play = async () => {
+                  await userEvent.click(button)
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
     {
       code: dedent`
         WithModalOpen.play = ({ canvasElement }) => {

--- a/code/lib/eslint-plugin/src/rules/await-interactions.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.ts
@@ -135,7 +135,8 @@ export default createStorybookRule({
     const isUserEventFromStorybookImported = (node: TSESTree.ImportDeclaration) => {
       return (
         (node.source.value === '@storybook/testing-library' ||
-          node.source.value === '@storybook/test') &&
+          node.source.value === '@storybook/test' ||
+          node.source.value === 'storybook/test') &&
         node.specifiers.find(
           (spec) =>
             isImportSpecifier(spec) &&
@@ -148,7 +149,9 @@ export default createStorybookRule({
 
     const isExpectFromStorybookImported = (node: TSESTree.ImportDeclaration) => {
       return (
-        (node.source.value === '@storybook/jest' || node.source.value === '@storybook/test') &&
+        (node.source.value === '@storybook/jest' ||
+          node.source.value === '@storybook/test' ||
+          node.source.value === 'storybook/test') &&
         node.specifiers.find(
           (spec) =>
             isImportSpecifier(spec) && 'name' in spec.imported && spec.imported.name === 'expect'


### PR DESCRIPTION
Closes #35456

## What I did

`await-interactions` didn't know v10's `storybook/test` import, only the older paths, so it stopped flagging un-awaited interactions on migrated projects. Added it to both helpers. Two tests, one per helper, both fail on `next` without the fix.

Didn't touch a pre-existing quirk where a trailing non-storybook import silences the rule (same on `@storybook/test`). Follow-up if you want it.

I didn't use AI assistance for this. The changes and the tests are mine, and I've verified them.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Run `npx eslint` on the issue's repro (https://github.com/bodograumann/repro-storybook-eslint-v10) after building this branch. On `next` only the old-import story is flagged; with this change the `storybook/test` one is too.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>