### PR TITLE
Blocks: Expose useGlobals in custom docs pages

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Controls.tsx
+++ b/code/addons/docs/src/blocks/blocks/Controls.tsx
@@ -72,7 +72,7 @@ function useControlsInteractiveState(
   // React versions that lack the built-in useId.
   const controlsId = useId();
   const [args, updateArgs, resetArgs] = useArgs(story, context);
-  const [globals] = useGlobals(story, context);
+  const [globals] = useGlobals();
 
   return { controlsId, args, globals, updateArgs, resetArgs };
 }

--- a/code/addons/docs/src/blocks/blocks/index.ts
+++ b/code/addons/docs/src/blocks/blocks/index.ts
@@ -26,6 +26,7 @@ export * from './Title';
 export * from './Unstyled';
 export * from './Wrapper';
 
+export * from './useGlobals';
 export * from './useOf';
 export * from './types';
 export * from './mdx';

--- a/code/addons/docs/src/blocks/blocks/useGlobals.test.tsx
+++ b/code/addons/docs/src/blocks/blocks/useGlobals.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import React from 'react';
+import type { FC, PropsWithChildren } from 'react';
+
+import { GLOBALS_UPDATED, UPDATE_GLOBALS } from 'storybook/internal/core-events';
+import type { Globals } from 'storybook/internal/csf';
+
+import type { DocsContextProps } from './DocsContext';
+import { DocsContext } from './DocsContext';
+import { useGlobals } from './useGlobals';
+
+type MockDocsContext = Pick<DocsContextProps, 'channel' | 'getGlobals'>;
+
+const Wrapper: FC<PropsWithChildren<{ context: MockDocsContext }>> = ({
+  children,
+  context,
+}) => <DocsContext.Provider value={context as DocsContextProps}>{children}</DocsContext.Provider>;
+
+describe('useGlobals', () => {
+  it('reads current globals and reacts to updates', () => {
+    let onGlobalsUpdated = (_changed: { globals: Globals }) => {};
+    const channel = {
+      on: vi.fn((event: string, listener: typeof onGlobalsUpdated) => {
+        if (event === GLOBALS_UPDATED) {
+          onGlobalsUpdated = listener;
+        }
+      }),
+      off: vi.fn(),
+      emit: vi.fn(),
+    };
+    const context = {
+      channel,
+      getGlobals: vi.fn(() => ({ theme: 'light' })),
+    } as unknown as MockDocsContext;
+
+    const { result, unmount } = renderHook(() => useGlobals(), {
+      wrapper: ({ children }) => <Wrapper context={context}>{children}</Wrapper>,
+    });
+
+    expect(result.current[0]).toEqual({ theme: 'light' });
+    expect(channel.on).toHaveBeenCalledWith(GLOBALS_UPDATED, onGlobalsUpdated);
+
+    act(() => onGlobalsUpdated({ globals: { theme: 'dark' } }));
+
+    expect(result.current[0]).toEqual({ theme: 'dark' });
+
+    unmount();
+    expect(channel.off).toHaveBeenCalledWith(GLOBALS_UPDATED, onGlobalsUpdated);
+  });
+
+  it('emits global updates', () => {
+    const channel = {
+      on: vi.fn(),
+      off: vi.fn(),
+      emit: vi.fn(),
+    };
+    const context = {
+      channel,
+      getGlobals: vi.fn(() => ({ theme: 'light' })),
+    } as unknown as MockDocsContext;
+
+    const { result } = renderHook(() => useGlobals(), {
+      wrapper: ({ children }) => <Wrapper context={context}>{children}</Wrapper>,
+    });
+
+    act(() => result.current[1]({ theme: 'dark' }));
+
+    expect(channel.emit).toHaveBeenCalledWith(UPDATE_GLOBALS, {
+      globals: { theme: 'dark' },
+    });
+  });
+});

--- a/code/addons/docs/src/blocks/blocks/useGlobals.test.tsx
+++ b/code/addons/docs/src/blocks/blocks/useGlobals.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import React from 'react';
 import type { FC, PropsWithChildren } from 'react';
