### PR TITLE
Docs: Clarify that "Vitest failed to find the current suite" can stem from untransformable stories

### DIFF
--- a/docs/writing-tests/integrations/vitest-addon/index.mdx
+++ b/docs/writing-tests/integrations/vitest-addon/index.mdx
@@ -344,15 +344,18 @@ export default defineConfig({
 
 ### How do I fix the `Error: Vitest failed to find the current suite` error?
 
-If you encounter this error, it's often not a Vitest issue but rather related to how your stories are being transformed. Here are steps to troubleshoot:
+If you encounter this error, it's often not a Vitest issue but rather related to how your stories are being transformed. The addon's setup file registers an `afterEach` hook, which cannot attach to a test suite when a story file fails to produce one. This error is therefore frequently a symptom of an earlier failure rather than the root cause.
 
-1. Check the complete error logs for additional context, particularly around story transformation
-2. Pay attention to Vite dependency optimization warnings (e.g., "new dependencies optimized: lodash")
-3. If you see dependency optimization warnings, these can cause test-breaking reloads during execution
+Here are steps to troubleshoot:
 
-The most common fix is to pre-optimize your dependencies. You can do this by adding the dependencies to your Vite config's [`optimizeDeps.include`](https://vitejs.dev/config/dep-optimization-options.html#optimizedeps-include) array.
+1. Check the complete error logs for additional context, particularly around story transformation. The actual cause is usually reported before this error.
+2. Verify that your story files are valid and can be parsed. A story file that fails to transform (for example, a `.svelte` file with invalid syntax) produces no test suite, which surfaces as this error.
+3. Pay attention to Vite dependency optimization warnings (e.g., "new dependencies optimized: lodash")
+4. If you see dependency optimization warnings, these can cause test-breaking reloads during execution
 
-This prevents mid-test dependency optimization, which can interfere with Vitest's test suite management.
+If the cause is a story file that can't be transformed, fix the syntax or setup error reported in the preceding logs.
+
+If the cause is dependency optimization, pre-optimize your dependencies by adding them to your Vite config's [`optimizeDeps.include`](https://vitejs.dev/config/dep-optimization-options.html#optimizedeps-include) array. This prevents mid-test dependency optimization, which can interfere with Vitest's test suite management.
 
 ### Why do my tests fail in CI with "Failed to fetch dynamically imported module" or "Cannot connect to the iframe"?
 


### PR DESCRIPTION
Closes #31128

## What I did

#31128 describes that when a story file cannot be transformed (e.g. the malformed Svelte files in #31119), Vitest reports:

```
Error: Vitest failed to find the current suite
```

The addon's setup file registers an `afterEach` hook. When a story file produces no test suite, that hook has nothing to attach to, so the failure surfaces as what looks like a bug in Vitest, and the stack trace points at the addon's internal setup file rather than the user's broken file.

The issue proposes two options. This PR does option 1: the documentation side.

There is already an FAQ entry for this exact error message in `docs/writing-tests/integrations/vitest-addon/index.mdx`, but it only covered one cause (Vite dependency optimization) and did not mention the untransformable-story case from the issue. Rather than adding a second, near-duplicate FAQ entry for the same error string, I extended the existing one:

- Explain why the error appears (the `afterEach` hook can't attach when no suite is produced), so it reads as a symptom rather than a root cause.
- Add the malformed/unparseable story file cause, with the `.svelte` example from the issue.
- Note that the real cause is usually logged before this error.
- Split the resolution into the two causes, so each troubleshooting path has a matching fix.

Option 2 from the issue (moving the `afterEach` into the transformed file) is a behavioral change in `code/core/src/csf-tools/vitest-plugin/transformer.ts` that would touch the transformer's output contract and its snapshots. I left that out of this PR deliberately so the docs fix can land independently. Happy to follow up on it if a maintainer wants to confirm the approach.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

This is a documentation-only content change (no code, no configuration), so no functional manual testing is necessary.

To verify the docs change itself:

1. Open `docs/writing-tests/integrations/vitest-addon/index.mdx`.
2. Find the FAQ entry **"How do I fix the `Error: Vitest failed to find the current suite` error?"**.
3. Confirm the section renders as valid MDX, with the heading, the ordered list of troubleshooting steps, and the `optimizeDeps.include` link intact.
4. Confirm the wording accurately describes both causes: a story file that fails to transform, and Vite dependency optimization.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<sub>Note: this PR needs the `documentation`, `ci:docs` and `qa:skip` labels, which I don't have permission to add. Danger is currently failing only on those three label checks.</sub>
