### PR TITLE
Core: Type registerLanguage explicitly to keep react-syntax-highlighter out of the d.ts

### DIFF
--- a/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
@@ -252,8 +252,7 @@ export const SyntaxHighlighter = ({
   );
 };
 
-// Typed explicitly so declaration emit doesn't reference the untyped deep
-// react-syntax-highlighter entrypoint (leaks into the published d.ts, #35539).
+// Typed explicitly: deriving the type from the untyped deep import leaks it into the d.ts
 SyntaxHighlighter.registerLanguage = (name: string, func: any): void =>
   ReactSyntaxHighlighter.registerLanguage(name, func);
 

--- a/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
@@ -252,8 +252,9 @@ export const SyntaxHighlighter = ({
   );
 };
 
-SyntaxHighlighter.registerLanguage = (
-  ...args: Parameters<typeof ReactSyntaxHighlighter.registerLanguage>
-) => ReactSyntaxHighlighter.registerLanguage(...args);
+// Typed explicitly so declaration emit doesn't reference the untyped deep
+// react-syntax-highlighter entrypoint (leaks into the published d.ts, #35539).
+SyntaxHighlighter.registerLanguage = (name: string, func: any): void =>
+  ReactSyntaxHighlighter.registerLanguage(name, func);
 
 export default SyntaxHighlighter;


### PR DESCRIPTION
Closes #35539

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

On main, declaration emit keeps the untyped `react-syntax-highlighter/dist/esm/prism-light` import in `dist/components/index.d.ts` because `SyntaxHighlighter.registerLanguage` derives its type from it, and the package ships neither that dependency nor its types. On next this was already fixed as a side effect of #35341, which is too large to patch back.

This change is emit-identical on next (10.6.0-alpha.3 already publishes `registerLanguage: (name: string, func: any) => void`). It exists to be cherry-picked to main: I built core on both branches and the react-syntax-highlighter reference is gone from the output in each. Needs the patch label to reach a 10.5 release.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

There is no runtime change. To verify the type fix: cherry-pick this commit onto `main`, run `yarn nx compile core -c production`, and grep `code/core/dist/components/index.d.ts` for `react-syntax-highlighter`. It has no matches with this change and one unresolvable import without it.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syntax highlighting language registration compatibility.
  * Prevented internal type details from leaking into generated public type declarations, resulting in cleaner TypeScript consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->