### PR TITLE
Core: Use npm 12-compatible registry flags

### DIFF
--- a/code/core/src/common/js-package-manager/BUNProxy.test.ts
+++ b/code/core/src/common/js-package-manager/BUNProxy.test.ts
@@ -43,6 +43,23 @@ describe('BUN Proxy', () => {
     expect(bunProxy.type).toEqual('bun');
   });
 
+  describe('getRegistryURL', () => {
+    it('uses npm 12-compatible workspace flags', async () => {
+      const executeCommandSpy = mockedExecuteCommand.mockResolvedValueOnce({
+        stdout: 'https://registry.npmjs.org/',
+      } as Awaited<ReturnType<typeof executeCommand>>);
+
+      await expect(bunProxy.getRegistryURL()).resolves.toBe('https://registry.npmjs.org/');
+
+      expect(executeCommandSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'npm',
+          args: ['config', 'get', 'registry', '--workspaces=false', '--include-workspace-root'],
+        })
+      );
+    });
+  });
+
   describe('installDependencies', () => {
     it('should run `bun install`', async () => {
       vi.mocked(prompt.executeTaskWithSpinner).mockImplementationOnce(async (fn: any) => {

--- a/code/core/src/common/js-package-manager/BUNProxy.ts
+++ b/code/core/src/common/js-package-manager/BUNProxy.ts
@@ -362,7 +362,7 @@ export class BUNProxy extends JsPackageManager {
       cwd: this.cwd,
       // "npm config" commands are not allowed in workspaces per default
       // https://github.com/npm/cli/issues/6099#issuecomment-1847584792
-      args: ['config', 'get', 'registry', '-ws=false', '-iwr'],
+      args: ['config', 'get', 'registry', '--workspaces=false', '--include-workspace-root'],
     });
     const result = await process;
     const url = (typeof result.stdout === 'string' ? result.stdout : '').trim();

--- a/code/core/src/common/js-package-manager/PNPMProxy.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.test.ts
@@ -45,6 +45,23 @@ describe('PNPM Proxy', () => {
     expect(pnpmProxy.type).toEqual('pnpm');
   });
 
+  describe('getRegistryURL', () => {
+    it('uses npm 12-compatible workspace flags', async () => {
+      const executeCommandSpy = mockedExecuteCommand.mockResolvedValueOnce({
+        stdout: 'https://registry.npmjs.org/',
+      } as Awaited<ReturnType<typeof executeCommand>>);
+
+      await expect(pnpmProxy.getRegistryURL()).resolves.toBe('https://registry.npmjs.org/');
+
+      expect(executeCommandSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'npm',
+          args: ['config', 'get', 'registry', '--workspaces=false', '--include-workspace-root'],
+        })
+      );
+    });
+  });
+
   describe('installDependencies', () => {
     it('should run `pnpm install`', async () => {
       // sort of un-mock part of the function so executeCommand (also mocked) is called

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -139,7 +139,7 @@ export class PNPMProxy extends JsPackageManager {
     const childProcess = await executeCommand({
       command: 'npm',
       cwd: this.cwd,
-      args: ['config', 'get', 'registry', '-ws=false', '-iwr'],
+      args: ['config', 'get', 'registry', '--workspaces=false', '--include-workspace-root'],
     });
     const url = (typeof childProcess.stdout === 'string' ? childProcess.stdout : '').trim();
     return url === 'undefined' ? undefined : url;


### PR DESCRIPTION
Closes #35566

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### Root cause

[npm 12.0.0](https://github.com/npm/cli/releases/tag/v12.0.0) changed abbreviated flags and single-hyphen multi-character shorthands from warnings into errors. `PNPMProxy` and `BUNProxy` still passed `-ws=false` and `-iwr`, causing registry resolution to fail.

### Change

- Replace the abbreviated flags with `--workspaces=false` and `--include-workspace-root`.
- Add regression tests for both package managers.
## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing
1. Publish the packages and start the local registry.

   ```bash
   yarn nx run scripts:run-registry -c production --skip-nx-cache
   ```
2. Initialize Storybook in another terminal.

   ```bash
   pnpm create vite app --template react-ts
   cd app
   npx --yes --registry=http://localhost:6001 --allow-remote=all create-storybook@xyz --package-manager pnpm
   ```

3. Confirm that Storybook initializes without an invalid npm flag error.


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package registry detection for Bun and PNPM when used with npm 12.
  * Updated registry checks to use compatible workspace options, ensuring the configured npm registry is read correctly.

* **Tests**
  * Added coverage verifying registry URL detection and command compatibility for both package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->