### PR TITLE
Build: Compress the pipeline workspace tarball with zstd via node:zlib

### DIFF
--- a/scripts/ci/utils/helpers.ts
+++ b/scripts/ci/utils/helpers.ts
@@ -1,17 +1,21 @@
-import { LINUX_ROOT_DIR, WINDOWS_ROOT_DIR } from './constants.ts';
+import { LINUX_ROOT_DIR, WINDOWS_ROOT_DIR, WORKING_DIR } from './constants.ts';
 import { type JobOrNoOpJob, type Workflow } from './types.ts';
 
 /**
  * The `Persisting to workspace` step is bytes-bound: CircleCI gzips the
  * workspace layer single-threaded at roughly 20MB/s, so ~2.5GB of
  * node_modules dominated the step regardless of file count (measured: packing
- * the trees into a plain tar left persist at 140s). Pre-compressing with
- * `gzip -1` (~3x smaller) makes CircleCI's own compression and every
- * downstream download proportionally cheaper. gzip is the only compressor
- * guaranteed on all executor images; zstd is not available on any of them
- * (cimg/node, playwright, machine), verified via step diagnostics.
+ * the trees into a plain tar left persist at 140s). Pre-compressing makes
+ * CircleCI's own compression and every downstream download proportionally
+ * cheaper. No executor image ships a zstd CLI (cimg/node, playwright,
+ * machine - verified via step diagnostics), but stock Node >= 22.15 exposes
+ * zstd through node:zlib, so scripts/ci/zstd-stream.mjs runs it straight from
+ * the git checkout, before (and without) node_modules. zstd level 3 both
+ * compresses better and runs faster than `gzip -1`.
  */
-export const PACKED_NODE_MODULES_ARCHIVE = 'workspace-node_modules.tar.gz';
+export const PACKED_NODE_MODULES_ARCHIVE = 'workspace-node_modules.tar.zst';
+
+const ZSTD_STREAM = `${WORKING_DIR}/scripts/ci/zstd-stream.mjs`;
 
 export const workspace = {
   attach: (at = LINUX_ROOT_DIR) => {
@@ -38,11 +42,13 @@ export const workspace = {
         // dependencies, so they are filtered at runtime; the root trees are
         // passed straight to tar so a missing one fails the job loudly.
         command: [
+          'node --version',
           'optional=""',
           `for p in ${optionalPaths.join(' ')}; do`,
           '  if [ -e "$p" ]; then optional="$optional $p"; fi',
           'done',
-          `tar --create ${requiredPaths.join(' ')} $optional | gzip -1 > ${PACKED_NODE_MODULES_ARCHIVE}`,
+          `tar --create ${requiredPaths.join(' ')} $optional | node ${ZSTD_STREAM} compress 3 > ${PACKED_NODE_MODULES_ARCHIVE}`,
+          `ls -la ${PACKED_NODE_MODULES_ARCHIVE}`,
         ].join('\n'),
       },
     };
@@ -52,7 +58,10 @@ export const workspace = {
       run: {
         name: 'Unpack node_modules from workspace',
         working_directory: root,
-        command: `tar --extract --gzip --file ${PACKED_NODE_MODULES_ARCHIVE}`,
+        command: [
+          'node --version',
+          `node ${ZSTD_STREAM} decompress < ${PACKED_NODE_MODULES_ARCHIVE} | tar --extract`,
+        ].join('\n'),
       },
     };
   },

--- a/scripts/ci/zstd-stream.mjs
+++ b/scripts/ci/zstd-stream.mjs
@@ -1,0 +1,44 @@
+/**
+ * Dependency-free zstd stdin->stdout stream for CI workspace tarballs.
+ *
+ * Runs on stock `node:zlib` (zstd support since Node 22.15 / 23.8), so it
+ * works on every executor image straight from the git checkout - before (and
+ * without) any node_modules being installed. Usage:
+ *
+ *   tar --create <paths> | node scripts/ci/zstd-stream.mjs compress > x.tar.zst
+ *   node scripts/ci/zstd-stream.mjs decompress < x.tar.zst | tar --extract
+ */
+import { pipeline } from 'node:stream/promises';
+import zlib from 'node:zlib';
+
+const [mode, levelArg] = process.argv.slice(2);
+
+if (typeof zlib.createZstdCompress !== 'function') {
+  console.error(
+    `zstd is not available in this Node (${process.version}); requires >= 22.15 or >= 23.8`
+  );
+  process.exit(2);
+}
+
+const level = Number(levelArg ?? 3);
+
+const transform =
+  mode === 'compress'
+    ? zlib.createZstdCompress({
+        params: {
+          [zlib.constants.ZSTD_c_compressionLevel]: level,
+          // Long-distance matching helps on multi-GB node_modules payloads
+          // with heavy cross-file redundancy.
+          [zlib.constants.ZSTD_c_enableLongDistanceMatching]: 1,
+        },
+      })
+    : mode === 'decompress'
+      ? zlib.createZstdDecompress()
+      : null;
+
+if (!transform) {
+  console.error(`Usage: zstd-stream.mjs <compress|decompress> [level]`);
+  process.exit(2);
+}
+
+await pipeline(process.stdin, transform, process.stdout);


