### PR TITLE
CI: Backport patch-labeling fix to latest-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,12 +127,26 @@ jobs:
         if: github.ref_name == 'latest-release'
         run: git fetch --tags origin
 
-      # when this is a patch release from main, label any patch PRs included in the release
+      # When this is a patch release from main, label any patch PRs included in the release as
+      # "patch:done". This is bookkeeping for the *next* release's cherry-pick step, not part of
+      # publishing itself, so it runs continue-on-error to avoid aborting an already-published
+      # release. It must not fail silently though (a swallowed permission error previously caused
+      # released PRs to be re-picked into later patch changelogs), so failure is alerted below.
       - name: Label patch PRs as picked
+        id: label-patches
         if: github.ref_name == 'latest-release'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn release:label-patches
+
+      - name: Report patch labeling failure to Discord
+        if: github.ref_name == 'latest-release' && steps.label-patches.outcome == 'failure'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # v0.4.0
+        with:
+          args: 'Publishing v${{ steps.version.outputs.current-version }} succeeded, but labeling patch PRs as "patch:done" failed. They must be labeled manually or they will reappear in the next patch changelog. See run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
       - name: Create GitHub Release
         if: steps.publish-needed.outputs.published == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
     environment: Release
     permissions:
       contents: write
-      issues: write
+      pull-requests: write # required for yarn release:label-patches (addLabelsToLabelable on PRs)
       actions: write # required for yarn release:cancel-preparation-runs
       id-token: write # required for npm provenance via yarn release:publish
     defaults:

--- a/scripts/release/__tests__/label-patches.test.ts
+++ b/scripts/release/__tests__/label-patches.test.ts
@@ -154,6 +154,19 @@ it('should label the PR associated with cherry picks in the current branch', asy
   `);
 });
 
+it('should re-throw when labeling fails, so an unattended run does not fail silently', async () => {
+  process.env.GH_TOKEN = 'MY_SECRET';
+  vi.spyOn(process.stderr, 'write').mockImplementation((() => {}) as any);
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  // Reproduces the incident where the publish job lacked `pull-requests: write`.
+  github.githubGraphQlClient.mockRejectedValueOnce(
+    new Error('Resource not accessible by integration')
+  );
+
+  await expect(run({})).rejects.toThrow('Resource not accessible by integration');
+});
+
 it('should label all PRs when the --all flag is passed', async () => {
   process.env.GH_TOKEN = 'MY_SECRET';
 

--- a/scripts/release/label-patches.ts
+++ b/scripts/release/label-patches.ts
@@ -93,6 +93,11 @@ export const run = async (options: unknown) => {
   } catch (e) {
     spinner3.fail(`Something went wrong when labelling the PRs.`);
     console.error(e);
+    // Re-throw so the process exits non-zero. This step also runs unattended in the publish
+    // workflow, where a swallowed error is invisible; the workflow marks the step
+    // continue-on-error and alerts on failure, so this does not abort an already-published
+    // release but is no longer silent.
+    throw e;
   }
 };
 


### PR DESCRIPTION
## Summary

Backports the patch-labeling fixes from `next` (#35524, #35525) onto `latest-release`, so the next patch publish can successfully label merged PRs with `patch:done`.

Fixes #35607.

Since May 2026, the publish workflow on `latest-release` has used `issues: write` instead of `pull-requests: write`, causing the GraphQL `addLabelsToLabelable` mutation to fail with "Resource not accessible by integration". The fix landed on `next` on 2026-07-17 but never reached `latest-release`, so v10.5.5 (and earlier patch releases since v10.5.0) still hit the broken workflow.

## Changes

- Restore `pull-requests: write` on the `publish-normal` job (replacing `issues: write`)
- Re-throw labeling errors in `label-patches.ts` so unattended publish runs don't fail silently
- Mark the labeling step `continue-on-error` and alert Discord on failure (labeling is bookkeeping — it must not abort an already-published release)
- Add regression test for the re-throw behavior

## Test plan

- [x] Merge to `latest-release` (with `[skip ci]` to avoid triggering publish)
- [ ] Verify on the next patch publish that the "Label patch PRs as picked" step succeeds
- [ ] Confirm affected PRs receive the `patch:done` label