### PR TITLE
TanStack: Carry lazy route bindings onto cloned routes

### DIFF
--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createLazyRoute,
   createMemoryHistory,
   createRootRoute,
   createRoute,
@@ -232,5 +233,39 @@ describe('duplicateRouteTree matrix (code-based and file-based trees)', () => {
 
     expect(override).toHaveBeenCalled();
     expect(original).not.toHaveBeenCalled();
+  });
+
+  it('carries lazy route bindings onto clones', async () => {
+    const marker = () => null;
+    const root = createRootRoute();
+    const page = createRoute({ path: '/lazy', getParentRoute: () => root });
+    page.lazy(() => Promise.resolve(createLazyRoute('/lazy')({ component: marker })));
+    root.addChildren([page]);
+
+    const { root: cloned } = duplicateRouteTree(root as any);
+    const router = createRouter({
+      routeTree: cloned,
+      history: createMemoryHistory({ initialEntries: ['/lazy'] }),
+    });
+    await router.load();
+
+    expect((router.routesById['/lazy'] as any).options.component).toBe(marker);
+  });
+
+  it('carries a lazy binding on the root route onto the clone', async () => {
+    const marker = () => null;
+    const root = createRootRoute();
+    (root as any).lazy(() => Promise.resolve(createLazyRoute('__root__')({ component: marker })));
+    const child = createRoute({ path: '/child', getParentRoute: () => root });
+    root.addChildren([child]);
+
+    const { root: cloned } = duplicateRouteTree(root as any);
+    const router = createRouter({
+      routeTree: cloned as any,
+      history: createMemoryHistory({ initialEntries: ['/child'] }),
+    });
+    await router.load();
+
+    expect((router.routesById['__root__'] as any).options.component).toBe(marker);
   });
 });

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.test.ts
@@ -249,7 +249,7 @@ describe('duplicateRouteTree matrix (code-based and file-based trees)', () => {
     });
     await router.load();
 
-    expect((router.routesById['/lazy'] as any).options.component).toBe(marker);
+    expect((router as any).routesById['/lazy'].options.component).toBe(marker);
   });
 
   it('carries a lazy binding on the root route onto the clone', async () => {
@@ -266,6 +266,6 @@ describe('duplicateRouteTree matrix (code-based and file-based trees)', () => {
     });
     await router.load();
 
-    expect((router.routesById['__root__'] as any).options.component).toBe(marker);
+    expect((router as any).routesById['__root__'].options.component).toBe(marker);
   });
 });

--- a/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
+++ b/code/frameworks/tanstack-react/src/routing/duplicate-tree.ts
@@ -96,6 +96,11 @@ function cloneChild(
     (cloned as any).update({ id: explicitId });
   }
 
+  const lazyFn = (oldRoute as any).lazyFn;
+  if (lazyFn) {
+    (cloned as any).lazy(lazyFn);
+  }
+
   byId.set(oldRoute.id, cloned as unknown as AnyRoute);
 
   const children = (oldRoute as any).children as AnyRoute[] | undefined;
@@ -150,6 +155,10 @@ export function duplicateRouteTree(
     ...restRoot,
     ...rootOverride,
   } as any);
+  const rootLazyFn = (rootRoute as any).lazyFn;
+  if (rootLazyFn) {
+    (newRoot as any).lazy(rootLazyFn);
+  }
   byId.set('__root__', newRoot as unknown as AnyRoute);
 
   const children = (rootRoute as any).children as AnyRoute[] | undefined;


### PR DESCRIPTION
Follows #35499

## What I did

Cloned routes lost their `.lazy()` binding, so components from `*.lazy.tsx` files never rendered in stories. 

`routeTree.gen` chains `.lazy(() => import('./page.lazy'))` on eager routes, and `.lazy()` stores the loader on the route instance (`lazyFn`), not in options,so an options-only clone drops it. The binding is now re-applied on the clone.

#### Manual testing

- `cd code/frameworks/tanstack-react && yarn vitest run` (55 tests).
- End to end: story-level conformance suite against a TanStack Router SPA
  and a TanStack Start app:
  https://github.com/unpunnyfuns/storybook-tanstack-conformance. The lazy
  file route scenario passes with this fix applied.

## AI disclosure

Root-cause analysis, fix, and tests developed with Claude (Claude Code), reviewed and submitted by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Route tree duplication now preserves lazily loaded component bindings on cloned routes, including both nested routes and the root route.
* **Tests**
  * Added async test coverage to verify that lazy bindings remain intact after duplicating the route tree and loading the duplicated router.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
