### PR TITLE
ReactNative: Telemetry framework detection fix

### DIFF
--- a/code/core/src/common/utils/get-storybook-info-rn.test.ts
+++ b/code/core/src/common/utils/get-storybook-info-rn.test.ts
@@ -2,6 +2,8 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
+import { SupportedRenderer } from 'storybook/internal/types';
+
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { getStorybookInfo } from './get-storybook-info.ts';
@@ -35,6 +37,7 @@ describe('getStorybookInfo React Native framework inference', () => {
 
     expect(info.frameworkPackage).toBe('@storybook/react-native');
     expect(info.rendererPackage).toBe('@storybook/react-native');
+    expect(info.renderer).toBe(SupportedRenderer.REACT_NATIVE);
   });
 
   it('does not infer RN framework for a plain .storybook without framework', async () => {

--- a/code/core/src/common/utils/get-storybook-info-rn.test.ts
+++ b/code/core/src/common/utils/get-storybook-info-rn.test.ts
@@ -1,0 +1,57 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getStorybookInfo } from './get-storybook-info.ts';
+
+describe('getStorybookInfo React Native framework inference', () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('infers @storybook/react-native when framework is missing in .rnstorybook', async () => {
+    dir = join(tmpdir(), `sb-rn-info-${Date.now()}`);
+    mkdirSync(join(dir, '.rnstorybook'), { recursive: true });
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'rn-app',
+        private: true,
+        devDependencies: { '@storybook/react-native': '10.5.1', storybook: '10.5.3' },
+      })
+    );
+    writeFileSync(
+      join(dir, '.rnstorybook/main.js'),
+      `module.exports = { stories: ['**/*.stories.tsx'], deviceAddons: [] };`
+    );
+
+    const info = await getStorybookInfo(join(dir, '.rnstorybook'), dir);
+
+    expect(info.frameworkPackage).toBe('@storybook/react-native');
+    expect(info.rendererPackage).toBe('@storybook/react-native');
+  });
+
+  it('does not infer RN framework for a plain .storybook without framework', async () => {
+    dir = join(tmpdir(), `sb-web-info-${Date.now()}`);
+    mkdirSync(join(dir, '.storybook'), { recursive: true });
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'web-app',
+        private: true,
+        devDependencies: { storybook: '10.5.3' },
+      })
+    );
+    writeFileSync(join(dir, '.storybook/main.js'), `module.exports = { stories: [] };`);
+
+    const info = await getStorybookInfo(join(dir, '.storybook'), dir);
+
+    expect(info.frameworkPackage).toBeUndefined();
+  });
+});

