### PR TITLE
Bench: Add the shared docgen bench plumbing and move the memory harness onto it

### DIFF
--- a/scripts/bench/docgen-memory/gate.ts
+++ b/scripts/bench/docgen-memory/gate.ts
@@ -22,7 +22,9 @@ import * as path from 'node:path';
 
 import { type MemoryBudgets, memoryBudgetsFor } from '../docgen-shared/budgets.ts';
 import { outputTail } from '../docgen-shared/child-output.ts';
-import { SANDBOX_DIRECTORY } from '../../utils/constants.ts';
+// The same SANDBOX_DIRECTORY the harness resolves its own default from, so the gate cannot write
+// its projects somewhere the harness would not have put them.
+import { SANDBOX_DIRECTORY } from '../docgen-shared/paths.ts';
 
 interface HarnessResult {
   baseline: { rssMb: number; heapUsedMb: number; retainedHeapMb?: number };

--- a/scripts/bench/docgen-memory/gate.ts
+++ b/scripts/bench/docgen-memory/gate.ts
@@ -2,18 +2,15 @@
  * CI regression gate for the docgen-server memory behavior
  * (https://github.com/storybookjs/storybook/issues/35260).
  *
- * Runs {@link file://./memory-harness.ts} in fresh child processes (so each measurement starts from a
- * clean heap) and asserts two independent things:
+ * Runs {@link file://./memory-harness.ts} in fresh child processes (one clean heap per measurement)
+ * and asserts two independent things:
  *
- *   1. Steady-state churn/leak-freeness (`changed-scope` metric config): post-GC `heapUsed` must not
- *      climb across saves, and the per-save transient working set must stay under budget. A regression
- *      that re-extracts the whole index would blow past these.
- *   2. The OOM fix itself, as a **crash → survive negative control** (`live` configs): the live path
- *      (many per-component `batchExtract` calls on the shared program) is run under a tight heap cap
- *      both WITH and WITHOUT program recycling.
- *        - recycle OFF (`--recycle off`, ratio Infinity) MUST OOM.
- *        - recycle ON (default) MUST survive.
- *      Asserting the flip (not just survival) is what guards the fix rather than the cap.
+ *   1. Steady-state leak-freeness (`changed-scope` metric config): post-GC `heapUsed` must not
+ *      climb across saves, and the per-save transient working set must stay under budget.
+ *   2. The OOM fix itself, as a **crash → survive negative control** (`live` configs): the live
+ *      path is run under a tight heap cap both WITH and WITHOUT program recycling - recycle OFF
+ *      (`--recycle off`, ratio Infinity) MUST OOM, recycle ON (default) MUST survive. Asserting
+ *      the flip, not just survival, is what guards the fix rather than the cap.
  *
  * Run:
  *   yarn bench:docgen-memory          # from scripts/
@@ -23,6 +20,8 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { type MemoryBudgets, memoryBudgetsFor } from '../docgen-shared/budgets.ts';
+import { outputTail } from '../docgen-shared/child-output.ts';
 import { SANDBOX_DIRECTORY } from '../../utils/constants.ts';
 
 interface HarnessResult {
@@ -33,15 +32,6 @@ interface HarnessResult {
   avgTransient?: number;
 }
 
-interface MetricBudgets {
-  /** Max allowed post-GC retained growth (MB) across the run. */
-  maxRetainedGrowthMb: number;
-  /** Max allowed average transient working set added per save (MB). */
-  maxTransientMb: number;
-  /** Max allowed post-GC retained-heap slope (MB/save). */
-  maxRetainedSlopeMb: number;
-}
-
 interface GateConfig {
   name: string;
   args: string[];
@@ -50,12 +40,12 @@ interface GateConfig {
   /** `--max-old-space-size` cap (MB) for the child. Omit to run uncapped. */
   capMb?: number;
   /**
-   * Crash → survive negative control. `true` ⇒ the child MUST OOM (recycle disabled); `false` ⇒ it
-   * MUST survive (recycle on). Omit for metric-only configs.
+   * Crash → survive negative control: `true` ⇒ MUST OOM (recycle disabled), `false` ⇒ MUST
+   * survive (recycle on). Omit for metric-only configs.
    */
   expectOom?: boolean;
   /** Post-GC metric budgets, asserted from `result.json` (metric configs only). */
-  budgets?: MetricBudgets;
+  budgets?: MemoryBudgets;
 }
 
 const HARNESS = path.join(import.meta.dirname, 'memory-harness.ts');
@@ -78,7 +68,7 @@ const CONFIGS: GateConfig[] = [
       '--scope', 'changed',
     ],
     outSubdir: 'changed-scope',
-    budgets: { maxRetainedGrowthMb: 60, maxTransientMb: 90, maxRetainedSlopeMb: 3 },
+    budgets: memoryBudgetsFor('react-osa'),
   },
   {
     // Positive control: the live per-edit workload survives under a tight cap BECAUSE the shared
@@ -153,15 +143,7 @@ function runHarness(config: GateConfig): RunOutcome {
 
   const proc = spawnSync(process.execPath, nodeArgs, { encoding: 'utf8' });
   const output = `${proc.stdout ?? ''}${proc.stderr ?? ''}`;
-  // Echo a compact tail so CI logs show what happened without the full V8 crash dump.
-  console.log(
-    output
-      .trim()
-      .split('\n')
-      .slice(-8)
-      .map((line) => `    ${line}`)
-      .join('\n')
-  );
+  console.log(outputTail(output, 8));
 
   const result = fs.existsSync(jsonPath)
     ? (JSON.parse(fs.readFileSync(jsonPath, 'utf8')) as HarnessResult)

--- a/scripts/bench/docgen-memory/generate-project.ts
+++ b/scripts/bench/docgen-memory/generate-project.ts
@@ -19,6 +19,11 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { z } from 'zod';
+
+import { countOption, parseHarnessOptions } from '../docgen-shared/args.ts';
+import type { ComponentRefLike, StoryRefLike } from '../docgen-shared/react-renderer-module.ts';
+
 const require = createRequire(import.meta.url);
 
 export interface GenerateOptions {
@@ -239,6 +244,26 @@ ${variantExports}
 `;
 }
 
+/** The renderer-side reference for the generated `Comp{i}`, matching the naming used above. */
+export function componentRef(i: number, componentPath: string): ComponentRefLike {
+  return {
+    componentName: `Comp${i}`,
+    importName: `Comp${i}`,
+    localImportName: `Comp${i}`,
+    importId: `./Comp${i}`,
+    isPackage: false,
+    path: componentPath,
+  };
+}
+
+/** Pairs {@link GeneratedProject.componentPaths} with `storyPaths`, which share an index. */
+export function buildStoryRefs(componentPaths: string[], storyPaths: string[]): StoryRefLike[] {
+  return componentPaths.map((componentPath, i) => ({
+    storyPath: storyPaths[i],
+    component: componentRef(i, componentPath),
+  }));
+}
+
 export function generateProject(options: GenerateOptions): GeneratedProject {
   const outDir = path.resolve(options.outDir);
   fs.rmSync(outDir, { recursive: true, force: true });
@@ -275,25 +300,40 @@ export function generateProject(options: GenerateOptions): GeneratedProject {
   return { outDir, configPath, componentPaths, storyPaths };
 }
 
-function parseArgs(argv: string[]): GenerateOptions {
-  const get = (flag: string, fallback: string) => {
-    const idx = argv.indexOf(flag);
-    return idx >= 0 && argv[idx + 1] ? argv[idx + 1] : fallback;
-  };
-  return {
-    outDir: get('--out', '../storybook-sandboxes/docgen-memory-stress'),
-    components: Number(get('--components', '500')),
-    variants: Number(get('--variants', '4')),
-    props: Number(get('--props', '8')),
-    heavyTypes: argv.includes('--heavy'),
-    heavyFactor: Number(get('--heavy-factor', '1')),
-    base64Kb: Number(get('--base64-kb', '0')),
-    withNodeModules: !argv.includes('--no-node-modules'),
-  };
+function parseOptions(argv: string[]): GenerateOptions {
+  return parseHarnessOptions<GenerateOptions>(
+    argv,
+    {
+      out: { type: 'string' },
+      components: { type: 'string' },
+      variants: { type: 'string' },
+      props: { type: 'string' },
+      heavy: { type: 'boolean' },
+      'heavy-factor': { type: 'string' },
+      'base64-kb': { type: 'string' },
+      'no-node-modules': { type: 'boolean' },
+    } as const,
+    z.object({
+      outDir: z.string().default('../storybook-sandboxes/docgen-memory-stress'),
+      components: countOption(500),
+      variants: countOption(4),
+      props: countOption(8),
+      heavyTypes: z.boolean().default(false),
+      heavyFactor: countOption(1),
+      base64Kb: countOption(0),
+      withNodeModules: z.boolean().default(true),
+    }),
+    (values) => ({
+      ...values,
+      outDir: values.out,
+      heavyTypes: values.heavy,
+      withNodeModules: !values.noNodeModules,
+    })
+  );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const options = parseArgs(process.argv.slice(2));
+  const options = parseOptions(process.argv.slice(2));
   const start = Date.now();
   const result = generateProject(options);
   console.log(

--- a/scripts/bench/docgen-memory/generate-project.ts
+++ b/scripts/bench/docgen-memory/generate-project.ts
@@ -21,7 +21,7 @@ import { pathToFileURL } from 'node:url';
 
 import { z } from 'zod';
 
-import { countOption, parseHarnessOptions } from '../docgen-shared/args.ts';
+import { countOption, parseHarnessOptions, positiveCountOption } from '../docgen-shared/args.ts';
 import type { ComponentRefLike, StoryRefLike } from '../docgen-shared/react-renderer-module.ts';
 
 const require = createRequire(import.meta.url);
@@ -204,7 +204,7 @@ export function componentSource(
   opts: { heavyTypes?: boolean; heavyFactor?: number; base64Kb?: number } = {}
 ): string {
   const heavy = opts.heavyTypes
-    ? heavyTypeBlock(i, Math.max(1, opts.heavyFactor ?? 1))
+    ? heavyTypeBlock(i, opts.heavyFactor ?? 1)
     : undefined;
   const base64 = opts.base64Kb ? base64Block(i, opts.base64Kb) : '';
   return `import * as React from 'react';
@@ -319,7 +319,7 @@ function parseOptions(argv: string[]): GenerateOptions {
       variants: countOption(4),
       props: countOption(8),
       heavyTypes: z.boolean().default(false),
-      heavyFactor: countOption(1),
+      heavyFactor: positiveCountOption(1),
       base64Kb: countOption(0),
       withNodeModules: z.boolean().default(true),
     }),

--- a/scripts/bench/docgen-memory/memory-harness.ts
+++ b/scripts/bench/docgen-memory/memory-harness.ts
@@ -2,22 +2,21 @@
  * Deterministic in-process memory harness for the docgen-server OOM
  * (https://github.com/storybookjs/storybook/issues/35260).
  *
- * It reproduces the "re-extract on every save" behavior without a browser or dev server, so it runs
- * fast and is fully deterministic. It drives the real {@link ComponentMetaManager} against a
- * generated project of N components, then simulates K file saves and samples memory after each one.
+ * Drives the real {@link ComponentMetaManager} against a generated project of N components, then
+ * simulates K file saves and samples memory after each one.
  *
- * Two failure signals are measured independently:
- *   - RETAINED growth: post-GC `heapUsed` trend across saves. A rising trend ⇒ a true leak (memory
- *     held between saves). A flat trend ⇒ the cost is transient allocation, not retained state.
- *   - PEAK pressure: pre-GC `rss` per save. With `--no-force-gc` and a `--max-old-space-size` cap at
- *     launch, this is what crashes the process when saves outpace GC (the reported OOM).
+ * Two independent failure signals:
+ *   - RETAINED growth: post-GC `heapUsed` trend across saves. Rising ⇒ a true leak (memory held
+ *     between saves), flat ⇒ transient allocation.
+ *   - PEAK pressure: pre-GC `rss` per save. Under `--no-force-gc` and a `--max-old-space-size` cap,
+ *     this is what crashes the process when saves outpace GC (the reported OOM).
  *
  * Modes:
- *   --mode refresh  call manager.batchExtract(allEntries) synchronously each save. Mirrors the docgen
+ *   --mode refresh  synchronous manager.batchExtract(allEntries) each save. Mirrors the docgen
  *                   open-service "refresh all extracted components" path (server.ts).
  *   --mode live     many per-component batchExtract calls on the shared program, mirroring the
- *                   docs-addon per-edit wave that drives the #35260 OOM. The program-recycle fix bounds
- *                   this path. Use --recycle off to assert the OOM still happens without the fix.
+ *                   docs-addon per-edit wave that drives the #35260 OOM. The program-recycle fix
+ *                   bounds this path; use --recycle off to assert the OOM still happens without it.
  *
  * Run (diagnose retained vs transient):
  *   node --expose-gc --import jiti/register scripts/bench/docgen-memory/memory-harness.ts \
@@ -36,28 +35,23 @@ import * as path from 'node:path';
 
 import ts from 'typescript';
 
-import { SANDBOX_DIRECTORY } from '../../utils/constants.ts';
-import { componentSource, generateProject } from './generate-project.ts';
+import { z } from 'zod';
 
-/**
- * Minimal structural view of the entry shape consumed by `ComponentMetaManager.batchExtract`. Kept
- * local so the `scripts` typecheck does not descend into `code/renderers` internals; the real types
- * live in `code/renderers/react/src/componentManifest`.
- */
-interface StoryRef {
-  storyPath: string;
-  component: {
-    componentName: string;
-    importName: string;
-    localImportName: string;
-    importId: string;
-    isPackage: boolean;
-    path: string;
-  };
-}
+import { countOption, parseHarnessOptions } from '../docgen-shared/args.ts';
+import { SANDBOX_DIRECTORY } from '../docgen-shared/paths.ts';
+import { type StoryRefLike, loadReactRendererModule } from '../docgen-shared/react-renderer-module.ts';
+import { MB, gcAvailable } from '../docgen-shared/sampling.ts';
+import {
+  type SeriesEngine,
+  harnessMain,
+  printSeriesSummary,
+  runSeries,
+} from '../docgen-shared/series.ts';
+import { leastSquaresSlope } from '../docgen-shared/stats.ts';
+import { buildStoryRefs, componentSource, generateProject } from './generate-project.ts';
 
 interface ComponentMetaManagerLike {
-  batchExtract(entries: StoryRef[]): void;
+  batchExtract(entries: StoryRefLike[]): void;
   onFilesChanged(changes: Array<{ filePath: string; type: 'changed' | 'created' | 'deleted' }>): void;
   dispose(): void;
 }
@@ -67,35 +61,24 @@ type ComponentMetaManagerCtor = new (
   recycleHeapPressureRatio?: number
 ) => ComponentMetaManagerLike;
 
+const MODES = ['refresh', 'live'] as const;
 /**
- * Load the real `ComponentMetaManager` at runtime. The specifier is built with `new URL` so the
- * static `scripts` typecheck does not pull `code/renderers` source into its program.
+ * Which entries to re-extract per save: `all` re-extracts every component (the docgen service
+ * refreshing on an empty change hint), `changed` re-extracts only the component whose file changed.
  */
-async function loadComponentMetaManager(): Promise<ComponentMetaManagerCtor> {
-  const url = new URL(
-    '../../../code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts',
-    import.meta.url
-  ).href;
-  const mod = (await import(url)) as { ComponentMetaManager: ComponentMetaManagerCtor };
-  return mod.ComponentMetaManager;
-}
+const SCOPES = ['all', 'changed'] as const;
+const RECYCLE = ['on', 'off'] as const;
 
 interface HarnessOptions {
   components: number;
   variants: number;
   props: number;
   saves: number;
-  mode: 'refresh' | 'live';
+  mode: (typeof MODES)[number];
   heavyTypes: boolean;
   heavyFactor: number;
   base64Kb: number;
-  /**
-   * Which entries to re-extract per save.
-   *   all     – re-extract every component each save (the docgen service refreshing all extracted
-   *             components on an empty change hint).
-   *   changed – re-extract only the component whose file changed.
-   */
-  scope: 'all' | 'changed';
+  scope: (typeof SCOPES)[number];
   forceGc: boolean;
   outDir: string;
   reuse: boolean;
@@ -104,120 +87,114 @@ interface HarnessOptions {
   maxRetainedGrowthMb: number;
   /**
    * Heap-pressure ratio forwarded to `ComponentMetaManager`. `Infinity` disables program recycling
-   * (the negative control: assert the OOM happens without the fix). `undefined` uses the product
-   * default.
+   * (negative control), `undefined` uses the product default.
    */
   recycleHeapPressureRatio?: number;
 }
 
-interface Sample {
-  save: number;
-  rssMb: number;
-  heapUsedMb: number;
-  retainedHeapMb?: number;
-}
+const OPTIONS = {
+  components: { type: 'string' },
+  variants: { type: 'string' },
+  props: { type: 'string' },
+  saves: { type: 'string' },
+  mode: { type: 'string' },
+  scope: { type: 'string' },
+  recycle: { type: 'string' },
+  heavy: { type: 'boolean' },
+  'heavy-factor': { type: 'string' },
+  'base64-kb': { type: 'string' },
+  'no-force-gc': { type: 'boolean' },
+  out: { type: 'string' },
+  reuse: { type: 'boolean' },
+  json: { type: 'string' },
+  'max-retained-growth': { type: 'string' },
+} as const;
 
-const MB = 1024 * 1024;
+const SCHEMA = z.object({
+  components: countOption(600),
+  variants: countOption(4),
+  props: countOption(8),
+  saves: countOption(25),
+  mode: z.enum(MODES).default('refresh'),
+  scope: z.enum(SCOPES).default('all'),
+  // `Infinity` disables program recycling; `undefined` leaves the product default in place.
+  recycleHeapPressureRatio: z
+    .enum(RECYCLE)
+    .default('on')
+    .transform((recycle) => (recycle === 'off' ? Number.POSITIVE_INFINITY : undefined)),
+  heavyTypes: z.boolean().default(false),
+  heavyFactor: countOption(1),
+  base64Kb: countOption(0),
+  forceGc: z.boolean().default(true),
+  outDir: z.string().default(path.join(SANDBOX_DIRECTORY, 'docgen-memory-stress')),
+  reuse: z.boolean().default(false),
+  jsonOut: z.string().optional(),
+  maxRetainedGrowthMb: countOption(400),
+});
 
-function parseArgs(argv: string[]): HarnessOptions {
-  const get = (flag: string, fallback: string) => {
-    const idx = argv.indexOf(flag);
-    return idx >= 0 && argv[idx + 1] ? argv[idx + 1] : fallback;
-  };
-  const mode = get('--mode', 'refresh');
-  if (mode !== 'refresh' && mode !== 'live') {
-    throw new Error(`--mode must be "refresh" or "live", got "${mode}"`);
-  }
-  const scope = get('--scope', 'all');
-  if (scope !== 'all' && scope !== 'changed') {
-    throw new Error(`--scope must be "all" or "changed", got "${scope}"`);
-  }
-  const recycle = get('--recycle', 'on');
-  if (recycle !== 'on' && recycle !== 'off') {
-    throw new Error(`--recycle must be "on" or "off", got "${recycle}"`);
-  }
-  return {
-    components: Number(get('--components', '600')),
-    variants: Number(get('--variants', '4')),
-    props: Number(get('--props', '8')),
-    saves: Number(get('--saves', '25')),
-    mode,
-    scope: scope as 'all' | 'changed',
-    recycleHeapPressureRatio: recycle === 'off' ? Number.POSITIVE_INFINITY : undefined,
-    heavyTypes: argv.includes('--heavy'),
-    heavyFactor: Number(get('--heavy-factor', '1')),
-    base64Kb: Number(get('--base64-kb', '0')),
-    forceGc: !argv.includes('--no-force-gc'),
-    outDir: get('--out', path.join(SANDBOX_DIRECTORY, 'docgen-memory-stress')),
-    reuse: argv.includes('--reuse'),
-    jsonOut: argv.indexOf('--json') >= 0 ? get('--json', '') : undefined,
-    maxRetainedGrowthMb: Number(get('--max-retained-growth', '400')),
-  };
-}
-
-function gc(): void {
-  if (typeof global.gc === 'function') {
-    global.gc();
-    global.gc();
-  }
-}
-
-function sampleMemory(forceGc: boolean): { rssMb: number; heapUsedMb: number; retainedHeapMb?: number } {
-  const pre = process.memoryUsage();
-  let retainedHeapMb: number | undefined;
-  if (forceGc) {
-    gc();
-    retainedHeapMb = process.memoryUsage().heapUsed / MB;
-  }
-  return { rssMb: pre.rss / MB, heapUsedMb: pre.heapUsed / MB, retainedHeapMb };
-}
-
-/** Least-squares slope of `values` vs index, in units-per-save. */
-function slopePerSave(values: number[]): number {
-  const n = values.length;
-  if (n < 2) {
-    return 0;
-  }
-  const meanX = (n - 1) / 2;
-  const meanY = values.reduce((a, b) => a + b, 0) / n;
-  let num = 0;
-  let den = 0;
-  for (let i = 0; i < n; i++) {
-    num += (i - meanX) * (values[i] - meanY);
-    den += (i - meanX) ** 2;
-  }
-  return den === 0 ? 0 : num / den;
-}
-
-function buildEntries(componentPaths: string[], storyPaths: string[]): StoryRef[] {
-  return componentPaths.map((componentPath, i) => ({
-    storyPath: storyPaths[i],
-    component: {
-      componentName: `Comp${i}`,
-      importName: `Comp${i}`,
-      localImportName: `Comp${i}`,
-      importId: `./Comp${i}`,
-      isPackage: false,
-      path: componentPath,
-    },
+function parseOptions(argv: string[]): HarnessOptions {
+  return parseHarnessOptions<HarnessOptions>(argv, OPTIONS, SCHEMA, (values) => ({
+    ...values,
+    recycleHeapPressureRatio: values.recycle,
+    heavyTypes: values.heavy,
+    forceGc: !values.noForceGc,
+    outDir: values.out,
+    jsonOut: values.json,
+    // The schema key carries the unit the flag name leaves off, so camel-casing alone misses it.
+    maxRetainedGrowthMb: values.maxRetainedGrowth,
   }));
 }
 
 /**
- * Live-path mode: mirrors the docs-addon per-edit "waves" that drive the #35260 OOM — many
- * individual per-component `batchExtract` calls on the ONE shared program, whose type-resolution
- * cache accumulates across calls. This is the exact shape the program-recycle fix bounds (the
- * recycle check runs between calls), unlike the `--scope all` single-call cold pass which OOMs
- * within one call regardless of recycling.
- *
- * Run under a `--max-old-space-size` cap:
- *   - recycle on (default): the heap sawtooths as the shared program is recycled, and survives.
- *   - `--recycle off` (ratio Infinity): the type cache climbs to the cap and the process OOMs —
- *     the negative control the gate asserts.
+ * Loaded via `new URL` at runtime, not a static import, so the `scripts` typecheck does not pull
+ * `code/renderers` source into its program.
+ */
+async function loadComponentMetaManager(): Promise<ComponentMetaManagerCtor> {
+  const mod = await loadReactRendererModule<{ ComponentMetaManager: ComponentMetaManagerCtor }>(
+    'componentMeta/ComponentMetaManager.ts'
+  );
+  return mod.ComponentMetaManager;
+}
+
+function resolveProject(options: HarnessOptions): ReturnType<typeof generateProject> {
+  const outDir = path.resolve(options.outDir);
+  const configPath = path.join(outDir, 'tsconfig.json');
+
+  if (options.reuse && fs.existsSync(configPath)) {
+    const componentPaths: string[] = [];
+    const storyPaths: string[] = [];
+    for (let i = 0; i < options.components; i++) {
+      componentPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.tsx`));
+      storyPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.stories.tsx`));
+    }
+    console.log(`  reusing generated project at ${outDir}`);
+    return { outDir, configPath, componentPaths, storyPaths };
+  }
+
+  const genStart = Date.now();
+  const project = generateProject({
+    outDir: options.outDir,
+    components: options.components,
+    variants: options.variants,
+    props: options.props,
+    heavyTypes: options.heavyTypes,
+    heavyFactor: options.heavyFactor,
+    base64Kb: options.base64Kb,
+    withNodeModules: true,
+  });
+  console.log(`  generated project in ${Date.now() - genStart}ms at ${project.outDir}`);
+  return project;
+}
+
+/**
+ * Unlike the `--scope all` single-call cold pass (which OOMs within one call regardless of
+ * recycling), the recycle check runs between the per-component calls here, so under a heap cap:
+ * recycle on sawtooths and survives, `--recycle off` climbs to the cap and OOMs (the negative
+ * control the gate asserts).
  */
 function runLiveMode(
   manager: ComponentMetaManagerLike,
-  entries: StoryRef[],
+  entries: StoryRefLike[],
   options: HarnessOptions
 ): void {
   const recycleEnabled = options.recycleHeapPressureRatio === undefined;
@@ -257,157 +234,101 @@ function runLiveMode(
   }
 }
 
-async function main() {
-  const options = parseArgs(process.argv.slice(2));
-  const gcAvailable = typeof global.gc === 'function';
+/**
+ * The cold pass is the *identical* operation a `scope=all` refresh save performs
+ * (extractPropsFromStories over every entry), so an OOM there is the same OOM every refresh-all
+ * save would hit.
+ */
+function refreshEngine(
+  manager: ComponentMetaManagerLike,
+  entries: StoryRefLike[],
+  project: ReturnType<typeof generateProject>,
+  options: HarnessOptions
+): SeriesEngine {
+  // Track how many extra props each component currently has, so each save grows the type.
+  const extraByComponent = new Array<number>(options.components).fill(options.props);
+  const changedIndex = (save: number) => (save - 1) % options.components;
+
+  return {
+    async cold() {
+      manager.batchExtract(entries);
+      return undefined;
+    },
+    async applySave(save) {
+      const i = changedIndex(save);
+      const componentPath = project.componentPaths[i];
+      // Mutate the component's props interface on disk so the type genuinely changes.
+      extraByComponent[i] += 1;
+      fs.writeFileSync(
+        componentPath,
+        componentSource(i, extraByComponent[i], {
+          heavyTypes: options.heavyTypes,
+          heavyFactor: options.heavyFactor,
+          base64Kb: options.base64Kb,
+        })
+      );
+      // Must run after the write, or the program serves a stale snapshot for this file.
+      manager.onFilesChanged([{ filePath: componentPath, type: 'changed' }]);
+    },
+    async reextract(save) {
+      manager.batchExtract(options.scope === 'changed' ? [entries[changedIndex(save)]] : entries);
+      return undefined;
+    },
+    dispose: () => manager.dispose(),
+  };
+}
+
+harnessMain(async () => {
+  const options = parseOptions(process.argv.slice(2));
 
   console.log('docgen-memory harness');
   console.log(
     `  components=${options.components} variants=${options.variants} props=${options.props} ` +
-      `saves=${options.saves} mode=${options.mode} scope=${options.scope} forceGc=${options.forceGc && gcAvailable}`
+      `saves=${options.saves} mode=${options.mode} scope=${options.scope} ` +
+      `forceGc=${options.forceGc && gcAvailable()}`
   );
-  if (options.forceGc && !gcAvailable) {
+  if (options.forceGc && !gcAvailable()) {
     console.log('  (run with `node --expose-gc` to measure retained heap; continuing without it)');
   }
 
-  const genStart = Date.now();
-  let project: ReturnType<typeof generateProject>;
-  if (options.reuse && fs.existsSync(path.join(path.resolve(options.outDir), 'tsconfig.json'))) {
-    const outDir = path.resolve(options.outDir);
-    const componentPaths: string[] = [];
-    const storyPaths: string[] = [];
-    for (let i = 0; i < options.components; i++) {
-      componentPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.tsx`));
-      storyPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.stories.tsx`));
-    }
-    project = { outDir, configPath: path.join(outDir, 'tsconfig.json'), componentPaths, storyPaths };
-    console.log(`  reusing generated project at ${outDir}`);
-  } else {
-    project = generateProject({
-      outDir: options.outDir,
-      components: options.components,
-      variants: options.variants,
-      props: options.props,
-      heavyTypes: options.heavyTypes,
-      heavyFactor: options.heavyFactor,
-      base64Kb: options.base64Kb,
-      withNodeModules: true,
-    });
-    console.log(`  generated project in ${Date.now() - genStart}ms at ${project.outDir}`);
-  }
-
+  const project = resolveProject(options);
   const ComponentMetaManager = await loadComponentMetaManager();
   const manager = new ComponentMetaManager(ts, options.recycleHeapPressureRatio);
-  const entries = buildEntries(project.componentPaths, project.storyPaths);
+  const entries = buildStoryRefs(project.componentPaths, project.storyPaths);
 
   if (options.mode === 'live') {
     runLiveMode(manager, entries, options);
     return;
   }
 
-  // Initial extraction — builds the full TS program once (the cold path). This is the *identical*
-  // operation a `scope=all` refresh save performs (extractPropsFromStories over every entry), so an
-  // OOM here is the same OOM every refresh-all save would hit; it simply lands on the first pass when
-  // the full-extraction working set already exceeds the heap cap.
-  const initialStart = Date.now();
-  console.log(`  full extraction over ${entries.length} components (cold pass == refresh-all save)…`);
-  manager.batchExtract(entries);
-  console.log(`  initial batchExtract: ${Date.now() - initialStart}ms`);
+  const series = await runSeries(refreshEngine(manager, entries, project, options), {
+    saves: options.saves,
+    coldLabel: `${entries.length} components`,
+    forceGc: options.forceGc,
+  });
 
-  const baseline = sampleMemory(options.forceGc && gcAvailable);
-  console.log(
-    `  baseline: rss=${baseline.rssMb.toFixed(0)}MB heapUsed=${baseline.heapUsedMb.toFixed(0)}MB` +
-      (baseline.retainedHeapMb !== undefined
-        ? ` retained=${baseline.retainedHeapMb.toFixed(0)}MB`
-        : '')
-  );
+  const rssValues = series.samples.map((s) => s.rssMb);
+  const peakRss = Math.max(series.baseline.rssMb, ...rssValues);
+  const finalRss = rssValues.at(-1) ?? series.baseline.rssMb;
+  const rssSlope = leastSquaresSlope(rssValues);
+  const { retainedGrowth } = series;
 
-  const samples: Sample[] = [];
-  // Track how many extra props each component currently has, so each save grows the type.
-  const extraByComponent = new Array(options.components).fill(options.props);
-
-  for (let save = 1; save <= options.saves; save++) {
-    const i = (save - 1) % options.components;
-    const componentPath = project.componentPaths[i];
-
-    // Mutate the component's props interface on disk so the type genuinely changes.
-    extraByComponent[i] += 1;
-    fs.writeFileSync(
-      componentPath,
-      componentSource(i, extraByComponent[i], {
-        heavyTypes: options.heavyTypes,
-        heavyFactor: options.heavyFactor,
-        base64Kb: options.base64Kb,
-      })
-    );
-    // Bump project versions so the next extraction re-reads the mutated file (matches the dev
-    // server's file-watcher → onFilesChanged flow); without this the program serves stale snapshots.
-    manager.onFilesChanged([{ filePath: componentPath, type: 'changed' }]);
-
-    const saveStart = Date.now();
-    const toExtract = options.scope === 'changed' ? [entries[i]] : entries;
-    manager.batchExtract(toExtract);
-    const durMs = Date.now() - saveStart;
-
-    const mem = sampleMemory(options.forceGc && gcAvailable);
-    samples.push({ save, ...mem });
-    console.log(
-      `  save ${String(save).padStart(3)}: ${String(durMs).padStart(5)}ms  ` +
-        `rss=${mem.rssMb.toFixed(0).padStart(5)}MB  heapUsed=${mem.heapUsedMb.toFixed(0).padStart(5)}MB` +
-        (mem.retainedHeapMb !== undefined
-          ? `  retained=${mem.retainedHeapMb.toFixed(0).padStart(5)}MB`
-          : '')
-    );
-  }
-
-  manager.dispose();
-
-  const rssValues = samples.map((s) => s.rssMb);
-  const peakRss = Math.max(baseline.rssMb, ...rssValues);
-  const finalRss = rssValues.at(-1) ?? baseline.rssMb;
-  const rssSlope = slopePerSave(rssValues);
-
-  const retainedValues = samples
-    .map((s) => s.retainedHeapMb)
-    .filter((v): v is number => v !== undefined);
-  const retainedSlope = retainedValues.length ? slopePerSave(retainedValues) : undefined;
-  const retainedGrowth =
-    retainedValues.length && baseline.retainedHeapMb !== undefined
-      ? (retainedValues.at(-1) as number) - baseline.retainedHeapMb
-      : undefined;
-
-  const transients = samples
-    .map((s) => (s.retainedHeapMb !== undefined ? s.heapUsedMb - s.retainedHeapMb : undefined))
-    .filter((v): v is number => v !== undefined);
-  const avgTransient = transients.length
-    ? transients.reduce((a, b) => a + b, 0) / transients.length
-    : undefined;
-
-  console.log('\nsummary');
+  printSeriesSummary(series, options.saves);
   console.log(`  peak rss:            ${peakRss.toFixed(0)}MB`);
-  if (avgTransient !== undefined) {
-    console.log(`  avg transient/save:  ${avgTransient.toFixed(0)}MB (pre-GC heapUsed − post-GC heapUsed)`);
-  }
   console.log(`  final rss:           ${finalRss.toFixed(0)}MB`);
   console.log(`  rss slope:           ${rssSlope.toFixed(1)}MB/save`);
-  if (retainedSlope !== undefined) {
-    console.log(`  retained slope:      ${retainedSlope.toFixed(2)}MB/save (post-GC heapUsed)`);
-    console.log(`  retained growth:     ${retainedGrowth!.toFixed(0)}MB over ${options.saves} saves`);
+  if (retainedGrowth !== undefined) {
     console.log(
-      retainedGrowth! > 5
+      retainedGrowth > 5
         ? '  → classification:    RETAINED leak (memory held between saves)'
-        : '  → classification:    TRANSIENT pressure (post-GC heap flat; OOM is GC-can\'t-keep-up)'
+        : "  → classification:    TRANSIENT pressure (post-GC heap flat; OOM is GC-can't-keep-up)"
     );
   }
 
   if (options.jsonOut) {
     fs.writeFileSync(
       options.jsonOut,
-      JSON.stringify(
-        { options, baseline, samples, peakRss, finalRss, rssSlope, retainedSlope, retainedGrowth, avgTransient },
-        null,
-        2
-      )
+      JSON.stringify({ options, ...series, peakRss, finalRss, rssSlope }, null, 2)
     );
     console.log(`  wrote ${options.jsonOut}`);
   }
@@ -418,9 +339,4 @@ async function main() {
     );
     process.exitCode = 1;
   }
-}
-
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
 });

--- a/scripts/bench/docgen-memory/memory-harness.ts
+++ b/scripts/bench/docgen-memory/memory-harness.ts
@@ -69,29 +69,6 @@ const MODES = ['refresh', 'live'] as const;
 const SCOPES = ['all', 'changed'] as const;
 const RECYCLE = ['on', 'off'] as const;
 
-interface HarnessOptions {
-  components: number;
-  variants: number;
-  props: number;
-  saves: number;
-  mode: (typeof MODES)[number];
-  heavyTypes: boolean;
-  heavyFactor: number;
-  base64Kb: number;
-  scope: (typeof SCOPES)[number];
-  forceGc: boolean;
-  outDir: string;
-  reuse: boolean;
-  jsonOut?: string;
-  /** Fail the process when post-GC retained growth exceeds this many MB across the run. */
-  maxRetainedGrowthMb: number;
-  /**
-   * Heap-pressure ratio forwarded to `ComponentMetaManager`. `Infinity` disables program recycling
-   * (negative control), `undefined` uses the product default.
-   */
-  recycleHeapPressureRatio?: number;
-}
-
 const OPTIONS = {
   components: { type: 'string' },
   variants: { type: 'string' },
@@ -107,7 +84,6 @@ const OPTIONS = {
   out: { type: 'string' },
   reuse: { type: 'boolean' },
   json: { type: 'string' },
-  'max-retained-growth': { type: 'string' },
 } as const;
 
 const SCHEMA = z.object({
@@ -129,8 +105,9 @@ const SCHEMA = z.object({
   outDir: z.string().default(path.join(SANDBOX_DIRECTORY, 'docgen-memory-stress')),
   reuse: z.boolean().default(false),
   jsonOut: z.string().optional(),
-  maxRetainedGrowthMb: countOption(400),
 });
+
+type HarnessOptions = z.infer<typeof SCHEMA>;
 
 function parseOptions(argv: string[]): HarnessOptions {
   return parseHarnessOptions<HarnessOptions>(argv, OPTIONS, SCHEMA, (values) => ({
@@ -140,8 +117,6 @@ function parseOptions(argv: string[]): HarnessOptions {
     forceGc: !values.noForceGc,
     outDir: values.out,
     jsonOut: values.json,
-    // The schema key carries the unit the flag name leaves off, so camel-casing alone misses it.
-    maxRetainedGrowthMb: values.maxRetainedGrowth,
   }));
 }
 
@@ -331,12 +306,5 @@ harnessMain(async () => {
       JSON.stringify({ options, ...series, peakRss, finalRss, rssSlope }, null, 2)
     );
     console.log(`  wrote ${options.jsonOut}`);
-  }
-
-  if (retainedGrowth !== undefined && retainedGrowth > options.maxRetainedGrowthMb) {
-    console.error(
-      `\nFAIL: retained growth ${retainedGrowth.toFixed(0)}MB exceeds threshold ${options.maxRetainedGrowthMb}MB`
-    );
-    process.exitCode = 1;
   }
 });

--- a/scripts/bench/docgen-memory/memory-harness.ts
+++ b/scripts/bench/docgen-memory/memory-harness.ts
@@ -37,7 +37,7 @@ import ts from 'typescript';
 
 import { z } from 'zod';
 
-import { countOption, parseHarnessOptions } from '../docgen-shared/args.ts';
+import { countOption, parseHarnessOptions, positiveCountOption } from '../docgen-shared/args.ts';
 import { SANDBOX_DIRECTORY } from '../docgen-shared/paths.ts';
 import { type StoryRefLike, loadReactRendererModule } from '../docgen-shared/react-renderer-module.ts';
 import { MB, gcAvailable } from '../docgen-shared/sampling.ts';
@@ -99,7 +99,7 @@ const SCHEMA = z.object({
     .default('on')
     .transform((recycle) => (recycle === 'off' ? Number.POSITIVE_INFINITY : undefined)),
   heavyTypes: z.boolean().default(false),
-  heavyFactor: countOption(1),
+  heavyFactor: positiveCountOption(1),
   base64Kb: countOption(0),
   forceGc: z.boolean().default(true),
   outDir: z.string().default(path.join(SANDBOX_DIRECTORY, 'docgen-memory-stress')),

--- a/scripts/bench/docgen-shared/args.test.ts
+++ b/scripts/bench/docgen-shared/args.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { countOption, parseHarnessOptions } from './args.ts';
+
+const OPTIONS = {
+  components: { type: 'string' },
+  scope: { type: 'string' },
+  heavy: { type: 'boolean' },
+  out: { type: 'string' },
+  'components-per-package': { type: 'string' },
+  'max-retained-growth': { type: 'string' },
+} as const;
+
+const SCHEMA = z.object({
+  components: countOption(300),
+  scope: z.enum(['all', 'changed']).default('changed'),
+  heavy: z.boolean().default(false),
+  outDir: z.string().default('/default'),
+  componentsPerPackage: countOption(10),
+  maxRetainedGrowthMb: countOption(400),
+});
+
+interface Options {
+  components: number;
+  scope: 'all' | 'changed';
+  heavy: boolean;
+  outDir: string;
+  componentsPerPackage: number;
+  maxRetainedGrowthMb: number;
+}
+
+const parse = (argv: string[]) =>
+  parseHarnessOptions<Options>(argv, OPTIONS, SCHEMA, (values) => ({
+    ...values,
+    outDir: values.out,
+    maxRetainedGrowthMb: values.maxRetainedGrowth,
+  }));
+
+describe('parseHarnessOptions', () => {
+  it('applies defaults when nothing is passed', () => {
+    expect(parse([])).toEqual({
+      components: 300,
+      scope: 'changed',
+      heavy: false,
+      outDir: '/default',
+      componentsPerPackage: 10,
+      maxRetainedGrowthMb: 400,
+    });
+  });
+
+  it('coerces numeric flags', () => {
+    expect(parse(['--components', '20']).components).toBe(20);
+  });
+
+  it('maps kebab-case flags onto the schema shape', () => {
+    expect(parse(['--components-per-package', '5']).componentsPerPackage).toBe(5);
+  });
+
+  it('carries a flag whose schema key is not its camelCase', () => {
+    // `--max-retained-growth` camel-cases to `maxRetainedGrowth`, but the schema names the unit.
+    // Without the rename in `toInput` the flag is accepted and then silently ignored, which is how
+    // the memory harness lost its threshold flag once already.
+    expect(parse(['--max-retained-growth', '50']).maxRetainedGrowthMb).toBe(50);
+  });
+
+  it('reads boolean flags', () => {
+    expect(parse(['--heavy']).heavy).toBe(true);
+  });
+
+  it('rejects an unknown flag', () => {
+    // The reason for strict mode: `--component 5` would otherwise be dropped silently and the
+    // harness would benchmark 300 components while reporting a run someone asked for at 5.
+    expect(() => parse(['--component', '5'])).toThrow(/Unknown option/);
+  });
+
+  it('rejects a flag whose value is another flag', () => {
+    expect(() => parse(['--components', '--out', 'x'])).toThrow(/ambiguous/);
+  });
+
+  it('rejects a flag with no value at all', () => {
+    expect(() => parse(['--components'])).toThrow(/argument missing/);
+  });
+
+  it('rejects a value outside an enum, naming the flag', () => {
+    expect(() => parse(['--scope', 'some'])).toThrow(/--scope/);
+  });
+
+  describe('countOption', () => {
+    it('rejects a non-numeric value', () => {
+      expect(() => parse(['--components', 'lots'])).toThrow(/--components/);
+    });
+
+    it('rejects a fraction', () => {
+      expect(() => parse(['--components', '2.5'])).toThrow(/--components/);
+    });
+
+    it('rejects a negative', () => {
+      expect(() => parse(['--components', '-3'])).toThrow(/--components/);
+    });
+  });
+});

--- a/scripts/bench/docgen-shared/args.test.ts
+++ b/scripts/bench/docgen-shared/args.test.ts
@@ -21,17 +21,8 @@ const SCHEMA = z.object({
   maxRetainedGrowthMb: countOption(400),
 });
 
-interface Options {
-  components: number;
-  scope: 'all' | 'changed';
-  heavy: boolean;
-  outDir: string;
-  componentsPerPackage: number;
-  maxRetainedGrowthMb: number;
-}
-
 const parse = (argv: string[]) =>
-  parseHarnessOptions<Options>(argv, OPTIONS, SCHEMA, (values) => ({
+  parseHarnessOptions<z.infer<typeof SCHEMA>>(argv, OPTIONS, SCHEMA, (values) => ({
     ...values,
     outDir: values.out,
     maxRetainedGrowthMb: values.maxRetainedGrowth,
@@ -59,8 +50,8 @@ describe('parseHarnessOptions', () => {
 
   it('carries a flag whose schema key is not its camelCase', () => {
     // `--max-retained-growth` camel-cases to `maxRetainedGrowth`, but the schema names the unit.
-    // Without the rename in `toInput` the flag is accepted and then silently ignored, which is how
-    // the memory harness lost its threshold flag once already.
+    // Without the rename in `toInput` the flag is accepted and then silently ignored - the flag
+    // parses, the schema falls back to its default, and the run measures something nobody asked for.
     expect(parse(['--max-retained-growth', '50']).maxRetainedGrowthMb).toBe(50);
   });
 

--- a/scripts/bench/docgen-shared/args.test.ts
+++ b/scripts/bench/docgen-shared/args.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-import { countOption, parseHarnessOptions } from './args.ts';
+import { countOption, parseHarnessOptions, positiveCountOption } from './args.ts';
 
 const OPTIONS = {
   components: { type: 'string' },
   scope: { type: 'string' },
   heavy: { type: 'boolean' },
+  'heavy-factor': { type: 'string' },
   out: { type: 'string' },
   'components-per-package': { type: 'string' },
   'max-retained-growth': { type: 'string' },
@@ -16,6 +17,7 @@ const SCHEMA = z.object({
   components: countOption(300),
   scope: z.enum(['all', 'changed']).default('changed'),
   heavy: z.boolean().default(false),
+  heavyFactor: positiveCountOption(1),
   outDir: z.string().default('/default'),
   componentsPerPackage: countOption(10),
   maxRetainedGrowthMb: countOption(400),
@@ -34,6 +36,7 @@ describe('parseHarnessOptions', () => {
       components: 300,
       scope: 'changed',
       heavy: false,
+      heavyFactor: 1,
       outDir: '/default',
       componentsPerPackage: 10,
       maxRetainedGrowthMb: 400,
@@ -88,6 +91,20 @@ describe('parseHarnessOptions', () => {
 
     it('rejects a negative', () => {
       expect(() => parse(['--components', '-3'])).toThrow(/--components/);
+    });
+
+    it('accepts zero, which is a meaningful count for most flags', () => {
+      expect(parse(['--components', '0']).components).toBe(0);
+    });
+  });
+
+  describe('positiveCountOption', () => {
+    it('rejects zero, so a multiplier cannot be accepted and then quietly raised', () => {
+      expect(() => parse(['--heavy-factor', '0'])).toThrow(/--heavyFactor/);
+    });
+
+    it('accepts one and above', () => {
+      expect(parse(['--heavy-factor', '3']).heavyFactor).toBe(3);
     });
   });
 });

--- a/scripts/bench/docgen-shared/args.ts
+++ b/scripts/bench/docgen-shared/args.ts
@@ -9,6 +9,13 @@ export const countOption = (fallback: number) =>
   z.coerce.number().int().nonnegative().default(fallback);
 
 /**
+ * A count a run cannot be made of zero of - a multiplier, say. Rejecting it here is what stops the
+ * flag being accepted and then quietly raised to something the caller did not ask for.
+ */
+export const positiveCountOption = (fallback: number) =>
+  z.coerce.number().int().positive().default(fallback);
+
+/**
  * parseArgs keys flags as written, so `--fan-out` arrives as `fan-out`; schema keys are camelCase.
  * A schema key that is not exactly its flag's camelCase — `maxRetainedGrowthMb` for
  * `--max-retained-growth` — must still be renamed in `toInput`, or Zod silently uses its default.

--- a/scripts/bench/docgen-shared/args.ts
+++ b/scripts/bench/docgen-shared/args.ts
@@ -1,0 +1,38 @@
+import { type ParseArgsConfig, parseArgs } from 'node:util';
+
+import { z } from 'zod';
+
+type OptionsConfig = NonNullable<ParseArgsConfig['options']>;
+
+/** parseArgs yields strings, so numeric flags are coerced here */
+export const countOption = (fallback: number) =>
+  z.coerce.number().int().nonnegative().default(fallback);
+
+/**
+ * parseArgs keys flags as written, so `--fan-out` arrives as `fan-out`; schema keys are camelCase.
+ * A schema key that is not exactly its flag's camelCase — `maxRetainedGrowthMb` for
+ * `--max-retained-growth` — must still be renamed in `toInput`, or Zod silently uses its default.
+ */
+function toCamelCase(flag: string): string {
+  return flag.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+export function parseHarnessOptions<Out>(
+  argv: string[],
+  options: OptionsConfig,
+  schema: z.ZodTypeAny,
+  toInput?: (values: Record<string, unknown>) => Record<string, unknown>
+): Out {
+  const { values } = parseArgs({ args: argv, options, strict: true });
+  const flags = Object.fromEntries(
+    Object.entries(values).map(([flag, value]) => [toCamelCase(flag), value])
+  );
+  const result = schema.safeParse(toInput ? toInput(flags) : flags);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `  --${issue.path.join('.')}: ${issue.message}`)
+      .join('\n');
+    throw new Error(`invalid options:\n${issues}`);
+  }
+  return result.data as Out;
+}

--- a/scripts/bench/docgen-shared/args.ts
+++ b/scripts/bench/docgen-shared/args.ts
@@ -17,6 +17,14 @@ function toCamelCase(flag: string): string {
   return flag.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
 }
 
+/**
+ * `Out` is asserted rather than inferred from the schema, which is not the obvious choice: returning
+ * `z.infer<Schema>` would make the two check against each other. It does not work here. `scripts`
+ * compiles with `strictNullChecks: false`, and under that flag Zod's `addQuestionMarks` finds no
+ * required keys, so every inferred field comes back optional and satisfies no caller's option type.
+ * Prefer `type Options = z.infer<typeof SCHEMA>` at the call site where the schema is the whole
+ * contract - that removes the second declaration this cast could drift from.
+ */
 export function parseHarnessOptions<Out>(
   argv: string[],
   options: OptionsConfig,

--- a/scripts/bench/docgen-shared/budgets.ts
+++ b/scripts/bench/docgen-shared/budgets.ts
@@ -1,0 +1,22 @@
+import type { EngineId } from './engine-ids.ts';
+
+export interface MemoryBudgets {
+  /** Max allowed post-GC retained growth (MB) across the run. */
+  maxRetainedGrowthMb: number;
+  /** Max allowed average transient working set added per save (MB). */
+  maxTransientMb: number;
+  /** Max allowed post-GC retained-heap slope (MB/save). */
+  maxRetainedSlopeMb: number;
+}
+
+const MEMORY_BUDGETS: Partial<Record<EngineId, MemoryBudgets>> = {
+  'react-osa': { maxRetainedGrowthMb: 60, maxTransientMb: 90, maxRetainedSlopeMb: 3 },
+};
+
+export function memoryBudgetsFor(engine: EngineId): MemoryBudgets {
+  const budgets = MEMORY_BUDGETS[engine];
+  if (!budgets) {
+    throw new Error(`no memory budgets recorded for "${engine}"`);
+  }
+  return budgets;
+}

--- a/scripts/bench/docgen-shared/child-output.ts
+++ b/scripts/bench/docgen-shared/child-output.ts
@@ -1,0 +1,8 @@
+export function outputTail(output: string, count: number): string {
+  return output
+    .trim()
+    .split('\n')
+    .slice(-count)
+    .map((line) => `    ${line}`)
+    .join('\n');
+}

--- a/scripts/bench/docgen-shared/engine-ids.ts
+++ b/scripts/bench/docgen-shared/engine-ids.ts
@@ -1,0 +1,4 @@
+/**
+ * The docgen engines under measurement. Each engine adds its own id when it lands.
+ */
+export type EngineId = 'react-osa';

--- a/scripts/bench/docgen-shared/paths.ts
+++ b/scripts/bench/docgen-shared/paths.ts
@@ -1,0 +1,13 @@
+/**
+ * Mirrors SANDBOX_DIRECTORY from scripts/utils/constants.ts. That module deliberately stays on the
+ * CJS-only `__dirname` global for Playwright compatibility, so the native-Node harness entry points
+ * here cannot import it.
+ */
+import * as path from 'node:path';
+
+const ROOT_DIRECTORY = path.join(import.meta.dirname, '..', '..', '..');
+
+export const SANDBOX_DIRECTORY =
+  process.env.STORYBOOK_SANDBOX_ROOT && path.isAbsolute(process.env.STORYBOOK_SANDBOX_ROOT)
+    ? process.env.STORYBOOK_SANDBOX_ROOT
+    : path.join(ROOT_DIRECTORY, process.env.STORYBOOK_SANDBOX_ROOT || '../storybook-sandboxes');

--- a/scripts/bench/docgen-shared/paths.ts
+++ b/scripts/bench/docgen-shared/paths.ts
@@ -1,13 +1,14 @@
 /**
- * Mirrors SANDBOX_DIRECTORY from scripts/utils/constants.ts. That module deliberately stays on the
- * CJS-only `__dirname` global for Playwright compatibility, so the native-Node harness entry points
- * here cannot import it.
+ * Mirrors SANDBOX_DIRECTORY from scripts/utils/constants.ts rather than importing it. That module
+ * reaches the repo root through the CJS-only `__dirname`, which Playwright's transpilation supplies
+ * for its own importers; the harness entry points here run as native ESM, where importing it throws
+ * `ReferenceError: __dirname is not defined in ES module scope`.
  */
-import * as path from 'node:path';
+import { isAbsolute, join } from 'node:path';
 
-const ROOT_DIRECTORY = path.join(import.meta.dirname, '..', '..', '..');
+const ROOT_DIRECTORY = join(import.meta.dirname, '..', '..', '..');
 
 export const SANDBOX_DIRECTORY =
-  process.env.STORYBOOK_SANDBOX_ROOT && path.isAbsolute(process.env.STORYBOOK_SANDBOX_ROOT)
+  process.env.STORYBOOK_SANDBOX_ROOT && isAbsolute(process.env.STORYBOOK_SANDBOX_ROOT)
     ? process.env.STORYBOOK_SANDBOX_ROOT
-    : path.join(ROOT_DIRECTORY, process.env.STORYBOOK_SANDBOX_ROOT || '../storybook-sandboxes');
+    : join(ROOT_DIRECTORY, process.env.STORYBOOK_SANDBOX_ROOT || '../storybook-sandboxes');

--- a/scripts/bench/docgen-shared/react-renderer-module.ts
+++ b/scripts/bench/docgen-shared/react-renderer-module.ts
@@ -1,7 +1,27 @@
-const COMPONENT_MANIFEST = '../../../code/renderers/react/src/componentManifest/';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * The React harnesses measure the renderer's own extraction code, so they load it from source
+ * rather than through the package's published surface.
+ *
+ * Joined as a path rather than concatenated into a URL: string concatenation only happens to work
+ * while the directory ends in a separator and the caller's argument does not begin with one.
+ */
+const COMPONENT_MANIFEST = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  '..',
+  'code',
+  'renderers',
+  'react',
+  'src',
+  'componentManifest'
+);
 
 export async function loadReactRendererModule<T>(relativePath: string): Promise<T> {
-  const url = new URL(`${COMPONENT_MANIFEST}${relativePath}`, import.meta.url).href;
+  const url = pathToFileURL(join(COMPONENT_MANIFEST, relativePath)).href;
   return (await import(url)) as T;
 }
 

--- a/scripts/bench/docgen-shared/react-renderer-module.ts
+++ b/scripts/bench/docgen-shared/react-renderer-module.ts
@@ -1,0 +1,20 @@
+const COMPONENT_MANIFEST = '../../../code/renderers/react/src/componentManifest/';
+
+export async function loadReactRendererModule<T>(relativePath: string): Promise<T> {
+  const url = new URL(`${COMPONENT_MANIFEST}${relativePath}`, import.meta.url).href;
+  return (await import(url)) as T;
+}
+
+export interface ComponentRefLike {
+  componentName: string;
+  importName: string;
+  localImportName: string;
+  importId: string;
+  isPackage: boolean;
+  path: string;
+}
+
+export interface StoryRefLike {
+  storyPath: string;
+  component: ComponentRefLike;
+}

--- a/scripts/bench/docgen-shared/samples.ts
+++ b/scripts/bench/docgen-shared/samples.ts
@@ -1,0 +1,15 @@
+export interface MemorySample {
+  /** Resident Set Size, the total memory allocated for the process. */
+  rssMb: number;
+  /** The V8 heap used by the process. */
+  heapUsedMb: number;
+  /** Post-GC heap. Present only when the child runs under `node --expose-gc`. */
+  retainedHeapMb?: number;
+}
+
+export interface SaveSample extends MemorySample {
+  /** The save number, counting from 1. */
+  save: number;
+  /** The duration of the save's re-extraction, in milliseconds. */
+  durMs: number;
+}

--- a/scripts/bench/docgen-shared/sampling.ts
+++ b/scripts/bench/docgen-shared/sampling.ts
@@ -30,7 +30,7 @@ export function sampleMemory(forceGc: boolean): MemorySample {
 /** The one per-save log line every harness prints, so their output stays comparable by eye. */
 export function formatSampleLine(save: number, durMs: number, mem: MemorySample): string {
   return (
-    `  save ${String(save).padStart(3)}: ${String(durMs).padStart(5)}ms  ` +
+    `  save ${String(save).padStart(3)}: ${durMs.toFixed(1).padStart(7)}ms  ` +
     `rss=${mem.rssMb.toFixed(0).padStart(5)}MB  heapUsed=${mem.heapUsedMb.toFixed(0).padStart(5)}MB` +
     (mem.retainedHeapMb !== undefined
       ? `  retained=${mem.retainedHeapMb.toFixed(0).padStart(5)}MB`

--- a/scripts/bench/docgen-shared/sampling.ts
+++ b/scripts/bench/docgen-shared/sampling.ts
@@ -1,0 +1,39 @@
+/**
+ * Memory sampling shared by every docgen bench harness: pre-GC rss/heapUsed is the transient-pressure
+ * signal, post-GC heapUsed (only under `node --expose-gc`) is the retained signal.
+ */
+import type { MemorySample } from './samples.ts';
+
+export const MB = 1024 * 1024;
+
+export function gc(): void {
+  if (typeof global.gc === 'function') {
+    global.gc();
+    global.gc();
+  }
+}
+
+export function gcAvailable(): boolean {
+  return typeof global.gc === 'function';
+}
+
+export function sampleMemory(forceGc: boolean): MemorySample {
+  const pre = process.memoryUsage();
+  let retainedHeapMb: number | undefined;
+  if (forceGc && gcAvailable()) {
+    gc();
+    retainedHeapMb = process.memoryUsage().heapUsed / MB;
+  }
+  return { rssMb: pre.rss / MB, heapUsedMb: pre.heapUsed / MB, retainedHeapMb };
+}
+
+/** The one per-save log line every harness prints, so their output stays comparable by eye. */
+export function formatSampleLine(save: number, durMs: number, mem: MemorySample): string {
+  return (
+    `  save ${String(save).padStart(3)}: ${String(durMs).padStart(5)}ms  ` +
+    `rss=${mem.rssMb.toFixed(0).padStart(5)}MB  heapUsed=${mem.heapUsedMb.toFixed(0).padStart(5)}MB` +
+    (mem.retainedHeapMb !== undefined
+      ? `  retained=${mem.retainedHeapMb.toFixed(0).padStart(5)}MB`
+      : '')
+  );
+}

--- a/scripts/bench/docgen-shared/series.ts
+++ b/scripts/bench/docgen-shared/series.ts
@@ -5,7 +5,7 @@
  * differ only in what those steps mean, so they implement {@link SeriesEngine} and this module owns
  * the timing.
  */
-import * as fs from 'node:fs';
+import { writeFileSync } from 'node:fs';
 
 import type { MemorySample, SaveSample } from './samples.ts';
 import { formatSampleLine, gcAvailable, sampleMemory } from './sampling.ts';
@@ -130,7 +130,7 @@ export async function runSeriesHarness(spec: SeriesHarnessSpec): Promise<void> {
   printSeriesSummary(result, spec.saves);
 
   if (spec.jsonOut) {
-    fs.writeFileSync(spec.jsonOut, JSON.stringify({ options: spec.options, ...result }, null, 2));
+    writeFileSync(spec.jsonOut, JSON.stringify({ options: spec.options, ...result }, null, 2));
     console.log(`  wrote ${spec.jsonOut}`);
   }
 }

--- a/scripts/bench/docgen-shared/series.ts
+++ b/scripts/bench/docgen-shared/series.ts
@@ -49,11 +49,12 @@ export async function runSeries(
   const forceGc = options.forceGc ?? true;
 
   console.log(`  full extraction over ${options.coldLabel} (cold pass)…`);
-  const coldStart = Date.now();
+  const coldStart = performance.now();
   const coldMembers = await engine.cold();
-  const coldMs = Date.now() - coldStart;
+  const coldMs = performance.now() - coldStart;
   console.log(
-    `  cold pass: ${coldMs}ms` + (coldMembers !== undefined ? ` (${coldMembers} documented members)` : '')
+    `  cold pass: ${coldMs.toFixed(0)}ms` +
+      (coldMembers !== undefined ? ` (${coldMembers} documented members)` : '')
   );
 
   const baseline = sampleMemory(forceGc);
@@ -63,9 +64,12 @@ export async function runSeries(
   for (let save = 1; save <= options.saves; save++) {
     await engine.applySave(save);
 
-    const saveStart = Date.now();
+    // performance.now(), not Date.now(): a warm re-extraction of a single component runs in single
+    // -digit milliseconds, and at Date.now()'s 1ms granularity a whole series can median to 0 - a
+    // number every ratio taken against it then divides by.
+    const saveStart = performance.now();
     warmMembers = await engine.reextract(save);
-    const durMs = Date.now() - saveStart;
+    const durMs = performance.now() - saveStart;
 
     const mem = sampleMemory(forceGc);
     samples.push({ save, durMs, ...mem });
@@ -79,11 +83,11 @@ export async function runSeries(
 
 export function printSeriesSummary(result: SeriesResult, saves: number): void {
   console.log('\nsummary');
-  console.log(`  cold pass:           ${result.coldMs}ms`);
+  console.log(`  cold pass:           ${result.coldMs.toFixed(0)}ms`);
   if (result.coldMembers !== undefined) {
-    console.log(
-      `  documented members:  ${result.coldMembers} cold, ${result.warmMembers ?? 0} on the last save`
-    );
+    // `n/a` rather than 0: an engine that reports no count did not document nothing.
+    const warm = result.warmMembers ?? 'n/a';
+    console.log(`  documented members:  ${result.coldMembers} cold, ${warm} on the last save`);
   }
   if (result.avgTransient !== undefined) {
     console.log(`  avg transient/save:  ${result.avgTransient.toFixed(0)}MB`);

--- a/scripts/bench/docgen-shared/series.ts
+++ b/scripts/bench/docgen-shared/series.ts
@@ -1,0 +1,140 @@
+/**
+ * The save-series harness every docgen engine child runs:
+ * one timed cold pass, then K simulated saves that mutate the project on disk, invalidate the
+ * engine's caches, and re-extract, with memory sampled around forced GC after every save. Engines
+ * differ only in what those steps mean, so they implement {@link SeriesEngine} and this module owns
+ * the timing.
+ */
+import * as fs from 'node:fs';
+
+import type { MemorySample, SaveSample } from './samples.ts';
+import { formatSampleLine, gcAvailable, sampleMemory } from './sampling.ts';
+import { type SeriesSummary, summarizeSeries } from './stats.ts';
+
+export interface SeriesEngine {
+  /**
+   * One full extraction over the measured set, from a cold start. Returns how many members it
+   * documented, when the engine can report that; two engines over one project can differ by an order
+   * of magnitude, and a timing ratio between them means nothing without it.
+   */
+  cold(): Promise<number | undefined>;
+  /** Mutate the project on disk for save `save` and invalidate the engine's caches. Never timed. */
+  applySave(save: number): Promise<void>;
+  /** Re-extract after save `save`. This call, and only this call, is the warm sample. */
+  reextract(save: number): Promise<number | undefined>;
+  dispose?(): void;
+}
+
+export interface SeriesResult extends SeriesSummary {
+  coldMs: number;
+  coldMembers?: number;
+  /** Members documented by the last timed re-extraction. */
+  warmMembers?: number;
+  baseline: MemorySample;
+  samples: SaveSample[];
+}
+
+export interface SeriesOptions {
+  saves: number;
+  /** Describes the measured set for the cold-pass log line, e.g. "300 components". */
+  coldLabel: string;
+  /** Off only for the memory harness's uncapped pressure configs, which measure pre-GC rss. */
+  forceGc?: boolean;
+}
+
+export async function runSeries(
+  engine: SeriesEngine,
+  options: SeriesOptions
+): Promise<SeriesResult> {
+  const forceGc = options.forceGc ?? true;
+
+  console.log(`  full extraction over ${options.coldLabel} (cold pass)…`);
+  const coldStart = Date.now();
+  const coldMembers = await engine.cold();
+  const coldMs = Date.now() - coldStart;
+  console.log(
+    `  cold pass: ${coldMs}ms` + (coldMembers !== undefined ? ` (${coldMembers} documented members)` : '')
+  );
+
+  const baseline = sampleMemory(forceGc);
+  const samples: SaveSample[] = [];
+  let warmMembers: number | undefined;
+
+  for (let save = 1; save <= options.saves; save++) {
+    await engine.applySave(save);
+
+    const saveStart = Date.now();
+    warmMembers = await engine.reextract(save);
+    const durMs = Date.now() - saveStart;
+
+    const mem = sampleMemory(forceGc);
+    samples.push({ save, durMs, ...mem });
+    console.log(formatSampleLine(save, durMs, mem));
+  }
+
+  engine.dispose?.();
+
+  return { coldMs, coldMembers, warmMembers, baseline, samples, ...summarizeSeries(samples, baseline) };
+}
+
+export function printSeriesSummary(result: SeriesResult, saves: number): void {
+  console.log('\nsummary');
+  console.log(`  cold pass:           ${result.coldMs}ms`);
+  if (result.coldMembers !== undefined) {
+    console.log(
+      `  documented members:  ${result.coldMembers} cold, ${result.warmMembers ?? 0} on the last save`
+    );
+  }
+  if (result.avgTransient !== undefined) {
+    console.log(`  avg transient/save:  ${result.avgTransient.toFixed(0)}MB`);
+  }
+  if (result.retainedSlope !== undefined && result.retainedGrowth !== undefined) {
+    console.log(`  retained slope:      ${result.retainedSlope.toFixed(2)}MB/save`);
+    console.log(`  retained growth:     ${result.retainedGrowth.toFixed(0)}MB over ${saves} saves`);
+  }
+}
+
+export interface SeriesHarnessSpec extends SeriesOptions {
+  /** Banner line, e.g. `vue-component-meta harness (workspace)`. */
+  title: string;
+  /** The resolved options, recorded in the result JSON so a stored run is self-describing. */
+  options: object;
+  /** The subset echoed under the banner. Defaults to {@link options}. */
+  banner?: Record<string, unknown>;
+  jsonOut?: string;
+  /** Build the project and the engine. Runs before the cold pass, so its cost is not measured. */
+  setup(): Promise<SeriesEngine>;
+}
+
+/**
+ * Children own only their {@link SeriesEngine}; everything the orchestrator reads back is produced
+ * here so the children cannot drift apart in what they report.
+ */
+export async function runSeriesHarness(spec: SeriesHarnessSpec): Promise<void> {
+  console.log(spec.title);
+  console.log(
+    `  ${Object.entries(spec.banner ?? spec.options)
+      .map(([key, value]) => `${key}=${String(value)}`)
+      .join(' ')}`
+  );
+  if ((spec.forceGc ?? true) && !gcAvailable()) {
+    console.log('  (run with `node --expose-gc` to measure retained heap; continuing without it)');
+  }
+
+  const engine = await spec.setup();
+  const result = await runSeries(engine, spec);
+  printSeriesSummary(result, spec.saves);
+
+  if (spec.jsonOut) {
+    fs.writeFileSync(spec.jsonOut, JSON.stringify({ options: spec.options, ...result }, null, 2));
+    console.log(`  wrote ${spec.jsonOut}`);
+  }
+}
+
+/** Entry-point wrapper: any throw becomes a non-zero exit, which is how the orchestrator sees it. */
+export function harnessMain(run: () => Promise<void>): void {
+  run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bench/docgen-shared/stats.test.ts
+++ b/scripts/bench/docgen-shared/stats.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { leastSquaresSlope, mean, median } from './stats.ts';
+
+describe('median', () => {
+  it('returns the middle value for odd-length input', () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  it('averages the two middle values for even-length input', () => {
+    expect(median([4, 1, 3, 2])).toBe(2.5);
+  });
+
+  it('returns the value itself for a single sample', () => {
+    expect(median([7])).toBe(7);
+  });
+
+  it('does not mutate its input', () => {
+    const values = [3, 1, 2];
+    median(values);
+    expect(values).toEqual([3, 1, 2]);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => median([])).toThrow('median() requires at least one value');
+  });
+});
+
+describe('mean', () => {
+  it('averages the values', () => {
+    expect(mean([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => mean([])).toThrow('mean() requires at least one value');
+  });
+});
+
+describe('leastSquaresSlope', () => {
+  it('returns 0 for fewer than two points', () => {
+    expect(leastSquaresSlope([])).toBe(0);
+    expect(leastSquaresSlope([5])).toBe(0);
+  });
+
+  it('recovers the slope of a perfect line', () => {
+    expect(leastSquaresSlope([1, 3, 5, 7])).toBe(2);
+  });
+
+  it('returns 0 for a flat series', () => {
+    expect(leastSquaresSlope([4, 4, 4])).toBe(0);
+  });
+
+  it('fits noisy data to the least-squares line', () => {
+    expect(leastSquaresSlope([0, 2, 1, 3])).toBeCloseTo(0.8, 5);
+  });
+});

--- a/scripts/bench/docgen-shared/stats.ts
+++ b/scripts/bench/docgen-shared/stats.ts
@@ -62,7 +62,9 @@ export function summarizeSeries(samples: SaveSample[], baseline: MemorySample): 
   const transients = gcSampled.map((s) => s.heapUsedMb - s.retainedHeapMb);
   const last = retained.at(-1);
   return {
-    retainedSlope: retained.length ? leastSquaresSlope(retained) : undefined,
+    // A slope needs two points. `leastSquaresSlope` answers 0 for a shorter series, which is
+    // indistinguishable from a measured flat one, so a series that short reports nothing instead.
+    retainedSlope: retained.length >= 2 ? leastSquaresSlope(retained) : undefined,
     retainedGrowth:
       last !== undefined && baseline.retainedHeapMb !== undefined
         ? last - baseline.retainedHeapMb

--- a/scripts/bench/docgen-shared/stats.ts
+++ b/scripts/bench/docgen-shared/stats.ts
@@ -1,0 +1,73 @@
+/** Statistics helpers shared by the docgen bench harnesses. */
+import type { MemorySample, SaveSample } from './samples.ts';
+
+/** Throws on an empty input so a missing series fails loudly. */
+export function median(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error('median() requires at least one value');
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** Throws on an empty input so a missing series fails loudly. */
+export function mean(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error('mean() requires at least one value');
+  }
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/** Least-squares slope of `values` vs index, in units-per-step. 0 for fewer than two points. */
+export function leastSquaresSlope(values: number[]): number {
+  const n = values.length;
+  if (n < 2) {
+    return 0;
+  }
+  const meanX = (n - 1) / 2;
+  const meanY = values.reduce((a, b) => a + b, 0) / n;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i++) {
+    num += (i - meanX) * (values[i] - meanY);
+    den += (i - meanX) ** 2;
+  }
+  return den === 0 ? 0 : num / den;
+}
+
+/** The retained- and transient-memory figures every series harness derives from its save series. */
+export interface SeriesSummary {
+  /** Least-squares slope of retained heap over the save series, MB per save. */
+  retainedSlope?: number;
+  /** Final retained sample minus the pre-series baseline, MB. */
+  retainedGrowth?: number;
+  /** Per-save allocation spike above the retained baseline, MB. */
+  transients: number[];
+  /** Mean of {@link transients}. */
+  avgTransient?: number;
+}
+
+/**
+ * Derive the retained/transient series figures shared by every series harness. Kept here so the
+ * memory harness and the per-engine harnesses cannot drift apart in how they compute them.
+ */
+export function summarizeSeries(samples: SaveSample[], baseline: MemorySample): SeriesSummary {
+  // Samples taken without --expose-gc carry no retained heap; dropping them keeps a missing reading
+  // from being averaged in as a zero.
+  const gcSampled = samples.filter(
+    (s): s is SaveSample & { retainedHeapMb: number } => s.retainedHeapMb !== undefined
+  );
+  const retained = gcSampled.map((s) => s.retainedHeapMb);
+  const transients = gcSampled.map((s) => s.heapUsedMb - s.retainedHeapMb);
+  const last = retained.at(-1);
+  return {
+    retainedSlope: retained.length ? leastSquaresSlope(retained) : undefined,
+    retainedGrowth:
+      last !== undefined && baseline.retainedHeapMb !== undefined
+        ? last - baseline.retainedHeapMb
+        : undefined,
+    transients,
+    avgTransient: transients.length ? mean(transients) : undefined,
+  };
+}


### PR DESCRIPTION
## What I did

We have two docgen benchmarks: the memory one that already runs as a daily CI gate, and a new per-engine performance one later in this stack. They need the same handful of pieces. Flag parsing, memory sampling, statistics, the save-series loop, budget numbers, child-output truncation. All extracted into sharable utils.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`args.test.ts` and `stats.test.ts`, 23 tests. `docgen-memory` has no unit tests, before or after — its gate run is its check.

#### Manual testing

```bash
yarn install
cd scripts && yarn check && yarn lint && yarn test bench/docgen-shared
```

Expect 2 test files and 23 tests passing. Then pass a flag that does not exist and confirm the harness refuses it instead of quietly using a default.

The gate is the real test for the second commit:

```bash
cd scripts && yarn bench:docgen-memory
```

Confirm both halves still behave: the recycle-on case survives the save series inside its budgets, and the recycle-off negative control still runs out of memory. If the control stops failing, the gate has stopped being able to catch the regression it exists for.

### Documentation

- [ ] Add or update documentation reflecting your changes

Part 1's methodology note already describes what this code implements.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below: `build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared tooling for documentation-generation memory benchmarks, including configurable budgets, memory sampling, statistical summaries, and reusable benchmark series execution.
  * Added stricter command-line validation with clear handling for numeric, boolean, enum, missing, and unknown options.
  * Added support for generating and pairing component and story reference metadata.

* **Bug Fixes**
  * Improved benchmark output consistency and error reporting.

* **Tests**
  * Added coverage for command-line parsing and statistical calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->