### PR TITLE
Docs: Update network mocking guide to msw-storybook-addon v3

### DIFF
--- a/docs/_snippets/msw-addon-configure-handlers-graphql.md
+++ b/docs/_snippets/msw-addon-configure-handlers-graphql.md
@@ -51,39 +51,35 @@ const TestData = {
 type Story = StoryObj<DocumentScreen>;
 
 export const MockedSuccess: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 };
 
 export const MockedError: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 };
 ```
@@ -139,39 +135,35 @@ const TestData = {
 };
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 });
 ```
@@ -274,39 +266,35 @@ export default {
 };
 
 export const MockedSuccess = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 };
 
 export const MockedError = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 };
 ```
@@ -375,39 +363,35 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const MockedSuccess: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 };
 
 export const MockedError: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 };
 ```
@@ -454,40 +438,36 @@ export const MockedError: Story = {
 
 <Story
   name="MockedSuccess"
-  parameters={{
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              AllInfoQuery: {
-                ...TestData,
-              },
+  beforeEach={({ msw }) => {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            AllInfoQuery: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   }}
 />
 
 <Story
   name="MockedError"
-  parameters={{
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  beforeEach={({ msw }) => {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   }}
 />
 ```
@@ -529,39 +509,35 @@ const TestData = {
 };
 
 export const MockedSuccess = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 };
 
 export const MockedError = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 };
 ```
@@ -632,40 +608,36 @@ export const MockedError = {
 
 <Story
   name="MockedSuccess"
-  parameters={{
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              AllInfoQuery: {
-                ...TestData,
-              },
+  beforeEach={({ msw }) => {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            AllInfoQuery: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   }}
 />
 
 <Story
   name="MockedError"
-  parameters={{
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  beforeEach={({ msw }) => {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   }}
 />
 ```
@@ -713,39 +685,35 @@ const TestData = {
 };
 
 export const MockedSuccess: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 };
 
 export const MockedError: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 };
 ```
@@ -818,39 +786,35 @@ const TestData = {
 };
 
 export const MockedSuccess = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 };
 
 export const MockedError = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 };
 ```
@@ -940,39 +904,35 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const MockedSuccess: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 };
 
 export const MockedError: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 };
 ```
@@ -1077,39 +1037,35 @@ const meta = preview.meta({
 });
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 });
 ```
@@ -1177,39 +1133,35 @@ const meta = preview.meta({
 });
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 });
 ```
@@ -1256,39 +1208,35 @@ const meta = preview.meta({
 });
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 });
 ```
@@ -1337,39 +1285,35 @@ const meta = preview.meta({
 });
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', () => {
-          return HttpResponse.json({
-            data: {
-              allInfo: {
-                ...TestData,
-              },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', () => {
+        return HttpResponse.json({
+          data: {
+            allInfo: {
+              ...TestData,
             },
-          });
-        }),
-      ],
-    },
+          },
+        });
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query('AllInfoQuery', async () => {
-          await delay(800);
-          return HttpResponse.json({
-            errors: [
-              {
-                message: 'Access denied',
-              },
-            ],
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      graphql.query('AllInfoQuery', async () => {
+        await delay(800);
+        return HttpResponse.json({
+          errors: [
+            {
+              message: 'Access denied',
+            },
+          ],
+        });
+      }),
+    );
   },
 });
 ```

--- a/docs/_snippets/msw-addon-configure-handlers-http.md
+++ b/docs/_snippets/msw-addon-configure-handlers-http.md
@@ -38,29 +38,25 @@ const TestData = {
 };
 
 export const MockedSuccess: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 };
 
 export const MockedError: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 };
 ```
@@ -102,29 +98,25 @@ const TestData = {
 };
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 });
 ```
@@ -169,30 +161,26 @@ export const MockedError = meta.story({
 
 <Story
   name="MockedSuccess"
-  parameters={{
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  beforeEach={({ msw }) => {
+    msw.use(
+      http.get('https://your-restful-endpoint', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   }}
 />
 
 <Story
   name="MockedError"
-  parameters={{
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  beforeEach={({ msw }) => {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   }}
 />
 ```
@@ -232,29 +220,25 @@ const TestData = {
 };
 
 export const MockedSuccess = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 };
 
 export const MockedError = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 };
 ```
@@ -294,29 +278,25 @@ const TestData = {
 };
 
 export const MockedSuccess = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 };
 
 export const MockedError = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 };
 ```
@@ -361,30 +341,26 @@ export const MockedError = {
 
 <Story
   name="MockedSuccess"
-  parameters={{
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  beforeEach={({ msw }) => {
+    msw.use(
+      http.get('https://your-restful-endpoint', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   }}
 />
 
 <Story
   name="MockedError"
-  parameters={{
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  beforeEach={({ msw }) => {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   }}
 />
 ```
@@ -430,29 +406,25 @@ const TestData = {
 };
 
 export const MockedSuccess: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 };
 
 export const MockedError: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 };
 ```
@@ -498,29 +470,25 @@ const TestData = {
 };
 
 export const MockedSuccess: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 };
 
 export const MockedError: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 };
 ```
@@ -558,29 +526,25 @@ const TestData = {
 };
 
 export const MockedSuccess = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 };
 
 export const MockedError = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 };
 ```
@@ -623,29 +587,25 @@ const TestData = {
 };
 
 export const MockedSuccess: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 };
 
 export const MockedError: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 };
 ```
@@ -685,29 +645,25 @@ const TestData = {
 };
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 });
 ```
@@ -747,29 +703,25 @@ const TestData = {
 };
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 });
 ```
@@ -811,29 +763,25 @@ const TestData = {
 };
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 });
 ```
@@ -877,29 +825,25 @@ const meta = preview.meta({
 });
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 });
 ```