--- a/code/core/src/common/utils/get-storybook-info.ts
+++ b/code/core/src/common/utils/get-storybook-info.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 import type {
   CoreCommon_StorybookInfo,
@@ -15,6 +15,7 @@ import {
 
 import invariant from 'tiny-invariant';
 
+import { RN_STORYBOOK_DIR } from '../../shared/constants/config-folder.ts';
 import { JsPackageManager } from '../js-package-manager/JsPackageManager.ts';
 import { frameworkToBuilder } from './framework.ts';
 import { getAddonNames } from './get-addon-names.ts';
@@ -165,6 +166,25 @@ export const getStorybookInfo = async (
   const versionSpecifier = getStorybookVersionSpecifier(configDir);
 
   if (!frameworkField) {
+    // React Native on-device Storybook historically omitted `framework` from main.ts.
+    // When the config lives in `.rnstorybook`, infer the framework so telemetry
+    // `metadata.framework.name` is populated for existing projects (scoped to the
+    // RN config dir to avoid mis-attributing web Storybooks in the same monorepo).
+    if (basename(configInfo.configDir) === RN_STORYBOOK_DIR) {
+      return {
+        ...configInfo,
+        versionSpecifier,
+        addons,
+        mainConfig,
+        frameworkPackage: '@storybook/react-native',
+        rendererPackage: '@storybook/react-native',
+        renderer: SupportedRenderer.REACT_NATIVE,
+        mainConfigPath: configInfo.mainConfigPath ?? undefined,
+        previewConfigPath: configInfo.previewConfigPath ?? undefined,
+        managerConfigPath: configInfo.managerConfigPath ?? undefined,
+      };
+    }
+
     return {
       ...configInfo,
       versionSpecifier,

--- a/code/core/src/common/utils/get-storybook-info.ts
+++ b/code/core/src/common/utils/get-storybook-info.ts
@@ -166,10 +166,12 @@ export const getStorybookInfo = async (
   const versionSpecifier = getStorybookVersionSpecifier(configDir);
 
   if (!frameworkField) {
-    // React Native on-device Storybook historically omitted `framework` from main.ts.
-    // When the config lives in `.rnstorybook`, infer the framework so telemetry
-    // `metadata.framework.name` is populated for existing projects (scoped to the
-    // RN config dir to avoid mis-attributing web Storybooks in the same monorepo).
+    /*
+      React Native on-device Storybook historically omitted `framework` from main.ts.
+      When the config lives in `.rnstorybook`, infer the framework so telemetry
+      `metadata.framework.name` is populated for existing projects (scoped to the
+      RN config dir to avoid mis-attributing web Storybooks in the same monorepo).
+    */
     if (basename(configInfo.configDir) === RN_STORYBOOK_DIR) {
       return {
         ...configInfo,

--- a/code/core/src/telemetry/storybook-metadata.ts
+++ b/code/core/src/telemetry/storybook-metadata.ts
@@ -313,12 +313,14 @@ async function hashMainConfig(configDir: string): Promise<string> {
 }
 
 function resolveDefaultConfigDir(packageJson: PackageJson): string {
-  // TODO: improve the way configDir is extracted, as a "storybook" script might not be present
-  // Scenarios:
-  // 1. user changed it to something else e.g. "storybook:dev"
-  // 2. they are using angular/nx where the storybook config is defined somewhere else
-  // 3. React Native on-device Storybook uses `.rnstorybook` and `storybook:ios`/`storybook:android`
-  //    scripts (no `storybook` script), so the `.storybook` default never finds the config.
+  /*
+    TODO: improve the way configDir is extracted, as a "storybook" script might not be present.
+    Scenarios:
+    1. user changed it to something else e.g. "storybook:dev"
+    2. they are using angular/nx where the storybook config is defined somewhere else
+    3. React Native on-device Storybook uses `.rnstorybook` and `storybook:ios`/`storybook:android`
+       scripts (no `storybook` script), so the `.storybook` default never finds the config.
+  */
   const fromScript = getStorybookConfiguration(
     String((packageJson?.scripts as Record<string, unknown> | undefined)?.storybook || ''),
     '-c',

--- a/code/core/src/telemetry/storybook-metadata.ts
+++ b/code/core/src/telemetry/storybook-metadata.ts
@@ -14,6 +14,8 @@ import { getInterpretedFile } from 'storybook/internal/common';
 import { readConfig } from 'storybook/internal/csf-tools';
 import type { PackageJson, StorybookConfig } from 'storybook/internal/types';
 
+import { RN_STORYBOOK_DIR } from '../shared/constants/config-folder.ts';
+
 import * as pkg from 'empathic/package';
 
 import { version } from '../../package.json';
@@ -310,20 +312,33 @@ async function hashMainConfig(configDir: string): Promise<string> {
   }
 }
 
-export const getStorybookMetadata = async (_configDir?: string) => {
-  const { packageJson, packageJsonPath } = await getPackageJsonDetails();
+function resolveDefaultConfigDir(packageJson: PackageJson): string {
   // TODO: improve the way configDir is extracted, as a "storybook" script might not be present
   // Scenarios:
   // 1. user changed it to something else e.g. "storybook:dev"
   // 2. they are using angular/nx where the storybook config is defined somewhere else
-  const configDir =
-    (_configDir ||
-      (getStorybookConfiguration(
-        String((packageJson?.scripts as Record<string, unknown> | undefined)?.storybook || ''),
-        '-c',
-        '--config-dir'
-      ) as string)) ??
-    '.storybook';
+  // 3. React Native on-device Storybook uses `.rnstorybook` and `storybook:ios`/`storybook:android`
+  //    scripts (no `storybook` script), so the `.storybook` default never finds the config.
+  const fromScript = getStorybookConfiguration(
+    String((packageJson?.scripts as Record<string, unknown> | undefined)?.storybook || ''),
+    '-c',
+    '--config-dir'
+  ) as string | null;
+
+  if (fromScript) {
+    return fromScript;
+  }
+
+  if (existsSync(resolve(RN_STORYBOOK_DIR))) {
+    return RN_STORYBOOK_DIR;
+  }
+
+  return '.storybook';
+}
+
+export const getStorybookMetadata = async (_configDir?: string) => {
+  const { packageJson, packageJsonPath } = await getPackageJsonDetails();
+  const configDir = _configDir || resolveDefaultConfigDir(packageJson);
   const contentHash = await hashMainConfig(configDir);
   const cacheKey = `${configDir}::${contentHash}`;
   const cached = metadataCache.get(cacheKey);

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -193,8 +193,8 @@ export async function doInitiate(options: CommandOptions): Promise<
     aiSetupCommand: packageManager.getPackageCommand(['storybook', 'ai', 'setup']),
   });
 
-  // Step 9: Track telemetry
-  await telemetryService.trackInitWithContext(projectType, selectedFeatures, newUser);
+  // Step 9: Track telemetry (pass configDir so RN `.rnstorybook` metadata is resolved)
+  await telemetryService.trackInitWithContext(projectType, selectedFeatures, newUser, configDir);
 
   // Signal dev to redirect to onboarding on first run
   if (selectedFeatures.has(Feature.ONBOARDING)) {

--- a/code/lib/create-storybook/src/services/TelemetryService.test.ts
+++ b/code/lib/create-storybook/src/services/TelemetryService.test.ts
@@ -59,7 +59,7 @@ describe('TelemetryService', () => {
 
       await telemetryService.trackInit(data);
 
-      expect(telemetry).toHaveBeenCalledWith('init', data);
+      expect(telemetry).toHaveBeenCalledWith('init', data, { configDir: undefined });
     });
 
     it('should track scaffolded event', async () => {
@@ -113,22 +113,31 @@ describe('TelemetryService', () => {
         { command: 'npx storybook@8.0.5 init' },
       ] as any);
 
-      await telemetryService.trackInitWithContext(ProjectType.REACT, selectedFeatures, true);
+      await telemetryService.trackInitWithContext(
+        ProjectType.REACT,
+        selectedFeatures,
+        true,
+        '.rnstorybook'
+      );
 
       expect(getProcessAncestry).toHaveBeenCalled();
-      expect(telemetry).toHaveBeenCalledWith('init', {
-        projectType: ProjectType.REACT,
-        features: {
-          dev: true,
-          docs: true,
-          test: true,
-          onboarding: false,
-          ai: false,
+      expect(telemetry).toHaveBeenCalledWith(
+        'init',
+        {
+          projectType: ProjectType.REACT,
+          features: {
+            dev: true,
+            docs: true,
+            test: true,
+            onboarding: false,
+            ai: false,
+          },
+          newUser: true,
+          versionSpecifier: '8.0.5',
+          cliIntegration: undefined,
         },
-        newUser: true,
-        versionSpecifier: '8.0.5',
-        cliIntegration: undefined,
-      });
+        { configDir: '.rnstorybook' }
+      );
     });
 
     it('should handle ancestry errors gracefully', async () => {
@@ -141,19 +150,23 @@ describe('TelemetryService', () => {
 
       await telemetryService.trackInitWithContext(ProjectType.VUE3, selectedFeatures, false);
 
-      expect(telemetry).toHaveBeenCalledWith('init', {
-        projectType: ProjectType.VUE3,
-        features: {
-          dev: true,
-          docs: false,
-          test: false,
-          onboarding: false,
-          ai: false,
+      expect(telemetry).toHaveBeenCalledWith(
+        'init',
+        {
+          projectType: ProjectType.VUE3,
+          features: {
+            dev: true,
+            docs: false,
+            test: false,
+            onboarding: false,
+            ai: false,
+          },
+          newUser: false,
+          versionSpecifier: undefined,
+          cliIntegration: undefined,
         },
-        newUser: false,
-        versionSpecifier: undefined,
-        cliIntegration: undefined,
-      });
+        { configDir: undefined }
+      );
     });
 
     it('should detect CLI integration from ancestry', async () => {
@@ -168,7 +181,8 @@ describe('TelemetryService', () => {
         'init',
         expect.objectContaining({
           cliIntegration: 'sv create',
-        })
+        }),
+        { configDir: undefined }
       );
     });
 
@@ -187,7 +201,8 @@ describe('TelemetryService', () => {
           'init',
           expect.objectContaining({
             features: expect.objectContaining({ ai: true }),
-          })
+          }),
+          { configDir: undefined }
         );
       });
     });

--- a/code/lib/create-storybook/src/services/TelemetryService.ts
+++ b/code/lib/create-storybook/src/services/TelemetryService.ts
@@ -50,20 +50,24 @@ export class TelemetryService {
   }
 
   /** Track the main init event with all metadata */
-  async trackInit(data: {
-    projectType: ProjectType;
-    features: {
-      dev: boolean;
-      docs: boolean;
-      test: boolean;
-      onboarding: boolean;
-      ai: boolean;
-    };
-    newUser: boolean;
-    versionSpecifier?: string;
-    cliIntegration?: string;
-  }): Promise<void> {
-    await telemetry('init', data);
+  async trackInit(
+    data: {
+      projectType: ProjectType;
+      features: {
+        dev: boolean;
+        docs: boolean;
+        test: boolean;
+        onboarding: boolean;
+        ai: boolean;
+      };
+      newUser: boolean;
+      versionSpecifier?: string;
+      cliIntegration?: string;
+    },
+    options: { configDir?: string } = {}
+  ): Promise<void> {
+    // Pass configDir so metadata resolves `.rnstorybook` (RN) instead of defaulting to `.storybook`.
+    await telemetry('init', data, { configDir: options.configDir });
   }
 
   /** Track empty directory scaffolding event */
@@ -78,7 +82,8 @@ export class TelemetryService {
   async trackInitWithContext(
     projectType: ProjectType,
     selectedFeatures: Set<Feature>,
-    newUser: boolean
+    newUser: boolean,
+    configDir?: string
   ): Promise<void> {
     // Get telemetry info from process ancestry
     let versionSpecifier: string | undefined;
@@ -101,13 +106,16 @@ export class TelemetryService {
       ai: selectedFeatures.has(Feature.AI),
     };
 
-    await this.trackInit({
-      projectType,
-      features: telemetryFeatures,
-      newUser,
-      versionSpecifier,
-      cliIntegration,
-    });
+    await this.trackInit(
+      {
+        projectType,
+        features: telemetryFeatures,
+        newUser,
+        versionSpecifier,
+        cliIntegration,
+      },
+      { configDir }
+    );
   }
 
   async trackPromptCancel(prompt: string): Promise<void> {


### PR DESCRIPTION
Closes #35462

## What I did

When `configDir` is `.rnstorybook` and `main` has no `framework` field, infer React Native framework metadata used by telemetry:

- `frameworkPackage`: `@storybook/react-native`
- `rendererPackage`: `@storybook/react-native`
- `renderer`: `REACT_NATIVE`

Also pass `configDir` through `create-storybook` init telemetry, and prefer `.rnstorybook` when resolving the default config dir (RN has no `scripts.storybook`).

Does **not** reintroduce `node_modules` package scanning.

<details>
<summary>Why this is needed (background)</summary>

RN on-device Storybook historically omitted `framework` from `.rnstorybook/main`. Framework used to be inferred by scanning installed packages under `node_modules`; that was removed because it was unreliable with monorepos / PnP / hoisting, and resolution moved to `main.framework` instead.

For most existing RN projects that field is missing, so `metadata.framework.name` stays empty and Metabase charts that filter on it look empty — even after [react-native#907](https://github.com/storybookjs/react-native/pull/907) restored `dev` event delivery (`setTelemetryEnabled` + `configDir`).

We discussed alternatives (automigration / rewriting user `main` / temp config dirs / metadata overrides on the telemetry options object) and agreed with @valentinpalkovic that matching on `.rnstorybook` in core is the simplest fix that covers upgrades without user file changes.

</details>

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!NOTE]
> No meaningful sandbox / UI manual test for this change. Behavior is pure metadata inference; the unit tests in `get-storybook-info-rn.test.ts` and `TelemetryService.test.ts` are the intended verification.

To re-run locally after building `storybook` / `eslint-plugin-storybook`:

```bash
yarn vitest run --config code/core/vitest.config.ts \
  code/core/src/common/utils/get-storybook-info-rn.test.ts
yarn vitest run --config code/lib/create-storybook/vitest.config.ts \
  code/lib/create-storybook/src/services/TelemetryService.test.ts
```

<details>
<summary>Optional end-to-end check (involved; not required for review)</summary>

Full Metabase-style validation needs a React Native app on `@storybook/react-native` ≥ 10.5.1 (for `setTelemetryEnabled` + `configDir`), a Storybook build that includes this PR, and a telemetry sink or `STORYBOOK_TELEMETRY_DEBUG=1`. That path is useful for release confidence, not for routine PR review.

</details>

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<details>
<summary>Release follow-up</summary>

1. Patch-release Storybook core with this change
2. RN apps still need `@storybook/react-native` with [react-native#907](https://github.com/storybookjs/react-native/pull/907) for `dev` events to send
3. The temp-dir workaround in [react-native#912](https://github.com/storybookjs/react-native/pull/912) can be dropped once this core fix is available

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of React Native Storybook projects using `.rnstorybook` configurations.
  * Storybook metadata now correctly resolves custom configuration directories, including React Native defaults.
  * Initialization telemetry now uses the project’s configured Storybook directory for more accurate metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->