@@ -20,9 +20,13 @@ const Wrapper: FC<PropsWithChildren<{ context: MockDocsContext }>> = ({
 }) => <DocsContext.Provider value={context as DocsContextProps}>{children}</DocsContext.Provider>;
 
 describe('useGlobals', () => {
-  it('reads current globals and reacts to updates', () => {
-    let onGlobalsUpdated = (_changed: { globals: Globals }) => {};
-    const channel = {
+  let onGlobalsUpdated: (changed: { globals: Globals }) => void;
+  let channel: Pick<DocsContextProps['channel'], 'emit' | 'off' | 'on'>;
+  let context: MockDocsContext;
+
+  beforeEach(() => {
+    onGlobalsUpdated = () => {};
+    channel = {
       on: vi.fn((event: string, listener: typeof onGlobalsUpdated) => {
         if (event === GLOBALS_UPDATED) {
           onGlobalsUpdated = listener;
@@ -31,11 +35,13 @@ describe('useGlobals', () => {
       off: vi.fn(),
       emit: vi.fn(),
     };
-    const context = {
+    context = {
       channel,
       getGlobals: vi.fn(() => ({ theme: 'light' })),
     } as unknown as MockDocsContext;
+  });
 
+  it('reads current globals and reacts to updates', () => {
     const { result, unmount } = renderHook(() => useGlobals(), {
       wrapper: ({ children }) => <Wrapper context={context}>{children}</Wrapper>,
     });
@@ -52,16 +58,6 @@ describe('useGlobals', () => {
   });
 
   it('emits global updates', () => {
-    const channel = {
-      on: vi.fn(),
-      off: vi.fn(),
-      emit: vi.fn(),
-    };
-    const context = {
-      channel,
-      getGlobals: vi.fn(() => ({ theme: 'light' })),
-    } as unknown as MockDocsContext;
-
     const { result } = renderHook(() => useGlobals(), {
       wrapper: ({ children }) => <Wrapper context={context}>{children}</Wrapper>,
     });

--- a/code/addons/docs/src/blocks/blocks/useGlobals.ts
+++ b/code/addons/docs/src/blocks/blocks/useGlobals.ts
@@ -25,23 +25,3 @@ export const useGlobals = (): [Globals, (globals: Globals) => void] => {
 
   return [globals, updateGlobals];
 };
-import { useEffect, useState } from 'react';
-
-import { GLOBALS_UPDATED } from 'storybook/internal/core-events';
-import type { Globals } from 'storybook/internal/csf';
-import type { DocsContextProps, PreparedStory } from 'storybook/internal/types';
-
-export const useGlobals = (story: PreparedStory, context: DocsContextProps): [Globals] => {
-  const storyContext = context.getStoryContext(story);
-
-  const [globals, setGlobals] = useState(storyContext.globals);
-  useEffect(() => {
-    const onGlobalsUpdated = (changed: { globals: Globals }) => {
-      setGlobals(changed.globals);
-    };
-    context.channel.on(GLOBALS_UPDATED, onGlobalsUpdated);
-    return () => context.channel.off(GLOBALS_UPDATED, onGlobalsUpdated);
-  }, [context.channel]);
-
-  return [globals];
-};

--- a/code/addons/docs/src/blocks/blocks/useGlobals.ts
+++ b/code/addons/docs/src/blocks/blocks/useGlobals.ts
@@ -1,3 +1,30 @@
+import { useCallback, useContext, useEffect, useState } from 'react';
+
+import { GLOBALS_UPDATED, UPDATE_GLOBALS } from 'storybook/internal/core-events';
+import type { Globals } from 'storybook/internal/csf';
+
+import { DocsContext } from './DocsContext';
+
+export const useGlobals = (): [Globals, (globals: Globals) => void] => {
+  const context = useContext(DocsContext);
+  const [globals, setGlobals] = useState(context.getGlobals());
+
+  useEffect(() => {
+    const onGlobalsUpdated = (changed: { globals: Globals }) => {
+      setGlobals(changed.globals);
+    };
+    context.channel.on(GLOBALS_UPDATED, onGlobalsUpdated);
+    return () => context.channel.off(GLOBALS_UPDATED, onGlobalsUpdated);
+  }, [context.channel]);
+
+  const updateGlobals = useCallback(
+    (updatedGlobals: Globals) =>
+      context.channel.emit(UPDATE_GLOBALS, { globals: updatedGlobals }),
+    [context.channel]
+  );
+
+  return [globals, updateGlobals];
+};
 import { useEffect, useState } from 'react';
 
 import { GLOBALS_UPDATED } from 'storybook/internal/core-events';

--- a/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.ts
@@ -317,6 +317,8 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
     return this.store.storyFromCSFFile({ storyId, csfFile });
   };
 
+  getGlobals = () => this.store.userGlobals.get();
+
   getStoryContext = (story: PreparedStory<TRenderer>) => {
     return {
       ...this.store.getStoryContext(story),

--- a/code/core/src/types/modules/docs.ts
+++ b/code/core/src/types/modules/docs.ts
@@ -1,6 +1,6 @@
 import type { Channel } from 'storybook/internal/channels';
 
-import type { Parameters, Renderer, StoryContext, StoryId, StoryName } from './csf.ts';
+import type { Globals, Parameters, Renderer, StoryContext, StoryId, StoryName } from './csf.ts';
 import type {
   CSFFile,
   ModuleExport,
@@ -92,6 +92,9 @@ export interface DocsContextProps<TRenderer extends Renderer = Renderer> {
 
   /** Syncronously find all stories by CSF file. */
   componentStoriesFromCSFFile: (csfFile: CSFFile<TRenderer>) => PreparedStory<TRenderer>[];
+
+  /** Get the current global args. */
+  getGlobals: () => Globals;
 
   /** Get the story context of the referenced story. */
   getStoryContext: (


### PR DESCRIPTION
Closes #12982

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- exported the docs-specific `useGlobals` hook from `@storybook/addon-docs/blocks`
- removed its dependency on a prepared story and read current globals directly from the docs context
- returned an update function that emits `UPDATE_GLOBALS`
- added unit coverage for initial values, channel updates, cleanup, and emitted updates

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Run `yarn test code/addons/docs/src/blocks/blocks/useGlobals.test.tsx`.
2. In a custom docs page, import `useGlobals` from `@storybook/addon-docs/blocks` and render one of the current global values.
3. Change that global from the toolbar and confirm the custom docs page updates.
4. Call the hook's update function from the custom docs page and confirm the toolbar reflects the new value.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [[MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml).

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs components can now read and update Storybook global values via a shared docs context interface.
  * The `useGlobals` hook is now zero-argument and provides both current globals and an updater function.
* **Bug Fixes**
  * Improved synchronization of global values across documentation and interactive controls.
* **Tests**
  * Added tests for reading initial globals, subscribing to updates, emitting global changes, and cleaning up listeners on unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->