### PR TITLE
CLI: Recover when pnpm blocks dependency build scripts

### DIFF
--- a/code/core/src/cli/AddonVitestService.ts
+++ b/code/core/src/cli/AddonVitestService.ts
@@ -40,6 +40,29 @@ export class AddonVitestService {
   constructor(private readonly packageManager: JsPackageManager) {}
 
   /**
+   * Get the platform-aware Playwright install command.
+   *
+   * @returns Command arguments, display command, and whether `--with-deps` is included.
+   */
+  getPlaywrightInstallCommand(): {
+    args: string[];
+    command: string;
+    useWithDeps: boolean;
+  } {
+    const platform = os.platform();
+    const useWithDeps = !!process.env.CI || platform === 'darwin' || platform === 'win32';
+    const args = useWithDeps
+      ? ['playwright', 'install', 'chromium', '--with-deps']
+      : ['playwright', 'install', 'chromium'];
+
+    return {
+      args,
+      command: this.packageManager.getPackageCommand(args),
+      useWithDeps,
+    };
+  }
+
+  /**
    * Reduce a Vitest version specifier (exact or range) to a single concrete version for
    * `semver.satisfies` comparisons, so dependency collection and postinstall template selection make
    * the same major/minor decision. Uses the lower bound of a valid range, then coerces so a
@@ -139,12 +162,11 @@ export class AddonVitestService {
   ): Promise<{ errors: string[]; result: 'installed' | 'skipped' | 'aborted' | 'failed' }> {
     const errors: string[] = [];
 
-    const platform = os.platform();
-    const useWithDeps = !!process.env.CI || platform === 'darwin' || platform === 'win32';
-    const playwrightCommand = useWithDeps
-      ? ['playwright', 'install', 'chromium', '--with-deps']
-      : ['playwright', 'install', 'chromium'];
-    const playwrightCommandString = this.packageManager.getPackageCommand(playwrightCommand);
+    const {
+      args: playwrightCommand,
+      command: playwrightCommandString,
+      useWithDeps,
+    } = this.getPlaywrightInstallCommand();
 
     let result: 'installed' | 'skipped' | 'aborted' | 'failed';
 

--- a/code/core/src/common/js-package-manager/BUNProxy.ts
+++ b/code/core/src/common/js-package-manager/BUNProxy.ts
@@ -16,7 +16,11 @@ import { dedent } from 'ts-dedent';
 import type { ExecuteCommandOptions } from '../utils/command.ts';
 import { executeCommand } from '../utils/command.ts';
 import { getProjectRoot } from '../utils/paths.ts';
-import { JsPackageManager, PackageManagerName } from './JsPackageManager.ts';
+import {
+  type InstallDependenciesOptions,
+  JsPackageManager,
+  PackageManagerName,
+} from './JsPackageManager.ts';
 import type { PackageJson } from './PackageJson.ts';
 import type { InstallationMetadata, PackageMetadata } from './types.ts';
 import {
@@ -227,7 +231,7 @@ export class BUNProxy extends JsPackageManager {
     });
   }
 
-  async installDependencies(options?: { force?: boolean }) {
+  async installDependencies(options?: InstallDependenciesOptions) {
     try {
       await super.installDependencies(options);
     } catch (error) {

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -95,6 +95,12 @@ export type PackageJsonInfo = {
   packageJson: PackageJsonWithDepsAndDevDeps;
 };
 
+export type InstallDependenciesOptions = {
+  force?: boolean;
+  /** Package-manager recovery is non-interactive by default. */
+  nonInteractive?: boolean;
+};
+
 export abstract class JsPackageManager {
   abstract readonly type: PackageManagerName;
 
@@ -177,7 +183,7 @@ export abstract class JsPackageManager {
     return false;
   }
 
-  async installDependencies(options?: { force?: boolean }) {
+  async installDependencies(options?: InstallDependenciesOptions) {
     await prompt.executeTaskWithSpinner(() => this.runInstall(options), {
       id: 'install-dependencies',
       intro: 'Installing dependencies...',

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -16,7 +16,11 @@ import { dedent } from 'ts-dedent';
 import type { ExecuteCommandOptions } from '../utils/command.ts';
 import { executeCommand } from '../utils/command.ts';
 import { getProjectRoot } from '../utils/paths.ts';
-import { JsPackageManager, PackageManagerName } from './JsPackageManager.ts';
+import {
+  type InstallDependenciesOptions,
+  JsPackageManager,
+  PackageManagerName,
+} from './JsPackageManager.ts';
 import type { PackageJson } from './PackageJson.ts';
 import type { InstallationMetadata, PackageMetadata } from './types.ts';
 import {
@@ -205,7 +209,7 @@ export class NPMProxy extends JsPackageManager {
     });
   }
 
-  async installDependencies(options?: { force?: boolean }) {
+  async installDependencies(options?: InstallDependenciesOptions) {
     try {
       await super.installDependencies(options);
     } catch (error) {

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -16,8 +16,13 @@ import { type Document, parseDocument } from 'yaml';
 
 import type { ExecuteCommandOptions } from '../utils/command.ts';
 import { executeCommand } from '../utils/command.ts';
+import { isCI } from '../utils/envs.ts';
 import { getProjectRoot } from '../utils/paths.ts';
-import { JsPackageManager, PackageManagerName } from './JsPackageManager.ts';
+import {
+  type InstallDependenciesOptions,
+  JsPackageManager,
+  PackageManagerName,
+} from './JsPackageManager.ts';
 import type { PackageJson } from './PackageJson.ts';
 import type { InstallationMetadata, PackageMetadata } from './types.ts';
 import {
@@ -369,11 +374,66 @@ export class PNPMProxy extends JsPackageManager {
     });
   }
 
-  async installDependencies(options?: { force?: boolean }) {
+  async installDependencies(options?: InstallDependenciesOptions) {
     try {
       await super.installDependencies(options);
     } catch (error) {
-      const logs = getErrorLogs(error);
+      let installError = error;
+      let logs = getErrorLogs(installError);
+
+      if (logs.includes('ERR_PNPM_IGNORED_BUILDS')) {
+        const canReviewBuildScripts =
+          options?.nonInteractive === false &&
+          process.stdin.isTTY === true &&
+          process.stdout.isTTY === true &&
+          !isCI();
+        let shouldReviewBuildScripts = false;
+        let approvalCommandFailed = false;
+
+        if (canReviewBuildScripts) {
+          shouldReviewBuildScripts = await prompt.confirm({
+            message:
+              'pnpm blocked dependency build scripts that have not been reviewed. Review them now?',
+            initialValue: true,
+          });
+
+          if (shouldReviewBuildScripts) {
+            // Keep package selection and approval in pnpm's terminal UI.
+            try {
+              await this.runInternalCommand('approve-builds', [], this.cwd, 'inherit');
+            } catch (approvalError) {
+              installError = approvalError;
+              logs = getErrorLogs(installError);
+              approvalCommandFailed = true;
+            }
+
+            if (!approvalCommandFailed) {
+              // Retry once to verify the install; approve-builds can succeed without approving a build.
+              try {
+                await super.installDependencies(options);
+                return;
+              } catch (retryError) {
+                installError = retryError;
+                logs = getErrorLogs(installError);
+              }
+            }
+          }
+        }
+
+        if (
+          !canReviewBuildScripts ||
+          !shouldReviewBuildScripts ||
+          approvalCommandFailed ||
+          logs.includes('ERR_PNPM_IGNORED_BUILDS')
+        ) {
+          logger.error(dedent`
+            pnpm blocked dependency build scripts that have not been reviewed.
+            Review the pending build scripts and retry the installation:
+            pnpm approve-builds
+            pnpm install
+          `);
+        }
+      }
 
       if (logs.includes('ERR_PNPM_NO_MATURE_MATCHING_VERSION')) {
         const handledError = new MinimumReleaseAgeHandledError({
@@ -384,14 +444,14 @@ export class PNPMProxy extends JsPackageManager {
           minimumReleaseAgeExclusionsConfigDocs:
             'https://pnpm.io/settings#minimumreleaseageexclude',
           failedPackage: this.extractFailedPackage(logs),
-          cause: error,
+          cause: installError,
         });
 
         logger.error(handledError.message);
         throw handledError;
       }
 
-      throw error;
+      throw installError;
     }
   }
 

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.ts
@@ -19,7 +19,11 @@ import { logger } from '../../node-logger/index.ts';
 import type { ExecuteCommandOptions } from '../utils/command.ts';
 import { executeCommand } from '../utils/command.ts';
 import { getProjectRoot } from '../utils/paths.ts';
-import { JsPackageManager, PackageManagerName } from './JsPackageManager.ts';
+import {
+  type InstallDependenciesOptions,
+  JsPackageManager,
+  PackageManagerName,
+} from './JsPackageManager.ts';
 import type { PackageJson } from './PackageJson.ts';
 import type { InstallationMetadata, PackageMetadata } from './types.ts';
 import {
@@ -259,7 +263,7 @@ export class Yarn2Proxy extends JsPackageManager {
     });
   }
 
-  async installDependencies(options?: { force?: boolean }) {
+  async installDependencies(options?: InstallDependenciesOptions) {
     try {
       await super.installDependencies(options);
     } catch (error) {

--- a/code/lib/create-storybook/src/commands/AddonConfigurationCommand.ts
+++ b/code/lib/create-storybook/src/commands/AddonConfigurationCommand.ts
@@ -18,6 +18,7 @@ const ADDON_INSTALLATION_INSTRUCTIONS = {
 type ExecuteAddonConfigurationParams = {
   addons: string[];
   configDir?: string;
+  dependencyInstallationStatus?: 'failed' | 'success';
 };
 
 export type ExecuteAddonConfigurationResult = {
@@ -45,6 +46,7 @@ export class AddonConfigurationCommand {
   async execute({
     addons,
     configDir,
+    dependencyInstallationStatus = 'success',
   }: ExecuteAddonConfigurationParams): Promise<ExecuteAddonConfigurationResult> {
     if (!configDir || addons.length === 0) {
       return { status: 'success' };
@@ -52,14 +54,23 @@ export class AddonConfigurationCommand {
 
     try {
       const { hasFailures, addonResults } = await this.configureAddons(configDir, addons);
+      const vitestConfiguredSuccessfully = addonResults.get('@storybook/addon-vitest') === null;
 
-      if (addonResults.has('@storybook/addon-vitest')) {
+      if (vitestConfiguredSuccessfully && dependencyInstallationStatus === 'success') {
         const { result } = await this.addonVitestService.installPlaywright({
           yes: this.commandOptions.yes,
           useRemotePkg: !!this.commandOptions.skipInstall,
         });
         // Map outcome to telemetry decision
         await this.telemetryService.trackPlaywrightPromptDecision(result);
+      } else if (vitestConfiguredSuccessfully && dependencyInstallationStatus === 'failed') {
+        const { command } = this.addonVitestService.getPlaywrightInstallCommand();
+
+        logger.warn(dedent`
+          Playwright browser installation was skipped because dependency installation failed.
+          Resolve the dependency installation error first, then run:
+          ${CLI_COLORS.cta(command)}
+        `);
       }
 
       // some addons failed

--- a/code/lib/create-storybook/src/commands/DependencyInstallationCommand.ts
+++ b/code/lib/create-storybook/src/commands/DependencyInstallationCommand.ts
@@ -8,6 +8,7 @@ import { Feature } from 'storybook/internal/types';
 import type { DependencyCollector } from '../dependency-collector.ts';
 
 type DependencyInstallationCommandParams = {
+  nonInteractive?: boolean;
   skipInstall: boolean;
   selectedFeatures: Set<Feature>;
 };
@@ -29,6 +30,7 @@ export class DependencyInstallationCommand {
   ) {}
   /** Execute dependency installation */
   async execute({
+    nonInteractive = true,
     skipInstall = false,
     selectedFeatures,
   }: DependencyInstallationCommandParams): Promise<{ status: 'success' | 'failed' }> {
@@ -69,7 +71,7 @@ export class DependencyInstallationCommand {
 
     if (!skipInstall && this.dependencyCollector.hasPackages()) {
       try {
-        await this.packageManager.installDependencies();
+        await this.packageManager.installDependencies({ nonInteractive });
       } catch (err) {
         if (err instanceof MinimumReleaseAgeHandledError) {
           throw err;

--- a/code/lib/create-storybook/src/commands/PreflightCheckCommand.ts
+++ b/code/lib/create-storybook/src/commands/PreflightCheckCommand.ts
@@ -68,12 +68,13 @@ export class PreflightCheckCommand {
     const packageManager = JsPackageManagerFactory.getPackageManager({
       force: options.packageManager,
     });
+    const nonInteractive = !!options.yes || !process.stdout.isTTY || !!isCI();
 
     logger.info(`Package manager: ${getPrettyPackageManagerName(packageManager.type)}`);
 
     // Install base project dependencies if we scaffolded a new project
     if (isEmptyDirProject && !options.skipInstall) {
-      await packageManager.installDependencies();
+      await packageManager.installDependencies({ nonInteractive });
     }
 
     const pnp = await detectPnp();
@@ -90,7 +91,7 @@ export class PreflightCheckCommand {
     try {
       await packageManager.precheckStorybookPackageInstall({
         storybookVersion: this.versionService.getCurrentVersion(),
-        nonInteractive: !!options.yes || !process.stdout.isTTY || !!isCI(),
+        nonInteractive,
         installContext: 'create',
       });
     } catch (error) {

--- a/code/lib/create-storybook/src/commands/PreflightCheckCommand.ts
+++ b/code/lib/create-storybook/src/commands/PreflightCheckCommand.ts
@@ -68,7 +68,8 @@ export class PreflightCheckCommand {
     const packageManager = JsPackageManagerFactory.getPackageManager({
       force: options.packageManager,
     });
-    const nonInteractive = !!options.yes || !process.stdout.isTTY || !!isCI();
+    const nonInteractive =
+      !!options.yes || !process.stdout.isTTY || !process.stdin.isTTY || !!isCI();
 
     logger.info(`Package manager: ${getPrettyPackageManagerName(packageManager.type)}`);
 

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -139,7 +139,7 @@ export async function doInitiate(options: CommandOptions): Promise<
   const dependencyInstallationResult = await executeDependencyInstallation({
     packageManager,
     dependencyCollector,
-    nonInteractive: !!options.yes || !process.stdout.isTTY || !!isCI(),
+    nonInteractive: !!options.yes || !process.stdout.isTTY || !process.stdin.isTTY || !!isCI(),
     skipInstall: !!options.skipInstall,
     selectedFeatures,
   });

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -6,6 +6,7 @@ import {
   PackageManagerName,
   cache,
   executeCommand,
+  isCI,
   type JsPackageManager,
 } from 'storybook/internal/common';
 import { getServerPort, withTelemetry } from 'storybook/internal/core-server';
@@ -138,6 +139,7 @@ export async function doInitiate(options: CommandOptions): Promise<
   const dependencyInstallationResult = await executeDependencyInstallation({
     packageManager,
     dependencyCollector,
+    nonInteractive: !!options.yes || !process.stdout.isTTY || !!isCI(),
     skipInstall: !!options.skipInstall,
     selectedFeatures,
   });
@@ -161,6 +163,7 @@ export async function doInitiate(options: CommandOptions): Promise<
     packageManager,
     addons: extraAddons,
     configDir,
+    dependencyInstallationStatus: dependencyInstallationResult.status,
     options,
   });
 


### PR DESCRIPTION
Closes #35427

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### Root cause

1. Add the Storybook dependencies to the target project and run `pnpm install`. The resolved dependency graph includes `esbuild`, which defines a `postinstall` script.
2. Trigger pnpm 11’s build-script review check. Regular project installs do not automatically start `approve-builds`, so pnpm records the unreviewed `esbuild` script and exits with `ERR_PNPM_IGNORED_BUILDS`.
3. Continue addon configuration after project dependency installation fails, causing `@storybook/addon-vitest` to attempt Playwright installation against an incomplete installation.

### Changes

- Offer native `pnpm approve-builds` during interactive setup and retry installation
- Keep CI and `--yes` non-interactive
- Continue addon configuration but skip Playwright after dependency installation fails
- Show manual recovery commands when needed

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a fresh pnpm 11 project:
   ```sh
   pnpm create vite sb-35427
   cd sb-35427
   pnpm install
   ```

2. Build the affected Storybook packages:
   ```sh
   cd /path/to/storybook
   yarn nx compile core
   yarn nx compile create-storybook
   ```

3. Run the local CLI from the test project:
   ```sh
   cd /path/to/sb-35427
   node /path/to/storybook/code/lib/create-storybook/dist/bin/index.js
   ```

Select the recommended configuration and approve Playwright installation. Review and approve `esbuild` when prompted, then verify dependency installation retries successfully and Playwright Chromium installs.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dependency installation now supports a non-interactive mode (CI, non-TTY, or `--yes`) to reduce prompts during setup.
  - PNPM can prompt to approve required build scripts and retry installation when in interactive mode.
  - When dependency installation fails, the Playwright step is skipped and a manual install command is provided.

- **Bug Fixes**
  - Playwright browser installation now runs only after dependency installation succeeds.
  - Failed dependency installation no longer leads to an unsuccessful Playwright setup flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->