### PR TITLE
Index: Remove synthetic component wrappers for unattached docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,7 @@
 <h1>Migration</h1>
 
+- [From version 10.5.0 to 10.6.0](#from-version-1050-to-1060)
+  - [Synthetic component wrappers for unattached docs removed from index](#synthetic-component-wrappers-for-unattached-docs-removed-from-index)
 - [From version 10.4.0 to 10.5.0](#from-version-1040-to-1050)
   - [ExternalDocs and ExternalDocsContainer are deprecated](#externaldocs-and-externaldocscontainer-are-deprecated)
 - [From version 10.3.0 to 10.4.0](#from-version-1030-to-1040)
@@ -524,6 +526,19 @@
   - [Webpack upgrade](#webpack-upgrade)
   - [Packages renaming](#packages-renaming)
   - [Deprecated embedded addons](#deprecated-embedded-addons)
+
+## From version 10.5.0 to 10.6.0
+
+### Synthetic component wrappers for unattached docs removed from index
+
+In previous versions, `transformStoryIndexToStoriesHash` generated synthetic `component` wrapper nodes for unattached documentation entries (such as standalone MDX pages). The Storybook sidebar UI unwrapped these at render time, creating a mismatch between `useStorybookState().index` and the sidebar tree.
+
+Starting in this release, `transformStoryIndexToStoriesHash` hoists single-docs-child component nodes directly in the data layer. Unattached docs entries now appear as `type === 'docs'` nodes without a synthetic `component` parent wrapper.
+
+If you maintain an addon or integration that reads `useStorybookState().index` or `useStorybookState().filteredIndex`:
+- Unattached docs entries now have `type === 'docs'` directly at their title level.
+- Synthetic component wrapper entries (which previously had `type === 'component'` and a child `"Docs"` entry) are no longer generated for standalone docs pages.
+- Title and ID lookups via `api.selectStory(title)` or `linkTo(title)` continue to resolve seamlessly.
 
 ## From version 10.4.0 to 10.5.0
 

--- a/code/core/src/manager-api/lib/stories.ts
+++ b/code/core/src/manager-api/lib/stories.ts
@@ -391,6 +391,35 @@ export const transformStoryIndexToStoriesHash = (
     return acc;
   }, {} as API_IndexHash);
 
+  // Hoist single-docs-child component nodes by removing the synthetic component wrapper
+  storiesHash = Object.values(storiesHash).reduce((acc, item) => {
+    if (
+      item.type === 'component' &&
+      item.children?.length === 1 &&
+      acc[item.children[0]]?.type === 'docs'
+    ) {
+      const docsChild = acc[item.children[0]] as API_DocsEntry;
+
+      if (item.parent && acc[item.parent] && 'children' in acc[item.parent]) {
+        const parentNode = acc[item.parent] as API_GroupEntry | API_RootEntry;
+        const indexInParent = parentNode.children.indexOf(item.id);
+        if (indexInParent !== -1) {
+          parentNode.children[indexInParent] = docsChild.id;
+        }
+      }
+
+      acc[docsChild.id] = {
+        ...docsChild,
+        name: item.name,
+        parent: item.parent,
+        depth: item.depth,
+      };
+
+      delete acc[item.id];
+    }
+    return acc;
+  }, storiesHash);
+
   return storiesHash;
 };
 
@@ -421,6 +450,11 @@ export const getComponentLookupList = memoize(1)((hash: API_IndexHash) => {
     const value = i[1];
     if (value.type === 'component') {
       acc.push([...value.children]);
+    } else if (
+      value.type === 'docs' &&
+      (!value.parent || hash[value.parent]?.type !== 'component')
+    ) {
+      acc.push([value.id]);
     }
     return acc;
   }, [] as StoryId[][]);

--- a/code/core/src/manager-api/modules/stories.ts
+++ b/code/core/src/manager-api/modules/stories.ts
@@ -659,7 +659,9 @@ export const init: ModuleFn<SubAPI, SubState> = ({
 
       if (!name) {
         // Find the entry (group, component, story or docs) that is referred to
-        let entry = titleOrId ? hash[titleOrId] || hash[sanitize(titleOrId)] : hash[kindSlug];
+        let entry: API_HashEntry | undefined = titleOrId
+          ? hash[titleOrId] || hash[sanitize(titleOrId)]
+          : hash[kindSlug];
 
         if (!entry && titleOrId) {
           const sanitizedTitle = sanitize(titleOrId);

--- a/code/core/src/manager-api/modules/stories.ts
+++ b/code/core/src/manager-api/modules/stories.ts
@@ -659,7 +659,14 @@ export const init: ModuleFn<SubAPI, SubState> = ({
 
       if (!name) {
         // Find the entry (group, component, story or docs) that is referred to
-        const entry = titleOrId ? hash[titleOrId] || hash[sanitize(titleOrId)] : hash[kindSlug];
+        let entry = titleOrId ? hash[titleOrId] || hash[sanitize(titleOrId)] : hash[kindSlug];
+
+        if (!entry && titleOrId) {
+          const sanitizedTitle = sanitize(titleOrId);
+          entry = Object.values(hash).find(
+            (e) => (e.type === 'docs' || e.type === 'story') && sanitize(e.title) === sanitizedTitle
+          );
+        }
 
         if (!entry) {
           throw new Error(`Unknown id or title: '${titleOrId}'`);

--- a/code/core/src/manager-api/tests/stories.test.ts
+++ b/code/core/src/manager-api/tests/stories.test.ts
@@ -558,7 +558,6 @@ describe('stories API', () => {
           'component-a',
           'component-a--page',
           'component-a--story-2',
-          'component-b',
           'component-b--docs',
           'component-c',
           'component-c--story-4',
@@ -578,7 +577,7 @@ describe('stories API', () => {
           const { store } = moduleArgs;
           api.setIndex({ v: 5, entries: docsEntries });
           const { index } = store.getState();
-          expect(Object.keys(index!)).toEqual(['component-b', 'component-b--docs']);
+          expect(Object.keys(index!)).toEqual(['component-b--docs']);
         });
       });
     });

--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -669,7 +669,6 @@ export const Tree = React.memo<{
   // Create a list of component IDs which should be collapsed into their (only) child.
   // That is:
   //  - components with a single story child with the same name
-  //  - components with only a single docs child
   const singleStoryComponentIds = useMemo(() => {
     return Object.keys(data).filter((id) => {
       const entry = data[id];
@@ -685,10 +684,6 @@ export const Tree = React.memo<{
       }
 
       const onlyChild = data[children[0]];
-
-      if (onlyChild.type === 'docs') {
-        return true;
-      }
 
       if (onlyChild.type === 'story' && onlyChild.subtype === 'story') {
         return isStoryHoistable(onlyChild.name, name);

--- a/code/core/src/types/modules/api-stories.ts
+++ b/code/core/src/types/modules/api-stories.ts
@@ -33,7 +33,7 @@ export interface API_ComponentEntry extends API_BaseEntry {
 
 export interface API_DocsEntry extends API_BaseEntry {
   type: 'docs';
-  parent: StoryId;
+  parent?: StoryId;
   title: ComponentTitle;
   importPath: Path;
   prepared: boolean;


### PR DESCRIPTION
Closes #35513

## What I did

- Removed synthetic component wrapper nodes for unattached documentation entries with a single docs child in the stories index hash.
- Updated `getComponentLookupList` in `manager-api/lib/stories.ts` to properly handle standalone unattached docs entries.
- Made `parent` optional (`parent?: StoryId`) on `API_DocsEntry` to correctly support root-level unattached docs without parent wrappers.
- Resolved TypeScript type diagnostics and verified unit tests.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run `yarn storybook:ui` from the `code/` directory.
2. Load a Storybook containing unattached MDX documentation entries (e.g. standalone docs with a single entry under a title).
3. Inspect the sidebar navigation tree.
4. Verify that the standalone documentation entry is hoisted cleanly without an extra synthetic component wrapper folder.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [x] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes.
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the change category labels (`feature request`, `bug`, `maintenance`, etc.).

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

<!-- CANARY_RELEASE_SECTION -->