### PR TITLE
TanStack: Fix route lookup, cloning, and mock resolution in story routing

### DIFF
--- a/code/frameworks/tanstack-react/src/export-mocks/start.test.ts
+++ b/code/frameworks/tanstack-react/src/export-mocks/start.test.ts
@@ -16,4 +16,19 @@ describe('createServerFn', () => {
 
     await expect(serverFn()).resolves.toBe('ok');
   });
+
+  it('keeps the handler implementation across mock resets', async () => {
+    // storybook/test resets all mocks before every story. Implementations
+    // installed with mockImplementation() are erased by a reset; only the
+    // implementation passed at fn() creation survives. Server functions are
+    // defined at module scope, so a reset must not turn them into
+    // undefined-returning stubs.
+    const serverFn = (createServerFn() as unknown as MockCreateServerFnBuilder)
+      .validator((input: unknown) => input)
+      .handler(async () => 'ok');
+
+    (serverFn as unknown as { mockReset: () => void }).mockReset();
+
+    await expect(serverFn()).resolves.toBe('ok');
+  });
 });

--- a/code/frameworks/tanstack-react/src/export-mocks/start.ts
+++ b/code/frameworks/tanstack-react/src/export-mocks/start.ts
@@ -593,11 +593,13 @@ function createMockServerFnBuilder(): any {
   };
 
   builder.handler = (handlerFn?: (...args: any[]) => any) => {
-    const mock = fn().mockName('@tanstack/start-client-core::createServerFn.handler()');
-
-    if (handlerFn) {
-      mock.mockImplementation(async (opts?: any) => handlerFn(opts));
-    }
+    // Pass the implementation to fn() itself: storybook/test resets all
+    // mocks before every story, and a reset erases implementations installed
+    // with mockImplementation() but restores the one given at creation.
+    // Server functions are defined at module scope, so they must survive.
+    const mock = (handlerFn ? fn(async (opts?: any) => handlerFn(opts)) : fn()).mockName(
+      '@tanstack/start-client-core::createServerFn.handler()'
+    );
 
     return mock;
   };

