### PR TITLE
Core: Include null union members as enum options in TS argTypes conversion

### DIFF
--- a/code/core/src/csf/SBType.ts
+++ b/code/core/src/csf/SBType.ts
@@ -22,7 +22,8 @@ export type SBObjectType = SBBaseType & {
 };
 export type SBEnumType = SBBaseType & {
   name: 'enum';
-  value: (string | number)[];
+  // `null` appears for TS unions that include `null`, e.g. `'a' | 'b' | null`
+  value: (string | number | null)[];
 };
 export type SBIntersectionType = SBBaseType & {
   name: 'intersection';

--- a/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/unions.tsx
+++ b/code/core/src/docs-tools/argTypes/convert/__testfixtures__/typescript/unions.tsx
@@ -17,5 +17,8 @@ interface Props {
   kind?: Kind;
   inlinedNumericLiteralUnion: 0 | 1;
   enumUnion: EnumUnion;
+  nullableLiteralUnion: 'red' | 'blue' | null;
+  nullableLiteralUnionWithUndefined: 'top' | 'bottom' | null | undefined;
+  nullableScalarUnion: string | number | null;
 }
 export const Component: FC<Props> = (props: Props) => <>JSON.stringify(props)</>;

--- a/code/core/src/docs-tools/argTypes/convert/convert.test.ts
+++ b/code/core/src/docs-tools/argTypes/convert/convert.test.ts
@@ -175,6 +175,9 @@ describe('storybook type system', () => {
           kind?: Kind;
           inlinedNumericLiteralUnion: 0 | 1;
           enumUnion: EnumUnion;
+          nullableLiteralUnion: 'red' | 'blue' | null;
+          nullableLiteralUnionWithUndefined: 'top' | 'bottom' | null | undefined;
+          nullableScalarUnion: string | number | null;
         }
         export const Component: FC<Props> = (props: Props) => <>JSON.stringify(props)</>;
         "
@@ -208,6 +211,40 @@ describe('storybook type system', () => {
               {
                 "name": "other",
                 "value": "NumericEnum"
+              }
+            ]
+          },
+          "nullableLiteralUnion": {
+            "raw": "'red' | 'blue' | null",
+            "name": "enum",
+            "value": [
+              "red",
+              "blue",
+              null
+            ]
+          },
+          "nullableLiteralUnionWithUndefined": {
+            "raw": "'top' | 'bottom' | null | undefined",
+            "name": "enum",
+            "value": [
+              "top",
+              "bottom",
+              null
+            ]
+          },
+          "nullableScalarUnion": {
+            "raw": "string | number | null",
+            "name": "union",
+            "value": [
+              {
+                "name": "string"
+              },
+              {
+                "name": "number"
+              },
+              {
+                "name": "other",
+                "value": "null"
               }
             ]
           }

--- a/code/core/src/docs-tools/argTypes/convert/typescript/convert.ts
+++ b/code/core/src/docs-tools/argTypes/convert/typescript/convert.ts
@@ -7,9 +7,11 @@ import type { TSSigType, TSType } from './types.ts';
 // Type guards for narrowing TSType discriminant unions
 type TSLiteralType = Extract<TSType, { name: 'literal' }>;
 type TSUndefinedType = Extract<TSType, { name: 'undefined' }>;
+type TSNullType = Extract<TSType, { name: 'null' }>;
 
 const isLiteral = (type: TSType): type is TSLiteralType => type.name === 'literal';
 const isUndefined = (type: TSType): type is TSUndefinedType => type.name === 'undefined';
+const isNull = (type: TSType): type is TSNullType => type.name === 'null';
 
 const convertSig = (type: TSSigType) => {
   switch (type.type) {
@@ -49,16 +51,22 @@ export const convert = (type: TSType): SBType | void => {
     case 'signature':
       return { ...base, ...convertSig(type) };
     case 'union': {
+      // `undefined` members (typically from optional props) are dropped from the options,
+      // while `null` members (emitted by react-docgen as `{ name: 'null' }`, not as literals)
+      // are kept as a selectable `null` option. At least one literal is required so that
+      // e.g. `string | null` is not misclassified as an enum.
       const nonUndefinedElements = type.elements.filter((element) => !isUndefined(element));
-      const allLiterals = nonUndefinedElements.length > 0 && nonUndefinedElements.every(isLiteral);
+      const isLiteralEnum =
+        nonUndefinedElements.some(isLiteral) &&
+        nonUndefinedElements.every((element) => isLiteral(element) || isNull(element));
 
-      if (allLiterals) {
-        // TypeScript can't infer from .every(), so we filter again with the type guard
-        const literalElements = nonUndefinedElements.filter(isLiteral);
+      if (isLiteralEnum) {
         return {
           ...base,
           name: 'enum',
-          value: literalElements.map((element) => parseLiteral(element.value)),
+          value: nonUndefinedElements.map((element) =>
+            isLiteral(element) ? parseLiteral(element.value) : null
+          ),
         };
       }
       return { ...base, name, value: type.elements.map(convert) };

--- a/code/core/src/docs-tools/argTypes/convert/typescript/types.ts
+++ b/code/core/src/docs-tools/argTypes/convert/typescript/types.ts
@@ -33,7 +33,17 @@ type TSObjectSigType = TSBaseType & {
 };
 
 type TSScalarType = TSBaseType & {
-  name: 'any' | 'boolean' | 'number' | 'void' | 'string' | 'symbol' | 'undefined';
+  name: 'any' | 'boolean' | 'number' | 'void' | 'string' | 'symbol';
+};
+
+// `undefined` and `null` get their own members (rather than being scalar names) so that
+// `Extract<TSType, { name: '...' }>` can narrow to them.
+type TSUndefinedType = TSBaseType & {
+  name: 'undefined';
+};
+
+type TSNullType = TSBaseType & {
+  name: 'null';
 };
 
 type TSLiteralType = TSBaseType & {
@@ -48,4 +58,11 @@ type TSArrayType = TSBaseType & {
 
 export type TSSigType = TSObjectSigType | TSFuncSigType;
 
-export type TSType = TSScalarType | TSLiteralType | TSCombinationType | TSSigType | TSArrayType;
+export type TSType =
+  | TSScalarType
+  | TSUndefinedType
+  | TSNullType
+  | TSLiteralType
+  | TSCombinationType
+  | TSSigType
+  | TSArrayType;


### PR DESCRIPTION
Closes #32106

## What I did

Unions containing `null` (e.g. `'red' | 'blue' | null`) lost their enum
classification in the TS argTypes converter, because react-docgen emits `null`
union members as `{ name: 'null' }`, which the union branch did not recognize.
As a result the controls panel dropped **all** options for such props, not
just `null`.

This PR:

- Treats `null` members as enum options: `'red' | 'blue' | null` now produces
  `{ name: 'enum', value: ['red', 'blue', null] }`. `undefined` members
  (typically from optional props) stay dropped, as before.
- Requires at least one literal in the union, so e.g. `string | null` is not
  misclassified as an enum.
- Splits `undefined`/`null` into their own `TSType` members so the
  `Extract<...>` type guards actually narrow (they previously resolved to
  `never`).
- Widens the public `SBEnumType['value']` to `(string | number | null)[]` to
  reflect that enum values can now be `null`. Note for reviewers: this is a
  type-level change for downstream consumers reading enum values.

Scope: this only touches the default `react-docgen` path. The
`react-docgen-typescript` path has separate handling (it renders `null` as the
string `'null'`) and is intentionally left unchanged.

Similar direction to #35315, which was closed without review.

AI disclosure: developed with the assistance of Claude Code.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Run a sandbox: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. In the sandbox's `Button.tsx`, add a prop typed `'red' | 'blue' | null` and pass it through to the component
3. Open Storybook and go to the Button story's Controls panel
4. Before this fix: the prop renders as an object control with no options. After: it renders as a radio control with `red` / `blue` / `null`, and selecting `null` passes a real `null` to the component

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TypeScript union props containing `null` are now recognized and represented correctly in generated ArgTypes.
  * Nullable literal unions support `null` as a selectable value.
  * Unions containing `undefined` continue to preserve accurate type information.

* **Bug Fixes**
  * Improved handling and classification of nullable scalar and literal unions during TypeScript conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->