### PR TITLE
Fix(ci): surface patch-labeling failures instead of swallowing them

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,12 +127,26 @@ jobs:
         if: github.ref_name == 'latest-release'
         run: git fetch --tags origin
 
-      # when this is a patch release from main, label any patch PRs included in the release
+      # When this is a patch release from main, label any patch PRs included in the release as
+      # "patch:done". This is bookkeeping for the *next* release's cherry-pick step, not part of
+      # publishing itself, so it runs continue-on-error to avoid aborting an already-published
+      # release. It must not fail silently though (a swallowed permission error previously caused
+      # released PRs to be re-picked into later patch changelogs), so failure is alerted below.
       - name: Label patch PRs as picked
+        id: label-patches
         if: github.ref_name == 'latest-release'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn release:label-patches
+
+      - name: Report patch labeling failure to Discord
+        if: github.ref_name == 'latest-release' && steps.label-patches.outcome == 'failure'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # v0.4.0
+        with:
+          args: 'Publishing v${{ steps.version.outputs.current-version }} succeeded, but labeling patch PRs as "patch:done" failed. They must be labeled manually or they will reappear in the next patch changelog. See run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
       - name: Create GitHub Release
         if: steps.publish-needed.outputs.published == 'false'

--- a/scripts/release/__tests__/label-patches.test.ts
+++ b/scripts/release/__tests__/label-patches.test.ts
@@ -154,19 +154,6 @@ it('should label the PR associated with cherry picks in the current branch', asy
   `);
 });
 
-it('should re-throw when labeling fails, so an unattended run does not fail silently', async () => {
-  process.env.GH_TOKEN = 'MY_SECRET';
-  vi.spyOn(process.stderr, 'write').mockImplementation((() => {}) as any);
-  vi.spyOn(console, 'error').mockImplementation(() => {});
-
-  // Reproduces the incident where the publish job lacked `pull-requests: write`.
-  github.githubGraphQlClient.mockRejectedValueOnce(
-    new Error('Resource not accessible by integration')
-  );
-
-  await expect(run({})).rejects.toThrow('Resource not accessible by integration');
-});
-
 it('should label all PRs when the --all flag is passed', async () => {
   process.env.GH_TOKEN = 'MY_SECRET';
 

--- a/scripts/release/__tests__/label-patches.test.ts
+++ b/scripts/release/__tests__/label-patches.test.ts
@@ -154,6 +154,19 @@ it('should label the PR associated with cherry picks in the current branch', asy
   `);
 });
 
+it('should re-throw when labeling fails, so an unattended run does not fail silently', async () => {
+  process.env.GH_TOKEN = 'MY_SECRET';
+  vi.spyOn(process.stderr, 'write').mockImplementation((() => {}) as any);
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  // Reproduces the incident where the publish job lacked `pull-requests: write`.
+  github.githubGraphQlClient.mockRejectedValueOnce(
+    new Error('Resource not accessible by integration')
+  );
+
+  await expect(run({})).rejects.toThrow('Resource not accessible by integration');
+});
+
 it('should label all PRs when the --all flag is passed', async () => {
   process.env.GH_TOKEN = 'MY_SECRET';
 

--- a/scripts/release/label-patches.ts
+++ b/scripts/release/label-patches.ts
@@ -93,6 +93,11 @@ export const run = async (options: unknown) => {
   } catch (e) {
     spinner3.fail(`Something went wrong when labelling the PRs.`);
     console.error(e);
+    // Re-throw so the process exits non-zero. This step also runs unattended in the publish
+    // workflow, where a swallowed error is invisible; the workflow marks the step
+    // continue-on-error and alerts on failure, so this does not abort an already-published
+    // release but is no longer silent.
+    throw e;
   }
 };
 


### PR DESCRIPTION
## What I did

Made the publish workflow's patch-labeling step fail **loudly** instead of silently. Follow-up to [#35524](https://github.com/storybookjs/storybook/pull/35524), which fixed the permission but left the silent-failure mechanism in place.

## Why

`release:label-patches` labels merged patch PRs `patch:done` so `pick-patches` doesn't re-cherry-pick them into the next patch changelog. Since it was introduced in [#22959](https://github.com/storybookjs/storybook/pull/22959) (2023), `label-patches.ts` has wrapped the labeling call in a `try/catch` that discards the error:

```ts
} catch (e) {
  spinner3.fail(`Something went wrong when labelling the PRs.`);
  console.error(e);
}
```

That made sense for its **original manual use** — it's a documented CLI step (`RELEASING.md` step 15) built around `ora` spinners, so a human watching the terminal sees the red ✗ and can re-run or label by hand, without a bookkeeping hiccup aborting the release.

But the **same** `run()` was wired into the unattended publish workflow in that same PR. In CI there's no human watching the spinner: the caught error goes to logs nobody reads, the step exits `0`, and the workflow stays green. That's exactly how the `pull-requests: write` → `issues: write` regression (see [#35524](https://github.com/storybookjs/storybook/pull/35524)) went unnoticed across **two** patch releases.

## The change

- **`label-patches.ts`** now re-throws after logging, so the process exits non-zero.
- **`publish.yml`**: the `Label patch PRs as picked` step is marked `continue-on-error: true` and a Discord alert fires on failure. Labeling is bookkeeping for the *next* release's cherry-pick, and it runs *before* the GitHub Release + merge-back steps, so it must not abort an already-published release — but it is no longer silent.

## Manual testing

Not runnable outside a real publish. Behavior on the next patch release: if labeling fails, the `Label patch PRs as picked` step shows as failed and a Discord alert is posted, while publishing/release/merge still complete; if labeling succeeds, nothing changes.

> [!NOTE]
> Like #35524, the publish workflow runs the copy of `publish.yml` on `latest-release`, so this only takes effect once it lands there — it should carry the **`patch:yes`** label.

## Checklist for Maintainers

- [ ] `patch:yes` (so it reaches `latest-release`)
- [ ] `build` category label
- [ ] `ci:normal` / `qa:skip`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow resilience when automatically labeling patch pull requests.
  * Added failure notifications so maintainers are alerted when manual labeling is required.
  * Corrected error handling so labeling failures are properly reported instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->