### PR TITLE
Vue3 Vite: Enable Schema Extraction for Vue Component Meta

### DIFF
--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -177,6 +177,7 @@ async function createVueComponentMetaChecker(tsconfigPath = 'tsconfig.json') {
     forceUseTs: true,
     noDeclarations: true,
     printer: { newLine: 1 },
+    schema: true,
   };
 
   const projectRoot = getProjectRoot();

--- a/code/renderers/vue3/src/__snapshots__/extractArgTypes.test.ts.snap
+++ b/code/renderers/vue3/src/__snapshots__/extractArgTypes.test.ts.snap
@@ -230,13 +230,9 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
       },
     },
     "type": {
-      "name": "enum",
+      "name": "other",
       "required": true,
-      "value": [
-        "MyEnum.Small",
-        "MyEnum.Medium",
-        "MyEnum.Large",
-      ],
+      "value": "MyEnum",
     },
   },
   "foo": {

--- a/code/renderers/vue3/src/extractArgTypes.test.ts
+++ b/code/renderers/vue3/src/extractArgTypes.test.ts
@@ -12,7 +12,7 @@ import {
   templateSlots,
   vueDocgenMocks,
 } from './docs/tests-meta-components/meta-components.ts';
-import { extractArgTypes } from './extractArgTypes.ts';
+import { convertVueComponentMetaProp, extractArgTypes } from './extractArgTypes.ts';
 
 vitest.mock('storybook/internal/docs-tools', async (importOriginal) => {
   const module: Record<string, unknown> = await importOriginal();
@@ -128,5 +128,51 @@ describe('extractArgTypes (vue-docgen-api)', () => {
     const argTypes = extractArgTypes(component);
 
     expect(argTypes).toMatchSnapshot();
+  });
+});
+
+describe('convertVueComponentMetaProp', () => {
+  it('should convert a literal union schema to an enum sbType with its values', () => {
+    expect(
+      convertVueComponentMetaProp({
+        type: '"small" | "medium" | "large"',
+        required: true,
+        schema: {
+          kind: 'enum',
+          type: '"small" | "medium" | "large"',
+          schema: ['"small"', '"medium"', '"large"'],
+        },
+      })
+    ).toEqual({ name: 'enum', value: ['small', 'medium', 'large'], required: true });
+  });
+
+  it('should not convert TS enum member references to an enum sbType', () => {
+    // the schema only carries the member names, not their runtime values; an enum
+    // sbType would make Controls inject the name string instead of the value
+    expect(
+      convertVueComponentMetaProp({
+        type: 'Severity',
+        required: true,
+        schema: {
+          kind: 'enum',
+          type: 'Severity',
+          schema: ['Severity.Info', 'Severity.Warning', 'Severity.Error'],
+        },
+      })
+    ).toEqual({ name: 'other', value: 'Severity', required: true });
+  });
+
+  it('should not convert numeric TS enum member references either', () => {
+    expect(
+      convertVueComponentMetaProp({
+        type: 'Level | undefined',
+        required: false,
+        schema: {
+          kind: 'enum',
+          type: 'Level | undefined',
+          schema: ['undefined', 'Level.Low', 'Level.High'],
+        },
+      })
+    ).toEqual({ name: 'other', value: 'Level | undefined', required: false });
   });
 });

--- a/code/renderers/vue3/src/extractArgTypes.ts
+++ b/code/renderers/vue3/src/extractArgTypes.ts
@@ -214,10 +214,18 @@ export const convertVueComponentMetaProp = (
         return { name: 'boolean', required };
       }
 
-      if (isLiteralUnionSchema(definedSchemas) || isEnumSchema(definedSchemas)) {
+      if (isLiteralUnionSchema(definedSchemas)) {
         // remove quotes from literals
         const literals = definedSchemas.map((literal) => literal.replace(/"/g, ''));
         return { name: 'enum', value: literals, required };
+      }
+
+      // TS enum members arrive as reference strings ("MyEnum.Foo") without their runtime
+      // values, and an enum sbType would make Controls inject those names verbatim
+      // (the string "MyEnum.Foo" instead of the member's value). Keep the type documented
+      // via the table but not selectable until the values are available.
+      if (isEnumSchema(definedSchemas)) {
+        return fallbackSbType;
       }
 
       if (definedSchemas.length === 1) {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/discussions/35552
Closes https://github.com/storybookjs/storybook/issues/35564

## Summary

Enable `schema: true` in the default `vue-component-meta` checker options.

## Motivation

After upgrading to `vue-component-meta` 3.x, metadata for some type aliases and unions may be returned as a string, for example:

```ts
"Color | undefined"
```

instead of an expanded schema object.

Enabling `schema: true` restores the expanded schema, allowing consumers to access enum and union metadata consistently.

## Changes

- Added `schema: true` to the default `MetaCheckerOptions` used by the Vue 3 Vite framework.

## Testing

Tested with a Vue component using a type alias:

```ts
type Color =
  | 'theme'
  | 'blue'
  | 'green'
  | 'orange'
  | 'red'
  | 'pink'
  | 'brand';

defineProps<{
  color?: Color;
}>();
```

Before:

```ts
schema: "Color | undefined"
```

After:

```ts
schema: {
  kind: "enum",
  schema: [...]
}
```

#### Manual testing

1. Create a Vue component with a prop using a string union type:

   ```ts
   type Color =
     | 'theme'
     | 'blue'
     | 'green'
     | 'orange'
     | 'red'
     | 'pink'
     | 'brand';

   defineProps<{
     color?: Color;
   }>();
   ```

2. Enable `vue-component-meta` in Storybook.

3. Verify that the generated metadata for the `color` prop contains a structured enum schema instead of a string representation.

Before:

```ts
schema: "Color | undefined"
```

After:

```ts
schema: {
  kind: "enum",
  schema: [...]
}
```

Related discussion: #35552
Fixes #35564


## AI assistance

I used ChatGPT to help investigate the issue and prepare the initial patch. I reviewed and tested the final change myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enabled schema support for Vue component metadata checking, improving compatibility with schema-aware tooling.
* **Bug Fixes**
  * Improved prop type conversion for Vue docgen metadata so literal-union enum-like schemas convert to selectable enum controls, while enum reference schemas no longer mis-convert.
* **Tests**
  * Added unit tests covering Vue prop schema conversion behavior for enum and enum-reference cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->