### PR TITLE
CLI: Run addon postinstall automigrations with the local storybook binary

### DIFF
--- a/code/addons/a11y/src/postinstall.ts
+++ b/code/addons/a11y/src/postinstall.ts
@@ -3,8 +3,11 @@ import { JsPackageManagerFactory, versions } from 'storybook/internal/common';
 import type { PostinstallOptions } from '../../../lib/cli-storybook/src/add.ts';
 
 export default async function postinstall(options: PostinstallOptions) {
+  const useRemotePkg = options.useRemotePkg ?? !!options.skipInstall;
   const args = [
-    options.skipInstall ? `storybook@${versions.storybook}` : `storybook`,
+    // A versioned spec only resolves through the ephemeral runner; the local
+    // binary is invoked by bare name.
+    useRemotePkg ? `storybook@${versions.storybook}` : `storybook`,
     'automigrate',
     'addon-a11y-addon-test',
   ];
@@ -35,6 +38,6 @@ export default async function postinstall(options: PostinstallOptions) {
   await jsPackageManager.runPackageCommand({
     args,
     stdio: ['ignore', 'pipe', 'pipe'],
-    useRemotePkg: !!options.skipInstall,
+    useRemotePkg,
   });
 }

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -447,8 +447,11 @@ export default async function postInstall(options: PostinstallOptions) {
 
   if (a11yAddon) {
     try {
+      const useRemotePkg = options.useRemotePkg ?? !!options.skipInstall;
       const command = [
-        options.skipInstall ? `storybook@${versions.storybook}` : `storybook`,
+        // A versioned spec only resolves through the ephemeral runner; the
+        // local binary is invoked by bare name.
+        useRemotePkg ? `storybook@${versions.storybook}` : `storybook`,
         'automigrate',
         'addon-a11y-addon-test',
         '--loglevel',
@@ -475,7 +478,7 @@ export default async function postInstall(options: PostinstallOptions) {
           packageManager.runPackageCommand({
             args: command,
             stdio: 'ignore',
-            useRemotePkg: !!options.skipInstall,
+            useRemotePkg,
           }),
         {
           intro: 'Setting up a11y addon for @storybook/addon-vitest',

--- a/code/lib/cli-storybook/src/add.ts
+++ b/code/lib/cli-storybook/src/add.ts
@@ -17,6 +17,14 @@ export interface PostinstallOptions {
   yes?: boolean;
   skipInstall?: boolean;
   /**
+   * Whether nested `storybook` CLI invocations must fetch the package into an ephemeral
+   * environment (dlx/npx) instead of running the locally installed binary. Defaults to
+   * `skipInstall`, since a skipped install is the one case where no local binary exists; the init
+   * command overrides it because it installs dependencies before postinstall scripts run while
+   * still passing `skipInstall: true` to keep dependency handling to itself.
+   */
+  useRemotePkg?: boolean;
+  /**
    * Skip all dependency management (collecting, adding to package.json, installing). Used when the
    * caller (e.g., init command) has already handled dependencies.
    */

--- a/code/lib/create-storybook/src/commands/AddonConfigurationCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/AddonConfigurationCommand.test.ts
@@ -101,6 +101,7 @@ describe('AddonConfigurationCommand', () => {
         configDir: '.storybook',
         yes: true,
         skipInstall: true,
+        useRemotePkg: false,
         skipDependencyManagement: true,
         logger,
         prompt,
@@ -127,6 +128,7 @@ describe('AddonConfigurationCommand', () => {
         configDir: '.storybook',
         yes: true,
         skipInstall: true,
+        useRemotePkg: false,
         skipDependencyManagement: true,
         logger,
         prompt,
@@ -149,6 +151,7 @@ describe('AddonConfigurationCommand', () => {
         configDir: '.storybook',
         yes: true,
         skipInstall: true,
+        useRemotePkg: false,
         skipDependencyManagement: true,
         logger,
         prompt,
@@ -156,7 +159,7 @@ describe('AddonConfigurationCommand', () => {
       expect(mockTaskLog.success).toHaveBeenCalledWith('Addons configured successfully');
     });
 
-    it('should configure multiple addons', async () => {
+    it('should skip the a11y postinstall when vitest was configured in the same run', async () => {
       vi.mocked(prompt.taskLog).mockReturnValue(mockTaskLog);
 
       const result = await command.execute({
@@ -166,7 +169,9 @@ describe('AddonConfigurationCommand', () => {
 
       expect(result).toEqual({ status: 'success' });
       expect(addonVitestPostinstall).toHaveBeenCalled();
-      expect(addonA11yPostinstall).toHaveBeenCalled();
+      // vitest's postinstall already runs the addon-a11y-addon-test
+      // automigration when both addons are configured together
+      expect(addonA11yPostinstall).not.toHaveBeenCalled();
       expect(mockTaskLog.message).toHaveBeenCalledWith('Configuring @storybook/addon-vitest...');
       expect(mockTaskLog.message).toHaveBeenCalledWith('Configuring @storybook/addon-a11y...');
     });

--- a/code/lib/create-storybook/src/commands/AddonConfigurationCommand.ts
+++ b/code/lib/create-storybook/src/commands/AddonConfigurationCommand.ts
@@ -128,6 +128,10 @@ export class AddonConfigurationCommand {
           configDir,
           yes: true,
           skipInstall: true,
+          // Dependencies were installed in the preceding init step (unless the
+          // user opted out), so nested `storybook` invocations can run the local
+          // binary instead of fetching an ephemeral copy via dlx/npx.
+          useRemotePkg: !!this.commandOptions.skipInstall,
           skipDependencyManagement: true,
           logger,
           prompt,
@@ -136,7 +140,16 @@ export class AddonConfigurationCommand {
         if (addon === '@storybook/addon-vitest') {
           await addonVitestPostinstall(options);
         } else if (addon === '@storybook/addon-a11y') {
-          await addonA11yPostinstall(options);
+          // When addon-vitest was configured in this same run, its postinstall
+          // already executed the addon-a11y-addon-test automigration; a11y's
+          // own postinstall consists of exactly that command, so running it
+          // again only spins up a second package-runner process to conclude
+          // there is nothing left to do. It still runs when vitest is absent
+          // or failed, matching the standalone `storybook add` behavior.
+          const vitestConfigured = addonResults.get('@storybook/addon-vitest') === null;
+          if (!vitestConfigured) {
+            await addonA11yPostinstall(options);
+          }
         } else {
           await postinstallAddon(addon, options);
         }


### PR DESCRIPTION
Product fix in the CI-timing series - and a real win for every `storybook init` user, not just CI. Originally stacked on #35480; now rebased on top of #35352 (build-in-create) to answer a concrete question: the critical chain on `ci:normal`/`ci:merged` is `angular-cli-latest (create → dev)`, and #35352 made the create job longer. This PR attacks the create job's dominant init block directly - if it works, the build-in-create restructuring starts paying off on wall clock too.

## What

`storybook init` hardcodes `skipInstall: true` for addon postinstall options (correct for dependency handling - init installs deps itself), but both the addon-vitest and addon-a11y postinstalls also derived their package-runner mode from that flag. Result: every init with the Test/A11y features spun up `yarn dlx`/`npx` ephemeral environments to fetch a `storybook` copy that was installed as a devDependency one step earlier.

- New optional `useRemotePkg` on `PostinstallOptions` decouples the runner choice from the subprocess flags; init passes the user's actual `--skip-install` value. With deps installed, the local binary runs via `yarn exec`/`pnpm exec`; with `--skip-install`, the ephemeral runner is still used (no local binary exists). Defaults to the old `skipInstall`-derived behavior for all other callers. (`next` already carries `useRemotePkg` on `runPackageCommand` from the stdin-freeze fix; the rebase keeps that stdio handling and only adds the decoupled option plumbing.)
- The a11y postinstall is skipped when addon-vitest was configured in the same init run: its single automigration (`addon-a11y-addon-test`) is already executed by vitest's postinstall when both addons are present and is idempotent, so the second invocation only spun up another runner to conclude there was nothing to do. It still runs for standalone `storybook add @storybook/addon-a11y` and as a fallback when vitest's postinstall failed (both pinned by tests).

## Measurement (ci:merged, measured)

Baseline is #35352's run on the direct parent commit ([workflow `5d17d874`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127452/workflows/5d17d874-b49e-4bea-8d90-3aa5c70dc66a)); this PR is that plus the postinstall commit ([workflow `aea0b726`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127457/workflows/aea0b726-9025-4614-8de5-58b9c2142ced)). Both fully green, identical 119-job topology.

| Metric | #35352 parent | This PR |
| --- | --- | --- |
| "Create Sandbox" steps summed (init lives here) | 1,960s | 1,704s (-256s; 20 of 25 creates faster) |
| create job durations summed | 4,216s | 3,892s (-324s, -7.7%) |
| next-js-latest (vite) create | 268s (init step 131s) | 173s (init step 80s) |
| dev start offsets, avg of 25 jobs | 379s | 368s |
| last dev job ends | 771s | 736s |
| **Workflow wall** | **777s** | **743s** |

- #35352's three merged walls were 758s/771s/777s; this run undercuts all of them. Against plain `next` (820s on the same fleet day), the two PRs together are ~-75s.
- Log-verified on both angular and next-js creates: the init block runs two fewer `yarn dlx`/`npx storybook@...` spins, and the remaining automigration executes via the local binary.
- `angular-cli (vite)` create read +11s this run - noise masking the saving (its webpack sibling: -19s init; the fix is log-verified on both).
- The experiment's answer: with faster creates, build-in-create (#35352) becomes a wall win as well - the dev tail (which never needed the build job) pulls in from 771s to 736s.
- Credits: -324s of large-class create time ≈ -108 credits per merged run; at fleet volume (~22.5k create runs/30d, avg ~-10s each) ≈ **-75k credits/30d (~$550/yr)** on top of the CI savings from the rest of the stack - plus every real-world `storybook init` with the Test/A11y features gets faster by two package-runner spins.

## Validation

- `AddonConfigurationCommand.test.ts`, `addons/vitest postinstall.test.ts`, `cli-storybook add.test.ts` re-run green on the rebased branch
- Every sandbox `(create)` job and the `init-empty`/`init-features` jobs exercise the init + postinstall path end-to-end on CI

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [x] end-to-end tests

#### Manual testing

1. ~On this PR's `ci:merged` run: the `(create)` jobs' "Create Sandbox" step must run the addon automigrations via the local `storybook` binary (no `yarn dlx`/`npx storybook@...` spins in the init block).~ Done: verified in the step logs of the angular-cli and next-js create jobs (two fewer ephemeral spins, one `exec` invocation instead).
2. ~Verify the `init-empty` and `init-features` jobs stay green (full init flow incl. postinstalls).~ Done: all green on [workflow `aea0b726`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127457/workflows/aea0b726-9025-4614-8de5-58b9c2142ced).
3. ~Verify sandboxes with both vitest and a11y still get the `addon-a11y-addon-test` automigration applied (now only via vitest's postinstall).~ Done: the automigration runs via the local binary in the create logs, and all sandbox `(vitest)` jobs are green.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved addon setup workflows by using the appropriate Storybook command during post-install configuration.
  * Prevented redundant accessibility addon setup when the Vitest addon has already been configured successfully.
  * Preserved accessibility addon configuration when Vitest is unavailable or its setup does not complete successfully.
* **Bug Fixes**
  * Improved consistency when configuring multiple addons in a single Storybook initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->