### PR TITLE
E2E: Fix addon-mcp toolset status locator

### DIFF
--- a/code/e2e-sandbox/addon-mcp.spec.ts
+++ b/code/e2e-sandbox/addon-mcp.spec.ts
@@ -137,12 +137,12 @@ test.describe('addon-mcp', () => {
         // Check that dev toolset is listed with its tools
         const devToolset = page.locator('.toolset', { has: page.locator('text=dev') });
         await expect(devToolset).toBeVisible();
-        await expect(devToolset.locator('.toolset-status')).toHaveText('enabled');
+        await expect(devToolset.locator('.toolset-status').first()).toHaveText('enabled');
 
         // Check that docs toolset is listed with its tools
         const docsToolset = page.locator('.toolset', { has: page.locator('text=docs') });
         await expect(docsToolset).toBeVisible();
-        await expect(docsToolset.locator('.toolset-status')).toHaveText('enabled');
+        await expect(docsToolset.locator('.toolset-status').first()).toHaveText('enabled');
 
         // Check that test toolset is listed with its tools
         const testToolset = page.locator('.toolset', { has: page.locator('text=test') });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Scope the addon-mcp dev and docs toolset status assertions to the first status badge. `@storybook/addon-mcp` 0.7.0 added per-tool status badges under the dev toolset, so the previous descendant locator deterministically matched four elements and violated Playwright strict mode.

This is the only failing assertion in [CircleCI job 1742523](https://app.circleci.com/pipelines/github/storybookjs/storybook/127108/workflows/324c3cf4-b44a-470b-acab-e3f263934c82/jobs/1742523). The same change already made [CircleCI job 1746128](https://circleci.com/gh/storybookjs/storybook/1746128) pass all 81 runnable React Vite E2Es on Valentin's branch.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Run `yarn task sandbox --template react-vite/default-ts --start-from auto` from the repository root.
2. Start the generated sandbox with `(cd ../storybook-sandboxes/react-vite-default-ts && yarn storybook --port 6006 --ci)`.
3. In another terminal at the repository root, run `(cd code && STORYBOOK_URL=http://localhost:6006 STORYBOOK_TYPE=dev STORYBOOK_TEMPLATE_NAME=react-vite/default-ts STORYBOOK_SANDBOX_DIR="$PWD/../../storybook-sandboxes/react-vite-default-ts" yarn playwright test --project=chromium e2e-sandbox/addon-mcp.spec.ts --grep 'should show both toolsets as enabled' --workers=1)`.
4. Verify Playwright reports both setup and the addon-mcp info-page test passing.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end checks for the Info Page to verify that the development and documentation toolsets display an “enabled” status correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->