### PR TITLE
CI: Restore `pull-requests:write` permission for patch labeling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
     environment: Release
     permissions:
       contents: write
-      issues: write
+      pull-requests: write # required for yarn release:label-patches (addLabelsToLabelable on PRs)
       actions: write # required for yarn release:cancel-preparation-runs
       id-token: write # required for npm provenance via yarn release:publish
     defaults:


### PR DESCRIPTION
## What I did

Restored `pull-requests: write` on the `publish-normal` job in `publish.yml`.

The `Label patch PRs as picked` step (`yarn release:label-patches`) adds the `patch:done` label to merged patch PRs via the GraphQL `addLabelsToLabelable` mutation, which requires `pull-requests: write`. Without it, the step fails with `Resource not accessible by integration`.

## How the wrong permission got in

1. In [#34905](https://github.com/storybookjs/storybook/pull/34905) (zizmor security hardening), workflow permissions were tightened from a workflow-level block into per-job blocks.
2. CodeRabbit flagged a genuinely missing `actions: write` — and its [suggested fix kept `pull-requests: write`](https://github.com/storybookjs/storybook/pull/34905#discussion_r3302432808).
3. A maintainer replied [`@copilot fix this`](https://github.com/storybookjs/storybook/pull/34905#discussion_r3317042254).
4. Beyond that ask, Copilot's agent [swapped `pull-requests: write` → `issues: write`](https://github.com/storybookjs/storybook/pull/34905#discussion_r3317133460) in commit [`93fb631`](https://github.com/storybookjs/storybook/commit/93fb6317d49b0d3010f31a5bb137c253badc9ad6), calling it "the narrower `issues: write` needed for labeling patch PRs." That premise is wrong: the labels go on **pull requests**, so `pull-requests: write` is the required scope — and `issues`/`pull-requests` are separate, non-overlapping scopes, not broad/narrow.
5. The broken permission reached `latest-release` with 10.5.0, so labeling has failed on every patch release since. Because these labels decide which PRs `pick-patches` cherry-picks, already-released PRs kept being re-picked and re-listed in later patch changelogs ([#35459](https://github.com/storybookjs/storybook/pull/35459) → [#35514](https://github.com/storybookjs/storybook/pull/35514) → [#35519](https://github.com/storybookjs/storybook/pull/35519)).

Confirmed against release history: `v10.4.6` (`pull-requests: write`, no `issues`) labeled successfully; `v10.5.0`–`v10.5.2` (`issues: write`, no `pull-requests`) all failed.

## Manual testing

On the next patch publish, the `Label patch PRs as picked` step succeeds (`Successfully labeled all PRs...`) and that release's patch PRs receive `patch:done` automatically, instead of `Resource not accessible by integration`.

> [!IMPORTANT]
> The publish workflow runs the copy of `publish.yml` that lives on `latest-release`, so this fix only takes effect once it lands there. It must carry the **`patch:yes`** label to be cherry-picked into the next patch.

## Not in scope

The failure was silent because `label-patches.ts` swallows the error — to be hardened in a follow-up.

## Checklist for Maintainers

- [ ] `patch:yes` (required — must reach `latest-release`)
- [ ] `build` category label
- [ ] `ci:normal` / `qa:skip`