### PR TITLE
NextJS: Normalize trailing slash in the next/link mock

### DIFF
--- a/code/frameworks/nextjs-vite/src/export-mocks/link/index.test.tsx
+++ b/code/frameworks/nextjs-vite/src/export-mocks/link/index.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -67,5 +67,61 @@ describe('next/link mock', () => {
     getAnchorOnClick({ href: '/about', onClick: mergedOnClick })(makeClickEvent());
 
     expect(userOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  describe('trailingSlash', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('appends a trailing slash when `trailingSlash` is enabled', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/about' })).toBe('/about/');
+      expect(renderHref({ href: '/users/[id]', as: '/users/123' })).toBe('/users/123/');
+      expect(renderHref({ href: { pathname: '/about' } })).toBe('/about/');
+    });
+
+    it('keeps the slash before the query and hash', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/about?ref=nav' })).toBe('/about/?ref=nav');
+      expect(renderHref({ href: '/about#team' })).toBe('/about/#team');
+      expect(renderHref({ href: '/about?ref=nav#team' })).toBe('/about/?ref=nav#team');
+    });
+
+    it('does not append a slash to a path that looks like a file', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/logo.png' })).toBe('/logo.png');
+      expect(renderHref({ href: '/logo.png/' })).toBe('/logo.png');
+    });
+
+    it('does not touch the root path or double up an existing slash', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/' })).toBe('/');
+      expect(renderHref({ href: '/about/' })).toBe('/about/');
+    });
+
+    it('strips a trailing slash when `trailingSlash` is disabled', () => {
+      expect(renderHref({ href: '/about/' })).toBe('/about');
+      expect(renderHref({ href: '/' })).toBe('/');
+    });
+
+    it('is a no-op when `skipTrailingSlashRedirect` is enabled', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+      vi.stubEnv('__NEXT_MANUAL_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/about' })).toBe('/about');
+      expect(renderHref({ href: '/about/' })).toBe('/about/');
+    });
+
+    it('leaves hrefs that are not absolute paths alone', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: 'https://example.com/about' })).toBe('https://example.com/about');
+      expect(renderHref({ href: '#section' })).toBe('#section');
+    });
   });
 });

--- a/code/frameworks/nextjs-vite/src/export-mocks/link/index.tsx
+++ b/code/frameworks/nextjs-vite/src/export-mocks/link/index.tsx
@@ -4,6 +4,45 @@ import { fn } from 'storybook/test';
 
 const linkAction = fn().mockName('next/link::Link');
 
