### PR TITLE
Build: Fix repository.directory path in create-storybook package.json

### DIFF
--- a/code/lib/create-storybook/package.json
+++ b/code/lib/create-storybook/package.json
@@ -15,7 +15,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/storybookjs/storybook.git",
-    "directory": "code/lib/cli"
+    "directory": "code/lib/create-storybook"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
Closes #31800

## What I did

`code/lib/create-storybook/package.json` still points `repository.directory` at
`code/lib/cli`, a directory that no longer exists. The package lives in
`code/lib/create-storybook`, which its own `homepage` field already reflects.

The two files originally listed in #31800 (`code/lib/cli-storybook/package.json` and
`code/lib/cli-sb/package.json`) are already correct on `next` - this was the remaining
occurrence of the stale path, so this change finishes off that issue.

This is a metadata-only fix and does not affect runtime behaviour. It does affect the
"Repository" link npm renders on the package page, which currently points at a path that
404s.

#### Manual testing

This is a metadata-only change to a `package.json` manifest field, so there is no runtime
behaviour to exercise. It was verified as follows:

1. Confirm the package location matches the new value:
   `ls code/lib/create-storybook/package.json` resolves, while `code/lib/cli/` no longer
   exists in the repo.
2. Confirm the value is now consistent with the sibling field in the same manifest:
   `homepage` already pointed at `.../tree/next/code/lib/create-storybook`.
3. Confirm no other manifest still carries the stale path:
   `grep -rn '"directory": "code/lib/cli"' code/` returns no matches after this change.

## Checklist for Contributors

### Testing

Metadata-only change, no automated tests applicable.

- [x] I have verified the corrected path matches the actual package location.

### Documentation

- [ ] Add or update documentation - not applicable.

---

Note for maintainers: this PR needs the mandatory labels (category / `ci:*` / `qa:*`) applied
before Danger will pass - I am unable to set labels as an external contributor. Suggested:
`maintenance` or `build`, `ci:normal`, `qa:skip`.