### PR TITLE
Angular: Preserve Signal Queries When Applying Story Props

### DIFF
--- a/code/frameworks/angular-vite/src/client/renderer/StorybookModule.test.ts
+++ b/code/frameworks/angular-vite/src/client/renderer/StorybookModule.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import type { NgModule } from '@angular/core';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, signal } from '@angular/core';
 import { describe, expect, it } from 'vitest';
 
 import { TestBed } from '@angular/core/testing';
@@ -330,6 +330,57 @@ describe('StorybookModule', () => {
         fixture.detectChanges();
 
         expect(fixture.nativeElement.innerHTML).toContain('The content');
+      });
+    });
+
+    describe('with signal properties', () => {
+      @Component({
+        selector: 'signal-property',
+        template: `
+          <p id="optionCount">{{ options().length }}</p>
+          <p id="label">{{ label }}</p>
+        `,
+      })
+      class SignalPropertyComponent {
+        public options = signal(['preserved']).asReadonly();
+
+        public label = '';
+      }
+
+      it('should preserve signals while updating ordinary props', async () => {
+        const initialProps = {
+          options: [],
+          label: 'initial label',
+        };
+        const storyProps$ = new BehaviorSubject<ICollection>(initialProps);
+
+        const analyzedMetadata = new PropertyExtractor({}, SignalPropertyComponent);
+        await analyzedMetadata.init();
+
+        const application = getApplication({
+          storyFnAngular: {
+            props: initialProps,
+            template: '<signal-property></signal-property>',
+          },
+          component: SignalPropertyComponent,
+          targetSelector: 'my-selector',
+          analyzedMetadata,
+        });
+
+        const { fixture } = await configureTestingModule({
+          imports: [application],
+          providers: [storyPropsProvider(storyProps$)],
+        });
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('p#optionCount').innerHTML).toEqual('1');
+        expect(fixture.nativeElement.querySelector('p#label').innerHTML).toEqual('initial label');
+
+        storyProps$.next({ options: [], label: 'updated label' });
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('p#optionCount').innerHTML).toEqual('1');
+        expect(fixture.nativeElement.querySelector('p#label').innerHTML).toEqual('updated label');
       });
     });
 

--- a/code/frameworks/angular-vite/src/client/renderer/StorybookWrapperComponent.ts
+++ b/code/frameworks/angular-vite/src/client/renderer/StorybookWrapperComponent.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   Inject,
+  isSignal,
   NgModule,
   ViewChild,
   ViewContainerRef,
