### PR TITLE
Vue: Allow the vue-component-meta docgen scope to be configured with include and exclude

### DIFF
--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -188,6 +188,18 @@ describe('vue-component-meta plugin', () => {
 
       expect(story).toBeUndefined();
     });
+
+    it('should keep ids carrying a query excluded when a caller widens include', async () => {
+      const widened = await getTransformHandler({ include: /.*/ });
+
+      const subRequest = await widened(
+        componentSrc,
+        '/project/src/Tab.vue?vue&type=script&setup=true&lang.ts'
+      );
+
+      expect(subRequest).toBeUndefined();
+      expect(mockChecker.getExportNames).not.toHaveBeenCalled();
+    });
   });
 
   describe('re-export detection', () => {

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -159,7 +159,7 @@ describe('vue-component-meta plugin', () => {
       const outside = await narrowed(componentSrc, '/project/node_modules/lib/Tab.ts');
       const inside = await narrowed(componentSrc, '/project/src/Tab.ts');
 
-      expect(outside?.code ?? '').not.toContain('__docgenInfo');
+      expect(outside).toBeUndefined();
       expect(inside!.code).toContain('Tab.__docgenInfo');
     });
 
@@ -169,26 +169,24 @@ describe('vue-component-meta plugin', () => {
       const excluded = await narrowed(componentSrc, '/project/src/Tab.generated.ts');
       const kept = await narrowed(componentSrc, '/project/src/Tab.ts');
 
-      expect(excluded?.code ?? '').not.toContain('__docgenInfo');
+      expect(excluded).toBeUndefined();
       expect(kept!.code).toContain('Tab.__docgenInfo');
     });
 
     it('should keep the built-in exclusions when a caller supplies exclude', async () => {
-      // `exclude` is additive, so stories stay excluded even though the caller named something else.
       const narrowed = await getTransformHandler({ exclude: /\.generated\.ts$/ });
 
       const story = await narrowed(componentSrc, '/project/src/Tab.stories.ts');
 
-      expect(story?.code ?? '').not.toContain('__docgenInfo');
+      expect(story).toBeUndefined();
     });
 
     it('should keep the built-in exclusions when a caller widens include', async () => {
-      // A permissive include must not resurrect stories either.
       const widened = await getTransformHandler({ include: /.*/ });
 
       const story = await widened(componentSrc, '/project/src/Tab.stories.ts');
 
-      expect(story?.code ?? '').not.toContain('__docgenInfo');
+      expect(story).toBeUndefined();
     });
   });
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -25,9 +25,11 @@ function makeComponentMeta() {
   };
 }
 
