### PR TITLE
Addon-vitest: Stop cleanOnRerun from wiping coverage mid-run

### DIFF
--- a/code/addons/vitest/src/node/test-manager.test.ts
+++ b/code/addons/vitest/src/node/test-manager.test.ts
@@ -1,3 +1,5 @@
+import { rm } from 'node:fs/promises';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TestResult } from 'vitest/node';
 
@@ -58,11 +60,16 @@ vi.mock('vitest/node', () => ({
   createVitest: mockCreateVitest,
 }));
 
+vi.mock('node:fs/promises', { spy: true });
+
 // Use the mock function directly
 const createVitest = mockCreateVitest;
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
+  const memfs = await import('memfs');
+  memfs.vol.reset();
+  vi.mocked(rm).mockImplementation(memfs.fs.promises.rm as unknown as typeof rm);
   mockStore.setState(() => ({
     ...storeOptions.initialState,
     index: mockIndex,
@@ -543,9 +550,37 @@ describe('TestManager', () => {
     expect(createVitest).toHaveBeenCalledWith(
       Tag.TEST,
       expect.objectContaining({
-        coverage: expect.objectContaining({ enabled: true }),
+        coverage: expect.objectContaining({ enabled: true, cleanOnRerun: false }),
       })
     );
+    // The fresh instance cleans the coverage directory itself; no manual clean needed.
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  it('should clean the coverage directory when reusing a coverage-enabled Vitest instance', async () => {
+    const testManager = await TestManager.start(options);
+    createVitest.mockClear();
+
+    mockStore.setState((s) => ({
+      ...s,
+      config: { coverage: true, a11y: false },
+    }));
+    // Simulate an instance that already ran with coverage: no restart happens, so the previous
+    // run's results must be cleaned manually before the new run.
+    vitest.config.coverage.enabled = true;
+
+    await testManager.handleTriggerRunEvent({
+      type: 'TRIGGER_RUN',
+      payload: {
+        triggeredBy: 'global',
+      },
+    });
+
+    expect(createVitest).not.toHaveBeenCalled();
+    expect(rm).toHaveBeenCalledWith(expect.stringContaining('coverage'), {
+      recursive: true,
+      force: true,
+    });
   });
 
   it('should not restart with coverage enabled Vitest before a focused test run', async () => {

--- a/code/addons/vitest/src/node/test-manager.test.ts
+++ b/code/addons/vitest/src/node/test-manager.test.ts
@@ -3,6 +3,7 @@ import { rm } from 'node:fs/promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TestResult } from 'vitest/node';
 
+import { resolvePathInStorybookCache } from 'storybook/internal/common';
 import { Tag, experimental_MockUniversalStore } from 'storybook/internal/core-server';
 import type {
   Options,
@@ -15,6 +16,7 @@ import path from 'pathe';
 import type { Report } from 'storybook/preview-api';
 
 import {
+  COVERAGE_DIRECTORY,
   STATUS_TYPE_ID_A11Y,
   STATUS_TYPE_ID_COMPONENT_TEST,
   STORYBOOK_TEST_PROVIDE_KEY,
@@ -62,8 +64,7 @@ vi.mock('vitest/node', () => ({
 
 vi.mock('node:fs/promises', { spy: true });
 
-// Use the mock function directly
-const createVitest = mockCreateVitest;
+const createVitest = vi.mocked(mockCreateVitest);
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -550,7 +551,7 @@ describe('TestManager', () => {
     expect(createVitest).toHaveBeenCalledWith(
       Tag.TEST,
       expect.objectContaining({
-        coverage: expect.objectContaining({ enabled: true, cleanOnRerun: false }),
+        coverage: expect.objectContaining({ enabled: true, clean: true, cleanOnRerun: false }),
       })
     );
     // The fresh instance cleans the coverage directory itself; no manual clean needed.
@@ -577,7 +578,7 @@ describe('TestManager', () => {
     });
 
     expect(createVitest).not.toHaveBeenCalled();
-    expect(rm).toHaveBeenCalledWith(expect.stringContaining('coverage'), {
+    expect(rm).toHaveBeenCalledWith(resolvePathInStorybookCache(COVERAGE_DIRECTORY), {
       recursive: true,
       force: true,
     });

--- a/code/addons/vitest/src/node/vitest-manager.ts
+++ b/code/addons/vitest/src/node/vitest-manager.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 
 import type {
   CoverageOptions,
@@ -69,7 +70,11 @@ export class VitestManager {
         ? {
             enabled: true,
             clean: true,
-            cleanOnRerun: true,
+            // Vitest runs in watch mode here, so `cleanOnRerun` would let any rerun wipe the
+            // coverage directory while a still-running suite writes its `.tmp` files, crashing
+            // large runs. The directory is cleaned in `runTests` instead, where no run is in
+            // flight.
+            cleanOnRerun: false,
             reportOnFailure: true,
             reporter: [['html', {}], storybookCoverageReporter],
             reportsDirectory: resolvePathInStorybookCache(COVERAGE_DIRECTORY),
@@ -400,6 +405,13 @@ export class VitestManager {
     this.resetGlobalTestNamePattern();
 
     await this.cancelCurrentRun();
+
+    // A freshly (re)started Vitest instance cleans the coverage directory itself (`clean: true`).
+    // When reusing an already coverage-enabled instance, clean it here — after the current run has
+    // been cancelled and drained — so the previous run's results don't leak into this one.
+    if (coverageShouldBeEnabled && currentCoverage) {
+      await rm(resolvePathInStorybookCache(COVERAGE_DIRECTORY), { recursive: true, force: true });
+    }
 
     const testSpecifications = await this.getStorybookTestSpecifications();
     const allStories = this.getStories();


### PR DESCRIPTION
Closes #35508

## What I did

The dev-UI coverage flow starts Vitest in **watch mode** with `cleanOnRerun: true` and a shared `reportsDirectory` inside the Storybook cache. With that combination, any rerun triggered while a large suite is still running lets Vitest wipe the coverage directory while workers are still writing their `.tmp` files — producing exactly the reported crash (`Something removed the coverage directory … ENOENT: … coverage/.tmp/coverage-140.json`) and killing `storybook dev`. The Vitest CLI path doesn't crash because it doesn't run in watch mode, and large suites crash because the race window scales with run duration.

The fix moves coverage cleaning to points the manager controls:

- `cleanOnRerun` is now `false`, so Vitest can never wipe the directory mid-run.
- A freshly (re)started instance still cleans once via the existing `clean: true`.
- When `runTests` reuses an already coverage-enabled instance, it removes the directory explicitly **after** `cancelCurrentRun()` has drained the previous run — the only point where no coverage I/O can be in flight — so results from a previous run don't leak into the next report.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Two additions in `test-manager.test.ts`: the coverage options passed to `createVitest` now include `cleanOnRerun: false`, and reusing a coverage-enabled instance triggers the explicit directory clean at the safe point (while a fresh restart does not, since `clean: true` already covers it). `node:fs/promises` is spied with the memfs redirect pattern used elsewhere in the repo.

Locally verified (WSL2/Ubuntu): the full `test-manager.test.ts` suite passes (18/18) with the fix, and red-green holds — reverting only the `vitest-manager.ts` change makes exactly the two new coverage assertions fail (2 failed | 16 passed).

#### Manual testing

1. Set up a project with `@storybook/addon-vitest` + browser mode + `@vitest/coverage-v8` and a large story suite (the issue reports ~900 tests / ~200 files).
2. Run `storybook dev`, enable coverage in the Tests panel, and run all tests.
3. Before: Vitest crashes near the end with `Something removed the coverage directory … .tmp/coverage-*.json` and `storybook dev` exits. After: the run completes and the coverage summary appears.
4. Run all tests with coverage a second time without restarting Storybook — the report should reflect only the latest run.

### Documentation

- [x] No documentation changes needed (bug fix, no API change).

---

*AI disclosure: implemented with Claude (Anthropic) as coding assistant — investigation, fix and tests were human-reviewed before submission.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch-mode reruns so coverage no longer causes failures from concurrent updates to temporary coverage artifacts.
  * Ensured coverage directories are cleaned between repeated runs, preventing stale or leaked results.
  * Added safeguards for reusing an already coverage-enabled test session by avoiding unnecessary restarts while still performing manual cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->