### PR TITLE
Build: Bump Codex SDK and cap setup install architectures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1'
       - run:
+          name: Limit installs to the runner architecture
+          command: yarn config set supportedArchitectures --json '{"os":["current"],"cpu":["current"]}'
+      - run:
           name: Install dependencies
           command: yarn workspaces focus @storybook/scripts
       - run:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -53,7 +53,7 @@
     "@google-cloud/bigquery": "^6.2.1",
     "@octokit/graphql": "^5.0.6",
     "@octokit/request": "^8.4.1",
-    "@openai/codex-sdk": "^0.117.0",
+    "@openai/codex-sdk": "^0.145.0",
     "@polka/parse": "^1.0.0-next.28",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5311,67 +5311,67 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openai/codex-darwin-arm64@npm:@openai/codex@0.117.0-darwin-arm64":
-  version: 0.117.0-darwin-arm64
-  resolution: "@openai/codex@npm:0.117.0-darwin-arm64"
+"@openai/codex-darwin-arm64@npm:@openai/codex@0.145.0-darwin-arm64":
+  version: 0.145.0-darwin-arm64
+  resolution: "@openai/codex@npm:0.145.0-darwin-arm64"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@openai/codex-darwin-x64@npm:@openai/codex@0.117.0-darwin-x64":
-  version: 0.117.0-darwin-x64
-  resolution: "@openai/codex@npm:0.117.0-darwin-x64"
+"@openai/codex-darwin-x64@npm:@openai/codex@0.145.0-darwin-x64":
+  version: 0.145.0-darwin-x64
+  resolution: "@openai/codex@npm:0.145.0-darwin-x64"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@openai/codex-linux-arm64@npm:@openai/codex@0.117.0-linux-arm64":
-  version: 0.117.0-linux-arm64
-  resolution: "@openai/codex@npm:0.117.0-linux-arm64"
+"@openai/codex-linux-arm64@npm:@openai/codex@0.145.0-linux-arm64":
+  version: 0.145.0-linux-arm64
+  resolution: "@openai/codex@npm:0.145.0-linux-arm64"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@openai/codex-linux-x64@npm:@openai/codex@0.117.0-linux-x64":
-  version: 0.117.0-linux-x64
-  resolution: "@openai/codex@npm:0.117.0-linux-x64"
+"@openai/codex-linux-x64@npm:@openai/codex@0.145.0-linux-x64":
+  version: 0.145.0-linux-x64
+  resolution: "@openai/codex@npm:0.145.0-linux-x64"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@openai/codex-sdk@npm:^0.117.0":
-  version: 0.117.0
-  resolution: "@openai/codex-sdk@npm:0.117.0"
+"@openai/codex-sdk@npm:^0.145.0":
+  version: 0.145.0
+  resolution: "@openai/codex-sdk@npm:0.145.0"
   dependencies:
-    "@openai/codex": "npm:0.117.0"
-  checksum: 10c0/96f86890fd45a4030a8e9b6f8466389a015d0ee534b1661b56463a1fd210c6fc3af0ea1f3ce57306a13a9b6ff6197d6409a4d5af7f6d7c90e672009eee15e3fd
+    "@openai/codex": "npm:0.145.0"
+  checksum: 10c0/960ec8b7b1573914a3c4b16e34acaf28674e27ea0cfc923b9a5afb503d4d1f9d12f20141a76c7d30f8c26a1b785405e830d0547e29a4e5abc0f766129aca0ed0
   languageName: node
   linkType: hard
 
-"@openai/codex-win32-arm64@npm:@openai/codex@0.117.0-win32-arm64":
-  version: 0.117.0-win32-arm64
-  resolution: "@openai/codex@npm:0.117.0-win32-arm64"
+"@openai/codex-win32-arm64@npm:@openai/codex@0.145.0-win32-arm64":
+  version: 0.145.0-win32-arm64
+  resolution: "@openai/codex@npm:0.145.0-win32-arm64"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@openai/codex-win32-x64@npm:@openai/codex@0.117.0-win32-x64":
-  version: 0.117.0-win32-x64
-  resolution: "@openai/codex@npm:0.117.0-win32-x64"
+"@openai/codex-win32-x64@npm:@openai/codex@0.145.0-win32-x64":
+  version: 0.145.0-win32-x64
+  resolution: "@openai/codex@npm:0.145.0-win32-x64"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@openai/codex@npm:0.117.0":
-  version: 0.117.0
-  resolution: "@openai/codex@npm:0.117.0"
+"@openai/codex@npm:0.145.0":
+  version: 0.145.0
+  resolution: "@openai/codex@npm:0.145.0"
   dependencies:
-    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.117.0-darwin-arm64"
-    "@openai/codex-darwin-x64": "npm:@openai/codex@0.117.0-darwin-x64"
-    "@openai/codex-linux-arm64": "npm:@openai/codex@0.117.0-linux-arm64"
-    "@openai/codex-linux-x64": "npm:@openai/codex@0.117.0-linux-x64"
-    "@openai/codex-win32-arm64": "npm:@openai/codex@0.117.0-win32-arm64"
-    "@openai/codex-win32-x64": "npm:@openai/codex@0.117.0-win32-x64"
+    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.145.0-darwin-arm64"
+    "@openai/codex-darwin-x64": "npm:@openai/codex@0.145.0-darwin-x64"
+    "@openai/codex-linux-arm64": "npm:@openai/codex@0.145.0-linux-arm64"
+    "@openai/codex-linux-x64": "npm:@openai/codex@0.145.0-linux-x64"
+    "@openai/codex-win32-arm64": "npm:@openai/codex@0.145.0-win32-arm64"
+    "@openai/codex-win32-x64": "npm:@openai/codex@0.145.0-win32-x64"
   dependenciesMeta:
     "@openai/codex-darwin-arm64":
       optional: true
@@ -5387,7 +5387,7 @@ __metadata:
       optional: true
   bin:
     codex: bin/codex.js
-  checksum: 10c0/a5104a396f0f33558c9a402012bf2dd954f5d3465d3b0bb5fe780d265760a3c72b64af4a2d42a0012f661b7e4a274a42c5d4f5582de115613557f480dbec3b5b
+  checksum: 10c0/231e69274b32913660bc94fce3785214a198b32bec10cbba1fadbf04fe42f79e9561f22426ae35002efff63111704fbdb1649f399d7d6c5a7d0f92deaca38c6a
   languageName: node
   linkType: hard
 
@@ -10408,7 +10408,7 @@ __metadata:
     "@google-cloud/bigquery": "npm:^6.2.1"
     "@octokit/graphql": "npm:^5.0.6"
     "@octokit/request": "npm:^8.4.1"
-    "@openai/codex-sdk": "npm:^0.117.0"
+    "@openai/codex-sdk": "npm:^0.145.0"
     "@polka/parse": "npm:^1.0.0-next.28"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.9.1"


### PR DESCRIPTION
## What I did

macOS revoked the signing certificate of the vendored binaries in Codex releases before 0.144, so `@openai/codex-sdk` moves `^0.117.0 → ^0.145.0` in `scripts/`.

The 0.145 platform binaries are roughly twice the size of 0.117 (~330 MB each), and `.yarnrc.yml` `supportedArchitectures` spans linux/darwin × x64/arm64 — four codex binaries per install. A first attempt at this bump OOM-killed the CircleCI setup job (`yarn workspaces focus @storybook/scripts`, exit 137 during fetch; see the revert `c953f1ef7c` on #35555). This PR therefore also caps the **setup job's** install to the runner's own architecture with a `yarn config set supportedArchitectures` step — the committed `.yarnrc.yml` is unchanged, so local installs and the lockfile still cover all platforms.

Measured on fresh isolated caches (scripts-focused install): **1.9 G → 789 M (−60.2%)**.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`yarn nx check scripts` and the scripts vitest project (28 files / 250 tests) pass; `yarn dedupe --check` green.

#### Manual testing

1. Fresh clone of this branch, then `yarn config set supportedArchitectures --json '{"os":["current"],"cpu":["current"]}'` followed by `YARN_GLOBAL_FOLDER=$(mktemp -d) yarn workspaces focus @storybook/scripts` — the global folder stays well under 1 GB.
2. Without the config step, the same install fetches ~1.9 GB (all four codex platform binaries).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation changes — internal tooling only.

## Checklist for Maintainers

- [x] `ci:normal` applied
- [x] `qa:skip` — internal build tooling, no user-facing behavior
- [x] Type label: `build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Codex SDK dependency to a newer version.
  * Improved CI dependency installation by limiting packages to the runner’s operating system and CPU architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->