--- a/code/frameworks/tanstack-react/src/plugins/module-interception.ts
+++ b/code/frameworks/tanstack-react/src/plugins/module-interception.ts
@@ -22,7 +22,19 @@ export function moduleInterceptionPlugin({
     enforce: 'pre',
     resolveId: {
       order: 'pre',
-      handler(id: string, importer: string | undefined) {
+      async handler(id: string, importer: string | undefined) {
+        // Resolve mock files through Vite instead of returning the raw file
+        // path. Users also import the mocks directly (the documented
+        // `@storybook/tanstack-react/react-router` spy-assertion path), and
+        // that import goes through Vite's resolver, which stamps a `?v=`
+        // query on the id. A raw path here would register a SECOND module
+        // instance of the same file, so user assertions would see spies the
+        // app never calls.
+        const resolveMock = async (mockPath: string) => {
+          const resolved = await this.resolve(mockPath, importer, { skipSelf: true });
+          return resolved ?? mockPath;
+        };
+
         // Redirect @tanstack/react-router to our mock, except when
         // the importer IS the mock (to avoid a circular alias).
         if (
@@ -30,21 +42,21 @@ export function moduleInterceptionPlugin({
           importer &&
           !importer.includes('export-mocks')
         ) {
-          return routerMockPath;
+          return resolveMock(routerMockPath);
         }
 
         if (START_SERVER_MODULES.includes(id) || id === '@tanstack/react-start') {
-          return startMockPath;
+          return resolveMock(startMockPath);
         }
 
         if (id === '@tanstack/start-storage-context') {
-          return startStorageContextMockPath;
+          return resolveMock(startStorageContextMockPath);
         }
 
         // Intercept virtual/server/worker entries
         for (const pattern of INTERCEPTED_PATTERNS) {
           if (id.includes(pattern)) {
-            return startMockPath;
+            return resolveMock(startMockPath);
           }
         }
 

--- a/code/frameworks/tanstack-react/src/routing/decorator.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/decorator.test.ts
@@ -121,3 +121,59 @@ describe('createStoryRouter with routeOverrides', () => {
     expect(clonedPage.options.component).toBe(Marker);
   });
 });
+
+// Explicit `path` selection previously compared init-backed `fullPath`
+// getters (always undefined on clones), so it silently fell through to the
+// bound route or the root's first child.
+describe('createStoryRouter leaf selection by path', () => {
+  it('selects the route matching an explicit path when only the routeTree is bound', async () => {
+    const root = createRootRoute();
+    const home = createRoute({ path: '/', getParentRoute: () => root });
+    const about = createRoute({ path: '/about', getParentRoute: () => root });
+    root.addChildren([home, about]);
+
+    const router = createStoryRouter({
+      Story: () => null,
+      context: fakeContext(root, { path: '/about' }),
+    });
+    await router.load();
+
+    expect(router.state.location.pathname).toBe('/about');
+    expect((router as any).routesById['/about'].options.component).toBeDefined();
+    expect((router as any).routesById['/'].options.component).toBeUndefined();
+  });
+
+  it('selects a param route by interpolating the provided params', async () => {
+    const root = createRootRoute();
+    const list = createRoute({ path: '/users', getParentRoute: () => root });
+    const detail = createRoute({ path: '/users/$userId', getParentRoute: () => root });
+    root.addChildren([list, detail]);
+
+    const router = createStoryRouter({
+      Story: () => null,
+      context: fakeContext(root, { path: '/users/42', params: { userId: '42' } }),
+    });
+    await router.load();
+
+    expect(router.state.location.pathname).toBe('/users/42');
+    expect((router as any).routesById['/users/$userId'].options.component).toBeDefined();
+    expect((router as any).routesById['/users'].options.component).toBeUndefined();
+  });
+
+  it('prefers the bound route when its mount path matches the explicit path', async () => {
+    const root = createRootRoute();
+    const post = createRoute({ path: '/posts/$postId', getParentRoute: () => root });
+    const postIndex = createRoute({ path: '/', getParentRoute: () => post });
+    post.addChildren([postIndex]);
+    root.addChildren([post]);
+
+    const router = createStoryRouter({
+      Story: () => null,
+      context: fakeContext(postIndex, { path: '/posts/$postId' }),
+    });
+    await router.load();
+
+    expect((router as any).routesById['/posts/$postId/'].options.component).toBeDefined();
+    expect((router as any).routesById['/posts/$postId'].options.component).toBeUndefined();
+  });
+});

--- a/code/frameworks/tanstack-react/src/routing/decorator.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/decorator.test.ts
@@ -98,3 +98,26 @@ describe('createStoryRouter with a pathless layout that already has an index chi
     expect(router.state.location.pathname).toBe('/products');
   });
 });
+
+// Overrides are keyed by the ORIGINAL route id; the cloned leaf's `id` getter
+// is init-backed and undefined at injection time, so the guard that respects
+// a user's component override must resolve the original id instead.
+describe('createStoryRouter with routeOverrides', () => {
+  it('respects a component override on the story-bound route', async () => {
+    const root = createRootRoute();
+    const page = createRoute({ path: '/page', getParentRoute: () => root });
+    root.addChildren([page]);
+    const Marker = () => null;
+
+    const router = createStoryRouter({
+      Story: () => null,
+      context: fakeContext(page, {
+        routeOverrides: { '/page': { component: Marker } },
+      }),
+    });
+    await router.load();
+
+    const clonedPage = (router as any).routesById['/page'];
+    expect(clonedPage.options.component).toBe(Marker);
+  });
+});

--- a/code/frameworks/tanstack-react/src/routing/decorator.tsx
+++ b/code/frameworks/tanstack-react/src/routing/decorator.tsx
@@ -212,6 +212,7 @@ function resolveTree(Story: ComponentType, context: Parameters<Decorator>[1]): R
     const leaf = resolveStoryLeaf(tree, {
       path: routerParameters.path as string | undefined,
       boundRouteId: resolvedRoute && resolvedRoute !== rootRoute ? resolvedRoute.id : undefined,
+      params: routerParameters.params as Record<string, unknown> | undefined,
     });
 
     injectStoryComponent(leaf, Story, routeOverrides, originalRouteId(tree, leaf) ?? leaf.id);

--- a/code/frameworks/tanstack-react/src/routing/decorator.tsx
+++ b/code/frameworks/tanstack-react/src/routing/decorator.tsx
@@ -17,6 +17,7 @@ import {
   duplicateRouteTree,
   findRootRoute,
   mountPathFor,
+  originalRouteId,
   resolveStoryLeaf,
   type DuplicatedTree,
 } from './duplicate-tree.ts';
@@ -213,7 +214,7 @@ function resolveTree(Story: ComponentType, context: Parameters<Decorator>[1]): R
       boundRouteId: resolvedRoute && resolvedRoute !== rootRoute ? resolvedRoute.id : undefined,
     });
 
