### PR TITLE
CLI: Add experimental `storybook ai simple-setup` command

### DIFF
--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -15,6 +15,7 @@ import picocolors from 'picocolors';
 
 import { version } from '../../package.json';
 import { aiSetup } from '../cli/ai/index.ts';
+import { aiSimpleSetup } from '../cli/ai/simple-setup.ts';
 import { isAiCliFeatureEnabled, registerAiMcpPassthrough } from '../cli/ai/mcp/register.ts';
 import { build } from '../cli/build.ts';
 import { buildIndex as index } from '../cli/buildIndex.ts';
@@ -261,6 +262,23 @@ aiCommand
     await withTelemetry('ai-setup', { cliOptions: mergedOptions }, async () => {
       await aiSetup(mergedOptions);
     }).catch(handleAiCommandFailure(mergedOptions.logfile));
+  });
+
+// Experimental: used only by the Storybook agent plugins/skills as the default
+// first-story path; not referenced from docs or nudges and sends no telemetry.
+aiCommand
+  .command('simple-setup')
+  .description('Generate instructions to write a first story for one simple component')
+  .addOption(
+    new Option('--package-manager <type>', 'Force package manager for installing deps').choices(
+      Object.values(PackageManagerName)
+    )
+  )
+  .option('-c, --config-dir <dir-name>', 'Directory of Storybook configuration')
+  .action(async (options, cmd) => {
+    const parentOptions = cmd.parent?.opts() ?? {};
+    const mergedOptions = { ...parentOptions, ...options };
+    await aiSimpleSetup(mergedOptions).catch(handleAiCommandFailure(mergedOptions.logfile));
   });
 
 // Show available subcommands when `storybook ai` is run without arguments

--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -15,8 +15,8 @@ import picocolors from 'picocolors';
 
 import { version } from '../../package.json';
 import { aiSetup } from '../cli/ai/index.ts';
-import { aiSimpleSetup } from '../cli/ai/simple-setup.ts';
 import { isAiCliFeatureEnabled, registerAiMcpPassthrough } from '../cli/ai/mcp/register.ts';
+import { aiSimpleSetup } from '../cli/ai/simple-setup.ts';
 import { build } from '../cli/build.ts';
 import { buildIndex as index } from '../cli/buildIndex.ts';
 import { dev } from '../cli/dev.ts';

--- a/code/core/src/cli/ai/index.ts
+++ b/code/core/src/cli/ai/index.ts
@@ -1,80 +1,24 @@
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import type { PackageManagerName } from 'storybook/internal/common';
-import { cache, getPrettyPackageManagerName } from 'storybook/internal/common';
+import { cache } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 import { telemetry } from 'storybook/internal/telemetry';
-import { SupportedLanguage } from 'storybook/internal/types';
 
-import { detectLanguage } from '../detectLanguage.ts';
-import { getStorybookData } from '../getStorybookData.ts';
+import { resolveProjectInfo } from './project-info.ts';
 import { getAiSetupMarkdownOutput } from './setup-prompts/index.ts';
-import type { ProjectInfo, AiSetupOptions } from './types.ts';
+import type { AiSetupOptions } from './types.ts';
 
 export async function aiSetup(options: AiSetupOptions): Promise<void> {
-  const { configDir: userConfigDir, packageManager, output } = options;
+  const { configDir, packageManager, output } = options;
 
-  let projectInfo: ProjectInfo;
+  const projectInfo = await resolveProjectInfo({
+    configDir,
+    packageManager,
+    needsUserOnboarding: () => cache.get<boolean>('onboarding-pending', false),
+  });
 
-  try {
-    const data = await getStorybookData({
-      configDir: userConfigDir,
-      packageManagerName: packageManager as PackageManagerName | undefined,
-    });
-
-    if (!data.frameworkPackage || !data.rendererPackage || !data.builderPackage) {
-      logger.error(
-        'Could not detect framework, renderer, or builder from your Storybook config. Make sure you are running this command from your project root, or specify --config-dir.'
-      );
-      return;
-    }
-
-    const majorVersion = data.versionInstalled
-      ? parseMajorVersion(data.versionInstalled)
-      : undefined;
-
-    const detectedLanguage = await detectLanguage(data.packageManager, data.workingDir);
-    const language = detectedLanguage === SupportedLanguage.TYPESCRIPT ? 'ts' : 'js';
-
-    const needsUserOnboarding = await cache.get<boolean>('onboarding-pending', false);
-
-    projectInfo = {
-      storybookVersion: data.versionInstalled,
-      majorVersion,
-      framework: data.frameworkPackage,
-      rendererPackage: data.rendererPackage,
-      renderer: data.renderer,
-      builderPackage: data.builderPackage,
-      addons: data.addons ?? [],
-      configDir: data.configDir,
-      storiesPaths: data.storiesPaths,
-      packageManager: data.packageManager,
-      packageManagerName: getPrettyPackageManagerName(data.packageManager.type),
-      language,
-      hasCsfFactoryPreview: data.hasCsfFactoryPreview,
-      needsUserOnboarding,
-    };
-  } catch (err) {
-    logger.error(
-      `Failed to read Storybook configuration: ${err instanceof Error ? err.message : String(err)}`
-    );
-    logger.log(
-      'Make sure you are running this command from your project root, or specify --config-dir.'
-    );
-    return;
-  }
-
-  if (
-    projectInfo.rendererPackage !== '@storybook/react' ||
-    projectInfo.builderPackage !== '@storybook/builder-vite'
-  ) {
-    logger.log(
-      'AI-assisted setup is currently only available for projects using the React renderer with Vite builder. Detected renderer: ' +
-        projectInfo.rendererPackage +
-        ', builder: ' +
-        projectInfo.builderPackage
-    );
+  if (!projectInfo) {
     return;
   }
 
@@ -117,9 +61,4 @@ export async function aiSetup(options: AiSetupOptions): Promise<void> {
   } else {
     process.stdout.write(`${markdownOutput}\n`);
   }
-}
-
-function parseMajorVersion(version: string): number | undefined {
-  const match = version.match(/^(\d+)/);
-  return match ? parseInt(match[1], 10) : undefined;
 }

--- a/code/core/src/cli/ai/project-info.test.ts
+++ b/code/core/src/cli/ai/project-info.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { logger } from 'storybook/internal/node-logger';
+import { SupportedLanguage, SupportedRenderer } from 'storybook/internal/types';
+
+import { detectLanguage } from '../detectLanguage.ts';
+import { getStorybookData } from '../getStorybookData.ts';
+import { resolveProjectInfo } from './project-info.ts';
+
+vi.mock('storybook/internal/node-logger', { spy: true });
+vi.mock('../getStorybookData.ts');
+vi.mock('../detectLanguage.ts');
+
+type StorybookData = Awaited<ReturnType<typeof getStorybookData>>;
+
+const storybookData = {
+  configDir: '.storybook',
+  workingDir: '/project',
+  versionInstalled: '10.5.2',
+  frameworkPackage: '@storybook/react-vite',
+  rendererPackage: '@storybook/react',
+  renderer: SupportedRenderer.REACT,
+  builderPackage: '@storybook/builder-vite',
+  addons: ['@storybook/addon-docs'],
+  storiesPaths: ['src/**/*.stories.tsx'],
+  packageManager: { type: 'npm' },
+  hasCsfFactoryPreview: false,
+} as unknown as StorybookData;
+
+describe('resolveProjectInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getStorybookData).mockResolvedValue(storybookData);
+    vi.mocked(detectLanguage).mockResolvedValue(SupportedLanguage.TYPESCRIPT);
+  });
+
+  it('maps the detected project data into ProjectInfo', async () => {
+    const projectInfo = await resolveProjectInfo({
+      needsUserOnboarding: async () => true,
+    });
+
+    expect(projectInfo).toEqual({
+      storybookVersion: '10.5.2',
+      majorVersion: 10,
+      framework: '@storybook/react-vite',
+      rendererPackage: '@storybook/react',
+      renderer: SupportedRenderer.REACT,
+      builderPackage: '@storybook/builder-vite',
+      addons: ['@storybook/addon-docs'],
+      configDir: '.storybook',
+      storiesPaths: ['src/**/*.stories.tsx'],
+      packageManager: storybookData.packageManager,
+      packageManagerName: 'npm',
+      language: 'ts',
+      hasCsfFactoryPreview: false,
+      needsUserOnboarding: true,
+    });
+  });
+
+  it('defaults needsUserOnboarding to false when no resolver is given', async () => {
+    const projectInfo = await resolveProjectInfo({});
+
+    expect(projectInfo?.needsUserOnboarding).toBe(false);
+  });
+
+  it('returns undefined when framework, renderer, or builder cannot be detected', async () => {
+    vi.mocked(getStorybookData).mockResolvedValue({
+      ...storybookData,
+      frameworkPackage: null,
+    } as unknown as StorybookData);
+
+    expect(await resolveProjectInfo({})).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Could not detect framework, renderer, or builder')
+    );
+  });
+
+  it('returns undefined for projects that are not React + Vite', async () => {
+    vi.mocked(getStorybookData).mockResolvedValue({
+      ...storybookData,
+      rendererPackage: '@storybook/vue3',
+    } as unknown as StorybookData);
+
+    expect(await resolveProjectInfo({})).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('only available for projects using the React renderer')
+    );
+  });
+
+  it('returns undefined when reading the Storybook configuration fails', async () => {
+    vi.mocked(getStorybookData).mockRejectedValue(new Error('boom'));
+
+    expect(await resolveProjectInfo({})).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to read Storybook configuration: boom')
+    );
+  });
+
+  it('reports a failing needsUserOnboarding resolver as a configuration error', async () => {
+    expect(
+      await resolveProjectInfo({
+        needsUserOnboarding: async () => {
+          throw new Error('cache corrupted');
+        },
+      })
+    ).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to read Storybook configuration: cache corrupted')
+    );
+  });
+});

