### PR TITLE
Addon: Pseudo-States Addon CSS Rule Rewrites

### DIFF
--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { rewriteStyleSheet } from './rewriteStyleSheet.ts';
 import { splitSelectors } from './splitSelectors.ts';
@@ -29,7 +29,12 @@ abstract class Rule {
   selectorText?: string;
 
   static parse(cssText: string): Rule {
-    return cssText.trim().startsWith('@') ? new GroupingRule(cssText) : new StyleRule(cssText);
+    if (cssText.trim().startsWith('@')) {
+      return new GroupingRule(cssText);
+    }
+
+    const innerCssText = cssText.substring(cssText.indexOf('{') + 1, cssText.lastIndexOf('}'));
+    return innerCssText.includes('{') ? new NestedStyleRule(cssText) : new StyleRule(cssText);
   }
 
   getSelectors(): string[] {
@@ -70,6 +75,13 @@ class GroupingRule extends Rule {
 
   insertRule(cssText: string, index: number) {
     this.cssRules.splice(index, 0, Rule.parse(cssText));
+  }
+}
+
+class NestedStyleRule extends GroupingRule {
+  constructor(cssText: string) {
+    super(cssText);
+    this.selectorText = cssText.substring(0, cssText.indexOf(' {'));
   }
 }
 
@@ -215,6 +227,18 @@ describe('rewriteStyleSheet', () => {
     const selectors = sheet.cssRules[0].getSelectors();
     selectors.splice(selectors.indexOf('a.pseudo-hover'), 1);
     expect(selectors).not.toContain('a.pseudo-hover');
+  });
+
+  it('does not mutate a rewritten rule again on subsequent rewrites', () => {
+    const sheet = new Sheet('a:hover { color: red }');
+    const deleteRule = vi.spyOn(sheet, 'deleteRule');
+    const insertRule = vi.spyOn(sheet, 'insertRule');
+
+    rewriteStyleSheet(sheet as any);
+    rewriteStyleSheet(sheet as any);
+
+    expect(deleteRule).toHaveBeenCalledOnce();
+    expect(insertRule).toHaveBeenCalledOnce();
   });
 
   it('supports combined pseudo selectors', () => {
@@ -566,5 +590,29 @@ describe('rewriteStyleSheet', () => {
         'a.pseudo-hover'
       );
     }
+  });
+
+  it('counts both a rewritten style rule and its nested rules toward the limit', () => {
+    const sheet = new Sheet(Array(501).fill('a:hover { b:hover { color: red } }').join('\n'));
+
+    rewriteStyleSheet(sheet as any);
+    rewriteStyleSheet(sheet as any);
+
+    expect(sheet.cssRules[499].getSelectors()).toContain('a.pseudo-hover');
+    expect(sheet.cssRules[500].getSelectors()).not.toContain('a.pseudo-hover');
+  });
+
+  it('does not rewrite nested rules after the outer rule reaches the limit', () => {
+    const sheet = new Sheet(
+      [...Array(999).fill('a:hover { color: red }'), 'b:hover { c:hover { color: red } }'].join(
+        '\n'
+      )
+    );
+
+    rewriteStyleSheet(sheet as any);
+
+    const finalRule = sheet.cssRules[999] as NestedStyleRule;
+    expect(finalRule.getSelectors()).toContain('b.pseudo-hover');
+    expect(finalRule.cssRules[0].getSelectors()).not.toContain('c.pseudo-hover');
   });
 });

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
@@ -215,18 +215,23 @@ const rewriteRuleContainer = (
       }
 
       // If it has nested rules, check them as well
-      if ('cssRules' in styleRule && (styleRule.cssRules as CSSRuleList).length) {
-        numRewritten = rewriteRuleContainer(
+      const remainingRewriteLimit = rewriteLimit - count - numRewritten;
+      if (
+        remainingRewriteLimit > 0 &&
+        'cssRules' in styleRule &&
+        (styleRule.cssRules as CSSRuleList).length
+      ) {
+        numRewritten += rewriteRuleContainer(
           styleRule as CSSGroupingRule,
-          rewriteLimit - count,
+          remainingRewriteLimit,
           forShadowDOM
         );
       }
 
       // @ts-expect-error We're adding this nonstandard property
-      cssRule.__processed = true;
+      styleRule.__processed = true;
       // @ts-expect-error We're adding this nonstandard property
-      cssRule.__pseudoStatesRewrittenCount = numRewritten;
+      styleRule.__pseudoStatesRewrittenCount = numRewritten;
     }
     count += numRewritten;
 


### PR DESCRIPTION
## Summary

We've received an increase in reports from Storybook users, especially on the Chromatic support side, that Chromatic snapshots aren't working for projects with extensive CSS usage and large stylesheets.
The common factor is that the pseudo-states addon is the culprit.

- Avoid rewriting the same CSSOM rule more than once when `rewriteStyleSheet` is invoked repeatedly.
- Track rewrite state on the actual style rule object so nested rules inherit the correct processed state.
- Propagate the remaining rewrite budget through nested grouping rules to prevent over-rewriting after the limit is reached.
- Add regression coverage for repeated rewrites and nested rules at the rewrite limit.

## Reproduction
The customer reproduced this by disabling the addon, and their builds in Chromatic started passing.
They then reintroduced the addon and removed complex rules from their `preview. tsx', but that didn't solve the build issues.
They also tested with the addon enabled and with the lengthy addon-docs customizations removed in their stories, but that didn't resolve the build issues either.

Everything I've tested points to the addon not replacing rules correctly, so this process alters the addon to store __processed and __pseudoStatesRewrittenCount on styleRule, which points at the replacement after insertion, rather than on the discarded cssRule.

## Testing
- Added Vitest coverage for repeated rewrite passes, nested pseudo-state rules, and limit accounting.
- Not run (not requested).

#### Manual testing
TBD