### PR TITLE
Pseudo States: Prevent :where() States from Gaining Specificity

### DIFF
--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -390,6 +390,22 @@ describe('rewriteStyleSheet', () => {
     );
   });
 
+  it('preserves zero specificity for pseudo-states inside ":where"', () => {
+    const sheet = new Sheet('.textLink:where(:focus-visible) { text-decoration: none }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].cssText).toEqual(
+      '.textLink:where(:focus-visible), .textLink:where(.pseudo-focus-visible), :where(.pseudo-focus-visible-all) .textLink { text-decoration: none }'
+    );
+  });
+
+  it('preserves the specificity of pseudo-states inside and outside ":where"', () => {
+    const sheet = new Sheet('.textLink:hover:where(:focus-visible) { text-decoration: none }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].cssText).toEqual(
+      '.textLink:hover:where(:focus-visible), .textLink.pseudo-hover:where(.pseudo-focus-visible), .pseudo-hover-all:where(.pseudo-focus-visible-all) .textLink { text-decoration: none }'
+    );
+  });
+
   it('keeps child-combinator pseudo-state selectors valid', () => {
     const sheet = new Sheet('.ds-card > :focus-visible { outline: none }');
     rewriteStyleSheet(sheet as any);

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
@@ -10,6 +10,47 @@ const pseudoStatesPattern = `${EXCLUDED_PSEUDO_ESCAPE_SEQUENCE}:(${pseudoStates.
 const matchOne = new RegExp(pseudoStatesPattern);
 const matchAll = new RegExp(pseudoStatesPattern, 'g');
 
+const getZeroSpecificityIndexes = (selector: string) => {
+  const indexes = new Set<number>();
+  const zeroSpecificityStack: boolean[] = [];
+  let quote: '"' | "'" | undefined;
+
+  for (let index = 0; index < selector.length; index++) {
+    const character = selector[index];
+
+    if (character === '\\') {
+      index++;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === '(') {
+      const parentHasZeroSpecificity = zeroSpecificityStack.at(-1) ?? false;
+      zeroSpecificityStack.push(
+        parentHasZeroSpecificity || selector.slice(0, index).endsWith(':where')
+      );
+      continue;
+    }
+    if (character === ')') {
+      zeroSpecificityStack.pop();
+      continue;
+    }
+    if (zeroSpecificityStack.at(-1)) {
+      indexes.add(index);
+    }
+  }
+
+  return indexes;
+};
+
 const warnings = new Set();
 const warnOnce = (message: string) => {
   if (warnings.has(message)) {
@@ -43,7 +84,14 @@ const replacePseudoStatesWithAncestorSelector = (
     return selector;
   }
 
-  const selectors = `${additionalHostSelectors ?? ''}${extracted.states.map((s) => `.pseudo-${s}-all`).join('')}`;
+  const selectors = `${additionalHostSelectors ?? ''}${extracted.states
+    .filter((state) => !extracted.zeroSpecificityStates.includes(state))
+    .map((state) => `.pseudo-${state}-all`)
+    .join('')}${
+    extracted.zeroSpecificityStates.length > 0
+      ? `:where(${extracted.zeroSpecificityStates.map((state) => `.pseudo-${state}-all`).join('')})`
+      : ''
+  }`;
 
   // If there was a :host-context() containing only pseudo-states, we will later add a :host selector that replaces it.
   let { withoutPseudoStates } = extracted;
@@ -59,11 +107,16 @@ const replacePseudoStatesWithAncestorSelector = (
 };
 
 const extractPseudoStates = (selector: string) => {
-  const states = new Set();
+  const states = new Set<string>();
+  const statesWithSpecificity = new Set<string>();
+  const zeroSpecificityIndexes = getZeroSpecificityIndexes(selector);
   const withoutPseudoStates =
     selector
-      .replace(matchAll, (_, state) => {
+      .replace(matchAll, (_, state: string, index: number) => {
         states.add(state);
+        if (!zeroSpecificityIndexes.has(index)) {
+          statesWithSpecificity.add(state);
+        }
         return '';
       })
       // If removing pseudo-state selectors from inside a functional selector left it empty (thus invalid), must fix it by adding '*'.
@@ -73,10 +126,13 @@ const extractPseudoStates = (selector: string) => {
       // keep the selector valid by targeting any child/sibling.
       .replace(/([>+~])\s*(?=$|[,)])/g, '$1 *')
       // If a selector list was left with blank items (e.g. ", foo, , bar, "), remove the extra commas/spaces.
-      .replace(/(?<=[\s(]),\s+|(,\s+)+(?=\))/g, '') || '*';
+      .replace(/(?<=[\s(]),\s+|(,\s+)+(?=\))/g, '')
+      // A :where() containing only pseudo-states no longer constrains the target element.
+      .replaceAll(':where(*)', '') || '*';
 
   return {
     states: Array.from(states),
+    zeroSpecificityStates: Array.from(states).filter((state) => !statesWithSpecificity.has(state)),
     withoutPseudoStates,
   };
 };


### PR DESCRIPTION
Closes #31411

## What I did

- Track pseudo-states extracted from `:where()` separately from states that contribute specificity.
- Wrap generated `*-all` ancestor classes in `:where()` only when the original pseudo-state was in a zero-specificity context.
- Remove the vacuous `:where(*)` left after extracting a state-only `:where()` selector.
- Add regression coverage for state-only and mixed-specificity selectors.

This keeps `.textLink:where(:focus-visible)` at specificity `0-1-0` after rewriting instead of raising the generated ancestor selector to `0-2-0`.

AI assistance disclosure: Codex was used to help investigate, implement, and test this change.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No separate manual test is necessary. The unit test exercises the exact selector from the issue and asserts the complete rewritten CSS selector list.

Validation run locally:

- `yarn vitest run --config code/addons/pseudo-states/vitest.config.ts code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts code/addons/pseudo-states/src/preview/splitSelectors.test.ts` (56 tests passed, no type errors)
- `yarn nx compile storybook-addon-pseudo-states`
- `yarn nx check storybook-addon-pseudo-states`
- Targeted ESLint (zero errors)

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes.
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains one release label.

### 🦋 Canary release

This PR does not have a canary release associated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pseudo-state styling within `:where(...)` selectors.
  - Preserved zero specificity for pseudo-states inside `:where(...)`.
  - Corrected specificity handling when pseudo-states appear both inside and outside `:where(...)`.
  - Improved selector cleanup after pseudo-state processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->