--- a/code/core/src/cli/ai/project-info.ts
+++ b/code/core/src/cli/ai/project-info.ts
@@ -1,0 +1,100 @@
+import type { PackageManagerName } from 'storybook/internal/common';
+import { getPrettyPackageManagerName } from 'storybook/internal/common';
+import { logger } from 'storybook/internal/node-logger';
+import { SupportedLanguage } from 'storybook/internal/types';
+
+import { detectLanguage } from '../detectLanguage.ts';
+import { getStorybookData } from '../getStorybookData.ts';
+import type { ProjectInfo } from './types.ts';
+
+interface ResolveProjectInfoOptions {
+  /** Location of the Storybook configuration directory. */
+  configDir?: string;
+  /** Package manager to use (npm, yarn1, yarn2, pnpm, bun). */
+  packageManager?: string;
+  /**
+   * Resolves whether the user has requested to be onboarded into Storybook. Called while the
+   * project is being inspected so that failures are reported like any other configuration error.
+   * Defaults to `false` when omitted.
+   */
+  needsUserOnboarding?: () => Promise<boolean>;
+}
+
+/**
+ * Inspects the user's project and assembles the {@link ProjectInfo} shared by the `storybook ai`
+ * prompt commands. Logs the failure reason and returns `undefined` when the project cannot be
+ * inspected or is not supported (currently React + Vite only).
+ */
+export async function resolveProjectInfo(
+  options: ResolveProjectInfoOptions
+): Promise<ProjectInfo | undefined> {
+  let projectInfo: ProjectInfo;
+
+  try {
+    const data = await getStorybookData({
+      configDir: options.configDir,
+      packageManagerName: options.packageManager as PackageManagerName | undefined,
+    });
+
+    if (!data.frameworkPackage || !data.rendererPackage || !data.builderPackage) {
+      logger.error(
+        'Could not detect framework, renderer, or builder from your Storybook config. Make sure you are running this command from your project root, or specify --config-dir.'
+      );
+      return undefined;
+    }
+
+    const majorVersion = data.versionInstalled
+      ? parseMajorVersion(data.versionInstalled)
+      : undefined;
+
+    const detectedLanguage = await detectLanguage(data.packageManager, data.workingDir);
+    const language = detectedLanguage === SupportedLanguage.TYPESCRIPT ? 'ts' : 'js';
+
+    const needsUserOnboarding = (await options.needsUserOnboarding?.()) ?? false;
+
+    projectInfo = {
+      storybookVersion: data.versionInstalled,
+      majorVersion,
+      framework: data.frameworkPackage,
+      rendererPackage: data.rendererPackage,
+      renderer: data.renderer,
+      builderPackage: data.builderPackage,
+      addons: data.addons ?? [],
+      configDir: data.configDir,
+      storiesPaths: data.storiesPaths,
+      packageManager: data.packageManager,
+      packageManagerName: getPrettyPackageManagerName(data.packageManager.type),
+      language,
+      hasCsfFactoryPreview: data.hasCsfFactoryPreview,
+      needsUserOnboarding,
+    };
+  } catch (err) {
+    logger.error(
+      `Failed to read Storybook configuration: ${err instanceof Error ? err.message : String(err)}`
+    );
+    logger.log(
+      'Make sure you are running this command from your project root, or specify --config-dir.'
+    );
+    return undefined;
+  }
+
+  if (
+    projectInfo.rendererPackage !== '@storybook/react' ||
+    projectInfo.builderPackage !== '@storybook/builder-vite'
+  ) {
+    logger.log(
+      'AI-assisted setup is currently only available for projects using the React renderer with Vite builder. Detected renderer: ' +
+        projectInfo.rendererPackage +
+        ', builder: ' +
+        projectInfo.builderPackage
+    );
+    return undefined;
+  }
+
+  return projectInfo;
+}
+
+function parseMajorVersion(version: string): number | undefined {
+  const match = version.match(/^(\d+)/);
+  return match ? parseInt(match[1], 10) : undefined;
+}

--- a/code/core/src/cli/ai/setup-prompts/__snapshots__/simple-setup.test.ts.snap
+++ b/code/core/src/cli/ai/setup-prompts/__snapshots__/simple-setup.test.ts.snap
@@ -46,12 +46,10 @@ export default preview;
 
 ### Step 3 — Write the story file
 
-Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+Write **one** colocated story file next to the chosen component: the default story and at most a couple of meaningful variants.
 
 \`\`\`jsx
 // src/components/Button.stories.jsx
-import { expect } from 'storybook/test';
-
 import { Button } from './Button';
 
 const meta = {
@@ -67,18 +65,6 @@ export const Primary = {
 
 export const Disabled = {
   args: { children: 'Order now', disabled: true },
-};
-
-// Proves the app's global CSS actually loaded: read a real styling value
-// from the component's source (hex color, Tailwind class, CSS variable)
-// and assert the resolved computed style.
-export const StyleCheck = {
-  args: { children: 'Submit' },
-  play: async ({ canvas }) => {
-    const button = canvas.getByRole('button', { name: /submit/i });
-    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
-  },
 };
 \`\`\`
 
@@ -97,7 +83,7 @@ STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
 \`\`\`
 
 1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
-2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.jsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.jsx\` (missing CSS import, missing provider) over story-local workarounds.
 3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
 
 ### Step 5 — Wrap up
@@ -155,13 +141,12 @@ export default definePreview({
 
 ### Step 3 — Write the story file
 
-Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+Write **one** colocated story file next to the chosen component: the default story and at most a couple of meaningful variants.
 
 \`\`\`jsx
 // src/components/Button.stories.jsx
-import { expect } from 'storybook/test';
-
 import preview from '#.storybook/preview';
+
 import { Button } from './Button';
 
 const meta = preview.meta({
@@ -175,18 +160,6 @@ export const Primary = meta.story({
 
 export const Disabled = meta.story({
   args: { children: 'Order now', disabled: true },
-});
-
-// Proves the app's global CSS actually loaded: read a real styling value
-// from the component's source (hex color, Tailwind class, CSS variable)
-// and assert the resolved computed style.
-export const StyleCheck = meta.story({
-  args: { children: 'Submit' },
-  play: async ({ canvas }) => {
-    const button = canvas.getByRole('button', { name: /submit/i });
-    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
-  },
 });
 \`\`\`
 
@@ -205,7 +178,7 @@ STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
 \`\`\`
 
 1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
-2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.jsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.jsx\` (missing CSS import, missing provider) over story-local workarounds.
 3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
 
 ### Step 5 — Wrap up
@@ -264,12 +237,11 @@ export default preview;
 
 ### Step 3 — Write the story file
 
-Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+Write **one** colocated story file next to the chosen component: the default story and at most a couple of meaningful variants.
 
 \`\`\`tsx
 // src/components/Button.stories.tsx
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect } from 'storybook/test';
 
 import { Button } from './Button';
 
@@ -288,18 +260,6 @@ export const Primary: Story = {
 export const Disabled: Story = {
   args: { children: 'Order now', disabled: true },
 };
-
-// Proves the app's global CSS actually loaded: read a real styling value
-// from the component's source (hex color, Tailwind class, CSS variable)
-// and assert the resolved computed style.
-export const StyleCheck: Story = {
-  args: { children: 'Submit' },
-  play: async ({ canvas }) => {
-    const button = canvas.getByRole('button', { name: /submit/i });
-    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
-  },
-};
 \`\`\`
 
 - Tag the file with \`tags: ['ai-generated']\`.
@@ -317,7 +277,7 @@ STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
 \`\`\`
 
 1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
-2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.tsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.tsx\` (missing CSS import, missing provider) over story-local workarounds.
 3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
 
 ### Step 5 — Wrap up
@@ -375,13 +335,12 @@ export default definePreview({
 
 ### Step 3 — Write the story file
 
-Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+Write **one** colocated story file next to the chosen component: the default story and at most a couple of meaningful variants.
 
 \`\`\`tsx
 // src/components/Button.stories.tsx
-import { expect } from 'storybook/test';
-
 import preview from '#.storybook/preview';
+
 import { Button } from './Button';
 
 const meta = preview.meta({
@@ -395,18 +354,6 @@ export const Primary = meta.story({
 
 export const Disabled = meta.story({
   args: { children: 'Order now', disabled: true },
-});
-
-// Proves the app's global CSS actually loaded: read a real styling value
-// from the component's source (hex color, Tailwind class, CSS variable)
-// and assert the resolved computed style.
-export const StyleCheck = meta.story({
-  args: { children: 'Submit' },
-  play: async ({ canvas }) => {
-    const button = canvas.getByRole('button', { name: /submit/i });
-    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
-  },
 });
 \`\`\`
 
@@ -425,7 +372,7 @@ STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
 \`\`\`
 
 1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
-2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.tsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.tsx\` (missing CSS import, missing provider) over story-local workarounds.
 3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
 
 ### Step 5 — Wrap up

--- a/code/core/src/cli/ai/setup-prompts/__snapshots__/simple-setup.test.ts.snap
+++ b/code/core/src/cli/ai/setup-prompts/__snapshots__/simple-setup.test.ts.snap
@@ -1,214 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`getAiSimpleSetupMarkdownOutput > csf-factory > renders with addon-vitest 1`] = `
-"# Storybook Simple Setup
-
-## Project Info
-
-| Property | Value |
-|----------|-------|
-| Version | 10.5.2 |
-| Renderer | @storybook/react |
-| Framework | @storybook/react-vite |
-| Builder | @storybook/builder-vite |
-| Config Dir | \`.storybook\` |
-| Language | TypeScript |
-| Package Manager | npm |
-| Addons | @storybook/addon-docs, @storybook/addon-vitest |
-
-Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
-
-### Step 1 — Pick one simple component (and note the runners-up)
-
-Look through the project's own components and pick the **simplest presentational leaf component** you can find — think Button, Badge, Tag, Avatar: a handful of props, no data fetching, no routing, no app-specific context. Skip anything created by \`storybook init\` (e.g. \`src/stories/\`).
-
-While scanning, note the 2–4 next-best candidates (a mix of simple and more interesting components). You will offer these to the user at the end — do **not** write stories for them now.
-
-### Step 2 — Make sure global styling loads
-
-Find how the app loads its global CSS and theme: a CSS import in the entry file (\`main.tsx\` / \`index.tsx\`), a \`<link>\` or inline \`<style>\` in \`index.html\`, Tailwind, CSS variables, or a theme provider.
-
-**Edit the existing \`.storybook/preview.tsx\`** (created by \`storybook init\`) so it loads the same global CSS the app uses — add to what is there, don't replace it:
-
-\`\`\`tsx
-// .storybook/preview.tsx
-import '../src/index.css'; // the same global CSS the app loads
-
-import { definePreview } from 'storybook/preview';
-
-export default definePreview({
-  // keep whatever is already configured here
-});
-\`\`\`
-
-- If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
-- Only add a decorator (e.g. a ThemeProvider) if the chosen component actually needs it to render. Don't invent providers.
-
-### Step 3 — Write the story file
-
-Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
-
-\`\`\`tsx
-// src/components/Button.stories.tsx
-import { expect } from 'storybook/test';
-
-import preview from '#.storybook/preview';
-import { Button } from './Button';
-
-const meta = preview.meta({
-  component: Button,
-  tags: ['ai-generated'],
-});
-
-export const Primary = meta.story({
-  args: { children: 'Order now' },
-});
-
-export const Disabled = meta.story({
-  args: { children: 'Order now', disabled: true },
-});
-
-// Proves the app's global CSS actually loaded: read a real styling value
-// from the component's source (hex color, Tailwind class, CSS variable)
-// and assert the resolved computed style.
-export const StyleCheck = meta.story({
-  args: { children: 'Submit' },
-  play: async ({ canvas }) => {
-    const button = canvas.getByRole('button', { name: /submit/i });
-    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
-  },
-});
-\`\`\`
-
-- Tag the file with \`tags: ['ai-generated']\`.
-- Don't add a custom \`title\`.
-- Don't create new app components or story-specific harnesses.
-
-### Step 4 — Start Storybook and verify
-
-Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
-
-Then run the story tests for the new file through Storybook itself and self-heal until they pass. Read the command's help in its entirety before the first run — it documents the payload shape:
-
-\`\`\`bash
-STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
-\`\`\`
-
-1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
-2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.tsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
-3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
-
-### Step 5 — Wrap up
-
-Tell the user what you built and where. Then end with this offer, filling in the real component names you noted in Step 1:
-
-> Do you want me to build out stories for more components? For example **A**, **B** and **C**.
-
-If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
-`;
-
-exports[`getAiSimpleSetupMarkdownOutput > csf-factory > renders without addon-vitest 1`] = `
-"# Storybook Simple Setup
-
-## Project Info
-
-| Property | Value |
-|----------|-------|
-| Version | 10.5.2 |
-| Renderer | @storybook/react |
-| Framework | @storybook/react-vite |
-| Builder | @storybook/builder-vite |
-| Config Dir | \`.storybook\` |
-| Language | TypeScript |
-| Package Manager | npm |
-| Addons | @storybook/addon-docs |
-
-Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
-
-### Step 1 — Pick one simple component (and note the runners-up)
-
-Look through the project's own components and pick the **simplest presentational leaf component** you can find — think Button, Badge, Tag, Avatar: a handful of props, no data fetching, no routing, no app-specific context. Skip anything created by \`storybook init\` (e.g. \`src/stories/\`).
-
-While scanning, note the 2–4 next-best candidates (a mix of simple and more interesting components). You will offer these to the user at the end — do **not** write stories for them now.
-
-### Step 2 — Make sure global styling loads
-
-Find how the app loads its global CSS and theme: a CSS import in the entry file (\`main.tsx\` / \`index.tsx\`), a \`<link>\` or inline \`<style>\` in \`index.html\`, Tailwind, CSS variables, or a theme provider.
-
-**Edit the existing \`.storybook/preview.tsx\`** (created by \`storybook init\`) so it loads the same global CSS the app uses — add to what is there, don't replace it:
-
-\`\`\`tsx
-// .storybook/preview.tsx
-import '../src/index.css'; // the same global CSS the app loads
-
-import { definePreview } from 'storybook/preview';
-
-export default definePreview({
-  // keep whatever is already configured here
-});
-\`\`\`
-
-- If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
-- Only add a decorator (e.g. a ThemeProvider) if the chosen component actually needs it to render. Don't invent providers.
-
-### Step 3 — Write the story file
-
-Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
-
-\`\`\`tsx
-// src/components/Button.stories.tsx
-import { expect } from 'storybook/test';
-
-import preview from '#.storybook/preview';
-import { Button } from './Button';
-
-const meta = preview.meta({
-  component: Button,
-  tags: ['ai-generated'],
-});
-
-export const Primary = meta.story({
-  args: { children: 'Order now' },
-});
-
-export const Disabled = meta.story({
-  args: { children: 'Order now', disabled: true },
-});
-
-// Proves the app's global CSS actually loaded: read a real styling value
-// from the component's source (hex color, Tailwind class, CSS variable)
-// and assert the resolved computed style.
-export const StyleCheck = meta.story({
-  args: { children: 'Submit' },
-  play: async ({ canvas }) => {
-    const button = canvas.getByRole('button', { name: /submit/i });
-    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
-  },
-});
-\`\`\`
-
-- Tag the file with \`tags: ['ai-generated']\`.
-- Don't add a custom \`title\`.
-- Don't create new app components or story-specific harnesses.
-
-### Step 4 — Start Storybook and verify
-
-Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
-
-Confirm the new stories render styled — the component should look exactly like it does in the app.
-
-### Step 5 — Wrap up
-
-Tell the user what you built and where. Then end with this offer, filling in the real component names you noted in Step 1:
-
-> Do you want me to build out stories for more components? For example **A**, **B** and **C**.
-
-If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
-`;
-
-exports[`getAiSimpleSetupMarkdownOutput > javascript > renders with addon-vitest 1`] = `
+exports[`getAiSimpleSetupMarkdownOutput > language: js > renders with csf-factory preview: false 1`] = `
 "# Storybook Simple Setup
 
 ## Project Info
@@ -317,7 +109,7 @@ Tell the user what you built and where. Then end with this offer, filling in the
 If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
 `;
 
-exports[`getAiSimpleSetupMarkdownOutput > javascript > renders without addon-vitest 1`] = `
+exports[`getAiSimpleSetupMarkdownOutput > language: js > renders with csf-factory preview: true 1`] = `
 "# Storybook Simple Setup
 
 ## Project Info
@@ -331,7 +123,7 @@ exports[`getAiSimpleSetupMarkdownOutput > javascript > renders without addon-vit
 | Config Dir | \`.storybook\` |
 | Language | JavaScript |
 | Package Manager | npm |
-| Addons | @storybook/addon-docs |
+| Addons | @storybook/addon-docs, @storybook/addon-vitest |
 
 Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
 
@@ -351,11 +143,11 @@ Find how the app loads its global CSS and theme: a CSS import in the entry file 
 // .storybook/preview.jsx
 import '../src/index.css'; // the same global CSS the app loads
 
-const preview = {
-  // keep whatever is already configured here
-};
+import { definePreview } from 'storybook/preview';
 
-export default preview;
+export default definePreview({
+  // keep whatever is already configured here
+});
 \`\`\`
 
 - If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
@@ -369,34 +161,33 @@ Write **one** colocated story file next to the chosen component: the default sto
 // src/components/Button.stories.jsx
 import { expect } from 'storybook/test';
 
+import preview from '#.storybook/preview';
 import { Button } from './Button';
 
-const meta = {
+const meta = preview.meta({
   component: Button,
   tags: ['ai-generated'],
-};
+});
 
-export default meta;
-
-export const Primary = {
+export const Primary = meta.story({
   args: { children: 'Order now' },
-};
+});
 
-export const Disabled = {
+export const Disabled = meta.story({
   args: { children: 'Order now', disabled: true },
-};
+});
 
 // Proves the app's global CSS actually loaded: read a real styling value
 // from the component's source (hex color, Tailwind class, CSS variable)
 // and assert the resolved computed style.
-export const StyleCheck = {
+export const StyleCheck = meta.story({
   args: { children: 'Submit' },
   play: async ({ canvas }) => {
     const button = canvas.getByRole('button', { name: /submit/i });
     // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
     await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
   },
-};
+});
 \`\`\`
 
 - Tag the file with \`tags: ['ai-generated']\`.
@@ -407,7 +198,15 @@ export const StyleCheck = {
 
 Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
 
-Confirm the new stories render styled — the component should look exactly like it does in the app.
+Then run the story tests for the new file through Storybook itself and self-heal until they pass. Read the command's help in its entirety before the first run — it documents the payload shape:
+
+\`\`\`bash
+STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
+\`\`\`
+
+1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
+2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.jsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
 
 ### Step 5 — Wrap up
 
@@ -418,7 +217,7 @@ Tell the user what you built and where. Then end with this offer, filling in the
 If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
 `;
 
-exports[`getAiSimpleSetupMarkdownOutput > typescript > renders with addon-vitest 1`] = `
+exports[`getAiSimpleSetupMarkdownOutput > language: ts > renders with csf-factory preview: false 1`] = `
 "# Storybook Simple Setup
 
 ## Project Info
