### PR TITLE
feat(utils): add truncateMiddle helper function to core formatter utils

### DIFF
--- a/code/core/src/common/utils/formatter.ts
+++ b/code/core/src/common/utils/formatter.ts
@@ -82,3 +82,12 @@ async function formatWithEditorConfig(filePath: string, content: string): Promis
     filepath: filePath,
   });
 }
+
+export function truncateMiddle(str: string, maxLength: number): string {
+  if (typeof str !== 'string' || str.length <= maxLength || maxLength <= 3) {
+    return str;
+  }
+  const charsToShow = Math.ceil((maxLength - 3) / 2);
+  const backChars = Math.floor((maxLength - 3) / 2);
+  return `${str.slice(0, charsToShow)}...${str.slice(str.length - backChars)}`;
+}


### PR DESCRIPTION
## Description
Adds a type-safe \	runcateMiddle(str, maxLength)\ string formatting helper function to \code/core/src/common/utils/formatter.ts\ for cleanly formatting long component names, story titles, and CLI log output in Storybook.

## Features
- Middle string truncation with \...\ ellipsis.
- Exported from Storybook core common utilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for shortening long text while preserving both its beginning and end.
  * Text that already fits within the specified limit remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->