### PR TITLE
Core: Guard focus prototype reads

### DIFF
--- a/code/core/src/test/preview.test.ts
+++ b/code/core/src/test/preview.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import testPreview from './preview.ts';
+
+describe('focus instrumentation', () => {
+  const NativeHTMLElement = HTMLElement;
+  class TestHTMLElement extends NativeHTMLElement {}
+
+  beforeAll(async () => {
+    customElements.define('test-focus-element', TestHTMLElement);
+    const windowWithClipboard = Object.create(window);
+    Object.defineProperty(windowWithClipboard, 'navigator', {
+      value: { clipboard: {} },
+    });
+    vi.stubGlobal('window', windowWithClipboard);
+    vi.stubGlobal('HTMLElement', TestHTMLElement);
+
+    const loaders = testPreview().loaders;
+    const enhanceContext = Array.isArray(loaders) ? loaders.at(-1) : loaders;
+    await enhanceContext?.({
+      canvasElement: document.body,
+      initialArgs: {},
+      parameters: {},
+    } as never);
+
+    expect(Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'focus')?.get).toBeTypeOf(
+      'function'
+    );
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('allows tooling to read focus from HTMLElement.prototype', () => {
+    Object.defineProperty(HTMLElement.prototype, 'ownerDocument', {
+      configurable: true,
+      get: () => {
+        throw new TypeError('Illegal invocation');
+      },
+    });
+
+    try {
+      expect(() => HTMLElement.prototype.focus).not.toThrow();
+    } finally {
+      Reflect.deleteProperty(HTMLElement.prototype, 'ownerDocument');
+    }
+  });
+
+  it('uses an assigned focus method for element instances', () => {
+    const assignedFocus = vi.fn(function (this: HTMLElement) {});
+    HTMLElement.prototype.focus = assignedFocus;
+
+    const element = document.createElement('test-focus-element');
+    element.focus();
+
+    expect(assignedFocus).toHaveBeenCalledOnce();
+    expect(assignedFocus.mock.instances[0]).toBe(element);
+  });
+});

--- a/code/core/src/test/preview.ts
+++ b/code/core/src/test/preview.ts
@@ -128,6 +128,11 @@ const enhanceContext: LoaderFunction = async (context) => {
               currentFocus = newFocus;
             },
             get() {
+              // Focus managers may read and wrap the method directly from the prototype.
+              if (this === HTMLElement.prototype) {
+                return currentFocus;
+              }
+
               // A node inside a removed iframe has no live browsing context as `ownerDocument.defaultView`
               // is null. The instrumented focus dispatches events through user-event, whose getWindow()
               // then throws "Could not determine window of node"; thrown in React's commit phase that


### PR DESCRIPTION
Closes #35502

## What I did

- Return the currently assigned focus method when the instrumentation getter is read directly from `HTMLElement.prototype`.
- Add regression coverage proving that prototype inspection does not throw while assigned focus methods still work on element instances.

This prevents the getter from evaluating `ownerDocument` with the prototype as its receiver without weakening normal focus instrumentation or its reentry protection.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No separate UI QA should be necessary because the focused test directly installs and exercises the production accessor.

After the normal repository compile, run:

1. `yarn test code/core/src/test/preview.test.ts`
2. Confirm both tests pass: prototype access does not throw, and an assigned focus method is called with the element instance.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, update `MIGRATION.md`

Documentation is not affected by this compatibility fix.

## Checklist for Maintainers

- [ ] Add the appropriate CI testing label.
- [ ] Declare whether manual QA is needed.
- [ ] Add the `bug` label.

## AI assistance

Codex was used to help prepare this change. I reviewed the implementation and validation results and am responsible for the pull request.