### PR DESCRIPTION
Experiment on top of #35343 (base branch is `valentin/build-linux-orchestration`, so this diff is only the zstd delta).

#35343 settled on `gzip -1` for the workspace node_modules tarball because no executor image ships a zstd CLI (cimg/node, playwright, machine - verified via step diagnostics). This experiment makes zstd available anyway, without installing anything: stock Node >= 22.15 exposes zstd through `node:zlib`, so a dependency-free stream helper (`scripts/ci/zstd-stream.mjs`) runs it straight from the git checkout - before, and without, any `node_modules`.

## Local measurement (real payload)

2.83GB raw tar of the workspace node_modules trees (root + `code` + `scripts` + 10 per-package trees), M1 Pro:

| Codec | compress | size | ratio | decompress |
| --- | --- | --- | --- | --- |
| `gzip -1` (current) | 22.9s | 878MB | 3.2x | 3.6s |
| `node:zlib` zstd-3 + long-distance matching | 15.1s | 609MB | 4.7x | 3.9s |
| `node:zlib` zstd-6 + LDM | 27.9s | 567MB | 5.0x | - |

zstd-3 + LDM is 31% smaller AND 34% faster to compress than `gzip -1`; decompression is a wash. Level 6 buys another 7% size for nearly 2x the compress time - not worth it. Fewer bytes also shrink CircleCI's own workspace-layer gzip pass in `Persist workspace` (bytes-bound at ~20MB/s: expected ~43s -> ~30s), the upload, and the download in every one of ~100 downstream `Attaching workspace` steps.

## The availability question this run answers

The only portability requirement is Node >= 22.15 (zstd landed in `node:zlib` in 22.15/23.8) at unpack time, on every executor image family. Every pack/unpack step now logs `node --version`, so a single pipeline run doubles as the evidence matrix across cimg/node, playwright, and machine images. If any family runs an older Node, the helper fails loudly with exit code 2 and a clear message (and that family's image tag - not the approach - is the follow-up).

## Measured CI results

Full matrix green: all 105 downstream jobs succeeded. Node versions observed at unpack time: cimg/node v22.22.1, playwright image v24.13.0, bench executor v22.22.1 - every family satisfies the >= 22.15 requirement, so the availability question is settled.

`build--linux` (zstd job 1753962 vs gzip baseline job 1753856, same merged head):

| Step | gzip -1 | zstd-3 |
| --- | --- | --- |
| Pack node_modules | 53.4s | 56.1s |
| Persist workspace | 41.0s | **31.2s** |
| Total build--linux | 213s | 209s |

Archive size: 744MB `.tar.zst` (the local-payload measurement scaled as predicted). Pack is a wash on CI - the tar read of ~500k files dominates there, not the codec.

Matched downstream jobs, `Attaching workspace` + `Unpack node_modules from workspace`:

| Job | gzip -1 | zstd-3 | delta |
| --- | --- | --- | --- |
| tests--linux | 11.3s + 25.9s | 7.3s + 13.6s | **-16.3s** |
| react-latest vite e2e (playwright image) | 17.3s + 30.7s | 12.7s + 16.2s | **-19.1s** |
| react-latest vite create | 10.8s + 28.2s | 7.1s + 13.8s | **-18.1s** |
| local-storybook chromatic | 10.7s + 27.2s | 8.0s + 16.2s | **-13.7s** |
| bench react-vite build | 16.3s + 27.3s | 12.8s + 14.8s | **-16.0s** |

That is roughly **-16s per downstream job, ~100 jobs per pipeline (~27 aggregate compute-minutes)**, plus ~30% less workspace storage and transfer, on top of the ~10s saved in `build--linux` persist.

#### Manual testing

CI-only change; nothing user-facing. Locally: `tar -c node_modules | node scripts/ci/zstd-stream.mjs compress 3 | node scripts/ci/zstd-stream.mjs decompress | tar -t | head` round-trips with stock Node >= 22.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