@@ -941,29 +885,25 @@ const meta = preview.meta({
 });
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 });
 ```
@@ -1005,29 +945,25 @@ const TestData = {
 };
 
 export const MockedSuccess = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint/', () => {
-          return HttpResponse.json(TestData);
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint/', () => {
+        return HttpResponse.json(TestData);
+      }),
+    );
   },
 });
 
 export const MockedError = meta.story({
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('https://your-restful-endpoint', async () => {
-          await delay(800);
-          return new HttpResponse(null, {
-            status: 403,
-          });
-        }),
-      ],
-    },
+  async beforeEach({ msw }) {
+    msw.use(
+      http.get('https://your-restful-endpoint', async () => {
+        await delay(800);
+        return new HttpResponse(null, {
+          status: 403,
+        });
+      }),
+    );
   },
 });
 ```

--- a/docs/_snippets/msw-addon-initialize.md
+++ b/docs/_snippets/msw-addon-initialize.md
@@ -1,15 +1,13 @@
 ```js filename=".storybook/preview.js|jsx" renderer="common" language="js" tabTitle="CSF 3"
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import { mswLoader } from 'msw-storybook-addon/csf3';
 
 /*
- * Initializes MSW
- * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * The loader starts MSW for you.
+ * See https://github.com/mswjs/msw-storybook-addon#custom-worker-setup
  * to learn how to customize it
  */
-initialize();
-
 export default {
-  loaders: [mswLoader], // 👈 Add the MSW loader to all stories
+  loaders: [mswLoader()], // 👈 Add the MSW loader to all stories
 };
 ```
 
