### PR TITLE
Vue: Resolve docgen per export so a type-only export does not drop a file's prop tables

### DIFF
--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -142,6 +142,63 @@ describe('vue-component-meta plugin', () => {
     });
   });
 
+  describe('non-component exports', () => {
+    it('should keep docgen for the other exports when getComponentMeta throws for one', async () => {
+      // `getExportNames` reports type-level exports too (e.g. `export type Variant` declared in an
+      // SFC's <script>), and `getComponentMeta` throws for those. One throw must not discard the
+      // docgen of the whole file.
+      const src = `import { defineComponent } from 'vue';\nexport const Tab = defineComponent({});\n`;
+      const id = '/project/src/components/Tab.ts';
+
+      mockChecker.getExportNames.mockReturnValue(['TabVariant', 'Tab']);
+      mockChecker.getComponentMeta.mockImplementation((_id: string, name: string) => {
+        if (name === 'TabVariant') {
+          throw new Error('Could not find export TabVariant');
+        }
+        return makeComponentMeta();
+      });
+
+      const result = await transform(src, id);
+
+      expect(result).toBeDefined();
+      expect(result!.code).toContain('Tab.__docgenInfo');
+    });
+
+    it('should return undefined when every export throws', async () => {
+      const src = `export type Variant = 'a' | 'b';\n`;
+      const id = '/project/src/components/types.ts';
+
+      mockChecker.getExportNames.mockReturnValue(['Variant']);
+      mockChecker.getComponentMeta.mockImplementation(() => {
+        throw new Error('Could not find export Variant');
+      });
+
+      const result = await transform(src, id);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should keep meta aligned with its export name when an earlier export throws', async () => {
+      // Regression guard for the index-alignment between `exportNames` and `componentsMeta`:
+      // a dropped export must not shift the remaining names by one.
+      const src = `export const Tabs = {};\n`;
+      const id = '/project/src/components/Tabs.ts';
+
+      mockChecker.getExportNames.mockReturnValue(['TabsVariant', 'Tabs']);
+      mockChecker.getComponentMeta.mockImplementation((_id: string, name: string) => {
+        if (name === 'TabsVariant') {
+          throw new Error('Could not find export TabsVariant');
+        }
+        return makeComponentMeta();
+      });
+
+      const result = await transform(src, id);
+
+      expect(result!.code).toContain('Tabs.__docgenInfo');
+      expect(result!.code).toContain('"displayName":"Tabs"');
+    });
+  });
+
   describe('re-export detection', () => {
     it('should skip named re-exports like "export { Tab } from ..."', async () => {
       const result = await transform(

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -39,8 +39,6 @@ async function getTransformHandler() {
 
 describe('vue-component-meta plugin', () => {
   let transform: Awaited<ReturnType<typeof getTransformHandler>>;
-  // Export name that `getComponentMeta` should reject, mirroring a type-only export. Set by the
-  // cases that need it; left undefined so every other case resolves normally.
   let rejectedExportName: string | undefined;
 
   beforeEach(async () => {
@@ -153,8 +151,6 @@ describe('vue-component-meta plugin', () => {
 
   describe('non-component exports', () => {
     it('should keep docgen for the other exports when getComponentMeta throws for one', async () => {
-      // `getExportNames` reports type-level exports too, and `getComponentMeta` throws for those.
-      // One throw must not discard the docgen of the whole file.
       const src = [
         `import { defineComponent } from 'vue';`,
         `export type TabVariant = 'primary' | 'secondary';`,
@@ -184,8 +180,6 @@ describe('vue-component-meta plugin', () => {
     });
 
     it('should keep meta aligned with its export name when an earlier export throws', async () => {
-      // Regression guard for the index-alignment between `exportNames` and `componentsMeta`:
-      // a dropped export must not shift the remaining names by one.
       const src = [
         `export type TabsVariant = 'horizontal' | 'vertical';`,
         `export const Tabs = {};`,

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -39,9 +39,13 @@ async function getTransformHandler() {
 
 describe('vue-component-meta plugin', () => {
   let transform: Awaited<ReturnType<typeof getTransformHandler>>;
+  // Export name that `getComponentMeta` should reject, mirroring a type-only export. Set by the
+  // cases that need it; left undefined so every other case resolves normally.
+  let rejectedExportName: string | undefined;
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    rejectedExportName = undefined;
 
     // Only mock what's actually called: createCheckerByJson, getProjectRoot, stat
     // createChecker, readFile, parseMulti are never reached in these tests
@@ -52,7 +56,12 @@ describe('vue-component-meta plugin', () => {
     vi.mocked(stat).mockRejectedValue(new Error('ENOENT'));
 
     mockChecker.getExportNames.mockReturnValue(['Tab']);
-    mockChecker.getComponentMeta.mockReturnValue(makeComponentMeta());
+    mockChecker.getComponentMeta.mockImplementation((_id: string, name: string) => {
+      if (name === rejectedExportName) {
+        throw new Error(`Could not find export ${name}`);
+      }
+      return makeComponentMeta();
+    });
 
     transform = await getTransformHandler();
   });
@@ -144,19 +153,17 @@ describe('vue-component-meta plugin', () => {
 
   describe('non-component exports', () => {
     it('should keep docgen for the other exports when getComponentMeta throws for one', async () => {
-      // `getExportNames` reports type-level exports too (e.g. `export type Variant` declared in an
-      // SFC's <script>), and `getComponentMeta` throws for those. One throw must not discard the
-      // docgen of the whole file.
-      const src = `import { defineComponent } from 'vue';\nexport const Tab = defineComponent({});\n`;
+      // `getExportNames` reports type-level exports too, and `getComponentMeta` throws for those.
+      // One throw must not discard the docgen of the whole file.
+      const src = [
+        `import { defineComponent } from 'vue';`,
+        `export type TabVariant = 'primary' | 'secondary';`,
+        `export const Tab = defineComponent({});`,
+      ].join('\n');
       const id = '/project/src/components/Tab.ts';
 
       mockChecker.getExportNames.mockReturnValue(['TabVariant', 'Tab']);
-      mockChecker.getComponentMeta.mockImplementation((_id: string, name: string) => {
-        if (name === 'TabVariant') {
-          throw new Error('Could not find export TabVariant');
-        }
-        return makeComponentMeta();
-      });
+      rejectedExportName = 'TabVariant';
 
       const result = await transform(src, id);
 
@@ -169,9 +176,7 @@ describe('vue-component-meta plugin', () => {
       const id = '/project/src/components/types.ts';
 
       mockChecker.getExportNames.mockReturnValue(['Variant']);
-      mockChecker.getComponentMeta.mockImplementation(() => {
-        throw new Error('Could not find export Variant');
-      });
+      rejectedExportName = 'Variant';
 
       const result = await transform(src, id);
 
@@ -181,16 +186,14 @@ describe('vue-component-meta plugin', () => {
     it('should keep meta aligned with its export name when an earlier export throws', async () => {
       // Regression guard for the index-alignment between `exportNames` and `componentsMeta`:
       // a dropped export must not shift the remaining names by one.
-      const src = `export const Tabs = {};\n`;
+      const src = [
+        `export type TabsVariant = 'horizontal' | 'vertical';`,
+        `export const Tabs = {};`,
+      ].join('\n');
       const id = '/project/src/components/Tabs.ts';
 
       mockChecker.getExportNames.mockReturnValue(['TabsVariant', 'Tabs']);
-      mockChecker.getComponentMeta.mockImplementation((_id: string, name: string) => {
-        if (name === 'TabsVariant') {
-          throw new Error('Could not find export TabsVariant');
-        }
-        return makeComponentMeta();
-      });
+      rejectedExportName = 'TabsVariant';
 
       const result = await transform(src, id);
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -44,10 +44,6 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
         }
 
         try {
-          // `getExportNames` also reports exports that are not components — most commonly a type
-          // or interface declared in an SFC's `<script>` block — and `getComponentMeta` throws for
-          // those. Resolve each export on its own so one such export cannot discard the docgen of
-          // every other export in the file. Both arrays stay index-aligned.
           const exportNames: string[] = [];
           let componentsMeta: ComponentMeta[] = [];
 
@@ -56,9 +52,7 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
               const meta = checker.getComponentMeta(id, name);
               exportNames.push(name);
               componentsMeta.push(meta);
-            } catch {
-              // not a component — leave it out and keep the rest of the file's docgen
-            }
+            } catch {}
           }
 
           if (componentsMeta.length === 0) {

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -44,8 +44,27 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
         }
 
         try {
-          const exportNames = checker.getExportNames(id);
-          let componentsMeta = exportNames.map((name) => checker.getComponentMeta(id, name));
+          // `getExportNames` also reports exports that are not components — most commonly a type
+          // or interface declared in an SFC's `<script>` block — and `getComponentMeta` throws for
+          // those. Resolve each export on its own so one such export cannot discard the docgen of
+          // every other export in the file. Both arrays stay index-aligned.
+          const exportNames: string[] = [];
+          let componentsMeta: ComponentMeta[] = [];
+
+          for (const name of checker.getExportNames(id)) {
+            try {
+              const meta = checker.getComponentMeta(id, name);
+              exportNames.push(name);
+              componentsMeta.push(meta);
+            } catch {
+              // not a component — leave it out and keep the rest of the file's docgen
+            }
+          }
+
+          if (componentsMeta.length === 0) {
+            return undefined;
+          }
+
           componentsMeta = await applyTempFixForEventDescriptions(id, componentsMeta);
 
           const metaSources: MetaSource[] = [];


### PR DESCRIPTION
Closes #35592

## What I did

`checker.getExportNames(id)` reports type-level exports (`export type` or `export interface` declared in an SFC's `<script>` block), and `checker.getComponentMeta(id, name)` throws for such a name. Those two calls sat inside one `try` whose `catch` returns `undefined`, so a single non-component export discarded the docgen for **every** component in the file:

```ts
const exportNames = checker.getExportNames(id);
let componentsMeta = exportNames.map((name) => checker.getComponentMeta(id, name));
```

Each export name is now resolved in its own `try`/`catch`, with `exportNames` and `componentsMeta` built in lockstep so they stay index-aligned, and `undefined` returned only when nothing resolved.

This is behaviour-preserving for any file that does not throw today, so it can only restore docgen that is currently being lost.

Because an SFC cannot `export` from `<script setup>`, reaching this requires the two-block form. That is supported and documented: "Declare named exports" is one of the reasons the Vue docs give for adding a normal `<script>` alongside `<script setup>`, see [Usage alongside normal `<script>`](https://vuejs.org/api/sfc-script-setup.html#usage-alongside-normal-script).

```vue
<script lang="ts">
export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
</script>
<script setup lang="ts">
defineProps<{ label: string; variant?: ButtonVariant }>();
</script>
```

[Reka UI](https://github.com/unovue/reka-ui) uses this as house style so each component's prop interface stays co-located with the component. A code search for `repo:unovue/reka-ui "export interface" "script setup" language:vue` currently returns 376 files, all of which would lose their prop tables under `docgen: 'vue-component-meta'`.

Value exports are unaffected, since `getExportNames()` does not surface an `export const` the same way and `getComponentMeta` is never handed that name. The trigger is specifically a type-only export.

This is not a regression in the plugin's own code, those lines predate 10.5. What changed underneath is the checker: `vue-component-meta@2`'s export enumeration was value-only, so `getComponentMeta` was never handed a type name. On 10.4.6 the affected components keep their docgen.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Three cases added to `code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts`, using the existing `mockChecker`:

- a rejected export name alongside a real component, where the component keeps its docgen
- an earlier export is rejected, where the surviving meta stays matched to its own export name (this guards the index alignment)
- every export is rejected, which still returns `undefined`

The first two fail on `next` without this change. The third passes either way, since the previous shared `catch` also returned `undefined`; it is there to guard against the fix over-correcting and emitting docgen when nothing resolved.

#### Manual testing

1. Clone the reproduction and install it:
   ```sh
   git clone https://github.com/seanogdev/sb-vue3-docgen-repro
   cd sb-vue3-docgen-repro
   npm install
   ```
2. Confirm the bug on the released version first:
   ```sh
   node verify.mjs dev
   ```
   `verify.mjs` asks the dev server for each fixture's transformed module over HTTP and reports whether `__docgenInfo` was attached. Expected output before the fix:
   ```
   storybook dev:
     CleanButton          docgen present
     TypeExportButton     DOCGEN MISSING
     ConstExportButton    docgen present
   ```
   `TypeExportButton.vue` differs from `CleanButton.vue` only by adding `export type TypeExportButtonVariant` in a plain `<script lang="ts">` block. `ConstExportButton.vue` adds an `export const` instead, and is the control showing value exports are unaffected.
3. To see it by eye instead, run `npm run storybook` and compare the **Docs** tab of `CleanButton` (full prop table) against `TypeExportButton` (no prop table).
4. Point the repro at this branch, or reproduce in a sandbox with `yarn task --task sandbox --start-from auto --template vue3-vite/default-ts` and add a component with a type export plus an `autodocs` story.
5. Re-run `node verify.mjs dev`. All three fixtures should now report `docgen present`, and `TypeExportButton`'s **Docs** tab should show the full `label` and `variant` prop table.

> Note: `node verify.mjs build` reports all three fixtures as missing both before and after this change. That is #35518, a separate defect with a fix already open in #35557, and is unrelated to this PR. Please use `dev` to assess this one.

## Documentation

No documentation change, since this restores previously-working behaviour rather than adding an API.

---

I do not have permission to apply labels, so the Danger check is failing on the missing type, `ci:*` and `qa:*` labels. Happy to adjust anything needed once a maintainer can kick CI off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue component metadata extraction by handling non-component exports more safely.
  * Preserved component documentation/metadata for valid components even when other exports cannot be analyzed.
  * Avoided transform failures when all exports are non-components.
  * Ensured metadata stays correctly aligned with the intended export.
* **Tests**
  * Added coverage for non-component export scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->