### PR TITLE
React: Respect tsconfigPath in reactDocgenTypescriptOptions

### DIFF
--- a/code/core/src/common/utils/__tests__/tsconfig.test.ts
+++ b/code/core/src/common/utils/__tests__/tsconfig.test.ts
@@ -9,6 +9,7 @@ vi.mock('../paths.ts', { spy: true });
 import {
   findTsconfigPathForFile,
   findTsconfigPathForPath,
+  findTsconfigPathOwningFile,
   getTsconfigPathsBaseDir,
 } from '../tsconfig.ts';
 import * as paths from '../paths.ts';
@@ -183,6 +184,27 @@ describe('findTsconfigPathForFile', () => {
     expect(findTsconfigPathForFile(dir, join(dir, 'src/utils/helper.ts'))).toBe(
       join(dir, 'tsconfig.json')
     );
+  });
+});
+
+describe('findTsconfigPathOwningFile', () => {
+  it('follows the references of a root config that is not the discoverable one', () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({ files: [], include: [] }),
+      'packages/ui/tsconfig.build.json': JSON.stringify({
+        files: [],
+        references: [{ path: './tsconfig.app.json' }],
+      }),
+      'packages/ui/tsconfig.app.json': JSON.stringify({ include: ['src'] }),
+      'packages/ui/src/Button.tsx': 'export const Button = () => null;',
+    });
+
+    expect(
+      findTsconfigPathOwningFile(
+        join(dir, 'packages/ui/tsconfig.build.json'),
+        join(dir, 'packages/ui/src/Button.tsx')
+      )
+    ).toBe(join(dir, 'packages/ui/tsconfig.app.json'));
   });
 });
 