-async function getTransformHandler() {
+async function getTransformHandler(
+  filterOptions?: import('./vue-component-meta.ts').DocgenFilterOptions
+) {
   const { vueComponentMeta } = await import('./vue-component-meta.ts');
-  const plugin = await vueComponentMeta();
+  const plugin = await vueComponentMeta('tsconfig.json', filterOptions);
 
   const handler =
     typeof plugin.transform === 'function'
@@ -139,6 +141,54 @@ describe('vue-component-meta plugin', () => {
       const result = await transform(src, id);
 
       expect(result?.code ?? '').not.toContain('__docgenInfo');
+    });
+  });
+
+  describe('docgen filter options', () => {
+    const componentSrc = `import { defineComponent } from 'vue';\nexport const Tab = defineComponent({});\n`;
+
+    it('should docgen a module the default filter accepts', async () => {
+      const result = await transform(componentSrc, '/project/node_modules/lib/Tab.ts');
+
+      expect(result!.code).toContain('Tab.__docgenInfo');
+    });
+
+    it('should skip a module outside a caller-supplied include', async () => {
+      const narrowed = await getTransformHandler({ include: /\/project\/src\// });
+
+      const outside = await narrowed(componentSrc, '/project/node_modules/lib/Tab.ts');
+      const inside = await narrowed(componentSrc, '/project/src/Tab.ts');
+
+      expect(outside?.code ?? '').not.toContain('__docgenInfo');
+      expect(inside!.code).toContain('Tab.__docgenInfo');
+    });
+
+    it('should skip a module matching a caller-supplied exclude', async () => {
+      const narrowed = await getTransformHandler({ exclude: /\.generated\.ts$/ });
+
+      const excluded = await narrowed(componentSrc, '/project/src/Tab.generated.ts');
+      const kept = await narrowed(componentSrc, '/project/src/Tab.ts');
+
+      expect(excluded?.code ?? '').not.toContain('__docgenInfo');
+      expect(kept!.code).toContain('Tab.__docgenInfo');
+    });
+
+    it('should keep the built-in exclusions when a caller supplies exclude', async () => {
+      // `exclude` is additive, so stories stay excluded even though the caller named something else.
+      const narrowed = await getTransformHandler({ exclude: /\.generated\.ts$/ });
+
+      const story = await narrowed(componentSrc, '/project/src/Tab.stories.ts');
+
+      expect(story?.code ?? '').not.toContain('__docgenInfo');
+    });
+
+    it('should keep the built-in exclusions when a caller widens include', async () => {
+      // A permissive include must not resurrect stories either.
+      const widened = await getTransformHandler({ include: /.*/ });
+
+      const story = await widened(componentSrc, '/project/src/Tab.stories.ts');
+
+      expect(story?.code ?? '').not.toContain('__docgenInfo');
     });
   });
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -23,12 +23,39 @@ type MetaSource = {
 } & ComponentMeta &
   MetaCheckerOptions['schema'];
 
-export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<Plugin> {
+/** Module id patterns accepted by the docgen transform's filter. */
+export type DocgenFilterPattern = string | RegExp | ReadonlyArray<string | RegExp>;
+
+/** Modules the docgen transform runs on. Both default to every module Storybook can document. */
+export type DocgenFilterOptions = {
+  include?: DocgenFilterPattern;
+  exclude?: DocgenFilterPattern;
+};
+
+/** Stories, virtual modules and storybook internals are never candidates for docgen. */
+const ALWAYS_EXCLUDE =
+  /\.stories\.(ts|tsx|js|jsx)$|^\0\/virtual:|^\/virtual:|\.storybook\/.*\.(ts|js)$/;
+
+const DEFAULT_INCLUDE = /\.(vue|ts|js|tsx|jsx)$/;
+
+function toPatternArray(pattern: DocgenFilterPattern | undefined): (string | RegExp)[] {
+  if (pattern === undefined) {
+    return [];
+  }
+  return Array.isArray(pattern) ? [...pattern] : [pattern as string | RegExp];
+}
+
+export async function vueComponentMeta(
+  tsconfigPath = 'tsconfig.json',
+  filterOptions: DocgenFilterOptions = {}
+): Promise<Plugin> {
   const { createFilter } = await import('vite');
 
-  // exclude stories, virtual modules and storybook internals
-  const exclude = /\.stories\.(ts|tsx|js|jsx)$|^\0\/virtual:|^\/virtual:|\.storybook\/.*\.(ts|js)$/;
-  const include = /\.(vue|ts|js|tsx|jsx)$/;
+  // A caller-supplied `include` replaces the default, so docgen can be narrowed to the components a
+  // project actually documents. `exclude` is additive instead: the built-in exclusions are always
+  // applied, so narrowing can never accidentally pull stories or storybook internals into docgen.
+  const include = filterOptions.include ?? DEFAULT_INCLUDE;
+  const exclude = [ALWAYS_EXCLUDE, ...toPatternArray(filterOptions.exclude)];
   const filter = createFilter(include, exclude);
 
   const checker = await createVueComponentMetaChecker(tsconfigPath);

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -23,16 +23,13 @@ type MetaSource = {
 } & ComponentMeta &
   MetaCheckerOptions['schema'];
 
-/** Module id patterns accepted by the docgen transform's filter. */
 export type DocgenFilterPattern = string | RegExp | ReadonlyArray<string | RegExp>;
 
-/** Modules the docgen transform runs on. Both default to every module Storybook can document. */
 export type DocgenFilterOptions = {
   include?: DocgenFilterPattern;
   exclude?: DocgenFilterPattern;
 };
 
-/** Stories, virtual modules and storybook internals are never candidates for docgen. */
 const ALWAYS_EXCLUDE =
   /\.stories\.(ts|tsx|js|jsx)$|^\0\/virtual:|^\/virtual:|\.storybook\/.*\.(ts|js)$/;
 
@@ -51,9 +48,6 @@ export async function vueComponentMeta(
 ): Promise<Plugin> {
   const { createFilter } = await import('vite');
 
-  // A caller-supplied `include` replaces the default, so docgen can be narrowed to the components a
-  // project actually documents. `exclude` is additive instead: the built-in exclusions are always
-  // applied, so narrowing can never accidentally pull stories or storybook internals into docgen.
   const include = filterOptions.include ?? DEFAULT_INCLUDE;
   const exclude = [ALWAYS_EXCLUDE, ...toPatternArray(filterOptions.exclude)];
   const filter = createFilter(include, exclude);

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -31,7 +31,7 @@ export type DocgenFilterOptions = {
 };
 
 const ALWAYS_EXCLUDE =
-  /\.stories\.(ts|tsx|js|jsx)$|^\0\/virtual:|^\/virtual:|\.storybook\/.*\.(ts|js)$/;
+  /\.stories\.(ts|tsx|js|jsx)$|\?|^\0\/virtual:|^\/virtual:|\.storybook\/.*\.(ts|js)$/;
 
 const DEFAULT_INCLUDE = /\.(vue|ts|js|tsx|jsx)$/;
 

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -2,6 +2,7 @@ import type { PresetProperty } from 'storybook/internal/types';
 
 import type { Plugin } from 'vite';
 
+import type { DocgenFilterPattern } from './plugins/vue-component-meta.ts';
 import { vueComponentMeta } from './plugins/vue-component-meta.ts';
 import { vueDocgen } from './plugins/vue-docgen.ts';
 import { templateCompilation } from './plugins/vue-template.ts';
@@ -24,7 +25,12 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
   // add docgen plugin depending on framework option
   if (docgen !== false) {
     if (docgen.plugin === 'vue-component-meta') {
-      plugins.push(await vueComponentMeta(docgen.tsconfig));
+      plugins.push(
+        await vueComponentMeta(docgen.tsconfig, {
+          include: docgen.include,
+          exclude: docgen.exclude,
+        })
+      );
     } else {
       plugins.push(await vueDocgen());
     }
@@ -39,7 +45,14 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
 /** Resolves the docgen framework option. */
 const resolveDocgenOptions = (
   docgen?: FrameworkOptions['docgen']
-): false | { plugin: VueDocgenPlugin; tsconfig?: string } => {
+):
+  | false
+  | {
+      plugin: VueDocgenPlugin;
+      tsconfig?: string;
+      include?: DocgenFilterPattern;
+      exclude?: DocgenFilterPattern;
+    } => {
   if (docgen === false) {
     return false;
   }

--- a/code/frameworks/vue3-vite/src/types.ts
+++ b/code/frameworks/vue3-vite/src/types.ts
@@ -14,6 +14,10 @@ type BuilderName = CompatibleString<'@storybook/builder-vite'>;
 /** Available docgen plugins for vue. */
 export type VueDocgenPlugin = 'vue-docgen-api' | 'vue-component-meta';
 
+import type { DocgenFilterPattern } from './plugins/vue-component-meta.ts';
+
+export type { DocgenFilterPattern };
+
 export type FrameworkOptions = {
   builder?: BuilderOptions;
   /**
@@ -45,6 +49,27 @@ export type FrameworkOptions = {
          * @default 'tsconfig.json'
          */
         tsconfig: `${string}/tsconfig${string}.json` | `tsconfig${string}.json`;
+        /**
+         * Modules to extract docgen from, as a glob or regular expression. Replaces the default of
+         * every `.vue`, `.ts`, `.js`, `.tsx` and `.jsx` module in the preview graph.
+         *
+         * Docgen resolves types through the whole program, so it is the most expensive part of a
+         * Vue build. Narrowing this to the components you actually document can cut build time
+         * substantially on larger projects, at the cost of no prop tables for anything excluded.
+         *
+         * Third-party components can be documented by including their path explicitly, for example
+         * `['src/**', 'node_modules/some-library/**']`.
+         *
+         * @default /\.(vue|ts|js|tsx|jsx)$/
+         */
+        include?: DocgenFilterPattern;
+        /**
+         * Modules to skip, as a glob or regular expression. Added to the built-in exclusions
+         * (stories, virtual modules and Storybook internals) rather than replacing them.
+         *
+         * @default undefined
+         */
+        exclude?: DocgenFilterPattern;
       };
 };
 


### PR DESCRIPTION
Refs #35556. This does not close it: it is a mitigation projects can reach for today, not a fix for the underlying per-call cost. See the measurements below for the split between the two.

## What I did

Added `include` and `exclude` to the `vue-component-meta` docgen framework option, so a project can control which modules the docgen transform runs on:

```ts
framework: {
  name: '@storybook/vue3-vite',
  options: {
    docgen: {
      plugin: 'vue-component-meta',
      include: ['src/**', 'node_modules/vuetify/lib/components/VSelect/**'],
    },
  },
}
```

Both are optional and default to today's behaviour, so nothing changes for existing projects.

The two options behave differently on purpose:

- `include` **replaces** the default `/\.(vue|ts|js|tsx|jsx)$/`, which is what makes narrowing possible.
- `exclude` is **additive**. The built-in exclusions for stories, virtual modules and Storybook internals are always applied, so narrowing or a permissive `include` can never pull those into docgen. Two of the added tests pin this.

### Why this is worth having

`getComponentMeta` resolves types through the whole TypeScript program, so it is the dominant cost in a Vue Storybook build, and the transform currently has no way to be told which modules are worth that cost. On the project I measured, a 271 component design system, I instrumented the transform to log every module id it is handed:

```
distinct modules handed to the transform: 1189
  inside node_modules:                     836  (70%)
    of which vuetify:                      469
  first-party:                             353  (282 .vue, 53 .ts, 18 .js)
```

All 836 of those `node_modules` modules are compiled `.js`. Vuetify ships prebuilt JavaScript, so 70% of the docgen work went into dependency output that produced no usable prop tables for this Storybook.

Narrowing `include` to first-party source plus the handful of third-party components that project documents (same machine, `n=1` each):

```
default include     vite build 24m 24s
narrowed include    vite build  4m 22s     = 5.6x faster
```

The only docgen lost was a `tv` helper (not a component) and an undocumented Vuetify internal.

I want to be straight about what this does not solve. On the same machine, 10.4.6 built the same project in 42s. So scoping accounts for roughly 20 of those 24 minutes, and the remaining gap from 42s to 4m 22s is per-call cost over only 353 first-party modules, which no amount of configuration will recover. This option is a lever projects can pull now; it is not a substitute for #32233 (scoping docgen to story-referenced components, which would make this automatic) or the direction in #35333.

A blanket `node_modules` exclusion, which is what `svelte-vite`'s equivalent filter already does, would have been a smaller change. I did not do that because it silently drops prop tables for projects that document third-party components on purpose, which the project above does. Making the scope explicit lets both cases work.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Five cases added to `code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts`:

- a module the default filter accepts still gets docgen, which pins that the default is unchanged
- a module outside a caller-supplied `include` is skipped, and one inside it is not
- a module matching a caller-supplied `exclude` is skipped, and one that does not match is not
- stories stay excluded when the caller supplies their own `exclude`
- stories stay excluded when the caller supplies a permissive `include` of `/.*/`

The nine pre-existing tests in that file pass unchanged.

I could not run `yarn lint` locally because `eslint-plugin-storybook` is not built in my checkout. `oxfmt --check` is clean across `frameworks/vue3-vite/src`.

#### Manual testing

`exclude` changes shape internally, from a single RegExp to an array containing the built-in exclusions plus any caller patterns, and that value is passed to the Rust-side object hook filter as well as to `createFilter`. So the thing most worth verifying is that the default path is genuinely unchanged.

1. Set up any Vue 3 project with `docgen: { plugin: 'vue-component-meta' }` and an `autodocs` story, or use https://github.com/seanogdev/sb-vue3-docgen-repro.
2. With no `include` or `exclude` set, run `storybook dev` and confirm prop tables render exactly as before, and that story modules are still excluded from docgen. In the repro above, `node verify.mjs dev` reports `CleanButton` and `ConstExportButton` as having docgen, which is the unchanged baseline for 10.5.x.
3. Add `include: ['src/**']` and confirm components under `src` still get prop tables.
4. Change it to `include: ['src/does-not-exist/**']` and confirm prop tables disappear, which shows the option is actually being applied.
5. Add `exclude: [/\.generated\.ts$/]` alongside a permissive `include: [/.*/]`, and confirm that `*.stories.*` files still do not receive `__docgenInfo`. This is the case that would regress if the built-in exclusions stopped being applied.

## Documentation

The options are documented with TSDoc on `FrameworkOptions['docgen']`, which is where the existing `tsconfig` option is documented, so they surface on hover in `main.ts`. Happy to add a section to the vue3-vite framework docs page if you would like that in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `include` and `exclude` filters for Vue component documentation generation.
  * Allows narrowing documentation extraction to matching files/patterns.
  * Preserves built-in exclusions (e.g., story modules) even when custom filters are provided.
* **Documentation**
  * Updated configuration types and usage guidance for the new filtering options.
* **Tests**
  * Added coverage to verify filtering behavior across default, include, exclude, and combined scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->