### PR TITLE
Vue: Fix Component Metadata in Production Builds

### DIFF
--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -130,6 +130,21 @@ describe('vue-component-meta plugin', () => {
       expect(result!.code).toContain('_sfc_main.__docgenInfo');
     });
 
+    it('should inject __docgenInfo when a production SFC imports its default export', async () => {
+      const src = [
+        `import _sfc_main from './Tab.vue?vue&type=script&setup=true&lang.ts';`,
+        `export default _sfc_main;`,
+      ].join('\n');
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result).toBeDefined();
+      expect(result!.code).toContain('_sfc_main.__docgenInfo');
+    });
+
     it('should NOT inject __docgenInfo when the default export is an inline expression with no local binding', async () => {
       const src = `import { defineComponent } from 'vue';\nexport default defineComponent({});\n`;
       const id = '/project/src/components/Tab.ts';

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -145,6 +145,30 @@ describe('vue-component-meta plugin', () => {
       expect(result!.code).toContain('_sfc_main.__docgenInfo');
     });
 
+    it('should not inject __docgenInfo when an SFC default export has no _sfc_main import', async () => {
+      const src = `export default { name: 'Tab' };\n`;
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result?.code ?? '').not.toContain('__docgenInfo');
+    });
+
+    it('should not inject __docgenInfo when _sfc_main is imported from a non-virtual module', async () => {
+      const src = [`import _sfc_main from './shared-component';`, `export default _sfc_main;`].join(
+        '\n'
+      );
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result?.code ?? '').not.toContain('__docgenInfo');
+    });
+
     it('should NOT inject __docgenInfo when the default export is an inline expression with no local binding', async () => {
       const src = `import { defineComponent } from 'vue';\nexport default defineComponent({});\n`;
       const id = '/project/src/components/Tab.ts';

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -153,6 +153,7 @@ describe('vue-component-meta plugin', () => {
 
       const result = await transform(src, id);
 
+      expect(result).toBeDefined();
       expect(result?.code ?? '').not.toContain('__docgenInfo');
     });
 
@@ -166,6 +167,7 @@ describe('vue-component-meta plugin', () => {
 
       const result = await transform(src, id);
 
+      expect(result).toBeDefined();
       expect(result?.code ?? '').not.toContain('__docgenInfo');
     });
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -126,7 +126,8 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
             const isDefaultExport = meta.exportName === 'default';
             const name = isDefaultExport ? '_sfc_main' : meta.exportName;
 
-            if (!localBindings.has(name)) {
+            // Production SFCs can import `_sfc_main` from their virtual script module.
+            if (!localBindings.has(name) && !(id.endsWith('.vue') && isDefaultExport)) {
               return;
             }
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -125,9 +125,15 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
           metaSources.forEach((meta) => {
             const isDefaultExport = meta.exportName === 'default';
             const name = isDefaultExport ? '_sfc_main' : meta.exportName;
+            const isImportedSfcMain =
+              isDefaultExport &&
+              id.endsWith('.vue') &&
+              /^import\s+_sfc_main\s+from\s+['"][^'"]+\?vue&type=script(?:&[^'"]*)?['"];?$/m.test(
+                src
+              );
 
             // Production SFCs can import `_sfc_main` from their virtual script module.
-            if (!localBindings.has(name) && !(id.endsWith('.vue') && isDefaultExport)) {
+            if (!localBindings.has(name) && !isImportedSfcMain) {
               return;
             }
 


### PR DESCRIPTION
## What I did

- allow Vue SFC default exports to receive `__docgenInfo` when `_sfc_main` is imported from the virtual script module
- add a regression test for the production `@vitejs/plugin-vue` output shape

## Why

Production builds can emit `_sfc_main` as an import rather than a top-level declaration. The local-binding guard therefore skipped metadata injection even though the imported component is a valid runtime binding.

Fixes #35518.

## Testing

- focused `vue-component-meta.test.ts`: 10 tests passed
- focused TypeScript `noEmit` check passed
- `oxfmt` 0.41.0 completed
- `git diff --check` passed

#### Manual testing

Build a Vue Storybook configured with `docgen: 'vue-component-meta'` and a component using `<script setup lang="ts">`, then confirm its controls and descriptions remain available in the production build.

This contribution was developed with assistance from OpenAI Codex; I reviewed and validated the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue component metadata injection for production builds when a component is default-exported from a `.vue` file, including cases using the setup-script virtual module.
  * Prevents incorrect `__docgenInfo` injection when the expected internal `_sfc_main` binding isn’t present or originates from a non-virtual module path.
* **Tests**
  * Expanded test coverage for production SFC default-export behavior, including added negative cases to ensure metadata is not injected incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->