-    injectStoryComponent(leaf, Story, routeOverrides, leaf.id);
+    injectStoryComponent(leaf, Story, routeOverrides, originalRouteId(tree, leaf) ?? leaf.id);
     const renderLeaf = ensureMatchableLeaf(tree, leaf);
     return { tree, leaf: renderLeaf };
   }
@@ -229,7 +230,7 @@ function resolveTree(Story: ComponentType, context: Parameters<Decorator>[1]): R
     syntheticRoot.addChildren([routerParameterRoute]);
     const tree = duplicateRouteTree(syntheticRoot, { overrides: routeOverrides });
     const leaf = tree.byId.get(routerParameterRoute.id) ?? tree.root;
-    injectStoryComponent(leaf, Story, routeOverrides, leaf.id);
+    injectStoryComponent(leaf, Story, routeOverrides, routerParameterRoute.id);
     const renderLeaf = ensureMatchableLeaf(tree, leaf);
     return { tree, leaf: renderLeaf };
   }
@@ -256,7 +257,12 @@ function resolveTree(Story: ComponentType, context: Parameters<Decorator>[1]): R
   } as any);
   syntheticRoot.addChildren([syntheticChild]);
 
-  injectStoryComponent(syntheticChild, Story, routeOverrides, syntheticChild.id);
+  injectStoryComponent(
+    syntheticChild,
+    Story,
+    routeOverrides,
+    syntheticRouteId ?? (plainRoutePath as string | undefined) ?? syntheticChild.id
+  );
   return {
     tree: { root: syntheticRoot, byId: new Map([[syntheticChild.id, syntheticChild]]) },
     leaf: syntheticChild,

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
@@ -1,11 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
 } from '@tanstack/react-router';
-import { fn } from 'storybook/test';
 
 import { createFileRoute } from '../export-mocks/react-router.ts';
 import { duplicateRouteTree } from './duplicate-tree.ts';