--- a/code/core/src/common/utils/tsconfig.ts
+++ b/code/core/src/common/utils/tsconfig.ts
@@ -58,8 +58,7 @@ export const findTsconfigPath = (cwd: string): string | undefined => {
  * nearest root config is just a references shell (for example Vite's `files: []` root tsconfig).
  *
  * Prefer the config that really owns the file instead of stopping at the first config filename we
- * discover. Ownership also resolves `extends` so inherited `include` / `exclude` / `files` participate
- * (patterns from a base config stay relative to that base, matching `tsc`).
+ * discover.
  */
 export const findTsconfigPathForFile = (cwd: string, filePath: string): string | undefined => {
   const rootTsconfigPath = findTsconfigPath(cwd);
@@ -67,6 +66,17 @@ export const findTsconfigPathForFile = (cwd: string, filePath: string): string |
     return undefined;
   }
 
+  return findTsconfigPathOwningFile(rootTsconfigPath, filePath);
+};
+
+/**
+ * Pick the tsconfig that owns a file, starting from a root config the caller already knows.
+ *
+ * Ownership resolves `extends` so inherited `include` / `exclude` / `files` participate (patterns
+ * from a base config stay relative to that base, matching `tsc`). Falls back to the root config when
+ * no referenced project owns the file.
+ */
+export const findTsconfigPathOwningFile = (rootTsconfigPath: string, filePath: string): string => {
   const absoluteFilePath = resolve(filePath);
   const matchingConfigs = collectTsconfigEntries(rootTsconfigPath, new Set()).filter((entry) =>
     tsconfigIncludesFile(entry, absoluteFilePath)

--- a/code/renderers/react/src/componentManifest/getComponentImports.ts
+++ b/code/renderers/react/src/componentManifest/getComponentImports.ts
@@ -10,8 +10,6 @@ import {
 import { logger } from 'storybook/internal/node-logger';
 import type { TypescriptOptions as TypescriptOptionsBase } from 'storybook/internal/types';
 
-import type { ParserOptions } from 'react-docgen-typescript';
-
 import { getImportTag, getReactDocgen, matchPath } from './reactDocgen.ts';
 import {
   type ComponentDocWithExportName,
@@ -19,7 +17,7 @@ import {
   matchComponentDoc,
   parseWithReactDocgenTypescript,
 } from './reactDocgenTypescript.ts';
-import type { ComponentRef } from './types.ts';
+import type { ComponentRef, ReactDocgenTypescriptOptions } from './types.ts';
 import { cachedResolveImport } from './utils.ts';
 
 export type ReactDocgenConfig = 'react-docgen' | 'react-docgen-typescript' | false;
@@ -27,7 +25,7 @@ export type DocgenEngine = 'react-docgen' | 'react-docgen-typescript' | 'react-c
 
 export interface TypescriptOptions extends TypescriptOptionsBase {
   reactDocgen: ReactDocgenConfig;
-  reactDocgenTypescriptOptions: ParserOptions;
+  reactDocgenTypescriptOptions: ReactDocgenTypescriptOptions;
 }
 
 export type { ComponentRef } from './types.ts';

--- a/code/renderers/react/src/componentManifest/reactDocgen/extractReactTypescriptDocgenInfo.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/extractReactTypescriptDocgenInfo.ts
@@ -40,11 +40,12 @@ export const extractArgTypesFromDocgenTypescript = async ({
       savePropValueAsString: true,
     };
 
-    const tsConfig = await getTsConfig(componentFilePath);
+    const { tsconfigPath, ...parserUserOptions } = reactDocgenTypescriptOptions ?? {};
+    const tsConfig = await getTsConfig(componentFilePath, tsconfigPath);
 
     const mergedOptions = {
       ...defaultOptions,
-      ...reactDocgenTypescriptOptions,
+      ...parserUserOptions,
       // Always ensure savePropValueAsString is true for consistency
       savePropValueAsString: true,
     };

--- a/code/renderers/react/src/componentManifest/reactDocgen/utils.test.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/utils.test.ts
@@ -60,6 +60,46 @@ describe('getTsConfig', () => {
     expect(options.jsx).toBe(ts.JsxEmit.Preserve);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('tsconfig.missing.json'));
   });
+
+  it('follows project references when tsconfigPath names a solution-style tsconfig', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({ files: [], include: [] }),
+      'packages/ui/tsconfig.json': JSON.stringify({
+        files: [],
+        references: [{ path: './tsconfig.app.json' }],
+      }),
+      'packages/ui/tsconfig.app.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', target: 'ES2022' },
+        include: ['src'],
+      }),
+      'packages/ui/src/Button.tsx': 'export const Button = () => null;',
+    });
+
+    const options = await getTsConfig(
+      path.join(dir, 'packages/ui/src/Button.tsx'),
+      './packages/ui/tsconfig.json'
+    );
+
+    expect(options.jsx).toBe(ts.JsxEmit.ReactJSX);
+    expect(options.target).toBe(ts.ScriptTarget.ES2022);
+  });
+
+  it('warns and falls back to the owning tsconfig when tsconfigPath is not a file', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'preserve', target: 'ES5' },
+        include: ['src'],
+      }),
+      'config/.keep': '',
+      'src/Button.tsx': 'export const Button = () => null;',
+    });
+
+    const options = await getTsConfig(path.join(dir, 'src/Button.tsx'), './config');
+
+    expect(options.jsx).toBe(ts.JsxEmit.Preserve);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(path.join(dir, 'config')));
+  });
 });
 
 function createTempProject(files: Record<string, string>) {

--- a/code/renderers/react/src/componentManifest/reactDocgen/utils.test.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/utils.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { logger } from 'storybook/internal/node-logger';
+
+import ts from 'typescript';
+
+import { invalidateCache } from '../utils.ts';
+import { getTsConfig } from './utils.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  invalidateCache();
+  vi.restoreAllMocks();
+
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('getTsConfig', () => {
+  it('reads the tsconfig named by tsconfigPath instead of the one owning the component', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'preserve', target: 'ES5' },
+        include: ['src'],
+      }),
+      'tsconfig.storybook.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', target: 'ES2022' },
+        include: ['src'],
+      }),
+      'src/Button.tsx': 'export const Button = () => null;',
+    });
+
+    const options = await getTsConfig(
+      path.join(dir, 'src/Button.tsx'),
+      './tsconfig.storybook.json'
+    );
+
+    expect(options.jsx).toBe(ts.JsxEmit.ReactJSX);
+    expect(options.target).toBe(ts.ScriptTarget.ES2022);
+  });
+
+  it('warns and falls back to the owning tsconfig when tsconfigPath does not exist', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'preserve', target: 'ES5' },
+        include: ['src'],
+      }),
+      'src/Button.tsx': 'export const Button = () => null;',
+    });
+
+    const options = await getTsConfig(path.join(dir, 'src/Button.tsx'), './tsconfig.missing.json');
+
+    expect(options.jsx).toBe(ts.JsxEmit.Preserve);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('tsconfig.missing.json'));
+  });
+});
+
+function createTempProject(files: Record<string, string>) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sb-rdt-tsconfig-'));
+  tempDirs.push(dir);
+
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = path.join(dir, name);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content, 'utf-8');
+  }
+
+  vi.spyOn(process, 'cwd').mockReturnValue(dir);
+  return dir;
+}

