### PR TITLE
Core: Prevent saved stories from inheriting the original story's name

### DIFF
--- a/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.test.ts
+++ b/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.test.ts
@@ -15,6 +15,8 @@ const makeTitle = (userTitle: string) => userTitle;
 const FILES = {
   csfVariances: join(__dirname, 'mocks/csf-variances.stories.tsx'),
   csf4Variances: join(__dirname, 'mocks/csf4-variances.stories.tsx'),
+  nameVariances: join(__dirname, 'mocks/name-variances.stories.tsx'),
+  csf4NameVariances: join(__dirname, 'mocks/csf4-name-variances.stories.tsx'),
   unsupportedCsfVariances: join(__dirname, 'mocks/unsupported-csf-variances.stories.tsx'),
   typescriptConstructs: join(__dirname, 'mocks/typescript-constructs.stories.tsx'),
 };
@@ -106,6 +108,86 @@ describe('success', () => {
         
       + export const EmptyDuplicated = meta.story({});
       + export const WithArgsDuplicated = meta.story({});
+      + "
+    `);
+  });
+  test('Name Variances', async () => {
+    const before = await format(await readFile(FILES.nameVariances, 'utf-8'), {
+      parser: 'typescript',
+    });
+    const CSF = await readCsf(FILES.nameVariances, { makeTitle });
+
+    const parsed = CSF.parse();
+    const names = Object.keys(parsed._stories);
+
+    names.forEach((name) => {
+      duplicateStoryWithNewName(parsed, name, name + 'Duplicated');
+    });
+
+    const after = await format(printCsf(parsed).code, {
+      parser: 'typescript',
+    });
+
+    // check if the code was updated at all
+    expect(after).not.toBe(before);
+
+    // the duplicates must not inherit the original story's `name`, while
+    // nested `name` keys (parameters, argTypes) must be preserved
+    expect(getDiff(before, after)).toMatchInlineSnapshot(`
+      "  ...
+        export const WithNameAs = {
+          name: "As Display Name",
+        } as Story;
+        
+      + export const WithNameDuplicated = {} satisfies Story;
+      + 
+      + export const WithNestedNameDuplicated = {
+      +   parameters: {
+      +     design: {
+      +       name: "nested name that must be preserved",
+      +     },
+      +   },
+      + 
+      +   argTypes: {
+      +     name: {
+      +       control: "text",
+      +     },
+      +   },
+      + } satisfies Story;
+      + 
+      + export const WithOnlyNameDuplicated = {} satisfies Story;
+      + export const WithNameAsDuplicated = {} as Story;
+      + "
+    `);
+  });
+  test('CSF4 Name Variances', async () => {
+    const before = await format(await readFile(FILES.csf4NameVariances, 'utf-8'), {
+      parser: 'typescript',
+    });
+    const CSF = await readCsf(FILES.csf4NameVariances, { makeTitle });
+
+    const parsed = CSF.parse();
+    const names = Object.keys(parsed._stories);
+
+    names.forEach((name) => {
+      duplicateStoryWithNewName(parsed, name, name + 'Duplicated');
+    });
+
+    const after = await format(printCsf(parsed).code, {
+      parser: 'typescript',
+    });
+
+    // check if the code was updated at all
+    expect(after).not.toBe(before);
+
+    // the duplicate must not inherit the original story's `name`
+    expect(getDiff(before, after)).toMatchInlineSnapshot(`
+      "  ...
+            foo: "bar",
+          },
+        });
+        
+      + export const WithNameDuplicated = meta.story({});
       + "
     `);
   });

--- a/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.test.ts
+++ b/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
-import { printCsf, readCsf } from 'storybook/internal/csf-tools';
+import { loadCsf, printCsf, readCsf } from 'storybook/internal/csf-tools';
 
 import { format } from 'prettier';
 
@@ -189,6 +189,54 @@ describe('success', () => {
         
       + export const WithNameDuplicated = meta.story({});
       + "
+    `);
+  });
+  test('String-literal and computed name keys', async () => {
+    // oxfmt normalizes quoted object keys in fixture files, so these key forms
+    // can only be exercised from an inline source string
+    const code = `
+      export default { title: 'MyComponent' };
+      const name = 'dynamic';
+      export const WithQuotedName = {
+        'name': 'Quoted Name',
+      };
+      export const WithComputedName = {
+        [name]: 'value',
+      };
+      export const WithComputedQuotedName = {
+        ['name']: 'Computed Quoted Name',
+      };
+    `;
+    const parsed = loadCsf(code, { makeTitle }).parse();
+
+    duplicateStoryWithNewName(parsed, 'WithQuotedName', 'WithQuotedNameDuplicated');
+    duplicateStoryWithNewName(parsed, 'WithComputedName', 'WithComputedNameDuplicated');
+    duplicateStoryWithNewName(parsed, 'WithComputedQuotedName', 'WithComputedQuotedNameDuplicated');
+
+    const after = await format(printCsf(parsed).code, { parser: 'typescript' });
+
+    // quoted 'name' and computed ['name'] keys are removed (both statically the
+    // name key), while the dynamic computed [name] key is preserved
+    expect(after).toMatchInlineSnapshot(`
+      "export default { title: "MyComponent" };
+      const name = "dynamic";
+      export const WithQuotedName = {
+        name: "Quoted Name",
+      };
+      export const WithComputedName = {
+        [name]: "value",
+      };
+      export const WithComputedQuotedName = {
+        ["name"]: "Computed Quoted Name",
+      };
+      export const WithQuotedNameDuplicated = {};
+
+      export const WithComputedNameDuplicated = {
+        [name]: "value",
+      };
+
+      export const WithComputedQuotedNameDuplicated = {};
+      "
     `);
   });
   test('Unsupported CSF Variances', async () => {

--- a/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.ts
+++ b/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.ts
@@ -73,7 +73,7 @@ export const duplicateStoryWithNewName = (csfFile: In, storyName: string, newSto
       (prop) =>
         !(
           t.isObjectProperty(prop) &&
-          ((t.isIdentifier(prop.key) && prop.key.name === 'name') ||
+          ((t.isIdentifier(prop.key) && !prop.computed && prop.key.name === 'name') ||
             (t.isStringLiteral(prop.key) && prop.key.value === 'name'))
         )
     );

--- a/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.ts
+++ b/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.ts
@@ -5,6 +5,22 @@ import { SaveStoryError } from './utils.ts';
 
 type In = ReturnType<CsfFile['parse']>;
 
+const getStoryObjectExpression = (
+  init: t.VariableDeclarator['init'],
+  isCsf4Story: boolean
+): t.ObjectExpression | undefined => {
+  if (isCsf4Story && t.isCallExpression(init) && t.isObjectExpression(init.arguments[0])) {
+    return init.arguments[0];
+  }
+
+  let node = init;
+  while (t.isTSSatisfiesExpression(node) || t.isTSAsExpression(node)) {
+    node = node.expression;
+  }
+
+  return t.isObjectExpression(node) ? node : undefined;
+};
+
 export const duplicateStoryWithNewName = (csfFile: In, storyName: string, newStoryName: string) => {
   const node = csfFile._storyExports[storyName];
   const cloned = t.cloneNode(node) as t.VariableDeclarator;
@@ -47,6 +63,20 @@ export const duplicateStoryWithNewName = (csfFile: In, storyName: string, newSto
     (t.isArrowFunctionExpression(cloned.init) || t.isCallExpression(cloned.init))
   ) {
     throw new SaveStoryError(`Creating a new story based on a CSF2 story is not supported`);
+  }
+
+  // Remove the story's own `name` so the duplicate doesn't inherit the original's
+  // display name. Nested `name` keys (parameters, argTypes) must be left untouched.
+  const storyObject = getStoryObjectExpression(cloned.init, isCsf4Story);
+  if (storyObject) {
+    storyObject.properties = storyObject.properties.filter(
+      (prop) =>
+        !(
+          t.isObjectProperty(prop) &&
+          ((t.isIdentifier(prop.key) && prop.key.name === 'name') ||
+            (t.isStringLiteral(prop.key) && prop.key.value === 'name'))
+        )
+    );
   }
 
   traverse(csfFile._ast, {

--- a/code/core/src/core-server/utils/save-story/mocks/csf4-name-variances.stories.tsx
+++ b/code/core/src/core-server/utils/save-story/mocks/csf4-name-variances.stories.tsx
@@ -1,0 +1,12 @@
+// @ts-expect-error this is just a mock file
+import preview from '#.storybook/preview';
+
+const meta = preview.meta({
+  title: 'MyComponent',
+});
+export const WithName = meta.story({
+  name: 'Custom Display Name',
+  args: {
+    foo: 'bar',
+  },
+});

--- a/code/core/src/core-server/utils/save-story/mocks/name-variances.stories.tsx
+++ b/code/core/src/core-server/utils/save-story/mocks/name-variances.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import type { FC } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+export default {
+  title: 'MyComponent',
+} satisfies Meta<typeof MyComponent>;
+
+type Story = StoryObj<typeof MyComponent>;
+
+// dummy component
+const MyComponent: FC<{ name: string; primary: boolean }> = (props) => (
+  <pre>{JSON.stringify(props)}</pre>
+);
+
+export const WithName = {
+  name: 'Custom Display Name',
+  args: {
+    primary: true,
+  },
+} satisfies Story;
+
+export const WithNestedName = {
+  name: 'Another Display Name',
+  parameters: {
+    design: {
+      name: 'nested name that must be preserved',
+    },
+  },
+  argTypes: {
+    name: {
+      control: 'text',
+    },
+  },
+} satisfies Story;
+
+export const WithOnlyName = {
+  name: 'Only A Name',
+} satisfies Story;
+
+export const WithNameAs = {
+  name: 'As Display Name',
+} as Story;


### PR DESCRIPTION
Closes #35446

## What I did

When creating a new story via "Save from Controls", `duplicateStoryWithNewName`clones the original story's AST node and strips its `args` but not its `name`. 
If the original story has an explicit `name` the duplicate inherits it so the sidebar shows two stories with identical labels.

This PR removes the story objects own top level `name` property from the clone

The new story's display name then derives from its new export name which matches the features intent the save dialogs input is an export name, the response's `newStoryName`/`newStoryId` are already derived from it server side and the new story file generator emits no `name` property. 

Previously the file contradicted this and the response reported a display name derived from the new export name, while the story on disk kept the original's `name` and rendered under the old label. Now they match.

Covered shapes are the CSF3 object stories including `satisfies Story` / `as Story` wrappers and CSF4 `meta.story({...})` with both identifier (`name:`) and string literal (`'name':`) keys removed

Nested `name` keys such as `parameters.*.name` or `argTypes` entry for a prop called `name` are deliberately left untouched which is why this doesn't reuse the existing any-depth traversal that removes `args`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Two new cases in `duplicate-story-with-new-name.test.ts` with dedicated mocks (`name-variances.stories.tsx`, `csf4-name-variances.stories.tsx`). They check that duplicates of named stories no longer inheriting `name` and nested `name` keys in `parameters`/`argTypes` are preserved. 
Both tests fail without the fix and the four pre existing test cases are unchanged.

#### Manual testing

1. Run a sandbox: `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. Give a story an explicit name, e.g. `export const Primary = { name: 'Primary!', args: { ... } }`
3. Open it, change any control, and use "Create new story" with a new export name
4. Before: the sidebar shows two entries both labeled "Primary!". After: the
   new story appears under its own name derived from the export name you typed.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No docs change needed as this makes save from controls behave as documented and nothing is deprecated or removed.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicated stories no longer inherit the original top-level display name.
  * Nested `name` values in story parameters and argument types remain unchanged.
  * Improved duplication behavior across CSF/CSF4 formats, including stories using TypeScript wrappers.

* **Tests**
  * Added automated coverage for name-variation scenarios (CSF and CSF4) and edge cases like string-literal vs computed name keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->