### PR TITLE
Core: Emit actionable warning when config default export is imported from another file

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -224,8 +224,8 @@ export class StoryIndexGenerator {
       this.specifierToCache.set(specifier, cache)
     );
 
-    const previewCode = await this.getPreviewCode();
-    const projectTags = this.getProjectTags(previewCode);
+    const preview = await this.getPreviewCode();
+    const projectTags = this.getProjectTags(preview);
 
     // Extract stories for each file
     await this.ensureExtracted({ projectTags });
@@ -737,8 +737,8 @@ export class StoryIndexGenerator {
       throw this.lastError;
     }
 
-    const previewCode = await this.getPreviewCode();
-    const projectTags = this.getProjectTags(previewCode);
+    const preview = await this.getPreviewCode();
+    const projectTags = this.getProjectTags(preview);
 
     // Extract any entries that are currently missing
     // Pull out each file's stories into a list of stories, to be composed and sorted
@@ -774,7 +774,7 @@ export class StoryIndexGenerator {
 
       const sorted = await this.sortStories(
         indexEntries,
-        previewCode && getStorySortParameter(previewCode)
+        preview && getStorySortParameter(preview.code)
       );
 
       this.lastStats = stats;
@@ -867,15 +867,20 @@ export class StoryIndexGenerator {
       .map((ext) => join(this.options.configDir, `preview.${ext}`))
       .find((fname) => existsSync(fname));
 
-    return previewFile && (await readFile(previewFile, { encoding: 'utf8' })).toString();
+    return previewFile
+      ? {
+          code: (await readFile(previewFile, { encoding: 'utf8' })).toString(),
+          fileName: previewFile,
+        }
+      : undefined;
   }
 
-  getProjectTags(previewCode?: string) {
+  getProjectTags(preview?: { code: string; fileName: string }) {
     let projectTags = [] as Tag[];
     const defaultTags = [Tag.DEV, Tag.TEST, Tag.MANIFEST];
-    if (previewCode) {
+    if (preview) {
       try {
-        const projectAnnotations = loadConfig(previewCode).parse();
+        const projectAnnotations = loadConfig(preview.code, preview.fileName).parse();
         projectTags = projectAnnotations.getFieldValue(['tags']) ?? [];
       } catch (err) {
         once.warn(dedent`
@@ -889,7 +894,7 @@ export class StoryIndexGenerator {
 
           Received:
 
-          ${previewCode}
+          ${preview.code}
         `);
       }
     }

--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -9,6 +9,8 @@ import { loadConfig, printConfig } from './ConfigFile.ts';
 
 vi.mock('storybook/internal/node-logger', { spy: true });
 
+const mockedLogger = vi.mocked(logger);
+
 expect.addSnapshotSerializer({
   serialize: (val: any) => (typeof val === 'string' ? val : val.toString()),
   test: (val) => true,
@@ -1945,10 +1947,10 @@ describe('ConfigFile', () => {
       ).parse();
       expect(config.hasDefaultExport).toBe(true);
       expect(config.getFieldValue(['tags'])).toBeUndefined();
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining("it is imported from './pre'")
       );
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining("default export of 'preview.ts'")
       );
     });
@@ -1960,7 +1962,7 @@ describe('ConfigFile', () => {
           export default previewConfig;
         `
       ).parse();
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining("default export of this config file: it is imported from './pre'")
       );
     });
@@ -1973,7 +1975,7 @@ describe('ConfigFile', () => {
           export default definePreview(previewConfig);
         `
       ).parse();
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining("it is imported from './pre'")
       );
     });
@@ -1987,7 +1989,7 @@ describe('ConfigFile', () => {
         `
       ).parse();
       expect(config.getFieldValue(['tags'])).toEqual(['autodocs']);
-      expect(logger.warn).not.toHaveBeenCalled();
+      expect(mockedLogger.warn).not.toHaveBeenCalled();
     });
 
     it('warns with an actionable message for a re-exported default', () => {
@@ -1997,7 +1999,7 @@ describe('ConfigFile', () => {
         `
       ).parse();
       expect(config.hasDefaultExport).toBe(true);
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining("it is imported from './pre'")
       );
     });