--- a/code/renderers/react/src/componentManifest/reactDocgen/utils.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/utils.ts
@@ -9,7 +9,9 @@ import type {
   TSFunctionSignatureType,
   TypeDescriptor,
 } from 'react-docgen';
-import type { ParserOptions as ReactDocgenTypescriptOptions } from 'react-docgen-typescript';
+
+import type { ReactDocgenTypescriptOptions } from '../types.ts';
+import { resolveConfiguredTsconfigPath } from '../utils.ts';
 
 export type ReactDocgenConfig = 'react-docgen' | 'react-docgen-typescript' | false;
 
@@ -127,12 +129,14 @@ export function mapCommonTypes(typeName: string): SBType | null {
   return null;
 }
 
-export const getTsConfig = async (componentFilePath?: string) => {
+export const getTsConfig = async (componentFilePath?: string, configuredTsconfigPath?: string) => {
   try {
     const ts = await import('typescript');
-    const tsconfigPath = componentFilePath
-      ? findTsconfigPathForFile(dirname(componentFilePath), componentFilePath)
-      : ts.findConfigFile(process.cwd(), ts.sys.fileExists);
+    const tsconfigPath =
+      resolveConfiguredTsconfigPath(configuredTsconfigPath) ??
+      (componentFilePath
+        ? findTsconfigPathForFile(dirname(componentFilePath), componentFilePath)
+        : ts.findConfigFile(process.cwd(), ts.sys.fileExists));
     if (tsconfigPath === undefined) {
       return {};
     }

--- a/code/renderers/react/src/componentManifest/reactDocgen/utils.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/utils.ts
@@ -1,5 +1,5 @@
 import type { SBType } from 'storybook/internal/csf';
-import { findTsconfigPathForFile } from 'storybook/internal/common';
+import { findTsconfigPathForFile, findTsconfigPathOwningFile } from 'storybook/internal/common';
 
 import { dirname } from 'node:path';
 import type {
@@ -132,11 +132,19 @@ export function mapCommonTypes(typeName: string): SBType | null {
 export const getTsConfig = async (componentFilePath?: string, configuredTsconfigPath?: string) => {
   try {
     const ts = await import('typescript');
-    const tsconfigPath =
-      resolveConfiguredTsconfigPath(configuredTsconfigPath) ??
-      (componentFilePath
-        ? findTsconfigPathForFile(dirname(componentFilePath), componentFilePath)
-        : ts.findConfigFile(process.cwd(), ts.sys.fileExists));
+    const configuredPath = resolveConfiguredTsconfigPath(configuredTsconfigPath);
+    let tsconfigPath: string | undefined;
+
+    if (configuredPath) {
+      tsconfigPath = componentFilePath
+        ? findTsconfigPathOwningFile(configuredPath, componentFilePath)
+        : configuredPath;
+    } else if (componentFilePath) {
+      tsconfigPath = findTsconfigPathForFile(dirname(componentFilePath), componentFilePath);
+    } else {
+      tsconfigPath = ts.findConfigFile(process.cwd(), ts.sys.fileExists);
+    }
+
     if (tsconfigPath === undefined) {
       return {};
     }

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.test.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.test.ts
@@ -269,6 +269,66 @@ describe('parseWithReactDocgenTypescript', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('tsconfig.missing.json'));
   });
 
+  test('follows project references when tsconfigPath names a solution-style tsconfig', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({ files: [], include: [] }),
+      'packages/ui/tsconfig.json': JSON.stringify({
+        files: [],
+        references: [{ path: './tsconfig.app.json' }],
+      }),
+      'packages/ui/tsconfig.app.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['src'],
+      }),
+      'packages/ui/src/Button.tsx': dedent`
+        interface ButtonProps {
+          /** The button label */
+          label: string;
+        }
+
+        export function Button(props: ButtonProps) {
+          return null;
+        }
+      `,
+    });
+
+    const docs = await parseWithReactDocgenTypescript(
+      path.join(dir, 'packages/ui/src/Button.tsx'),
+      { tsconfigPath: './packages/ui/tsconfig.json' }
+    );
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].props.label.required).toBe(true);
+  });
+
+  test('warns and falls back to the discovered tsconfig when tsconfigPath is not a file', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['*.tsx'],
+      }),
+      'config/.keep': '',
+      'Button.tsx': dedent`
+        interface ButtonProps {
+          label: string;
+        }
+
+        export function Button(props: ButtonProps) {
+          return null;
+        }
+      `,
+    });
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'Button.tsx'), {
+      tsconfigPath: './config',
+    });
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].props.label).toBeDefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(path.join(dir, 'config')));
+  });
+
   test('handles Vite-style project references tsconfig files', async () => {
     const dir = createTempProject({
       'tsconfig.json': JSON.stringify({

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.test.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.test.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
+import { logger } from 'storybook/internal/node-logger';
+
 import { dedent } from 'ts-dedent';
 
 import {
@@ -208,6 +210,63 @@ describe('parseWithReactDocgenTypescript', () => {
     expect(docs[0].props.label).toBeDefined();
     expect(propNames).not.toContain('className');
     expect(propNames).not.toContain('style');
+  });
+
+  test('builds the program from the tsconfig named by tsconfigPath', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({ files: [], include: [] }),
+      'tsconfig.storybook.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['src'],
+      }),
+      'src/Button.tsx': dedent`
+        interface ButtonProps {
+          /** The button label */
+          label: string;
+          disabled?: boolean;
+        }
+
+        export function Button(props: ButtonProps) {
+          return null;
+        }
+      `,
+    });
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'src/Button.tsx'), {
+      tsconfigPath: './tsconfig.storybook.json',
+    });
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].exportName).toBe('Button');
+    expect(docs[0].props.label.required).toBe(true);
+    expect(docs[0].props.disabled.required).toBe(false);
+  });
+
+  test('warns and falls back to the discovered tsconfig when tsconfigPath does not exist', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { jsx: 'react-jsx', strict: true },
+        include: ['*.tsx'],
+      }),
+      'Button.tsx': dedent`
+        interface ButtonProps {
+          label: string;
+        }
+
+        export function Button(props: ButtonProps) {
+          return null;
+        }
+      `,
+    });
+
+    const docs = await parseWithReactDocgenTypescript(path.join(dir, 'Button.tsx'), {
+      tsconfigPath: './tsconfig.missing.json',
+    });
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].props.label).toBeDefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('tsconfig.missing.json'));
   });
 
   test('handles Vite-style project references tsconfig files', async () => {

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
@@ -10,7 +10,8 @@ import type ts from 'typescript';
 
 import { logger } from 'storybook/internal/node-logger';
 
-import { asyncCache, cached, findTsconfigPath } from './utils.ts';
+import type { ReactDocgenTypescriptOptions } from './types.ts';
+import { asyncCache, cached, findTsconfigPath, resolveConfiguredTsconfigPath } from './utils.ts';
 
 export type ComponentDocWithExportName = ComponentDoc & { exportName: string };
 
@@ -181,18 +182,21 @@ export function invalidateParser() {
   previousProgramsByConfigKey.clear();
 }
 
-async function getParser(filePath: string, userOptions?: ParserOptions) {
+async function getParser(filePath: string, userOptions?: ReactDocgenTypescriptOptions) {
   const [typescript, reactDocgenTypescript] = await Promise.all([
     loadTypeScript(),
     loadReactDocgenTypescript(),
   ]);
+  const { tsconfigPath, ...parserUserOptions } = userOptions ?? {};
   const optionsKey = JSON.stringify(userOptions ?? {});
 
   // Mirror the Volar-inspired project selection we already use in react-component-meta:
   // if the nearest root tsconfig is only a project-references shell, follow references and pick
   // the config that actually includes this file. This is the manifest-side extension of #34353.
   const configPath =
-    findOwningTsconfigPath(typescript, process.cwd(), filePath) ?? findTsconfigPath(process.cwd());
+    resolveConfiguredTsconfigPath(tsconfigPath) ??
+    findOwningTsconfigPath(typescript, process.cwd(), filePath) ??
+    findTsconfigPath(process.cwd());
   const configKey = configPath ?? '<no-tsconfig>';
   const parserKey = `${configKey}::${optionsKey}`;
   const cachedParser = parserCache.get(parserKey);
@@ -232,7 +236,7 @@ async function getParser(filePath: string, userOptions?: ParserOptions) {
     const parserOptions: ParserOptions = {
       shouldExtractLiteralValuesFromEnum: true,
       shouldRemoveUndefinedFromOptional: true,
-      ...userOptions,
+      ...parserUserOptions,
       // Always force savePropValueAsString so default values are in a consistent format
       savePropValueAsString: true,
     };
@@ -314,7 +318,10 @@ export function getReactDocgenTypescriptError(
  * `invalidateCache()`. The underlying TS program is a long-lived singleton.
  */
 export const parseWithReactDocgenTypescript = asyncCache(
-  async (filePath: string, userOptions?: ParserOptions): Promise<ComponentDocWithExportName[]> => {
+  async (
+    filePath: string,
+    userOptions?: ReactDocgenTypescriptOptions
+  ): Promise<ComponentDocWithExportName[]> => {
     const { program, fileParser, typescript } = await getParser(filePath, userOptions);
     const checker = program.getTypeChecker();
     const sourceFile = program.getSourceFile(filePath);

--- a/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgenTypescript.ts
@@ -191,12 +191,13 @@ async function getParser(filePath: string, userOptions?: ReactDocgenTypescriptOp
   const optionsKey = JSON.stringify(userOptions ?? {});
 
   // Mirror the Volar-inspired project selection we already use in react-component-meta:
-  // if the nearest root tsconfig is only a project-references shell, follow references and pick
-  // the config that actually includes this file. This is the manifest-side extension of #34353.
-  const configPath =
-    resolveConfiguredTsconfigPath(tsconfigPath) ??
-    findOwningTsconfigPath(typescript, process.cwd(), filePath) ??
-    findTsconfigPath(process.cwd());
+  // if the root tsconfig is only a project-references shell, follow references and pick the config
+  // that actually includes this file. This is the manifest-side extension of #34353.
+  const rootConfigPath =
+    resolveConfiguredTsconfigPath(tsconfigPath) ?? findTsconfigPath(process.cwd());
+  const configPath = rootConfigPath
+    ? findOwningTsconfigPath(typescript, rootConfigPath, filePath)
+    : undefined;
   const configKey = configPath ?? '<no-tsconfig>';
   const parserKey = `${configKey}::${optionsKey}`;
   const cachedParser = parserCache.get(parserKey);
@@ -354,17 +355,12 @@ export const parseWithReactDocgenTypescript = asyncCache(
 );
 
 const findOwningTsconfigPath = cached(
-  (typescript: TypeScriptRuntime, cwd: string, filePath: string): string | undefined => {
-    const configPath = findTsconfigPath(cwd);
-    if (!configPath) {
-      return undefined;
-    }
-
-    return findTsconfigPathIncludingFile(typescript, configPath, filePath, new Set()) ?? configPath;
-  },
+  (typescript: TypeScriptRuntime, rootConfigPath: string, filePath: string): string =>
+    findTsconfigPathIncludingFile(typescript, rootConfigPath, filePath, new Set()) ??
+    rootConfigPath,
   {
-    key: (typescript, cwd, filePath) =>
-      `${normalizeFileName(typescript, resolve(cwd))}::${normalizeFileName(
+    key: (typescript, rootConfigPath, filePath) =>
+      `${normalizeFileName(typescript, rootConfigPath)}::${normalizeFileName(
         typescript,
         resolve(filePath)
       )}`,

--- a/code/renderers/react/src/componentManifest/types.ts
+++ b/code/renderers/react/src/componentManifest/types.ts
@@ -1,6 +1,13 @@
 import type { ComponentImportRef } from 'storybook/internal/csf-tools';
 
+import type { ParserOptions } from 'react-docgen-typescript';
 import type ts from 'typescript';
+
+// `tsconfigPath` is absent from react-docgen-typescript's own `ParserOptions`, but the Vite and
+// Webpack docgen plugins Storybook documents both accept it, so users already write it in `main.ts`.
+export type ReactDocgenTypescriptOptions = ParserOptions & {
+  tsconfigPath?: string;
+};
 
 export type ComponentRef = ComponentImportRef & {
   componentJsDocTags?: Record<string, string[]>;

--- a/code/renderers/react/src/componentManifest/utils.test.ts
+++ b/code/renderers/react/src/componentManifest/utils.test.ts
@@ -9,7 +9,8 @@ vi.mock('node:fs', { spy: true });
 import * as common from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
-import { readFileSync, statSync } from 'node:fs';
+import { accessSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 import { fs as memfs, vol } from 'memfs';
 
@@ -21,6 +22,7 @@ import {
   groupBy,
   invalidateCache,
   invariant,
+  resolveConfiguredTsconfigPath,
 } from './utils.ts';
 
 // Helpers
@@ -289,5 +291,34 @@ describe('findTsconfigPath', () => {
 
     expect(result).toBe('/project-root/tsconfig.json');
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveConfiguredTsconfigPath', () => {
+  beforeEach(() => {
+    vi.mocked(statSync).mockReturnValue({ isFile: () => true } as unknown as ReturnType<
+      typeof statSync
+    >);
+    vi.mocked(logger.warn).mockImplementation(() => {});
+  });
+
+  test('returns the configured path when it points at a readable file', () => {
+    vi.mocked(accessSync).mockImplementation(() => {});
+
+    expect(resolveConfiguredTsconfigPath('/project-root/tsconfig.storybook.json')).toBe(
+      resolve('/project-root/tsconfig.storybook.json')
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test('warns and falls back to discovery when the configured file cannot be read', () => {
+    vi.mocked(accessSync).mockImplementation(() => {
+      throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+    });
+
+    expect(resolveConfiguredTsconfigPath('/project-root/tsconfig.storybook.json')).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(resolve('/project-root/tsconfig.storybook.json'))
+    );
   });
 });

--- a/code/renderers/react/src/componentManifest/utils.ts
+++ b/code/renderers/react/src/componentManifest/utils.ts
@@ -1,5 +1,5 @@
 // Object.groupBy polyfill
-import { readFileSync, statSync } from 'node:fs';
+import { accessSync, constants, readFileSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import {
@@ -222,9 +222,9 @@ export const resolveConfiguredTsconfigPath = (tsconfigPath: string | undefined) 
   const configuredPath = resolve(process.cwd(), tsconfigPath);
   // Prop extraction is best effort, so an unusable path warns and lets the caller keep looking
   // instead of failing the build.
-  if (!isExistingFile(configuredPath)) {
+  if (!isReadableFile(configuredPath)) {
     logger.warn(
-      `The tsconfig configured in typescript.reactDocgenTypescriptOptions.tsconfigPath does not point to a file at ${configuredPath}. Falling back to the tsconfig found from the working directory.`
+      `The tsconfig configured in typescript.reactDocgenTypescriptOptions.tsconfigPath cannot be read as a file at ${configuredPath}. Falling back to the tsconfig found from the working directory.`
     );
     return undefined;
   }
@@ -232,9 +232,16 @@ export const resolveConfiguredTsconfigPath = (tsconfigPath: string | undefined) 
   return configuredPath;
 };
 
-const isExistingFile = (filePath: string) => {
+const isReadableFile = (filePath: string) => {
   try {
-    return statSync(filePath).isFile();
+    if (!statSync(filePath).isFile()) {
+      return false;
+    }
+    // A path that stats as a file can still be unopenable, for example a tsconfig owned by another
+    // user inside a container. TypeScript reports a read error for it and every caller ends up with
+    // no compiler options at all, so treat it the same as a missing path and keep looking.
+    accessSync(filePath, constants.R_OK);
+    return true;
   } catch {
     return false;
   }

--- a/code/renderers/react/src/componentManifest/utils.ts
+++ b/code/renderers/react/src/componentManifest/utils.ts
@@ -1,5 +1,5 @@
 // Object.groupBy polyfill
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import {
@@ -222,12 +222,20 @@ export const resolveConfiguredTsconfigPath = (tsconfigPath: string | undefined) 
   const configuredPath = resolve(process.cwd(), tsconfigPath);
   // Prop extraction is best effort, so an unusable path warns and lets the caller keep looking
   // instead of failing the build.
-  if (!existsSync(configuredPath)) {
+  if (!isExistingFile(configuredPath)) {
     logger.warn(
-      `The tsconfig configured in typescript.reactDocgenTypescriptOptions.tsconfigPath does not exist at ${configuredPath}. Falling back to the tsconfig found from the working directory.`
+      `The tsconfig configured in typescript.reactDocgenTypescriptOptions.tsconfigPath does not point to a file at ${configuredPath}. Falling back to the tsconfig found from the working directory.`
     );
     return undefined;
   }
 
   return configuredPath;
+};
+
+const isExistingFile = (filePath: string) => {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
 };

--- a/code/renderers/react/src/componentManifest/utils.ts
+++ b/code/renderers/react/src/componentManifest/utils.ts
@@ -1,5 +1,6 @@
 // Object.groupBy polyfill
-import { readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 import {
   findTsconfigPath as findTsconfigPathCommon,
@@ -212,3 +213,21 @@ export const findTsconfigPath = cached(
     name: 'findTsconfigPath',
   }
 );
+
+export const resolveConfiguredTsconfigPath = (tsconfigPath: string | undefined) => {
+  if (!tsconfigPath) {
+    return undefined;
+  }
+
+  const configuredPath = resolve(process.cwd(), tsconfigPath);
+  // Prop extraction is best effort, so an unusable path warns and lets the caller keep looking
+  // instead of failing the build.
+  if (!existsSync(configuredPath)) {
+    logger.warn(
+      `The tsconfig configured in typescript.reactDocgenTypescriptOptions.tsconfigPath does not exist at ${configuredPath}. Falling back to the tsconfig found from the working directory.`
+    );
+    return undefined;
+  }
+
+  return configuredPath;
+};

--- a/docs/_snippets/main-config-typescript-react-docgen-typescript-tsconfig-path.md
+++ b/docs/_snippets/main-config-typescript-react-docgen-typescript-tsconfig-path.md
@@ -1,0 +1,33 @@
+```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF 3"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+import type { StorybookConfig } from '@storybook/your-framework';
+
+const config: StorybookConfig = {
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      tsconfigPath: './tsconfig.storybook.json',
+    },
+  },
+};
+
+export default config;
+```
+
+```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { defineMain } from '@storybook/your-framework/node';
+
+export default defineMain({
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      tsconfigPath: './tsconfig.storybook.json',
+    },
+  },
+});
+```

--- a/docs/api/main-config/main-config-typescript.mdx
+++ b/docs/api/main-config/main-config-typescript.mdx
@@ -75,6 +75,14 @@ Configures the options to pass to `react-docgen-typescript-plugin` if `react-doc
 
 <CodeSnippets path="main-config-typescript-react-docgen-typescript-options.md" />
 
+### `reactDocgenTypescriptOptions.tsconfigPath`
+
+Type: `string`
+
+Path to the tsconfig used to build the TypeScript program that props are extracted from, resolved relative to the working directory. When omitted, Storybook uses the tsconfig that owns each component file, following project references from the nearest `tsconfig.json`. Set it when that file is not the one that should describe your components, such as a solution-style root `tsconfig.json` with empty `include` and `files`, or a tsconfig written specifically for documentation.
+
+<CodeSnippets path="main-config-typescript-react-docgen-typescript-tsconfig-path.md" />
+
 </If>
 
 ## `skipCompiler`


### PR DESCRIPTION
Closes #34386

## What I did

`getParser` and `getTsConfig` ignore `reactDocgenTypescriptOptions.tsconfigPath` and always use an auto-discovered tsconfig. A solution-style root owns no files, so props come back empty.

Both now resolve it against the working directory, follow its project references to the config that owns the component, warn and fall back to discovery when the path cannot be read as a file, and strip the key before it reaches the parser. The walk is `findTsconfigPathOwningFile`, extracted from `findTsconfigPathForFile`. Typed and documented, per #34390.

### Testing
- [x] unit tests

#### Manual testing
1. Root `tsconfig.json` is `{"files": []}`, real config in `tsconfig.storybook.json`.
2. Set `tsconfigPath: './tsconfig.storybook.json'` under `typescript.reactDocgenTypescriptOptions`.
3. Controls show props instead of none.

### Documentation
- [x] Updated

