### PR TITLE
CI: Skip the redundant Compodoc run when documentation.json ships with the sandbox

### DIFF
--- a/scripts/combine-compodoc.ts
+++ b/scripts/combine-compodoc.ts
@@ -1,6 +1,7 @@
 // Compodoc does not follow symlinks (it ignores them and their contents entirely)
 // So, we need to run a separate compodoc process on every symlink inside the project,
 // then combine the results into one large documentation.json
+import { existsSync } from 'node:fs';
 import { lstat, readFile, realpath, writeFile } from 'node:fs/promises';
 
 // eslint-disable-next-line depend/ban-dependencies
@@ -30,6 +31,17 @@ async function findSymlinks(dir: string) {
 }
 
 async function run(cwd: string) {
+  const combinedDocsPath = join(cwd, 'documentation.json');
+
+  // On CI the sandbox tree is immutable once the create job has packed it, so a
+  // documentation.json travelling in the sandbox archive is current by
+  // construction. Regenerating it would stall every dev-server start behind a
+  // full Compodoc pass for identical output.
+  if (process.env.CI && existsSync(combinedDocsPath)) {
+    logger.log(`Skipping Compodoc: ${combinedDocsPath} already exists on CI`);
+    return;
+  }
+
   const dirs = [
     cwd,
     ...(await findSymlinks(resolve(cwd, './src'))),


### PR DESCRIPTION
Last PR of the CI-timing stack: sits on top of #35486, which sits on #35352 (both rebased onto `next`). The Angular dev/e2e/chromatic jobs boot storybook through a `docs:json` prefix that unconditionally regenerates `documentation.json` before the server can start - even though the create job already generated it during the in-create static build (#35352) and `packSandbox` ships it in the sandbox archive with no excludes.

## What

`scripts/combine-compodoc.ts` early-returns when `CI` is set and `documentation.json` already exists in the sandbox root.

## Why it is safe

- On CI the sandbox tree is immutable once the create job has packed it, so an existing `documentation.json` is current by construction - the second Compodoc pass reproduced identical output.
- The create job itself is unaffected: when its build runs Compodoc, the file does not exist yet, so it is generated exactly once and then travels in the tarball.
- Local sandboxes (no `CI` env) keep regenerating on every start, preserving the edit loop.
- The angular-vite preset's own `viteFinal` already has an exists-guard for this file; it just never helped because the `docs:json` wrapper clobbered the file first.

## Measurement (ci:merged, measured)

Baseline is #35486's run on the direct parent commit ([workflow `aea0b726`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127457/workflows/aea0b726-9025-4614-8de5-58b9c2142ced)); this PR is that plus the Compodoc-skip commit ([workflow `17cdb131`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127460/workflows/17cdb131-2b2a-4f19-9288-d35b31cc717a)). Both fully green, identical 119-job topology.

| Metric | #35486 parent | This PR |
| --- | --- | --- |
| angular-vite dev boot ("Wait on servers") | 40s | 27s |
| angular-webpack dev boot | 54s | 46s |
| all other dev boots, 15 jobs (control group) | 245s | 246s (untouched, as designed) |
| angular-vite dev chain ends | 736s (wall-defining tail) | 645s |
| latest dev job ends | 736s | 687s |
| **Workflow wall** | **743s** | **692s** |

- Log-verified: both Angular dev boots print exactly one "Skipping Compodoc: ... already exists on CI" and run zero Compodoc passes; the create jobs show no skip message (the file is generated there once and ships in the tarball), and the docgen-dependent Angular e2e assertions are green.
- The angular-vite chain leaves the top-5 finishers entirely; the tail is now a ~685s cluster (next-js vite dev, angular webpack dev, react vite dev), so further wall work has to attack dev-server boots broadly rather than one template.
- angular-webpack's create/e2e/chromatic read slower this run (+29s/+37s/+62s) - queue noise on a contended fleet; the boots this PR touches all got faster.

Stack summary on `ci:merged` walls: `next` 820s → #35352 758-777s → +#35486 743s → **+#35480 692s**.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [x] integration tests
- [x] end-to-end tests

Every Angular sandbox job on this PR's CI run exercises the skip path: the dev/e2e/chromatic jobs boot against the shipped `documentation.json`, so a stale or missing file would fail their smoke and E2E assertions.

#### Manual testing

1. ~On this PR's `ci:merged` run: the Angular `(dev)`/`(e2e)` jobs' boot logs must show "Skipping Compodoc: ... already exists on CI" instead of a Compodoc pass.~ Done: verified in both Angular dev jobs' "Run storybook" logs (one skip message, zero Compodoc invocations).
2. ~Verify the Angular `(create)` jobs still run Compodoc exactly once (no skip message during the in-create build).~ Done: no skip message anywhere in the create jobs; the shipped `documentation.json` is consumed downstream.
3. ~Verify Angular docgen still works downstream: the Angular e2e and vitest jobs stay green (they assert on argtype-derived controls).~ Done: all Angular jobs green on [workflow `17cdb131`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127460/workflows/17cdb131-2b2a-4f19-9288-d35b31cc717a).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced CI build time by reusing existing generated documentation when available.
  * Avoided unnecessary documentation generation and processing during CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->