### PR TITLE
Update CHANGELOG.md for v10.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
+## 10.5.4
+
+- ReactNative: Telemetry framework detection fix - [#35560](https://github.com/storybookjs/storybook/pull/35560), thanks @ndelangen!
+- SyntaxHighlighter: Fix PrismJS dark mode mismatch - [#35541](https://github.com/storybookjs/storybook/pull/35541), thanks @hxy-asdw!
+
 ## 10.5.3
 
 - Dependencies: Upgrade TypeScript to 6.0.3 - [#34971](https://github.com/storybookjs/storybook/pull/34971), thanks @valentinpalkovic!
 
 ## 10.5.2
 
-- Angular-Vite: Drop @angular/platform-browser-dynamic peer dependency - [#35457](https://github.com/storybookjs/storybook/pull/35457), thanks @valentinpalkovic!
-- Angular-Vite: Widen TypeScript peer dependency range to support TypeScript 6 - [#35455](https://github.com/storybookjs/storybook/pull/35455), thanks @valentinpalkovic!
-- Core: Include chromatic packages in ecosystem identifier - [#35170](https://github.com/storybookjs/storybook/pull/35170), thanks @yannbf!
 - TanStack: Fix createServerFn validator mock - [#35185](https://github.com/storybookjs/storybook/pull/35185), thanks @sjh9714!
 - TanStack: Support pathless layout routes (id-only) in story routing - [#35465](https://github.com/storybookjs/storybook/pull/35465), thanks @unpunnyfuns!
 - Tanstack-react: Add missing Hydrate export - [#35111](https://github.com/storybookjs/storybook/pull/35111), thanks @arun-357!


### PR DESCRIPTION
## Summary

Syncs `CHANGELOG.md` from `main` after the interrupted v10.5.4 publish was completed manually (`latest-release` → `main` via #35577).

This matches the publish workflow step “Sync CHANGELOG.md from main to next”.

- Adds the `## 10.5.4` section
- Aligns the `10.5.2` section with `main` (moves a few entries that already live under later versions on `main`)

No package version bumps. Does not publish.

## Test plan
- [ ] Diff is CHANGELOG-only
- [ ] After merge, `next` CHANGELOG starts with `## 10.5.4`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved React Native telemetry framework detection.
  * Fixed a PrismJS dark mode mismatch.

* **Documentation**
  * Updated the changelog with release 10.5.4 details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->