@@ -530,7 +329,7 @@ Tell the user what you built and where. Then end with this offer, filling in the
 If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
 `;
 
-exports[`getAiSimpleSetupMarkdownOutput > typescript > renders without addon-vitest 1`] = `
+exports[`getAiSimpleSetupMarkdownOutput > language: ts > renders with csf-factory preview: true 1`] = `
 "# Storybook Simple Setup
 
 ## Project Info
@@ -544,7 +343,7 @@ exports[`getAiSimpleSetupMarkdownOutput > typescript > renders without addon-vit
 | Config Dir | \`.storybook\` |
 | Language | TypeScript |
 | Package Manager | npm |
-| Addons | @storybook/addon-docs |
+| Addons | @storybook/addon-docs, @storybook/addon-vitest |
 
 Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
 
@@ -562,14 +361,13 @@ Find how the app loads its global CSS and theme: a CSS import in the entry file 
 
 \`\`\`tsx
 // .storybook/preview.tsx
-import type { Preview } from '@storybook/react-vite';
 import '../src/index.css'; // the same global CSS the app loads
 
-const preview: Preview = {
-  // keep whatever is already configured here
-};
+import { definePreview } from 'storybook/preview';
 
-export default preview;
+export default definePreview({
+  // keep whatever is already configured here
+});
 \`\`\`
 
 - If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
@@ -581,38 +379,35 @@ Write **one** colocated story file next to the chosen component: the default sto
 
 \`\`\`tsx
 // src/components/Button.stories.tsx
-import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
+import preview from '#.storybook/preview';
 import { Button } from './Button';
 
-const meta = {
+const meta = preview.meta({
   component: Button,
   tags: ['ai-generated'],
-} satisfies Meta<typeof Button>;
+});
 
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Primary: Story = {
+export const Primary = meta.story({
   args: { children: 'Order now' },
-};
+});
 
-export const Disabled: Story = {
+export const Disabled = meta.story({
   args: { children: 'Order now', disabled: true },
-};
+});
 
 // Proves the app's global CSS actually loaded: read a real styling value
 // from the component's source (hex color, Tailwind class, CSS variable)
 // and assert the resolved computed style.
-export const StyleCheck: Story = {
+export const StyleCheck = meta.story({
   args: { children: 'Submit' },
   play: async ({ canvas }) => {
     const button = canvas.getByRole('button', { name: /submit/i });
     // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
     await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
   },
-};
+});
 \`\`\`
 
 - Tag the file with \`tags: ['ai-generated']\`.
@@ -623,7 +418,15 @@ export const StyleCheck: Story = {
 
 Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
 
-Confirm the new stories render styled — the component should look exactly like it does in the app.
+Then run the story tests for the new file through Storybook itself and self-heal until they pass. Read the command's help in its entirety before the first run — it documents the payload shape:
+
+\`\`\`bash
+STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
+\`\`\`
+
+1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
+2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.tsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
 
 ### Step 5 — Wrap up
 

--- a/code/core/src/cli/ai/setup-prompts/__snapshots__/simple-setup.test.ts.snap
+++ b/code/core/src/cli/ai/setup-prompts/__snapshots__/simple-setup.test.ts.snap
@@ -1,0 +1,635 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`getAiSimpleSetupMarkdownOutput > csf-factory > renders with addon-vitest 1`] = `
+"# Storybook Simple Setup
+
+## Project Info
+
+| Property | Value |
+|----------|-------|
+| Version | 10.5.2 |
+| Renderer | @storybook/react |
+| Framework | @storybook/react-vite |
+| Builder | @storybook/builder-vite |
+| Config Dir | \`.storybook\` |
+| Language | TypeScript |
+| Package Manager | npm |
+| Addons | @storybook/addon-docs, @storybook/addon-vitest |
+
+Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
+
+### Step 1 — Pick one simple component (and note the runners-up)
+
+Look through the project's own components and pick the **simplest presentational leaf component** you can find — think Button, Badge, Tag, Avatar: a handful of props, no data fetching, no routing, no app-specific context. Skip anything created by \`storybook init\` (e.g. \`src/stories/\`).
+
+While scanning, note the 2–4 next-best candidates (a mix of simple and more interesting components). You will offer these to the user at the end — do **not** write stories for them now.
+
+### Step 2 — Make sure global styling loads
+
+Find how the app loads its global CSS and theme: a CSS import in the entry file (\`main.tsx\` / \`index.tsx\`), a \`<link>\` or inline \`<style>\` in \`index.html\`, Tailwind, CSS variables, or a theme provider.
+
+**Edit the existing \`.storybook/preview.tsx\`** (created by \`storybook init\`) so it loads the same global CSS the app uses — add to what is there, don't replace it:
+
+\`\`\`tsx
+// .storybook/preview.tsx
+import '../src/index.css'; // the same global CSS the app loads
+
+import { definePreview } from 'storybook/preview';
+
+export default definePreview({
+  // keep whatever is already configured here
+});
+\`\`\`
+
+- If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
+- Only add a decorator (e.g. a ThemeProvider) if the chosen component actually needs it to render. Don't invent providers.
+
+### Step 3 — Write the story file
+
+Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+
+\`\`\`tsx
+// src/components/Button.stories.tsx
+import { expect } from 'storybook/test';
+
+import preview from '#.storybook/preview';
+import { Button } from './Button';
+
+const meta = preview.meta({
+  component: Button,
+  tags: ['ai-generated'],
+});
+
+export const Primary = meta.story({
+  args: { children: 'Order now' },
+});
+
+export const Disabled = meta.story({
+  args: { children: 'Order now', disabled: true },
+});
+
+// Proves the app's global CSS actually loaded: read a real styling value
+// from the component's source (hex color, Tailwind class, CSS variable)
+// and assert the resolved computed style.
+export const StyleCheck = meta.story({
+  args: { children: 'Submit' },
+  play: async ({ canvas }) => {
+    const button = canvas.getByRole('button', { name: /submit/i });
+    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+  },
+});
+\`\`\`
+
+- Tag the file with \`tags: ['ai-generated']\`.
+- Don't add a custom \`title\`.
+- Don't create new app components or story-specific harnesses.
+
+### Step 4 — Start Storybook and verify
+
+Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
+
+Then run the story tests for the new file through Storybook itself and self-heal until they pass. Read the command's help in its entirety before the first run — it documents the payload shape:
+
+\`\`\`bash
+STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
+\`\`\`
+
+1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
+2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.tsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
+
+### Step 5 — Wrap up
+
+Tell the user what you built and where. Then end with this offer, filling in the real component names you noted in Step 1:
+
+> Do you want me to build out stories for more components? For example **A**, **B** and **C**.
+
+If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
+`;
+
+exports[`getAiSimpleSetupMarkdownOutput > csf-factory > renders without addon-vitest 1`] = `
+"# Storybook Simple Setup
+
+## Project Info
+
+| Property | Value |
+|----------|-------|
+| Version | 10.5.2 |
+| Renderer | @storybook/react |
+| Framework | @storybook/react-vite |
+| Builder | @storybook/builder-vite |
+| Config Dir | \`.storybook\` |
+| Language | TypeScript |
+| Package Manager | npm |
+| Addons | @storybook/addon-docs |
+
+Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
+
+### Step 1 — Pick one simple component (and note the runners-up)
+
+Look through the project's own components and pick the **simplest presentational leaf component** you can find — think Button, Badge, Tag, Avatar: a handful of props, no data fetching, no routing, no app-specific context. Skip anything created by \`storybook init\` (e.g. \`src/stories/\`).
+
+While scanning, note the 2–4 next-best candidates (a mix of simple and more interesting components). You will offer these to the user at the end — do **not** write stories for them now.
+
+### Step 2 — Make sure global styling loads
+
+Find how the app loads its global CSS and theme: a CSS import in the entry file (\`main.tsx\` / \`index.tsx\`), a \`<link>\` or inline \`<style>\` in \`index.html\`, Tailwind, CSS variables, or a theme provider.
+
+**Edit the existing \`.storybook/preview.tsx\`** (created by \`storybook init\`) so it loads the same global CSS the app uses — add to what is there, don't replace it:
+
+\`\`\`tsx
+// .storybook/preview.tsx
+import '../src/index.css'; // the same global CSS the app loads
+
+import { definePreview } from 'storybook/preview';
+
+export default definePreview({
+  // keep whatever is already configured here
+});
+\`\`\`
+
+- If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
+- Only add a decorator (e.g. a ThemeProvider) if the chosen component actually needs it to render. Don't invent providers.
+
+### Step 3 — Write the story file
+
+Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+
+\`\`\`tsx
+// src/components/Button.stories.tsx
+import { expect } from 'storybook/test';
+
+import preview from '#.storybook/preview';
+import { Button } from './Button';
+
+const meta = preview.meta({
+  component: Button,
+  tags: ['ai-generated'],
+});
+
+export const Primary = meta.story({
+  args: { children: 'Order now' },
+});
+
+export const Disabled = meta.story({
+  args: { children: 'Order now', disabled: true },
+});
+
+// Proves the app's global CSS actually loaded: read a real styling value
+// from the component's source (hex color, Tailwind class, CSS variable)
+// and assert the resolved computed style.
+export const StyleCheck = meta.story({
+  args: { children: 'Submit' },
+  play: async ({ canvas }) => {
+    const button = canvas.getByRole('button', { name: /submit/i });
+    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+  },
+});
+\`\`\`
+
+- Tag the file with \`tags: ['ai-generated']\`.
+- Don't add a custom \`title\`.
+- Don't create new app components or story-specific harnesses.
+
+### Step 4 — Start Storybook and verify
+
+Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
+
+Confirm the new stories render styled — the component should look exactly like it does in the app.
+
+### Step 5 — Wrap up
+
+Tell the user what you built and where. Then end with this offer, filling in the real component names you noted in Step 1:
+
+> Do you want me to build out stories for more components? For example **A**, **B** and **C**.
+
+If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
+`;
+
+exports[`getAiSimpleSetupMarkdownOutput > javascript > renders with addon-vitest 1`] = `
+"# Storybook Simple Setup
+
+## Project Info
+
+| Property | Value |
+|----------|-------|
+| Version | 10.5.2 |
+| Renderer | @storybook/react |
+| Framework | @storybook/react-vite |
+| Builder | @storybook/builder-vite |
+| Config Dir | \`.storybook\` |
+| Language | JavaScript |
+| Package Manager | npm |
+| Addons | @storybook/addon-docs, @storybook/addon-vitest |
+
+Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
+
+### Step 1 — Pick one simple component (and note the runners-up)
+
+Look through the project's own components and pick the **simplest presentational leaf component** you can find — think Button, Badge, Tag, Avatar: a handful of props, no data fetching, no routing, no app-specific context. Skip anything created by \`storybook init\` (e.g. \`src/stories/\`).
+
+While scanning, note the 2–4 next-best candidates (a mix of simple and more interesting components). You will offer these to the user at the end — do **not** write stories for them now.
+
+### Step 2 — Make sure global styling loads
+
+Find how the app loads its global CSS and theme: a CSS import in the entry file (\`main.jsx\` / \`index.jsx\`), a \`<link>\` or inline \`<style>\` in \`index.html\`, Tailwind, CSS variables, or a theme provider.
+
+**Edit the existing \`.storybook/preview.jsx\`** (created by \`storybook init\`) so it loads the same global CSS the app uses — add to what is there, don't replace it:
+
+\`\`\`jsx
+// .storybook/preview.jsx
+import '../src/index.css'; // the same global CSS the app loads
+
+const preview = {
+  // keep whatever is already configured here
+};
+
+export default preview;
+\`\`\`
+
+- If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
+- Only add a decorator (e.g. a ThemeProvider) if the chosen component actually needs it to render. Don't invent providers.
+
+### Step 3 — Write the story file
+
+Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+
+\`\`\`jsx
+// src/components/Button.stories.jsx
+import { expect } from 'storybook/test';
+
+import { Button } from './Button';
+
+const meta = {
+  component: Button,
+  tags: ['ai-generated'],
+};
+
+export default meta;
+
+export const Primary = {
+  args: { children: 'Order now' },
+};
+
+export const Disabled = {
+  args: { children: 'Order now', disabled: true },
+};
+
+// Proves the app's global CSS actually loaded: read a real styling value
+// from the component's source (hex color, Tailwind class, CSS variable)
+// and assert the resolved computed style.
+export const StyleCheck = {
+  args: { children: 'Submit' },
+  play: async ({ canvas }) => {
+    const button = canvas.getByRole('button', { name: /submit/i });
+    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+  },
+};
+\`\`\`
+
+- Tag the file with \`tags: ['ai-generated']\`.
+- Don't add a custom \`title\`.
+- Don't create new app components or story-specific harnesses.
+
+### Step 4 — Start Storybook and verify
+
+Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
+
+Then run the story tests for the new file through Storybook itself and self-heal until they pass. Read the command's help in its entirety before the first run — it documents the payload shape:
+
+\`\`\`bash
+STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
+\`\`\`
+
+1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
+2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.jsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
+
+### Step 5 — Wrap up
+
+Tell the user what you built and where. Then end with this offer, filling in the real component names you noted in Step 1:
+
+> Do you want me to build out stories for more components? For example **A**, **B** and **C**.
+
+If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
+`;
+
+exports[`getAiSimpleSetupMarkdownOutput > javascript > renders without addon-vitest 1`] = `
+"# Storybook Simple Setup
+
+## Project Info
+
+| Property | Value |
+|----------|-------|
+| Version | 10.5.2 |
+| Renderer | @storybook/react |
+| Framework | @storybook/react-vite |
+| Builder | @storybook/builder-vite |
+| Config Dir | \`.storybook\` |
+| Language | JavaScript |
+| Package Manager | npm |
+| Addons | @storybook/addon-docs |
+
+Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
+
+### Step 1 — Pick one simple component (and note the runners-up)
+
+Look through the project's own components and pick the **simplest presentational leaf component** you can find — think Button, Badge, Tag, Avatar: a handful of props, no data fetching, no routing, no app-specific context. Skip anything created by \`storybook init\` (e.g. \`src/stories/\`).
+
+While scanning, note the 2–4 next-best candidates (a mix of simple and more interesting components). You will offer these to the user at the end — do **not** write stories for them now.
+
+### Step 2 — Make sure global styling loads
+
+Find how the app loads its global CSS and theme: a CSS import in the entry file (\`main.jsx\` / \`index.jsx\`), a \`<link>\` or inline \`<style>\` in \`index.html\`, Tailwind, CSS variables, or a theme provider.
+
+**Edit the existing \`.storybook/preview.jsx\`** (created by \`storybook init\`) so it loads the same global CSS the app uses — add to what is there, don't replace it:
+
+\`\`\`jsx
+// .storybook/preview.jsx
+import '../src/index.css'; // the same global CSS the app loads
+
+const preview = {
+  // keep whatever is already configured here
+};
+
+export default preview;
+\`\`\`
+
+- If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
+- Only add a decorator (e.g. a ThemeProvider) if the chosen component actually needs it to render. Don't invent providers.
+
+### Step 3 — Write the story file
+
+Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+
+\`\`\`jsx
+// src/components/Button.stories.jsx
+import { expect } from 'storybook/test';
+
+import { Button } from './Button';
+
+const meta = {
+  component: Button,
+  tags: ['ai-generated'],
+};
+
+export default meta;
+
+export const Primary = {
+  args: { children: 'Order now' },
+};
+
+export const Disabled = {
+  args: { children: 'Order now', disabled: true },
+};
+
+// Proves the app's global CSS actually loaded: read a real styling value
+// from the component's source (hex color, Tailwind class, CSS variable)
+// and assert the resolved computed style.
+export const StyleCheck = {
+  args: { children: 'Submit' },
+  play: async ({ canvas }) => {
+    const button = canvas.getByRole('button', { name: /submit/i });
+    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+  },
+};
+\`\`\`
+
+- Tag the file with \`tags: ['ai-generated']\`.
+- Don't add a custom \`title\`.
+- Don't create new app components or story-specific harnesses.
+
+### Step 4 — Start Storybook and verify
+
+Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
+
+Confirm the new stories render styled — the component should look exactly like it does in the app.
+
+### Step 5 — Wrap up
+
+Tell the user what you built and where. Then end with this offer, filling in the real component names you noted in Step 1:
+
+> Do you want me to build out stories for more components? For example **A**, **B** and **C**.
+
+If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
+`;
+
+exports[`getAiSimpleSetupMarkdownOutput > typescript > renders with addon-vitest 1`] = `
+"# Storybook Simple Setup
+
+## Project Info
+
+| Property | Value |
+|----------|-------|
+| Version | 10.5.2 |
+| Renderer | @storybook/react |
+| Framework | @storybook/react-vite |
+| Builder | @storybook/builder-vite |
+| Config Dir | \`.storybook\` |
+| Language | TypeScript |
+| Package Manager | npm |
+| Addons | @storybook/addon-docs, @storybook/addon-vitest |
+
+Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
+
+### Step 1 — Pick one simple component (and note the runners-up)
+
+Look through the project's own components and pick the **simplest presentational leaf component** you can find — think Button, Badge, Tag, Avatar: a handful of props, no data fetching, no routing, no app-specific context. Skip anything created by \`storybook init\` (e.g. \`src/stories/\`).
+
+While scanning, note the 2–4 next-best candidates (a mix of simple and more interesting components). You will offer these to the user at the end — do **not** write stories for them now.
+
+### Step 2 — Make sure global styling loads
+
+Find how the app loads its global CSS and theme: a CSS import in the entry file (\`main.tsx\` / \`index.tsx\`), a \`<link>\` or inline \`<style>\` in \`index.html\`, Tailwind, CSS variables, or a theme provider.
+
+**Edit the existing \`.storybook/preview.tsx\`** (created by \`storybook init\`) so it loads the same global CSS the app uses — add to what is there, don't replace it:
+
+\`\`\`tsx
+// .storybook/preview.tsx
+import type { Preview } from '@storybook/react-vite';
+import '../src/index.css'; // the same global CSS the app loads
+
+const preview: Preview = {
+  // keep whatever is already configured here
+};
+
+export default preview;
+\`\`\`
+
+- If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
+- Only add a decorator (e.g. a ThemeProvider) if the chosen component actually needs it to render. Don't invent providers.
+
+### Step 3 — Write the story file
+
+Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+
+\`\`\`tsx
+// src/components/Button.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
+
+import { Button } from './Button';
+
+const meta = {
+  component: Button,
+  tags: ['ai-generated'],
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: { children: 'Order now' },
+};
+
+export const Disabled: Story = {
+  args: { children: 'Order now', disabled: true },
+};
+
+// Proves the app's global CSS actually loaded: read a real styling value
+// from the component's source (hex color, Tailwind class, CSS variable)
+// and assert the resolved computed style.
+export const StyleCheck: Story = {
+  args: { children: 'Submit' },
+  play: async ({ canvas }) => {
+    const button = canvas.getByRole('button', { name: /submit/i });
+    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+  },
+};
+\`\`\`
+
+- Tag the file with \`tags: ['ai-generated']\`.
+- Don't add a custom \`title\`.
+- Don't create new app components or story-specific harnesses.
+
+### Step 4 — Start Storybook and verify
+
+Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
+
+Then run the story tests for the new file through Storybook itself and self-heal until they pass. Read the command's help in its entirety before the first run — it documents the payload shape:
+
+\`\`\`bash
+STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
+\`\`\`
+
+1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
+2. If a test fails, read the error and fix the cause — prefer fixing \`.storybook/preview.tsx\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
+
+### Step 5 — Wrap up
+
+Tell the user what you built and where. Then end with this offer, filling in the real component names you noted in Step 1:
+
+> Do you want me to build out stories for more components? For example **A**, **B** and **C**.
+
+If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
+`;
+
+exports[`getAiSimpleSetupMarkdownOutput > typescript > renders without addon-vitest 1`] = `
+"# Storybook Simple Setup
+
+## Project Info
+
+| Property | Value |
+|----------|-------|
+| Version | 10.5.2 |
+| Renderer | @storybook/react |
+| Framework | @storybook/react-vite |
+| Builder | @storybook/builder-vite |
+| Config Dir | \`.storybook\` |
+| Language | TypeScript |
+| Package Manager | npm |
+| Addons | @storybook/addon-docs |
+
+Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
+
+### Step 1 — Pick one simple component (and note the runners-up)
+
+Look through the project's own components and pick the **simplest presentational leaf component** you can find — think Button, Badge, Tag, Avatar: a handful of props, no data fetching, no routing, no app-specific context. Skip anything created by \`storybook init\` (e.g. \`src/stories/\`).
+
+While scanning, note the 2–4 next-best candidates (a mix of simple and more interesting components). You will offer these to the user at the end — do **not** write stories for them now.
+
+### Step 2 — Make sure global styling loads
+
+Find how the app loads its global CSS and theme: a CSS import in the entry file (\`main.tsx\` / \`index.tsx\`), a \`<link>\` or inline \`<style>\` in \`index.html\`, Tailwind, CSS variables, or a theme provider.
+
+**Edit the existing \`.storybook/preview.tsx\`** (created by \`storybook init\`) so it loads the same global CSS the app uses — add to what is there, don't replace it:
+
+\`\`\`tsx
+// .storybook/preview.tsx
+import type { Preview } from '@storybook/react-vite';
+import '../src/index.css'; // the same global CSS the app loads
+
+const preview: Preview = {
+  // keep whatever is already configured here
+};
+
+export default preview;
+\`\`\`
+
+- If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
+- Only add a decorator (e.g. a ThemeProvider) if the chosen component actually needs it to render. Don't invent providers.
+
+### Step 3 — Write the story file
+
+Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+
+\`\`\`tsx
+// src/components/Button.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
+
+import { Button } from './Button';
+
+const meta = {
+  component: Button,
+  tags: ['ai-generated'],
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: { children: 'Order now' },
+};
+
+export const Disabled: Story = {
+  args: { children: 'Order now', disabled: true },
+};
+
+// Proves the app's global CSS actually loaded: read a real styling value
+// from the component's source (hex color, Tailwind class, CSS variable)
+// and assert the resolved computed style.
+export const StyleCheck: Story = {
+  args: { children: 'Submit' },
+  play: async ({ canvas }) => {
+    const button = canvas.getByRole('button', { name: /submit/i });
+    // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+    await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+  },
+};
+\`\`\`
+
+- Tag the file with \`tags: ['ai-generated']\`.
+- Don't add a custom \`title\`.
+- Don't create new app components or story-specific harnesses.
+
+### Step 4 — Start Storybook and verify
+
+Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
+
+Confirm the new stories render styled — the component should look exactly like it does in the app.
+
+### Step 5 — Wrap up
+
+Tell the user what you built and where. Then end with this offer, filling in the real component names you noted in Step 1:
+
+> Do you want me to build out stories for more components? For example **A**, **B** and **C**.
+
+If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project."
+`;

