### PR TITLE
Addon Vitest: Pin storybook/test in optimizeDeps so its CJS-only deps are prebundled

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -429,6 +429,9 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
             '@storybook/addon-vitest/internal/global-setup',
             '@storybook/addon-vitest/internal/test-utils',
             'storybook/preview-api',
+            // imported by the setup files; without pinning, its CJS-only deps (via
+            // @testing-library/dom) reach the browser raw on hoisted node_modules layouts
+            'storybook/test',
             ...(frameworkName?.includes('react') || frameworkName?.includes('nextjs')
               ? ['react-dom/test-utils']
               : []),


### PR DESCRIPTION
## What I did

In Vitest browser mode, whether `storybook/test`'s CJS-only deps (`aria-query`, `lz-string`, `pretty-format`, all via `@testing-library/dom`) get prebundled depends on the project's node_modules layout. On npm's hoisted layout, in a project whose stories don't import `storybook/test` directly, every story test fails at import:

```
Caused by: SyntaxError: The requested module '/node_modules/aria-query/lib/index.js?v=...' does not provide an export named 'elementRoles'
```

pnpm's isolated layout works because the scanner happens to discover `storybook/test` there: it shows up in the dep-optimizer metadata, on hoisted it doesn't. Pinning it makes all layouts behave like the working one. Diagnosed in vitejs/vite#23030; reproduces identically on Vite 7.3.6 and 8.1.5, so it's an addon-side gap, not a Vite 8 regression. Vitest pins the same package for its own preview provider.

## Checklist for Contributors

### Testing

#### Manual testing

On https://github.com/OpenSourceScouting/design-system branch `repro/vite8-rolldown-cjs-interop` (Storybook 10.5.2, Vitest 4.1.10, Vite 8.1.5, hoisted node_modules), `vitest run --project storybook` fails all 36 story files with the error above; with `'storybook/test'` in the published addon's include list, all 36 files (95 tests) pass. A pnpm isolated install passes before and after.

