### PR TITLE
Build: Fix repository.directory path in @storybook/nextjs-vite package.json

### DIFF
--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -18,7 +18,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/storybookjs/storybook.git",
-    "directory": "code/frameworks/nextjs"
+    "directory": "code/frameworks/nextjs-vite"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
## What I did

`code/frameworks/nextjs-vite/package.json` declares:

```json
"repository": {
  "directory": "code/frameworks/nextjs"
}
```

but the package lives in `code/frameworks/nextjs-vite`. The declared path belongs to a *different* published package, `@storybook/nextjs`. The `homepage` field in the same file already points at the correct directory (`.../tree/next/code/frameworks/nextjs-vite`), so the two fields disagreed.

The effect is on the "Repository" link npm renders on the [`@storybook/nextjs-vite` package page](https://www.npmjs.com/package/@storybook/nextjs-vite): it resolves to the `nextjs` framework directory instead of `nextjs-vite`.

This is the same class of issue as #31800 / #35596, in a package that wasn't covered there.

I also audited every `package.json` under `code/` to confirm this was the only remaining occurrence. Of the 45 packages that declare `repository.directory`, this was the single mismatch; after the change there are none.

This is a metadata-only fix and does not affect runtime behavior or the build.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No functional manual testing is necessary — this changes package metadata only, with no effect on runtime, build output, or published code.

To verify the correctness of the value:

1. Confirm the package directory exists: `ls code/frameworks/nextjs-vite`
2. Confirm `code/frameworks/nextjs-vite/package.json` now has `repository.directory` set to `code/frameworks/nextjs-vite`, matching its own `homepage` field.
3. Optionally confirm no other package disagrees, by checking that each `package.json` under `code/` declaring `repository.directory` points at the directory that actually contains it.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<sub>Note: the `maintenance` (or `build`), `ci:*` and `qa:*` labels need to be applied by a maintainer, as I don't have permission to add labels.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package repository path to accurately reflect the Next.js Vite framework location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->