+// Mirrors next/dist/client/normalize-trailing-slash, which the real <Link> applies to
+// every href it renders. Both flags come from Next's own getDefineEnv: __NEXT_TRAILING_SLASH
+// is `trailingSlash` and __NEXT_MANUAL_TRAILING_SLASH is `skipTrailingSlashRedirect`.
+const removeTrailingSlash = (route: string) =>
+  route.endsWith('/') && route.length > 1 ? route.slice(0, -1) : route;
+
+const parsePath = (path: string) => {
+  const hashIndex = path.indexOf('#');
+  const queryIndex = path.indexOf('?');
+  const hasQuery = queryIndex > -1 && (hashIndex < 0 || queryIndex < hashIndex);
+
+  if (hasQuery || hashIndex > -1) {
+    return {
+      pathname: path.substring(0, hasQuery ? queryIndex : hashIndex),
+      query: hasQuery ? path.substring(queryIndex, hashIndex > -1 ? hashIndex : undefined) : '',
+      hash: hashIndex > -1 ? path.slice(hashIndex) : '',
+    };
+  }
+
+  return { pathname: path, query: '', hash: '' };
+};
+
+const normalizePathTrailingSlash = (path: string) => {
+  if (!path.startsWith('/') || process.env.__NEXT_MANUAL_TRAILING_SLASH) {
+    return path;
+  }
+
+  const { pathname, query, hash } = parsePath(path);
+
+  if (process.env.__NEXT_TRAILING_SLASH) {
+    if (/\.[^/]+\/?$/.test(pathname)) {
+      return `${removeTrailingSlash(pathname)}${query}${hash}`;
+    }
+    return `${pathname.endsWith('/') ? pathname : `${pathname}/`}${query}${hash}`;
+  }
+
+  return `${removeTrailingSlash(pathname)}${query}${hash}`;
+};
+
 const MockLink = React.forwardRef<HTMLAnchorElement, any>(function MockLink(
   {
     href,
@@ -22,10 +61,11 @@ const MockLink = React.forwardRef<HTMLAnchorElement, any>(function MockLink(
   ref
 ) {
   const resolvedHref = as ?? href;
-  const hrefString =
+  const rawHref =
     typeof resolvedHref === 'object'
       ? `${resolvedHref.pathname || ''}${resolvedHref.query ? '?' + new URLSearchParams(resolvedHref.query).toString() : ''}${resolvedHref.hash || ''}`
       : resolvedHref;
+  const hrefString = typeof rawHref === 'string' ? normalizePathTrailingSlash(rawHref) : rawHref;
 
   const navigate = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (e.defaultPrevented) {

--- a/code/frameworks/nextjs-vite/src/export-mocks/link/index.tsx
+++ b/code/frameworks/nextjs-vite/src/export-mocks/link/index.tsx
@@ -4,9 +4,11 @@ import { fn } from 'storybook/test';
 
 const linkAction = fn().mockName('next/link::Link');
 
-// Mirrors next/dist/client/normalize-trailing-slash, which the real <Link> applies to
-// every href it renders. Both flags come from Next's own getDefineEnv: __NEXT_TRAILING_SLASH
-// is `trailingSlash` and __NEXT_MANUAL_TRAILING_SLASH is `skipTrailingSlashRedirect`.
+/*
+ * Mirrors next/dist/client/normalize-trailing-slash, which the real <Link> applies to
+ * every href it renders. Both flags come from Next's own getDefineEnv: __NEXT_TRAILING_SLASH
+ * is `trailingSlash` and __NEXT_MANUAL_TRAILING_SLASH is `skipTrailingSlashRedirect`.
+ */
 const removeTrailingSlash = (route: string) =>
   route.endsWith('/') && route.length > 1 ? route.slice(0, -1) : route;
 

--- a/code/frameworks/nextjs/src/config/webpack.ts
+++ b/code/frameworks/nextjs/src/config/webpack.ts
@@ -79,6 +79,11 @@ const setupRuntimeConfig = async (
 
   definePluginConfig['process.env.__NEXT_NEW_LINK_BEHAVIOR'] = newNextLinkBehavior;
 
+  // Consumed by the next/link mock to normalize hrefs the way the real <Link> does.
+  definePluginConfig['process.env.__NEXT_TRAILING_SLASH'] = nextConfig.trailingSlash;
+  definePluginConfig['process.env.__NEXT_MANUAL_TRAILING_SLASH'] =
+    nextConfig.skipTrailingSlashRedirect;
+
   // Load DefinePlugin with a dynamic import to ensure that Next.js can first
   // replace webpack with its own internal instance, and we get that here.
   baseConfig.plugins?.push(new (await import('webpack')).default.DefinePlugin(definePluginConfig));

--- a/code/frameworks/nextjs/src/export-mocks/link/index.test.tsx
+++ b/code/frameworks/nextjs/src/export-mocks/link/index.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -67,5 +67,61 @@ describe('next/link mock', () => {
     getAnchorOnClick({ href: '/about', onClick: mergedOnClick })(makeClickEvent());
 
     expect(userOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  describe('trailingSlash', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('appends a trailing slash when `trailingSlash` is enabled', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/about' })).toBe('/about/');
+      expect(renderHref({ href: '/users/[id]', as: '/users/123' })).toBe('/users/123/');
+      expect(renderHref({ href: { pathname: '/about' } })).toBe('/about/');
+    });
+
+    it('keeps the slash before the query and hash', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/about?ref=nav' })).toBe('/about/?ref=nav');
+      expect(renderHref({ href: '/about#team' })).toBe('/about/#team');
+      expect(renderHref({ href: '/about?ref=nav#team' })).toBe('/about/?ref=nav#team');
+    });
+
+    it('does not append a slash to a path that looks like a file', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/logo.png' })).toBe('/logo.png');
+      expect(renderHref({ href: '/logo.png/' })).toBe('/logo.png');
+    });
+
+    it('does not touch the root path or double up an existing slash', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/' })).toBe('/');
+      expect(renderHref({ href: '/about/' })).toBe('/about/');
+    });
+
+    it('strips a trailing slash when `trailingSlash` is disabled', () => {
+      expect(renderHref({ href: '/about/' })).toBe('/about');
+      expect(renderHref({ href: '/' })).toBe('/');
+    });
+
+    it('is a no-op when `skipTrailingSlashRedirect` is enabled', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+      vi.stubEnv('__NEXT_MANUAL_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: '/about' })).toBe('/about');
+      expect(renderHref({ href: '/about/' })).toBe('/about/');
+    });
+
+    it('leaves hrefs that are not absolute paths alone', () => {
+      vi.stubEnv('__NEXT_TRAILING_SLASH', 'true');
+
+      expect(renderHref({ href: 'https://example.com/about' })).toBe('https://example.com/about');
+      expect(renderHref({ href: '#section' })).toBe('#section');
+    });
   });
 });

--- a/code/frameworks/nextjs/src/export-mocks/link/index.tsx
+++ b/code/frameworks/nextjs/src/export-mocks/link/index.tsx
@@ -4,6 +4,45 @@ import { fn } from 'storybook/test';
 
 const linkAction = fn().mockName('next/link::Link');
 
+// Mirrors next/dist/client/normalize-trailing-slash, which the real <Link> applies to
+// every href it renders. Both flags come from Next's own getDefineEnv: __NEXT_TRAILING_SLASH
+// is `trailingSlash` and __NEXT_MANUAL_TRAILING_SLASH is `skipTrailingSlashRedirect`.
+const removeTrailingSlash = (route: string) =>
+  route.endsWith('/') && route.length > 1 ? route.slice(0, -1) : route;
+
+const parsePath = (path: string) => {
+  const hashIndex = path.indexOf('#');
+  const queryIndex = path.indexOf('?');
+  const hasQuery = queryIndex > -1 && (hashIndex < 0 || queryIndex < hashIndex);
+
+  if (hasQuery || hashIndex > -1) {
+    return {
+      pathname: path.substring(0, hasQuery ? queryIndex : hashIndex),
+      query: hasQuery ? path.substring(queryIndex, hashIndex > -1 ? hashIndex : undefined) : '',
+      hash: hashIndex > -1 ? path.slice(hashIndex) : '',
+    };
+  }
+
+  return { pathname: path, query: '', hash: '' };
+};
+
+const normalizePathTrailingSlash = (path: string) => {
+  if (!path.startsWith('/') || process.env.__NEXT_MANUAL_TRAILING_SLASH) {
+    return path;
+  }
+
+  const { pathname, query, hash } = parsePath(path);
+
+  if (process.env.__NEXT_TRAILING_SLASH) {
+    if (/\.[^/]+\/?$/.test(pathname)) {
+      return `${removeTrailingSlash(pathname)}${query}${hash}`;
+    }
+    return `${pathname.endsWith('/') ? pathname : `${pathname}/`}${query}${hash}`;
+  }
+
+  return `${removeTrailingSlash(pathname)}${query}${hash}`;
+};
+
 const MockLink = React.forwardRef<HTMLAnchorElement, any>(function MockLink(
   {
     href,
@@ -22,10 +61,11 @@ const MockLink = React.forwardRef<HTMLAnchorElement, any>(function MockLink(
   ref
 ) {
   const resolvedHref = as ?? href;
-  const hrefString =
+  const rawHref =
     typeof resolvedHref === 'object'
       ? `${resolvedHref.pathname || ''}${resolvedHref.query ? '?' + new URLSearchParams(resolvedHref.query).toString() : ''}${resolvedHref.hash || ''}`
       : resolvedHref;
+  const hrefString = typeof rawHref === 'string' ? normalizePathTrailingSlash(rawHref) : rawHref;
 
   const navigate = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (e.defaultPrevented) {

--- a/code/frameworks/nextjs/src/export-mocks/link/index.tsx
+++ b/code/frameworks/nextjs/src/export-mocks/link/index.tsx
@@ -4,9 +4,11 @@ import { fn } from 'storybook/test';
 
 const linkAction = fn().mockName('next/link::Link');
 
-// Mirrors next/dist/client/normalize-trailing-slash, which the real <Link> applies to
-// every href it renders. Both flags come from Next's own getDefineEnv: __NEXT_TRAILING_SLASH
-// is `trailingSlash` and __NEXT_MANUAL_TRAILING_SLASH is `skipTrailingSlashRedirect`.
+/*
+ * Mirrors next/dist/client/normalize-trailing-slash, which the real <Link> applies to
+ * every href it renders. Both flags come from Next's own getDefineEnv: __NEXT_TRAILING_SLASH
+ * is `trailingSlash` and __NEXT_MANUAL_TRAILING_SLASH is `skipTrailingSlashRedirect`.
+ */
 const removeTrailingSlash = (route: string) =>
   route.endsWith('/') && route.length > 1 ? route.slice(0, -1) : route;
 


### PR DESCRIPTION
Closes #35576

## What I did

The `next/link` mock renders `href` verbatim, so with `trailingSlash: true` in `next.config.js` a `<Link href="/about">` renders `/about` in Storybook but `/about/` in the real app. `__NEXT_TRAILING_SLASH` did not appear anywhere in the repo before this change.

This mirrors [`next/dist/client/normalize-trailing-slash`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/normalize-trailing-slash.ts) inside the mock, which is what the real `<Link>` applies to every href it renders.

Both flags it reads come straight from Next's own `getDefineEnv`:

- `process.env.__NEXT_TRAILING_SLASH` ← `config.trailingSlash`
- `process.env.__NEXT_MANUAL_TRAILING_SLASH` ← `config.skipTrailingSlashRedirect`

For `nextjs-vite` these are already available: `vite-plugin-storybook-nextjs` spreads `getDefineEnv({ config: nextConfig, isClient: true, ... })` into Vite's `define` — the same mechanism that already supplies `process.env.__NEXT_RUNTIME_CONFIG` to `config/preview.ts`.

For `nextjs` (webpack) neither was defined, so `setupRuntimeConfig` now adds both next to the existing `__NEXT_NEW_LINK_BEHAVIOR` line. Without that the mock would read an undefined value and strip slashes instead of adding them, so those two lines are load-bearing rather than a drive-by.

I mirrored `skipTrailingSlashRedirect` as well as `trailingSlash` because handling only the latter would make the mock diverge from the real `<Link>` for anyone who sets it — upstream treats it as a complete opt-out of normalization.

The two `export-mocks/link/index.tsx` files were byte-identical before this change and still are, as are the two test files.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Added a `trailingSlash` block to `code/frameworks/nextjs-vite/src/export-mocks/link/index.test.tsx` and its `nextjs` twin, covering: slash appended, slash kept before query and hash, file-like paths left alone, root and already-slashed paths not doubled, slash stripped when the option is off, full no-op under `skipTrailingSlashRedirect`, and non-absolute hrefs untouched.

Four of them fail on `next` without the source change:

```
× appends a trailing slash when `trailingSlash` is enabled
    AssertionError: expected '/about' to be '/about/'
× keeps the slash before the query and hash
    AssertionError: expected '/about?ref=nav' to be '/about/?ref=nav'
× does not append a slash to a path that looks like a file
    AssertionError: expected '/logo.png/' to be '/logo.png'
× strips a trailing slash when `trailingSlash` is disabled
    AssertionError: expected '/about/' to be '/about'
```

With the change both suites are 12/12 green and the 5 pre-existing tests in each file are untouched. `oxfmt --check` is clean on all changed files, and `tsc --noEmit` on `code/frameworks/nextjs` reports the same three pre-existing errors before and after (all in `core/src/shared/utils/agent-environment.ts` and `renderers/react`, unrelated here).

#### Manual testing

Reproduces the steps from #35576:

1. Create or reuse a Next.js sandbox with the vite framework, e.g. `yarn task --task sandbox --start-from auto --template nextjs-vite/default-ts`
2. In the sandbox's `next.config.js`, set `trailingSlash: true`
3. Add a story rendering `<Link href="/about">About</Link>`
4. Open it in Storybook and inspect the rendered anchor

Before this change the anchor is `href="/about"`; after it is `href="/about/"`, matching what `next dev` renders for the same component. Setting `skipTrailingSlashRedirect: true` alongside it should return the anchor to `/about`.

The same check applies to the webpack framework via `--template nextjs/default-ts`, which is the half that additionally needed the `webpack.ts` defines.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation change: this aligns the mock with documented `next/link` behaviour rather than introducing new API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Next.js Link mock to normalize trailing slashes in rendered URLs based on configured trailing-slash settings.
  * Preserved query strings, hash fragments, root paths, file-like paths, and anchor-style/unchanged hrefs during formatting.
  * Ensured correct behavior for both automatic and manual trailing-slash modes.
* **Tests**
  * Added a dedicated trailing-slash test suite covering multiple href formatting scenarios and configuration combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->