### PR TITLE
Run abort phase on cancelling render

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
@@ -457,6 +457,7 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
   // happens inside the user's code.
   cancelRender() {
     this.abortController.abort();
+    this.runPhase(this.abortController.signal, "aborted");
   }
 
   cancelPlayFunction() {


### PR DESCRIPTION
Closes #29007

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Well this was a rabbit hole.

Observable symptoms - changing globals on a docs page that renders two stories causes a whole page refresh.

### Direct cause:

This line right here:

https://github.com/storybookjs/storybook/blob/1e0f18322773e4ea9c5db7529c20d7b5151c128b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts#L490-L493

### Indirect cause:

The teardown function runs aborts the abortcontroller, but does _not_ change the phase.

https://github.com/storybookjs/storybook/blob/1e0f18322773e4ea9c5db7529c20d7b5151c128b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts#L471

In the happy path, this is set in `checkIfAborted` which is called frequently throughout the render cycle:

https://github.com/storybookjs/storybook/blob/1e0f18322773e4ea9c5db7529c20d7b5151c128b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts#L118-L120

Setting the phase to aborted means that this poll will resolve and the teardown will run:

https://github.com/storybookjs/storybook/blob/1e0f18322773e4ea9c5db7529c20d7b5151c128b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts#L482-L484

However, when _two_ or more stories are running this, at least one of them will run `cancelRender` but _not_ run `checkIfAborted` (still not worked out why) which means the polling will timeout and the page will reload.

### Even more indirect cause:

Changing the globals restarts the rendering process on the existing renderers; they run through loading and rendering phases before being torn down, aborted, and replaced with a brand new rendering object. It's this briefly lived render cycle that's causing the bug and it probably shouldn't even be happening. 

### Solution?

The fix in this PR is to run the abort phase immediately after cancelling the signal. I can't see this making things worse - subsequent calls to `checkIfAborted` will behave the same. Subsequent calls to runPhase will re-set the phase to aborted if called after, but again, don't know if that's possible.

There are a _lot_ of unawaited promises in this class, which also make me quite uneasy.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Check  that changing globals on a docs page with more than one story does not force a page reload.

A minimum viable storybook with such a page is here: https://github.com/mrginglymus/sb-rerender-doom

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canceled renders now transition explicitly to an aborted state, improving render cancellation handling and related state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->