### PR TITLE
Manager: Render the review summary footer landmark as a section

### DIFF
--- a/code/core/src/manager/components/review/screens/SummaryScreen.tsx
+++ b/code/core/src/manager/components/review/screens/SummaryScreen.tsx
@@ -239,9 +239,10 @@ const CollectionLandmark: FC<{ titleId: string; children: ReactNode }> = ({
   );
 };
 
-// A `contentinfo` landmark must stay top-level, but this footer is rendered
-// inside the `main` landmark, so it is exposed as a named `region` instead
-// (a `<footer>` nested in `<main>` has no implicit `contentinfo` role).
+// A `contentinfo` landmark must stay top-level, but this footer sits inside the
+// `main` landmark, so it is exposed as a named `region` instead. It renders as a
+// `section` because `region` is not an allowed role on `footer` (aria-allowed-role),
+// and a `<footer>` nested in `<main>` has no implicit `contentinfo` role anyway.
 const FooterLandmark: FC<{ children: ReactNode }> = ({ children }) => {
   const regionRef = useRef<HTMLDivElement>(null);
   const { landmarkProps } = useLandmark(
@@ -249,7 +250,7 @@ const FooterLandmark: FC<{ children: ReactNode }> = ({ children }) => {
     regionRef
   );
   return (
-    <Footer as="footer" ref={regionRef} {...landmarkProps}>
+    <Footer as="section" ref={regionRef} {...landmarkProps}>
       {children}
     </Footer>
   );


### PR DESCRIPTION
## What I did

Axe's `aria-allowed-role` rule flags `role="region"` on a `footer` element, so every `SummaryScreen` story carries one accessibility violation. Chromatic then asks for a baseline acceptance on any PR whose build re-snapshots the story (it surfaced on #35548 via a lockfile-triggered full re-snapshot).

The `FooterLandmark` in `code/core/src/manager/components/review/screens/SummaryScreen.tsx` now renders as a `section` instead of a `footer`. A named `section` is a valid `region` landmark, and a `footer` nested in `main` has no implicit `contentinfo` role to lose — the landmark keeps its name, position, and keyboard-navigation behavior.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

All 10 `SummaryScreen` story tests pass with the change.

#### Manual testing

1. `cd code && yarn storybook:ui`
2. Open `Manager / Components / Review / Screens / Summary Screen` → `Minimal`
3. Open the Accessibility panel: violations must be 0 (before this change: 1 × "Appropriate role value" on the review footer)

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Updated the “About this review” landmark to use the appropriate section semantics while preserving its accessible label and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->