@@ -18,7 +19,8 @@ import { PropertyExtractor } from './utils/PropertyExtractor.ts';
 
 const getNonInputsOutputsProps = (
   ngComponentInputsOutputs: ComponentInputsOutputs,
-  props: ICollection = {}
+  props: ICollection = {},
+  target?: object
 ) => {
   const inputs = ngComponentInputsOutputs.inputs
     .filter((i) => i.templateName in props)
@@ -26,7 +28,11 @@ const getNonInputsOutputsProps = (
   const outputs = ngComponentInputsOutputs.outputs
     .filter((o) => o.templateName in props)
     .map((o) => o.templateName);
-  return Object.keys(props).filter((k) => ![...inputs, ...outputs].includes(k));
+  return Object.keys(props).filter(
+    (k) =>
+      ![...inputs, ...outputs].includes(k) &&
+      !isSignal(target === undefined ? undefined : Reflect.get(target, k))
+  );
 };
 
 /** Wraps the story template into a component */
@@ -105,7 +111,11 @@ export const createStorybookWrapperComponent = ({
       if (this.storyComponentElementRef) {
         const ngComponentInputsOutputs = getComponentInputsOutputs(storyComponent);
 
-        const initialOtherProps = getNonInputsOutputsProps(ngComponentInputsOutputs, initialProps);
+        const initialOtherProps = getNonInputsOutputsProps(
+          ngComponentInputsOutputs,
+          initialProps,
+          this.storyComponentElementRef
+        );
 
         // Initializes properties that are not Inputs | Outputs
         // Allows story props to override local component properties
@@ -122,7 +132,11 @@ export const createStorybookWrapperComponent = ({
           .pipe(
             skip(1),
             map((props) => {
-              const propsKeyToKeep = getNonInputsOutputsProps(ngComponentInputsOutputs, props);
+              const propsKeyToKeep = getNonInputsOutputsProps(
+                ngComponentInputsOutputs,
+                props,
+                this.storyComponentElementRef
+              );
               return propsKeyToKeep.reduce((acc, p) => ({ ...acc, [p]: props[p] }), {});
             })
           )

--- a/code/frameworks/angular-vite/template/stories/basics/signal-content-children/signal-content-children.stories.ts
+++ b/code/frameworks/angular-vite/template/stories/basics/signal-content-children/signal-content-children.stories.ts
@@ -1,0 +1,32 @@
+import { moduleMetadata, type Meta, type StoryObj } from '@storybook/angular-vite';
+import { expect } from 'storybook/test';
+
+import { ContentChildComponent, ContentParentComponent } from './signal-content-children';
+
+const meta = {
+  component: ContentParentComponent,
+  decorators: [moduleMetadata({ declarations: [ContentChildComponent] })],
+} satisfies Meta<ContentParentComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const PreservesSignalQuery: Story = {
+  render: () => ({
+    props: {
+      options: [],
+      label: 'Ordinary props still update',
+    },
+    template: `
+      <storybook-content-parent>
+        <storybook-content-child />
+        <storybook-content-child />
+      </storybook-content-parent>
+    `,
+  }),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByTestId('query-result')).toHaveTextContent('2 projected children');
+    await expect(canvas.getByTestId('label')).toHaveTextContent('Ordinary props still update');
+  },
+};

--- a/code/frameworks/angular-vite/template/stories/basics/signal-content-children/signal-content-children.ts
+++ b/code/frameworks/angular-vite/template/stories/basics/signal-content-children/signal-content-children.ts
@@ -1,0 +1,23 @@
+import { Component, contentChildren } from '@angular/core';
+
+@Component({
+  selector: 'storybook-content-child',
+  template: 'Child',
+  standalone: false,
+})
+export class ContentChildComponent {}
+
+@Component({
+  selector: 'storybook-content-parent',
+  template: `
+    <p data-testid="query-result">{{ options().length }} projected children</p>
+    <p data-testid="label">{{ label }}</p>
+    <ng-content />
+  `,
+  standalone: false,
+})
+export class ContentParentComponent {
+  options = contentChildren(ContentChildComponent);
+
+  label = '';
+}

--- a/code/frameworks/angular/src/client/angular-beta/StorybookModule.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/StorybookModule.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import type { NgModule } from '@angular/core';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, signal } from '@angular/core';
 import { describe, expect, it } from 'vitest';
 
 import { TestBed } from '@angular/core/testing';
@@ -330,6 +330,57 @@ describe('StorybookModule', () => {
         fixture.detectChanges();
 
         expect(fixture.nativeElement.innerHTML).toContain('The content');
+      });
+    });
+
+    describe('with signal properties', () => {
+      @Component({
+        selector: 'signal-property',
+        template: `
+          <p id="optionCount">{{ options().length }}</p>
+          <p id="label">{{ label }}</p>
+        `,
+      })
+      class SignalPropertyComponent {
+        public options = signal(['preserved']).asReadonly();
+
+        public label = '';
+      }
+
+      it('should preserve signals while updating ordinary props', async () => {
+        const initialProps = {
+          options: [],
+          label: 'initial label',
+        };
+        const storyProps$ = new BehaviorSubject<ICollection>(initialProps);
+
+        const analyzedMetadata = new PropertyExtractor({}, SignalPropertyComponent);
+        await analyzedMetadata.init();
+
+        const application = getApplication({
+          storyFnAngular: {
+            props: initialProps,
+            template: '<signal-property></signal-property>',
+          },
+          component: SignalPropertyComponent,
+          targetSelector: 'my-selector',
+          analyzedMetadata,
+        });
+
+        const { fixture } = await configureTestingModule({
+          imports: [application],
+          providers: [storyPropsProvider(storyProps$)],
+        });
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('p#optionCount').innerHTML).toEqual('1');
+        expect(fixture.nativeElement.querySelector('p#label').innerHTML).toEqual('initial label');
+
+        storyProps$.next({ options: [], label: 'updated label' });
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('p#optionCount').innerHTML).toEqual('1');
+        expect(fixture.nativeElement.querySelector('p#label').innerHTML).toEqual('updated label');
       });
     });
 

--- a/code/frameworks/angular/src/client/angular-beta/StorybookWrapperComponent.ts
+++ b/code/frameworks/angular/src/client/angular-beta/StorybookWrapperComponent.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   Inject,
+  isSignal,
   NgModule,
   ViewChild,
   ViewContainerRef,
