### PR TITLE
feat: render context for channel events

### DIFF
--- a/code/core/src/core-events/data/phases.ts
+++ b/code/core/src/core-events/data/phases.ts
@@ -1,7 +1,17 @@
 import type { Report } from 'storybook/preview-api';
 
+export interface StoryRenderPhaseChangedPayload {
+  storyId: string;
+  renderId: number;
+  newPhase: string;
+  renderContext?: unknown;
+  reason?: 'unchanged' | 'aborted' | 'superseded';
+}
+
 export interface StoryFinishedPayload {
   storyId: string;
   status: 'error' | 'success';
   reporters: Report[];
+  renderId?: number;
+  renderContext?: unknown;
 }

--- a/code/core/src/preview-api/modules/preview-web/Preview.tsx
+++ b/code/core/src/preview-api/modules/preview-web/Preview.tsx
@@ -421,8 +421,10 @@ export class Preview<TRenderer extends Renderer> {
     await Promise.all(this.storyRenders.map((r) => r.rerender()));
   }
 
-  async onForceRemount({ storyId }: { storyId: StoryId }) {
-    await Promise.all(this.storyRenders.filter((r) => r.id === storyId).map((r) => r.remount()));
+  async onForceRemount({ storyId, renderContext }: { storyId: StoryId; renderContext?: unknown }) {
+    await Promise.all(
+      this.storyRenders.filter((r) => r.id === storyId).map((r) => r.remount(renderContext))
+    );
   }
 
   async onStoryHotUpdated() {

--- a/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
@@ -20,6 +20,7 @@ import {
   STORY_ERRORED,
   STORY_MISSING,
   STORY_PREPARED,
+  STORY_RENDER_PHASE_CHANGED,
   STORY_RENDERED,
   STORY_SPECIFIED,
   STORY_THREW_EXCEPTION,
@@ -1832,6 +1833,39 @@ describe('PreviewWeb', () => {
 
         await waitForEvents([STORY_UNCHANGED]);
         expect(mockChannel.emit).toHaveBeenCalledWith(STORY_UNCHANGED, 'component-one--a');
+      });
+
+      it('emits a correlated abort when the selection has render context', async () => {
+        document.location.search = '?id=component-one--a';
+        await createAndRenderPreview();
+
+        const renderContext = { requestId: 'request-1' };
+        emitter.emit(SET_CURRENT_STORY, {
+          storyId: 'component-one--a',
+          viewMode: 'story',
+          renderContext,
+        });
+        await vi.waitFor(() => {
+          expect(mockChannel.emit).toHaveBeenCalledWith(STORY_UNCHANGED, 'component-one--a');
+          expect(mockChannel.emit).toHaveBeenCalledWith(STORY_RENDER_PHASE_CHANGED, {
+            storyId: 'component-one--a',
+            renderId: expect.any(Number),
+            newPhase: 'aborted',
+            reason: 'unchanged',
+            renderContext,
+          });
+        });
+
+        const unchangedEventIndex = mockChannel.emit.mock.calls.findIndex(
+          ([event]) => event === STORY_UNCHANGED
+        );
+        const abortedEventIndex = mockChannel.emit.mock.calls.findIndex(
+          ([event, payload]) =>
+            event === STORY_RENDER_PHASE_CHANGED &&
+            payload.newPhase === 'aborted' &&
+            payload.renderContext === renderContext
+        );
+        expect(unchangedEventIndex).toBeLessThan(abortedEventIndex);
       });
 
       it('does NOT call renderToCanvas', async () => {

--- a/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
@@ -235,18 +235,23 @@ export class PreviewWithSelection<TRenderer extends Renderer> extends Preview<TR
     }
   }
 
-  async onSetCurrentStory(selection: { storyId: StoryId; viewMode?: ViewMode }) {
+  async onSetCurrentStory(selection: {
+    storyId: StoryId;
+    viewMode?: ViewMode;
+    renderContext?: unknown;
+  }) {
+    const { renderContext, ...storySelection } = selection;
     /**
      * At the end of the initialization promise we will read the current story from the selection
      * store, so make sure we've updated it with the new selection or we'll lose track of it at the
      * end of init.
      */
-    this.selectionStore.setSelection({ viewMode: 'story', ...selection });
+    this.selectionStore.setSelection({ viewMode: 'story', ...storySelection });
 
     await this.storeInitializationPromise;
 
     this.channel.emit(CURRENT_STORY_WAS_SET, this.selectionStore.selection);
-    this.renderSelection();
+    this.renderSelection({ renderContext });
   }
 
   onUpdateQueryParams(queryParams: any) {
@@ -290,7 +295,10 @@ export class PreviewWithSelection<TRenderer extends Renderer> extends Preview<TR
   //     in which case we render it to the root element, OR
   // - a story selected in "docs" viewMode,
   //     in which case we render the docsPage for that story
-  protected async renderSelection({ persistedArgs }: { persistedArgs?: Args } = {}) {
+  protected async renderSelection({
+    persistedArgs,
+    renderContext,
+  }: { persistedArgs?: Args; renderContext?: unknown } = {}) {
     const { renderToCanvas } = this;
 
     if (!this.storyStoreValue || !renderToCanvas) {
@@ -344,7 +352,10 @@ export class PreviewWithSelection<TRenderer extends Renderer> extends Preview<TR
         this.mainStoryCallbacks(storyId),
         storyId,
         'story',
-        { autoplay: shouldAutoplay({ search: globalWindow.location?.search ?? '' }) }
+        {
+          autoplay: shouldAutoplay({ search: globalWindow.location?.search ?? '' }),
+          renderContext,
+        }
       );
     } else if (isMdxEntry(entry)) {
       render = new MdxDocsRender<TRenderer>(
@@ -400,6 +411,15 @@ export class PreviewWithSelection<TRenderer extends Renderer> extends Preview<TR
     ) {
       this.currentRender = lastRender;
       this.channel.emit(STORY_UNCHANGED, storyId);
+      if (renderContext !== undefined) {
+        this.channel.emit(STORY_RENDER_PHASE_CHANGED, {
+          storyId,
+          renderId: render.renderId,
+          newPhase: 'aborted',
+          reason: 'unchanged',
+          renderContext,
+        });
+      }
       this.view.showMain();
       return;
     }

--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.test.ts
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Channel } from 'storybook/internal/channels';
-import { STORY_FINISHED } from 'storybook/internal/core-events';
+import { STORY_FINISHED, STORY_RENDER_PHASE_CHANGED } from 'storybook/internal/core-events';
 import type {
   PreparedStory,
   Renderer,
@@ -302,6 +302,7 @@ describe('StoryRender', () => {
       reporters: [],
       status: 'success',
       storyId: 'id',
+      renderId: render.renderId,
     });
   });
 
@@ -347,7 +348,79 @@ describe('StoryRender', () => {
       reporters: [],
       status: 'error',
       storyId: 'id',
+      renderId: render.renderId,
     });
+  });
+
+  it('preserves render context across remounts', async () => {
+    const renderContext = { requestId: 'request-1' };
+    const channel = new Channel({});
+    const emitSpy = vi.spyOn(channel, 'emit');
+    const render = new StoryRender(
+      channel,
+      buildStore(),
+      vi.fn() as any,
+      {} as any,
+      entry.id,
+      'story',
+      { autoplay: true },
+      buildStory()
+    );
+
+    await render.renderToElement({} as any);
+    emitSpy.mockClear();
+
+    await render.remount(renderContext);
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      STORY_RENDER_PHASE_CHANGED,
+      expect.objectContaining({
+        storyId: 'component--a',
+        renderId: render.renderId,
+        newPhase: 'loading',
+        renderContext,
+      })
+    );
+    expect(emitSpy).toHaveBeenCalledWith(STORY_FINISHED, {
+      storyId: 'id',
+      status: 'success',
+      reporters: [],
+      renderId: render.renderId,
+      renderContext,
+    });
+  });
+
+  it('does not retain render context for unrelated rerenders', async () => {
+    const renderContext = { requestId: 'request-1' };
+    const channel = new Channel({});
+    const emitSpy = vi.spyOn(channel, 'emit');
+    const render = new StoryRender(
+      channel,
+      buildStore(),
+      vi.fn() as any,
+      {} as any,
+      entry.id,
+      'story',
+      { autoplay: true },
+      buildStory()
+    );
+
+    await render.renderToElement({} as any);
+    emitSpy.mockClear();
+    await render.remount(renderContext);
+    emitSpy.mockClear();
+
+    await render.rerender();
+
+    expect(emitSpy).toHaveBeenCalledWith(STORY_FINISHED, {
+      storyId: 'id',
+      status: 'success',
+      reporters: [],
+      renderId: render.renderId,
+    });
+    expect(emitSpy.mock.calls).not.toContainEqual(
+      expect.arrayContaining([expect.anything(), expect.objectContaining({ renderContext })])
+    );
   });
 
   describe('teardown', () => {

--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
@@ -102,26 +102,34 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
     }
   }
 
-  private async runPhase(signal: AbortSignal, phase: RenderPhase, phaseFn?: () => Promise<void>) {
+  private async runPhase(
+    signal: AbortSignal,
+    phase: RenderPhase,
+    phaseFn?: () => Promise<void>,
+    renderContext?: unknown
+  ) {
     this.phase = phase;
     this.channel.emit(STORY_RENDER_PHASE_CHANGED, {
       newPhase: this.phase,
       renderId: this.renderId,
       storyId: this.id,
+      ...(renderContext !== undefined ? { renderContext } : {}),
     });
     if (phaseFn) {
       await phaseFn();
-      this.checkIfAborted(signal);
+      this.checkIfAborted(signal, renderContext);
     }
   }
 
-  private checkIfAborted(signal: AbortSignal): boolean {
+  private checkIfAborted(signal: AbortSignal, renderContext?: unknown): boolean {
     if (signal.aborted && !['finished', 'aborted', 'errored'].includes(this.phase as RenderPhase)) {
       this.phase = 'aborted';
       this.channel.emit(STORY_RENDER_PHASE_CHANGED, {
         newPhase: this.phase,
         renderId: this.renderId,
         storyId: this.id,
+        reason: 'aborted',
+        ...(renderContext !== undefined ? { renderContext } : {}),
       });
     }
     return signal.aborted;
@@ -165,7 +173,11 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
     // function below right away, so if the user changes story during the first render we can cancel
     // it without having to first wait for it to finish.
     // Whenever the selection changes we want to force the component to be remounted.
-    return this.render({ initial: true, forceRemount: true });
+    return this.render({
+      initial: true,
+      forceRemount: true,
+      renderContext: this.renderOptions.renderContext,
+    });
   }
 
   private storyContext() {
@@ -179,10 +191,13 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
   async render({
     initial = false,
     forceRemount = false,
+    renderContext,
   }: {
     initial?: boolean;
     forceRemount?: boolean;
+    renderContext?: unknown;
   } = {}) {
+    const invocationContext = renderContext;
     const { canvasElement } = this;
 
     if (!this.story) {
@@ -219,6 +234,8 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
     // We need a stable reference to the signal -- if a re-mount happens the
     // abort controller may be torn down (above) before we actually check the signal.
     const abortSignal = this.abortController.signal;
+    const runPhase = (phase: RenderPhase, phaseFn?: () => Promise<void>) =>
+      this.runPhase(abortSignal, phase, phaseFn, invocationContext);
 
     let mounted = false;
 
@@ -248,13 +265,13 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
         mount: async (...args) => {
           this.callbacks.showStoryDuringRender?.();
           let mountReturn: Awaited<ReturnType<StoryContext['mount']>> = null!;
-          await this.runPhase(abortSignal, 'rendering', async () => {
+          await runPhase('rendering', async () => {
             mountReturn = await story.mount(context)(...args);
           });
 
           // start playing phase if mount is used inside a play function
           if (isMountDestructured) {
-            await this.runPhase(abortSignal, 'playing');
+            await runPhase('playing');
           }
           return mountReturn;
         },
@@ -284,7 +301,7 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
         storyFn: () => unboundStoryFn(context),
         unboundStoryFn,
       };
-      await this.runPhase(abortSignal, 'loading', async () => {
+      await runPhase('loading', async () => {
         context.loaded = await applyLoaders(context);
       });
 
@@ -295,7 +312,7 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
       const cleanupCallbacks = await applyBeforeEach(context);
       this.store.addCleanupCallbacks(story, ...cleanupCallbacks);
 
-      if (this.checkIfAborted(abortSignal)) {
+      if (this.checkIfAborted(abortSignal, invocationContext)) {
         return;
       }
 
@@ -334,7 +351,7 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
             context.mount = async () => {
               throw new MountMustBeDestructuredError({ playFunction: playFunction.toString() });
             };
-            await this.runPhase(abortSignal, 'playing', async () => playFunction(context));
+            await runPhase('playing', async () => playFunction(context));
           } else {
             // when mount is used the playing phase will start later, right after mount is called in the play function
             await playFunction(context);
@@ -343,18 +360,18 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
           if (!mounted) {
             throw new NoStoryMountedError();
           }
-          this.checkIfAborted(abortSignal);
+          this.checkIfAborted(abortSignal, invocationContext);
 
           if (!ignoreUnhandledErrors && unhandledErrors.size > 0) {
-            await this.runPhase(abortSignal, 'errored');
+            await runPhase('errored');
           } else {
-            await this.runPhase(abortSignal, 'played');
+            await runPhase('played');
           }
         } catch (error) {
           // Remove the loading screen, even if there was an error before rendering
           this.callbacks.showStoryDuringRender?.();
 
-          await this.runPhase(abortSignal, 'errored', async () => {
+          await runPhase('errored', async () => {
             this.channel.emit(PLAY_FUNCTION_THREW_EXCEPTION, serializeError(error));
           });
 
@@ -378,7 +395,7 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
         }
       }
 
-      await this.runPhase(abortSignal, 'completing', async () => {
+      await runPhase('completing', async () => {
         if (isTestEnvironment()) {
           this.store.addCleanupCallbacks(story, pauseAnimations());
         } else {
@@ -386,12 +403,12 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
         }
       });
 
-      await this.runPhase(abortSignal, 'completed', async () => {
+      await runPhase('completed', async () => {
         this.channel.emit(STORY_RENDERED, id);
       });
 
       if (this.phase !== 'errored') {
-        await this.runPhase(abortSignal, 'afterEach', async () => {
+        await runPhase('afterEach', async () => {
           await applyAfterEach(context);
         });
       }
@@ -404,22 +421,26 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
 
       const hasStoryErrored = hasUnhandledErrors || hasSomeReportsFailed;
 
-      await this.runPhase(abortSignal, 'finished', async () =>
+      await runPhase('finished', async () =>
         this.channel.emit(STORY_FINISHED, {
           storyId: id,
           status: hasStoryErrored ? 'error' : 'success',
           reporters: context.reporting.reports,
+          renderId: this.renderId,
+          ...(invocationContext !== undefined ? { renderContext: invocationContext } : {}),
         } as StoryFinishedPayload)
       );
     } catch (err) {
       this.phase = 'errored';
       this.callbacks.showException(err as Error);
 
-      await this.runPhase(abortSignal, 'finished', async () =>
+      await runPhase('finished', async () =>
         this.channel.emit(STORY_FINISHED, {
           storyId: id,
           status: 'error',
           reporters: [],
+          renderId: this.renderId,
+          ...(invocationContext !== undefined ? { renderContext: invocationContext } : {}),
         } as StoryFinishedPayload)
       );
     }
@@ -445,9 +466,9 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
     }
   }
 
-  async remount() {
+  async remount(renderContext?: unknown) {
     await this.teardown();
-    return this.render({ forceRemount: true });
+    return this.render({ forceRemount: true, renderContext });
   }
 
   // If the story is torn down (either a new story is rendered or the docs page removes it)

--- a/code/core/src/types/modules/docs.ts
+++ b/code/core/src/types/modules/docs.ts
@@ -19,6 +19,7 @@ export type RenderContextCallbacks<TRenderer extends Renderer> = Pick<
 export type StoryRenderOptions = {
   autoplay?: boolean;
   forceInitialArgs?: boolean;
+  renderContext?: unknown;
 };
 
 export type ResolvedModuleExportType = 'component' | 'meta' | 'story';


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## Preliminary context

I am using those changes in production via a pnpm patch. The specific use case is for an automated runner that uses stories to run screenshot test on android leveraging the addons channel API.

I am proposing to merge those changes upstream, because the feature itself is quite generic and can be used for many other situations where a reliable correlation between events belonging to the same rendering cycle is required. And of course making it part of the official channel API will remove the maintenance cost of a local pnpm patch.

**DISCLAIMER**: the code in this PR has been generated with LLM help based on the currently used pnpm patch. I am open to discuss alternative approaches and API details, as long as we can guarantee the same capabilities

## What I did

<!-- Briefly describe what your PR does -->

Add an optional opaque `renderContext` to programmatic Storybook render requests and lifecycle responses.

This is intended for integrations that need to correlate an exact `SET_CURRENT_STORY` or `FORCE_REMOUNT` request with asynchronous render lifecycle events. `renderId` identifies a `StoryRender` instance, so it is reused by same-story remounts and cannot provide that correlation alone.

The context is captured per `render()` invocation and echoed on:

- `STORY_RENDER_PHASE_CHANGED`
- `STORY_FINISHED`

The existing protocol remains backward compatible:

- `renderContext` is optional.
- Existing event names and required payload fields are unchanged.
- Unrelated rerenders do not inherit a previous context.
- Existing consumers that do not send or read `renderContext` keep the current behavior.

For an unchanged story selection, Storybook now emits:

1. `STORY_UNCHANGED`
2. a correlated `STORY_RENDER_PHASE_CHANGED` with:
```ts
{
  newPhase: 'aborted',
  reason: 'unchanged',
  renderContext,
}
```

I also added and exported `StoryRenderPhaseChangedPayload`, including the optional `renderContext` and `reason` fields.

This allows consumers to use request-scoped lifecycle correlation without relying on event order or renderId ordering.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Start the internal Storybook UI:

```bash
cd code
yarn storybook:ui
```

2. Open the preview iframe in a browser and select any story. Note its storyId from the preview URL, for example example-button--primary.

3. In the preview iframe DevTools console, register listeners and emit a same-story remount with an opaque context:

```js
const channel = globalThis.__STORYBOOK_ADDONS_CHANNEL__;
const renderContext = { id: 'manual-remount-1' };

channel.on('storyRenderPhaseChanged', console.log);
channel.on('storyFinished', console.log);

channel.emit('forceRemount', {
  storyId: 'button-component--base',
  renderContext,
});
```

4. Verify that lifecycle phase payloads and the final storyFinished payload include the same value:

```js
{
  renderContext: { id: 'manual-remount-1' }
}
```

Verify that the remount keeps the same renderId, while the context still identifies this specific invocation.

5. Emit a different-story selection with a new context:

```js
const renderContext = { id: 'manual-selection-1' };

channel.emit('setCurrentStory', {
  storyId: 'button-component--base',
  renderContext,
});
```

6. Verify that the selected story emits correlated phase and completion payloads with renderContext: { id: 'manual-selection-1' }.

7. Select the currently selected story again with a new context:

```js
const renderContext = { id: 'manual-unchanged-1' };

channel.emit('setCurrentStory', {
  storyId: 'button-component--base',
  renderContext,
});
```

8. Verify that the preview emits storyUnchanged, followed by:

```js
{
  newPhase: 'aborted',
  reason: 'unchanged',
  renderContext: { id: 'manual-unchanged-1' },
}
```

9. Trigger a normal arg update or rerender without renderContext. Verify that its lifecycle events do not include a context inherited from a previous request.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added render context support when selecting, rendering, and remounting stories.
  - Render lifecycle events now include render identifiers, context details, and reasons for aborted or unchanged renders.
  - Story completion events now provide additional render metadata.
- **Bug Fixes**
  - Preserved render context across remounts while preventing unrelated rerenders from reusing stale context.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->