### PR TITLE
Core: Make FileSystemCache resilient to file system errors

### DIFF
--- a/code/core/src/common/utils/file-cache.test.ts
+++ b/code/core/src/common/utils/file-cache.test.ts
@@ -1,32 +1,47 @@
-import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { vol } from 'memfs';
 import { logger } from 'storybook/internal/node-logger';
 
 import { createFileSystemCache } from './file-cache.ts';
 
-vi.mock('node:fs');
-vi.mock('node:fs/promises');
-vi.mock('storybook/internal/node-logger', () => ({
-  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
-}));
+// Spy-only mocks: keep the real module shapes and redirect fs calls to `memfs`, so disk state
+// stays scoped to `vol`. Individual tests override a single spy to simulate a file system failure.
+vi.mock('node:fs', { spy: true });
+vi.mock('node:fs/promises', { spy: true });
 
 // A non-EBUSY error so writeFileWithRetry rejects immediately without retrying.
 const fsError = Object.assign(new Error('OPEN: operation not permitted'), { code: 'EPERM' });
 
 describe('FileSystemCache', () => {
-  beforeEach(() => {
-    vi.mocked(mkdir).mockResolvedValue(undefined);
-    vi.mocked(writeFile).mockResolvedValue(undefined);
-    vi.mocked(readFile).mockResolvedValue('{}');
-    vi.mocked(readdir).mockResolvedValue([]);
-    vi.mocked(rm).mockResolvedValue(undefined);
+  beforeEach(async () => {
+    const memfs = await vi.importActual<typeof import('memfs')>('memfs');
+
+    vi.mocked(mkdirSync).mockImplementation(memfs.fs.mkdirSync);
+    vi.mocked(writeFileSync).mockImplementation(memfs.fs.writeFileSync);
+    vi.mocked(readFileSync).mockImplementation(memfs.fs.readFileSync);
+    vi.mocked(readdirSync).mockImplementation(memfs.fs.readdirSync);
+    vi.mocked(rmSync).mockImplementation(memfs.fs.rmSync);
+
+    vi.mocked(mkdir).mockImplementation(memfs.fs.promises.mkdir as unknown as typeof mkdir);
+    vi.mocked(writeFile).mockImplementation(
+      memfs.fs.promises.writeFile as unknown as typeof writeFile
+    );
+    vi.mocked(readFile).mockImplementation(
+      memfs.fs.promises.readFile as unknown as typeof readFile
+    );
+    vi.mocked(readdir).mockImplementation(memfs.fs.promises.readdir as unknown as typeof readdir);
+    vi.mocked(rm).mockImplementation(memfs.fs.promises.rm as unknown as typeof rm);
+
+    vi.spyOn(logger, 'debug').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vol.reset();
   });
 
   it('does not throw when the cache directory cannot be created', () => {
@@ -34,15 +49,15 @@ describe('FileSystemCache', () => {
       throw fsError;
     });
 
-    expect(() => createFileSystemCache({ ns: 'test' })).not.toThrow();
+    expect(() => createFileSystemCache({ ns: 'test', basePath: '/cache' })).not.toThrow();
     expect(logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('create the cache directory')
     );
   });
 
   it('degrades gracefully when an async write fails', async () => {
-    vi.mocked(writeFile).mockRejectedValue(fsError);
-    const cache = createFileSystemCache({ ns: 'test' });
+    vi.mocked(writeFile).mockRejectedValueOnce(fsError);
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
 
     await expect(cache.set('key', { some: 'value' })).resolves.toBeUndefined();
     expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('write cache entry "key"'));
@@ -52,15 +67,15 @@ describe('FileSystemCache', () => {
     vi.mocked(writeFileSync).mockImplementationOnce(() => {
       throw fsError;
     });
-    const cache = createFileSystemCache({ ns: 'test' });
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
 
     expect(() => cache.setSync('key', { some: 'value' })).not.toThrow();
     expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('write cache entry "key"'));
   });
 
   it('returns the fallback when a read fails', async () => {
-    vi.mocked(readFile).mockRejectedValue(fsError);
-    const cache = createFileSystemCache({ ns: 'test' });
+    vi.mocked(readFile).mockRejectedValueOnce(fsError);
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
 
     await expect(cache.get('missing', 'fallback')).resolves.toBe('fallback');
   });
@@ -69,30 +84,49 @@ describe('FileSystemCache', () => {
     vi.mocked(readFileSync).mockImplementationOnce(() => {
       throw fsError;
     });
-    const cache = createFileSystemCache({ ns: 'test' });
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
 
     expect(cache.getSync('missing', 'fallback')).toBe('fallback');
   });
 
-  it('returns an empty list when reading all entries fails', async () => {
-    vi.mocked(readdir).mockRejectedValue(fsError);
-    const cache = createFileSystemCache({ ns: 'test' });
+  it('returns an empty list when listing cache entries fails', async () => {
+    vi.mocked(readdir).mockRejectedValueOnce(fsError);
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
+
+    await expect(cache.getAll()).resolves.toEqual([]);
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('read cache entries'));
+  });
+
+  it('returns an empty list when reading a cache entry fails', async () => {
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
+    await cache.set('key', { some: 'value' });
+    vi.mocked(readFile).mockRejectedValueOnce(fsError);
 
     await expect(cache.getAll()).resolves.toEqual([]);
     expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('read cache entries'));
   });
 
   it('does not throw when removing an entry fails', async () => {
-    vi.mocked(rm).mockRejectedValue(fsError);
-    const cache = createFileSystemCache({ ns: 'test' });
+    vi.mocked(rm).mockRejectedValueOnce(fsError);
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
 
     await expect(cache.remove('key')).resolves.toBeUndefined();
     expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('remove cache entry "key"'));
   });
 
+  it('does not throw when removing an entry synchronously fails', () => {
+    vi.mocked(rmSync).mockImplementationOnce(() => {
+      throw fsError;
+    });
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
+
+    expect(() => cache.removeSync('key')).not.toThrow();
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('remove cache entry "key"'));
+  });
+
   it('does not throw when clearing the cache fails', async () => {
-    vi.mocked(readdir).mockRejectedValue(fsError);
-    const cache = createFileSystemCache({ ns: 'test' });
+    vi.mocked(readdir).mockRejectedValueOnce(fsError);
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
 
     await expect(cache.clear()).resolves.toBeUndefined();
     expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('clear the cache'));
@@ -102,14 +136,14 @@ describe('FileSystemCache', () => {
     vi.mocked(readdirSync).mockImplementationOnce(() => {
       throw fsError;
     });
-    const cache = createFileSystemCache({ ns: 'test' });
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
 
     expect(() => cache.clearSync()).not.toThrow();
     expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('clear the cache'));
   });
 
   it('still writes successfully when the file system is healthy', async () => {
-    const cache = createFileSystemCache({ ns: 'test' });
+    const cache = createFileSystemCache({ ns: 'test', basePath: '/cache' });
 
     await cache.set('key', { some: 'value' });
 

--- a/code/core/src/common/utils/file-cache.test.ts
+++ b/code/core/src/common/utils/file-cache.test.ts
@@ -1,0 +1,119 @@
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { logger } from 'storybook/internal/node-logger';
+
+import { createFileSystemCache } from './file-cache.ts';
+
+vi.mock('node:fs');
+vi.mock('node:fs/promises');
+vi.mock('storybook/internal/node-logger', () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// A non-EBUSY error so writeFileWithRetry rejects immediately without retrying.
+const fsError = Object.assign(new Error('OPEN: operation not permitted'), { code: 'EPERM' });
+
+describe('FileSystemCache', () => {
+  beforeEach(() => {
+    vi.mocked(mkdir).mockResolvedValue(undefined);
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+    vi.mocked(readFile).mockResolvedValue('{}');
+    vi.mocked(readdir).mockResolvedValue([]);
+    vi.mocked(rm).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not throw when the cache directory cannot be created', () => {
+    vi.mocked(mkdirSync).mockImplementationOnce(() => {
+      throw fsError;
+    });
+
+    expect(() => createFileSystemCache({ ns: 'test' })).not.toThrow();
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('create the cache directory')
+    );
+  });
+
+  it('degrades gracefully when an async write fails', async () => {
+    vi.mocked(writeFile).mockRejectedValue(fsError);
+    const cache = createFileSystemCache({ ns: 'test' });
+
+    await expect(cache.set('key', { some: 'value' })).resolves.toBeUndefined();
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('write cache entry "key"'));
+  });
+
+  it('degrades gracefully when a sync write fails', () => {
+    vi.mocked(writeFileSync).mockImplementationOnce(() => {
+      throw fsError;
+    });
+    const cache = createFileSystemCache({ ns: 'test' });
+
+    expect(() => cache.setSync('key', { some: 'value' })).not.toThrow();
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('write cache entry "key"'));
+  });
+
+  it('returns the fallback when a read fails', async () => {
+    vi.mocked(readFile).mockRejectedValue(fsError);
+    const cache = createFileSystemCache({ ns: 'test' });
+
+    await expect(cache.get('missing', 'fallback')).resolves.toBe('fallback');
+  });
+
+  it('returns the fallback when a sync read fails', () => {
+    vi.mocked(readFileSync).mockImplementationOnce(() => {
+      throw fsError;
+    });
+    const cache = createFileSystemCache({ ns: 'test' });
+
+    expect(cache.getSync('missing', 'fallback')).toBe('fallback');
+  });
+
+  it('returns an empty list when reading all entries fails', async () => {
+    vi.mocked(readdir).mockRejectedValue(fsError);
+    const cache = createFileSystemCache({ ns: 'test' });
+
+    await expect(cache.getAll()).resolves.toEqual([]);
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('read cache entries'));
+  });
+
+  it('does not throw when removing an entry fails', async () => {
+    vi.mocked(rm).mockRejectedValue(fsError);
+    const cache = createFileSystemCache({ ns: 'test' });
+
+    await expect(cache.remove('key')).resolves.toBeUndefined();
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('remove cache entry "key"'));
+  });
+
+  it('does not throw when clearing the cache fails', async () => {
+    vi.mocked(readdir).mockRejectedValue(fsError);
+    const cache = createFileSystemCache({ ns: 'test' });
+
+    await expect(cache.clear()).resolves.toBeUndefined();
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('clear the cache'));
+  });
+
+  it('does not throw when clearing the cache synchronously fails', () => {
+    vi.mocked(readdirSync).mockImplementationOnce(() => {
+      throw fsError;
+    });
+    const cache = createFileSystemCache({ ns: 'test' });
+
+    expect(() => cache.clearSync()).not.toThrow();
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('clear the cache'));
+  });
+
+  it('still writes successfully when the file system is healthy', async () => {
+    const cache = createFileSystemCache({ ns: 'test' });
+
+    await cache.set('key', { some: 'value' });
+
+    expect(writeFile).toHaveBeenCalledOnce();
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+});