@@ -158,8 +157,8 @@ describe('duplicateRouteTree matrix (code-based and file-based trees)', () => {
   });
 
   it('applies routeOverrides to cloned pathless routes by original id', async () => {
-    const original = fn();
-    const override = fn();
+    const original = vi.fn();
+    const override = vi.fn();
     const { root } = buildAuthedTree({ beforeLoad: original });
 
     const { root: cloned } = duplicateRouteTree(root as any, {

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createLazyRoute,
   createMemoryHistory,
   createRootRoute,
   createRoute,
@@ -176,6 +177,26 @@ describe('duplicateRouteTree matrix (code-based and file-based trees)', () => {
     const { root: cloned } = duplicateRouteTree(root as any);
 
     expect((await matchedRouteIds(cloned, '/posts/7')).join(',')).toContain('$postId');
+  });
+
+  it('carries lazy route bindings onto clones', async () => {
+    // routeTree.gen chains `.lazy(() => import('./page.lazy'))` on eager
+    // routes; `.lazy()` stores the loader as an instance property (`lazyFn`),
+    // not an option, so an options-only clone silently drops the component.
+    const marker = () => null;
+    const root = createRootRoute();
+    const page = createRoute({ path: '/lazy', getParentRoute: () => root });
+    page.lazy(() => Promise.resolve(createLazyRoute('/lazy')({ component: marker })));
+    root.addChildren([page]);
+
+    const { root: cloned } = duplicateRouteTree(root as any);
+    const router = createRouter({
+      routeTree: cloned,
+      history: createMemoryHistory({ initialEntries: ['/lazy'] }),
+    });
+    await router.load();
+
+    expect((router.routesById['/lazy'] as any).options.component).toBe(marker);
   });
 
   it('applies routeOverrides to cloned pathless routes by original id', async () => {

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
@@ -96,6 +96,28 @@ describe('duplicateRouteTree with pathless layout routes', () => {
 
     expect((await matchedRouteIds(cloned, '/posts/settings')).join(',')).toContain('settings');
   });
+
+  it('preserves composed ids through cloning so strict from-lookups match', async () => {
+    // Real routeTree.gen output for `posts/_archive/archived.tsx`: the nested
+    // pathless layout keeps its id AND carries the pathful prefix as `path`.
+    // Strict hooks (`Route.useLoaderData()`) resolve matches by the original
+    // composed id, so clones must compose to identical ids.
+    const root = createRootRoute();
+    const layout = (
+      createFileRoute('/posts/_archive')({ getParentRoute: () => root }) as any
+    ).update({ id: '/posts/_archive', path: '/posts', getParentRoute: () => root } as any);
+    const archived = (
+      createFileRoute('/posts/_archive/archived')({ getParentRoute: () => layout }) as any
+    ).update({ id: '/archived', path: '/archived', getParentRoute: () => layout } as any);
+    layout.addChildren([archived]);
+    root.addChildren([layout]);
+
+    const { root: cloned } = duplicateRouteTree(root as any);
+    const ids = await matchedRouteIds(cloned, '/posts/archived');
+
+    expect(ids).toContain('/posts/_archive');
+    expect(ids).toContain('/posts/_archive/archived');
+  });
 });
 
 describe('duplicateRouteTree matrix (code-based and file-based trees)', () => {

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
@@ -3,6 +3,7 @@ import {
   createRoute,
   RootRoute,
   createRootRouteWithContext,
+  interpolatePath,
   joinPaths,
 } from '@tanstack/react-router';
 
@@ -190,25 +191,55 @@ export function originalRouteId(tree: DuplicatedTree, route: AnyRoute): string |
  *
  * Resolution order:
  *
- * 1. The route whose `fullPath` exactly matches the explicit `path` parameter.
+ * 1. The route whose mount path (from the cloned parent chain's options —
+ *    `fullPath` getters are undefined before `init()`) matches the explicit
+ *    `path` parameter, either literally or after interpolating `params`.
  * 2. The route bound to the story (`boundRouteId`), if it is present in the cloned tree.
  * 3. The first top-level child of the root.
  * 4. The root itself.
  */
 export function resolveStoryLeaf(
   tree: DuplicatedTree,
-  { path, boundRouteId }: { path?: string | undefined; boundRouteId?: string | undefined }
+  {
+    path,
+    boundRouteId,
+    params,
+  }: {
+    path?: string | undefined;
+    boundRouteId?: string | undefined;
+    params?: Record<string, unknown> | undefined;
+  }
 ): AnyRoute {
   const { root, byId } = tree;
 
   if (path) {
+    // The explicitly bound route wins whenever its own mount path matches the
+    // requested path — without this, a parent whose mount path ties with its
+    // bound index child would steal the leaf by scan order.
+    const bound = boundRouteId ? byId.get(boundRouteId) : undefined;
+    if (bound) {
+      const boundCandidate = mountPathFor(bound);
+      const boundInterpolated = params
+        ? interpolatePath({ path: boundCandidate, params }).interpolatedPath
+        : boundCandidate;
+      if (boundCandidate === path || boundInterpolated === path) {
+        return bound;
+      }
+    }
+
     let bestMatch: AnyRoute | undefined;
     let bestMatchLength = -1;
     for (const route of byId.values()) {
-      const fullPath = (route as any).fullPath as string | undefined;
-      if (fullPath && fullPath === path && fullPath.length > bestMatchLength) {
+      if (route === (root as unknown as AnyRoute)) {
+        continue;
+      }
+      const candidate = mountPathFor(route);
+      const interpolated = params
+        ? interpolatePath({ path: candidate, params }).interpolatedPath
+        : candidate;
+      if ((candidate === path || interpolated === path) && candidate.length > bestMatchLength) {
         bestMatch = route;
-        bestMatchLength = fullPath.length;
+        bestMatchLength = candidate.length;
       }
     }
     if (bestMatch) {

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
@@ -91,6 +91,16 @@ function cloneChild(
     getParentRoute: () => parent as any,
   } as any);
 
+  // A pathful route may still carry an explicit id (routeTree.gen gives a
+  // nested pathless layout `id: '/posts/_archive'` AND `path: '/posts'`).
+  // `createRoute` rejects id+path together, but `.update()` accepts it — the
+  // same mechanism routeTree.gen uses. Restoring the id keeps composed ids
+  // identical to the source tree, which strict hooks (`Route.useLoaderData()`)
+  // rely on to find their match.
+  if (merged.path && originalId != null && !('id' in override)) {
+    (cloned as any).update({ id: originalId });
+  }
+
   byId.set(oldRoute.id, cloned as unknown as AnyRoute);
 
   const children = (oldRoute as any).children as AnyRoute[] | undefined;

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
@@ -101,6 +101,14 @@ function cloneChild(
     (cloned as any).update({ id: originalId });
   }
 
+  // `.lazy()` bindings (routeTree.gen chains them for `*.lazy.tsx` files)
+  // live on the route instance as `lazyFn`, not in options, so carry them
+  // over explicitly or clones lose their lazily-loaded component.
+  const lazyFn = (oldRoute as any).lazyFn;
+  if (lazyFn) {
+    (cloned as any).lazy(lazyFn);
+  }
+
   byId.set(oldRoute.id, cloned as unknown as AnyRoute);
 
   const children = (oldRoute as any).children as AnyRoute[] | undefined;

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
@@ -172,6 +172,20 @@ export function mountPathFor(route: AnyRoute): string {
 }
 
 /**
+ * The original (pre-clone) id of a cloned route — the key users address it by
+ * in `routeOverrides`. The clone's own `id` getter is init-backed and
+ * undefined at resolution time.
+ */
+export function originalRouteId(tree: DuplicatedTree, route: AnyRoute): string | undefined {
+  for (const [id, cloned] of tree.byId) {
+    if (cloned === route) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Picks the route in the cloned tree that should host the `<Story />`.
  *
  * Resolution order:


### PR DESCRIPTION
Follow-up to #35465. Six commits, each green on its own.

## What I did

Fixes five bugs in how the framework picks, clones, and resolves the routes
and mocks behind a story. The first four share one root cause: route identity
is not always in `options`. The `id` and `fullPath` getters only work after
`init()`, and `.lazy()` stores its loader on the route instance. Code that
only reads options loses all of that.

1. `routeOverrides` component overrides were ignored. The guard looked up
   overrides with the cloned leaf's `id` getter, which is undefined before
   init, so the story component always replaced the override. It now uses the
   original route id, which is the key users write.
2. `parameters.tanstack.router.path` never selected the story leaf. The
   resolver compared `fullPath` getters (also undefined before init) and fell
   back to the bound route or the first child. It now compares mount paths
   built from route options, and interpolates `params`, so `path: '/users/42'`
   with `params: { userId: '42' }` selects `/users/$userId`.
3. Clones lost their explicit id when they also had a path. The generated
   route tree gives nested pathless layouts both (`id: '/posts/_archive'`,
   `path: '/posts'`). Without the id, every composed id below it changes, and
   strict hooks like `Route.useLoaderData()` throw "Could not find an active
   match". The clone now restores the id with `.update()`, the same way
   `routeTree.gen` sets id and path together.
4. Clones lost their `.lazy()` binding, so components from `*.lazy.tsx` files
   never rendered in stories. The binding lives on the route instance
   (`lazyFn`), not in options. It is now copied to the clone.
5. Spy assertions through `@storybook/tanstack-react/react-router` (the
   documented module for asserting on the mocks) never saw calls. The
   interception plugin returned raw file paths for mock redirects, while
   direct imports of the same module resolve through Vite with a version
   query. Same file, two module instances. The plugin now resolves through
   `this.resolve()`, so both import paths share one module.

The first commit applies the review note from #35465: unit tests use
`vi.fn()` instead of `fn` from `storybook/test`.

## AI disclosure

Root-cause analysis, fix, and tests developed with Claude (Claude Code);
reviewed and submitted by me.

#### Manual testing

- `cd code/frameworks/tanstack-react && yarn vitest run` (61 tests).
- End to end: 74 story scenarios against a real TanStack Router SPA and a
  TanStack Start app (file-based and code-based trees):
  https://github.com/unpunnyfuns/storybook-tanstack-conformance. All 74 pass
  with this branch applied. Bugs 3, 4, and 5 were found by that suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved story route selection for explicit paths, parameterized routes, and nested route trees.
  - Preserved route component overrides and lazy-loaded components when duplicating routes.
  - Improved route identity handling for more reliable navigation and lookups.
  - Ensured mocked server functions retain their handlers after mock resets.
  - Improved compatibility when resolving intercepted framework modules through the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->