### PR TITLE
Dependencies: Pin `@testing-library/jest-dom` to `6.9.1`

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -247,7 +247,7 @@
     "@storybook/global": "^5.0.0",
     "@storybook/icons": "^2.0.2",
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/jest-dom": "6.9.1",
     "@testing-library/user-event": "^14.6.1",
     "@vitest/expect": "3.2.4",
     "@vitest/spy": "3.2.4",

--- a/code/core/src/test/expect.ts
+++ b/code/core/src/test/expect.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+// TODO SB11: Upgrade @testing-library/jest-dom to v7+ across the monorepo.
 import * as matchers from '@testing-library/jest-dom/matchers';
 import type { TestingLibraryMatchers } from '@testing-library/jest-dom/matchers';
 

--- a/code/package.json
+++ b/code/package.json
@@ -86,7 +86,7 @@
     "@storybook/web-components": "workspace:*",
     "@storybook/web-components-vite": "workspace:*",
     "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "patch:@testing-library/user-event@npm%3A14.6.1#~/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch",
     "@types/lodash-es": "^4.17.12",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@babel/traverse": "latest",
     "@babel/types": "^7.28.4",
     "@playwright/test": "1.58.2",
+    "@testing-library/jest-dom": "6.9.1",
     "@testing-library/user-event@npm:^14.4.0": "patch:@testing-library/user-event@npm%3A14.6.1#~/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch",
     "@testing-library/user-event@npm:^14.6.1": "patch:@testing-library/user-event@npm%3A14.6.1#~/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch",
     "@types/babel__traverse@npm:*": "patch:@types/babel__traverse@npm%3A7.20.6#~/.yarn/patches/@types-babel__traverse-npm-7.20.6-fac4243243.patch",

--- a/scripts/ecosystem-ci/existing-resolutions.js
+++ b/scripts/ecosystem-ci/existing-resolutions.js
@@ -11,6 +11,7 @@ export const EXISTING_RESOLUTIONS = new Set([
   '@babel/traverse',
   '@babel/types',
   '@playwright/test',
+  '@testing-library/jest-dom',
   '@testing-library/user-event@npm:^14.4.0',
   '@testing-library/user-event@npm:^14.6.1',
   '@types/babel__traverse@npm:*',

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -56,7 +56,7 @@
     "@openai/codex-sdk": "^0.117.0",
     "@polka/parse": "^1.0.0-next.28",
     "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/cross-spawn": "^6.0.6",

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -132,7 +132,7 @@ export const addWorkaroundResolutions = async ({
   packageJson.resolutions = {
     ...packageJson.resolutions,
     '@testing-library/dom': '^9.3.4',
-    '@testing-library/jest-dom': '^6.6.3',
+    '@testing-library/jest-dom': '6.9.1',
     '@testing-library/user-event': '^14.5.2',
     ...additionalResolutions,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9822,7 +9822,7 @@ __metadata:
     "@storybook/web-components": "workspace:*"
     "@storybook/web-components-vite": "workspace:*"
     "@testing-library/dom": "npm:^10.4.0"
-    "@testing-library/jest-dom": "npm:^6.9.1"
+    "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^16.2.0"
     "@testing-library/user-event": "patch:@testing-library/user-event@npm%3A14.6.1#~/.yarn/patches/@testing-library-user-event-npm-14.6.1-5da7e1d4e2.patch"
     "@types/lodash-es": "npm:^4.17.12"
@@ -10411,7 +10411,7 @@ __metadata:
     "@openai/codex-sdk": "npm:^0.117.0"
     "@polka/parse": "npm:^1.0.0-next.28"
     "@testing-library/dom": "npm:^10.4.0"
-    "@testing-library/jest-dom": "npm:^6.9.1"
+    "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^16.0.0"
     "@testing-library/user-event": "npm:^14.5.2"
     "@types/cross-spawn": "npm:^6.0.6"
@@ -11094,7 +11094,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^6.9.1":
+"@testing-library/jest-dom@npm:6.9.1":
   version: 6.9.1
   resolution: "@testing-library/jest-dom@npm:6.9.1"
   dependencies:
@@ -31364,7 +31364,7 @@ __metadata:
     "@storybook/icons": "npm:^2.0.2"
     "@tanstack/react-virtual": "npm:^3.3.0"
     "@testing-library/dom": "npm:^10.4.1"
-    "@testing-library/jest-dom": "npm:^6.9.1"
+    "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.6.1"
     "@types/cross-spawn": "npm:^6.0.6"


### PR DESCRIPTION
Closes #35613

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Pinned `@testing-library/jest-dom` to `6.9.1` in the published `storybook` package and related workspace manifests. The previous `^6.9.1` range allowed npm to resolve the deprecated `6.10.0` release, which triggered the npmx deprecation warning.

Also added a root `resolutions` entry as a belt-and-suspenders guard for the monorepo.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual testing needed — this is a dependency version pin with no runtime or API changes. The lockfile already resolved to 6.9.1.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Standardized the testing utility version across project packages by pinning `@testing-library/jest-dom` to `6.9.1` for more consistent, reproducible installs.
- **Tests**
  - Updated the ecosystem CI resolution allowlist and Yarn resolution handling to match the pinned `@testing-library/jest-dom` version.
  - Added a note to track a future upgrade to `@testing-library/jest-dom` v7+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->