@@ -2011,7 +2013,26 @@ describe('ConfigFile', () => {
       ).parse();
       expect(config.hasDefaultExport).toBe(true);
       expect(config.getFieldValue(['tags'])).toEqual(['autodocs']);
-      expect(logger.warn).not.toHaveBeenCalled();
+      expect(mockedLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('warns only once when the same config is parsed repeatedly', () => {
+      const source = dedent`
+        import { previewConfig } from './pre';
+        export default previewConfig;
+      `;
+      loadConfig(source, 'preview.ts').parse();
+      loadConfig(source, 'preview.ts').parse();
+      expect(mockedLogger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when setting a field on a re-exported default', () => {
+      const config = loadConfig(
+        dedent`
+          export { previewConfig as default } from './pre';
+        `
+      ).parse();
+      expect(() => config.setFieldValue(['tags'], ['test'])).toThrow(/default export/);
     });
 
     it('falls back to the generic parsing warning for other unresolvable default exports', () => {
@@ -2020,8 +2041,10 @@ describe('ConfigFile', () => {
           export default foo;
         `
       ).parse();
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('CSF Parsing error'));
-      expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('it is imported from'));
+      expect(mockedLogger.warn).toHaveBeenCalledWith(expect.stringContaining('CSF Parsing error'));
+      expect(mockedLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('it is imported from')
+      );
     });
   });
 });

--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { babelPrint } from 'storybook/internal/babel';
+import { logger, once } from 'storybook/internal/node-logger';
 
 import { dedent } from 'ts-dedent';
 
 import { loadConfig, printConfig } from './ConfigFile.ts';
+
+vi.mock('storybook/internal/node-logger', { spy: true });
 
 expect.addSnapshotSerializer({
   serialize: (val: any) => (typeof val === 'string' ? val : val.toString()),
@@ -1922,6 +1925,103 @@ describe('ConfigFile', () => {
         expect(config._exportsObject?.type).toBe('ObjectExpression');
         expect(config._exportsObject?.properties).toHaveLength(1);
       }
+    });
+  });
+
+  describe('default export analysis warnings', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      // several tests emit an identical message, which `once` would otherwise dedupe across tests
+      once.clear();
+    });
+
+    it('warns with an actionable message when the default export is a named import', () => {
+      const config = loadConfig(
+        dedent`
+          import { previewConfig } from './pre';
+          export default previewConfig;
+        `,
+        'preview.ts'
+      ).parse();
+      expect(config.hasDefaultExport).toBe(true);
+      expect(config.getFieldValue(['tags'])).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("it is imported from './pre'")
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("default export of 'preview.ts'")
+      );
+    });
+
+    it('warns with an actionable message when the default export is a default import', () => {
+      loadConfig(
+        dedent`
+          import previewConfig from './pre';
+          export default previewConfig;
+        `
+      ).parse();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("default export of this config file: it is imported from './pre'")
+      );
+    });
+
+    it('warns with an actionable message when an imported config is passed to a csf factory', () => {
+      loadConfig(
+        dedent`
+          import { definePreview } from '@storybook/react-vite';
+          import { previewConfig } from './pre';
+          export default definePreview(previewConfig);
+        `
+      ).parse();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("it is imported from './pre'")
+      );
+    });
+
+    it('resolves a local variable passed to a csf factory', () => {
+      const config = loadConfig(
+        dedent`
+          import { definePreview } from '@storybook/react-vite';
+          const previewConfig = { tags: ['autodocs'] };
+          export default definePreview(previewConfig);
+        `
+      ).parse();
+      expect(config.getFieldValue(['tags'])).toEqual(['autodocs']);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('warns with an actionable message for a re-exported default', () => {
+      const config = loadConfig(
+        dedent`
+          export { previewConfig as default } from './pre';
+        `
+      ).parse();
+      expect(config.hasDefaultExport).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("it is imported from './pre'")
+      );
+    });
+
+    it('resolves a local variable exported as default via an export specifier', () => {
+      const config = loadConfig(
+        dedent`
+          const previewConfig = { tags: ['autodocs'] };
+          export { previewConfig as default };
+        `
+      ).parse();
+      expect(config.hasDefaultExport).toBe(true);
+      expect(config.getFieldValue(['tags'])).toEqual(['autodocs']);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the generic parsing warning for other unresolvable default exports', () => {
+      loadConfig(
+        dedent`
+          export default foo;
+        `
+      ).parse();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('CSF Parsing error'));
+      expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('it is imported from'));
     });
   });
 });

--- a/code/core/src/csf-tools/ConfigFile.ts
+++ b/code/core/src/csf-tools/ConfigFile.ts
@@ -8,7 +8,7 @@ import {
   types as t,
   traverse,
 } from 'storybook/internal/babel';
-import { logger } from 'storybook/internal/node-logger';
+import { logger, once } from 'storybook/internal/node-logger';
 
 import { dedent } from 'ts-dedent';
 
@@ -112,6 +112,22 @@ const _findVarInitialization = (identifier: string, program: t.Program) => {
   return declarator?.init;
 };
 
+const _findImportSource = (identifier: string, program: t.Program): string | undefined => {
+  let source: string | undefined;
+  program.body.find((node: t.Node) => {
+    if (
+      t.isImportDeclaration(node) &&
+      (node.importKind == null || node.importKind === 'value') &&
+      node.specifiers.some((spec) => spec.local.name === identifier)
+    ) {
+      source = node.source.value;
+      return true;
+    }
+    return false;
+  });
+  return source;
+};
+
 const _makeObjectExpression = (path: string[], value: t.Expression): t.Expression => {
   if (path.length === 0) {
     return value;
@@ -195,6 +211,38 @@ export class ConfigFile {
     return decl;
   };
 
+  /**
+   * Warn about a default export that could not be resolved to an object expression. When the
+   * export turns out to be imported from another file, emit an actionable message instead of the
+   * generic parsing error: the module still evaluates correctly at runtime, but static reads
+   * (e.g. project tags) silently degrade.
+   */
+  _warnUnresolvableDefaultExport = (
+    decl: t.Node | undefined,
+    fallbackNode: t.Node | undefined | null,
+    importSourceOverride?: string
+  ) => {
+    const importSource =
+      importSourceOverride ??
+      (t.isIdentifier(decl) ? _findImportSource(decl.name, this._ast.program) : undefined);
+    if (importSource !== undefined) {
+      // `once` because consumers like StoryIndexGenerator re-parse on every invalidation,
+      // which would repeat this warning on each file save in watch mode.
+      once.warn(dedent`
+        Could not statically analyze the default export of ${this.fileName ? `'${this.fileName}'` : 'this config file'}: it is imported from '${importSource}'.
+        Storybook features that read this file statically will not see this config. Define the object inline, e.g. "export default { ... }".
+      `);
+    } else {
+      logger.warn(
+        getCsfParsingErrorMessage({
+          expectedType: 'ObjectExpression',
+          foundType: decl?.type,
+          node: decl || fallbackNode,
+        })
+      );
+    }
+  };
+
   parse() {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
@@ -206,8 +254,12 @@ export class ConfigFile {
 
           // csf factory - unwrap call expressions like definePreview({...}) or definePreview({...}).type<T>()
           while (t.isCallExpression(decl)) {
-            if (t.isObjectExpression(decl.arguments[0])) {
-              decl = decl.arguments[0];
+            const arg = decl.arguments.length
+              ? self._resolveDeclaration(decl.arguments[0] as t.Node, parent)
+              : undefined;
+            if (t.isObjectExpression(arg) || t.isIdentifier(arg)) {
+              // an unresolvable identifier surfaces below, so it can be diagnosed as an import
+              decl = arg;
               break;
             } else if (
               t.isMemberExpression(decl.callee) &&
@@ -222,13 +274,7 @@ export class ConfigFile {
           if (t.isObjectExpression(decl)) {
             self._parseExportsObject(decl);
           } else {
-            logger.warn(
-              getCsfParsingErrorMessage({
-                expectedType: 'ObjectExpression',
-                foundType: decl?.type,
-                node: decl || node.declaration,
-              })
-            );
+            self._warnUnresolvableDefaultExport(decl, node.declaration);
           }
         },
       },
@@ -263,8 +309,21 @@ export class ConfigFile {
                 const { name: exportName } = spec.exported;
 
                 const decl = _findVarDeclarator(localName, parent as t.Program) as any;
-                // decl can be empty in case X from `import { X } from ....` because it is not handled in _findVarDeclarator
-                if (decl) {
+                if (exportName === 'default') {
+                  // export { X as default } (possibly re-exported from another file)
+                  self.hasDefaultExport = true;
+                  const resolved = decl && self._resolveDeclaration(decl.init, parent);
+                  if (t.isObjectExpression(resolved)) {
+                    self._parseExportsObject(resolved);
+                  } else {
+                    self._warnUnresolvableDefaultExport(
+                      resolved || spec.local,
+                      spec.local,
+                      node.source?.value
+                    );
+                  }
+                } else if (decl) {
+                  // decl can be empty in case X from `import { X } from ....` because it is not handled in _findVarDeclarator
                   self._exports[exportName] = self._resolveDeclaration(decl.init, parent);
                   self._exportDecls[exportName] = decl;
                 }


### PR DESCRIPTION
Closes #31104

## What I did

When a config file's default export is imported from another file, e.g.

```ts
// .storybook/preview.ts
import { previewConfig } from './pre';
export default previewConfig;
```

the static parser (`ConfigFile`) cannot follow the import, so it logged a
cryptic warning with no file name ("CSF Parsing error: Expected
'ObjectExpression' but found 'Identifier' instead in 'Identifier'."), and
features that read the config statically (e.g. project tags in
`StoryIndexGenerator.getProjectTags`) silently degraded — a `tags:
['autodocs']` in such a config is dropped without explanation.

This PR:

- Detects the imported-identifier case (via a `_findImportSource` helper) and
  replaces the cryptic warning with an actionable one: the file name, the
  import source, and inline-object guidance. Emitted with `once.warn` so
  watch-mode re-indexing doesn't repeat it on every file save.
- Threads the preview file name through `StoryIndexGenerator` into
  `loadConfig`, so the warning emitted during dev startup can name the actual
  file (this call site previously passed no file name at all).
- Covers the same failure through CSF factories (`export default
  definePreview(previewConfig)`) and export specifiers (`export { x as
  default }`, including re-exports), which previously produced the cryptic
  message or failed silently with `hasDefaultExport: false`.
- As a side effect, *local* identifiers passed to CSF factories
  (`definePreview(localConfig)`) or exported via `export { localConfig as
  default }` now resolve correctly instead of warning.
- Non-import unresolvable exports keep the existing generic message unchanged.

Note for reviewers: `export { x as default } from './other'` now sets
`hasDefaultExport: true`, so writer APIs (`setFieldValue` used by
automigrations) throw the existing "default export is not an object" error
for that shape instead of silently doing nothing effective — same failure
mode the plain `export default <imported>` shape already had.

AI disclosure: developed with the assistance of Claude Code.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. In any sandbox (e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`), split the preview config:
   - `.storybook/pre.js`: `export const previewConfig = { tags: ['autodocs'] };`
   - `.storybook/preview.ts`: `import { previewConfig } from './pre'; export default previewConfig;`
2. Run `yarn storybook` and watch the terminal during startup
3. Before this PR: `CSF Parsing error: Expected 'ObjectExpression' but found 'Identifier' instead in 'Identifier'.` — no file name, no cause. After: the warning names the preview file, says its default export is imported from `./pre`, and suggests defining the object inline
4. Save a story file a few times: the warning appears only once per session

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->