### PR TITLE
Test: Add red provider registration tests for Vue and Angular

### DIFF
--- a/code/lib/docgen-harness/README.md
+++ b/code/lib/docgen-harness/README.md
@@ -9,10 +9,12 @@ Nothing here ships to npm (`private: true`).
 ```text
 code/lib/docgen-harness/src/
 ├── index.ts                      # package entry (the expectCurrentOrBetter comparator lands here)
+├── provider-seam-control.test.ts # green control: the seam files' assertion bodies pass against React
 ├── vue3/
-│   ├── vue3-baselines.test.ts    # legacy baseline recorder (argTypes + snippets)
-│   ├── vue3-legacy-gaps.test.ts  # test.fails red markers for the closeable legacy gaps
-│   ├── vue3-render.test.ts       # portable-stories render smoke test (happy-dom)
+│   ├── vue3-baselines.test.ts     # legacy baseline recorder (argTypes + snippets)
+│   ├── vue3-legacy-gaps.test.ts   # test.fails red markers for the closeable legacy gaps
+│   ├── vue3-provider-seam.test.ts # test.fails red markers for the unregistered OSA providers
+│   ├── vue3-render.test.ts        # portable-stories render smoke test (happy-dom)
 │   └── __testfixtures__/
 │       └── <fixture-case>/
 │           ├── <CaseName>.vue            # the SFC under test; the filename IS the recorded component name
@@ -21,10 +23,11 @@ code/lib/docgen-harness/src/
 │           ├── argtypes.snapshot         # normalized StrictArgTypes from the legacy extractArgTypes path
 │           └── snippet-<story>.snapshot  # legacy Source-block snippet per named story export
 ├── angular/
-│   ├── angular-baselines.test.ts    # legacy baseline recorder (argTypes both flag states + snippets)
-│   ├── angular-legacy-gaps.test.ts  # test.fails red markers for the closeable legacy gaps
-│   ├── angular-render.test.ts       # JIT TestBed render smoke test (happy-dom, decorator fixtures)
-│   ├── csf-types.ts                 # type-only CSF re-export the fixture stories import
+│   ├── angular-baselines.test.ts     # legacy baseline recorder (argTypes both flag states + snippets)
+│   ├── angular-legacy-gaps.test.ts   # test.fails red markers for the closeable legacy gaps
+│   ├── angular-provider-seam.test.ts # test.fails red markers for the unregistered OSA providers
+│   ├── angular-render.test.ts        # JIT TestBed render smoke test (happy-dom, decorator fixtures)
+│   ├── csf-types.ts                  # type-only CSF re-export the fixture stories import
 │   └── __testfixtures__/
 │       └── <fixture-case>/
 │           ├── <case-name>.component.ts    # the component under test; its class name IS the recorded identity
@@ -51,7 +54,7 @@ code/lib/docgen-harness/src/
 - angular: signal members (`input()`/`output()`/`model()`) are invisible to JIT - `ɵcmp.inputs`/`ɵcmp.outputs` stay empty without AOT.
   Signal fixtures therefore commit an `aot-cmp.ts`: the runtime `ɵcmp` maps captured from real `ngc` output (@angular/compiler-cli 21.2.17, compiled and loaded once to read the processed maps).
   The recorder attaches it wholesale before snippet generation and asserts the production reader sees its members, so a broken attach fails loudly.
-- angular: fixture stories import their CSF types from `src/angular/csf-types.ts`, and `angular-baselines.test.ts` / `angular-render.test.ts` are excluded from the package's vue-tsc program - angular-vite client source is authored under `strict: false` and cannot join this strict program; vitest is those two files' check.
+- angular: fixture stories import their CSF types from `src/angular/csf-types.ts`, and `angular-baselines.test.ts` / `angular-provider-seam.test.ts` / `angular-render.test.ts` are excluded from the package's vue-tsc program - angular-vite source (client runtime and preset) is authored under `strict: false` and cannot join this strict program; vitest is those files' check.
 - Snapshots must be deterministic: no timestamps, no absolute paths.
   Committed compodoc captures make OS-suffixed snapshots unnecessary here: no path-sensitive layer is ever snapshotted.
 
@@ -135,6 +138,16 @@ Same rules as vue3: thin or wrong output is recorded as-is, closeable gaps carry
 - #33779 (not reproduced) -> `decorator-union-enum/`: the reported union-controls collapse does not occur at the pinned compodoc 2.0.0 - all three union/enum inputs resolve to enum sbTypes, recorded as an engine-swap regression baseline; no marker.
 - #29697 (not reproduced) -> `signal-io/`: the aliased `input(_, { alias })` records under its alias at 2.0.0, so the reported alias blindness does not occur; regression baseline, no marker.
 - #22007 -> `properties-methods-noise/`: the filter flag's origin case; both flag states are recorded, and this is the fixture where they meaningfully differ.
+
+## Provider red tests
+
+Red means no OSA provider is registered on the package preset surface: the target `src/preset.ts` does not export `experimental_docgenProvider` / `experimental_storyDocsProvider` yet.
+`src/vue3/vue3-provider-seam.test.ts` and `src/angular/angular-provider-seam.test.ts` pin that state with bare `test.fails` markers, one per provider kind.
+When a qualifying provider export lands, vitest fails the marker ("Expect test to fail"), so the owning slice must edit `test.fails` into a plain test - that flip is the definition-of-done signal the Epic 3/4 slice exit criteria reference.
+`src/provider-seam-control.test.ts` proves the mechanism: the same assertion bodies pass against React's registered providers.
+The seam markers are independent of the gap markers: gaps flip on a reviewed baseline re-record via `BASELINE_PATH`, seam tests flip on provider registration, and the seam files never read `BASELINE_PATH`.
+The Vue markers accept either `renderers/vue3` or `frameworks/vue3-vite` as the registration surface; the Epic 3 flip pins the final location.
+Svelte and Web Components get their seam tests when their stretch slices (Epics 6/7) activate.
 
 ## What does not live here
 

--- a/code/lib/docgen-harness/package.json
+++ b/code/lib/docgen-harness/package.json
@@ -32,6 +32,7 @@
     "@angular/platform-browser": "^21.2.14",
     "@angular/platform-browser-dynamic": "^21.2.14",
     "@storybook/angular-vite": "workspace:*",
+    "@storybook/react": "workspace:*",
     "@storybook/vue3": "workspace:*",
     "@testing-library/vue": "^8.0.0",
     "@vitejs/plugin-vue": "^4.6.2",

--- a/code/lib/docgen-harness/package.json
+++ b/code/lib/docgen-harness/package.json
@@ -34,6 +34,7 @@
     "@storybook/angular-vite": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/vue3": "workspace:*",
+    "@storybook/vue3-vite": "workspace:*",
     "@testing-library/vue": "^8.0.0",
     "@vitejs/plugin-vue": "^4.6.2",
     "rxjs": "^7.4.0",

--- a/code/lib/docgen-harness/src/angular/angular-provider-seam.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-provider-seam.test.ts
@@ -1,0 +1,51 @@
+import { existsSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import * as angularVitePreset from '../../../../frameworks/angular-vite/src/preset.ts';
+
+// Bare test.fails seam markers: red while no OSA provider is registered on the
+// angular-vite preset surface (the Angular slice is scoped to angular-vite only). A
+// qualifying provider export makes vitest fail a marker "expected to fail but passed";
+// the flip to a plain test is the definition-of-done signal. Unlike the gap markers
+// these are independent of BASELINE_PATH: they flip on provider registration.
+
+const presetModules: Record<string, Record<string, unknown>> = {
+  'frameworks/angular-vite': angularVitePreset,
+};
+
+// Guards the markers below: a moved or broken preset module would throw inside a
+// test.fails body and silently masquerade as the expected failure.
+test('the preset modules asserted by the markers resolve', () => {
+  for (const [name, ns] of Object.entries(presetModules)) {
+    expect(ns, name).toBeTypeOf('object');
+    expect(Object.keys(ns).length, name).toBeGreaterThan(0);
+  }
+});
+
+test.fails('angular: docgen provider registered', async () => {
+  // Applying the preset value and requiring a real on-disk worker module stops a stub
+  // export (empty array or dangling descriptor) from flipping this marker.
+  const value = Object.values(presetModules)
+    .map((ns) => ns.experimental_docgenProvider)
+    .find((v) => v !== undefined);
+  expect(value).toBeDefined();
+  const applied = (typeof value === 'function' ? await value([]) : value) as {
+    moduleSpecifier: string;
+  }[];
+  expect(applied.length).toBeGreaterThanOrEqual(1);
+  expect(isAbsolute(applied[0].moduleSpecifier)).toBe(true);
+  expect(existsSync(applied[0].moduleSpecifier)).toBe(true);
+});
+
+test.fails('angular: story-docs provider registered', () => {
+  // The value form and the reducer form are both functions and cannot be told apart
+  // without invoking with real Options, which no cold test fabricates - the flip edit
+  // adds the behavioral assertion against the real provider.
+  const value = Object.values(presetModules)
+    .map((ns) => ns.experimental_storyDocsProvider)
+    .find((v) => v !== undefined);
+  expect(value).toBeDefined();
+  expect(value).toBeTypeOf('function');
+});

--- a/code/lib/docgen-harness/src/angular/angular-provider-seam.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-provider-seam.test.ts
@@ -15,8 +15,10 @@ const presetModules: Record<string, Record<string, unknown>> = {
   'frameworks/angular-vite': angularVitePreset,
 };
 
-// Guards the markers below: a moved or broken preset module would throw inside a
-// test.fails body and silently masquerade as the expected failure.
+// Guards the markers below: the preset imports are static, so a moved module fails
+// collection loudly, but a module that still resolves while losing its exports would
+// keep the markers red on the key-absent assertion and masquerade as the expected
+// failure - this pins the namespaces as real, non-empty objects.
 test('the preset modules asserted by the markers resolve', () => {
   for (const [name, ns] of Object.entries(presetModules)) {
     expect(ns, name).toBeTypeOf('object');
@@ -25,27 +27,44 @@ test('the preset modules asserted by the markers resolve', () => {
 });
 
 test.fails('angular: docgen provider registered', async () => {
-  // Applying the preset value and requiring a real on-disk worker module stops a stub
-  // export (empty array or dangling descriptor) from flipping this marker.
-  const value = Object.values(presetModules)
-    .map((ns) => ns.experimental_docgenProvider)
-    .find((v) => v !== undefined);
-  expect(value).toBeDefined();
-  const applied = (typeof value === 'function' ? await value([]) : value) as {
-    moduleSpecifier: string;
-  }[];
-  expect(applied.length).toBeGreaterThanOrEqual(1);
-  expect(isAbsolute(applied[0].moduleSpecifier)).toBe(true);
-  expect(existsSync(applied[0].moduleSpecifier)).toBe(true);
+  // Applying every asserted module and requiring a real on-disk worker module keeps
+  // the flip honest in both directions: a stub export (empty array, dangling
+  // descriptor, or a value that cannot be applied cold) neither flips the marker nor
+  // masks a qualifying provider registered on another asserted module.
+  const descriptors: unknown[] = [];
+  for (const ns of Object.values(presetModules)) {
+    const value = ns.experimental_docgenProvider;
+    if (value === undefined) {
+      continue;
+    }
+    try {
+      const applied = typeof value === 'function' ? await value([]) : value;
+      if (Array.isArray(applied)) {
+        descriptors.push(...applied);
+      }
+    } catch {
+      // A cold apply carries no real Options; a value that throws does not register.
+    }
+  }
+  const qualifying = descriptors.filter(
+    (d) =>
+      typeof d === 'object' &&
+      d !== null &&
+      'moduleSpecifier' in d &&
+      typeof d.moduleSpecifier === 'string' &&
+      isAbsolute(d.moduleSpecifier) &&
+      existsSync(d.moduleSpecifier)
+  );
+  expect(qualifying.length).toBeGreaterThanOrEqual(1);
 });
 
 test.fails('angular: story-docs provider registered', () => {
   // The value form and the reducer form are both functions and cannot be told apart
   // without invoking with real Options, which no cold test fabricates - the flip edit
-  // adds the behavioral assertion against the real provider.
-  const value = Object.values(presetModules)
+  // adds the behavioral assertion against the real provider. Every asserted module is
+  // checked so a non-function stub cannot mask a real provider on another one.
+  const values = Object.values(presetModules)
     .map((ns) => ns.experimental_storyDocsProvider)
-    .find((v) => v !== undefined);
-  expect(value).toBeDefined();
-  expect(value).toBeTypeOf('function');
+    .filter((v) => v !== undefined);
+  expect(values.some((v) => typeof v === 'function')).toBe(true);
 });

--- a/code/lib/docgen-harness/src/provider-seam-control.test.ts
+++ b/code/lib/docgen-harness/src/provider-seam-control.test.ts
@@ -1,0 +1,43 @@
+import { existsSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import * as reactPreset from '../../../renderers/react/src/preset.ts';
+
+// Green control for the vue3/angular provider-seam files: the same assertion bodies
+// their test.fails markers use (kept byte-parallel on purpose - copied, not shared)
+// pass here against React's registered providers, proving a provider landing on a red
+// surface forces the flip.
+
+const presetModules: Record<string, Record<string, unknown>> = {
+  'renderers/react': reactPreset,
+};
+
+test('the preset modules asserted by the markers resolve', () => {
+  for (const [name, ns] of Object.entries(presetModules)) {
+    expect(ns, name).toBeTypeOf('object');
+    expect(Object.keys(ns).length, name).toBeGreaterThan(0);
+  }
+});
+
+test('react: docgen provider registered', async () => {
+  const value = Object.values(presetModules)
+    .map((ns) => ns.experimental_docgenProvider)
+    .find((v) => v !== undefined);
+  expect(value).toBeDefined();
+  const applied = (typeof value === 'function' ? await value([]) : value) as {
+    moduleSpecifier: string;
+  }[];
+  expect(applied.length).toBeGreaterThanOrEqual(1);
+  expect(isAbsolute(applied[0].moduleSpecifier)).toBe(true);
+  expect(existsSync(applied[0].moduleSpecifier)).toBe(true);
+});
+
+test('react: story-docs provider registered', () => {
+  const value = Object.values(presetModules)
+    .map((ns) => ns.experimental_storyDocsProvider)
+    .find((v) => v !== undefined);
+  expect(value).toBeDefined();
+  expect(value).toBeTypeOf('function');
+});

--- a/code/lib/docgen-harness/src/provider-seam-control.test.ts
+++ b/code/lib/docgen-harness/src/provider-seam-control.test.ts
@@ -22,22 +22,36 @@ test('the preset modules asserted by the markers resolve', () => {
 });
 
 test('react: docgen provider registered', async () => {
-  const value = Object.values(presetModules)
-    .map((ns) => ns.experimental_docgenProvider)
-    .find((v) => v !== undefined);
-  expect(value).toBeDefined();
-  const applied = (typeof value === 'function' ? await value([]) : value) as {
-    moduleSpecifier: string;
-  }[];
-  expect(applied.length).toBeGreaterThanOrEqual(1);
-  expect(isAbsolute(applied[0].moduleSpecifier)).toBe(true);
-  expect(existsSync(applied[0].moduleSpecifier)).toBe(true);
+  const descriptors: unknown[] = [];
+  for (const ns of Object.values(presetModules)) {
+    const value = ns.experimental_docgenProvider;
+    if (value === undefined) {
+      continue;
+    }
+    try {
+      const applied = typeof value === 'function' ? await value([]) : value;
+      if (Array.isArray(applied)) {
+        descriptors.push(...applied);
+      }
+    } catch {
+      // A cold apply carries no real Options; a value that throws does not register.
+    }
+  }
+  const qualifying = descriptors.filter(
+    (d) =>
+      typeof d === 'object' &&
+      d !== null &&
+      'moduleSpecifier' in d &&
+      typeof d.moduleSpecifier === 'string' &&
+      isAbsolute(d.moduleSpecifier) &&
+      existsSync(d.moduleSpecifier)
+  );
+  expect(qualifying.length).toBeGreaterThanOrEqual(1);
 });
 
 test('react: story-docs provider registered', () => {
-  const value = Object.values(presetModules)
+  const values = Object.values(presetModules)
     .map((ns) => ns.experimental_storyDocsProvider)
-    .find((v) => v !== undefined);
-  expect(value).toBeDefined();
-  expect(value).toBeTypeOf('function');
+    .filter((v) => v !== undefined);
+  expect(values.some((v) => typeof v === 'function')).toBe(true);
 });

--- a/code/lib/docgen-harness/src/vue3/vue3-provider-seam.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-provider-seam.test.ts
@@ -1,0 +1,53 @@
+import { existsSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import * as vue3VitePreset from '../../../../frameworks/vue3-vite/src/preset.ts';
+import * as vue3Preset from '../../../../renderers/vue3/src/preset.ts';
+
+// Bare test.fails seam markers: red while no OSA provider is registered on the vue3
+// preset surface (renderer or framework - Epic 3 pins the placement). A qualifying
+// provider export makes vitest fail a marker "expected to fail but passed"; the flip
+// to a plain test is the definition-of-done signal. Unlike the gap markers these are
+// independent of BASELINE_PATH: they flip on provider registration, not on re-record.
+
+const presetModules: Record<string, Record<string, unknown>> = {
+  'renderers/vue3': vue3Preset,
+  'frameworks/vue3-vite': vue3VitePreset,
+};
+
+// Guards the markers below: a moved or broken preset module would throw inside a
+// test.fails body and silently masquerade as the expected failure.
+test('the preset modules asserted by the markers resolve', () => {
+  for (const [name, ns] of Object.entries(presetModules)) {
+    expect(ns, name).toBeTypeOf('object');
+    expect(Object.keys(ns).length, name).toBeGreaterThan(0);
+  }
+});
+
+test.fails('vue3: docgen provider registered', async () => {
+  // Applying the preset value and requiring a real on-disk worker module stops a stub
+  // export (empty array or dangling descriptor) from flipping this marker.
+  const value = Object.values(presetModules)
+    .map((ns) => ns.experimental_docgenProvider)
+    .find((v) => v !== undefined);
+  expect(value).toBeDefined();
+  const applied = (typeof value === 'function' ? await value([]) : value) as {
+    moduleSpecifier: string;
+  }[];
+  expect(applied.length).toBeGreaterThanOrEqual(1);
+  expect(isAbsolute(applied[0].moduleSpecifier)).toBe(true);
+  expect(existsSync(applied[0].moduleSpecifier)).toBe(true);
+});
+
+test.fails('vue3: story-docs provider registered', () => {
+  // The value form and the reducer form are both functions and cannot be told apart
+  // without invoking with real Options, which no cold test fabricates - the flip edit
+  // adds the behavioral assertion against the real provider.
+  const value = Object.values(presetModules)
+    .map((ns) => ns.experimental_storyDocsProvider)
+    .find((v) => v !== undefined);
+  expect(value).toBeDefined();
+  expect(value).toBeTypeOf('function');
+});

--- a/code/lib/docgen-harness/src/vue3/vue3-provider-seam.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-provider-seam.test.ts
@@ -17,8 +17,10 @@ const presetModules: Record<string, Record<string, unknown>> = {
   'frameworks/vue3-vite': vue3VitePreset,
 };
 
-// Guards the markers below: a moved or broken preset module would throw inside a
-// test.fails body and silently masquerade as the expected failure.
+// Guards the markers below: the preset imports are static, so a moved module fails
+// collection loudly, but a module that still resolves while losing its exports would
+// keep the markers red on the key-absent assertion and masquerade as the expected
+// failure - this pins the namespaces as real, non-empty objects.
 test('the preset modules asserted by the markers resolve', () => {
   for (const [name, ns] of Object.entries(presetModules)) {
     expect(ns, name).toBeTypeOf('object');
@@ -27,27 +29,44 @@ test('the preset modules asserted by the markers resolve', () => {
 });
 
 test.fails('vue3: docgen provider registered', async () => {
-  // Applying the preset value and requiring a real on-disk worker module stops a stub
-  // export (empty array or dangling descriptor) from flipping this marker.
-  const value = Object.values(presetModules)
-    .map((ns) => ns.experimental_docgenProvider)
-    .find((v) => v !== undefined);
-  expect(value).toBeDefined();
-  const applied = (typeof value === 'function' ? await value([]) : value) as {
-    moduleSpecifier: string;
-  }[];
-  expect(applied.length).toBeGreaterThanOrEqual(1);
-  expect(isAbsolute(applied[0].moduleSpecifier)).toBe(true);
-  expect(existsSync(applied[0].moduleSpecifier)).toBe(true);
+  // Applying every asserted module and requiring a real on-disk worker module keeps
+  // the flip honest in both directions: a stub export (empty array, dangling
+  // descriptor, or a value that cannot be applied cold) neither flips the marker nor
+  // masks a qualifying provider registered on another asserted module.
+  const descriptors: unknown[] = [];
+  for (const ns of Object.values(presetModules)) {
+    const value = ns.experimental_docgenProvider;
+    if (value === undefined) {
+      continue;
+    }
+    try {
+      const applied = typeof value === 'function' ? await value([]) : value;
+      if (Array.isArray(applied)) {
+        descriptors.push(...applied);
+      }
+    } catch {
+      // A cold apply carries no real Options; a value that throws does not register.
+    }
+  }
+  const qualifying = descriptors.filter(
+    (d) =>
+      typeof d === 'object' &&
+      d !== null &&
+      'moduleSpecifier' in d &&
+      typeof d.moduleSpecifier === 'string' &&
+      isAbsolute(d.moduleSpecifier) &&
+      existsSync(d.moduleSpecifier)
+  );
+  expect(qualifying.length).toBeGreaterThanOrEqual(1);
 });
 
 test.fails('vue3: story-docs provider registered', () => {
   // The value form and the reducer form are both functions and cannot be told apart
   // without invoking with real Options, which no cold test fabricates - the flip edit
-  // adds the behavioral assertion against the real provider.
-  const value = Object.values(presetModules)
+  // adds the behavioral assertion against the real provider. Every asserted module is
+  // checked so a non-function stub cannot mask a real provider on another one.
+  const values = Object.values(presetModules)
     .map((ns) => ns.experimental_storyDocsProvider)
-    .find((v) => v !== undefined);
-  expect(value).toBeDefined();
-  expect(value).toBeTypeOf('function');
+    .filter((v) => v !== undefined);
+  expect(values.some((v) => typeof v === 'function')).toBe(true);
 });

--- a/code/lib/docgen-harness/tsconfig.json
+++ b/code/lib/docgen-harness/tsconfig.json
@@ -9,9 +9,13 @@
     "../../renderers/vue3/src/typings.d.ts",
     "../../frameworks/angular-vite/src/typings.d.ts"
   ],
-  // These two import angular-vite client runtime source, which is authored under
-  // `strict: false` and cannot join this strict program; vitest is their check.
-  "exclude": ["src/angular/angular-baselines.test.ts", "src/angular/angular-render.test.ts"],
+  // These import angular-vite source (client runtime and preset), which is authored
+  // under `strict: false` and cannot join this strict program; vitest is their check.
+  "exclude": [
+    "src/angular/angular-baselines.test.ts",
+    "src/angular/angular-provider-seam.test.ts",
+    "src/angular/angular-render.test.ts"
+  ],
   "vueCompilerOptions": {
     "target": 3
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9949,6 +9949,7 @@ __metadata:
     "@angular/platform-browser": "npm:^21.2.14"
     "@angular/platform-browser-dynamic": "npm:^21.2.14"
     "@storybook/angular-vite": "workspace:*"
+    "@storybook/react": "workspace:*"
     "@storybook/vue3": "workspace:*"
     "@testing-library/vue": "npm:^8.0.0"
     "@vitejs/plugin-vue": "npm:^4.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9951,6 +9951,7 @@ __metadata:
     "@storybook/angular-vite": "workspace:*"
     "@storybook/react": "workspace:*"
     "@storybook/vue3": "workspace:*"
+    "@storybook/vue3-vite": "workspace:*"
     "@testing-library/vue": "npm:^8.0.0"
     "@vitejs/plugin-vue": "npm:^4.6.2"
     rxjs: "npm:^7.4.0"


### PR DESCRIPTION
## What I did

Vue and Angular do not register OSA docgen or story-docs providers yet, and there was no automated signal that tells "not started" apart from "silently broken". This PR adds four `test.fails` markers to `@storybook/docgen-harness` — docgen and story-docs, per framework — that stay red until a provider export lands on the package preset. The markers are strict about what counts: the applied provider must yield a descriptor pointing at a real on-disk worker module, so a stub export cannot fake the green state.

Once a real provider lands, vitest fails the marker with "Expect test to fail", which forces us to turn it into a plain passing test — that flip is the definition-of-done signal for the Vue and Angular slices. A green control (`src/provider-seam-control.test.ts`) runs the same assertions against React's registered providers, so the mechanism is proven and not assumed. The Vue markers accept the renderer or the framework package; Story 3.1 pins the final location. CI stays green the whole time, though!

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual test is necessary — this is test-only scaffolding. To see it in action, run `yarn test code/lib/docgen-harness` from the repo root: 10 test files, 78 passed, 28 expected failures.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfunNgLwxsUw7FV566ydwi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider seam coverage for React, Vue 3, and Angular preset integrations.
  * Added checks for documentation and story-provider registration, including valid module descriptors.

* **Documentation**
  * Clarified Angular tooling conventions and provider test expectations in the harness documentation.

* **Chores**
  * Expanded Storybook development tooling coverage for React and Vue.
  * Updated test configuration to include the new Angular provider checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->