### PR TITLE
Build: Remove baseUrl from tsconfigs for TypeScript 7 compatibility

### DIFF
--- a/code/core/src/components/components/Select/Select.stories.tsx
+++ b/code/core/src/components/components/Select/Select.stories.tsx
@@ -4,7 +4,7 @@ import { Button, Toolbar } from 'storybook/internal/components';
 
 import { LinuxIcon } from '@storybook/icons';
 
-import type { StoryAnnotations } from 'core/src/types';
+import type { StoryAnnotations } from 'storybook/internal/types';
 import { expect, fn, screen, userEvent, within } from 'storybook/test';
 import { styled } from 'storybook/theming';
 

--- a/code/frameworks/html-vite/tsconfig.json
+++ b/code/frameworks/html-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/preact-vite/tsconfig.json
+++ b/code/frameworks/preact-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/react-native-web-vite/tsconfig.json
+++ b/code/frameworks/react-native-web-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/react-vite/tsconfig.json
+++ b/code/frameworks/react-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/svelte-vite/tsconfig.json
+++ b/code/frameworks/svelte-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/sveltekit/tsconfig.json
+++ b/code/frameworks/sveltekit/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     }

--- a/code/frameworks/tanstack-react/tsconfig.json
+++ b/code/frameworks/tanstack-react/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/vue3-vite/tsconfig.json
+++ b/code/frameworks/vue3-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/frameworks/web-components-vite/tsconfig.json
+++ b/code/frameworks/web-components-vite/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
     },

--- a/code/renderers/react/tsconfig.json
+++ b/code/renderers/react/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@storybook/react": ["./src"]
     }

--- a/code/renderers/web-components/tsconfig.json
+++ b/code/renderers/web-components/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "resolveJsonModule": true,
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]

--- a/code/tsconfig.json
+++ b/code/tsconfig.json
@@ -2,7 +2,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "customConditions": ["code"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Fixes the `tests-unit--windows` failure that every `ci:daily` run hits since the TypeScript 6 upgrade / rolldown-dts merge (#34971 / #35341) landed on `next` (first seen on the daily runs of 2026-07-14, e.g. job [1754407](https://circleci.com/gh/storybookjs/storybook/1754407)).

## The failure chain

1. `typescript-native` (`npm:typescript@^7.0.2`, added for the TS7 native d.ts emitter) and `typescript@6.0.3` both ship a `tsc` bin. In the hoisted root `node_modules/.bin`, `tsc` now resolves to **TS 7.0.2**.
2. Vitest's `typecheck` spawns that bin. Exactly one Vitest project enables typecheck: `storybook-addon-pseudo-states`.
3. TS 7 has *removed* `baseUrl` (TS 6 only deprecates it, silenced by `ignoreDeprecations: "6.0"`), so config parsing fails with `TS5102: Option 'baseUrl' has been removed`, Vitest reports it as an unhandled error, and the job exits 1 - even though all 6,994 tests pass.
4. Only `tests-unit--windows` trips because it runs the whole suite (`yarn test`); the Linux tests job passes an explicit `TEST_FILES` glob that never triggers the typecheck pass.

## The fix

Remove `baseUrl` from `code/tsconfig.json` and the 11 package tsconfigs that set it. The `paths` entries in those configs resolve relative to the tsconfig directory when `baseUrl` is absent (supported since TS 4.1), so they keep working unchanged. The single consumer of `baseUrl`-relative resolution in the whole repo was one bare `'core/src/types'` import in `Select.stories.tsx`, which is now a proper `storybook/internal/types` import.

This is also simply the TS7-forward direction: the repo's d.ts emit already runs on TS 7, and `baseUrl` has to go before any other tooling picks up the TS 7 binary.

## Verification

- [x] `node_modules/.bin/tsc` (7.0.2) `-p code/addons/pseudo-states/tsconfig.json --noEmit` exits 0 (failed with TS5102 before)
- [x] `yarn test --project storybook-addon-pseudo-states` passes including its typecheck pass (the exact CI failure mode)
- [x] `yarn nx run-many -t check` green for all 44 projects on TS 6

#### Manual testing

CI-only/type-level change. Run `yarn test --project storybook-addon-pseudo-states` and `yarn nx run-many -t check` locally; both should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized TypeScript configuration across supported frameworks and renderers.
  * Improved module resolution consistency for development and builds.
  * Updated Storybook story type integration for better compatibility with current tooling.

* **Chores**
  * Simplified project configuration while preserving existing path mappings and compilation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->