### PR TITLE
Test: Record Angular legacy docgen and snippet baselines in the harness

### DIFF
--- a/code/core/src/manager/components/review/screens/SummaryScreen.tsx
+++ b/code/core/src/manager/components/review/screens/SummaryScreen.tsx
@@ -239,9 +239,10 @@ const CollectionLandmark: FC<{ titleId: string; children: ReactNode }> = ({
   );
 };
 
-// A `contentinfo` landmark must stay top-level, but this footer is rendered
-// inside the `main` landmark, so it is exposed as a named `region` instead
-// (a `<footer>` nested in `<main>` has no implicit `contentinfo` role).
+// A `contentinfo` landmark must stay top-level, but this footer sits inside the
+// `main` landmark, so it is exposed as a named `region` instead. It renders as a
+// `section` because `region` is not an allowed role on `footer` (aria-allowed-role),
+// and a `<footer>` nested in `<main>` has no implicit `contentinfo` role anyway.
 const FooterLandmark: FC<{ children: ReactNode }> = ({ children }) => {
   const regionRef = useRef<HTMLDivElement>(null);
   const { landmarkProps } = useLandmark(
@@ -249,7 +250,7 @@ const FooterLandmark: FC<{ children: ReactNode }> = ({ children }) => {
     regionRef
   );
   return (
-    <Footer as="footer" ref={regionRef} {...landmarkProps}>
+    <Footer as="section" ref={regionRef} {...landmarkProps}>
       {children}
     </Footer>
   );

--- a/code/lib/docgen-harness/README.md
+++ b/code/lib/docgen-harness/README.md
@@ -20,7 +20,22 @@ code/lib/docgen-harness/src/
 │           ├── *.ts                      # supporting sources some cases need
 │           ├── argtypes.snapshot         # normalized StrictArgTypes from the legacy extractArgTypes path
 │           └── snippet-<story>.snapshot  # legacy Source-block snippet per named story export
-├── angular/            (planned, same shape - not created yet)
+├── angular/
+│   ├── angular-baselines.test.ts    # legacy baseline recorder (argTypes both flag states + snippets)
+│   ├── angular-legacy-gaps.test.ts  # test.fails red markers for the closeable legacy gaps
+│   ├── angular-render.test.ts       # JIT TestBed render smoke test (happy-dom, decorator fixtures)
+│   ├── csf-types.ts                 # type-only CSF re-export the fixture stories import
+│   └── __testfixtures__/
+│       └── <fixture-case>/
+│           ├── <case-name>.component.ts    # the component under test; its class name IS the recorded identity
+│           ├── input.stories.ts            # real CSF stories driving the snippet baselines
+│           ├── *.ts                        # supporting sources some cases need
+│           ├── tsconfig.json               # capture-scoped tsconfig for the compodoc run
+│           ├── compodoc-input.json         # captured compodoc output the recorder feeds to setCompodocJson
+│           ├── aot-cmp.ts                  # signal fixtures only: captured AOT ɵcmp input/output maps
+│           ├── argtypes.snapshot           # normalized argTypes, angularFilterNonInputControls OFF
+│           ├── argtypes-filtered.snapshot  # same with the filter flag ON
+│           └── snippet-<story>.snapshot    # legacy Source-block snippet per named story export
 ├── svelte/             (planned, same shape - not created yet)
 └── web-components/     (planned, same shape - not created yet)
 ```
@@ -31,8 +46,26 @@ code/lib/docgen-harness/src/
 - vue3: exactly one PascalCase SFC per case.
   The filename becomes `displayName` and therefore the component tag in every snippet - never share a filename like `input.vue`.
 - Both baseline layers come from one production-faithful `parse()` call per fixture: zero options, plugin-exact `__docgenInfo` attach.
+- angular: one kebab-case `<case-name>.component.ts` per case; the PascalCase class name must byte-match the captured compodoc entry (`findComponentByName` is name-only).
+  The recorder drives the full production entry: `setCompodocJson(compodoc-input.json)` then `extractArgTypes(class)`, recorded with `angularFilterNonInputControls` OFF and ON; snippets come from `computesTemplateSourceFromComponent` with `{ ...meta.args, ...story.args }`.
+- angular: signal members (`input()`/`output()`/`model()`) are invisible to JIT - `ɵcmp.inputs`/`ɵcmp.outputs` stay empty without AOT.
+  Signal fixtures therefore commit an `aot-cmp.ts`: the runtime `ɵcmp` maps captured from real `ngc` output (@angular/compiler-cli 21.2.17, compiled and loaded once to read the processed maps).
+  The recorder attaches it wholesale before snippet generation and asserts the production reader sees its members, so a broken attach fails loudly.
+- angular: fixture stories import their CSF types from `src/angular/csf-types.ts`, and `angular-baselines.test.ts` / `angular-render.test.ts` are excluded from the package's vue-tsc program - angular-vite client source is authored under `strict: false` and cannot join this strict program; vitest is those two files' check.
 - Snapshots must be deterministic: no timestamps, no absolute paths.
-  OS-sensitive engines use OS-suffixed snapshot files (see `compodoc-*.snapshot` in `code/frameworks/angular-vite`).
+  Committed compodoc captures make OS-suffixed snapshots unnecessary here: no path-sensitive layer is ever snapshotted.
+
+### Compodoc capture procedure (angular)
+
+Captures are pinned to `@compodoc/compodoc@2.0.0`; re-capturing with any other version (signal parsing drifts hard across versions) is a reviewed baseline change, never a silent one.
+Compodoc scans every `.ts` under the nearest `package.json` ancestor and ignores tsconfig `include`, so captures run from a staging directory outside any Node package:
+
+1. Copy the case's component and supporting sources (never `input.stories.ts`) plus its `tsconfig.json` into an empty directory outside the repo, e.g. `$(mktemp -d)`.
+2. In that directory, run `npx -y @compodoc/compodoc@2.0.0 -p tsconfig.json -e json -d .`.
+3. Move the emitted `documentation.json` back into the case directory as `compodoc-input.json`.
+4. Run `cd code && yarn fmt:write` - captures are committed in the repo formatter's shape (the `doc-model` precedent), not compodoc's raw indentation.
+
+The result has case-relative `file` fields and no absolute paths; capture plus format is byte-reproducible.
 
 ## Known legacy gaps (vue3)
 
@@ -72,6 +105,30 @@ Each line has a matching red marker in `vue3-legacy-gaps.test.ts`.
   The issue reports the `vue-component-meta` engine losing slot doc comments, defaults, and HMR; these baselines record the `vue-docgen-api` path, so the marker covers only the binding-type symptom, not the issue's own repro.
 - #29354 -> `cross-file-union-alias/`: imported literal-union aliases must unfold to their options (legacy records the alias name only).
 - #30045 -> `type-intersection-whole/`: an intersection as the whole `defineProps<>` type argument must resolve its props (legacy extracts none).
+
+## Known legacy gaps (angular)
+
+Same rules as vue3: thin or wrong output is recorded as-is, closeable gaps carry `test.fails` markers in `src/angular/angular-legacy-gaps.test.ts`, and `src/angular/baseline-path.ts` hardens them on the `'osa'` flip.
+
+- Accepted deltas (Story 4.6's v1 scope, no markers): snippets are bindings-only - no ng-content children, no banana-in-a-box for `model()`, functions and explicit `undefined` interpolate raw, outputs always render `(name)="name($event)"`.
+- Every decorator input records `required: true` - compodoc never emits `optional`, not even for TS-`?` members (#28706).
+- Number-typed inputs without a literal default record an invented `NaN` default (`Number(undefined)`); numeric expression defaults like `5 * 60 * 1000` also collapse to `NaN`, losing the source text.
+- Non-numeric expression defaults record raw source strings (`Math.max(1, 3)`).
+- JSDoc tags never reach argTypes structurally: `@deprecated` vanishes entirely, `@see`/custom tag text leaks into the description prose, and `@default` values keep their quotes and a trailing newline (#28506).
+- `function`, `any`, and generic (`T`, `T[]`) type strings collapse to `{ name: 'other', value: 'empty-enum' }`.
+- Literal unions, alias unions, and TS enums all RESOLVE to enum sbTypes at compodoc 2.0.0 (it double-quotes union type strings, which makes them JSON-parseable) - the #33779 collapse does not reproduce at this version.
+- Cross-file inheritance is fully resolved: inherited `@Input`/`@Output` members land in the component's own capture entries (a regression baseline, not a gap).
+- With `angularFilterNonInputControls` OFF, `properties`/`methods`/`view child` sections surface as argTypes - including private fields - which is why the flag exists (#22007); ON restricts to inputs, and the model() `${name}Change` synthesis survives it by design.
+- `model()` records the patched shape: one input entry plus a synthesized `${name}Change` output with no `table.defaultValue`; boolean-typed entries without defaults record `defaultValue.summary: false` from the cast quirk.
+- Snippets use only the first comma-separated selector, and attribute selectors are mangled to bare attributes (`button[x]` -> `<button x>`).
+
+## Issue-linked cases (angular)
+
+- #28706 -> `decorator-io-basics/`: TS-optional decorator inputs must record `required: false` (legacy: `required: true` everywhere, plus the invented `NaN` default). Red markers in `angular-legacy-gaps.test.ts`.
+- #28506 -> `jsdoc-tags/`: member JSDoc tags must reach `table.jsDocTags` structurally (legacy: nothing structured; `@deprecated` is lost). Red marker.
+- #33779 (not reproduced) -> `decorator-union-enum/`: the reported union-controls collapse does not occur at the pinned compodoc 2.0.0 - all three union/enum inputs resolve to enum sbTypes, recorded as an engine-swap regression baseline; no marker.
+- #29697 (not reproduced) -> `signal-io/`: the aliased `input(_, { alias })` records under its alias at 2.0.0, so the reported alias blindness does not occur; regression baseline, no marker.
+- #22007 -> `properties-methods-noise/`: the filter flag's origin case; both flag states are recorded, and this is the fixture where they meaningfully differ.
 
 ## What does not live here
 

--- a/code/lib/docgen-harness/README.md
+++ b/code/lib/docgen-harness/README.md
@@ -47,7 +47,7 @@ code/lib/docgen-harness/src/
   The filename becomes `displayName` and therefore the component tag in every snippet - never share a filename like `input.vue`.
 - Both baseline layers come from one production-faithful `parse()` call per fixture: zero options, plugin-exact `__docgenInfo` attach.
 - angular: one kebab-case `<case-name>.component.ts` per case; the PascalCase class name must byte-match the captured compodoc entry (`findComponentByName` is name-only).
-  The recorder drives the full production entry: `setCompodocJson(compodoc-input.json)` then `extractArgTypes(class)`, recorded with `angularFilterNonInputControls` OFF and ON; snippets come from `computesTemplateSourceFromComponent` with `{ ...meta.args, ...story.args }`.
+  The recorder drives the full production entry: `setCompodocJson(compodoc-input.json)` then `extractArgTypes(class)`, recorded with `angularFilterNonInputControls` OFF and ON; snippets come from `computesTemplateSourceFromComponent` with `{ ...meta.args, ...story.args }` plus a stub arg per unset output argType, mirroring the actions addon's args enhancer that production always runs.
 - angular: signal members (`input()`/`output()`/`model()`) are invisible to JIT - `ɵcmp.inputs`/`ɵcmp.outputs` stay empty without AOT.
   Signal fixtures therefore commit an `aot-cmp.ts`: the runtime `ɵcmp` maps captured from real `ngc` output (@angular/compiler-cli 21.2.17, compiled and loaded once to read the processed maps).
   The recorder attaches it wholesale before snippet generation and asserts the production reader sees its members, so a broken attach fails loudly.
@@ -66,6 +66,12 @@ Compodoc scans every `.ts` under the nearest `package.json` ancestor and ignores
 4. Run `cd code && yarn fmt:write` - captures are committed in the repo formatter's shape (the `doc-model` precedent), not compodoc's raw indentation.
 
 The result has case-relative `file` fields and no absolute paths; capture plus format is byte-reproducible.
+
+Nothing in the tests detects drift between a fixture's `.ts` sources and its committed `compodoc-input.json`.
+Editing a fixture component or its supporting sources therefore always requires a re-capture in the same change.
+
+The signal fixtures' `aot-cmp.ts` maps follow the same rule: they are captured once from real `ngc` output (`@angular/compiler-cli` 21.2.17) by compiling the staged component and reading the emitted class's `ɵcmp.inputs`/`ɵcmp.outputs`, and re-capturing with another Angular version is a reviewed baseline change.
+The production reader consumes only each input tuple's first slot and the plain output strings; the remaining tuple slots are carried for shape fidelity only.
 
 ## Known legacy gaps (vue3)
 
@@ -110,11 +116,11 @@ Each line has a matching red marker in `vue3-legacy-gaps.test.ts`.
 
 Same rules as vue3: thin or wrong output is recorded as-is, closeable gaps carry `test.fails` markers in `src/angular/angular-legacy-gaps.test.ts`, and `src/angular/baseline-path.ts` hardens them on the `'osa'` flip.
 
-- Accepted deltas (Story 4.6's v1 scope, no markers): snippets are bindings-only - no ng-content children, no banana-in-a-box for `model()`, functions and explicit `undefined` interpolate raw, outputs always render `(name)="name($event)"`.
+- Accepted deltas (the documented v1 scope of the OSA snippet work, no markers): snippets are bindings-only - no ng-content children, no banana-in-a-box for `model()`, functions and explicit `undefined` interpolate raw, outputs always render `(name)="name($event)"`.
 - Every decorator input records `required: true` - compodoc never emits `optional`, not even for TS-`?` members (#28706).
 - Number-typed inputs without a literal default record an invented `NaN` default (`Number(undefined)`); numeric expression defaults like `5 * 60 * 1000` also collapse to `NaN`, losing the source text.
 - Non-numeric expression defaults record raw source strings (`Math.max(1, 3)`).
-- JSDoc tags never reach argTypes structurally: `@deprecated` vanishes entirely, `@see`/custom tag text leaks into the description prose, and `@default` values keep their quotes and a trailing newline (#28506).
+- JSDoc tags never reach argTypes structurally: `@deprecated` vanishes entirely (#9721 tracks displaying it), `@see`/custom tag text leaks into the description prose, and `@default` values keep their quotes and a trailing newline.
 - `function`, `any`, and generic (`T`, `T[]`) type strings collapse to `{ name: 'other', value: 'empty-enum' }`.
 - Literal unions, alias unions, and TS enums all RESOLVE to enum sbTypes at compodoc 2.0.0 (it double-quotes union type strings, which makes them JSON-parseable) - the #33779 collapse does not reproduce at this version.
 - Cross-file inheritance is fully resolved: inherited `@Input`/`@Output` members land in the component's own capture entries (a regression baseline, not a gap).
@@ -125,7 +131,7 @@ Same rules as vue3: thin or wrong output is recorded as-is, closeable gaps carry
 ## Issue-linked cases (angular)
 
 - #28706 -> `decorator-io-basics/`: TS-optional decorator inputs must record `required: false` (legacy: `required: true` everywhere, plus the invented `NaN` default). Red markers in `angular-legacy-gaps.test.ts`.
-- #28506 -> `jsdoc-tags/`: member JSDoc tags must reach `table.jsDocTags` structurally (legacy: nothing structured; `@deprecated` is lost). Red marker.
+- #9721 -> `jsdoc-tags/`: `@deprecated` props must surface in docs, which needs member JSDoc tags to reach `table.jsDocTags` structurally (legacy: nothing structured; `@deprecated` is lost). Red marker.
 - #33779 (not reproduced) -> `decorator-union-enum/`: the reported union-controls collapse does not occur at the pinned compodoc 2.0.0 - all three union/enum inputs resolve to enum sbTypes, recorded as an engine-swap regression baseline; no marker.
 - #29697 (not reproduced) -> `signal-io/`: the aliased `input(_, { alias })` records under its alias at 2.0.0, so the reported alias blindness does not occur; regression baseline, no marker.
 - #22007 -> `properties-methods-noise/`: the filter flag's origin case; both flag states are recorded, and this is the fixture where they meaningfully differ.

--- a/code/lib/docgen-harness/package.json
+++ b/code/lib/docgen-harness/package.json
@@ -26,12 +26,20 @@
     "./package.json": "./package.json"
   },
   "devDependencies": {
+    "@angular/common": "^21.2.14",
+    "@angular/compiler": "^21.2.14",
+    "@angular/core": "^21.2.14",
+    "@angular/platform-browser": "^21.2.14",
+    "@angular/platform-browser-dynamic": "^21.2.14",
+    "@storybook/angular-vite": "workspace:*",
     "@storybook/vue3": "workspace:*",
     "@testing-library/vue": "^8.0.0",
     "@vitejs/plugin-vue": "^4.6.2",
+    "rxjs": "^7.4.0",
     "typescript": "^6.0.3",
     "vue": "^3.2.47",
     "vue-docgen-api": "^4.75.1",
-    "vue-tsc": "latest"
+    "vue-tsc": "latest",
+    "zone.js": "^0.16.2"
   }
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/argtypes-filtered.snapshot
@@ -1,0 +1,20 @@
+{
+  "emphasis": {
+    "description": "
+",
+    "name": "emphasis",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "boolean",
+      },
+    },
+    "type": {
+      "name": "boolean",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/argtypes.snapshot
@@ -1,0 +1,20 @@
+{
+  "emphasis": {
+    "description": "
+",
+    "name": "emphasis",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "boolean",
+      },
+    },
+    "type": {
+      "name": "boolean",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/complex-selector.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/complex-selector.component.ts
@@ -1,0 +1,9 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'button[sb-harness-action], a[sb-harness-action]',
+  template: '<span class="chip">{{ emphasis }}</span>',
+})
+export class ComplexSelectorComponent {
+  @Input() emphasis = false;
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/compodoc-input.json
@@ -1,0 +1,87 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "ComplexSelectorComponent",
+      "id": "component-ComplexSelectorComponent-260b1794ac77a84b6b28eeb3fb7556027fee759d38af2efefa3ffdf647d02ed32f9173bec3e05c06eaa6a6d2d2f15ac373da8443e93a0edf15f5d8f13887aaa0",
+      "file": "complex-selector.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "button[sb-harness-action], a[sb-harness-action]",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<span class=\"chip\">{{ emphasis }}</span>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "emphasis",
+          "defaultValue": "false",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 8,
+          "type": "boolean",
+          "decorators": []
+        }
+      ],
+      "outputsClass": [],
+      "propertiesClass": [],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import { Component, Input } from '@angular/core';\n\n@Component({\n  selector: 'button[sb-harness-action], a[sb-harness-action]',\n  template: '<span class=\"chip\">{{ emphasis }}</span>',\n})\nexport class ComplexSelectorComponent {\n  @Input() emphasis = false;\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": [],
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 0,
+    "status": "low",
+    "files": [
+      {
+        "filePath": "complex-selector.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "ComplexSelectorComponent",
+        "coveragePercent": 0,
+        "coverageCount": "0/2",
+        "status": "low"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/input.stories.ts
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { ComplexSelectorComponent } from './complex-selector.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/ComplexSelector',
+  component: ComplexSelectorComponent,
+} satisfies Meta<ComplexSelectorComponent>;
+
+export default meta;
+
+export const PropsAsWritten: StoryObj<ComplexSelectorComponent> = {
+  args: { emphasis: true },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<button sb-harness-action [emphasis]="true"></button>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/argtypes-filtered.snapshot
@@ -1,0 +1,38 @@
+{
+  "dismissible": {
+    "description": "
+Whether the alert shows a close button.",
+    "name": "dismissible",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "boolean",
+      },
+    },
+    "type": {
+      "name": "boolean",
+    },
+  },
+  "heading": {
+    "description": "
+",
+    "name": "heading",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/argtypes.snapshot
@@ -1,0 +1,57 @@
+{
+  "dismissed": {
+    "action": "dismissed",
+    "description": undefined,
+    "name": "dismissed",
+    "table": {
+      "category": "outputs",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": true,
+        "summary": "EventEmitter",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+  "dismissible": {
+    "description": "
+Whether the alert shows a close button.",
+    "name": "dismissible",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "boolean",
+      },
+    },
+    "type": {
+      "name": "boolean",
+    },
+  },
+  "heading": {
+    "description": "
+",
+    "name": "heading",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/base.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/base.component.ts
@@ -1,0 +1,8 @@
+import { EventEmitter, Input, Output } from '@angular/core';
+
+export abstract class BaseAlertComponent {
+  /** Whether the alert shows a close button. */
+  @Input() dismissible = false;
+
+  @Output() dismissed = new EventEmitter<void>();
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/compodoc-input.json
@@ -1,0 +1,181 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [
+    {
+      "name": "BaseAlertComponent",
+      "id": "class-BaseAlertComponent-456480b84d05e90cef808138d41d57b91979d3adba5b134d9d2a7028cffe398c20d688217be568620f6809342d3e94af7554c902a46c11990a0d0141c9f95e43",
+      "file": "base.component.ts",
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "type": "class",
+      "sourceCode": "import { EventEmitter, Input, Output } from '@angular/core';\n\nexport abstract class BaseAlertComponent {\n  /** Whether the alert shows a close button. */\n  @Input() dismissible = false;\n\n  @Output() dismissed = new EventEmitter<void>();\n}\n",
+      "displayName": "BaseAlertComponent",
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "dismissible",
+          "defaultValue": "false",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\nWhether the alert shows a close button.",
+          "description": "<p>Whether the alert shows a close button.</p>\n",
+          "line": 5,
+          "type": "boolean",
+          "decorators": []
+        }
+      ],
+      "outputsClass": [
+        {
+          "name": "dismissed",
+          "coverageIgnore": false,
+          "defaultValue": "new EventEmitter<void>()",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "line": 7,
+          "type": "EventEmitter"
+        }
+      ],
+      "properties": [],
+      "methods": [],
+      "indexSignatures": [],
+      "extends": [],
+      "hostBindings": [],
+      "hostListeners": [],
+      "relationships": {
+        "incoming": [
+          {
+            "name": "CrossFileInheritanceComponent",
+            "type": "component"
+          }
+        ],
+        "outgoing": []
+      }
+    }
+  ],
+  "directives": [],
+  "components": [
+    {
+      "name": "CrossFileInheritanceComponent",
+      "id": "component-CrossFileInheritanceComponent-76bbf65a6cdab052222602861c3fe7252096a37d2ebfcfa8d5d8c9ee7d44ad6e033f62b9e0f69400ad84ba4fdc103f293635c430f37a405e7026beba76315e47",
+      "file": "cross-file-inheritance.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-cross-file-inheritance",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<div role=\"alert\" (click)=\"dismissed.emit()\">{{ heading }} {{ dismissible }}</div>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "heading",
+          "defaultValue": "''",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 10,
+          "type": "string",
+          "decorators": []
+        },
+        {
+          "coverageIgnore": false,
+          "name": "dismissible",
+          "defaultValue": "false",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\nWhether the alert shows a close button.",
+          "description": "<p>Whether the alert shows a close button.</p>\n",
+          "line": 5,
+          "type": "boolean",
+          "decorators": [],
+          "inheritance": {
+            "file": "BaseAlertComponent"
+          }
+        }
+      ],
+      "outputsClass": [
+        {
+          "name": "dismissed",
+          "coverageIgnore": false,
+          "defaultValue": "new EventEmitter<void>()",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "line": 7,
+          "type": "EventEmitter",
+          "inheritance": {
+            "file": "BaseAlertComponent"
+          }
+        }
+      ],
+      "propertiesClass": [],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import { Component, Input } from '@angular/core';\n\nimport { BaseAlertComponent } from './base.component.ts';\n\n@Component({\n  selector: 'sb-cross-file-inheritance',\n  template: '<div role=\"alert\" (click)=\"dismissed.emit()\">{{ heading }} {{ dismissible }}</div>',\n})\nexport class CrossFileInheritanceComponent extends BaseAlertComponent {\n  @Input() heading = '';\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": ["BaseAlertComponent"],
+      "relationships": {
+        "incoming": [],
+        "outgoing": [
+          {
+            "name": "BaseAlertComponent",
+            "type": "class"
+          }
+        ]
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 12,
+    "status": "low",
+    "files": [
+      {
+        "filePath": "base.component.ts",
+        "type": "class",
+        "linktype": "classe",
+        "name": "BaseAlertComponent",
+        "coveragePercent": 0,
+        "coverageCount": "0/1",
+        "status": "low"
+      },
+      {
+        "filePath": "cross-file-inheritance.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "CrossFileInheritanceComponent",
+        "coveragePercent": 25,
+        "coverageCount": "1/4",
+        "status": "low"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/cross-file-inheritance.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/cross-file-inheritance.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+import { BaseAlertComponent } from './base.component.ts';
+
+@Component({
+  selector: 'sb-cross-file-inheritance',
+  template: '<div role="alert" (click)="dismissed.emit()">{{ heading }} {{ dismissible }}</div>',
+})
+export class CrossFileInheritanceComponent extends BaseAlertComponent {
+  @Input() heading = '';
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/input.stories.ts
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { CrossFileInheritanceComponent } from './cross-file-inheritance.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/CrossFileInheritance',
+  component: CrossFileInheritanceComponent,
+} satisfies Meta<CrossFileInheritanceComponent>;
+
+export default meta;
+
+export const PropsAsWritten: StoryObj<CrossFileInheritanceComponent> = {
+  args: { heading: 'Storage almost full', dismissible: true },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-cross-file-inheritance [dismissible]="true" [heading]="'Storage almost full'"></sb-cross-file-inheritance>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/snippet-PropsAsWritten.snapshot
@@ -1,1 +1,1 @@
-<sb-cross-file-inheritance [dismissible]="true" [heading]="'Storage almost full'"></sb-cross-file-inheritance>
+<sb-cross-file-inheritance [dismissible]="true" [heading]="'Storage almost full'" (dismissed)="dismissed($event)"></sb-cross-file-inheritance>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/argtypes-filtered.snapshot
@@ -1,0 +1,40 @@
+{
+  "items": {
+    "description": "
+",
+    "name": "items",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "[]",
+      },
+      "type": {
+        "required": true,
+        "summary": "T[]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+  "selected": {
+    "description": "
+",
+    "name": "selected",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": true,
+        "summary": "T",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/argtypes.snapshot
@@ -1,0 +1,40 @@
+{
+  "items": {
+    "description": "
+",
+    "name": "items",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "[]",
+      },
+      "type": {
+        "required": true,
+        "summary": "T[]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+  "selected": {
+    "description": "
+",
+    "name": "selected",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": true,
+        "summary": "T",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/compodoc-input.json
@@ -1,0 +1,98 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "DecoratorGenericComponent",
+      "id": "component-DecoratorGenericComponent-6a48e595066efee336431d0609944fee1702f1b7de4acb15246287579cc8b6dfaf0b073ce8971024f1ce9c437f6daeb72a9ae81b414b7c37dc3eaf55010551c2",
+      "file": "decorator-generic.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-decorator-generic",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<ul>@for (item of items; track $index) {<li>{{ item }}</li>}</ul>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "items",
+          "defaultValue": "[]",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 8,
+          "type": "T[]",
+          "decorators": []
+        },
+        {
+          "coverageIgnore": false,
+          "name": "selected",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 10,
+          "type": "T",
+          "decorators": []
+        }
+      ],
+      "outputsClass": [],
+      "propertiesClass": [],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import { Component, Input } from '@angular/core';\n\n@Component({\n  selector: 'sb-decorator-generic',\n  template: '<ul>@for (item of items; track $index) {<li>{{ item }}</li>}</ul>',\n})\nexport class DecoratorGenericComponent<T> {\n  @Input() items: T[] = [];\n\n  @Input() selected?: T;\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": [],
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 0,
+    "status": "low",
+    "files": [
+      {
+        "filePath": "decorator-generic.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "DecoratorGenericComponent",
+        "coveragePercent": 0,
+        "coverageCount": "0/3",
+        "status": "low"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/decorator-generic.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/decorator-generic.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'sb-decorator-generic',
+  template: '<ul>@for (item of items; track $index) {<li>{{ item }}</li>}</ul>',
+})
+export class DecoratorGenericComponent<T> {
+  @Input() items: T[] = [];
+
+  @Input() selected?: T;
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/input.stories.ts
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { DecoratorGenericComponent } from './decorator-generic.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/DecoratorGeneric',
+  component: DecoratorGenericComponent,
+} satisfies Meta<DecoratorGenericComponent<string>>;
+
+export default meta;
+
+export const PropsAsWritten: StoryObj<DecoratorGenericComponent<string>> = {
+  args: { items: ['alpha', 'beta'], selected: 'alpha' },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-generic [items]="['alpha', 'beta']" [selected]="'alpha'"></sb-decorator-generic>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/argtypes-filtered.snapshot
@@ -1,0 +1,20 @@
+{
+  "volume": {
+    "description": "
+Playback volume, clamped between 0 and 10.",
+    "name": "volume",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": NaN,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/argtypes.snapshot
@@ -1,0 +1,38 @@
+{
+  "innerVolume": {
+    "description": "
+",
+    "name": "innerVolume",
+    "table": {
+      "category": "properties",
+      "defaultValue": {
+        "summary": 5,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+  "volume": {
+    "description": "
+Playback volume, clamped between 0 and 10.",
+    "name": "volume",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": NaN,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/compodoc-input.json
@@ -1,0 +1,147 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "DecoratorGetterSetterComponent",
+      "id": "component-DecoratorGetterSetterComponent-26d145cd7e5479dcca9a6c38231152762f0080cb67fe46528f03da980df77d987429eea3714bdc1086fa14a4b423b72ae07fe3193ba985b4e26bd92903b171c9",
+      "file": "decorator-getter-setter.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-decorator-getter-setter",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<span>{{ volume }}</span>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "volume",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\nPlayback volume, clamped between 0 and 10.",
+          "description": "<p>Playback volume, clamped between 0 and 10.</p>\n",
+          "line": 12,
+          "type": "number",
+          "decorators": []
+        }
+      ],
+      "outputsClass": [],
+      "propertiesClass": [
+        {
+          "name": "innerVolume",
+          "coverageIgnore": false,
+          "defaultValue": "5",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "number",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 8,
+          "rawdescription": "\n",
+          "modifierKind": [123]
+        }
+      ],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import { Component, Input } from '@angular/core';\n\n@Component({\n  selector: 'sb-decorator-getter-setter',\n  template: '<span>{{ volume }}</span>',\n})\nexport class DecoratorGetterSetterComponent {\n  private innerVolume = 5;\n\n  /** Playback volume, clamped between 0 and 10. */\n  @Input()\n  get volume(): number {\n    return this.innerVolume;\n  }\n  set volume(value: number) {\n    this.innerVolume = Math.min(10, Math.max(0, value));\n  }\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": [],
+      "accessors": {
+        "volume": {
+          "name": "volume",
+          "setSignature": {
+            "name": "volume",
+            "type": "void",
+            "deprecated": false,
+            "deprecationMessage": "",
+            "args": [
+              {
+                "name": "value",
+                "type": "number",
+                "optional": false,
+                "dotDotDotToken": false,
+                "deprecated": false,
+                "deprecationMessage": ""
+              }
+            ],
+            "returnType": "void",
+            "line": 15,
+            "rawdescription": "\n",
+            "description": "",
+            "jsdoctags": [
+              {
+                "name": "value",
+                "type": "number",
+                "optional": false,
+                "dotDotDotToken": false,
+                "deprecated": false,
+                "deprecationMessage": "",
+                "tagName": {
+                  "text": "param"
+                }
+              }
+            ]
+          },
+          "getSignature": {
+            "name": "volume",
+            "type": "number",
+            "returnType": "number",
+            "line": 12,
+            "rawdescription": "\nPlayback volume, clamped between 0 and 10.",
+            "description": "<p>Playback volume, clamped between 0 and 10.</p>\n"
+          }
+        }
+      },
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 33,
+    "status": "medium",
+    "files": [
+      {
+        "filePath": "decorator-getter-setter.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "DecoratorGetterSetterComponent",
+        "coveragePercent": 33,
+        "coverageCount": "1/3",
+        "status": "medium"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/decorator-getter-setter.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/decorator-getter-setter.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'sb-decorator-getter-setter',
+  template: '<span>{{ volume }}</span>',
+})
+export class DecoratorGetterSetterComponent {
+  private innerVolume = 5;
+
+  /** Playback volume, clamped between 0 and 10. */
+  @Input()
+  get volume(): number {
+    return this.innerVolume;
+  }
+  set volume(value: number) {
+    this.innerVolume = Math.min(10, Math.max(0, value));
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/input.stories.ts
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { DecoratorGetterSetterComponent } from './decorator-getter-setter.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/DecoratorGetterSetter',
+  component: DecoratorGetterSetterComponent,
+} satisfies Meta<DecoratorGetterSetterComponent>;
+
+export default meta;
+
+export const PropsAsWritten: StoryObj<DecoratorGetterSetterComponent> = {
+  args: { volume: 7 },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-getter-setter [volume]="7"></sb-decorator-getter-setter>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/argtypes-filtered.snapshot
@@ -1,0 +1,76 @@
+{
+  "count": {
+    "description": "
+",
+    "name": "count",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": NaN,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+  "data": {
+    "description": "
+",
+    "name": "data",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": true,
+        "summary": "any",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+  "formatter": {
+    "description": "
+",
+    "name": "formatter",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": true,
+        "summary": "function",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+  "label": {
+    "description": "
+The text shown on the badge.",
+    "name": "label",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "Badge",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/argtypes.snapshot
@@ -1,0 +1,95 @@
+{
+  "clicked": {
+    "action": "clicked",
+    "description": undefined,
+    "name": "clicked",
+    "table": {
+      "category": "outputs",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": true,
+        "summary": "EventEmitter",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+  "count": {
+    "description": "
+",
+    "name": "count",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": NaN,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+  "data": {
+    "description": "
+",
+    "name": "data",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": true,
+        "summary": "any",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+  "formatter": {
+    "description": "
+",
+    "name": "formatter",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": true,
+        "summary": "function",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+  "label": {
+    "description": "
+The text shown on the badge.",
+    "name": "label",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "Badge",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/compodoc-input.json
@@ -1,0 +1,130 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "DecoratorIoBasicsComponent",
+      "id": "component-DecoratorIoBasicsComponent-20990023b658accf7db8729b8b3071ca57a6e0c259b912282d6be4f7e7c36c5bbf212a4dd640b7ba597cfae9e888d2c8b27c341fc25debeab3e124589d7c98b1",
+      "file": "decorator-io-basics.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-decorator-io-basics",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<span (click)=\"clicked.emit(label)\">{{ label }} {{ count }}</span>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "count",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 11,
+          "type": "number",
+          "decorators": []
+        },
+        {
+          "coverageIgnore": false,
+          "name": "data",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 15,
+          "type": "any",
+          "decorators": []
+        },
+        {
+          "coverageIgnore": false,
+          "name": "formatter",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 17,
+          "type": "function",
+          "decorators": []
+        },
+        {
+          "coverageIgnore": false,
+          "name": "label",
+          "defaultValue": "'Badge'",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\nThe text shown on the badge.",
+          "description": "<p>The text shown on the badge.</p>\n",
+          "line": 9,
+          "type": "string",
+          "decorators": []
+        }
+      ],
+      "outputsClass": [
+        {
+          "name": "clicked",
+          "coverageIgnore": false,
+          "defaultValue": "new EventEmitter<string>()",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "line": 19,
+          "type": "EventEmitter"
+        }
+      ],
+      "propertiesClass": [],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\n\n@Component({\n  selector: 'sb-decorator-io-basics',\n  template: '<span (click)=\"clicked.emit(label)\">{{ label }} {{ count }}</span>',\n})\nexport class DecoratorIoBasicsComponent {\n  /** The text shown on the badge. */\n  @Input() label = 'Badge';\n\n  @Input() count?: number;\n\n  // `any` stands in for an untyped input: a truly annotation-free member cannot\n  // exist under the harness's strict/noImplicitAny check.\n  @Input() data: any;\n\n  @Input() formatter!: (value: number) => string;\n\n  @Output() clicked = new EventEmitter<string>();\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": [],
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 16,
+    "status": "low",
+    "files": [
+      {
+        "filePath": "decorator-io-basics.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "DecoratorIoBasicsComponent",
+        "coveragePercent": 16,
+        "coverageCount": "1/6",
+        "status": "low"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/decorator-io-basics.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/decorator-io-basics.component.ts
@@ -1,0 +1,20 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'sb-decorator-io-basics',
+  template: '<span (click)="clicked.emit(label)">{{ label }} {{ count }}</span>',
+})
+export class DecoratorIoBasicsComponent {
+  /** The text shown on the badge. */
+  @Input() label = 'Badge';
+
+  @Input() count?: number;
+
+  // `any` stands in for an untyped input: a truly annotation-free member cannot
+  // exist under the harness's strict/noImplicitAny check.
+  @Input() data: any;
+
+  @Input() formatter!: (value: number) => string;
+
+  @Output() clicked = new EventEmitter<string>();
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/input.stories.ts
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { DecoratorIoBasicsComponent } from './decorator-io-basics.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/DecoratorIoBasics',
+  component: DecoratorIoBasicsComponent,
+} satisfies Meta<DecoratorIoBasicsComponent>;
+
+export default meta;
+
+type Story = StoryObj<DecoratorIoBasicsComponent>;
+
+export const PropsAsWritten: Story = {
+  args: { label: 'Save', count: 3 },
+};
+
+export const EventHandlerArg: Story = {
+  args: {
+    label: 'Save',
+    clicked: () => {},
+  },
+};
+
+export const ObjectAndArrayArgs: Story = {
+  args: {
+    label: 'Save',
+    data: { id: 7, tags: ['a', 'b'], nested: { deep: true } },
+  },
+};
+
+export const ExplicitUndefinedArg: Story = {
+  args: { label: undefined, count: 1 },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-EventHandlerArg.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-EventHandlerArg.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-io-basics [label]="'Save'" (clicked)="clicked($event)"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-ExplicitUndefinedArg.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-ExplicitUndefinedArg.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-io-basics [label]="undefined" [count]="1"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-ExplicitUndefinedArg.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-ExplicitUndefinedArg.snapshot
@@ -1,1 +1,1 @@
-<sb-decorator-io-basics [label]="undefined" [count]="1"></sb-decorator-io-basics>
+<sb-decorator-io-basics [label]="undefined" [count]="1" (clicked)="clicked($event)"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-ObjectAndArrayArgs.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-ObjectAndArrayArgs.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-io-basics [label]="'Save'" [data]="{id: 7, tags: ['a', 'b'], nested: {deep: true}}"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-ObjectAndArrayArgs.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-ObjectAndArrayArgs.snapshot
@@ -1,1 +1,1 @@
-<sb-decorator-io-basics [label]="'Save'" [data]="{id: 7, tags: ['a', 'b'], nested: {deep: true}}"></sb-decorator-io-basics>
+<sb-decorator-io-basics [label]="'Save'" [data]="{id: 7, tags: ['a', 'b'], nested: {deep: true}}" (clicked)="clicked($event)"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-io-basics [label]="'Save'" [count]="3"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/snippet-PropsAsWritten.snapshot
@@ -1,1 +1,1 @@
-<sb-decorator-io-basics [label]="'Save'" [count]="3"></sb-decorator-io-basics>
+<sb-decorator-io-basics [label]="'Save'" [count]="3" (clicked)="clicked($event)"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/argtypes-filtered.snapshot
@@ -1,0 +1,69 @@
+{
+  "kind": {
+    "description": "
+",
+    "name": "kind",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "ButtonKind.Primary",
+      },
+      "type": {
+        "required": true,
+        "summary": "ButtonKind",
+      },
+    },
+    "type": {
+      "name": "enum",
+      "value": [
+        "primary",
+        "secondary",
+      ],
+    },
+  },
+  "size": {
+    "description": "
+",
+    "name": "size",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "small",
+      },
+      "type": {
+        "required": true,
+        "summary": ""small" | "large"",
+      },
+    },
+    "type": {
+      "name": "enum",
+      "value": [
+        "small",
+        "large",
+      ],
+    },
+  },
+  "tone": {
+    "description": "
+",
+    "name": "tone",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "info",
+      },
+      "type": {
+        "required": true,
+        "summary": "ToneOption",
+      },
+    },
+    "type": {
+      "name": "enum",
+      "value": [
+        "info",
+        "warn",
+        "error",
+      ],
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/argtypes.snapshot
@@ -1,0 +1,69 @@
+{
+  "kind": {
+    "description": "
+",
+    "name": "kind",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "ButtonKind.Primary",
+      },
+      "type": {
+        "required": true,
+        "summary": "ButtonKind",
+      },
+    },
+    "type": {
+      "name": "enum",
+      "value": [
+        "primary",
+        "secondary",
+      ],
+    },
+  },
+  "size": {
+    "description": "
+",
+    "name": "size",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "small",
+      },
+      "type": {
+        "required": true,
+        "summary": ""small" | "large"",
+      },
+    },
+    "type": {
+      "name": "enum",
+      "value": [
+        "small",
+        "large",
+      ],
+    },
+  },
+  "tone": {
+    "description": "
+",
+    "name": "tone",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "info",
+      },
+      "type": {
+        "required": true,
+        "summary": "ToneOption",
+      },
+    },
+    "type": {
+      "name": "enum",
+      "value": [
+        "info",
+        "warn",
+        "error",
+      ],
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/compodoc-input.json
@@ -1,0 +1,212 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "DecoratorUnionEnumComponent",
+      "id": "component-DecoratorUnionEnumComponent-929a72a04e601a59f03d1c5168c80a74334056ef2507347d1a654cdbbe5b8a5418a0b80c90628e7dfc89bafc25b56a11ff329bc457a624c0482d8efd26952cfe",
+      "file": "decorator-union-enum.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-decorator-union-enum",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<span>{{ size }} {{ tone }} {{ kind }}</span>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "kind",
+          "defaultValue": "ButtonKind.Primary",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 14,
+          "type": "ButtonKind",
+          "decorators": []
+        },
+        {
+          "coverageIgnore": false,
+          "name": "size",
+          "defaultValue": "'small'",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 10,
+          "type": "\"small\" | \"large\"",
+          "decorators": []
+        },
+        {
+          "coverageIgnore": false,
+          "name": "tone",
+          "defaultValue": "'info'",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 12,
+          "type": "ToneOption",
+          "decorators": []
+        }
+      ],
+      "outputsClass": [],
+      "propertiesClass": [],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import { Component, Input } from '@angular/core';\n\nimport { ButtonKind, type ToneOption } from './types.ts';\n\n@Component({\n  selector: 'sb-decorator-union-enum',\n  template: '<span>{{ size }} {{ tone }} {{ kind }}</span>',\n})\nexport class DecoratorUnionEnumComponent {\n  @Input() size: 'small' | 'large' = 'small';\n\n  @Input() tone: ToneOption = 'info';\n\n  @Input() kind: ButtonKind = ButtonKind.Primary;\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": [],
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": {
+    "variables": [],
+    "functions": [],
+    "typealiases": [
+      {
+        "name": "ToneOption",
+        "ctype": "miscellaneous",
+        "subtype": "typealias",
+        "coverageIgnore": false,
+        "rawtype": "\"info\" | \"warn\" | \"error\"",
+        "file": "types.ts",
+        "deprecated": false,
+        "deprecationMessage": "",
+        "rawdescription": "",
+        "description": "",
+        "kind": 193
+      }
+    ],
+    "enumerations": [
+      {
+        "name": "ButtonKind",
+        "childs": [
+          {
+            "name": "Primary",
+            "deprecated": false,
+            "deprecationMessage": "",
+            "value": "primary"
+          },
+          {
+            "name": "Secondary",
+            "deprecated": false,
+            "deprecationMessage": "",
+            "value": "secondary"
+          }
+        ],
+        "ctype": "miscellaneous",
+        "subtype": "enum",
+        "deprecated": false,
+        "deprecationMessage": "",
+        "rawdescription": "",
+        "description": "",
+        "file": "types.ts"
+      }
+    ],
+    "groupedVariables": {},
+    "groupedFunctions": {},
+    "groupedEnumerations": {
+      "types.ts": [
+        {
+          "name": "ButtonKind",
+          "childs": [
+            {
+              "name": "Primary",
+              "deprecated": false,
+              "deprecationMessage": "",
+              "value": "primary"
+            },
+            {
+              "name": "Secondary",
+              "deprecated": false,
+              "deprecationMessage": "",
+              "value": "secondary"
+            }
+          ],
+          "ctype": "miscellaneous",
+          "subtype": "enum",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "",
+          "description": "",
+          "file": "types.ts"
+        }
+      ]
+    },
+    "groupedTypeAliases": {
+      "types.ts": [
+        {
+          "name": "ToneOption",
+          "ctype": "miscellaneous",
+          "subtype": "typealias",
+          "coverageIgnore": false,
+          "rawtype": "\"info\" | \"warn\" | \"error\"",
+          "file": "types.ts",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "",
+          "description": "",
+          "kind": 193
+        }
+      ]
+    }
+  },
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 0,
+    "status": "low",
+    "files": [
+      {
+        "filePath": "decorator-union-enum.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "DecoratorUnionEnumComponent",
+        "coveragePercent": 0,
+        "coverageCount": "0/4",
+        "status": "low"
+      },
+      {
+        "filePath": "types.ts",
+        "type": "type alias",
+        "linktype": "miscellaneous",
+        "linksubtype": "typealias",
+        "name": "ToneOption",
+        "coveragePercent": 0,
+        "coverageCount": "0/1",
+        "status": "low"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/decorator-union-enum.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/decorator-union-enum.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+
+import { ButtonKind, type ToneOption } from './types.ts';
+
+@Component({
+  selector: 'sb-decorator-union-enum',
+  template: '<span>{{ size }} {{ tone }} {{ kind }}</span>',
+})
+export class DecoratorUnionEnumComponent {
+  @Input() size: 'small' | 'large' = 'small';
+
+  @Input() tone: ToneOption = 'info';
+
+  @Input() kind: ButtonKind = ButtonKind.Primary;
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/input.stories.ts
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { ButtonKind } from './types.ts';
+import { DecoratorUnionEnumComponent } from './decorator-union-enum.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/DecoratorUnionEnum',
+  component: DecoratorUnionEnumComponent,
+} satisfies Meta<DecoratorUnionEnumComponent>;
+
+export default meta;
+
+export const PropsAsWritten: StoryObj<DecoratorUnionEnumComponent> = {
+  args: { size: 'large', tone: 'warn', kind: ButtonKind.Secondary },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-union-enum [size]="'large'" [tone]="'warn'" [kind]="'secondary'"></sb-decorator-union-enum>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/types.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/types.ts
@@ -1,0 +1,6 @@
+export type ToneOption = 'info' | 'warn' | 'error';
+
+export enum ButtonKind {
+  Primary = 'primary',
+  Secondary = 'secondary',
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/argtypes-filtered.snapshot
@@ -1,0 +1,39 @@
+{
+  "rows": {
+    "description": "
+",
+    "name": "rows",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "Math.max(1, 3)",
+      },
+      "type": {
+        "required": true,
+        "summary": "any",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+  "timeoutMs": {
+    "description": "
+",
+    "name": "timeoutMs",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": NaN,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/argtypes.snapshot
@@ -1,0 +1,58 @@
+{
+  "rows": {
+    "description": "
+",
+    "name": "rows",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "Math.max(1, 3)",
+      },
+      "type": {
+        "required": true,
+        "summary": "any",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+  "saved": {
+    "action": "saved",
+    "description": undefined,
+    "name": "saved",
+    "table": {
+      "category": "outputs",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": true,
+        "summary": "EventEmitter",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+  "timeoutMs": {
+    "description": "
+",
+    "name": "timeoutMs",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": NaN,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/compodoc-input.json
@@ -1,0 +1,109 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "ExpressionDefaultsComponent",
+      "id": "component-ExpressionDefaultsComponent-cbb6506530263f4d0a4182050dd562765086076165ef63ce6a939579656c810b0ae36b8ada95a8dcca45c1a3e86b2b8963c778604b6b768f7314c8a7cdfeb38b",
+      "file": "expression-defaults.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-expression-defaults",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<span (click)=\"saved.emit()\">{{ rows }} {{ timeoutMs }}</span>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "rows",
+          "defaultValue": "Math.max(1, 3)",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 8,
+          "type": "any",
+          "decorators": []
+        },
+        {
+          "coverageIgnore": false,
+          "name": "timeoutMs",
+          "defaultValue": "5 * 60 * 1000",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 10,
+          "type": "number",
+          "decorators": []
+        }
+      ],
+      "outputsClass": [
+        {
+          "name": "saved",
+          "coverageIgnore": false,
+          "defaultValue": "new EventEmitter<void>()",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "line": 12,
+          "type": "EventEmitter"
+        }
+      ],
+      "propertiesClass": [],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\n\n@Component({\n  selector: 'sb-expression-defaults',\n  template: '<span (click)=\"saved.emit()\">{{ rows }} {{ timeoutMs }}</span>',\n})\nexport class ExpressionDefaultsComponent {\n  @Input() rows = Math.max(1, 3);\n\n  @Input() timeoutMs = 5 * 60 * 1000;\n\n  @Output() saved = new EventEmitter<void>();\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": [],
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 0,
+    "status": "low",
+    "files": [
+      {
+        "filePath": "expression-defaults.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "ExpressionDefaultsComponent",
+        "coveragePercent": 0,
+        "coverageCount": "0/4",
+        "status": "low"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/expression-defaults.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/expression-defaults.component.ts
@@ -1,0 +1,13 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'sb-expression-defaults',
+  template: '<span (click)="saved.emit()">{{ rows }} {{ timeoutMs }}</span>',
+})
+export class ExpressionDefaultsComponent {
+  @Input() rows = Math.max(1, 3);
+
+  @Input() timeoutMs = 5 * 60 * 1000;
+
+  @Output() saved = new EventEmitter<void>();
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/input.stories.ts
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { ExpressionDefaultsComponent } from './expression-defaults.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/ExpressionDefaults',
+  component: ExpressionDefaultsComponent,
+} satisfies Meta<ExpressionDefaultsComponent>;
+
+export default meta;
+
+export const PropsAsWritten: StoryObj<ExpressionDefaultsComponent> = {
+  args: { rows: 8, timeoutMs: 1000 },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-expression-defaults [rows]="8" [timeoutMs]="1000"></sb-expression-defaults>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/snippet-PropsAsWritten.snapshot
@@ -1,1 +1,1 @@
-<sb-expression-defaults [rows]="8" [timeoutMs]="1000"></sb-expression-defaults>
+<sb-expression-defaults [rows]="8" [timeoutMs]="1000" (saved)="saved($event)"></sb-expression-defaults>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/argtypes-filtered.snapshot
@@ -1,0 +1,48 @@
+{
+  "accent": {
+    "description": "
+
+Accent color applied to the chip text.
+
+'steelblue'
+",
+    "name": "accent",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "'steelblue'
+",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+  "text": {
+    "description": "
+
+Chip text.
+
+See https://example.com/docs/chip-text
+presentation
+",
+    "name": "text",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/argtypes.snapshot
@@ -1,0 +1,48 @@
+{
+  "accent": {
+    "description": "
+
+Accent color applied to the chip text.
+
+'steelblue'
+",
+    "name": "accent",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "'steelblue'
+",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+  "text": {
+    "description": "
+
+Chip text.
+
+See https://example.com/docs/chip-text
+presentation
+",
+    "name": "text",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/compodoc-input.json
@@ -1,0 +1,235 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "JsdocTagsComponent",
+      "id": "component-JsdocTagsComponent-ddf01d5c1a823a652285e3333c2e4d16d7d1a131d8aca0c808fd9b2fa6f74a22f6fe96ddb56d119c03ef3de06ca3d13834332ded412db9b25eb6900187984813",
+      "file": "jsdoc-tags.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-jsdoc-tags",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<span [style.color]=\"accent\">{{ text }}</span>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "accent",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "jsdoctags": [
+            {
+              "pos": 527,
+              "end": 551,
+              "kind": 328,
+              "id": 0,
+              "flags": 16842752,
+              "modifierFlagsCache": 0,
+              "transformFlags": 0,
+              "tagName": {
+                "pos": 528,
+                "end": 535,
+                "kind": 80,
+                "id": 0,
+                "flags": 16842752,
+                "transformFlags": 0,
+                "escapedText": "default"
+              },
+              "comment": "<p>&#39;steelblue&#39;</p>\n"
+            }
+          ],
+          "rawdescription": "\n\nAccent color applied to the chip text.\n\n'steelblue'\n",
+          "description": "<p>Accent color applied to the chip text.</p>\n<p>&#39;steelblue&#39;</p>\n",
+          "line": 27,
+          "type": "string",
+          "decorators": []
+        },
+        {
+          "coverageIgnore": false,
+          "name": "text",
+          "defaultValue": "''",
+          "deprecated": true,
+          "deprecationMessage": "Use `label` on the parent panel instead.",
+          "jsdoctags": [
+            {
+              "pos": 310,
+              "end": 368,
+              "kind": 332,
+              "id": 0,
+              "flags": 16842752,
+              "modifierFlagsCache": 0,
+              "transformFlags": 0,
+              "tagName": {
+                "pos": 311,
+                "end": 321,
+                "kind": 80,
+                "id": 0,
+                "flags": 16842752,
+                "transformFlags": 0,
+                "escapedText": "deprecated"
+              },
+              "comment": "<p>Use <code>label</code> on the parent panel instead.</p>\n"
+            },
+            {
+              "pos": 368,
+              "end": 413,
+              "kind": 348,
+              "id": 0,
+              "flags": 16842752,
+              "modifierFlagsCache": 0,
+              "transformFlags": 0,
+              "tagName": {
+                "pos": 369,
+                "end": 372,
+                "kind": 80,
+                "id": 0,
+                "flags": 16842752,
+                "transformFlags": 0,
+                "escapedText": "see"
+              },
+              "comment": "<p>://example.com/docs/chip-text</p>\n",
+              "name": {
+                "pos": 373,
+                "end": 378,
+                "kind": 311,
+                "id": 0,
+                "flags": 16842752,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "name": {
+                  "pos": 373,
+                  "end": 378,
+                  "kind": 80,
+                  "id": 0,
+                  "flags": 16842752,
+                  "transformFlags": 0,
+                  "escapedText": "https"
+                }
+              }
+            },
+            {
+              "pos": 413,
+              "end": 441,
+              "kind": 328,
+              "id": 0,
+              "flags": 16842752,
+              "modifierFlagsCache": 0,
+              "transformFlags": 0,
+              "tagName": {
+                "pos": 414,
+                "end": 424,
+                "kind": 80,
+                "id": 0,
+                "flags": 16842752,
+                "transformFlags": 0,
+                "escapedText": "sbCategory"
+              },
+              "comment": "<p>presentation</p>\n"
+            }
+          ],
+          "rawdescription": "\n\nChip text.\n\nSee https://example.com/docs/chip-text\npresentation\n",
+          "description": "<p>Chip text.</p>\n<p>See <a href=\"https://example.com/docs/chip-text\">https://example.com/docs/chip-text</a>\npresentation</p>\n",
+          "line": 20,
+          "type": "string",
+          "decorators": []
+        }
+      ],
+      "outputsClass": [],
+      "propertiesClass": [],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "<p>Renders a colored status chip.</p>\n<p>See <a href=\"https://example.com/design/chips\">https://example.com/design/chips</a></p>\n",
+      "rawdescription": "\n\nRenders a colored status chip.\n\nSee https://example.com/design/chips\n",
+      "type": "component",
+      "sourceCode": "import { Component, Input } from '@angular/core';\n\n/**\n * Renders a colored status chip.\n *\n * @see https://example.com/design/chips\n */\n@Component({\n  selector: 'sb-jsdoc-tags',\n  template: '<span [style.color]=\"accent\">{{ text }}</span>',\n})\nexport class JsdocTagsComponent {\n  /**\n   * Chip text.\n   *\n   * @deprecated Use `label` on the parent panel instead.\n   * @see https://example.com/docs/chip-text\n   * @sbCategory presentation\n   */\n  @Input() text = '';\n\n  /**\n   * Accent color applied to the chip text.\n   *\n   * @default 'steelblue'\n   */\n  @Input() accent?: string;\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "jsdoctags": [
+        {
+          "pos": 95,
+          "end": 134,
+          "kind": 348,
+          "id": 0,
+          "flags": 16777216,
+          "modifierFlagsCache": 0,
+          "transformFlags": 0,
+          "tagName": {
+            "pos": 96,
+            "end": 99,
+            "kind": 80,
+            "id": 0,
+            "flags": 16777216,
+            "transformFlags": 0,
+            "escapedText": "see"
+          },
+          "comment": "<p>://example.com/design/chips</p>\n",
+          "name": {
+            "pos": 100,
+            "end": 105,
+            "kind": 311,
+            "id": 0,
+            "flags": 16777216,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "name": {
+              "pos": 100,
+              "end": 105,
+              "kind": 80,
+              "id": 0,
+              "flags": 16777216,
+              "transformFlags": 0,
+              "escapedText": "https"
+            }
+          }
+        }
+      ],
+      "extends": [],
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 100,
+    "status": "very-good",
+    "files": [
+      {
+        "filePath": "jsdoc-tags.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "JsdocTagsComponent",
+        "coveragePercent": 100,
+        "coverageCount": "3/3",
+        "status": "very-good"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/input.stories.ts
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { JsdocTagsComponent } from './jsdoc-tags.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/JsdocTags',
+  component: JsdocTagsComponent,
+} satisfies Meta<JsdocTagsComponent>;
+
+export default meta;
+
+export const PropsAsWritten: StoryObj<JsdocTagsComponent> = {
+  args: { text: 'Deployed', accent: 'seagreen' },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/jsdoc-tags.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/jsdoc-tags.component.ts
@@ -1,0 +1,28 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * Renders a colored status chip.
+ *
+ * @see https://example.com/design/chips
+ */
+@Component({
+  selector: 'sb-jsdoc-tags',
+  template: '<span [style.color]="accent">{{ text }}</span>',
+})
+export class JsdocTagsComponent {
+  /**
+   * Chip text.
+   *
+   * @deprecated Use `label` on the parent panel instead.
+   * @see https://example.com/docs/chip-text
+   * @sbCategory presentation
+   */
+  @Input() text = '';
+
+  /**
+   * Accent color applied to the chip text.
+   *
+   * @default 'steelblue'
+   */
+  @Input() accent?: string;
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-jsdoc-tags [text]="'Deployed'" [accent]="'seagreen'"></sb-jsdoc-tags>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/argtypes-filtered.snapshot
@@ -1,0 +1,20 @@
+{
+  "title": {
+    "description": "
+",
+    "name": "title",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/argtypes.snapshot
@@ -1,0 +1,95 @@
+{
+  "currentPage": {
+    "description": "
+",
+    "name": "currentPage",
+    "table": {
+      "category": "properties",
+      "defaultValue": {
+        "summary": 1,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+  "isActive": {
+    "description": "
+",
+    "name": "isActive",
+    "table": {
+      "category": "properties",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "unknown",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "empty-enum",
+    },
+  },
+  "nextPage": {
+    "description": "
+",
+    "name": "nextPage",
+    "table": {
+      "category": "methods",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": false,
+        "summary": "() => void",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+  "panel": {
+    "description": "
+",
+    "name": "panel",
+    "table": {
+      "category": "view child",
+      "defaultValue": {
+        "summary": undefined,
+      },
+      "type": {
+        "required": false,
+        "summary": "ElementRef<HTMLDivElement>",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+  "title": {
+    "description": "
+",
+    "name": "title",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/compodoc-input.json
@@ -1,0 +1,168 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "PropertiesMethodsNoiseComponent",
+      "id": "component-PropertiesMethodsNoiseComponent-6d8f11599bef17c0ba839c2f891b8720044f22ef8a5893157453b76b86f6e04164eeaa2818fb2a8839dfbfd343973f7a9587c7f57c82c545c7f842fd748fdaec",
+      "file": "properties-methods-noise.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-properties-methods-noise",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<div #panel>{{ title }} {{ currentPage }}</div>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "coverageIgnore": false,
+          "name": "title",
+          "defaultValue": "''",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 9,
+          "type": "string",
+          "decorators": []
+        }
+      ],
+      "outputsClass": [],
+      "propertiesClass": [
+        {
+          "name": "currentPage",
+          "coverageIgnore": false,
+          "defaultValue": "1",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "number",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 11,
+          "rawdescription": "\n"
+        },
+        {
+          "name": "isActive",
+          "coverageIgnore": false,
+          "defaultValue": "false",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "unknown",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 15,
+          "rawdescription": "\n",
+          "decorators": [
+            {
+              "name": "HostBinding",
+              "stringifiedArguments": "'class.active'"
+            }
+          ],
+          "modifierKind": [171]
+        },
+        {
+          "name": "panel",
+          "coverageIgnore": false,
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "ElementRef<HTMLDivElement>",
+          "indexKey": "",
+          "optional": true,
+          "description": "",
+          "line": 13,
+          "rawdescription": "\n",
+          "decorators": [
+            {
+              "name": "ViewChild",
+              "stringifiedArguments": "'panel'"
+            }
+          ],
+          "modifierKind": [171]
+        }
+      ],
+      "methodsClass": [
+        {
+          "name": "nextPage",
+          "coverageIgnore": false,
+          "args": [],
+          "optional": false,
+          "returnType": "void",
+          "typeParameters": [],
+          "line": 17,
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": ""
+        }
+      ],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [
+        {
+          "coverageIgnore": false,
+          "name": "class.active",
+          "actualName": "isActive",
+          "defaultValue": "false",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "rawdescription": "\n",
+          "description": "",
+          "line": 15,
+          "type": "boolean",
+          "decorators": []
+        }
+      ],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import type { ElementRef } from '@angular/core';\nimport { Component, HostBinding, Input, ViewChild } from '@angular/core';\n\n@Component({\n  selector: 'sb-properties-methods-noise',\n  template: '<div #panel>{{ title }} {{ currentPage }}</div>',\n})\nexport class PropertiesMethodsNoiseComponent {\n  @Input() title = '';\n\n  currentPage = 1;\n\n  @ViewChild('panel') panel?: ElementRef<HTMLDivElement>;\n\n  @HostBinding('class.active') isActive = false;\n\n  nextPage(): void {\n    this.currentPage += 1;\n  }\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": [],
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 0,
+    "status": "low",
+    "files": [
+      {
+        "filePath": "properties-methods-noise.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "PropertiesMethodsNoiseComponent",
+        "coveragePercent": 0,
+        "coverageCount": "0/7",
+        "status": "low"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/input.stories.ts
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { PropertiesMethodsNoiseComponent } from './properties-methods-noise.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/PropertiesMethodsNoise',
+  component: PropertiesMethodsNoiseComponent,
+} satisfies Meta<PropertiesMethodsNoiseComponent>;
+
+export default meta;
+
+export const PropsAsWritten: StoryObj<PropertiesMethodsNoiseComponent> = {
+  args: { title: 'Paged results' },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/properties-methods-noise.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/properties-methods-noise.component.ts
@@ -1,0 +1,20 @@
+import type { ElementRef } from '@angular/core';
+import { Component, HostBinding, Input, ViewChild } from '@angular/core';
+
+@Component({
+  selector: 'sb-properties-methods-noise',
+  template: '<div #panel>{{ title }} {{ currentPage }}</div>',
+})
+export class PropertiesMethodsNoiseComponent {
+  @Input() title = '';
+
+  currentPage = 1;
+
+  @ViewChild('panel') panel?: ElementRef<HTMLDivElement>;
+
+  @HostBinding('class.active') isActive = false;
+
+  nextPage(): void {
+    this.currentPage += 1;
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-properties-methods-noise [title]="'Paged results'"></sb-properties-methods-noise>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/aot-cmp.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/aot-cmp.ts
@@ -1,0 +1,16 @@
+// Captured build product: the runtime `ɵcmp.inputs`/`ɵcmp.outputs` maps this component
+// gets under AOT, read off the loaded output of `ngc` (@angular/compiler-cli 21.2.17).
+// Bare JIT leaves both maps empty for signal members, so the recorder attaches this
+// before generating snippets (see the README capture procedure).
+export const aotCmp: {
+  inputs: Record<string, [string, number, null]>;
+  outputs: Record<string, string>;
+} = {
+  inputs: {
+    label: ['label', 1, null],
+    count: ['count', 1, null],
+    increment: ['step', 1, null],
+    disabled: ['disabled', 1, null],
+  },
+  outputs: { toggled: 'toggled' },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/argtypes-filtered.snapshot
@@ -1,0 +1,74 @@
+{
+  "count": {
+    "description": "
+",
+    "name": "count",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": NaN,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+  "disabled": {
+    "description": "
+",
+    "name": "disabled",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "boolean",
+      },
+    },
+    "type": {
+      "name": "boolean",
+    },
+  },
+  "increment": {
+    "description": "
+",
+    "name": "increment",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": 1,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+  "label": {
+    "description": "
+Visible caption next to the control.",
+    "name": "label",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/argtypes.snapshot
@@ -1,0 +1,112 @@
+{
+  "count": {
+    "description": "
+",
+    "name": "count",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": NaN,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+  "disabled": {
+    "description": "
+",
+    "name": "disabled",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "boolean",
+      },
+    },
+    "type": {
+      "name": "boolean",
+    },
+  },
+  "increment": {
+    "description": "
+",
+    "name": "increment",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": 1,
+      },
+      "type": {
+        "required": true,
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+    },
+  },
+  "label": {
+    "description": "
+Visible caption next to the control.",
+    "name": "label",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+  "toggled": {
+    "action": "toggled",
+    "description": "
+",
+    "name": "toggled",
+    "table": {
+      "category": "outputs",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "boolean",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+  "version": {
+    "description": "
+",
+    "name": "version",
+    "table": {
+      "category": "properties",
+      "defaultValue": {
+        "summary": "v1",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/compodoc-input.json
@@ -1,0 +1,159 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "SignalIoComponent",
+      "id": "component-SignalIoComponent-d8bd6334b404ea07eec08c3f9c73a057d44261ff47d1103ebfa74e8bfe89d8b14daf6ddc3389fb68b81ec37698cba1a3ef25a5876feddac344fd9adde9970910",
+      "file": "signal-io.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-signal-io",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<span>{{ label() }} {{ count() }} {{ step() }} {{ disabled() }}</span>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "name": "count",
+          "coverageIgnore": false,
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "number",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 11,
+          "rawdescription": "\n",
+          "required": true
+        },
+        {
+          "name": "disabled",
+          "coverageIgnore": false,
+          "defaultValue": "false",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "boolean",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 15,
+          "rawdescription": "\n",
+          "required": false
+        },
+        {
+          "name": "label",
+          "coverageIgnore": false,
+          "defaultValue": "''",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "string",
+          "indexKey": "",
+          "optional": false,
+          "description": "<p>Visible caption next to the control.</p>\n",
+          "line": 9,
+          "rawdescription": "\nVisible caption next to the control.",
+          "required": false
+        },
+        {
+          "name": "increment",
+          "coverageIgnore": false,
+          "defaultValue": "1",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "number",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 13,
+          "rawdescription": "\n",
+          "required": false
+        }
+      ],
+      "outputsClass": [
+        {
+          "name": "toggled",
+          "coverageIgnore": false,
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "boolean",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 17,
+          "rawdescription": "\n",
+          "required": false
+        }
+      ],
+      "propertiesClass": [
+        {
+          "name": "version",
+          "coverageIgnore": false,
+          "defaultValue": "'v1'",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "string",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 19,
+          "rawdescription": "\n",
+          "modifierKind": [148]
+        }
+      ],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import { Component, booleanAttribute, input, output } from '@angular/core';\n\n@Component({\n  selector: 'sb-signal-io',\n  template: '<span>{{ label() }} {{ count() }} {{ step() }} {{ disabled() }}</span>',\n})\nexport class SignalIoComponent {\n  /** Visible caption next to the control. */\n  label = input('');\n\n  count = input.required<number>();\n\n  step = input(1, { alias: 'increment' });\n\n  disabled = input(false, { transform: booleanAttribute });\n\n  toggled = output<boolean>();\n\n  readonly version = 'v1';\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": [],
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 14,
+    "status": "low",
+    "files": [
+      {
+        "filePath": "signal-io.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "SignalIoComponent",
+        "coveragePercent": 14,
+        "coverageCount": "1/7",
+        "status": "low"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/input.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { SignalIoComponent } from './signal-io.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/SignalIo',
+  component: SignalIoComponent,
+} satisfies Meta<SignalIoComponent>;
+
+export default meta;
+
+// Args are keyed by BINDING names (the aliased `step` binds as `increment`), matching
+// what the legacy argTypes surface as controls; the class-derived StoryObj typing would
+// key by property name instead.
+type SignalIoArgs = {
+  label: string;
+  count: number;
+  increment: number;
+  disabled: boolean;
+  toggled: (checked: boolean) => void;
+};
+
+export const PropsAsWritten: StoryObj<SignalIoArgs> = {
+  args: { label: 'Quantity', count: 2, increment: 5, disabled: true },
+};
+
+export const EventHandlerArg: StoryObj<SignalIoArgs> = {
+  args: { label: 'Quantity', count: 2, toggled: () => {} },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/signal-io.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/signal-io.component.ts
@@ -1,0 +1,20 @@
+import { Component, booleanAttribute, input, output } from '@angular/core';
+
+@Component({
+  selector: 'sb-signal-io',
+  template: '<span>{{ label() }} {{ count() }} {{ step() }} {{ disabled() }}</span>',
+})
+export class SignalIoComponent {
+  /** Visible caption next to the control. */
+  label = input('');
+
+  count = input.required<number>();
+
+  step = input(1, { alias: 'increment' });
+
+  disabled = input(false, { transform: booleanAttribute });
+
+  toggled = output<boolean>();
+
+  readonly version = 'v1';
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/snippet-EventHandlerArg.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/snippet-EventHandlerArg.snapshot
@@ -1,0 +1,1 @@
+<sb-signal-io [label]="'Quantity'" [count]="2" (toggled)="toggled($event)"></sb-signal-io>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-signal-io [label]="'Quantity'" [count]="2" [increment]="5" [disabled]="true"></sb-signal-io>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/snippet-PropsAsWritten.snapshot
@@ -1,1 +1,1 @@
-<sb-signal-io [label]="'Quantity'" [count]="2" [increment]="5" [disabled]="true"></sb-signal-io>
+<sb-signal-io [label]="'Quantity'" [count]="2" [increment]="5" [disabled]="true" (toggled)="toggled($event)"></sb-signal-io>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/aot-cmp.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/aot-cmp.ts
@@ -1,0 +1,14 @@
+// Captured build product: the runtime `ɵcmp.inputs`/`ɵcmp.outputs` maps this component
+// gets under AOT, read off the loaded output of `ngc` (@angular/compiler-cli 21.2.17).
+// Bare JIT leaves both maps empty for signal members, so the recorder attaches this
+// before generating snippets (see the README capture procedure).
+export const aotCmp: {
+  inputs: Record<string, [string, number, null]>;
+  outputs: Record<string, string>;
+} = {
+  inputs: {
+    value: ['value', 1, null],
+    checked: ['checked', 1, null],
+  },
+  outputs: { valueChange: 'value', checkedChange: 'checked' },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/argtypes-filtered.snapshot
@@ -1,0 +1,72 @@
+{
+  "checked": {
+    "description": "
+",
+    "name": "checked",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "boolean",
+      },
+    },
+    "type": {
+      "name": "boolean",
+    },
+  },
+  "checkedChange": {
+    "action": "checkedChange",
+    "description": "
+",
+    "name": "checkedChange",
+    "table": {
+      "category": "outputs",
+      "type": {
+        "required": true,
+        "summary": "(e: boolean) => void",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+  "value": {
+    "description": "
+Current text value of the field.",
+    "name": "value",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "start",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+  "valueChange": {
+    "action": "valueChange",
+    "description": "
+Current text value of the field.",
+    "name": "valueChange",
+    "table": {
+      "category": "outputs",
+      "type": {
+        "required": true,
+        "summary": "(e: string) => void",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/argtypes.snapshot
@@ -1,0 +1,72 @@
+{
+  "checked": {
+    "description": "
+",
+    "name": "checked",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": false,
+      },
+      "type": {
+        "required": true,
+        "summary": "boolean",
+      },
+    },
+    "type": {
+      "name": "boolean",
+    },
+  },
+  "checkedChange": {
+    "action": "checkedChange",
+    "description": "
+",
+    "name": "checkedChange",
+    "table": {
+      "category": "outputs",
+      "type": {
+        "required": true,
+        "summary": "(e: boolean) => void",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+  "value": {
+    "description": "
+Current text value of the field.",
+    "name": "value",
+    "table": {
+      "category": "inputs",
+      "defaultValue": {
+        "summary": "start",
+      },
+      "type": {
+        "required": true,
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+    },
+  },
+  "valueChange": {
+    "action": "valueChange",
+    "description": "
+Current text value of the field.",
+    "name": "valueChange",
+    "table": {
+      "category": "outputs",
+      "type": {
+        "required": true,
+        "summary": "(e: string) => void",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "void",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/compodoc-input.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/compodoc-input.json
@@ -1,0 +1,130 @@
+{
+  "pipes": [],
+  "interfaces": [],
+  "injectables": [],
+  "guards": [],
+  "interceptors": [],
+  "classes": [],
+  "directives": [],
+  "components": [
+    {
+      "name": "SignalModelComponent",
+      "id": "component-SignalModelComponent-1c9a845afd4327b5fd4636f5cecbf8dd8a111b79ee305c2f108001703c3227485d75f5c1cc17ed3ca96f355fe565b1d1da726069554224565394db53066724d6",
+      "file": "signal-model.component.ts",
+      "encapsulation": [],
+      "entryComponents": [],
+      "inputs": [],
+      "outputs": [],
+      "providers": [],
+      "selector": "sb-signal-model",
+      "styleUrls": [],
+      "styles": [],
+      "template": "<span>{{ value() }} {{ checked() }}</span>",
+      "templateUrl": [],
+      "templateVariables": [],
+      "viewProviders": [],
+      "hostDirectives": [],
+      "inputsClass": [
+        {
+          "name": "checked",
+          "coverageIgnore": false,
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "boolean",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 11,
+          "rawdescription": "\n",
+          "required": true
+        },
+        {
+          "name": "value",
+          "coverageIgnore": false,
+          "defaultValue": "'start'",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "string",
+          "indexKey": "",
+          "optional": false,
+          "description": "<p>Current text value of the field.</p>\n",
+          "line": 9,
+          "rawdescription": "\nCurrent text value of the field.",
+          "required": false
+        }
+      ],
+      "outputsClass": [
+        {
+          "name": "checked",
+          "coverageIgnore": false,
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "boolean",
+          "indexKey": "",
+          "optional": false,
+          "description": "",
+          "line": 11,
+          "rawdescription": "\n",
+          "required": true
+        },
+        {
+          "name": "value",
+          "coverageIgnore": false,
+          "defaultValue": "'start'",
+          "deprecated": false,
+          "deprecationMessage": "",
+          "type": "string",
+          "indexKey": "",
+          "optional": false,
+          "description": "<p>Current text value of the field.</p>\n",
+          "line": 9,
+          "rawdescription": "\nCurrent text value of the field.",
+          "required": false
+        }
+      ],
+      "propertiesClass": [],
+      "methodsClass": [],
+      "coverageIgnore": false,
+      "deprecated": false,
+      "deprecationMessage": "",
+      "hostBindings": [],
+      "hostListeners": [],
+      "standalone": false,
+      "imports": [],
+      "description": "",
+      "rawdescription": "\n",
+      "type": "component",
+      "sourceCode": "import { Component, model } from '@angular/core';\n\n@Component({\n  selector: 'sb-signal-model',\n  template: '<span>{{ value() }} {{ checked() }}</span>',\n})\nexport class SignalModelComponent {\n  /** Current text value of the field. */\n  value = model('start');\n\n  checked = model.required<boolean>();\n}\n",
+      "assetsDirs": [],
+      "styleUrlsData": "",
+      "stylesData": "",
+      "extends": [],
+      "relationships": {
+        "incoming": [],
+        "outgoing": []
+      }
+    }
+  ],
+  "modules": [],
+  "miscellaneous": [],
+  "routes": {
+    "name": "<root>",
+    "kind": "module",
+    "children": []
+  },
+  "coverage": {
+    "count": 40,
+    "status": "medium",
+    "files": [
+      {
+        "filePath": "signal-model.component.ts",
+        "type": "component",
+        "linktype": "component",
+        "name": "SignalModelComponent",
+        "coveragePercent": 40,
+        "coverageCount": "2/5",
+        "status": "medium"
+      }
+    ]
+  }
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/input.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '../../csf-types.ts';
+
+import { SignalModelComponent } from './signal-model.component.ts';
+
+const meta = {
+  title: 'AngularFixtures/SignalModel',
+  component: SignalModelComponent,
+} satisfies Meta<SignalModelComponent>;
+
+export default meta;
+
+export const TwoWayBinding: StoryObj<SignalModelComponent> = {
+  args: {
+    value: 'hello',
+    valueChange: () => {},
+    checked: true,
+  },
+};

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/signal-model.component.ts
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/signal-model.component.ts
@@ -1,0 +1,12 @@
+import { Component, model } from '@angular/core';
+
+@Component({
+  selector: 'sb-signal-model',
+  template: '<span>{{ value() }} {{ checked() }}</span>',
+})
+export class SignalModelComponent {
+  /** Current text value of the field. */
+  value = model('start');
+
+  checked = model.required<boolean>();
+}

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/snippet-TwoWayBinding.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/snippet-TwoWayBinding.snapshot
@@ -1,1 +1,1 @@
-<sb-signal-model [value]="'hello'" [checked]="true" (valueChange)="valueChange($event)"></sb-signal-model>
+<sb-signal-model [value]="'hello'" [checked]="true" (valueChange)="valueChange($event)" (checkedChange)="checkedChange($event)"></sb-signal-model>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/snippet-TwoWayBinding.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/snippet-TwoWayBinding.snapshot
@@ -1,0 +1,1 @@
+<sb-signal-model [value]="'hello'" [checked]="true" (valueChange)="valueChange($event)"></sb-signal-model>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./*.ts"]
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/angular-baselines.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-baselines.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+// happy-dom provides the DOMParser that compodoc.ts instantiates for @default JSDoc tags.
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// compodoc.ts destructures FEATURES from the global once at first import, so the stub
+// must exist before that import evaluates; only property mutation on this reference is
+// live afterwards (the precedent test's direct globalThis assignment is banned).
+const flags = vi.hoisted(() => {
+  const f = { angularFilterNonInputControls: false };
+  vi.stubGlobal('FEATURES', f);
+  return f;
+});
+
+import {
+  extractArgTypes,
+  setCompodocJson,
+} from '../../../../frameworks/angular-vite/src/client/compodoc.ts';
+import { computesTemplateSourceFromComponent } from '../../../../frameworks/angular-vite/src/client/renderer/ComputesTemplateFromComponent.ts';
+import { getComponentInputsOutputs } from '../../../../frameworks/angular-vite/src/client/renderer/utils/NgComponentAnalyzer.ts';
+import { BASELINE_PATH } from './baseline-path.ts';
+
+if (BASELINE_PATH !== 'legacy') {
+  throw new Error(
+    'angular-baselines.test.ts records the legacy Compodoc client path; update the recorder or baseline-path.ts'
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
+
+const fixtureCases = readdirSync(fixturesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+type AotCmp = {
+  inputs: Record<string, [string, number, null]>;
+  outputs: Record<string, string>;
+};
+
+describe('angular legacy baselines', () => {
+  it.each(fixtureCases)('%s', async (fixtureCase) => {
+    const testDir = join(fixturesDir, fixtureCase);
+    const dirFiles = readdirSync(testDir);
+    expect(dirFiles.filter((file) => file === `${fixtureCase}.component.ts`)).toHaveLength(1);
+
+    setCompodocJson(JSON.parse(readFileSync(join(testDir, 'compodoc-input.json'), 'utf8')));
+
+    const storiesModule = await import(`./__testfixtures__/${fixtureCase}/input.stories.ts`);
+    const { default: meta, ...stories } = storiesModule;
+    const component = meta.component;
+
+    if (existsSync(join(testDir, 'aot-cmp.ts'))) {
+      // Signal fixture: bare JIT leaves ɵcmp.inputs/outputs empty, which would record
+      // `<tag></tag>` harness artifacts instead of legacy truth. Replace ɵcmp wholesale
+      // with the committed AOT-shaped fragment (defineProperty, because the JIT decorator
+      // installs a getter), then assert the production reader sees its members so a
+      // broken attach fails loudly instead of recording silently.
+      const { aotCmp } = (await import(`./__testfixtures__/${fixtureCase}/aot-cmp.ts`)) as {
+        aotCmp: AotCmp;
+      };
+      Object.defineProperty(component, 'ɵcmp', { value: aotCmp, configurable: true });
+
+      const { inputs, outputs } = getComponentInputsOutputs(component);
+      for (const [templateName, [propName]] of Object.entries(aotCmp.inputs)) {
+        expect(inputs).toContainEqual({ propName, templateName });
+      }
+      for (const [templateName, propName] of Object.entries(aotCmp.outputs)) {
+        expect(outputs).toContainEqual({ propName, templateName });
+      }
+    }
+
+    // extractArgTypes declares the compodoc-JSON-shaped Component | Directive parameter;
+    // production passes the real class through an untyped parameters slot, so the
+    // recorder needs a call-site cast. The uncast class stays correct for the snippet
+    // call (Type<unknown> accepts it structurally).
+    const asCompodocRef = component as unknown as Parameters<typeof extractArgTypes>[0];
+
+    flags.angularFilterNonInputControls = false;
+    const argTypes = extractArgTypes(asCompodocRef);
+    await expect(argTypes).toMatchFileSnapshot(join(testDir, 'argtypes.snapshot'));
+
+    flags.angularFilterNonInputControls = true;
+    await expect(extractArgTypes(asCompodocRef)).toMatchFileSnapshot(
+      join(testDir, 'argtypes-filtered.snapshot')
+    );
+    flags.angularFilterNonInputControls = false;
+
+    for (const [exportName, story] of Object.entries<{ args?: Record<string, unknown> }>(stories)) {
+      const props = { ...meta.args, ...story.args };
+      await expect(
+        computesTemplateSourceFromComponent(component, props, argTypes)
+      ).toMatchFileSnapshot(join(testDir, `snippet-${exportName}.snapshot`));
+    }
+
+    // toMatchFileSnapshot files sit outside vitest's obsolete-snapshot detection, so a
+    // renamed or removed story export would silently leave its old snapshot on disk.
+    const snippetFilesOnDisk = readdirSync(testDir)
+      .filter((file) => file.startsWith('snippet-') && file.endsWith('.snapshot'))
+      .sort();
+    const expectedSnippetFiles = Object.keys(stories)
+      .map((exportName) => `snippet-${exportName}.snapshot`)
+      .sort();
+    expect(snippetFilesOnDisk).toEqual(expectedSnippetFiles);
+  });
+});

--- a/code/lib/docgen-harness/src/angular/angular-baselines.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-baselines.test.ts
@@ -93,8 +93,20 @@ describe('angular legacy baselines', () => {
     );
     flags.angularFilterNonInputControls = false;
 
+    expect(Object.keys(stories).length).toBeGreaterThan(0);
+
     for (const [exportName, story] of Object.entries<{ args?: Record<string, unknown> }>(stories)) {
-      const props = { ...meta.args, ...story.args };
+      // Production runs the actions addon's addActionsFromArgTypes args enhancer before
+      // the source decorator: every output argType carries `action`, so outputs a story
+      // does not set still receive an auto-injected handler arg and the legacy snippet
+      // binds every declared output. Only key presence reaches the snippet text, so a
+      // plain stub stands in for the injected action.
+      const props: Record<string, unknown> = { ...meta.args, ...story.args };
+      for (const [name, argType] of Object.entries(argTypes ?? {})) {
+        if (argType.action && !(name in props)) {
+          props[name] = () => {};
+        }
+      }
       await expect(
         computesTemplateSourceFromComponent(component, props, argTypes)
       ).toMatchFileSnapshot(join(testDir, `snippet-${exportName}.snapshot`));

--- a/code/lib/docgen-harness/src/angular/angular-legacy-gaps.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-legacy-gaps.test.ts
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, test } from 'vitest';
+
+import { BASELINE_PATH } from './baseline-path.ts';
+
+const gapTest = BASELINE_PATH === 'legacy' ? test.fails : test;
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
+
+const BASELINES = {
+  ioBasicsArgTypes: 'decorator-io-basics/argtypes.snapshot',
+  expressionDefaultsArgTypes: 'expression-defaults/argtypes.snapshot',
+  jsdocArgTypes: 'jsdoc-tags/argtypes.snapshot',
+} as const;
+
+const baseline = (key: keyof typeof BASELINES) =>
+  readFileSync(join(fixturesDir, BASELINES[key]), 'utf-8');
+
+// Guards the markers below: a missing snapshot would throw inside a test.fails body and
+// silently masquerade as the expected failure.
+test('every baseline referenced by a red marker exists', () => {
+  for (const relativePath of Object.values(BASELINES)) {
+    expect(existsSync(join(fixturesDir, relativePath)), relativePath).toBe(true);
+  }
+});
+
+describe('legacy argTypes gaps (red until a re-recorded baseline closes them)', () => {
+  gapTest('TS-optional decorator inputs are recorded as not required', () => {
+    // #28706 - legacy: compodoc never emits `optional` for decorator inputsClass
+    // entries, so `required: !item.optional` is true across the board. Only `count`
+    // is TS-optional in the fixture, so the required:false must sit inside its block
+    // (before the alphabetically-next `data` entry) - a fix elsewhere must not close
+    // this marker.
+    expect(baseline('ioBasicsArgTypes')).toMatch(
+      /"count": \{(?:(?!"data": \{)[^])*"required": false/
+    );
+  });
+
+  gapTest('numeric inputs never record an invented NaN default', () => {
+    // Legacy: `castDefaultValue` runs `Number(undefined)` for a number-typed input
+    // without a literal default (`count`), and `Number('5 * 60 * 1000')` for an
+    // expression default (`timeoutMs`) - both record `NaN`. Both files must be
+    // NaN-free; a fix for only one path must not close this marker.
+    expect(baseline('ioBasicsArgTypes')).not.toContain('NaN');
+    expect(baseline('expressionDefaultsArgTypes')).not.toContain('NaN');
+  });
+
+  gapTest('prop JSDoc tags are recorded in table.jsDocTags', () => {
+    // #28506 - legacy: tag names and values never reach argTypes as structured data
+    // (`@deprecated` vanishes entirely; `@see`/custom tag text leaks into the
+    // description prose instead).
+    expect(baseline('jsdocArgTypes')).toContain('"jsDocTags"');
+    expect(baseline('jsdocArgTypes')).toContain('deprecated');
+  });
+
+  gapTest('function-typed inputs get a structured function sbType', () => {
+    // Legacy: compodoc's bare `function` type string falls through the enum
+    // resolution into `{ name: 'other', value: 'empty-enum' }`.
+    expect(baseline('ioBasicsArgTypes')).toContain('"name": "function"');
+  });
+
+  gapTest('@default tag values are extracted clean', () => {
+    // Legacy: the DOMParser extraction keeps the surrounding quotes and the trailing
+    // newline of the JSDoc comment (`'steelblue'\n`).
+    expect(baseline('jsdocArgTypes')).toContain('"summary": "steelblue"');
+  });
+});
+
+// Snippet-side deltas (bindings-only templates, no ng-content, no banana-in-a-box for
+// model(), raw interpolation of functions and undefined) are Story 4.6's documented v1
+// scope, not closeable gaps - they deliberately carry no markers.

--- a/code/lib/docgen-harness/src/angular/angular-legacy-gaps.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-legacy-gaps.test.ts
@@ -49,9 +49,9 @@ describe('legacy argTypes gaps (red until a re-recorded baseline closes them)', 
   });
 
   gapTest('prop JSDoc tags are recorded in table.jsDocTags', () => {
-    // #28506 - legacy: tag names and values never reach argTypes as structured data
-    // (`@deprecated` vanishes entirely; `@see`/custom tag text leaks into the
-    // description prose instead).
+    // Legacy: tag names and values never reach argTypes as structured data
+    // (`@deprecated` vanishes entirely - #9721 tracks displaying it; `@see`/custom
+    // tag text leaks into the description prose instead).
     expect(baseline('jsdocArgTypes')).toContain('"jsDocTags"');
     expect(baseline('jsdocArgTypes')).toContain('deprecated');
   });
@@ -70,5 +70,5 @@ describe('legacy argTypes gaps (red until a re-recorded baseline closes them)', 
 });
 
 // Snippet-side deltas (bindings-only templates, no ng-content, no banana-in-a-box for
-// model(), raw interpolation of functions and undefined) are Story 4.6's documented v1
-// scope, not closeable gaps - they deliberately carry no markers.
+// model(), raw interpolation of functions and undefined) are the documented v1 scope
+// of the OSA snippet work, not closeable gaps - they deliberately carry no markers.

--- a/code/lib/docgen-harness/src/angular/angular-render.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-render.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+// Angular test environment is set up inside this file only: a package-level setupFiles
+// entry would zone-patch the Vue tests too.
+import '@angular/compiler';
+import 'zone.js';
+import 'zone.js/testing';
+
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { TestBed, getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+import { BehaviorSubject } from 'rxjs';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { ICollection } from '../../../../frameworks/angular-vite/src/client/types.ts';
+import { getApplication } from '../../../../frameworks/angular-vite/src/client/renderer/StorybookModule.ts';
+import { storyPropsProvider } from '../../../../frameworks/angular-vite/src/client/renderer/StorybookProvider.ts';
+import { PropertyExtractor } from '../../../../frameworks/angular-vite/src/client/renderer/utils/PropertyExtractor.ts';
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+
+afterEach(() => {
+  TestBed.resetTestingModule();
+});
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
+
+// Signal fixtures cannot render under JIT: their ɵcmp input/output maps stay empty, so
+// bindings are dropped and required signals throw NG0950 at change detection; the OSA
+// path they feed is static and never mounts components either. Their compile evidence
+// is the vue-tsc check; runtime exercise arrives with Epic 4's sandbox stories.
+const SIGNAL_FIXTURES = new Set(['signal-io', 'signal-model']);
+
+const fixtureCases = readdirSync(fixturesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && !SIGNAL_FIXTURES.has(entry.name))
+  .map((entry) => entry.name)
+  .sort();
+
+describe('angular fixtures render (JIT TestBed smoke)', () => {
+  it.each(fixtureCases)('%s', async (fixtureCase) => {
+    const storiesModule = await import(`./__testfixtures__/${fixtureCase}/input.stories.ts`);
+    const { default: meta, ...stories } = storiesModule;
+    const component = meta.component;
+
+    for (const [storyName, story] of Object.entries<{ args?: Record<string, unknown> }>(stories)) {
+      const props: ICollection = { ...meta.args, ...story.args };
+
+      const analyzedMetadata = new PropertyExtractor({}, component);
+      await analyzedMetadata.init();
+
+      const application = getApplication({
+        storyFnAngular: { props },
+        component,
+        targetSelector: 'sb-harness-target',
+        analyzedMetadata,
+      });
+
+      await TestBed.configureTestingModule({
+        imports: [application],
+        providers: [storyPropsProvider(new BehaviorSubject<ICollection>(props))],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(application);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.firstElementChild, `${fixtureCase}/${storyName}`).not.toBeNull();
+      TestBed.resetTestingModule();
+    }
+  });
+});

--- a/code/lib/docgen-harness/src/angular/angular-render.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-render.test.ts
@@ -18,10 +18,10 @@ import {
 import { BehaviorSubject } from 'rxjs';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { ICollection } from '../../../../frameworks/angular-vite/src/client/types.ts';
 import { getApplication } from '../../../../frameworks/angular-vite/src/client/renderer/StorybookModule.ts';
 import { storyPropsProvider } from '../../../../frameworks/angular-vite/src/client/renderer/StorybookProvider.ts';
 import { PropertyExtractor } from '../../../../frameworks/angular-vite/src/client/renderer/utils/PropertyExtractor.ts';
+import type { ICollection } from '../../../../frameworks/angular-vite/src/client/types.ts';
 
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 
@@ -33,8 +33,7 @@ const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__testfixture
 
 // Signal fixtures cannot render under JIT: their ɵcmp input/output maps stay empty, so
 // bindings are dropped and required signals throw NG0950 at change detection; the OSA
-// path they feed is static and never mounts components either. Their compile evidence
-// is the vue-tsc check; runtime exercise arrives once sandbox stories cover signals.
+// path they feed is static and never mounts components either.
 const SIGNAL_FIXTURES = new Set(['signal-io', 'signal-model']);
 
 const fixtureCases = readdirSync(fixturesDir, { withFileTypes: true })

--- a/code/lib/docgen-harness/src/angular/angular-render.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-render.test.ts
@@ -34,7 +34,7 @@ const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__testfixture
 // Signal fixtures cannot render under JIT: their ɵcmp input/output maps stay empty, so
 // bindings are dropped and required signals throw NG0950 at change detection; the OSA
 // path they feed is static and never mounts components either. Their compile evidence
-// is the vue-tsc check; runtime exercise arrives with Epic 4's sandbox stories.
+// is the vue-tsc check; runtime exercise arrives once sandbox stories cover signals.
 const SIGNAL_FIXTURES = new Set(['signal-io', 'signal-model']);
 
 const fixtureCases = readdirSync(fixturesDir, { withFileTypes: true })
@@ -47,6 +47,8 @@ describe('angular fixtures render (JIT TestBed smoke)', () => {
     const storiesModule = await import(`./__testfixtures__/${fixtureCase}/input.stories.ts`);
     const { default: meta, ...stories } = storiesModule;
     const component = meta.component;
+
+    expect(Object.keys(stories).length).toBeGreaterThan(0);
 
     for (const [storyName, story] of Object.entries<{ args?: Record<string, unknown> }>(stories)) {
       const props: ICollection = { ...meta.args, ...story.args };

--- a/code/lib/docgen-harness/src/angular/baseline-path.ts
+++ b/code/lib/docgen-harness/src/angular/baseline-path.ts
@@ -1,0 +1,6 @@
+// Which pipeline produced the committed baselines in __testfixtures__.
+// Flipping this to 'osa' (together with re-pointing the recorder in angular-baselines.test.ts)
+// hardens every test.fails red marker in angular-legacy-gaps.test.ts into a plain requirement.
+export type BaselinePath = 'legacy' | 'osa';
+
+export const BASELINE_PATH: BaselinePath = 'legacy';

--- a/code/lib/docgen-harness/src/angular/csf-types.ts
+++ b/code/lib/docgen-harness/src/angular/csf-types.ts
@@ -1,0 +1,8 @@
+// Fixture stories type their CSF against these instead of '@storybook/angular-vite':
+// the package root resolves to angular-vite's full client source (via the `code`
+// exports condition), which is authored under `strict: false` and cannot join this
+// package's strict vue-tsc program. public-types.ts and its type-only graph can.
+export type {
+  Meta,
+  StoryObj,
+} from '../../../../frameworks/angular-vite/src/client/public-types.ts';

--- a/code/lib/docgen-harness/tsconfig.json
+++ b/code/lib/docgen-harness/tsconfig.json
@@ -1,7 +1,17 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
-  "include": ["src/**/*", "../../renderers/vue3/src/typings.d.ts"],
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": [
+    "src/**/*",
+    "../../renderers/vue3/src/typings.d.ts",
+    "../../frameworks/angular-vite/src/typings.d.ts"
+  ],
+  // These two import angular-vite client runtime source, which is authored under
+  // `strict: false` and cannot join this strict program; vitest is their check.
+  "exclude": ["src/angular/angular-baselines.test.ts", "src/angular/angular-render.test.ts"],
   "vueCompilerOptions": {
     "target": 3
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9943,13 +9943,21 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/docgen-harness@workspace:code/lib/docgen-harness"
   dependencies:
+    "@angular/common": "npm:^21.2.14"
+    "@angular/compiler": "npm:^21.2.14"
+    "@angular/core": "npm:^21.2.14"
+    "@angular/platform-browser": "npm:^21.2.14"
+    "@angular/platform-browser-dynamic": "npm:^21.2.14"
+    "@storybook/angular-vite": "workspace:*"
     "@storybook/vue3": "workspace:*"
     "@testing-library/vue": "npm:^8.0.0"
     "@vitejs/plugin-vue": "npm:^4.6.2"
+    rxjs: "npm:^7.4.0"
     typescript: "npm:^6.0.3"
     vue: "npm:^3.2.47"
     vue-docgen-api: "npm:^4.75.1"
     vue-tsc: "npm:latest"
+    zone.js: "npm:^0.16.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Stacked on #35545 — the diff here is only the Angular vertical (plus one cherry-pick, see below).

## What I did

This adds the Angular vertical to the docgen harness, following the same pattern as the Vue one: record what the legacy Compodoc pipeline produces today, so we can hold the upcoming OSA engine to "current or better" instead of guessing.

We now have Angular fixtures for the tricky docgen cases: decorator inputs and outputs, signals, inheritance, JSDoc. Each with real CSF stories. The recorder replays the production pipeline over them and snapshots the extracted `argTypes` and the generated code snippets as reviewed baselines. Where legacy output is wrong but fixable, the gap is pinned as a `test.fails` red marker; on the OSA, those markers must turn green. The README documents the details.

Quick heads-up: the branch cherry-picks #35551 to keep Chromatic green. The commit dedupes once that fix lands on `next`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `yarn && yarn nx run-many -t compile`
2. `yarn test code/lib/docgen-harness` (from the repo root) — expect 92 tests: 69 passed, 23 expected fail. The expected failures are the red markers (18 Vue, 5 Angular).
3. `yarn nx check docgen-harness`
4. Optional: flip `BASELINE_PATH` in `src/angular/baseline-path.ts` to `'osa'` and re-run step 2 — the five Angular markers now fail hard and the recorder refuses to run. Flip it back afterwards. :slightly_smiling_face:

### Documentation

- [x] Add or update documentation reflecting your changes (`code/lib/docgen-harness/README.md`)
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