--- a/code/core/src/common/utils/file-cache.ts
+++ b/code/core/src/common/utils/file-cache.ts
@@ -5,6 +5,8 @@ import { mkdir, readFile, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { logger } from 'storybook/internal/node-logger';
+
 import { writeFileWithRetry } from './write-file-with-retry.ts';
 
 interface FileSystemCacheOptions {
@@ -42,7 +44,21 @@ export class FileSystemCache {
       options.basePath || join(tmpdir(), randomBytes(15).toString('base64').replace(/\//g, '-'));
     this.ttl = options.ttl || 0;
     createHash(this.hash_alg); // Verifies hash algorithm is available
-    mkdirSync(this.cache_dir, { recursive: true });
+    // The cache is a best-effort optimization, not mission critical. Creating the
+    // directory can fail (e.g. permissions, antivirus file locks); if it does, we
+    // degrade gracefully and let individual reads/writes fail softly later on.
+    try {
+      mkdirSync(this.cache_dir, { recursive: true });
+    } catch (e) {
+      this.logFailure('create the cache directory', e);
+    }
+  }
+
+  /** Logs a file system failure at debug level without throwing. */
+  private logFailure(action: string, error: unknown): void {
+    logger.debug(
+      `[FileSystemCache] Failed to ${action}: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 
   private generateHash(name: string): string {
@@ -87,18 +103,26 @@ export class FileSystemCache {
     orgOpts: CacheSetOptions | number = {}
   ): Promise<void> {
     const opts: CacheSetOptions = typeof orgOpts === 'number' ? { ttl: orgOpts } : orgOpts;
-    await mkdir(this.cache_dir, { recursive: true });
-    await writeFileWithRetry(this.generateHash(name), this.parseSetData(name, data, opts), {
-      encoding: opts.encoding || 'utf8',
-    });
+    try {
+      await mkdir(this.cache_dir, { recursive: true });
+      await writeFileWithRetry(this.generateHash(name), this.parseSetData(name, data, opts), {
+        encoding: opts.encoding || 'utf8',
+      });
+    } catch (e) {
+      this.logFailure(`write cache entry "${name}"`, e);
+    }
   }
 
   public setSync<T>(name: string, data: T, orgOpts: CacheSetOptions | number = {}): void {
     const opts: CacheSetOptions = typeof orgOpts === 'number' ? { ttl: orgOpts } : orgOpts;
-    mkdirSync(this.cache_dir, { recursive: true });
-    writeFileSync(this.generateHash(name), this.parseSetData(name, data, opts), {
-      encoding: opts.encoding || 'utf8',
-    });
+    try {
+      mkdirSync(this.cache_dir, { recursive: true });
+      writeFileSync(this.generateHash(name), this.parseSetData(name, data, opts), {
+        encoding: opts.encoding || 'utf8',
+      });
+    } catch (e) {
+      this.logFailure(`write cache entry "${name}"`, e);
+    }
   }
 
   public async setMany(items: CacheItem[], options?: CacheSetOptions): Promise<void> {
@@ -110,39 +134,60 @@ export class FileSystemCache {
   }
 
   public async remove(name: string): Promise<void> {
-    await rm(this.generateHash(name), { force: true });
+    try {
+      await rm(this.generateHash(name), { force: true });
+    } catch (e) {
+      this.logFailure(`remove cache entry "${name}"`, e);
+    }
   }
 
   public removeSync(name: string): void {
-    rmSync(this.generateHash(name), { force: true });
+    try {
+      rmSync(this.generateHash(name), { force: true });
+    } catch (e) {
+      this.logFailure(`remove cache entry "${name}"`, e);
+    }
   }
 
   public async clear(): Promise<void> {
-    const files = await readdir(this.cache_dir);
-    await Promise.all(
-      files
-        .filter((f) => f.startsWith(this.prefix))
-        .map((f) => rm(join(this.cache_dir, f), { force: true }))
-    );
+    try {
+      const files = await readdir(this.cache_dir);
+      await Promise.all(
+        files
+          .filter((f) => f.startsWith(this.prefix))
+          .map((f) => rm(join(this.cache_dir, f), { force: true }))
+      );
+    } catch (e) {
+      this.logFailure('clear the cache', e);
+    }
   }
 
   public clearSync(): void {
-    readdirSync(this.cache_dir)
-      .filter((f) => f.startsWith(this.prefix))
-      .forEach((f) => rmSync(join(this.cache_dir, f), { force: true }));
+    try {
+      readdirSync(this.cache_dir)
+        .filter((f) => f.startsWith(this.prefix))
+        .forEach((f) => rmSync(join(this.cache_dir, f), { force: true }));
+    } catch (e) {
+      this.logFailure('clear the cache', e);
+    }
   }
 
   public async getAll(): Promise<CacheItem[]> {
     const now = Date.now();
-    const files = await readdir(this.cache_dir);
-    const items = await Promise.all(
-      files
-        .filter((f) => f.startsWith(this.prefix))
-        .map((f) => readFile(join(this.cache_dir, f), 'utf8'))
-    );
-    return items
-      .map((data) => JSON.parse(data))
-      .filter((entry) => entry.content && !this.isExpired(entry, now));
+    try {
+      const files = await readdir(this.cache_dir);
+      const items = await Promise.all(
+        files
+          .filter((f) => f.startsWith(this.prefix))
+          .map((f) => readFile(join(this.cache_dir, f), 'utf8'))
+      );
+      return items
+        .map((data) => JSON.parse(data))
+        .filter((entry) => entry.content && !this.isExpired(entry, now));
+    } catch (e) {
+      this.logFailure('read cache entries', e);
+      return [];
+    }
   }
 
   public async load(): Promise<{ files: CacheItem[] }> {


### PR DESCRIPTION
Closes #30665

## What I did

The Storybook dev-server cache (`FileSystemCache`, used via the shared `cache` singleton in `storybook/internal/common`) performs file system writes and directory operations that were not wrapped in error handling. On machines where writes to the temp/cache folder can fail — e.g. antivirus tools such as McAfee Solidifier that lock files during creation — an unhandled `EPERM`/`EBUSY`/`OPEN` error would bubble up out of `cache.set(...)` and crash the running Storybook server. Two call sites also invoke `cache.set(...)` without awaiting, so a failure there becomes an unhandled promise rejection.

Reads (`get`/`getSync`) already degraded gracefully to the fallback, and writes already retried on `EBUSY` via `writeFileWithRetry`, but once retries were exhausted (or a non-EBUSY error occurred) the error still crashed the process. Directory creation, removals, `clear`, and `getAll` were completely unguarded.

This PR treats the cache as the best-effort optimization it is: every file system operation now degrades gracefully instead of throwing. A failed write is skipped, a failed read of all entries becomes an empty list, and the failure is logged at `debug` level via the existing `node-logger`.

Changes in `code/core/src/common/utils/file-cache.ts`:
- Wrap the constructor's `mkdirSync` so cache creation can never crash at import time (the shared `cache` singleton is created on module load).
- Wrap `set` / `setSync` (and therefore `setMany` / `setManySync`, which delegate).
- Wrap `remove` / `removeSync`, `clear` / `clearSync`, and `getAll` (and therefore `load`, which delegates).
- Add a small private `logFailure(action, error)` helper for consistent, non-throwing `logger.debug` logging.

Reads were already safe and are left unchanged. `createHash(this.hash_alg)` intentionally still throws — an unavailable hash algorithm is a configuration error, not a file system error.

## Scope note

The original issue also lists unchecked fs writes in a few other places (`builder-manager/utils/files.ts`, `csf-tools/ConfigFile.ts`, the builder-vite external-globals plugin, and the create-storybook `configure.ts` generator). I kept this PR focused on `file-cache.ts` — the crux of the "cache is unstable" report. Happy to address the others here or in a follow-up if desired; are any of them already tracked elsewhere?

## Tests

Added `code/core/src/common/utils/file-cache.test.ts` (there was no existing test for this file). It follows the sibling `write-file-with-retry.test.ts` mocking conventions, forces each operation to fail, and asserts the cache degrades gracefully (does not throw, returns the fallback / an empty list) and logs at debug — plus a happy-path test proving normal writes still work. 10/10 pass locally with vitest typecheck enabled; `oxfmt` and `lint:js` are clean on the changed files.

#### Manual testing

1. In any project with Storybook installed, make the cache directory unwritable — e.g. find the Storybook cache folder under your OS temp directory (or `node_modules/.cache/storybook`) and `chmod -R a-w` it, or use a tool that locks freshly created files (the original report used McAfee Solidifier).
2. Before this change: running `storybook dev` crashes with an unhandled `EPERM`/`OPEN` error from `cache.set(...)` (e.g. from telemetry or the update check).
3. With this change: the server starts and keeps running; cache writes are skipped. Run with `--loglevel debug` to see the `[FileSystemCache] Failed to ...` messages.
4. Restore write permissions and confirm caching works again (no debug messages, cache files created).

## Direction

Following @valentinpalkovic's guidance on the issue ("please feel free to pick up the work and contribute a PR, since the solution seems to be pretty straightforward") — harden the file system access so cache failures degrade instead of crashing the server.

## AI disclosure

Per the CONTRIBUTING guide: this change was prepared with the assistance of Claude. I reviewed the change and am submitting it myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem cache resilience when cache directory creation or read/write operations fail.
  * Cache `get` now returns the provided fallback on failures; `getAll` returns an empty list when listing/read fails.
  * Cache `set`, `remove`, and `clear` failures no longer interrupt execution.
  * Added debug logging to help diagnose cache-related filesystem errors.
* **Tests**
  * Added automated coverage for cache error-handling and logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->