### PR TITLE
Angular: Honor stylePreprocessorOptions.includePaths in angular-vite

### DIFF
--- a/code/frameworks/angular-vite/build-schema.json
+++ b/code/frameworks/angular-vite/build-schema.json
@@ -97,6 +97,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "loadPaths": {
+          "description": "Alias for `includePaths` using the dart-sass/Vite spelling. Paths will be resolved to workspace root.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolve } from 'node:path';
+
+import { normalizePath } from 'vite';
+
+import { angularOptionsPlugin } from './preset.ts';
+import type { StandaloneOptions } from './builders/utils/standalone-options.ts';
+
+// The plugin's `config` hook looks up the preview file on disk before reading
+// style options; stub just that lookup so the test stays hermetic.
+vi.mock(import('storybook/internal/common'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  findConfigFile: () => undefined,
+}));
+
+const WORKSPACE_ROOT = '/workspace';
+
+function runConfig(stylePreprocessorOptions: Record<string, unknown> | undefined) {
+  const options = {
+    configDir: '/workspace/.storybook',
+    angularBuilderContext: { workspaceRoot: WORKSPACE_ROOT } as any,
+    angularBuilderOptions: stylePreprocessorOptions ? { stylePreprocessorOptions } : {},
+  } as unknown as StandaloneOptions;
+
+  const plugin = angularOptionsPlugin(options, { normalizePath, zoneless: true });
+  // `config` is defined as a plain method above, so invoke it directly.
+  return (plugin.config as (userConfig: unknown) => any)({ root: WORKSPACE_ROOT });
+}
+
+describe('angularOptionsPlugin style preprocessor paths', () => {
+  it('resolves `includePaths` (angular.json spelling) to workspace-absolute SCSS load paths', () => {
+    const result = runConfig({ includePaths: ['src/styles', 'libs/theme'] });
+
+    expect(result.css.preprocessorOptions.scss.loadPaths).toEqual([
+      resolve(WORKSPACE_ROOT, 'src/styles'),
+      resolve(WORKSPACE_ROOT, 'libs/theme'),
+    ]);
+  });
+
+  it('accepts `loadPaths` as a dart-sass/Vite-spelling alias', () => {
+    const result = runConfig({ loadPaths: ['src/styles'] });
+
+    expect(result.css.preprocessorOptions.scss.loadPaths).toEqual([
+      resolve(WORKSPACE_ROOT, 'src/styles'),
+    ]);
+  });
+
+  it('prefers `includePaths` over `loadPaths` when both are present', () => {
+    const result = runConfig({ includePaths: ['a'], loadPaths: ['b'] });
+
+    expect(result.css.preprocessorOptions.scss.loadPaths).toEqual([resolve(WORKSPACE_ROOT, 'a')]);
+  });
+
+  it('forwards `sass` options alongside the resolved load paths', () => {
+    const result = runConfig({
+      includePaths: ['src/styles'],
+      sass: { silenceDeprecations: ['import'] },
+    });
+
+    expect(result.css.preprocessorOptions.scss).toMatchObject({
+      silenceDeprecations: ['import'],
+      loadPaths: [resolve(WORKSPACE_ROOT, 'src/styles')],
+    });
+  });
+
+  it('returns nothing when no style preprocessor paths are configured', () => {
+    expect(runConfig(undefined)).toBeUndefined();
+    expect(runConfig({})).toBeUndefined();
+  });
+});

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -238,8 +238,15 @@ export function angularOptionsPlugin(
     config(userConfig: UserConfig) {
       resolvedConfig = userConfig;
       resolvedPreviewPath = findConfigFile('preview', options.configDir) ?? undefined;
-      const loadPaths = options?.angularBuilderOptions?.stylePreprocessorOptions?.loadPaths;
-      const sassOptions = options?.angularBuilderOptions?.stylePreprocessorOptions?.sass;
+      const stylePreprocessorOptions =
+        options?.angularBuilderOptions?.stylePreprocessorOptions ?? {};
+      // Angular's builder schema (and this framework's builder schema) names the
+      // SCSS search-path array `includePaths`, matching angular.json. dart-sass
+      // and Vite call the same thing `loadPaths`; accept that spelling too so
+      // configs written against either convention work. `includePaths` wins when
+      // both are present.
+      const loadPaths = stylePreprocessorOptions.includePaths ?? stylePreprocessorOptions.loadPaths;
+      const sassOptions = stylePreprocessorOptions.sass;
 
       if (Array.isArray(loadPaths)) {
         const workspaceRoot =

--- a/code/frameworks/angular-vite/start-schema.json
+++ b/code/frameworks/angular-vite/start-schema.json
@@ -110,6 +110,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "loadPaths": {
+          "description": "Alias for `includePaths` using the dart-sass/Vite spelling. Paths will be resolved to workspace root.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/docs/get-started/frameworks/angular-vite.mdx
+++ b/docs/get-started/frameworks/angular-vite.mdx
@@ -195,7 +195,54 @@ export default config;
 
 ### TypeScript paths
 
-Storybook reads your `tsconfig.json`'s `baseUrl` and `paths` settings and maps them into Vite's resolver, so TypeScript path aliases work without additional configuration.
+Unlike the Webpack-based `@storybook/angular`, this framework does not automatically map your `tsconfig.json` `paths` aliases into Vite's module resolver. Vite resolves modules on disk and does not read the `paths` compiler option, so imports such as `@app/shared` will fail unless you register them yourself.
+
+The simplest fix is the [`vite-tsconfig-paths`](https://github.com/aleclarson/vite-tsconfig-paths) plugin, which reads `baseUrl` and `paths` from your `tsconfig.json` and adds the matching aliases:
+
+```ts title=".storybook/main.ts"
+import type { StorybookConfig } from '@storybook/angular-vite';
+
+const config: StorybookConfig = {
+  framework: '@storybook/angular-vite',
+  async viteFinal(config) {
+    const { mergeConfig } = await import('vite');
+    const { default: tsconfigPaths } = await import('vite-tsconfig-paths');
+    return mergeConfig(config, {
+      plugins: [tsconfigPaths()],
+    });
+  },
+};
+
+export default config;
+```
+
+Install it as a dev dependency first: `npm install --save-dev vite-tsconfig-paths`. If you prefer not to add a plugin, you can instead declare the aliases explicitly under [`resolve.alias`](https://vite.dev/config/shared-options.html#resolve-alias) in the same `viteFinal` hook.
+
+### SCSS include paths
+
+Like `paths`, SCSS search paths from your application's `build` target in `angular.json` are not inherited. Configure them on the Storybook builder target instead, using `stylePreprocessorOptions`. Both the Angular-style `includePaths` and the dart-sass/Vite spelling `loadPaths` are accepted, and paths are resolved relative to the workspace root:
+
+```jsonc title="angular.json"
+"storybook": {
+  "builder": "@storybook/angular-vite:start-storybook",
+  "options": {
+    "stylePreprocessorOptions": {
+      "includePaths": ["src/styles"],
+    },
+  },
+},
+```
+
+When running through the Storybook CLI (`storybook dev` / `storybook build`) rather than the Angular builders, there is no `angular.json` builder context to read from. In that case set the search paths directly in `.storybook/main.ts`:
+
+```ts title=".storybook/main.ts"
+async viteFinal(config) {
+  const { mergeConfig } = await import('vite');
+  return mergeConfig(config, {
+    css: { preprocessorOptions: { scss: { loadPaths: ['src/styles'] } } },
+  });
+},
+```
 
 ## Migration from `@storybook/angular`
 


### PR DESCRIPTION
The builder schema exposes SCSS search paths as `includePaths` (matching angular.json), but the framework preset read `loadPaths`, so the value was silently dropped end-to-end. Read `includePaths` (with `loadPaths` accepted as a dart-sass/Vite-spelling alias) and allow both spellings in the builder schemas.

Also fix the docs: the "TypeScript paths" section claimed aliases work out of the box, but nothing maps tsconfig `paths` into Vite's resolver. Document the `vite-tsconfig-paths` workaround and how to configure SCSS include paths.

Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- **Fix:** `@storybook/angular-vite`'s preset read `stylePreprocessorOptions.loadPaths`, but the builder schema (and `angular.json`) expose the field as `includePaths`, so user-configured SCSS include paths were silently dropped. The preset now reads `includePaths`, keeping `loadPaths` as a dart-sass/Vite-spelling alias, and both spellings are allowed in the `start-storybook`/`build-storybook` schemas.
- **Test:** Added unit coverage for the exported `angularOptionsPlugin` (resolution, alias, precedence, `sass` passthrough, empty config).
- **Docs:** Corrected the "TypeScript paths" section — nothing maps `tsconfig` `paths` into Vite's resolver, so documented the `vite-tsconfig-paths` / `resolve.alias` workaround — and added a "SCSS include paths" section covering `includePaths`/`loadPaths` on the builder target and the CLI-only `viteFinal` path.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Using the `angular-vite` sandbox (`yarn task --task sandbox --start-from auto --template angular-vite/default-ts`):

1. Add an SCSS partial the stories can reference, e.g. `src/styles/_theme.scss` containing `$primary: hotpink;`.
2. Configure the Storybook builder target in `angular.json` to include that folder, using the Angular spelling:
   ```jsonc
   "storybook": {
     "builder": "@storybook/angular-vite:start-storybook",
     "options": {
       "stylePreprocessorOptions": { "includePaths": ["src/styles"] }
     }
   }
   ```
3. In a component's SCSS, import the partial by its bare name: `@use 'theme';` (relying on the include path, not a relative path).
4. Run Storybook via `ng run <project>:storybook` and confirm the story renders with the styles applied — before this fix the build fails to resolve `theme` because `includePaths` was ignored.
5. Repeat with `"loadPaths"` instead of `"includePaths"` and confirm it behaves identically (alias).

**Docs-only changes** (TypeScript paths / SCSS include paths sections of `docs/get-started/frameworks/angular-vite.mdx`) require no runtime testing — review the rendered MDX for accuracy.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring SCSS search paths using either `includePaths` or `loadPaths`.
  * SCSS paths are resolved relative to the workspace and passed through with Sass options.

* **Documentation**
  * Clarified TypeScript path-alias configuration for Angular Vite projects.
  * Added guidance for configuring SCSS include paths in Storybook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