--- a/code/core/src/cli/ai/setup-prompts/simple-setup.test.ts
+++ b/code/core/src/cli/ai/setup-prompts/simple-setup.test.ts
@@ -13,7 +13,7 @@ const baseProjectInfo: ProjectInfo = {
   rendererPackage: '@storybook/react',
   renderer: SupportedRenderer.REACT,
   builderPackage: '@storybook/builder-vite',
-  addons: ['@storybook/addon-docs'],
+  addons: ['@storybook/addon-docs', '@storybook/addon-vitest'],
   configDir: '.storybook',
   storiesPaths: ['src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   packageManager: { type: 'npm' } as JsPackageManager,
@@ -23,27 +23,14 @@ const baseProjectInfo: ProjectInfo = {
   needsUserOnboarding: false,
 };
 
-const variants: Array<[string, Partial<ProjectInfo>]> = [
-  ['typescript', {}],
-  ['javascript', { language: 'js' }],
-  ['csf-factory', { hasCsfFactoryPreview: true }],
-];
+const languages = ['ts', 'js'] as const;
+const csfFactory = [false, true] as const;
 
 describe('getAiSimpleSetupMarkdownOutput', () => {
-  describe.each(variants)('%s', (_name, overrides) => {
-    it('renders without addon-vitest', () => {
+  describe.each(languages)('language: %s', (language) => {
+    it.each(csfFactory)('renders with csf-factory preview: %s', (hasCsfFactoryPreview) => {
       expect(
-        getAiSimpleSetupMarkdownOutput({ ...baseProjectInfo, ...overrides })
-      ).toMatchSnapshot();
-    });
-
-    it('renders with addon-vitest', () => {
-      expect(
-        getAiSimpleSetupMarkdownOutput({
-          ...baseProjectInfo,
-          ...overrides,
-          addons: [...baseProjectInfo.addons, '@storybook/addon-vitest'],
-        })
+        getAiSimpleSetupMarkdownOutput({ ...baseProjectInfo, language, hasCsfFactoryPreview })
       ).toMatchSnapshot();
     });
   });

--- a/code/core/src/cli/ai/setup-prompts/simple-setup.test.ts
+++ b/code/core/src/cli/ai/setup-prompts/simple-setup.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import type { JsPackageManager } from 'storybook/internal/common';
+import { SupportedRenderer } from 'storybook/internal/types';
+
+import type { ProjectInfo } from '../types.ts';
+import { getAiSimpleSetupMarkdownOutput } from './simple-setup.ts';
+
+const baseProjectInfo: ProjectInfo = {
+  storybookVersion: '10.5.2',
+  majorVersion: 10,
+  framework: '@storybook/react-vite',
+  rendererPackage: '@storybook/react',
+  renderer: SupportedRenderer.REACT,
+  builderPackage: '@storybook/builder-vite',
+  addons: ['@storybook/addon-docs'],
+  configDir: '.storybook',
+  storiesPaths: ['src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  packageManager: { type: 'npm' } as JsPackageManager,
+  packageManagerName: 'npm',
+  language: 'ts',
+  hasCsfFactoryPreview: false,
+  needsUserOnboarding: false,
+};
+
+const variants: Array<[string, Partial<ProjectInfo>]> = [
+  ['typescript', {}],
+  ['javascript', { language: 'js' }],
+  ['csf-factory', { hasCsfFactoryPreview: true }],
+];
+
+describe('getAiSimpleSetupMarkdownOutput', () => {
+  describe.each(variants)('%s', (_name, overrides) => {
+    it('renders without addon-vitest', () => {
+      expect(
+        getAiSimpleSetupMarkdownOutput({ ...baseProjectInfo, ...overrides })
+      ).toMatchSnapshot();
+    });
+
+    it('renders with addon-vitest', () => {
+      expect(
+        getAiSimpleSetupMarkdownOutput({
+          ...baseProjectInfo,
+          ...overrides,
+          addons: [...baseProjectInfo.addons, '@storybook/addon-vitest'],
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/code/core/src/cli/ai/setup-prompts/simple-setup.ts
+++ b/code/core/src/cli/ai/setup-prompts/simple-setup.ts
@@ -10,7 +10,8 @@
  * - the project has no user-written stories yet (only `storybook init` examples)
  *
  * The goal is the smallest possible first win: one story for one simple
- * component, verifiably styled, ending with an offer to build out more. The
+ * component, rendered with the app's real styling, ending with an offer to
+ * build out more. The
  * build-out itself is `npx storybook ai setup` territory.
  */
 import { dedent } from 'ts-dedent';
@@ -79,9 +80,8 @@ function getStoryExample(projectInfo: ProjectInfo): string {
     return dedent`
       \`\`\`${tsx}
       // src/components/Button.stories.${tsx}
-      import { expect } from 'storybook/test';
-
       import preview from '#.storybook/preview';
+
       import { Button } from './Button';
 
       const meta = preview.meta({
@@ -96,18 +96,6 @@ function getStoryExample(projectInfo: ProjectInfo): string {
       export const Disabled = meta.story({
         args: { children: 'Order now', disabled: true },
       });
-
-      // Proves the app's global CSS actually loaded: read a real styling value
-      // from the component's source (hex color, Tailwind class, CSS variable)
-      // and assert the resolved computed style.
-      export const StyleCheck = meta.story({
-        args: { children: 'Submit' },
-        play: async ({ canvas }) => {
-          const button = canvas.getByRole('button', { name: /submit/i });
-          // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-          await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
-        },
-      });
       \`\`\`
     `;
   }
@@ -116,8 +104,6 @@ function getStoryExample(projectInfo: ProjectInfo): string {
     return dedent`
       \`\`\`${tsx}
       // src/components/Button.stories.${tsx}
-      import { expect } from 'storybook/test';
-
       import { Button } from './Button';
 
       const meta = {
@@ -134,18 +120,6 @@ function getStoryExample(projectInfo: ProjectInfo): string {
       export const Disabled = {
         args: { children: 'Order now', disabled: true },
       };
-
-      // Proves the app's global CSS actually loaded: read a real styling value
-      // from the component's source (hex color, Tailwind class, CSS variable)
-      // and assert the resolved computed style.
-      export const StyleCheck = {
-        args: { children: 'Submit' },
-        play: async ({ canvas }) => {
-          const button = canvas.getByRole('button', { name: /submit/i });
-          // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-          await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
-        },
-      };
       \`\`\`
     `;
   }
@@ -154,7 +128,6 @@ function getStoryExample(projectInfo: ProjectInfo): string {
     \`\`\`${tsx}
     // src/components/Button.stories.${tsx}
     import type { Meta, StoryObj } from '${typeImport}';
-    import { expect } from 'storybook/test';
 
     import { Button } from './Button';
 
@@ -172,18 +145,6 @@ function getStoryExample(projectInfo: ProjectInfo): string {
 
     export const Disabled: Story = {
       args: { children: 'Order now', disabled: true },
-    };
-
-    // Proves the app's global CSS actually loaded: read a real styling value
-    // from the component's source (hex color, Tailwind class, CSS variable)
-    // and assert the resolved computed style.
-    export const StyleCheck: Story = {
-      args: { children: 'Submit' },
-      play: async ({ canvas }) => {
-        const button = canvas.getByRole('button', { name: /submit/i });
-        // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-        await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
-      },
     };
     \`\`\`
   `;
@@ -221,7 +182,7 @@ function renderSteps(projectInfo: ProjectInfo): string {
 
     ### Step 3 — Write the story file
 
-    Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+    Write **one** colocated story file next to the chosen component: the default story and at most a couple of meaningful variants.
 
     ${getStoryExample(projectInfo)}
 
@@ -240,7 +201,7 @@ function renderSteps(projectInfo: ProjectInfo): string {
     \`\`\`
 
     1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
-    2. If a test fails, read the error and fix the cause — prefer fixing \`${configDir}/preview.${tsx}\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+    2. If a test fails, read the error and fix the cause — prefer fixing \`${configDir}/preview.${tsx}\` (missing CSS import, missing provider) over story-local workarounds.
     3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
 
     ### Step 5 — Wrap up

--- a/code/core/src/cli/ai/setup-prompts/simple-setup.ts
+++ b/code/core/src/cli/ai/setup-prompts/simple-setup.ts
@@ -1,0 +1,281 @@
+/**
+ * Prompt for `npx storybook ai simple-setup`.
+ *
+ * Experimental command used only by the Storybook agent plugins/skills. It is
+ * intentionally not referenced from docs or in-app nudges and emits no
+ * telemetry. The invoking skill guarantees the preconditions:
+ *
+ * - Storybook is installed and running 10.5.2 or later
+ * - `@storybook/addon-mcp` is installed
+ * - the project has no user-written stories yet (only `storybook init` examples)
+ *
+ * The goal is the smallest possible first win: one story for one simple
+ * component, verifiably styled, ending with an offer to build out more. The
+ * build-out itself is `npx storybook ai setup` territory.
+ */
+import { dedent } from 'ts-dedent';
+
+import type { ProjectInfo } from '../types.ts';
+import { ext } from '../utils/ext.ts';
+import { getProjectOverview } from '../utils/project-overview.ts';
+
+function getPreviewCssExample(projectInfo: ProjectInfo): string {
+  const { configDir, language, framework, rendererPackage } = projectInfo;
+  const tsx = ext(language, true);
+  const typeImport = framework || rendererPackage || '@storybook/react-vite';
+
+  if (projectInfo.hasCsfFactoryPreview) {
+    return dedent`
+      \`\`\`${tsx}
+      // ${configDir}/preview.${tsx}
+      import '../src/index.css'; // the same global CSS the app loads
+
+      import { definePreview } from 'storybook/preview';
+
+      export default definePreview({
+        // keep whatever is already configured here
+      });
+      \`\`\`
+    `;
+  }
+
+  if (language === 'js') {
+    return dedent`
+      \`\`\`${tsx}
+      // ${configDir}/preview.${tsx}
+      import '../src/index.css'; // the same global CSS the app loads
+
+      const preview = {
+        // keep whatever is already configured here
+      };
+
+      export default preview;
+      \`\`\`
+    `;
+  }
+
+  return dedent`
+    \`\`\`${tsx}
+    // ${configDir}/preview.${tsx}
+    import type { Preview } from '${typeImport}';
+    import '../src/index.css'; // the same global CSS the app loads
+
+    const preview: Preview = {
+      // keep whatever is already configured here
+    };
+
+    export default preview;
+    \`\`\`
+  `;
+}
+
+function getStoryExample(projectInfo: ProjectInfo): string {
+  const { language, framework, rendererPackage } = projectInfo;
+  const tsx = ext(language, true);
+  const typeImport = framework || rendererPackage || '@storybook/react-vite';
+
+  if (projectInfo.hasCsfFactoryPreview) {
+    return dedent`
+      \`\`\`${tsx}
+      // src/components/Button.stories.${tsx}
+      import { expect } from 'storybook/test';
+
+      import preview from '#.storybook/preview';
+      import { Button } from './Button';
+
+      const meta = preview.meta({
+        component: Button,
+        tags: ['ai-generated'],
+      });
+
+      export const Primary = meta.story({
+        args: { children: 'Order now' },
+      });
+
+      export const Disabled = meta.story({
+        args: { children: 'Order now', disabled: true },
+      });
+
+      // Proves the app's global CSS actually loaded: read a real styling value
+      // from the component's source (hex color, Tailwind class, CSS variable)
+      // and assert the resolved computed style.
+      export const StyleCheck = meta.story({
+        args: { children: 'Submit' },
+        play: async ({ canvas }) => {
+          const button = canvas.getByRole('button', { name: /submit/i });
+          // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+          await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+        },
+      });
+      \`\`\`
+    `;
+  }
+
+  if (language === 'js') {
+    return dedent`
+      \`\`\`${tsx}
+      // src/components/Button.stories.${tsx}
+      import { expect } from 'storybook/test';
+
+      import { Button } from './Button';
+
+      const meta = {
+        component: Button,
+        tags: ['ai-generated'],
+      };
+
+      export default meta;
+
+      export const Primary = {
+        args: { children: 'Order now' },
+      };
+
+      export const Disabled = {
+        args: { children: 'Order now', disabled: true },
+      };
+
+      // Proves the app's global CSS actually loaded: read a real styling value
+      // from the component's source (hex color, Tailwind class, CSS variable)
+      // and assert the resolved computed style.
+      export const StyleCheck = {
+        args: { children: 'Submit' },
+        play: async ({ canvas }) => {
+          const button = canvas.getByRole('button', { name: /submit/i });
+          // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+          await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+        },
+      };
+      \`\`\`
+    `;
+  }
+
+  return dedent`
+    \`\`\`${tsx}
+    // src/components/Button.stories.${tsx}
+    import type { Meta, StoryObj } from '${typeImport}';
+    import { expect } from 'storybook/test';
+
+    import { Button } from './Button';
+
+    const meta = {
+      component: Button,
+      tags: ['ai-generated'],
+    } satisfies Meta<typeof Button>;
+
+    export default meta;
+    type Story = StoryObj<typeof meta>;
+
+    export const Primary: Story = {
+      args: { children: 'Order now' },
+    };
+
+    export const Disabled: Story = {
+      args: { children: 'Order now', disabled: true },
+    };
+
+    // Proves the app's global CSS actually loaded: read a real styling value
+    // from the component's source (hex color, Tailwind class, CSS variable)
+    // and assert the resolved computed style.
+    export const StyleCheck: Story = {
+      args: { children: 'Submit' },
+      play: async ({ canvas }) => {
+        const button = canvas.getByRole('button', { name: /submit/i });
+        // Button uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+        await expect(getComputedStyle(button).backgroundColor).toBe('rgb(37, 99, 235)');
+      },
+    };
+    \`\`\`
+  `;
+}
+
+export function instructions(projectInfo: ProjectInfo): string {
+  const { configDir, language } = projectInfo;
+  const tsx = ext(language, true);
+  const hasVitestAddon = projectInfo.addons.some((addon) =>
+    addon.includes('@storybook/addon-vitest')
+  );
+
+  const verifyStep = hasVitestAddon
+    ? dedent`
+      ### Step 4 — Start Storybook and verify
+
+      Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
+
+      Then run the story tests for the new file through Storybook itself and self-heal until they pass. Read the command's help in its entirety before the first run — it documents the payload shape:
+
+      \`\`\`bash
+      STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
+      \`\`\`
+
+      1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
+      2. If a test fails, read the error and fix the cause — prefer fixing \`${configDir}/preview.${tsx}\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+      3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
+    `
+    : dedent`
+      ### Step 4 — Start Storybook and verify
+
+      Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
+
+      Confirm the new stories render styled — the component should look exactly like it does in the app.
+    `;
+
+  return dedent`
+    Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
+
+    ${renderSteps(projectInfo, verifyStep)}
+  `;
+}
+
+function renderSteps(projectInfo: ProjectInfo, verifyStep: string): string {
+  const { configDir, language } = projectInfo;
+  const tsx = ext(language, true);
+
+  return dedent`
+    ### Step 1 — Pick one simple component (and note the runners-up)
+
+    Look through the project's own components and pick the **simplest presentational leaf component** you can find — think Button, Badge, Tag, Avatar: a handful of props, no data fetching, no routing, no app-specific context. Skip anything created by \`storybook init\` (e.g. \`src/stories/\`).
+
+    While scanning, note the 2–4 next-best candidates (a mix of simple and more interesting components). You will offer these to the user at the end — do **not** write stories for them now.
+
+    ### Step 2 — Make sure global styling loads
+
+    Find how the app loads its global CSS and theme: a CSS import in the entry file (\`main.${tsx}\` / \`index.${tsx}\`), a \`<link>\` or inline \`<style>\` in \`index.html\`, Tailwind, CSS variables, or a theme provider.
+
+    **Edit the existing \`${configDir}/preview.${tsx}\`** (created by \`storybook init\`) so it loads the same global CSS the app uses — add to what is there, don't replace it:
+
+    ${getPreviewCssExample(projectInfo)}
+
+    - If the CSS is loaded via \`<link>\` in \`index.html\` rather than imported in JS, import that same file in the preview.
+    - Only add a decorator (e.g. a ThemeProvider) if the chosen component actually needs it to render. Don't invent providers.
+
+    ### Step 3 — Write the story file
+
+    Write **one** colocated story file next to the chosen component: the default story, at most a couple of meaningful variants, and one \`StyleCheck\` story.
+
+    ${getStoryExample(projectInfo)}
+
+    - Tag the file with \`tags: ['ai-generated']\`.
+    - Don't add a custom \`title\`.
+    - Don't create new app components or story-specific harnesses.
+
+    ${verifyStep}
+
+    ### Step 5 — Wrap up
+
+    Tell the user what you built and where. Then end with this offer, filling in the real component names you noted in Step 1:
+
+    > Do you want me to build out stories for more components? For example **A**, **B** and **C**.
+
+    If the user says yes, run \`npx storybook ai setup\` and follow its instructions to build out stories for the rest of the project.
+  `;
+}
+
+export function getAiSimpleSetupMarkdownOutput(projectInfo: ProjectInfo): string {
+  return dedent`
+    # Storybook Simple Setup
+
+    ${getProjectOverview(projectInfo)}
+
+    ${instructions(projectInfo)}
+  `;
+}

--- a/code/core/src/cli/ai/setup-prompts/simple-setup.ts
+++ b/code/core/src/cli/ai/setup-prompts/simple-setup.ts
@@ -188,7 +188,7 @@ function getStoryExample(projectInfo: ProjectInfo): string {
   `;
 }
 
-export function instructions(projectInfo: ProjectInfo): string {
+function instructions(projectInfo: ProjectInfo): string {
   const { configDir, language } = projectInfo;
   const tsx = ext(language, true);
   const hasVitestAddon = projectInfo.addons.some((addon) =>

--- a/code/core/src/cli/ai/setup-prompts/simple-setup.ts
+++ b/code/core/src/cli/ai/setup-prompts/simple-setup.ts
@@ -6,7 +6,7 @@
  * telemetry. The invoking skill guarantees the preconditions:
  *
  * - Storybook is installed and running 10.5.2 or later
- * - `@storybook/addon-mcp` is installed
+ * - `@storybook/addon-mcp` and `@storybook/addon-vitest` are installed
  * - the project has no user-written stories yet (only `storybook init` examples)
  *
  * The goal is the smallest possible first win: one story for one simple
@@ -18,11 +18,12 @@ import { dedent } from 'ts-dedent';
 import type { ProjectInfo } from '../types.ts';
 import { ext } from '../utils/ext.ts';
 import { getProjectOverview } from '../utils/project-overview.ts';
+import { getTypeImportSource } from '../utils/type-import-source.ts';
 
 function getPreviewCssExample(projectInfo: ProjectInfo): string {
-  const { configDir, language, framework, rendererPackage } = projectInfo;
+  const { configDir, language } = projectInfo;
   const tsx = ext(language, true);
-  const typeImport = framework || rendererPackage || '@storybook/react-vite';
+  const typeImport = getTypeImportSource(projectInfo);
 
   if (projectInfo.hasCsfFactoryPreview) {
     return dedent`
@@ -70,9 +71,9 @@ function getPreviewCssExample(projectInfo: ProjectInfo): string {
 }
 
 function getStoryExample(projectInfo: ProjectInfo): string {
-  const { language, framework, rendererPackage } = projectInfo;
+  const { language } = projectInfo;
   const tsx = ext(language, true);
-  const typeImport = framework || rendererPackage || '@storybook/react-vite';
+  const typeImport = getTypeImportSource(projectInfo);
 
   if (projectInfo.hasCsfFactoryPreview) {
     return dedent`
@@ -189,44 +190,14 @@ function getStoryExample(projectInfo: ProjectInfo): string {
 }
 
 function instructions(projectInfo: ProjectInfo): string {
-  const { configDir, language } = projectInfo;
-  const tsx = ext(language, true);
-  const hasVitestAddon = projectInfo.addons.some((addon) =>
-    addon.includes('@storybook/addon-vitest')
-  );
-
-  const verifyStep = hasVitestAddon
-    ? dedent`
-      ### Step 4 — Start Storybook and verify
-
-      Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
-
-      Then run the story tests for the new file through Storybook itself and self-heal until they pass. Read the command's help in its entirety before the first run — it documents the payload shape:
-
-      \`\`\`bash
-      STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
-      \`\`\`
-
-      1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
-      2. If a test fails, read the error and fix the cause — prefer fixing \`${configDir}/preview.${tsx}\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
-      3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
-    `
-    : dedent`
-      ### Step 4 — Start Storybook and verify
-
-      Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
-
-      Confirm the new stories render styled — the component should look exactly like it does in the app.
-    `;
-
   return dedent`
     Your goal is to write **one story file for one simple component**, so the user sees their own component rendered in Storybook. Keep it fast and minimal: no new addons, no data mocking, no refactors, no extra stories.
 
-    ${renderSteps(projectInfo, verifyStep)}
+    ${renderSteps(projectInfo)}
   `;
 }
 
-function renderSteps(projectInfo: ProjectInfo, verifyStep: string): string {
+function renderSteps(projectInfo: ProjectInfo): string {
   const { configDir, language } = projectInfo;
   const tsx = ext(language, true);
 
@@ -258,7 +229,19 @@ function renderSteps(projectInfo: ProjectInfo, verifyStep: string): string {
     - Don't add a custom \`title\`.
     - Don't create new app components or story-specific harnesses.
 
-    ${verifyStep}
+    ### Step 4 — Start Storybook and verify
+
+    Start the Storybook dev server in the background (or reuse one that already serves this project, usually \`http://localhost:6006\`), using the project's existing \`package.json\` script. Leave it running when you are done — it is part of the deliverable.
+
+    Then run the story tests for the new file through Storybook itself and self-heal until they pass. Read the command's help in its entirety before the first run — it documents the payload shape:
+
+    \`\`\`bash
+    STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests --help
+    \`\`\`
+
+    1. Run the tests for the new story file only (\`STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai run-story-tests ...\`).
+    2. If a test fails, read the error and fix the cause — prefer fixing \`${configDir}/preview.${tsx}\` (missing CSS import, missing provider) over story-local workarounds. If the \`StyleCheck\` assertion fails, the global CSS is not loading in the preview; fix that before anything else.
+    3. Re-run the tests and repeat. Cap this loop at ~5 attempts — if the tests still fail, stop and explain to the user what went wrong and what the possible next steps are.
 
     ### Step 5 — Wrap up
 

--- a/code/core/src/cli/ai/simple-setup.ts
+++ b/code/core/src/cli/ai/simple-setup.ts
@@ -1,0 +1,41 @@
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { logger } from 'storybook/internal/node-logger';
+
+import { resolveProjectInfo } from './project-info.ts';
+import { getAiSimpleSetupMarkdownOutput } from './setup-prompts/simple-setup.ts';
+
+interface AiSimpleSetupOptions {
+  /** Location of the Storybook configuration directory. */
+  configDir?: string;
+  /** Package manager to use (npm, yarn1, yarn2, pnpm, bun). */
+  packageManager?: string;
+  /** If provided, the generated instructions will be written to this file instead of the console. */
+  output?: string;
+}
+
+/**
+ * Experimental sibling of `aiSetup` for the agent plugins/skills: prints instructions to write a
+ * first story for one simple component. Unlike `aiSetup` it sends no telemetry and writes no
+ * `ai-setup-ran` cache entry — it is not part of the in-app onboarding funnel.
+ */
+export async function aiSimpleSetup(options: AiSimpleSetupOptions): Promise<void> {
+  const { configDir, packageManager, output } = options;
+
+  const projectInfo = await resolveProjectInfo({ configDir, packageManager });
+
+  if (!projectInfo) {
+    return;
+  }
+
+  const markdownOutput = getAiSimpleSetupMarkdownOutput(projectInfo);
+
+  if (output) {
+    const outputPath = resolve(output);
+    await writeFile(outputPath, markdownOutput, 'utf-8');
+    logger.log(`Prompt written to ${outputPath}`);
+  } else {
+    process.stdout.write(`${markdownOutput}\n`);
+  }
+}


### PR DESCRIPTION
## What I did

Added an experimental `storybook ai simple-setup` subcommand, a sibling of `storybook ai setup`, intended to be used only by the Storybook agent plugins/skills (not referenced from docs or in-app nudges).

**Problem:** the existing `ai setup` prompt instructs the agent to write up to 10 stories, which is slow and expensive as a *first* Storybook experience.

**Solution:** `simple-setup` prints a much smaller prompt: write **one** story file for **one** simple presentational component, make sure it renders with the app's real global CSS loaded in the preview, and end with an opt-in offer to build out stories for more components — which routes back to the full `npx storybook ai setup`.

Details:

- New prompt builder in `code/core/src/cli/ai/setup-prompts/simple-setup.ts`. It is deliberately **not** registered in the `EVAL_SETUP_PROMPT` variant registry — it is its own command, not a setup variant.
- New handler `aiSimpleSetup` in `code/core/src/cli/ai/simple-setup.ts`. Unlike `aiSetup` it sends **no telemetry** and writes **no `ai-setup-ran` cache entry** — it is intentionally outside the onboarding funnel.
- Extracted the ProjectInfo assembly that `aiSetup` and `aiSimpleSetup` share into `resolveProjectInfo()` (`code/core/src/cli/ai/project-info.ts`) instead of duplicating ~70 lines. `aiSetup` behavior is unchanged (including the `onboarding-pending` cache read and error handling), covered by regression tests in `project-info.test.ts`.
- The verify step always runs the `storybook ai run-story-tests` self-heal loop (capped at ~5 attempts): the invoking skills guarantee `@storybook/addon-vitest` is installed, alongside Storybook ≥ 10.5.2 and `@storybook/addon-mcp`.
- Same React + Vite guard as `ai setup`.

This PR was written with AI assistance (Claude), reviewed and submitted by a human.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`code/core/src/cli/ai/setup-prompts/simple-setup.test.ts` snapshots the generated prompt for the full TS/JS × CSF-factory matrix, and `code/core/src/cli/ai/project-info.test.ts` covers the extracted `resolveProjectInfo()` (mapping, guards, and error handling shared with `ai setup`).

#### Manual testing

1. Run a sandbox, e.g. `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. In the sandbox directory, run `npx storybook ai simple-setup`
3. Verify it prints a "Storybook Simple Setup" markdown prompt with a project info table and 5 steps, and that `npx storybook ai simple-setup -o prompt.md` writes the same output to a file
4. Verify `npx storybook ai setup` still works unchanged

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Intentionally undocumented: the command is experimental and only invoked by the Storybook agent plugins/skills.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the experimental `storybook ai simple-setup` command.
  * Produces guided, markdown-based instructions for setting up a first component story, wiring global CSS into Storybook, and validating via the Storybook agent.
  * Works with JavaScript and TypeScript, and supports custom config directories, selecting a package manager, and writing the instructions to a file (or printing to the console).

* **Bug Fixes**
  * Improved project/config detection with clearer messaging and safer early exits for unsupported setups or read failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->