### PR TITLE
CI: Run the tail-defining Playwright dev jobs on xlarge with more workers

### DIFF
--- a/scripts/ci/sandboxes.ts
+++ b/scripts/ci/sandboxes.ts
@@ -37,9 +37,9 @@ function getSandboxSetupSteps(template: string) {
 /**
  * The dev-mode e2e jobs are the workflow tail. xlarge (8 vCPUs) with 6
  * Playwright workers cuts their test phase ~38% vs large/3, but doubles the
- * per-minute cost - so only the templates whose dev chains define the wall
- * (the slowest measured on #35510) get the big class; the rest stay on
- * large/3, where the extra speed would not move the workflow wall at all.
+ * per-minute cost - so only the templates whose dev chains define the
+ * workflow wall (the slowest dev test phases) get the big class; the rest
+ * stay on large/3, where the extra speed would not move the wall at all.
  */
 const XLARGE_DEV_TEMPLATES = new Set<string>([
   'angular-cli/default-ts',
@@ -64,16 +64,16 @@ function defineSandboxJob_dev({
   template: string;
   options: {
     e2e: boolean;
+    resourceClass: 'large' | 'xlarge';
   };
 }) {
-  const xlarge = XLARGE_DEV_TEMPLATES.has(template);
   return defineJob(
     name,
     () => ({
       executor: options.e2e
         ? {
             name: 'sb_playwright',
-            class: xlarge ? 'xlarge' : 'large',
+            class: options.resourceClass,
           }
         : {
             name: 'sb_node_22_classic',
@@ -97,7 +97,7 @@ function defineSandboxJob_dev({
                 run: {
                   name: 'Running E2E Tests',
                   environment: {
-                    PLAYWRIGHT_WORKERS: xlarge ? '6' : '3',
+                    PLAYWRIGHT_WORKERS: options.resourceClass === 'xlarge' ? '6' : '3',
                   },
                   command: [
                     'TEST_FILES=$(circleci tests glob "code/e2e-sandbox/*.{test,spec}.{ts,js,mjs}")',
@@ -225,7 +225,10 @@ export function defineSandboxFlow<Key extends string>(key: Key) {
     template: key,
     directory: id,
     requires: [createJob],
-    options: { e2e: !skipTasks?.includes('e2e-tests-dev') },
+    options: {
+      e2e: !skipTasks?.includes('e2e-tests-dev'),
+      resourceClass: XLARGE_DEV_TEMPLATES.has(key) ? 'xlarge' : 'large',
+    },
   });
   const chromaticJob = defineJob(
     `${name} (chromatic)`,

--- a/scripts/ci/sandboxes.ts
+++ b/scripts/ci/sandboxes.ts
@@ -52,12 +52,15 @@ function defineSandboxJob_dev({
   return defineJob(
     name,
     () => ({
-      // large so the dev server and the parallel Playwright workers don't
-      // starve each other; the shorter runtime more than pays for the class.
+      // xlarge (8 vCPUs) so the dev server and the parallel Playwright workers
+      // don't starve each other: ~2 cores serve the dev server, 6 run test
+      // workers - the same headroom ratio that made large/3 the sweet spot.
+      // These jobs are the workflow tail, so the shorter runtime buys wall
+      // clock directly.
       executor: options.e2e
         ? {
             name: 'sb_playwright',
-            class: 'large',
+            class: 'xlarge',
           }
         : {
             name: 'sb_node_22_classic',
@@ -81,7 +84,7 @@ function defineSandboxJob_dev({
                 run: {
                   name: 'Running E2E Tests',
                   environment: {
-                    PLAYWRIGHT_WORKERS: '3',
+                    PLAYWRIGHT_WORKERS: '6',
                   },
                   command: [
                     'TEST_FILES=$(circleci tests glob "code/e2e-sandbox/*.{test,spec}.{ts,js,mjs}")',

--- a/scripts/ci/sandboxes.ts
+++ b/scripts/ci/sandboxes.ts
@@ -34,6 +34,23 @@ function getSandboxSetupSteps(template: string) {
   return extraSteps;
 }
 
+/**
+ * The dev-mode e2e jobs are the workflow tail. xlarge (8 vCPUs) with 6
+ * Playwright workers cuts their test phase ~38% vs large/3, but doubles the
+ * per-minute cost - so only the templates whose dev chains define the wall
+ * (the slowest measured on #35510) get the big class; the rest stay on
+ * large/3, where the extra speed would not move the workflow wall at all.
+ */
+const XLARGE_DEV_TEMPLATES = new Set<string>([
+  'angular-cli/default-ts',
+  'angular-vite/default-ts',
+  'nextjs/default-ts',
+  'nextjs-vite/default-ts',
+  'react-vite/default-ts',
+  'react-webpack/18-ts',
+  'vue3-vite/default-ts',
+]);
+
 function defineSandboxJob_dev({
   directory,
   name,
@@ -49,18 +66,14 @@ function defineSandboxJob_dev({
     e2e: boolean;
   };
 }) {
+  const xlarge = XLARGE_DEV_TEMPLATES.has(template);
   return defineJob(
     name,
     () => ({
-      // xlarge (8 vCPUs) so the dev server and the parallel Playwright workers
-      // don't starve each other: ~2 cores serve the dev server, 6 run test
-      // workers - the same headroom ratio that made large/3 the sweet spot.
-      // These jobs are the workflow tail, so the shorter runtime buys wall
-      // clock directly.
       executor: options.e2e
         ? {
             name: 'sb_playwright',
-            class: 'xlarge',
+            class: xlarge ? 'xlarge' : 'large',
           }
         : {
             name: 'sb_node_22_classic',
@@ -84,7 +97,7 @@ function defineSandboxJob_dev({
                 run: {
                   name: 'Running E2E Tests',
                   environment: {
-                    PLAYWRIGHT_WORKERS: '6',
+                    PLAYWRIGHT_WORKERS: xlarge ? '6' : '3',
                   },
                   command: [
                     'TEST_FILES=$(circleci tests glob "code/e2e-sandbox/*.{test,spec}.{ts,js,mjs}")',


### PR DESCRIPTION
Final PR of the CI-timing stack: sits on #35480 → #35486 → #35352. After those three, the merged workflow tail is a tight cluster of dev-mode e2e jobs - a dev server and Playwright sharing a `large` (4 vCPU) executor with 3 workers. This PR gives the **tail-defining** dev jobs twice the hardware.

## What

The dev jobs of the seven templates whose chains define the wall move to **`xlarge` / `PLAYWRIGHT_WORKERS=6`** (8 vCPUs: ~2 for the dev server, 6 for test workers - the headroom ratio that made large/3 the sweet spot in #35347):

`angular-cli/default-ts`, `angular-vite/default-ts`, `nextjs/default-ts`, `nextjs-vite/default-ts`, `react-vite/default-ts`, `react-webpack/18-ts`, `vue3-vite/default-ts`

`react-webpack/18-ts` goes beyond the obvious tail set deliberately: in the full-fleet baseline it was the second-latest finisher (334s duration), so leaving it on large would have simply made it the new wall.

Everything else stays put (verified in the generated configs - exactly 7 dev jobs in merged and 7 in daily change): the other e2e-mode dev jobs keep large/3 (extra speed there cannot move the wall), smoke-only dev jobs keep medium classic, serve-based e2e jobs keep medium+/3.

## Experiment 1: full fleet (commit 243c6afb575, superseded)

All 17 e2e-dev jobs on xlarge/6. Matched A/B, back-to-back on the same fleet, 2s queues both sides: baseline [`7ed67b80`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127481/workflows/7ed67b80-04e9-46b7-8d6e-edd4c68d80da) vs treatment [`277ac606`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127482/workflows/277ac606-0a44-4bf5-bd58-a4d3c848407c):

- Test phases 3,129s → 1,937s (-38%), dev durations -27%, boots and serve-e2e controls flat, zero flakes.
- Wall 778s → 678s; after subtracting a 44s `build--linux` variance in the treatment's favor, the genuine effect is **~-55s**.
- Cost: e2e-dev family 1,565 → 2,273 credits, **+708 credits (+45%) per merged run** ≈ +750k credits/30d fleet-wide (~$5,500/yr) - more than the rest of the stack saves. That killed the full-fleet variant.
- (A first comparison run, [`edc57fab`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127480/workflows/edc57fab-350e-4479-96f4-ae73034cb46c) at 837s, was discarded: it overlapped a merged run on `next` and hit 28-110s org-concurrency queues - single-run walls are meaningless under contention.)

## Experiment 2: targeted variant (current HEAD, measured)

Matched A/B: baseline [`0e1a6863`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127492/workflows/0e1a6863-7979-4da0-b15b-4fd1a68ab022) vs this PR [`4a506a7f`](https://app.circleci.com/pipelines/gh/storybookjs/storybook/127486/workflows/4a506a7f-807d-4a74-89ba-3b5db9d84ee2). Both fully green. `build--linux` was dead even (213s/211s); this time the **baseline** was queue-handicapped (30s avg sampled queues vs 2s), so the raw wall delta overstates slightly.

| Metric | #35480 baseline | This PR |
| --- | --- | --- |
| upgraded-7 dev durations summed | 2,117s | 1,498s (-29%) |
| non-upgraded-10 dev durations (control) | 2,681s | 2,641s (flat) |
| dev boots summed (control) | 328s | 328s |
| latest dev job ends | 809s | 698s |
| **Workflow wall** | **817s** | **703s** (raw -114s; ~-75-85s after the baseline's queue handicap) |

- The seven upgraded chains (ends 732-809s in the baseline) all dropped below the non-upgraded pack; the wall is now defined by the large/3 pack at ~680-700s - exactly the design intent, and the sign that this set captures all the wall there is to buy.
- Cost with the correct split rates: e2e-dev family 1,599 → 1,879 credits, **+280 credits per merged run** ≈ +300k credits/30d fleet-wide (~$2,200/yr).

## Verdict

The targeted variant keeps ~90% of the achievable wall win at ~40% of the cost. Combined with the rest of the stack (≈ -370k credits/30d), the whole stack stays credits-negative (≈ -70k/30d) while the `ci:merged` wall goes from 820s (`next`, quiet fleet) to the ~660-700s band.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [x] integration tests
- [x] end-to-end tests

#### Manual testing

1. ~The seven listed templates' `(dev)` jobs must report the xlarge resource class and 6 Playwright workers; all other dev jobs stay large/3.~ Done: verified in the generated configs and via the job API on the measurement runs.
2. ~Compare dev-job durations and the workflow wall against a matched #35480 baseline; verify controls (non-upgraded devs, boots, serve-e2e) unchanged.~ Done: tables above.
3. ~Watch for resource-related flakiness (more parallel browsers against one dev server).~ Done: three xlarge runs total, zero non-success dev jobs.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved development end-to-end test execution for select templates by allocating additional resources.
  * Increased parallel test capacity for eligible configurations, helping tests complete more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->