### PR TITLE
Core: Evaluate Conditional Args Against Unmapped Values

### DIFF
--- a/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
@@ -610,6 +610,94 @@ describe('prepareStory', () => {
     });
   });
 
+
+    it('evaluates conditional args against unmapped values (eq)', () => {
+      const story = prepareStory(
+        {
+          id,
+          name,
+          args: { icon: 'star', iconPosition: 'left' },
+          argTypes: {
+            icon: { name: 'icon', mapping: { none: undefined, star: 'mapped-star' } },
+            iconPosition: { name: 'iconPosition', if: { arg: 'icon', eq: 'star' } },
+          },
+          moduleExport,
+        },
+        { id, title },
+        { render: vi.fn() as any }
+      );
+
+      const context = prepareContext({ args: story.initialArgs, globals: {}, ...story });
+
+      expect(context.args).toEqual({ icon: 'mapped-star', iconPosition: 'left' });
+    });
+
+    it('evaluates conditional args against unmapped values (neq)', () => {
+      const story = prepareStory(
+        {
+          id,
+          name,
+          args: { icon: 'star', iconPosition: 'left' },
+          argTypes: {
+            icon: { name: 'icon', mapping: { none: undefined, star: 'mapped-star' } },
+            iconPosition: { name: 'iconPosition', if: { arg: 'icon', neq: 'none' } },
+          },
+          moduleExport,
+        },
+        { id, title },
+        { render: vi.fn() as any }
+      );
+
+      const context = prepareContext({ args: story.initialArgs, globals: {}, ...story });
+
+      expect(context.args).toEqual({ icon: 'mapped-star', iconPosition: 'left' });
+    });
+
+    it('evaluates conditional args against unmapped values (truthy with falsy mapping)', () => {
+      const story = prepareStory(
+        {
+          id,
+          name,
+          args: { icon: 'star', iconPosition: 'left' },
+          argTypes: {
+            icon: { name: 'icon', mapping: { star: '', none: undefined } },
+            iconPosition: { name: 'iconPosition', if: { arg: 'icon' } },
+          },
+          moduleExport,
+        },
+        { id, title },
+        { render: vi.fn() as any }
+      );
+
+      const context = prepareContext({ args: story.initialArgs, globals: {}, ...story });
+
+      // icon is truthy in unmapped form ('star'), so iconPosition should be included
+      // even though the mapped value ('') is falsy
+      expect(context.args).toEqual({ icon: '', iconPosition: 'left' });
+    });
+
+    it('evaluates conditional args against unmapped values (exists)', () => {
+      const story = prepareStory(
+        {
+          id,
+          name,
+          args: { icon: 'star', iconPosition: 'left' },
+          argTypes: {
+            icon: { name: 'icon', mapping: { star: undefined, none: undefined } },
+            iconPosition: { name: 'iconPosition', if: { arg: 'icon', exists: true } },
+          },
+          moduleExport,
+        },
+        { id, title },
+        { render: vi.fn() as any }
+      );
+
+      const context = prepareContext({ args: story.initialArgs, globals: {}, ...story });
+
+      // icon exists in unmapped form ('star'), so iconPosition should be included
+      expect(context.args).toEqual({ icon: undefined, iconPosition: 'left' });
+    });
+
   describe('with `FEATURES.argTypeTargetsV7`', () => {
     beforeEach(() => {
       vi.stubGlobal('FEATURES', { argTypeTargetsV7: true });

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.ts
@@ -345,7 +345,7 @@ export function prepareContext<
   const includedArgs = Object.entries(mappedArgs).reduce((acc, [key, val]) => {
     const argType = targetedContext.argTypes[key] || {};
 
-    if (includeConditionalArg(argType, mappedArgs, targetedContext.globals)) {
+    if (includeConditionalArg(argType, unmappedArgs, targetedContext.globals)) {
       acc[key] = val;
     }
     return acc;


### PR DESCRIPTION
## Problem

When using conditional controls (the `if` property) with mapped options, the conditional check evaluates against **mapped** values instead of **unmapped** (original) values, causing conditional controls to break.

Fixes #19130.

## Solution

Use `unmappedArgs` instead of `mappedArgs` in the `includeConditionalArg` call within `prepareContext`:

```diff
- if (includeConditionalArg(argType, mappedArgs, targetedContext.globals)) {
+ if (includeConditionalArg(argType, unmappedArgs, targetedContext.globals)) {
```

### Why `unmappedArgs` is correct

1. Users write conditions against unmapped values (what they see in code)
2. `unmappedArgs` always contains all args, regardless of `argTypeTargetsV7` feature flag
3. PR #35360 uses `mappedArgs` which only has untargeted subset when V7 is enabled

## Test Coverage

- `eq` condition with mapping
- `neq` condition with mapping
- `truthy` condition where mapping produces a falsy value
- `exists` condition where mapping produces `undefined`

#### Manual testing

I created a standalone test script that simulates the exact `prepareContext()` logic and demonstrates the before/after behavior across 5 test cases:

```
====== PR #35602 Proof: Conditional args should evaluate against unmapped values ======

--- Case 1: eq condition with mapping ---
  icon="star" maps to "mapped-star", iconPosition shows if icon eq "star"
  BEFORE (bug):  iconPosition absent  WRONG (bug reproduced)
  AFTER  (fix):  iconPosition present  correct
  EXPECTED:      iconPosition present

--- Case 2: neq condition with mapping ---
  icon="star" maps to "mapped-star", iconPosition shows if icon neq "none"
  BEFORE (bug):  iconPosition present  correct
  AFTER  (fix):  iconPosition present  correct
  EXPECTED:      iconPosition present

--- Case 3: truthy condition where mapping produces falsy value ---
  icon="star" maps to "" (empty string), iconPosition shows if icon is truthy
  BEFORE (bug):  iconPosition absent  WRONG (bug reproduced)
  AFTER  (fix):  iconPosition present  correct
  EXPECTED:      iconPosition present

--- Case 4: eq condition fails (icon is not "circle") ---
  icon="star" maps to "mapped-star", iconPosition hidden if icon eq "circle"
  BEFORE (bug):  iconPosition absent  correct
  AFTER  (fix):  iconPosition absent  correct
  EXPECTED:      iconPosition absent

--- Case 5: exists condition with mapping to undefined ---
  icon="star" maps to undefined, iconPosition shows if icon exists
  BEFORE (bug):  iconPosition absent  WRONG (bug reproduced)
  AFTER  (fix):  iconPosition present  correct
  EXPECTED:      iconPosition present

SUMMARY
BEFORE (bug):  2/5 cases correct, 3 broken by mapping
AFTER  (fix):  5/5 cases correct
```

**Before the fix**: 3 out of 5 test cases produce wrong results because `includeConditionalArg` receives mapped values (e.g., `"mapped-star"` instead of `"star"`, or `""` instead of `"star"`, or `undefined` instead of `"star"`).

**After the fix**: All 5 cases produce correct results because `includeConditionalArg` receives the original unmapped values that the user wrote their conditions against.

The unit tests in `prepareStory.test.ts` also pass, covering the same scenarios (`eq`, `neq`, truthy with falsy mapping, and `exists` with undefined mapping).