@@ -18,7 +19,8 @@ import { PropertyExtractor } from './utils/PropertyExtractor.ts';
 
 const getNonInputsOutputsProps = (
   ngComponentInputsOutputs: ComponentInputsOutputs,
-  props: ICollection = {}
+  props: ICollection = {},
+  target?: object
 ) => {
   const inputs = ngComponentInputsOutputs.inputs
     .filter((i) => i.templateName in props)
@@ -26,7 +28,11 @@ const getNonInputsOutputsProps = (
   const outputs = ngComponentInputsOutputs.outputs
     .filter((o) => o.templateName in props)
     .map((o) => o.templateName);
-  return Object.keys(props).filter((k) => ![...inputs, ...outputs].includes(k));
+  return Object.keys(props).filter(
+    (k) =>
+      ![...inputs, ...outputs].includes(k) &&
+      !isSignal(target === undefined ? undefined : Reflect.get(target, k))
+  );
 };
 
 /** Wraps the story template into a component */
@@ -105,7 +111,11 @@ export const createStorybookWrapperComponent = ({
       if (this.storyComponentElementRef) {
         const ngComponentInputsOutputs = getComponentInputsOutputs(storyComponent);
 
-        const initialOtherProps = getNonInputsOutputsProps(ngComponentInputsOutputs, initialProps);
+        const initialOtherProps = getNonInputsOutputsProps(
+          ngComponentInputsOutputs,
+          initialProps,
+          this.storyComponentElementRef
+        );
 
         // Initializes properties that are not Inputs | Outputs
         // Allows story props to override local component properties
@@ -122,7 +132,11 @@ export const createStorybookWrapperComponent = ({
           .pipe(
             skip(1),
             map((props) => {
-              const propsKeyToKeep = getNonInputsOutputsProps(ngComponentInputsOutputs, props);
+              const propsKeyToKeep = getNonInputsOutputsProps(
+                ngComponentInputsOutputs,
+                props,
+                this.storyComponentElementRef
+              );
               return propsKeyToKeep.reduce((acc, p) => ({ ...acc, [p]: props[p] }), {});
             })
           )

--- a/code/frameworks/angular/template/stories/basics/signal-content-children/signal-content-children.stories.ts
+++ b/code/frameworks/angular/template/stories/basics/signal-content-children/signal-content-children.stories.ts
@@ -1,0 +1,32 @@
+import { moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
+import { expect } from 'storybook/test';
+
+import { ContentChildComponent, ContentParentComponent } from './signal-content-children';
+
+const meta = {
+  component: ContentParentComponent,
+  decorators: [moduleMetadata({ declarations: [ContentChildComponent] })],
+} satisfies Meta<ContentParentComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const PreservesSignalQuery: Story = {
+  render: () => ({
+    props: {
+      options: [],
+      label: 'Ordinary props still update',
+    },
+    template: `
+      <storybook-content-parent>
+        <storybook-content-child />
+        <storybook-content-child />
+      </storybook-content-parent>
+    `,
+  }),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByTestId('query-result')).toHaveTextContent('2 projected children');
+    await expect(canvas.getByTestId('label')).toHaveTextContent('Ordinary props still update');
+  },
+};

--- a/code/frameworks/angular/template/stories/basics/signal-content-children/signal-content-children.ts
+++ b/code/frameworks/angular/template/stories/basics/signal-content-children/signal-content-children.ts
@@ -1,0 +1,23 @@
+import { Component, contentChildren } from '@angular/core';
+
+@Component({
+  selector: 'storybook-content-child',
+  template: 'Child',
+  standalone: false,
+})
+export class ContentChildComponent {}
+
+@Component({
+  selector: 'storybook-content-parent',
+  template: `
+    <p data-testid="query-result">{{ options().length }} projected children</p>
+    <p data-testid="label">{{ label }}</p>
+    <ng-content />
+  `,
+  standalone: false,
+})
+export class ContentParentComponent {
+  options = contentChildren(ContentChildComponent);
+
+  label = '';
+}


### PR DESCRIPTION
﻿﻿Closes #32201

## What I did

- Prevent Storybook's Angular wrappers from replacing framework-owned signal properties when applying non-input/output story props.
- Use Angular's public `isSignal()` API so ordinary properties and functions continue to initialize and update normally.
- Keep the Angular and Angular-Vite implementations in parity.
- Add wrapper regression tests and sandbox stories covering `contentChildren()` with projected children.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run `yarn task dev --template angular-vite/21-ts --start-from auto`.
2. Open `Basics / Signal Content Children / Preserves Signal Query`.
3. Verify it displays `2 projected children` and `Ordinary props still update` without console errors.

Local validation:

- `yarn test code/frameworks/angular code/frameworks/angular-vite`: 368 passed, 33 skipped; no type errors.
- Focused post-rebase regression tests: 18 passed.
- `yarn nx run-many -t compile -p angular angular-vite --parallel=4`: passed.
- Repository formatting and changed-file lint completed successfully.

The local Angular-Vite sandbox build did not reach story execution because its Rolldown native binding rejected the `builtin:oxc-runtime` plugin. The committed play assertion and broader Angular sandbox matrix are therefore delegated to CI.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

AI assistance: Codex was used to investigate, implement, and test this change.
