### PR TITLE
Vue: Detect an imported _sfc_main from the AST rather than a source pattern

### DIFF
--- a/code/core/src/oxc-parser/index.test.ts
+++ b/code/core/src/oxc-parser/index.test.ts
@@ -1,7 +1,7 @@
 // Integration tests for parseReExports — exercises the real oxc-parser binary.
 import { describe, expect, it } from 'vitest';
 
-import { parseLocalBindings, parseReExports } from './index.ts';
+import { parseLocalBindings, parseModuleBindings, parseReExports } from './index.ts';
 
 describe('parseReExports', () => {
   it('maps a named re-export to its source specifier and imported name', async () => {
@@ -109,5 +109,63 @@ describe('parseLocalBindings', () => {
 
     expect(names).toBeInstanceOf(Set);
     expect(names.size).toBe(0);
+  });
+});
+
+describe('parseModuleBindings', () => {
+  it('maps imported names to the specifier they came from', async () => {
+    const source = [
+      `import _sfc_main from './Tab.vue?vue&type=script&setup=true&lang.ts';`,
+      `import { Baz } from './B';`,
+      `import * as NS from './C';`,
+    ].join('\n');
+
+    const { declared, imported } = await parseModuleBindings('/project/src/Tab.ts', source);
+
+    expect(declared.size).toBe(0);
+    expect(imported.get('_sfc_main')).toBe('./Tab.vue?vue&type=script&setup=true&lang.ts');
+    expect(imported.get('Baz')).toBe('./B');
+    expect(imported.get('NS')).toBe('./C');
+  });
+
+  it('excludes type-only imports, which leave no runtime binding', async () => {
+    const source = [
+      `import type Foo from './Foo';`,
+      `import { type Bar, Baz } from './B';`,
+      `import './side-effect';`,
+    ].join('\n');
+
+    const { imported } = await parseModuleBindings('/project/src/Tab.ts', source);
+
+    expect([...imported.keys()]).toEqual(['Baz']);
+  });
+
+  it('leaves re-exports out of both sets, since they bind nothing here', async () => {
+    const source = [
+      `export { default as Card } from './Card.vue';`,
+      `export * from './Other';`,
+    ].join('\n');
+
+    const { declared, imported } = await parseModuleBindings('/project/src/barrel.ts', source);
+
+    expect(declared.size).toBe(0);
+    expect(imported.size).toBe(0);
+  });
+
+  it('keeps a name in `declared` when it is declared rather than imported', async () => {
+    const { declared, imported } = await parseModuleBindings(
+      '/project/src/Tab.ts',
+      `const _sfc_main = {};\nexport default _sfc_main;`
+    );
+
+    expect([...declared]).toEqual(['_sfc_main']);
+    expect(imported.size).toBe(0);
+  });
+
+  it('returns empty sets on parse failure', async () => {
+    const { declared, imported } = await parseModuleBindings('/project/src/Tab.ts', `const = ;`);
+
+    expect(declared.size).toBe(0);
+    expect(imported.size).toBe(0);
   });
 });

--- a/code/core/src/oxc-parser/index.ts
+++ b/code/core/src/oxc-parser/index.ts
@@ -118,28 +118,46 @@ function collectDeclaredNames(
   }
 }
 
+/** Bindings a module introduces into its own scope, split by how they got there. */
+export interface ModuleBindings {
+  /**
+   * Names declared in this module: top-level `var`/`let`/`const`, function and class declarations,
+   * including those introduced via `export <declaration>`.
+   */
+  declared: Set<string>;
+  /**
+   * Names bound by an `import`, mapped to the specifier they came from. These are referenceable
+   * identifiers here even though the value lives in another module, so a property can be assigned
+   * to them. Type-only imports are excluded because they leave no runtime binding.
+   */
+  imported: Map<string, string>;
+}
+
 /**
- * Names declared locally in this module — top-level `var`/`let`/`const`, function and class
- * declarations, including those introduced via `export <declaration>`. Imports and re-exports
- * (`export { X } from '...'`, `export * from '...'`) are excluded because their bindings live in
- * another module and are not referenceable identifiers here.
+ * Bindings this module introduces into its own scope, whether declared locally or imported.
+ * Re-exports (`export { X } from '...'`, `export * from '...'`) appear in neither set, since they
+ * introduce no identifier here at all.
  *
  * Used by the Vue docgen plugin to decide whether a generated `.__docgenInfo` assignment can
  * safely target a name without producing a reference to an undefined binding.
  */
-export async function parseLocalBindings(filePath: string, source: string): Promise<Set<string>> {
+export async function parseModuleBindings(
+  filePath: string,
+  source: string
+): Promise<ModuleBindings> {
+  const declared = new Set<string>();
+  const imported = new Map<string, string>();
+
   let parseResult: Awaited<ReturnType<typeof oxcRawParseSync>>;
   try {
     parseResult = oxcRawParseSync(filePath, source);
   } catch {
-    return new Set();
+    return { declared, imported };
   }
   const body = parseResult.program?.body;
   if (!Array.isArray(body)) {
-    return new Set();
+    return { declared, imported };
   }
-
-  const names = new Set<string>();
 
   for (const statement of body) {
     const node = statement;
@@ -148,15 +166,34 @@ export async function parseLocalBindings(filePath: string, source: string): Prom
       node.type === 'FunctionDeclaration' ||
       node.type === 'ClassDeclaration'
     ) {
-      collectDeclaredNames(node, names);
+      collectDeclaredNames(node, declared);
     } else if (node.type === 'ExportNamedDeclaration' && node.declaration && !node.source) {
       // `export const X` / `export function X` / `export class X` — a local declaration.
       // Specifier-only (`export { X }`) and re-exports (with a `source`) introduce no binding here.
-      collectDeclaredNames(node.declaration, names);
+      collectDeclaredNames(node.declaration, declared);
+    } else if (node.type === 'ImportDeclaration' && node.importKind !== 'type') {
+      for (const specifier of node.specifiers ?? []) {
+        // `import { type X }` leaves no runtime binding, unlike the rest of the clause.
+        if (specifier.type === 'ImportSpecifier' && specifier.importKind === 'type') {
+          continue;
+        }
+        if (specifier.local?.name) {
+          imported.set(specifier.local.name, node.source.value);
+        }
+      }
     }
   }
 
-  return names;
+  return { declared, imported };
+}
+
+/**
+ * Names declared locally in this module. See {@link parseModuleBindings} for imports, which are
+ * also referenceable here.
+ */
+export async function parseLocalBindings(filePath: string, source: string): Promise<Set<string>> {
+  const { declared } = await parseModuleBindings(filePath, source);
+  return declared;
 }
 
 export async function parseReExports(

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -130,6 +130,21 @@ describe('vue-component-meta plugin', () => {
       expect(result!.code).toContain('_sfc_main.__docgenInfo');
     });
 
+    it('should inject __docgenInfo when a production SFC imports its default export', async () => {
+      const src = [
+        `import _sfc_main from './Tab.vue?vue&type=script&setup=true&lang.ts';`,
+        `export default _sfc_main;`,
+      ].join('\n');
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result).toBeDefined();
+      expect(result!.code).toContain('_sfc_main.__docgenInfo');
+    });
+
     it('should NOT inject __docgenInfo when the default export is an inline expression with no local binding', async () => {
       const src = `import { defineComponent } from 'vue';\nexport default defineComponent({});\n`;
       const id = '/project/src/components/Tab.ts';

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -145,6 +145,30 @@ describe('vue-component-meta plugin', () => {
       expect(result!.code).toContain('_sfc_main.__docgenInfo');
     });
 
+    it('should not inject __docgenInfo when an SFC default export has no _sfc_main import', async () => {
+      const src = `export default { name: 'Tab' };\n`;
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result?.code ?? '').not.toContain('__docgenInfo');
+    });
+
+    it('should not inject __docgenInfo when _sfc_main is imported from a non-virtual module', async () => {
+      const src = [`import _sfc_main from './shared-component';`, `export default _sfc_main;`].join(
+        '\n'
+      );
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result?.code ?? '').not.toContain('__docgenInfo');
+    });
+
     it('should NOT inject __docgenInfo when the default export is an inline expression with no local binding', async () => {
       const src = `import { defineComponent } from 'vue';\nexport default defineComponent({});\n`;
       const id = '/project/src/components/Tab.ts';

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -153,6 +153,7 @@ describe('vue-component-meta plugin', () => {
 
       const result = await transform(src, id);
 
+      expect(result).toBeDefined();
       expect(result?.code ?? '').not.toContain('__docgenInfo');
     });
 
@@ -166,6 +167,7 @@ describe('vue-component-meta plugin', () => {
 
       const result = await transform(src, id);
 
+      expect(result).toBeDefined();
       expect(result?.code ?? '').not.toContain('__docgenInfo');
     });
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -138,6 +138,21 @@ describe('vue-component-meta plugin', () => {
       expect(result!.code).toContain('_sfc_main.__docgenInfo');
     });
 
+    it('should inject __docgenInfo when a production SFC imports its default export', async () => {
+      const src = [
+        `import _sfc_main from './Tab.vue?vue&type=script&setup=true&lang.ts';`,
+        `export default _sfc_main;`,
+      ].join('\n');
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result).toBeDefined();
+      expect(result!.code).toContain('_sfc_main.__docgenInfo');
+    });
+
     it('should NOT inject __docgenInfo when the default export is an inline expression with no local binding', async () => {
       const src = `import { defineComponent } from 'vue';\nexport default defineComponent({});\n`;
       const id = '/project/src/components/Tab.ts';

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -153,6 +153,24 @@ describe('vue-component-meta plugin', () => {
       expect(result!.code).toContain('_sfc_main.__docgenInfo');
     });
 
+    it('should inject __docgenInfo when another plugin emits ahead of the _sfc_main import', async () => {
+      // This hook runs in "post", so anything earlier in the chain can prepend to the module.
+      // unplugin-vue-components puts its marker on the same line as the import, which a
+      // line-anchored pattern match would miss.
+      const src = [
+        `/* unplugin-vue-components disabled */import _sfc_main from './Tab.vue?vue&type=script&setup=true&lang.ts';`,
+        `export default _sfc_main;`,
+      ].join('\n');
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result).toBeDefined();
+      expect(result!.code).toContain('_sfc_main.__docgenInfo');
+    });
+
     it('should not inject __docgenInfo when an SFC default export has no _sfc_main import', async () => {
       const src = `export default { name: 'Tab' };\n`;
       const id = '/project/src/components/Tab.vue';

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -161,6 +161,7 @@ describe('vue-component-meta plugin', () => {
 
       const result = await transform(src, id);
 
+      expect(result).toBeDefined();
       expect(result?.code ?? '').not.toContain('__docgenInfo');
     });
 
@@ -174,6 +175,7 @@ describe('vue-component-meta plugin', () => {
 
       const result = await transform(src, id);
 
+      expect(result).toBeDefined();
       expect(result?.code ?? '').not.toContain('__docgenInfo');
     });
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.test.ts
@@ -153,6 +153,30 @@ describe('vue-component-meta plugin', () => {
       expect(result!.code).toContain('_sfc_main.__docgenInfo');
     });
 
+    it('should not inject __docgenInfo when an SFC default export has no _sfc_main import', async () => {
+      const src = `export default { name: 'Tab' };\n`;
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result?.code ?? '').not.toContain('__docgenInfo');
+    });
+
+    it('should not inject __docgenInfo when _sfc_main is imported from a non-virtual module', async () => {
+      const src = [`import _sfc_main from './shared-component';`, `export default _sfc_main;`].join(
+        '\n'
+      );
+      const id = '/project/src/components/Tab.vue';
+
+      mockChecker.getExportNames.mockReturnValue(['default']);
+
+      const result = await transform(src, id);
+
+      expect(result?.code ?? '').not.toContain('__docgenInfo');
+    });
+
     it('should NOT inject __docgenInfo when the default export is an inline expression with no local binding', async () => {
       const src = `import { defineComponent } from 'vue';\nexport default defineComponent({});\n`;
       const id = '/project/src/components/Tab.ts';

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -126,7 +126,8 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
             const isDefaultExport = meta.exportName === 'default';
             const name = isDefaultExport ? '_sfc_main' : meta.exportName;
 
-            if (!localBindings.has(name)) {
+            // Production SFCs can import `_sfc_main` from their virtual script module.
+            if (!localBindings.has(name) && !(id.endsWith('.vue') && isDefaultExport)) {
               return;
             }
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -125,9 +125,15 @@ export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<
           metaSources.forEach((meta) => {
             const isDefaultExport = meta.exportName === 'default';
             const name = isDefaultExport ? '_sfc_main' : meta.exportName;
+            const isImportedSfcMain =
+              isDefaultExport &&
+              id.endsWith('.vue') &&
+              /^import\s+_sfc_main\s+from\s+['"][^'"]+\?vue&type=script(?:&[^'"]*)?['"];?$/m.test(
+                src
+              );
 
             // Production SFCs can import `_sfc_main` from their virtual script module.
-            if (!localBindings.has(name) && !(id.endsWith('.vue') && isDefaultExport)) {
+            if (!localBindings.has(name) && !isImportedSfcMain) {
               return;
             }
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -1,4 +1,4 @@
-import { parseLocalBindings } from 'storybook/internal/oxc-parser';
+import { parseModuleBindings } from 'storybook/internal/oxc-parser';
 
 import MagicString from 'magic-string';
 import type { ModuleNode, Plugin } from 'vite';
@@ -45,24 +45,24 @@ export async function vueComponentMeta(
 
           const s = new MagicString(src);
 
-          // Names with a local binding in this module that we can safely attach "__docgenInfo" to.
+          // Names bound in this module that we can safely attach "__docgenInfo" to.
           // Re-exports (e.g. "export { default as MyComponent } from './MyComponent.vue'" or
-          // "export * from './Tabs'") resolve via checker.getExportNames but have no local binding
-          // here, so attaching to them would reference an undefined variable at runtime.
-          const localBindings = await parseLocalBindings(id, src);
+          // "export * from './Tabs'") resolve via checker.getExportNames but bind nothing here,
+          // so attaching to them would reference an undefined variable at runtime.
+          const { declared, imported } = await parseModuleBindings(id, src);
 
           metaSources.forEach((meta) => {
             const isDefaultExport = meta.exportName === 'default';
             const name = isDefaultExport ? '_sfc_main' : meta.exportName;
+
+            // This hook runs in "post", so a built SFC arrives as a shim that imports _sfc_main
+            // from its own virtual script module rather than declaring it.
             const isImportedSfcMain =
               isDefaultExport &&
               id.endsWith('.vue') &&
-              /^import\s+_sfc_main\s+from\s+['"][^'"]+\?vue&type=script(?:&[^'"]*)?['"];?$/m.test(
-                src
-              );
+              (imported.get(name)?.includes('?vue&type=script') ?? false);
 
-            // Production SFCs can import `_sfc_main` from their virtual script module.
-            if (!localBindings.has(name) && !isImportedSfcMain) {
+            if (!declared.has(name) && !isImportedSfcMain) {
               return;
             }
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -54,9 +54,15 @@ export async function vueComponentMeta(
           metaSources.forEach((meta) => {
             const isDefaultExport = meta.exportName === 'default';
             const name = isDefaultExport ? '_sfc_main' : meta.exportName;
+            const isImportedSfcMain =
+              isDefaultExport &&
+              id.endsWith('.vue') &&
+              /^import\s+_sfc_main\s+from\s+['"][^'"]+\?vue&type=script(?:&[^'"]*)?['"];?$/m.test(
+                src
+              );
 
             // Production SFCs can import `_sfc_main` from their virtual script module.
-            if (!localBindings.has(name) && !(id.endsWith('.vue') && isDefaultExport)) {
+            if (!localBindings.has(name) && !isImportedSfcMain) {
               return;
             }
 

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -55,7 +55,8 @@ export async function vueComponentMeta(
             const isDefaultExport = meta.exportName === 'default';
             const name = isDefaultExport ? '_sfc_main' : meta.exportName;
 
-            if (!localBindings.has(name)) {
+            // Production SFCs can import `_sfc_main` from their virtual script module.
+            if (!localBindings.has(name) && !(id.endsWith('.vue') && isDefaultExport)) {
               return;
             }
 


### PR DESCRIPTION
Closes #35518

## What I did

#35557 is closed, so this stands alone now. The bottom three commits are Anran-eleven's, mine is the top one, and their three tests are carried here.

huang-julien has since put the same AST approach up as #36030. I'm happy for that to land instead, I've commented there with the one regression test this has that it doesn't.

#35557 fixes a real bug. `order: 'post'` was added to this hook in 5fb8113258, so a built SFC now arrives as a shim that *imports* `_sfc_main` from its own virtual script module rather than declaring it. Then 7da5be9fea replaced the old source regexes with `parseLocalBindings`, which only collects declarations. Every `.vue` file gets skipped and production builds lose their prop tables.

It fixes that by matching the shim import against the module source:

```ts
/^import\s+_sfc_main\s+from\s+['"][^'"]+\?vue&type=script(?:&[^'"]*)?['"];?$/m.test(src)
```

Because the hook runs in `post`, every earlier plugin has already had a turn at the module by then. Any of them emitting so much as a comment ahead of that import defeats a `^` anchored pattern, and the guard fails closed: no error, no warning, just no prop table. This plugin is enough to do it:

```ts
{
  name: 'prepend-comment',
  enforce: 'post',
  transform: (code, id) => (id.endsWith('.vue') ? { code: `/* anything at all */${code}` } : undefined),
}
```

`unplugin-vue-components` is the same thing happening without anyone trying. Its transformer ends with `s.prepend(DISABLE_COMMENT)`, a MagicString prepend at position 0 with no newline, so every `.vue` module it touches starts:

```js
/* unplugin-vue-components disabled */import _sfc_main from '/src/CleanButton.vue?vue&type=script&setup=true&lang.ts';
```

I hit this on our own design system, 3,961 SFCs, with the whole docgen stack applied (#35557, #35593, #35565, #35598 and vuejs/language-tools#6136). Instrumenting the guard:

```
gate evaluations : 152
  local binding  :  18
  importMatch    :   0
  BLOCKED        : 134     (every one a .vue file)
```

## What this changes

The same check, from the AST:

- `parseModuleBindings` returns `{ declared, imported }` from a single parse, with `imported` mapping each name to the specifier it came from. Type only imports are excluded, both `import type X` and `{ type X }`, since they leave no runtime binding.
- The guard becomes `imported.get(name)?.includes('?vue&type=script')`, a plain check on the specifier the AST gave us rather than a pattern over the source.

An `import` does create a referenceable binding in the importing module. It's immutable, so you can't reassign it, but the plugin only assigns a property, and that reaches the same object. Re-exports bind nothing at all, so the #34521 barrel cases stay excluded exactly as before.

`parseLocalBindings` is kept as a thin wrapper over the new function, so its existing tests and its export from `storybook/internal/oxc-parser` are untouched.


### Measured effect

Five production builds against the same three fixtures, in the reproduction below:

```
storybook build, __docgenInfo in the emitted chunk:

                                     CleanButton        ConstExportButton  TypeExportButton
  #35557, nothing ahead of it        present            present            MISSING
  #35557, + comment prepended        MISSING            MISSING            MISSING
  #35557, + unplugin-vue-components  MISSING            MISSING            MISSING
  #35611, + comment prepended        present            present            MISSING
  #35611, + unplugin-vue-components  present            present            MISSING
```

`TypeExportButton` is missing throughout for an unrelated reason, #35593, which is merged but not in 10.5.4. The pair that moves is `CleanButton` and `ConstExportButton`.

On our design system, same machine and commit:

| | 10.4.6 | 10.5.4 + stack, #35557 as-is | with this change |
|---|---|---|---|
| `storybook build` | 39s | 39s | 43s |
| files with `__docgenInfo` | 101 | 13 | 101 |
| documented components | 141 | 10 | 141 |

The 141 are the same components in both directions, so it's parity with 10.4.6 rather than a different set.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`parseModuleBindings` gets five tests in `code/core/src/oxc-parser/index.test.ts` covering specifier mapping, type only exclusion, re-exports and parse failure. The plugin gets one more in `vue-component-meta.test.ts` for a comment emitted ahead of the import. That test fails against #35557 as it stands and passes with this change, and #35557's own three tests plus the barrel and re-export guards all still pass.

#### Manual testing

There's a runnable reproduction at https://github.com/seanogdev/sb-vue3-docgen-repro, on 10.5.4:

```sh
git clone https://github.com/seanogdev/sb-vue3-docgen-repro
cd sb-vue3-docgen-repro && npm install
node verify-post-order.mjs
```

That prints the table above. It patches the installed guard between states with `patch-docgen.mjs`, keeps a `.stock` copy of every file it touches, and restores the install when it finishes.

To see it as a prop table rather than a grep, `npx http-server storybook-static-run2` (#35557, comment prepended) and `storybook-static-run4` (this PR, same comment prepended), then open `/iframe.html?viewMode=docs&id=cleanbutton--docs` in each. Screenshots of both are attached below.

To be clear about what I checked myself: the design system numbers come from our own builds rather than a sandbox, and the reproduction plus the unit tests cover the module shapes directly.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user facing behaviour changes beyond docgen appearing where it should, so nothing to document.

