### PR TITLE
fix: wait for inline stories before rerendering docs

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
@@ -963,9 +963,30 @@ describe('PreviewWeb', () => {
         mockChannel.emit.mockClear();
         docsRenderer.render.mockClear();
         emitter.emit(UPDATE_GLOBALS, { globals: { a: 'd' } });
-        await waitForEvents([GLOBALS_UPDATED]);
+        await waitForEvents([DOCS_RENDERED]);
 
         expect(docsRenderer.render).toHaveBeenCalled();
+      });
+
+      it('waits for inline stories to rerender before rerendering the docs container', async () => {
+        document.location.search = '?id=component-one--docs&viewMode=docs';
+        const preview = await createAndRenderPreview();
+        const [inlineStoryRerender, finishInlineStoryRerender] = createGate();
+        const rerenderInlineStory = vi.fn(() => inlineStoryRerender);
+        preview.storyRenders.push({
+          rerender: rerenderInlineStory,
+        } as unknown as (typeof preview.storyRenders)[number]);
+        const rerenderDocs = vi.spyOn(preview.currentRender!, 'rerender');
+
+        const updateGlobals = preview.onUpdateGlobals({ globals: { a: 'd' } });
+        await vi.waitFor(() => expect(rerenderInlineStory).toHaveBeenCalled());
+
+        expect(rerenderDocs).not.toHaveBeenCalled();
+
+        finishInlineStoryRerender();
+        await updateGlobals;
+
+        expect(rerenderDocs).toHaveBeenCalledOnce();
       });
     });
   });

--- a/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWithSelection.tsx
@@ -256,7 +256,7 @@ export class PreviewWithSelection<TRenderer extends Renderer> extends Preview<TR
   async onUpdateGlobals({ globals }: { globals: Globals }) {
     const currentStory =
       (this.currentRender instanceof StoryRender && this.currentRender.story) || undefined;
-    super.onUpdateGlobals({ globals, currentStory });
+    await super.onUpdateGlobals({ globals, currentStory });
     if (
       this.currentRender instanceof MdxDocsRender ||
       this.currentRender instanceof CsfDocsRender


### PR DESCRIPTION
Closes #29007

## What I did

- Wait for globals-driven inline story rerenders to finish before rerendering the docs container.
- Update the existing docs-mode assertion to wait for the completed docs render lifecycle.
- Add a regression test that blocks an inline story rerender and verifies the docs container cannot rerender concurrently.

This prevents overlapping docs and inline-story lifecycles from causing repeated reloads, missing event sources, and stale globals when backgrounds change.

Implementation and tests were developed with assistance from OpenAI Codex. I reviewed the resulting diff and validation results.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a local Storybook from this branch with the backgrounds toolbar enabled and an autodocs page containing at least two inline stories.
2. Open that component's Docs page.
3. Switch between toolbar backgrounds several times.
4. Verify every inline story applies the selected background/global, the docs page does not repeatedly reload, and no missing event-source errors appear in the manager console.

### Documentation

Documentation is not required because this fixes internal preview render ordering without changing the public API or documented behavior.

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains one of the required changelog labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved docs-mode global updates so documentation renders refresh only after inline stories finish rerendering.
  - Ensured documentation updates occur in the correct order, preventing stale or incomplete renders.
  - Updated rendering behavior for both MDX and CSF documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->