### PR TITLE
Core: Insert saved args after spread elements in CSF stories

### DIFF
--- a/code/core/src/core-server/utils/save-story/mocks/spread-variances.stories.tsx
+++ b/code/core/src/core-server/utils/save-story/mocks/spread-variances.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { FC } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+export default {
+  title: 'MyComponent',
+  args: {
+    initial: 'foo',
+  },
+} satisfies Meta<typeof MyComponent>;
+
+type Story = StoryObj<typeof MyComponent>;
+
+// dummy component
+const MyComponent: FC<{ absolute: boolean; bordered: boolean; initial: string }> = (props) => (
+  <pre>{JSON.stringify(props)}</pre>
+);
+
+export const Primary = {
+  args: {
+    absolute: true,
+    initial: 'bar',
+  },
+} satisfies Story;
+
+// args must be inserted after the spread, otherwise the spread's args always win
+export const SpreadOnly = {
+  ...Primary,
+} satisfies Story;
+
+export const SpreadWithRender = {
+  ...Primary,
+  render: (args) => <MyComponent {...args} />,
+} satisfies Story;
+
+export const SpreadPlainObject = {
+  ...Primary,
+};

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
@@ -19,6 +19,7 @@ const FILES = {
   unsupportedCsfVariances: join(__dirname, 'mocks/unsupported-csf-variances.stories.tsx'),
   exportVariances: join(__dirname, 'mocks/export-variances.stories.tsx'),
   dataVariances: join(__dirname, 'mocks/data-variances.stories.tsx'),
+  spreadVariances: join(__dirname, 'mocks/spread-variances.stories.tsx'),
 };
 
 describe('success', () => {
@@ -329,6 +330,82 @@ describe('success', () => {
         
         const BlockExport: Story = {
         ..."
+    `);
+  });
+  test('Spread Variances', async () => {
+    const newArgs = { bordered: true, initial: 'test1' };
+
+    const before = await format(await readFile(FILES.spreadVariances, 'utf-8'), {
+      parser: 'typescript',
+    });
+    const CSF = await readCsf(FILES.spreadVariances, { makeTitle });
+
+    const parsed = CSF.parse();
+    const names = Object.keys(parsed._stories);
+    const nodes = names.map((name) => CSF.getStoryExport(name));
+
+    nodes.forEach((node) => {
+      updateArgsInCsfFile(node, newArgs);
+    });
+
+    const after = await format(printCsf(parsed).code, {
+      parser: 'typescript',
+    });
+
+    // check if the code was updated at all
+    expect(after).not.toBe(before);
+
+    // args must be inserted after spread elements, otherwise the spread's args always win
+    expect(getDiff(before, after)).toMatchInlineSnapshot(`
+      "  ...
+        export const Primary = {
+          args: {
+            absolute: true,
+        
+      -     initial: "bar",
+      - 
+      +     initial: "test1",
+      +     bordered: true,
+      + 
+          },
+        } satisfies Story;
+        
+        // args must be inserted after the spread, otherwise the spread's args always win
+        export const SpreadOnly = {
+          ...Primary,
+        
+      + 
+      +   args: {
+      +     bordered: true,
+      +     initial: "test1",
+      +   },
+      + 
+        } satisfies Story;
+        
+        export const SpreadWithRender = {
+          ...Primary,
+        
+      + 
+      +   args: {
+      +     bordered: true,
+      +     initial: "test1",
+      +   },
+      + 
+      + 
+          render: (args) => <MyComponent {...args} />,
+        } satisfies Story;
+        
+        export const SpreadPlainObject = {
+          ...Primary,
+        
+      + 
+      +   args: {
+      +     bordered: true,
+      +     initial: "test1",
+      +   },
+      + 
+        };
+        "
     `);
   });
   test('Data Variances', async () => {

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
@@ -3,6 +3,11 @@ import { types as t, traverse } from 'storybook/internal/babel';
 import { SaveStoryError } from './utils.ts';
 import { valueToAST } from './valueToAST.ts';
 
+// Insert after the last spread element (e.g. `...PrimaryStory`), otherwise the
+// spread's own `args` would always override the newly saved args.
+const getArgsInsertionIndex = (properties: t.ObjectExpression['properties']) =>
+  properties.reduce((acc, property, index) => (t.isSpreadElement(property) ? index + 1 : acc), 0);
+
 export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, any>) => {
   let found = false;
   const args = Object.fromEntries(
@@ -55,7 +60,9 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
         }
       }
     } else {
-      properties.unshift(
+      properties.splice(
+        getArgsInsertionIndex(properties),
+        0,
         t.objectProperty(
           t.identifier('args'),
           t.objectExpression(
@@ -107,8 +114,9 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
           }
         }
       } else {
-        path.unshiftContainer(
-          'properties',
+        path.node.properties.splice(
+          getArgsInsertionIndex(path.node.properties),
+          0,
           t.objectProperty(
             t.identifier('args'),
             t.objectExpression(


### PR DESCRIPTION
Closes #35447

## What I did

When saving args from the Controls panel for a story that has no explicit `args` property, `updateArgsInCsfFile` unshifted the new `args` property to the front of the story object. If the story spreads another story whose own `args` come later (e.g. `{ ...Primary }`), the spread always overrode the newly saved args — so the story stayed dirty after refresh and even after restarting Storybook.

This PR inserts the new `args` property **after the last spread element** instead, so the saved args take effect. Stories without spreads keep the previous insertion position (front of the object), so no unrelated diffs are produced.

Both code paths (direct `ObjectExpression` and the `traverse` fallback used for `satisfies` / `as` expressions) are fixed via a shared `getArgsInsertionIndex` helper.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

New `Spread Variances` test in `update-args-in-csf-file.test.ts` with a new `spread-variances.stories.tsx` mock covering `{ ...Primary }` with `satisfies`, with `render`, and as a plain object.

#### Manual testing

1. Run a sandbox, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Add a story that spreads another story, e.g. `export const Spread = { ...Primary };`
3. Change some args in the Controls panel and click "Update story"
4. Refresh the page — before this fix the story stays dirty (saved args are written before `...Primary` and overridden by it); after this fix the args are written after the spread and the story renders the saved args.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated saved Storybook arguments to remain effective when stories use spread syntax.
  * Ensured generated `args` entries are placed correctly without being overridden by inherited story settings.

* **Tests**
  * Added coverage for multiple story spread patterns, including custom render functions and plain-object spreads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->