### PR TITLE
Docs: Make forceInitialArgs configurable in Stories block

### DIFF
--- a/code/addons/docs/src/blocks/blocks/DocsStory.tsx
+++ b/code/addons/docs/src/blocks/blocks/DocsStory.tsx
@@ -13,10 +13,13 @@ const DocsStoryImpl: FC<DocsStoryProps> = ({
   of,
   expanded = true,
   withToolbar: withToolbarProp = false,
-  __forceInitialArgs = false,
+  __forceInitialArgs,
+  forceInitialArgs = false,
   __primary = false,
 }) => {
   const { story } = useOf(of || 'story', ['story']);
+
+  const resolvedForceInitialArgs = __forceInitialArgs ?? forceInitialArgs;
 
   // use withToolbar from parameters or default to true in autodocs
   const withToolbar = story.parameters.docs?.canvas?.withToolbar ?? withToolbarProp;
@@ -32,8 +35,8 @@ const DocsStoryImpl: FC<DocsStoryProps> = ({
       <Canvas
         of={of}
         withToolbar={withToolbar}
-        story={{ __forceInitialArgs, __primary }}
-        source={{ __forceInitialArgs }}
+        story={{ __forceInitialArgs: resolvedForceInitialArgs, __primary }}
+        source={{ __forceInitialArgs: resolvedForceInitialArgs }}
       />
     </Anchor>
   );

--- a/code/addons/docs/src/blocks/blocks/Stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Stories.tsx
@@ -14,6 +14,7 @@ import type { DocsParameters } from '../../types.ts';
 interface StoriesProps {
   title?: ReactElement | string;
   includePrimary?: boolean;
+  forceInitialArgs?: boolean;
 }
 
 const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
@@ -32,12 +33,18 @@ const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
   },
 }));
 
-const StoriesImpl: FC<StoriesProps> = ({ title = 'Stories', includePrimary = true }) => {
+const StoriesImpl: FC<StoriesProps> = ({
+  title = 'Stories',
+  includePrimary = true,
+  forceInitialArgs: forceInitialArgsProp,
+}) => {
   const { componentStories, projectAnnotations, getStoryContext } = useContext(DocsContext);
 
+  const storiesConfig = (projectAnnotations.parameters as DocsParameters | undefined)?.docs?.stories;
+  const forceInitialArgs = forceInitialArgsProp ?? storiesConfig?.forceInitialArgs ?? true;
+
   let stories = componentStories();
-  const filter = (projectAnnotations.parameters as DocsParameters | undefined)?.docs?.stories
-    ?.filter;
+  const filter = storiesConfig?.filter;
   if (filter) {
     stories = stories.filter((story) => filter(story, getStoryContext(story)));
   }
@@ -67,7 +74,14 @@ const StoriesImpl: FC<StoriesProps> = ({ title = 'Stories', includePrimary = tru
       {typeof title === 'string' ? <StyledHeading>{title}</StyledHeading> : title}
       {stories.map(
         (story) =>
-          story && <DocsStory key={story.id} of={story.moduleExport} expanded __forceInitialArgs />
+          story && (
+            <DocsStory
+              key={story.id}
+              of={story.moduleExport}
+              expanded
+              forceInitialArgs={forceInitialArgs}
+            />
+          )
       )}
     </>
   );

--- a/code/addons/docs/src/blocks/blocks/types.ts
+++ b/code/addons/docs/src/blocks/blocks/types.ts
@@ -11,5 +11,6 @@ export type DocsStoryProps = {
   expanded?: boolean;
   withToolbar?: boolean;
   __forceInitialArgs?: boolean;
+  forceInitialArgs?: boolean;
   __primary?: boolean;
 };

--- a/code/addons/docs/src/types.ts
+++ b/code/addons/docs/src/types.ts
@@ -46,6 +46,10 @@ type StoriesBlockParameters = {
     Story: PreparedStory<TRenderer>,
     Context: ReturnType<DocsContextProps['getStoryContext']>
   ) => boolean;
+  /**
+   * Whether stories in autodocs keep their initial args or react dynamically to controls changes.
+   */
+  forceInitialArgs?: boolean;
 };
 
 type ControlsBlockParameters = {


### PR DESCRIPTION
## Summary

Closes #22195

Makes `forceInitialArgs` configurable in autodocs by:
1. Adding a `forceInitialArgs` prop to `<Stories>` block component (`StoriesProps`).
2. Supporting `forceInitialArgs` in `<DocsStory>` component (`DocsStoryProps`).
3. Supporting parameter configuration via `parameters.docs.stories.forceInitialArgs = boolean`.

This resolves the issue where stories rendered in autodocs using controlled state components (`useArgs`) were forced to remain immutable because `forceInitialArgs` was hardcoded to `true`.

## Changes

- `code/addons/docs/src/types.ts`: Added `forceInitialArgs?: boolean` to `StoriesBlockParameters`
- `code/addons/docs/src/blocks/blocks/types.ts`: Added `forceInitialArgs?: boolean` to `DocsStoryProps`
- `code/addons/docs/src/blocks/blocks/DocsStory.tsx`: Resolved `forceInitialArgs` prop and passed to `<Canvas>`
- `code/addons/docs/src/blocks/blocks/Stories.tsx`: Checked `parameters.docs.stories.forceInitialArgs` and passed `forceInitialArgs` prop to `<DocsStory>`

#### Manual testing

1. Configure `parameters.docs.stories.forceInitialArgs = false` in a story CSF file.
2. Render autodocs for a controlled component that uses `useArgs()`.
3. Interact with controls in the autodocs view -> verify that story state now updates dynamically instead of remaining forced to initial args.
