### PR TITLE
Build: Bump @openai/codex-sdk to 0.145.0 for re-signed macOS binaries

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -53,7 +53,7 @@
     "@google-cloud/bigquery": "^6.2.1",
     "@octokit/graphql": "^5.0.6",
     "@octokit/request": "^8.4.1",
-    "@openai/codex-sdk": "^0.117.0",
+    "@openai/codex-sdk": "^0.145.0",
     "@polka/parse": "^1.0.0-next.28",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5311,67 +5311,67 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openai/codex-darwin-arm64@npm:@openai/codex@0.117.0-darwin-arm64":
-  version: 0.117.0-darwin-arm64
-  resolution: "@openai/codex@npm:0.117.0-darwin-arm64"
+"@openai/codex-darwin-arm64@npm:@openai/codex@0.145.0-darwin-arm64":
+  version: 0.145.0-darwin-arm64
+  resolution: "@openai/codex@npm:0.145.0-darwin-arm64"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@openai/codex-darwin-x64@npm:@openai/codex@0.117.0-darwin-x64":
-  version: 0.117.0-darwin-x64
-  resolution: "@openai/codex@npm:0.117.0-darwin-x64"
+"@openai/codex-darwin-x64@npm:@openai/codex@0.145.0-darwin-x64":
+  version: 0.145.0-darwin-x64
+  resolution: "@openai/codex@npm:0.145.0-darwin-x64"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@openai/codex-linux-arm64@npm:@openai/codex@0.117.0-linux-arm64":
-  version: 0.117.0-linux-arm64
-  resolution: "@openai/codex@npm:0.117.0-linux-arm64"
+"@openai/codex-linux-arm64@npm:@openai/codex@0.145.0-linux-arm64":
+  version: 0.145.0-linux-arm64
+  resolution: "@openai/codex@npm:0.145.0-linux-arm64"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@openai/codex-linux-x64@npm:@openai/codex@0.117.0-linux-x64":
-  version: 0.117.0-linux-x64
-  resolution: "@openai/codex@npm:0.117.0-linux-x64"
+"@openai/codex-linux-x64@npm:@openai/codex@0.145.0-linux-x64":
+  version: 0.145.0-linux-x64
+  resolution: "@openai/codex@npm:0.145.0-linux-x64"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@openai/codex-sdk@npm:^0.117.0":
-  version: 0.117.0
-  resolution: "@openai/codex-sdk@npm:0.117.0"
+"@openai/codex-sdk@npm:^0.145.0":
+  version: 0.145.0
+  resolution: "@openai/codex-sdk@npm:0.145.0"
   dependencies:
-    "@openai/codex": "npm:0.117.0"
-  checksum: 10c0/96f86890fd45a4030a8e9b6f8466389a015d0ee534b1661b56463a1fd210c6fc3af0ea1f3ce57306a13a9b6ff6197d6409a4d5af7f6d7c90e672009eee15e3fd
+    "@openai/codex": "npm:0.145.0"
+  checksum: 10c0/960ec8b7b1573914a3c4b16e34acaf28674e27ea0cfc923b9a5afb503d4d1f9d12f20141a76c7d30f8c26a1b785405e830d0547e29a4e5abc0f766129aca0ed0
   languageName: node
   linkType: hard
 
-"@openai/codex-win32-arm64@npm:@openai/codex@0.117.0-win32-arm64":
-  version: 0.117.0-win32-arm64
-  resolution: "@openai/codex@npm:0.117.0-win32-arm64"
+"@openai/codex-win32-arm64@npm:@openai/codex@0.145.0-win32-arm64":
+  version: 0.145.0-win32-arm64
+  resolution: "@openai/codex@npm:0.145.0-win32-arm64"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@openai/codex-win32-x64@npm:@openai/codex@0.117.0-win32-x64":
-  version: 0.117.0-win32-x64
-  resolution: "@openai/codex@npm:0.117.0-win32-x64"
+"@openai/codex-win32-x64@npm:@openai/codex@0.145.0-win32-x64":
+  version: 0.145.0-win32-x64
+  resolution: "@openai/codex@npm:0.145.0-win32-x64"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@openai/codex@npm:0.117.0":
-  version: 0.117.0
-  resolution: "@openai/codex@npm:0.117.0"
+"@openai/codex@npm:0.145.0":
+  version: 0.145.0
+  resolution: "@openai/codex@npm:0.145.0"
   dependencies:
-    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.117.0-darwin-arm64"
-    "@openai/codex-darwin-x64": "npm:@openai/codex@0.117.0-darwin-x64"
-    "@openai/codex-linux-arm64": "npm:@openai/codex@0.117.0-linux-arm64"
-    "@openai/codex-linux-x64": "npm:@openai/codex@0.117.0-linux-x64"
-    "@openai/codex-win32-arm64": "npm:@openai/codex@0.117.0-win32-arm64"
-    "@openai/codex-win32-x64": "npm:@openai/codex@0.117.0-win32-x64"
+    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.145.0-darwin-arm64"
+    "@openai/codex-darwin-x64": "npm:@openai/codex@0.145.0-darwin-x64"
+    "@openai/codex-linux-arm64": "npm:@openai/codex@0.145.0-linux-arm64"
+    "@openai/codex-linux-x64": "npm:@openai/codex@0.145.0-linux-x64"
+    "@openai/codex-win32-arm64": "npm:@openai/codex@0.145.0-win32-arm64"
+    "@openai/codex-win32-x64": "npm:@openai/codex@0.145.0-win32-x64"
   dependenciesMeta:
     "@openai/codex-darwin-arm64":
       optional: true
@@ -5387,7 +5387,7 @@ __metadata:
       optional: true
   bin:
     codex: bin/codex.js
-  checksum: 10c0/a5104a396f0f33558c9a402012bf2dd954f5d3465d3b0bb5fe780d265760a3c72b64af4a2d42a0012f661b7e4a274a42c5d4f5582de115613557f480dbec3b5b
+  checksum: 10c0/231e69274b32913660bc94fce3785214a198b32bec10cbba1fadbf04fe42f79e9561f22426ae35002efff63111704fbdb1649f399d7d6c5a7d0f92deaca38c6a
   languageName: node
   linkType: hard
 
@@ -10386,7 +10386,7 @@ __metadata:
     "@google-cloud/bigquery": "npm:^6.2.1"
     "@octokit/graphql": "npm:^5.0.6"
     "@octokit/request": "npm:^8.4.1"
-    "@openai/codex-sdk": "npm:^0.117.0"
+    "@openai/codex-sdk": "npm:^0.145.0"
     "@polka/parse": "npm:^1.0.0-next.28"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.9.1"


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Bumped `@openai/codex-sdk` in `scripts/package.json` from `^0.117.0` to `^0.145.0` (caret on 0.x only allows patch updates, so the range itself had to change).

After [OpenAI's March 31, 2026 code-signing CI compromise via a malicious Axios build](https://openai.com/index/axios-developer-tool-compromise/), Apple revoked the Developer ID certificates used to sign older Codex builds. Since May 8, 2026, macOS SIGKILLs the vendored `@openai/codex` platform binaries from 0.117.0 on launch (`CSSMERR_TP_CERT_REVOKED`) and then removes the binary file, leaving an empty `vendor/*/codex/` directory in `node_modules` that a subsequent `yarn install` does not repair. Any tool that spawns `codex` with `node_modules/.bin` on `PATH` (e.g. via tinyexec/execa) then fails with ENOENT instead of reaching a globally installed codex CLI.

0.145.0's platform binaries are signed with OpenAI's replacement certificate (verified: the darwin-arm64 binary executes on macOS and `spctl` no longer reports the certificate as revoked). Linux CI was never affected, which is why this went unnoticed.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

No automated tests apply — this is a dependency bump of an internal scripts dependency; there is no runtime code change to cover.

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

On an Apple Silicon Mac:

1. Check out this branch and run `yarn` from the repo root
2. Run `node_modules/.bin/codex --version` — it should print `codex-cli 0.145.0` (before this PR, the process is killed with exit code 137, or fails with ENOENT once macOS has swept the revoked binary)

On Linux/Windows this PR should be behavior-neutral.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->