@@ -17,17 +15,15 @@ export default {
 // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
 import type { Preview } from '@storybook/your-framework';
 
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import { mswLoader } from 'msw-storybook-addon/csf3';
 
 /*
- * Initializes MSW
- * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * The loader starts MSW for you.
+ * See https://github.com/mswjs/msw-storybook-addon#custom-worker-setup
  * to learn how to customize it
  */
-initialize();
-
 const preview: Preview = {
-  loaders: [mswLoader], // 👈 Add the MSW loader to all stories
+  loaders: [mswLoader()], // 👈 Add the MSW loader to all stories
 };
 
 export default preview;
@@ -37,17 +33,15 @@ export default preview;
 // Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
 import { definePreview } from '@storybook/your-framework';
 
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import addonMsw from 'msw-storybook-addon';
 
 /*
- * Initializes MSW
- * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * The addon starts MSW for you.
+ * See https://github.com/mswjs/msw-storybook-addon#custom-worker-setup
  * to learn how to customize it
  */
-initialize();
-
 export default definePreview({
-  loaders: [mswLoader], // 👈 Add the MSW loader to all stories
+  addons: [addonMsw()], // 👈 Add the MSW addon to all stories
 });
 ```
 
@@ -57,85 +51,75 @@ export default definePreview({
 // Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
 import { definePreview } from '@storybook/your-framework';
 
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import addonMsw from 'msw-storybook-addon';
 
 /*
- * Initializes MSW
- * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * The addon starts MSW for you.
+ * See https://github.com/mswjs/msw-storybook-addon#custom-worker-setup
  * to learn how to customize it
  */
-initialize();
-
 export default definePreview({
-  loaders: [mswLoader], // 👈 Add the MSW loader to all stories
+  addons: [addonMsw()], // 👈 Add the MSW addon to all stories
 });
 ```
 
 ```ts filename=".storybook/preview.ts" renderer="vue" language="ts" tabTitle="CSF Next 🧪"
 import { definePreview } from '@storybook/vue3-vite';
 
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import addonMsw from 'msw-storybook-addon';
 
 /*
- * Initializes MSW
- * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * The addon starts MSW for you.
+ * See https://github.com/mswjs/msw-storybook-addon#custom-worker-setup
  * to learn how to customize it
  */
-initialize();
-
 export default definePreview({
-  loaders: [mswLoader], // 👈 Add the MSW loader to all stories
+  addons: [addonMsw()], // 👈 Add the MSW addon to all stories
 });
 ```
 
 ```js filename=".storybook/preview.js" renderer="vue" language="js" tabTitle="CSF Next 🧪"
 import { definePreview } from '@storybook/vue3-vite';
 
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import addonMsw from 'msw-storybook-addon';
 
 /*
- * Initializes MSW
- * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * The addon starts MSW for you.
+ * See https://github.com/mswjs/msw-storybook-addon#custom-worker-setup
  * to learn how to customize it
  */
-initialize();
-
 export default definePreview({
-  loaders: [mswLoader], // 👈 Add the MSW loader to all stories
+  addons: [addonMsw()], // 👈 Add the MSW addon to all stories
 });
 ```
 
 ```ts filename=".storybook/preview.ts" renderer="angular" language="ts" tabTitle="CSF Next 🧪"
 import { definePreview } from '@storybook/angular';
 
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import addonMsw from 'msw-storybook-addon';
 
 /*
- * Initializes MSW
- * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * The addon starts MSW for you.
+ * See https://github.com/mswjs/msw-storybook-addon#custom-worker-setup
  * to learn how to customize it
  */
-initialize();
-
 export default definePreview({
-  loaders: [mswLoader], // 👈 Add the MSW loader to all stories
+  addons: [addonMsw()], // 👈 Add the MSW addon to all stories
 });
 ```
 
 ```ts filename=".storybook/preview.ts" renderer="web-components" language="ts" tabTitle="CSF Next 🧪"
 import { definePreview } from '@storybook/web-components-vite';
 
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import addonMsw from 'msw-storybook-addon';
 
 /*
- * Initializes MSW
- * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * The addon starts MSW for you.
+ * See https://github.com/mswjs/msw-storybook-addon#custom-worker-setup
  * to learn how to customize it
  */
-initialize();
-
 export default definePreview({
-  loaders: [mswLoader], // 👈 Add the MSW loader to all stories
+  addons: [addonMsw()], // 👈 Add the MSW addon to all stories
 });
 ```
 
@@ -144,16 +128,14 @@ export default definePreview({
 ```js filename=".storybook/preview.js" renderer="web-components" language="js" tabTitle="CSF Next 🧪"
 import { definePreview } from '@storybook/web-components-vite';
 
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import addonMsw from 'msw-storybook-addon';
 
 /*
- * Initializes MSW
- * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * The addon starts MSW for you.
+ * See https://github.com/mswjs/msw-storybook-addon#custom-worker-setup
  * to learn how to customize it
  */
-initialize();
-
 export default definePreview({
-  loaders: [mswLoader], // 👈 Add the MSW loader to all stories
+  addons: [addonMsw()], // 👈 Add the MSW addon to all stories
 });
 ```

--- a/docs/_snippets/msw-addon-install.md
+++ b/docs/_snippets/msw-addon-install.md
@@ -1,11 +1,14 @@
 ```sh renderer="common" packageManager="npm"
-npm install msw msw-storybook-addon --save-dev
+npm install msw --save-dev
+npx storybook add msw-storybook-addon
 ```
 
 ```sh renderer="common" packageManager="pnpm"
-pnpm add msw msw-storybook-addon --save-dev
+pnpm add msw --save-dev
+pnpm exec storybook add msw-storybook-addon
 ```
 
 ```sh renderer="common" packageManager="yarn"
-yarn add msw msw-storybook-addon --save-dev
+yarn add msw --save-dev
+yarn exec storybook add msw-storybook-addon
 ```

--- a/docs/writing-stories/mocking-data-and-modules/mocking-network-requests.mdx
+++ b/docs/writing-stories/mocking-data-and-modules/mocking-network-requests.mdx
@@ -11,7 +11,7 @@ The [MSW addon](https://storybook.js.org/addons/msw-storybook-addon/) brings thi
 
 ## Set up the MSW addon
 
-First, if necessary, run this command to install MSW and the MSW addon:
+First, if necessary, run these commands to install MSW and register the MSW addon:
 
 <CodeSnippets path="msw-addon-install.md" />
 
@@ -33,7 +33,7 @@ Then ensure the [`staticDirs`](../../api/main-config/main-config-static-dirs.mdx
 
 <CodeSnippets path="main-config-static-dirs.md" />
 
-Finally, initialize the addon and apply it to all stories with a [project-level loader](../loaders.mdx#global-loaders):
+Finally, apply the addon to all stories. In CSF 3, that is done with a [project-level loader](../loaders.mdx#global-loaders); with CSF Next, by registering the addon in your preview file:
 
 <CodeSnippets path="msw-addon-initialize.md" />
 
@@ -85,4 +85,4 @@ The MSW addon allows you to write stories that use MSW to mock the GraphQL reque
 
 ## Configuring MSW for stories
 
-In the examples above, note how each story is configured with `parameters.msw` to define the request handlers for the mock server. Because it uses parameters in this way, it can also be configured at the [component](../parameters.mdx#component-parameters) or even [project](../parameters.mdx#global-parameters) level, allowing you to share the same mock server configuration across multiple stories.
+In the examples above, note how each story defines its request handlers in a [`beforeEach` hook](../../writing-tests/interaction-testing.mdx#run-code-before-the-component-gets-rendered), using the `msw` object available on the story context. Because it uses a hook in this way, it can also be configured at the [component](../../writing-tests/interaction-testing.mdx#run-code-before-each-story-in-a-file) or even [project](../../writing-tests/interaction-testing.mdx#set-up-or-reset-state-for-all-tests) level, allowing you to share the same mock server configuration across multiple stories. Handlers added with `msw.use()` are reset between stories automatically.


### PR DESCRIPTION
## What I did

The [network mocking guide](https://storybook.js.org/docs/writing-stories/mocking-data-and-modules/mocking-network-requests) teaches the msw-storybook-addon v2 API. Under the upcoming v3 ([mswjs/msw-storybook-addon#193](https://github.com/mswjs/msw-storybook-addon/pull/193)), the preview snippet crashes at module load: `initialize` no longer exists and `mswLoader` moved to the `msw-storybook-addon/csf3` subpath.

- **`msw-addon-install.md`**: the addon is registered with `storybook add` (so it also lands in the main config); `msw` itself stays a package-manager install.
- **`msw-addon-initialize.md`**: no more `initialize()` — CSF 3 tabs use `loaders: [mswLoader()]` imported from `/csf3`, CSF Next tabs register `addons: [addonMsw()]` in `definePreview`. The customization comment now points at the addon's custom-worker-setup docs.
- **`msw-addon-configure-handlers-http.md` / `-graphql.md`**: all 60 stories across the renderer/language/CSF tabs define handlers in `async beforeEach({ msw })` + `msw.use(...)` instead of the deprecated `parameters.msw` (Svelte CSF uses the `beforeEach` prop). Handler expressions and test data are unchanged — the diff is purely the wiring.
- **`mocking-network-requests.mdx`**: setup prose follows the new flow, and the "Configuring MSW for stories" section explains the hook-based configuration (story/component/project levels, automatic handler reset), linking the existing `beforeEach` docs in the interaction testing guide.

Sibling PR updating the AI setup instructions: #35512.

## ⚠️ Merge coupling

Draft until `msw-storybook-addon@3` is published — these snippets describe the v3 API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)