### PR TITLE
Test: Register afterEach in transformed story files

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -544,6 +544,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
           tagsFilter: finalOptions.tags,
           stories: storiesGlobs,
           previewLevelTags,
+          registerStorybookAfterEach: true,
         });
       }
     },

--- a/code/addons/vitest/src/vitest-plugin/setup-file.ts
+++ b/code/addons/vitest/src/vitest-plugin/setup-file.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, vi } from 'vitest';
+import { beforeAll, vi } from 'vitest';
 import type { RunnerTask } from 'vitest';
 
 import { Channel } from 'storybook/internal/channels';
@@ -66,7 +66,7 @@ beforeAll(() => {
   }
 });
 
-afterEach((ctx) => {
+export const afterEachStory = (ctx: { task: Task }) => {
   restoreDefaultChannel();
   modifyErrorMessage({ task: ctx.task });
-});
+};

--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -32,6 +32,7 @@ const transform = async ({
   configDir = '.storybook',
   stories = [],
   previewLevelTags = [],
+  registerStorybookAfterEach = false,
 }) => {
   const transformed = await originalTransform({
     code,
@@ -40,6 +41,7 @@ const transform = async ({
     stories,
     tagsFilter,
     previewLevelTags,
+    registerStorybookAfterEach,
   });
   if (typeof transformed === 'string') {
     return { code: transformed, map: null };
@@ -49,6 +51,24 @@ const transform = async ({
 };
 
 describe('transformer', () => {
+  it('registers the Storybook afterEach hook in transformed story files', async () => {
+    const result = await transform({
+      code: `
+        export default {};
+        export const Story = {};
+      `,
+      registerStorybookAfterEach: true,
+    });
+
+    expect(result.code).toContain(
+      'import { test as _test, expect as _expect, afterEach as _afterEach } from "vitest";'
+    );
+    expect(result.code).toContain(
+      'import { afterEachStory as _afterEachStory } from "@storybook/addon-vitest/internal/setup-file";'
+    );
+    expect(result.code).toContain('_afterEach(_afterEachStory);');
+  });
+
   describe('CSF v1/v2/v3', () => {
     describe('default exports (meta)', () => {
       it('should add title to inline default export if not present', async () => {

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -112,6 +112,7 @@ export async function vitestTransform({
   stories,
   tagsFilter,
   previewLevelTags = [],
+  registerStorybookAfterEach = false,
 }: {
   code: string;
   fileName: string;
@@ -119,6 +120,7 @@ export async function vitestTransform({
   tagsFilter: TagsFilter;
   stories: StoriesEntry[];
   previewLevelTags: Tag[];
+  registerStorybookAfterEach?: boolean;
 }): Promise<ReturnType<typeof formatCsf>> {
   const parsed = loadCsf(code, {
     fileName,
@@ -212,6 +214,12 @@ export async function vitestTransform({
   }
 
   const vitestExpectId = parsed._file.path.scope.generateUidIdentifier('expect');
+  const vitestAfterEachId = registerStorybookAfterEach
+    ? parsed._file.path.scope.generateUidIdentifier('afterEach')
+    : null;
+  const afterEachStoryId = registerStorybookAfterEach
+    ? parsed._file.path.scope.generateUidIdentifier('afterEachStory')
+    : null;
   const testStoryId = parsed._file.path.scope.generateUidIdentifier('testStory');
   const skipTagsId = t.identifier(JSON.stringify(tagsFilter.skip));
   const componentPathLiteral = parsed._rawComponentPath
@@ -389,6 +397,12 @@ export async function vitestTransform({
 
   const testBlock = t.ifStatement(isRunningFromThisFileId, t.blockStatement(storyTestStatements));
 
+  if (vitestAfterEachId && afterEachStoryId) {
+    ast.program.body.push(
+      t.expressionStatement(t.callExpression(vitestAfterEachId, [afterEachStoryId]))
+    );
+  }
+
   ast.program.body.push(testBlock);
 
   const hasTests = Object.keys(validStories).some(
@@ -400,6 +414,9 @@ export async function vitestTransform({
       [
         t.importSpecifier(vitestTestId, t.identifier('test')),
         t.importSpecifier(vitestExpectId, t.identifier('expect')),
+        ...(vitestAfterEachId
+          ? [t.importSpecifier(vitestAfterEachId, t.identifier('afterEach'))]
+          : []),
         ...(hasTests ? [t.importSpecifier(vitestDescribeId, t.identifier('describe'))] : []),
       ],
       t.stringLiteral('vitest')
@@ -411,6 +428,14 @@ export async function vitestTransform({
       ],
       t.stringLiteral('@storybook/addon-vitest/internal/test-utils')
     ),
+    ...(afterEachStoryId
+      ? [
+          t.importDeclaration(
+            [t.importSpecifier(afterEachStoryId, t.identifier('afterEachStory'))],
+            t.stringLiteral('@storybook/addon-vitest/internal/setup-file')
+          ),
+        ]
+      : []),
   ];
 
   ast.program.body.unshift(...imports);


### PR DESCRIPTION
Closes #31128

## What I did

- Removed the Vitest `afterEach` registration from the global addon setup file.
- Exported the existing cleanup callback and registered it from successfully transformed story files instead.
- Added focused transformer coverage for the generated Vitest hook import and registration.

This prevents the addon setup hook from being collected when a story cannot be transformed, so the original transformation error remains the useful error shown to the user.

## Checklist for Contributors

### Testing

The changes in this PR are covered by:

- [x] Unit tests
- [ ] Stories
- [ ] Integration tests
- [ ] End-to-end tests

Commands run:

- `yarn vitest run --config code/core/vitest.config.ts code/core/src/csf-tools/vitest-plugin/transformer.test.ts` — 37 passed, 1 existing skip, no type errors
- `yarn vitest run --config code/addons/vitest/vitest.config.ts code/addons/vitest/src/vitest-plugin/setup-file.test.ts` — 9 passed
- `yarn nx run-many -t check -p core addon-vitest` — passed
- `yarn nx run-many -t compile -p core addon-vitest` — passed
- `yarn --cwd code fmt:write` — passed
- Touched-file lint — passed with pre-existing warnings only

An additional addon-wide run passed 12 of 13 test files (156 tests). The unrelated `node/test-manager.test.ts` suite timed out on native Windows (17 tests).

#### Manual testing

No manual UI testing is necessary. This change affects generated Vitest test modules and is covered by focused transformer and setup-file unit tests.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] Update `MIGRATION.md`

No documentation change is needed because this restores the intended error-reporting behavior without changing the public API.

## AI assistance

OpenAI Codex assisted with investigation, implementation, and validation. I reviewed the resulting changes and test results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Storybook Vitest test cleanup by consistently restoring the Storybook channel after each test.
  - Enhanced failed test messages with clickable links to relevant Storybook debugging information.
  - Added automatic Storybook-specific after-test handling when running transformed stories with Vitest.

- **Tests**
  - Added coverage to verify generated Vitest setup includes the required Storybook cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->