### PR TITLE
Angular: Serve ancestor node_modules for addon-vitest in browser mode

### DIFF
--- a/code/frameworks/angular-vite/src/node/find-node-modules-roots.test.ts
+++ b/code/frameworks/angular-vite/src/node/find-node-modules-roots.test.ts
@@ -1,45 +1,47 @@
-import * as fs from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { normalizePath } from 'vite';
 
 import { findNodeModulesRoots } from './vitest.ts';
 
-vi.mock('node:fs', async () => import('../../../../__mocks__/fs.ts'));
+vi.mock('node:fs', { spy: true });
 
 const WORKSPACE = resolve('/workspace');
 const LIB = join(WORKSPACE, 'projects', 'my-lib');
 
-const setNodeModulesDirs = (dirs: string[]) => {
-  vi.mocked<typeof import('../../../../__mocks__/fs.ts')>(fs as any).__setMockFiles(
-    Object.fromEntries(dirs.map((dir) => [join(dir, 'node_modules'), '{}']))
-  );
+// Directories whose `node_modules` child should be reported as existing for a given test.
+let nodeModulesDirs: Set<string>;
+
+beforeEach(() => {
+  nodeModulesDirs = new Set();
+  vi.mocked(existsSync).mockImplementation((path) => nodeModulesDirs.has(String(path)));
+});
+
+const withNodeModules = (...dirs: string[]) => {
+  for (const dir of dirs) {
+    nodeModulesDirs.add(join(dir, 'node_modules'));
+  }
 };
 
 describe('findNodeModulesRoots', () => {
-  afterEach(() => {
-    setNodeModulesDirs([]);
-  });
-
   it('returns the ancestor that contains node_modules', () => {
     // Angular workspace layout: dependencies at the workspace root, root served from projects/<lib>.
-    setNodeModulesDirs([WORKSPACE]);
+    withNodeModules(WORKSPACE);
 
     expect(findNodeModulesRoots(LIB)).toEqual([normalizePath(WORKSPACE)]);
   });
 
   it('does not stop at a nearer node_modules (e.g. Storybook cache) and still finds the root', () => {
     // Storybook's cache creates node_modules/.cache in the project dir; the real deps live higher up.
-    setNodeModulesDirs([LIB, WORKSPACE]);
+    withNodeModules(LIB, WORKSPACE);
 
     expect(findNodeModulesRoots(LIB)).toEqual([normalizePath(LIB), normalizePath(WORKSPACE)]);
   });
 
   it('returns an empty array when no ancestor has node_modules', () => {
-    setNodeModulesDirs([]);
-
     expect(findNodeModulesRoots(LIB)).toEqual([]);
   });
 });

--- a/code/frameworks/angular-vite/src/node/find-node-modules-roots.test.ts
+++ b/code/frameworks/angular-vite/src/node/find-node-modules-roots.test.ts
@@ -1,0 +1,45 @@
+import * as fs from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { normalizePath } from 'vite';
+
+import { findNodeModulesRoots } from './vitest.ts';
+
+vi.mock('node:fs', async () => import('../../../../__mocks__/fs.ts'));
+
+const WORKSPACE = resolve('/workspace');
+const LIB = join(WORKSPACE, 'projects', 'my-lib');
+
+const setNodeModulesDirs = (dirs: string[]) => {
+  vi.mocked<typeof import('../../../../__mocks__/fs.ts')>(fs as any).__setMockFiles(
+    Object.fromEntries(dirs.map((dir) => [join(dir, 'node_modules'), '{}']))
+  );
+};
+
+describe('findNodeModulesRoots', () => {
+  afterEach(() => {
+    setNodeModulesDirs([]);
+  });
+
+  it('returns the ancestor that contains node_modules', () => {
+    // Angular workspace layout: dependencies at the workspace root, root served from projects/<lib>.
+    setNodeModulesDirs([WORKSPACE]);
+
+    expect(findNodeModulesRoots(LIB)).toEqual([normalizePath(WORKSPACE)]);
+  });
+
+  it('does not stop at a nearer node_modules (e.g. Storybook cache) and still finds the root', () => {
+    // Storybook's cache creates node_modules/.cache in the project dir; the real deps live higher up.
+    setNodeModulesDirs([LIB, WORKSPACE]);
+
+    expect(findNodeModulesRoots(LIB)).toEqual([normalizePath(LIB), normalizePath(WORKSPACE)]);
+  });
+
+  it('returns an empty array when no ancestor has node_modules', () => {
+    setNodeModulesDirs([]);
+
+    expect(findNodeModulesRoots(LIB)).toEqual([]);
+  });
+});

--- a/code/frameworks/angular-vite/src/node/vitest.ts
+++ b/code/frameworks/angular-vite/src/node/vitest.ts
@@ -107,12 +107,13 @@ export function storybookAngularVitest(options: AngularVitestOptions = {}): Plug
     // `node_modules`. `configureServer` is required: Vitest builds the browser server's allow-list
     // itself, so entries added via the `config` hook or static config never reach it.
     configureServer(server) {
-      const fsAllow = server.config.server?.fs?.allow;
-      if (Array.isArray(fsAllow)) {
-        for (const nodeModulesRoot of findNodeModulesRoots(server.config.root)) {
-          if (!fsAllow.includes(nodeModulesRoot)) {
-            fsAllow.push(nodeModulesRoot);
-          }
+      // Vitest always populates `fs.allow` today; initialize it defensively so the workspace root
+      // is still allowed if that ever changes.
+      const fs = server.config.server.fs as { allow?: string[] };
+      fs.allow ??= [];
+      for (const nodeModulesRoot of findNodeModulesRoots(server.config.root)) {
+        if (!fs.allow.includes(nodeModulesRoot)) {
+          fs.allow.push(nodeModulesRoot);
         }
       }
     },

--- a/code/frameworks/angular-vite/src/node/vitest.ts
+++ b/code/frameworks/angular-vite/src/node/vitest.ts
@@ -1,8 +1,34 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
 import { logger } from 'storybook/internal/node-logger';
 
-import type { Plugin, UserConfig } from 'vite';
+import { type Plugin, type UserConfig, normalizePath } from 'vite';
 
 const ENV_KEY = 'STORYBOOK_ANGULAR_BUILDER_OPTIONS_JSON';
+
+/**
+ * Collect every ancestor directory of `startDir` (inclusive) that contains a `node_modules` folder,
+ * normalized to Vite's forward-slash convention. All are kept rather than stopping at the first
+ * because Storybook's cache creates a `node_modules/.cache` in the project directory, which would
+ * otherwise shadow the real workspace root (e.g. an Angular workspace, where dependencies live at
+ * the root above `projects/<lib>/`).
+ */
+export const findNodeModulesRoots = (startDir: string): string[] => {
+  const roots: string[] = [];
+  let dir = resolve(startDir);
+  for (;;) {
+    if (existsSync(join(dir, 'node_modules'))) {
+      roots.push(normalizePath(dir));
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return roots;
+};
 
 /**
  * Storybook renders Angular with the JIT compiler, so `@angular/compiler` must be registered before
@@ -72,5 +98,23 @@ export function storybookAngularVitest(options: AngularVitestOptions = {}): Plug
     // Vitest augments Vite's `UserConfig` with `test`; assert the shape here rather than import
     // Vitest's types, which would pull its whole type graph into the framework's d.ts build.
     config: () => ({ test: { setupFiles: [COMPILER_SETUP] } }) as unknown as UserConfig,
+    // In an Angular workspace library the Vite dev-server root is `projects/<lib>/`, but
+    // `node_modules` (with `@angular/compiler`) lives at the workspace root. Vite only treats
+    // `pnpm-workspace.yaml`, `lerna.json`, or a `workspaces` field as workspace-root markers, so a
+    // plain Angular workspace resolves the root to the library folder — and the `@angular/compiler`
+    // setup file above falls outside `server.fs.allow`, failing to load in the browser with
+    // "Failed to fetch dynamically imported module". Allow every ancestor that contains
+    // `node_modules`. `configureServer` is required: Vitest builds the browser server's allow-list
+    // itself, so entries added via the `config` hook or static config never reach it.
+    configureServer(server) {
+      const fsAllow = server.config.server?.fs?.allow;
+      if (Array.isArray(fsAllow)) {
+        for (const nodeModulesRoot of findNodeModulesRoots(server.config.root)) {
+          if (!fsAllow.includes(nodeModulesRoot)) {
+            fsAllow.push(nodeModulesRoot);
+          }
+        }
+      }
+    },
   };
 }


### PR DESCRIPTION
Closes #35578

## What I did

Fixes `@storybook/addon-vitest` failing to run story tests in an Angular workspace **library** (`ng generate library`), where every suite fails with:

```
Failed to import test file .../my-workspace/node_modules/@angular/compiler/fesm2022/compiler.mjs
Caused by: TypeError: Failed to fetch dynamically imported module: .../node_modules/@angular/compiler/fesm2022/compiler.mjs
```

**Root cause.** In an Angular workspace, `ng generate library` creates `projects/<lib>/package.json` while `node_modules` stays at the workspace root. Vite 7 only treats `pnpm-workspace.yaml`, `lerna.json`, or a `workspaces` field as workspace-root markers (not `.git` or a lockfile), so `searchForWorkspaceRoot` resolves the root to `projects/<lib>`. Vitest's browser server then builds `server.fs.allow` from that subfolder, and the `@angular/compiler` setup file injected by `storybookAngularVitest` — which resolves from the ancestor `node_modules` — falls outside the allow list and 404s in the browser.

**Fix.** `storybookAngularVitest()` now adds every ancestor directory that contains `node_modules` to the browser server's `fs.allow` from a `configureServer` hook. Notes on the approach:

- `configureServer` is used deliberately: Vitest builds the browser server's allow-list itself, so entries added via the `config` hook or static `server.fs.allow` never reach it.
- All ancestors are kept (not just the nearest) because Storybook's own cache creates a `node_modules/.cache` in the project directory, which would otherwise shadow the real workspace root higher up.
- Entries are normalized with Vite's `normalizePath` to match Vite's own allow-list convention on Windows.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`findNodeModulesRoots` is covered by unit tests (`code/frameworks/angular-vite/src/node/find-node-modules-roots.test.ts`), including the case where a nearer `node_modules/.cache` must not shadow the real workspace root.

#### Manual testing

1. Scaffold an Angular workspace library and add Storybook:
   ```bash
   ng new my-workspace --no-create-application
   cd my-workspace
   ng generate library my-lib
   npx storybook@latest init
   ```
   (This produces `projects/my-lib/vitest.config.ts` and `projects/my-lib/.storybook`, with `node_modules` at the workspace root.)
2. Run the Vitest addon tests (from the Storybook UI "run tests", or `vitest run` against `projects/my-lib/vitest.config.ts`).
3. **Before this change:** every story suite fails with `Failed to fetch dynamically imported module … @angular/compiler`.
4. **After this change:** the story suites collect and run normally.

This was verified end-to-end against exactly this scaffold: baseline reproduces the reported error (3 files failed); with the fix the suites pass (3 files / 8 tests).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation changes — this is an internal bug fix.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsoQV75vUEGjWo6YFd35cj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Angular Vitest/Vite dev-server support for nested Angular library workspaces.
  * Automatically expands Vite’s filesystem allow-list to include required ancestor `node_modules` roots, ensuring Angular compiler setup files resolve reliably.
  * More consistently handles scenarios with multiple possible `node_modules` locations while selecting the correct workspace-level roots.
* **Tests**
  * Added Vitest coverage for detecting `node_modules` ancestor roots and the case where none are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->