### PR TITLE
Bench: Move the memory harness onto the shared plumbing

### DIFF
--- a/scripts/bench/PERF-METHODOLOGY.md
+++ b/scripts/bench/PERF-METHODOLOGY.md
@@ -1,0 +1,164 @@
+# Docgen performance methodology
+
+This note is the measurement contract for the per-engine docgen performance suite.
+It fixes the metric set, the determinism method, the budget shape, and the CI tiers that the harness and its budgets implement.
+The suite measures; it never optimizes.
+
+## Scope
+
+The gated suite runs in plain Node: no browser, no dev server, no Vite.
+Each engine is measured through a directly callable entry point:
+
+- React, new engine: `ComponentMetaManager.batchExtract` (`code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts`).
+  `buildDocgenPayload` (`code/renderers/react/src/docgen/buildDocgen.ts`) wraps it with story-file resolution and argTypes conversion, so it measures more work than the bare legacy parse calls; `batchExtract` is the metric of record.
+- React, legacy engines: `getReactDocgen` (`code/renderers/react/src/componentManifest/reactDocgen.ts`) and `parseWithReactDocgenTypescript` (`code/renderers/react/src/componentManifest/reactDocgenTypescript.ts`).
+  The live legacy paths are builder plugins - a Vite plugin or a webpack loader, some third-party - and cannot run standalone; these wrappers share their extraction logic without being byte-identical to any of them, so legacy numbers describe the engines, not the builder pipelines.
+  Both wrappers cache per file for the life of the process and expose only global invalidation; a simulated save must invalidate before re-parsing or the warm sample is a cache hit.
+  `react-docgen` is the budgeted legacy control; `react-docgen-typescript` is measurable through the same wrappers but carries no budget row.
+- Angular: a standalone Compodoc CLI run.
+  Storybook shells out to the same CLI (`runCompodoc`, `code/frameworks/angular/src/builders/utils/run-compodoc.ts`), so the harness measures the tool the framework actually runs.
+  `@compodoc/compodoc` is pinned exactly at 2.0.0 in `scripts/package.json`, the version the Angular docgen baselines capture against (`code/lib/docgen-harness/README.md`).
+  The pin is exact rather than a range because compodoc's cost moves across versions, and the resolved version is recorded with the results.
+- Vue, legacy engine: `parse` from `vue-docgen-api`, called per `.vue` file the way the Vite plugin calls it (`code/frameworks/vue3-vite/src/plugins/vue-docgen.ts`).
+  This is still the default plugin (`resolveDocgenOptions`, `code/frameworks/vue3-vite/src/preset.ts`), so it is Vue's legacy control the way `react-docgen` is React's.
+  The parser reads the file from disk on every call and keeps no cache, so one save costs one `parse` of one file - the per-save sample needs no invalidation step and matches production.
+- Vue, new engine: `createChecker` and `createCheckerByJson` from `vue-component-meta`, with the checker options the Vite plugin passes (`code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts`).
+  One caveat the budgets must respect: that plugin falls back to `createCheckerByJson` whenever the project's root tsconfig declares `references`, because `vue-component-meta` does not resolve them.
+  The harness's `workspace` and `base-type-touch` scenarios drive `createChecker` at a package tsconfig, which measures the engine rather than the plugin's path for that project shape.
+- Svelte and web components: their extraction engines are plain functions callable from Node; exact entry points get pinned when each engine's harness lands.
+
+## Metrics
+
+Five metrics per engine, all candidates for gating:
+
+- **Cold extraction**: time for the first full extraction in a fresh process.
+  For engines that build a TypeScript program, this includes building it.
+- **Warm extraction**: time to re-extract one changed component after a simulated save, once the process is warm.
+- **Whole-project scan**: time for one batch pass over the entire project.
+  Only Compodoc works this way, so this metric applies to Compodoc alone; per-component engines record it as n/a rather than a faked equivalent.
+- **Peak memory (transient)**: the allocation spike a save causes above the retained baseline, sampled around forced GC.
+- **Leak detection**: retained-heap growth after the save series, plus the least-squares slope of retained heap over that series.
+
+Compodoc maps onto these differently because it is a fresh CLI process per run: cold extraction and whole-project scan are the same full-project measurement, warm extraction is a second full run after touching one file, and peak memory is the child's peak RSS sampled from outside the process.
+Whether the retained-series metrics mean anything for a fresh-process engine is settled when its baselines are recorded; until then its leak cells stay placeholders.
+
+Two harnesses implement this.
+`scripts/bench/docgen-memory/` (`yarn bench:docgen-memory`) gates React memory and is the only tier that fails a build today.
+`scripts/bench/docgen-perf/` (`yarn bench:docgen-perf`) records all five metrics for every engine and gates nothing yet, because no budget values exist.
+
+## Determinism method
+
+- **Fixed synthetic projects.**
+  Inputs come from a generator with fixed parameters (component count, props per component, type-heaviness levers), never from real-world checkouts.
+  The existing generator is `scripts/bench/docgen-memory/generate-project.ts`.
+- **Warmup.**
+  Every run starts with one full cold pass.
+  That pass is the cold-extraction sample and is excluded from all warm samples.
+  This exists today in the refresh mode of `scripts/bench/docgen-memory/memory-harness.ts`; live mode skips it by design.
+- **Median-of-N for latency.**
+  Each latency metric records a median, never a single-run number.
+  Cold extraction and whole-project scan yield one sample per fresh process, so their N samples come from N spawns.
+  Warm extraction records the median of the per-save durations inside a single run's save series.
+  That run is the repetition whose cold sample is the median, never the first: repetition 1 pays for a cold module graph and a cold page cache, and measures several times slower than the rest.
+  The harness pins one N for all engines and records it with the results; numbers taken at different N are not comparable.
+  An engine that fails part-way through its repetitions is reported as failed, never as measured at an N it did not reach.
+  `scripts/bench/docgen-perf/aggregate.ts` implements this; the memory gate still runs each configuration exactly once.
+- **Series statistics for leak metrics.**
+  Retained slope is a least-squares fit over the save series; retained growth is the delta between the final retained sample and the pre-run baseline.
+  Both read one run's series instead of repeated runs.
+  This exists today.
+- **Series mean for transient memory.**
+  Peak memory (transient) is the mean of the per-save spikes across the save series - not repeated and medianed like cold latency, not slope-fitted like retained slope.
+  Warm latency, transient memory, and the leak metrics all read the same fixed-length series from the same run.
+  This exists today in `scripts/bench/docgen-memory/memory-harness.ts`.
+- **Fresh process per measurement.**
+  Every measured process is spawned fresh so it starts from a clean heap.
+  This exists today in `scripts/bench/docgen-memory/gate.ts`.
+- **Relative comparison on the same machine.**
+  Perf questions are answered by ratios between runs executed sequentially inside a single CI job on one executor, or on one local machine.
+  "Same machine" means exactly that; cross-job, cross-run, and cross-PR comparisons are non-comparisons because CI executors are ephemeral and not guaranteed identical.
+  The two standing comparisons are docgen-server flag on vs off, and new engine vs legacy engine, both measured in the same run.
+  Paired runs alternate their order across repetitions so cache warming and thermal drift do not consistently favor one side.
+
+## Budget shape
+
+Timing budgets are ratios or slopes, never absolute milliseconds; absolute wall-clock on shared CI executors is too noisy to gate.
+A timing ratio divides the median of one side by the median of the other, both measured in the same job.
+The calibration reference for React is the legacy-vs-new-engine ratio measured in the same run on the same machine.
+
+The warm half of that ratio carries a caveat the baseline work must settle.
+Both sides re-extract one changed component per save, which compares the engines on equal work.
+Only the new engine has a production path shaped that way: `buildDocgenPayload` hardcodes `react-component-meta`, so the single-component docgen worker never runs a legacy parser.
+The legacy parsers are reachable only through `generator.ts`, which invalidates every cache and re-extracts every component on each manifest build.
+A real legacy save therefore costs the whole project, not one file, and the recorded warm ratio understates legacy's true per-save cost by roughly the component count.
+Run `react-legacy.ts --scope all` for the production-shaped number; the equal-work ratio is the engine comparison, not a saving a user would feel.
+
+Vue's pair carries a different caveat, and a sharper one.
+`vue-docgen-api` does not resolve tsconfig `paths` aliases, and the Vite plugin calls `parse(id)` without an alias map, so on the generated projects it documents a fraction of what `vue-component-meta` documents.
+Every run so far has the legacy engine finishing its cold pass an order of magnitude faster while documenting an order of magnitude fewer members, and documenting nothing at all on the save it was timed on.
+The engines are not doing the same work, so the Vue ratio measures resolution depth as much as speed.
+Both engines therefore report their documented-member counts, and the suite prints those counts beside every ratio - the warm one as much as the cold one - and marks the pair not like-for-like whenever they disagree.
+A ratio marked not like-for-like must not become a budget.
+
+Angular needs a second signal, because equal member counts there would not mean equal work.
+Compodoc never resolves a named type: it records the name written at the property, so `@Input() kind: ButtonKind` is stored as `ButtonKind` and an `@Output()` is stored as `EventEmitter` with its payload dropped, while the same union written inline is stored in full.
+Chain a type through twenty files and it still documents every member, at the same speed, having looked through none of them - so a member count alone would read as identical to an engine that expanded all of them.
+Compodoc therefore also reports how many of its documented members carry a type it never resolved, and a future Angular pair must compare that alongside the counts before calling a ratio like-for-like.
+Its warm member count is a second whole-project total rather than the one member re-extracted, so it is not comparable with a series engine's warm count either.
+
+Signals are documented, not benchmarked.
+Compodoc reads `input()`, `output()` and `model()` by matching the initializer's source text, not by resolving the import or the type, and it documents them at the same speed and count as the decorator form - so there is no timing to measure.
+What the textual match costs is fidelity: an aliased `import { input as ngInput }` stops being recognised as an input at all, and a non-literal default without an explicit generic loses its type.
+Those belong in the docgen-harness fixtures that pin compodoc's behaviour, not in a bench scenario that would report two rows indistinguishable from the baseline.
+
+The baseline work records the figures; quoting any here would pin numbers taken at one profile on one machine.
+Engines without a second implementation in the same job get their timing reference picked when their baselines are recorded; until then their timing budgets stay placeholders.
+Memory budgets stay absolute megabytes with generous headroom: budgets sit well above observed values so the gate is not flaky, while still failing hard on a real regression.
+Every engine must also carry its own negative control - a configuration that must fail, proving the gate can catch the regression class it exists for.
+A control names its lever and the one metric it must trip; it does not need to trip every metric, and where no credible lever exists the gap is recorded instead of inventing a hollow control.
+The only worked example today is the React memory gate's out-of-memory control.
+Budgets and controls are derived per engine from that engine's own baseline runs; nothing is ported between engines.
+
+## CI tiers
+
+- **Per PR: report-only.**
+  Per-PR perf jobs attach to the unconditional job block of the generated CircleCI config (`scripts/ci/main.ts`), where the package benchmark job already runs on every build without gating.
+  They report numbers and never fail the build.
+- **Daily: the only gating tier.**
+  "Daily" names the CircleCI `workflow=daily` pipeline parameter (tier order `normal < merged < daily`, `scripts/ci/utils/types.ts`); daily-only jobs attach in `scripts/ci/main.ts`, where the docgen memory gate already runs.
+- **The daily cadence is unproven.**
+  The only trigger for the daily tier in version control is the `ci:daily` PR label (`.github/workflows/trigger-circle-ci-workflow.yml`); no scheduled trigger exists in the repo, and no CircleCI-side schedule is confirmed to exist.
+  Until that is resolved, gating on the daily tier means gating when someone applies the label.
+  The baseline-and-budget work must settle the cadence before this gate can be described as nightly protection.
+
+## User-perceived metrics
+
+Three user-perceived metrics join the suite as report-only extensions of the sandbox bench task; none joins the gated floor.
+They need a real dev server and Chromium, which makes them variance-heavy; they exist to show user-visible impact, not to gate.
+All three build on existing tooling and add no new dependencies:
+
+- **Dev-server startup delta.**
+  Run the sandbox bench task (`scripts/tasks/bench.ts` driving `scripts/bench/browse.ts` over Playwright/Chromium, with dev-server readiness timings from `scripts/tasks/dev.ts`) twice, docgen-server feature on and off, and report the delta.
+  Today only the internal Storybook config reads the on/off switch (`code/.storybook/main.ts`); generated sandboxes do not, so the harness work must inject the feature toggle into the sandbox config before the delta can be measured there.
+  No first-class on/off comparison mode exists yet; today this is two runs diffed by hand.
+- **Time-to-Controls-populated.**
+  Adapt the existing Playwright flow that selects a story, opens the Controls panel, and waits for an args-table cell (`code/e2e-internal/docgen-hot-update.spec.ts`) into a timing probe, using the elapsed-time pattern from `browse.ts`.
+  Today that flow is a pass/fail assertion and records no elapsed time.
+- **Docs-page props-table render.**
+  `benchAutodocs` in `scripts/bench/browse.ts` times the docs page today, but its wait on the component description text is a locator construction with no real wait condition, so the recorded number mostly reflects page load.
+  The probe waits on a props-table element with a real wait condition; it does not exist yet.
+
+## Budgets table skeleton
+
+The baseline work fills in the values; until then every cell is a placeholder.
+The exception is react-osa's memory row, which the docgen memory gate already enforces from `scripts/bench/docgen-shared/budgets.ts`.
+
+| Engine                                    | Cold extraction | Warm extraction | Whole-project scan | Peak memory (transient) | Retained growth | Retained slope | Negative control | Tier       |
+| ----------------------------------------- | --------------- | --------------- | ------------------ | ----------------------- | --------------- | -------------- | ---------------- | ---------- |
+| react-legacy (react-docgen, control)      | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| react-osa (ComponentMetaManager, control)  | TBD (1.12)      | TBD (1.12)      | n/a                | 90MB                    | 60MB            | 3MB/save       | OOM (gate.ts)    | daily      |
+| vue-docgen-api (legacy, current default)  | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| vue-component-meta                        | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| compodoc                                  | TBD (1.12)      | TBD (1.12)      | TBD (1.12)         | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| svelte (stretch)                          | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| cem (stretch)                             | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |

--- a/scripts/bench/docgen-memory/gate.ts
+++ b/scripts/bench/docgen-memory/gate.ts
@@ -2,18 +2,15 @@
  * CI regression gate for the docgen-server memory behavior
  * (https://github.com/storybookjs/storybook/issues/35260).
  *
- * Runs {@link file://./memory-harness.ts} in fresh child processes (so each measurement starts from a
- * clean heap) and asserts two independent things:
+ * Runs {@link file://./memory-harness.ts} in fresh child processes (one clean heap per measurement)
+ * and asserts two independent things:
  *
- *   1. Steady-state churn/leak-freeness (`changed-scope` metric config): post-GC `heapUsed` must not
- *      climb across saves, and the per-save transient working set must stay under budget. A regression
- *      that re-extracts the whole index would blow past these.
- *   2. The OOM fix itself, as a **crash → survive negative control** (`live` configs): the live path
- *      (many per-component `batchExtract` calls on the shared program) is run under a tight heap cap
- *      both WITH and WITHOUT program recycling.
- *        - recycle OFF (`--recycle off`, ratio Infinity) MUST OOM.
- *        - recycle ON (default) MUST survive.
- *      Asserting the flip (not just survival) is what guards the fix rather than the cap.
+ *   1. Steady-state leak-freeness (`changed-scope` metric config): post-GC `heapUsed` must not
+ *      climb across saves, and the per-save transient working set must stay under budget.
+ *   2. The OOM fix itself, as a **crash → survive negative control** (`live` configs): the live
+ *      path is run under a tight heap cap both WITH and WITHOUT program recycling - recycle OFF
+ *      (`--recycle off`, ratio Infinity) MUST OOM, recycle ON (default) MUST survive. Asserting
+ *      the flip, not just survival, is what guards the fix rather than the cap.
  *
  * Run:
  *   yarn bench:docgen-memory          # from scripts/
@@ -23,6 +20,8 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { type MemoryBudgets, memoryBudgetsFor } from '../docgen-shared/budgets.ts';
+import { outputTail } from '../docgen-shared/child-output.ts';
 import { SANDBOX_DIRECTORY } from '../../utils/constants.ts';
 
 interface HarnessResult {
@@ -33,15 +32,6 @@ interface HarnessResult {
   avgTransient?: number;
 }
 
-interface MetricBudgets {
-  /** Max allowed post-GC retained growth (MB) across the run. */
-  maxRetainedGrowthMb: number;
-  /** Max allowed average transient working set added per save (MB). */
-  maxTransientMb: number;
-  /** Max allowed post-GC retained-heap slope (MB/save). */
-  maxRetainedSlopeMb: number;
-}
-
 interface GateConfig {
   name: string;
   args: string[];
@@ -50,12 +40,12 @@ interface GateConfig {
   /** `--max-old-space-size` cap (MB) for the child. Omit to run uncapped. */
   capMb?: number;
   /**
-   * Crash → survive negative control. `true` ⇒ the child MUST OOM (recycle disabled); `false` ⇒ it
-   * MUST survive (recycle on). Omit for metric-only configs.
+   * Crash → survive negative control: `true` ⇒ MUST OOM (recycle disabled), `false` ⇒ MUST
+   * survive (recycle on). Omit for metric-only configs.
    */
   expectOom?: boolean;
   /** Post-GC metric budgets, asserted from `result.json` (metric configs only). */
-  budgets?: MetricBudgets;
+  budgets?: MemoryBudgets;
 }
 
 const HARNESS = path.join(import.meta.dirname, 'memory-harness.ts');
@@ -78,7 +68,7 @@ const CONFIGS: GateConfig[] = [
       '--scope', 'changed',
     ],
     outSubdir: 'changed-scope',
-    budgets: { maxRetainedGrowthMb: 60, maxTransientMb: 90, maxRetainedSlopeMb: 3 },
+    budgets: memoryBudgetsFor('react-osa'),
   },
   {
     // Positive control: the live per-edit workload survives under a tight cap BECAUSE the shared
@@ -153,15 +143,7 @@ function runHarness(config: GateConfig): RunOutcome {
 
   const proc = spawnSync(process.execPath, nodeArgs, { encoding: 'utf8' });
   const output = `${proc.stdout ?? ''}${proc.stderr ?? ''}`;
-  // Echo a compact tail so CI logs show what happened without the full V8 crash dump.
-  console.log(
-    output
-      .trim()
-      .split('\n')
-      .slice(-8)
-      .map((line) => `    ${line}`)
-      .join('\n')
-  );
+  console.log(outputTail(output, 8));
 
   const result = fs.existsSync(jsonPath)
     ? (JSON.parse(fs.readFileSync(jsonPath, 'utf8')) as HarnessResult)

--- a/scripts/bench/docgen-memory/generate-project.ts
+++ b/scripts/bench/docgen-memory/generate-project.ts
@@ -19,6 +19,11 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { z } from 'zod';
+
+import { countOption, parseHarnessOptions } from '../docgen-shared/args.ts';
+import type { ComponentRefLike, StoryRefLike } from '../docgen-shared/react-renderer-module.ts';
+
 const require = createRequire(import.meta.url);
 
 export interface GenerateOptions {
@@ -239,6 +244,26 @@ ${variantExports}
 `;
 }
 
+/** The renderer-side reference for the generated `Comp{i}`, matching the naming used above. */
+export function componentRef(i: number, componentPath: string): ComponentRefLike {
+  return {
+    componentName: `Comp${i}`,
+    importName: `Comp${i}`,
+    localImportName: `Comp${i}`,
+    importId: `./Comp${i}`,
+    isPackage: false,
+    path: componentPath,
+  };
+}
+
+/** Pairs {@link GeneratedProject.componentPaths} with `storyPaths`, which share an index. */
+export function buildStoryRefs(componentPaths: string[], storyPaths: string[]): StoryRefLike[] {
+  return componentPaths.map((componentPath, i) => ({
+    storyPath: storyPaths[i],
+    component: componentRef(i, componentPath),
+  }));
+}
+
 export function generateProject(options: GenerateOptions): GeneratedProject {
   const outDir = path.resolve(options.outDir);
   fs.rmSync(outDir, { recursive: true, force: true });
@@ -275,25 +300,40 @@ export function generateProject(options: GenerateOptions): GeneratedProject {
   return { outDir, configPath, componentPaths, storyPaths };
 }
 
-function parseArgs(argv: string[]): GenerateOptions {
-  const get = (flag: string, fallback: string) => {
-    const idx = argv.indexOf(flag);
-    return idx >= 0 && argv[idx + 1] ? argv[idx + 1] : fallback;
-  };
-  return {
-    outDir: get('--out', '../storybook-sandboxes/docgen-memory-stress'),
-    components: Number(get('--components', '500')),
-    variants: Number(get('--variants', '4')),
-    props: Number(get('--props', '8')),
-    heavyTypes: argv.includes('--heavy'),
-    heavyFactor: Number(get('--heavy-factor', '1')),
-    base64Kb: Number(get('--base64-kb', '0')),
-    withNodeModules: !argv.includes('--no-node-modules'),
-  };
+function parseOptions(argv: string[]): GenerateOptions {
+  return parseHarnessOptions<GenerateOptions>(
+    argv,
+    {
+      out: { type: 'string' },
+      components: { type: 'string' },
+      variants: { type: 'string' },
+      props: { type: 'string' },
+      heavy: { type: 'boolean' },
+      'heavy-factor': { type: 'string' },
+      'base64-kb': { type: 'string' },
+      'no-node-modules': { type: 'boolean' },
+    } as const,
+    z.object({
+      outDir: z.string().default('../storybook-sandboxes/docgen-memory-stress'),
+      components: countOption(500),
+      variants: countOption(4),
+      props: countOption(8),
+      heavyTypes: z.boolean().default(false),
+      heavyFactor: countOption(1),
+      base64Kb: countOption(0),
+      withNodeModules: z.boolean().default(true),
+    }),
+    (values) => ({
+      ...values,
+      outDir: values.out,
+      heavyTypes: values.heavy,
+      withNodeModules: !values.noNodeModules,
+    })
+  );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const options = parseArgs(process.argv.slice(2));
+  const options = parseOptions(process.argv.slice(2));
   const start = Date.now();
   const result = generateProject(options);
   console.log(

--- a/scripts/bench/docgen-memory/memory-harness.ts
+++ b/scripts/bench/docgen-memory/memory-harness.ts
@@ -2,22 +2,21 @@
  * Deterministic in-process memory harness for the docgen-server OOM
  * (https://github.com/storybookjs/storybook/issues/35260).
  *
- * It reproduces the "re-extract on every save" behavior without a browser or dev server, so it runs
- * fast and is fully deterministic. It drives the real {@link ComponentMetaManager} against a
- * generated project of N components, then simulates K file saves and samples memory after each one.
+ * Drives the real {@link ComponentMetaManager} against a generated project of N components, then
+ * simulates K file saves and samples memory after each one.
  *
- * Two failure signals are measured independently:
- *   - RETAINED growth: post-GC `heapUsed` trend across saves. A rising trend ⇒ a true leak (memory
- *     held between saves). A flat trend ⇒ the cost is transient allocation, not retained state.
- *   - PEAK pressure: pre-GC `rss` per save. With `--no-force-gc` and a `--max-old-space-size` cap at
- *     launch, this is what crashes the process when saves outpace GC (the reported OOM).
+ * Two independent failure signals:
+ *   - RETAINED growth: post-GC `heapUsed` trend across saves. Rising ⇒ a true leak (memory held
+ *     between saves), flat ⇒ transient allocation.
+ *   - PEAK pressure: pre-GC `rss` per save. Under `--no-force-gc` and a `--max-old-space-size` cap,
+ *     this is what crashes the process when saves outpace GC (the reported OOM).
  *
  * Modes:
- *   --mode refresh  call manager.batchExtract(allEntries) synchronously each save. Mirrors the docgen
+ *   --mode refresh  synchronous manager.batchExtract(allEntries) each save. Mirrors the docgen
  *                   open-service "refresh all extracted components" path (server.ts).
  *   --mode live     many per-component batchExtract calls on the shared program, mirroring the
- *                   docs-addon per-edit wave that drives the #35260 OOM. The program-recycle fix bounds
- *                   this path. Use --recycle off to assert the OOM still happens without the fix.
+ *                   docs-addon per-edit wave that drives the #35260 OOM. The program-recycle fix
+ *                   bounds this path; use --recycle off to assert the OOM still happens without it.
  *
  * Run (diagnose retained vs transient):
  *   node --expose-gc --import jiti/register scripts/bench/docgen-memory/memory-harness.ts \
@@ -36,28 +35,23 @@ import * as path from 'node:path';
 
 import ts from 'typescript';
 
-import { SANDBOX_DIRECTORY } from '../../utils/constants.ts';
-import { componentSource, generateProject } from './generate-project.ts';
+import { z } from 'zod';
 
-/**
- * Minimal structural view of the entry shape consumed by `ComponentMetaManager.batchExtract`. Kept
- * local so the `scripts` typecheck does not descend into `code/renderers` internals; the real types
- * live in `code/renderers/react/src/componentManifest`.
- */
-interface StoryRef {
-  storyPath: string;
-  component: {
-    componentName: string;
-    importName: string;
-    localImportName: string;
-    importId: string;
-    isPackage: boolean;
-    path: string;
-  };
-}
+import { countOption, parseHarnessOptions } from '../docgen-shared/args.ts';
+import { SANDBOX_DIRECTORY } from '../docgen-shared/paths.ts';
+import { type StoryRefLike, loadReactRendererModule } from '../docgen-shared/react-renderer-module.ts';
+import { MB, gcAvailable } from '../docgen-shared/sampling.ts';
+import {
+  type SeriesEngine,
+  harnessMain,
+  printSeriesSummary,
+  runSeries,
+} from '../docgen-shared/series.ts';
+import { leastSquaresSlope } from '../docgen-shared/stats.ts';
+import { buildStoryRefs, componentSource, generateProject } from './generate-project.ts';
 
 interface ComponentMetaManagerLike {
-  batchExtract(entries: StoryRef[]): void;
+  batchExtract(entries: StoryRefLike[]): void;
   onFilesChanged(changes: Array<{ filePath: string; type: 'changed' | 'created' | 'deleted' }>): void;
   dispose(): void;
 }
@@ -67,35 +61,24 @@ type ComponentMetaManagerCtor = new (
   recycleHeapPressureRatio?: number
 ) => ComponentMetaManagerLike;
 
+const MODES = ['refresh', 'live'] as const;
 /**
- * Load the real `ComponentMetaManager` at runtime. The specifier is built with `new URL` so the
- * static `scripts` typecheck does not pull `code/renderers` source into its program.
+ * Which entries to re-extract per save: `all` re-extracts every component (the docgen service
+ * refreshing on an empty change hint), `changed` re-extracts only the component whose file changed.
  */
-async function loadComponentMetaManager(): Promise<ComponentMetaManagerCtor> {
-  const url = new URL(
-    '../../../code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts',
-    import.meta.url
-  ).href;
-  const mod = (await import(url)) as { ComponentMetaManager: ComponentMetaManagerCtor };
-  return mod.ComponentMetaManager;
-}
+const SCOPES = ['all', 'changed'] as const;
+const RECYCLE = ['on', 'off'] as const;
 
 interface HarnessOptions {
   components: number;
   variants: number;
   props: number;
   saves: number;
-  mode: 'refresh' | 'live';
+  mode: (typeof MODES)[number];
   heavyTypes: boolean;
   heavyFactor: number;
   base64Kb: number;
-  /**
-   * Which entries to re-extract per save.
-   *   all     – re-extract every component each save (the docgen service refreshing all extracted
-   *             components on an empty change hint).
-   *   changed – re-extract only the component whose file changed.
-   */
-  scope: 'all' | 'changed';
+  scope: (typeof SCOPES)[number];
   forceGc: boolean;
   outDir: string;
   reuse: boolean;
@@ -104,120 +87,114 @@ interface HarnessOptions {
   maxRetainedGrowthMb: number;
   /**
    * Heap-pressure ratio forwarded to `ComponentMetaManager`. `Infinity` disables program recycling
-   * (the negative control: assert the OOM happens without the fix). `undefined` uses the product
-   * default.
+   * (negative control), `undefined` uses the product default.
    */
   recycleHeapPressureRatio?: number;
 }
 
-interface Sample {
-  save: number;
-  rssMb: number;
-  heapUsedMb: number;
-  retainedHeapMb?: number;
-}
+const OPTIONS = {
+  components: { type: 'string' },
+  variants: { type: 'string' },
+  props: { type: 'string' },
+  saves: { type: 'string' },
+  mode: { type: 'string' },
+  scope: { type: 'string' },
+  recycle: { type: 'string' },
+  heavy: { type: 'boolean' },
+  'heavy-factor': { type: 'string' },
+  'base64-kb': { type: 'string' },
+  'no-force-gc': { type: 'boolean' },
+  out: { type: 'string' },
+  reuse: { type: 'boolean' },
+  json: { type: 'string' },
+  'max-retained-growth': { type: 'string' },
+} as const;
 
-const MB = 1024 * 1024;
+const SCHEMA = z.object({
+  components: countOption(600),
+  variants: countOption(4),
+  props: countOption(8),
+  saves: countOption(25),
+  mode: z.enum(MODES).default('refresh'),
+  scope: z.enum(SCOPES).default('all'),
+  // `Infinity` disables program recycling; `undefined` leaves the product default in place.
+  recycleHeapPressureRatio: z
+    .enum(RECYCLE)
+    .default('on')
+    .transform((recycle) => (recycle === 'off' ? Number.POSITIVE_INFINITY : undefined)),
+  heavyTypes: z.boolean().default(false),
+  heavyFactor: countOption(1),
+  base64Kb: countOption(0),
+  forceGc: z.boolean().default(true),
+  outDir: z.string().default(path.join(SANDBOX_DIRECTORY, 'docgen-memory-stress')),
+  reuse: z.boolean().default(false),
+  jsonOut: z.string().optional(),
+  maxRetainedGrowthMb: countOption(400),
+});
 
-function parseArgs(argv: string[]): HarnessOptions {
-  const get = (flag: string, fallback: string) => {
-    const idx = argv.indexOf(flag);
-    return idx >= 0 && argv[idx + 1] ? argv[idx + 1] : fallback;
-  };
-  const mode = get('--mode', 'refresh');
-  if (mode !== 'refresh' && mode !== 'live') {
-    throw new Error(`--mode must be "refresh" or "live", got "${mode}"`);
-  }
-  const scope = get('--scope', 'all');
-  if (scope !== 'all' && scope !== 'changed') {
-    throw new Error(`--scope must be "all" or "changed", got "${scope}"`);
-  }
-  const recycle = get('--recycle', 'on');
-  if (recycle !== 'on' && recycle !== 'off') {
-    throw new Error(`--recycle must be "on" or "off", got "${recycle}"`);
-  }
-  return {
-    components: Number(get('--components', '600')),
-    variants: Number(get('--variants', '4')),
-    props: Number(get('--props', '8')),
-    saves: Number(get('--saves', '25')),
-    mode,
-    scope: scope as 'all' | 'changed',
-    recycleHeapPressureRatio: recycle === 'off' ? Number.POSITIVE_INFINITY : undefined,
-    heavyTypes: argv.includes('--heavy'),
-    heavyFactor: Number(get('--heavy-factor', '1')),
-    base64Kb: Number(get('--base64-kb', '0')),
-    forceGc: !argv.includes('--no-force-gc'),
-    outDir: get('--out', path.join(SANDBOX_DIRECTORY, 'docgen-memory-stress')),
-    reuse: argv.includes('--reuse'),
-    jsonOut: argv.indexOf('--json') >= 0 ? get('--json', '') : undefined,
-    maxRetainedGrowthMb: Number(get('--max-retained-growth', '400')),
-  };
-}
-
-function gc(): void {
-  if (typeof global.gc === 'function') {
-    global.gc();
-    global.gc();
-  }
-}
-
-function sampleMemory(forceGc: boolean): { rssMb: number; heapUsedMb: number; retainedHeapMb?: number } {
-  const pre = process.memoryUsage();
-  let retainedHeapMb: number | undefined;
-  if (forceGc) {
-    gc();
-    retainedHeapMb = process.memoryUsage().heapUsed / MB;
-  }
-  return { rssMb: pre.rss / MB, heapUsedMb: pre.heapUsed / MB, retainedHeapMb };
-}
-
-/** Least-squares slope of `values` vs index, in units-per-save. */
-function slopePerSave(values: number[]): number {
-  const n = values.length;
-  if (n < 2) {
-    return 0;
-  }
-  const meanX = (n - 1) / 2;
-  const meanY = values.reduce((a, b) => a + b, 0) / n;
-  let num = 0;
-  let den = 0;
-  for (let i = 0; i < n; i++) {
-    num += (i - meanX) * (values[i] - meanY);
-    den += (i - meanX) ** 2;
-  }
-  return den === 0 ? 0 : num / den;
-}
-
-function buildEntries(componentPaths: string[], storyPaths: string[]): StoryRef[] {
-  return componentPaths.map((componentPath, i) => ({
-    storyPath: storyPaths[i],
-    component: {
-      componentName: `Comp${i}`,
-      importName: `Comp${i}`,
-      localImportName: `Comp${i}`,
-      importId: `./Comp${i}`,
-      isPackage: false,
-      path: componentPath,
-    },
+function parseOptions(argv: string[]): HarnessOptions {
+  return parseHarnessOptions<HarnessOptions>(argv, OPTIONS, SCHEMA, (values) => ({
+    ...values,
+    recycleHeapPressureRatio: values.recycle,
+    heavyTypes: values.heavy,
+    forceGc: !values.noForceGc,
+    outDir: values.out,
+    jsonOut: values.json,
+    // The schema key carries the unit the flag name leaves off, so camel-casing alone misses it.
+    maxRetainedGrowthMb: values.maxRetainedGrowth,
   }));
 }
 
 /**
- * Live-path mode: mirrors the docs-addon per-edit "waves" that drive the #35260 OOM — many
- * individual per-component `batchExtract` calls on the ONE shared program, whose type-resolution
- * cache accumulates across calls. This is the exact shape the program-recycle fix bounds (the
- * recycle check runs between calls), unlike the `--scope all` single-call cold pass which OOMs
- * within one call regardless of recycling.
- *
- * Run under a `--max-old-space-size` cap:
- *   - recycle on (default): the heap sawtooths as the shared program is recycled, and survives.
- *   - `--recycle off` (ratio Infinity): the type cache climbs to the cap and the process OOMs —
- *     the negative control the gate asserts.
+ * Loaded via `new URL` at runtime, not a static import, so the `scripts` typecheck does not pull
+ * `code/renderers` source into its program.
+ */
+async function loadComponentMetaManager(): Promise<ComponentMetaManagerCtor> {
+  const mod = await loadReactRendererModule<{ ComponentMetaManager: ComponentMetaManagerCtor }>(
+    'componentMeta/ComponentMetaManager.ts'
+  );
+  return mod.ComponentMetaManager;
+}
+
+function resolveProject(options: HarnessOptions): ReturnType<typeof generateProject> {
+  const outDir = path.resolve(options.outDir);
+  const configPath = path.join(outDir, 'tsconfig.json');
+
+  if (options.reuse && fs.existsSync(configPath)) {
+    const componentPaths: string[] = [];
+    const storyPaths: string[] = [];
+    for (let i = 0; i < options.components; i++) {
+      componentPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.tsx`));
+      storyPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.stories.tsx`));
+    }
+    console.log(`  reusing generated project at ${outDir}`);
+    return { outDir, configPath, componentPaths, storyPaths };
+  }
+
+  const genStart = Date.now();
+  const project = generateProject({
+    outDir: options.outDir,
+    components: options.components,
+    variants: options.variants,
+    props: options.props,
+    heavyTypes: options.heavyTypes,
+    heavyFactor: options.heavyFactor,
+    base64Kb: options.base64Kb,
+    withNodeModules: true,
+  });
+  console.log(`  generated project in ${Date.now() - genStart}ms at ${project.outDir}`);
+  return project;
+}
+
+/**
+ * Unlike the `--scope all` single-call cold pass (which OOMs within one call regardless of
+ * recycling), the recycle check runs between the per-component calls here, so under a heap cap:
+ * recycle on sawtooths and survives, `--recycle off` climbs to the cap and OOMs (the negative
+ * control the gate asserts).
  */
 function runLiveMode(
   manager: ComponentMetaManagerLike,
-  entries: StoryRef[],
+  entries: StoryRefLike[],
   options: HarnessOptions
 ): void {
   const recycleEnabled = options.recycleHeapPressureRatio === undefined;
@@ -257,157 +234,101 @@ function runLiveMode(
   }
 }
 
-async function main() {
-  const options = parseArgs(process.argv.slice(2));
-  const gcAvailable = typeof global.gc === 'function';
+/**
+ * The cold pass is the *identical* operation a `scope=all` refresh save performs
+ * (extractPropsFromStories over every entry), so an OOM there is the same OOM every refresh-all
+ * save would hit.
+ */
+function refreshEngine(
+  manager: ComponentMetaManagerLike,
+  entries: StoryRefLike[],
+  project: ReturnType<typeof generateProject>,
+  options: HarnessOptions
+): SeriesEngine {
+  // Track how many extra props each component currently has, so each save grows the type.
+  const extraByComponent = new Array<number>(options.components).fill(options.props);
+  const changedIndex = (save: number) => (save - 1) % options.components;
+
+  return {
+    async cold() {
+      manager.batchExtract(entries);
+      return undefined;
+    },
+    async applySave(save) {
+      const i = changedIndex(save);
+      const componentPath = project.componentPaths[i];
+      // Mutate the component's props interface on disk so the type genuinely changes.
+      extraByComponent[i] += 1;
+      fs.writeFileSync(
+        componentPath,
+        componentSource(i, extraByComponent[i], {
+          heavyTypes: options.heavyTypes,
+          heavyFactor: options.heavyFactor,
+          base64Kb: options.base64Kb,
+        })
+      );
+      // Must run after the write, or the program serves a stale snapshot for this file.
+      manager.onFilesChanged([{ filePath: componentPath, type: 'changed' }]);
+    },
+    async reextract(save) {
+      manager.batchExtract(options.scope === 'changed' ? [entries[changedIndex(save)]] : entries);
+      return undefined;
+    },
+    dispose: () => manager.dispose(),
+  };
+}
+
+harnessMain(async () => {
+  const options = parseOptions(process.argv.slice(2));
 
   console.log('docgen-memory harness');
   console.log(
     `  components=${options.components} variants=${options.variants} props=${options.props} ` +
-      `saves=${options.saves} mode=${options.mode} scope=${options.scope} forceGc=${options.forceGc && gcAvailable}`
+      `saves=${options.saves} mode=${options.mode} scope=${options.scope} ` +
+      `forceGc=${options.forceGc && gcAvailable()}`
   );
-  if (options.forceGc && !gcAvailable) {
+  if (options.forceGc && !gcAvailable()) {
     console.log('  (run with `node --expose-gc` to measure retained heap; continuing without it)');
   }
 
-  const genStart = Date.now();
-  let project: ReturnType<typeof generateProject>;
-  if (options.reuse && fs.existsSync(path.join(path.resolve(options.outDir), 'tsconfig.json'))) {
-    const outDir = path.resolve(options.outDir);
-    const componentPaths: string[] = [];
-    const storyPaths: string[] = [];
-    for (let i = 0; i < options.components; i++) {
-      componentPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.tsx`));
-      storyPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.stories.tsx`));
-    }
-    project = { outDir, configPath: path.join(outDir, 'tsconfig.json'), componentPaths, storyPaths };
-    console.log(`  reusing generated project at ${outDir}`);
-  } else {
-    project = generateProject({
-      outDir: options.outDir,
-      components: options.components,
-      variants: options.variants,
-      props: options.props,
-      heavyTypes: options.heavyTypes,
-      heavyFactor: options.heavyFactor,
-      base64Kb: options.base64Kb,
-      withNodeModules: true,
-    });
-    console.log(`  generated project in ${Date.now() - genStart}ms at ${project.outDir}`);
-  }
-
+  const project = resolveProject(options);
   const ComponentMetaManager = await loadComponentMetaManager();
   const manager = new ComponentMetaManager(ts, options.recycleHeapPressureRatio);
-  const entries = buildEntries(project.componentPaths, project.storyPaths);
+  const entries = buildStoryRefs(project.componentPaths, project.storyPaths);
 
   if (options.mode === 'live') {
     runLiveMode(manager, entries, options);
     return;
   }
 
-  // Initial extraction — builds the full TS program once (the cold path). This is the *identical*
-  // operation a `scope=all` refresh save performs (extractPropsFromStories over every entry), so an
-  // OOM here is the same OOM every refresh-all save would hit; it simply lands on the first pass when
-  // the full-extraction working set already exceeds the heap cap.
-  const initialStart = Date.now();
-  console.log(`  full extraction over ${entries.length} components (cold pass == refresh-all save)…`);
-  manager.batchExtract(entries);
-  console.log(`  initial batchExtract: ${Date.now() - initialStart}ms`);
+  const series = await runSeries(refreshEngine(manager, entries, project, options), {
+    saves: options.saves,
+    coldLabel: `${entries.length} components`,
+    forceGc: options.forceGc,
+  });
 
-  const baseline = sampleMemory(options.forceGc && gcAvailable);
-  console.log(
-    `  baseline: rss=${baseline.rssMb.toFixed(0)}MB heapUsed=${baseline.heapUsedMb.toFixed(0)}MB` +
-      (baseline.retainedHeapMb !== undefined
-        ? ` retained=${baseline.retainedHeapMb.toFixed(0)}MB`
-        : '')
-  );
+  const rssValues = series.samples.map((s) => s.rssMb);
+  const peakRss = Math.max(series.baseline.rssMb, ...rssValues);
+  const finalRss = rssValues.at(-1) ?? series.baseline.rssMb;
+  const rssSlope = leastSquaresSlope(rssValues);
+  const { retainedGrowth } = series;
 
-  const samples: Sample[] = [];
-  // Track how many extra props each component currently has, so each save grows the type.
-  const extraByComponent = new Array(options.components).fill(options.props);
-
-  for (let save = 1; save <= options.saves; save++) {
-    const i = (save - 1) % options.components;
-    const componentPath = project.componentPaths[i];
-
-    // Mutate the component's props interface on disk so the type genuinely changes.
-    extraByComponent[i] += 1;
-    fs.writeFileSync(
-      componentPath,
-      componentSource(i, extraByComponent[i], {
-        heavyTypes: options.heavyTypes,
-        heavyFactor: options.heavyFactor,
-        base64Kb: options.base64Kb,
-      })
-    );
-    // Bump project versions so the next extraction re-reads the mutated file (matches the dev
-    // server's file-watcher → onFilesChanged flow); without this the program serves stale snapshots.
-    manager.onFilesChanged([{ filePath: componentPath, type: 'changed' }]);
-
-    const saveStart = Date.now();
-    const toExtract = options.scope === 'changed' ? [entries[i]] : entries;
-    manager.batchExtract(toExtract);
-    const durMs = Date.now() - saveStart;
-
-    const mem = sampleMemory(options.forceGc && gcAvailable);
-    samples.push({ save, ...mem });
-    console.log(
-      `  save ${String(save).padStart(3)}: ${String(durMs).padStart(5)}ms  ` +
-        `rss=${mem.rssMb.toFixed(0).padStart(5)}MB  heapUsed=${mem.heapUsedMb.toFixed(0).padStart(5)}MB` +
-        (mem.retainedHeapMb !== undefined
-          ? `  retained=${mem.retainedHeapMb.toFixed(0).padStart(5)}MB`
-          : '')
-    );
-  }
-
-  manager.dispose();
-
-  const rssValues = samples.map((s) => s.rssMb);
-  const peakRss = Math.max(baseline.rssMb, ...rssValues);
-  const finalRss = rssValues.at(-1) ?? baseline.rssMb;
-  const rssSlope = slopePerSave(rssValues);
-
-  const retainedValues = samples
-    .map((s) => s.retainedHeapMb)
-    .filter((v): v is number => v !== undefined);
-  const retainedSlope = retainedValues.length ? slopePerSave(retainedValues) : undefined;
-  const retainedGrowth =
-    retainedValues.length && baseline.retainedHeapMb !== undefined
-      ? (retainedValues.at(-1) as number) - baseline.retainedHeapMb
-      : undefined;
-
-  const transients = samples
-    .map((s) => (s.retainedHeapMb !== undefined ? s.heapUsedMb - s.retainedHeapMb : undefined))
-    .filter((v): v is number => v !== undefined);
-  const avgTransient = transients.length
-    ? transients.reduce((a, b) => a + b, 0) / transients.length
-    : undefined;
-
-  console.log('\nsummary');
+  printSeriesSummary(series, options.saves);
   console.log(`  peak rss:            ${peakRss.toFixed(0)}MB`);
-  if (avgTransient !== undefined) {
-    console.log(`  avg transient/save:  ${avgTransient.toFixed(0)}MB (pre-GC heapUsed − post-GC heapUsed)`);
-  }
   console.log(`  final rss:           ${finalRss.toFixed(0)}MB`);
   console.log(`  rss slope:           ${rssSlope.toFixed(1)}MB/save`);
-  if (retainedSlope !== undefined) {
-    console.log(`  retained slope:      ${retainedSlope.toFixed(2)}MB/save (post-GC heapUsed)`);
-    console.log(`  retained growth:     ${retainedGrowth!.toFixed(0)}MB over ${options.saves} saves`);
+  if (retainedGrowth !== undefined) {
     console.log(
-      retainedGrowth! > 5
+      retainedGrowth > 5
         ? '  → classification:    RETAINED leak (memory held between saves)'
-        : '  → classification:    TRANSIENT pressure (post-GC heap flat; OOM is GC-can\'t-keep-up)'
+        : "  → classification:    TRANSIENT pressure (post-GC heap flat; OOM is GC-can't-keep-up)"
     );
   }
 
   if (options.jsonOut) {
     fs.writeFileSync(
       options.jsonOut,
-      JSON.stringify(
-        { options, baseline, samples, peakRss, finalRss, rssSlope, retainedSlope, retainedGrowth, avgTransient },
-        null,
-        2
-      )
+      JSON.stringify({ options, ...series, peakRss, finalRss, rssSlope }, null, 2)
     );
     console.log(`  wrote ${options.jsonOut}`);
   }
@@ -418,9 +339,4 @@ async function main() {
     );
     process.exitCode = 1;
   }
-}
-
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
 });

--- a/scripts/bench/docgen-shared/args.test.ts
+++ b/scripts/bench/docgen-shared/args.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { countOption, parseHarnessOptions } from './args.ts';
+
+const OPTIONS = {
+  components: { type: 'string' },
+  scope: { type: 'string' },
+  heavy: { type: 'boolean' },
+  out: { type: 'string' },
+  'components-per-package': { type: 'string' },
+  'max-retained-growth': { type: 'string' },
+} as const;
+
+const SCHEMA = z.object({
+  components: countOption(300),
+  scope: z.enum(['all', 'changed']).default('changed'),
+  heavy: z.boolean().default(false),
+  outDir: z.string().default('/default'),
+  componentsPerPackage: countOption(10),
+  maxRetainedGrowthMb: countOption(400),
+});
+
+interface Options {
+  components: number;
+  scope: 'all' | 'changed';
+  heavy: boolean;
+  outDir: string;
+  componentsPerPackage: number;
+  maxRetainedGrowthMb: number;
+}
+
+const parse = (argv: string[]) =>
+  parseHarnessOptions<Options>(argv, OPTIONS, SCHEMA, (values) => ({
+    ...values,
+    outDir: values.out,
+    maxRetainedGrowthMb: values.maxRetainedGrowth,
+  }));
+
+describe('parseHarnessOptions', () => {
+  it('applies defaults when nothing is passed', () => {
+    expect(parse([])).toEqual({
+      components: 300,
+      scope: 'changed',
+      heavy: false,
+      outDir: '/default',
+      componentsPerPackage: 10,
+      maxRetainedGrowthMb: 400,
+    });
+  });
+
+  it('coerces numeric flags', () => {
+    expect(parse(['--components', '20']).components).toBe(20);
+  });
+
+  it('maps kebab-case flags onto the schema shape', () => {
+    expect(parse(['--components-per-package', '5']).componentsPerPackage).toBe(5);
+  });
+
+  it('carries a flag whose schema key is not its camelCase', () => {
+    // `--max-retained-growth` camel-cases to `maxRetainedGrowth`, but the schema names the unit.
+    // Without the rename in `toInput` the flag is accepted and then silently ignored, which is how
+    // the memory harness lost its threshold flag once already.
+    expect(parse(['--max-retained-growth', '50']).maxRetainedGrowthMb).toBe(50);
+  });
+
+  it('reads boolean flags', () => {
+    expect(parse(['--heavy']).heavy).toBe(true);
+  });
+
+  it('rejects an unknown flag', () => {
+    // The reason for strict mode: `--component 5` would otherwise be dropped silently and the
+    // harness would benchmark 300 components while reporting a run someone asked for at 5.
+    expect(() => parse(['--component', '5'])).toThrow(/Unknown option/);
+  });
+
+  it('rejects a flag whose value is another flag', () => {
+    expect(() => parse(['--components', '--out', 'x'])).toThrow(/ambiguous/);
+  });
+
+  it('rejects a flag with no value at all', () => {
+    expect(() => parse(['--components'])).toThrow(/argument missing/);
+  });
+
+  it('rejects a value outside an enum, naming the flag', () => {
+    expect(() => parse(['--scope', 'some'])).toThrow(/--scope/);
+  });
+
+  describe('countOption', () => {
+    it('rejects a non-numeric value', () => {
+      expect(() => parse(['--components', 'lots'])).toThrow(/--components/);
+    });
+
+    it('rejects a fraction', () => {
+      expect(() => parse(['--components', '2.5'])).toThrow(/--components/);
+    });
+
+    it('rejects a negative', () => {
+      expect(() => parse(['--components', '-3'])).toThrow(/--components/);
+    });
+  });
+});

--- a/scripts/bench/docgen-shared/args.ts
+++ b/scripts/bench/docgen-shared/args.ts
@@ -1,0 +1,38 @@
+import { type ParseArgsConfig, parseArgs } from 'node:util';
+
+import { z } from 'zod';
+
+type OptionsConfig = NonNullable<ParseArgsConfig['options']>;
+
+/** parseArgs yields strings, so numeric flags are coerced here */
+export const countOption = (fallback: number) =>
+  z.coerce.number().int().nonnegative().default(fallback);
+
+/**
+ * parseArgs keys flags as written, so `--fan-out` arrives as `fan-out`; schema keys are camelCase.
+ * A schema key that is not exactly its flag's camelCase — `maxRetainedGrowthMb` for
+ * `--max-retained-growth` — must still be renamed in `toInput`, or Zod silently uses its default.
+ */
+function toCamelCase(flag: string): string {
+  return flag.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+export function parseHarnessOptions<Out>(
+  argv: string[],
+  options: OptionsConfig,
+  schema: z.ZodTypeAny,
+  toInput?: (values: Record<string, unknown>) => Record<string, unknown>
+): Out {
+  const { values } = parseArgs({ args: argv, options, strict: true });
+  const flags = Object.fromEntries(
+    Object.entries(values).map(([flag, value]) => [toCamelCase(flag), value])
+  );
+  const result = schema.safeParse(toInput ? toInput(flags) : flags);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `  --${issue.path.join('.')}: ${issue.message}`)
+      .join('\n');
+    throw new Error(`invalid options:\n${issues}`);
+  }
+  return result.data as Out;
+}

--- a/scripts/bench/docgen-shared/budgets.ts
+++ b/scripts/bench/docgen-shared/budgets.ts
@@ -1,0 +1,22 @@
+import type { EngineId } from './engine-ids.ts';
+
+export interface MemoryBudgets {
+  /** Max allowed post-GC retained growth (MB) across the run. */
+  maxRetainedGrowthMb: number;
+  /** Max allowed average transient working set added per save (MB). */
+  maxTransientMb: number;
+  /** Max allowed post-GC retained-heap slope (MB/save). */
+  maxRetainedSlopeMb: number;
+}
+
+const MEMORY_BUDGETS: Partial<Record<EngineId, MemoryBudgets>> = {
+  'react-osa': { maxRetainedGrowthMb: 60, maxTransientMb: 90, maxRetainedSlopeMb: 3 },
+};
+
+export function memoryBudgetsFor(engine: EngineId): MemoryBudgets {
+  const budgets = MEMORY_BUDGETS[engine];
+  if (!budgets) {
+    throw new Error(`no memory budgets recorded for "${engine}"`);
+  }
+  return budgets;
+}

--- a/scripts/bench/docgen-shared/child-output.ts
+++ b/scripts/bench/docgen-shared/child-output.ts
@@ -1,0 +1,8 @@
+export function outputTail(output: string, count: number): string {
+  return output
+    .trim()
+    .split('\n')
+    .slice(-count)
+    .map((line) => `    ${line}`)
+    .join('\n');
+}

--- a/scripts/bench/docgen-shared/engine-ids.ts
+++ b/scripts/bench/docgen-shared/engine-ids.ts
@@ -1,0 +1,10 @@
+/**
+ * The docgen engines under measurement.
+ */
+export type EngineId =
+  | 'react-legacy'
+  | 'react-legacy-rdt'
+  | 'react-osa'
+  | 'vue-docgen-api'
+  | 'vue-component-meta'
+  | 'compodoc';

--- a/scripts/bench/docgen-shared/paths.ts
+++ b/scripts/bench/docgen-shared/paths.ts
@@ -1,0 +1,13 @@
+/**
+ * Mirrors SANDBOX_DIRECTORY from scripts/utils/constants.ts. That module deliberately stays on the
+ * CJS-only `__dirname` global for Playwright compatibility, so the native-Node harness entry points
+ * here cannot import it.
+ */
+import * as path from 'node:path';
+
+const ROOT_DIRECTORY = path.join(import.meta.dirname, '..', '..', '..');
+
+export const SANDBOX_DIRECTORY =
+  process.env.STORYBOOK_SANDBOX_ROOT && path.isAbsolute(process.env.STORYBOOK_SANDBOX_ROOT)
+    ? process.env.STORYBOOK_SANDBOX_ROOT
+    : path.join(ROOT_DIRECTORY, process.env.STORYBOOK_SANDBOX_ROOT || '../storybook-sandboxes');

--- a/scripts/bench/docgen-shared/react-renderer-module.ts
+++ b/scripts/bench/docgen-shared/react-renderer-module.ts
@@ -1,0 +1,20 @@
+const COMPONENT_MANIFEST = '../../../code/renderers/react/src/componentManifest/';
+
+export async function loadReactRendererModule<T>(relativePath: string): Promise<T> {
+  const url = new URL(`${COMPONENT_MANIFEST}${relativePath}`, import.meta.url).href;
+  return (await import(url)) as T;
+}
+
+export interface ComponentRefLike {
+  componentName: string;
+  importName: string;
+  localImportName: string;
+  importId: string;
+  isPackage: boolean;
+  path: string;
+}
+
+export interface StoryRefLike {
+  storyPath: string;
+  component: ComponentRefLike;
+}

--- a/scripts/bench/docgen-shared/samples.ts
+++ b/scripts/bench/docgen-shared/samples.ts
@@ -1,0 +1,15 @@
+export interface MemorySample {
+  /** Resident Set Size, the total memory allocated for the process. */
+  rssMb: number;
+  /** The V8 heap used by the process. */
+  heapUsedMb: number;
+  /** Post-GC heap. Present only when the child runs under `node --expose-gc`. */
+  retainedHeapMb?: number;
+}
+
+export interface SaveSample extends MemorySample {
+  /** The save number, counting from 1. */
+  save: number;
+  /** The duration of the save's re-extraction, in milliseconds. */
+  durMs: number;
+}

--- a/scripts/bench/docgen-shared/sampling.ts
+++ b/scripts/bench/docgen-shared/sampling.ts
@@ -1,0 +1,39 @@
+/**
+ * Memory sampling shared by every docgen bench harness: pre-GC rss/heapUsed is the transient-pressure
+ * signal, post-GC heapUsed (only under `node --expose-gc`) is the retained signal.
+ */
+import type { MemorySample } from './samples.ts';
+
+export const MB = 1024 * 1024;
+
+export function gc(): void {
+  if (typeof global.gc === 'function') {
+    global.gc();
+    global.gc();
+  }
+}
+
+export function gcAvailable(): boolean {
+  return typeof global.gc === 'function';
+}
+
+export function sampleMemory(forceGc: boolean): MemorySample {
+  const pre = process.memoryUsage();
+  let retainedHeapMb: number | undefined;
+  if (forceGc && gcAvailable()) {
+    gc();
+    retainedHeapMb = process.memoryUsage().heapUsed / MB;
+  }
+  return { rssMb: pre.rss / MB, heapUsedMb: pre.heapUsed / MB, retainedHeapMb };
+}
+
+/** The one per-save log line every harness prints, so their output stays comparable by eye. */
+export function formatSampleLine(save: number, durMs: number, mem: MemorySample): string {
+  return (
+    `  save ${String(save).padStart(3)}: ${String(durMs).padStart(5)}ms  ` +
+    `rss=${mem.rssMb.toFixed(0).padStart(5)}MB  heapUsed=${mem.heapUsedMb.toFixed(0).padStart(5)}MB` +
+    (mem.retainedHeapMb !== undefined
+      ? `  retained=${mem.retainedHeapMb.toFixed(0).padStart(5)}MB`
+      : '')
+  );
+}

--- a/scripts/bench/docgen-shared/series.ts
+++ b/scripts/bench/docgen-shared/series.ts
@@ -1,0 +1,140 @@
+/**
+ * The save-series harness every docgen engine child runs:
+ * one timed cold pass, then K simulated saves that mutate the project on disk, invalidate the
+ * engine's caches, and re-extract, with memory sampled around forced GC after every save. Engines
+ * differ only in what those steps mean, so they implement {@link SeriesEngine} and this module owns
+ * the timing.
+ */
+import * as fs from 'node:fs';
+
+import type { MemorySample, SaveSample } from './samples.ts';
+import { formatSampleLine, gcAvailable, sampleMemory } from './sampling.ts';
+import { type SeriesSummary, summarizeSeries } from './stats.ts';
+
+export interface SeriesEngine {
+  /**
+   * One full extraction over the measured set, from a cold start. Returns how many members it
+   * documented, when the engine can report that; two engines over one project can differ by an order
+   * of magnitude, and a timing ratio between them means nothing without it.
+   */
+  cold(): Promise<number | undefined>;
+  /** Mutate the project on disk for save `save` and invalidate the engine's caches. Never timed. */
+  applySave(save: number): Promise<void>;
+  /** Re-extract after save `save`. This call, and only this call, is the warm sample. */
+  reextract(save: number): Promise<number | undefined>;
+  dispose?(): void;
+}
+
+export interface SeriesResult extends SeriesSummary {
+  coldMs: number;
+  coldMembers?: number;
+  /** Members documented by the last timed re-extraction. */
+  warmMembers?: number;
+  baseline: MemorySample;
+  samples: SaveSample[];
+}
+
+export interface SeriesOptions {
+  saves: number;
+  /** Describes the measured set for the cold-pass log line, e.g. "300 components". */
+  coldLabel: string;
+  /** Off only for the memory harness's uncapped pressure configs, which measure pre-GC rss. */
+  forceGc?: boolean;
+}
+
+export async function runSeries(
+  engine: SeriesEngine,
+  options: SeriesOptions
+): Promise<SeriesResult> {
+  const forceGc = options.forceGc ?? true;
+
+  console.log(`  full extraction over ${options.coldLabel} (cold pass)…`);
+  const coldStart = Date.now();
+  const coldMembers = await engine.cold();
+  const coldMs = Date.now() - coldStart;
+  console.log(
+    `  cold pass: ${coldMs}ms` + (coldMembers !== undefined ? ` (${coldMembers} documented members)` : '')
+  );
+
+  const baseline = sampleMemory(forceGc);
+  const samples: SaveSample[] = [];
+  let warmMembers: number | undefined;
+
+  for (let save = 1; save <= options.saves; save++) {
+    await engine.applySave(save);
+
+    const saveStart = Date.now();
+    warmMembers = await engine.reextract(save);
+    const durMs = Date.now() - saveStart;
+
+    const mem = sampleMemory(forceGc);
+    samples.push({ save, durMs, ...mem });
+    console.log(formatSampleLine(save, durMs, mem));
+  }
+
+  engine.dispose?.();
+
+  return { coldMs, coldMembers, warmMembers, baseline, samples, ...summarizeSeries(samples, baseline) };
+}
+
+export function printSeriesSummary(result: SeriesResult, saves: number): void {
+  console.log('\nsummary');
+  console.log(`  cold pass:           ${result.coldMs}ms`);
+  if (result.coldMembers !== undefined) {
+    console.log(
+      `  documented members:  ${result.coldMembers} cold, ${result.warmMembers ?? 0} on the last save`
+    );
+  }
+  if (result.avgTransient !== undefined) {
+    console.log(`  avg transient/save:  ${result.avgTransient.toFixed(0)}MB`);
+  }
+  if (result.retainedSlope !== undefined && result.retainedGrowth !== undefined) {
+    console.log(`  retained slope:      ${result.retainedSlope.toFixed(2)}MB/save`);
+    console.log(`  retained growth:     ${result.retainedGrowth.toFixed(0)}MB over ${saves} saves`);
+  }
+}
+
+export interface SeriesHarnessSpec extends SeriesOptions {
+  /** Banner line, e.g. `vue-component-meta harness (workspace)`. */
+  title: string;
+  /** The resolved options, recorded in the result JSON so a stored run is self-describing. */
+  options: object;
+  /** The subset echoed under the banner. Defaults to {@link options}. */
+  banner?: Record<string, unknown>;
+  jsonOut?: string;
+  /** Build the project and the engine. Runs before the cold pass, so its cost is not measured. */
+  setup(): Promise<SeriesEngine>;
+}
+
+/**
+ * Children own only their {@link SeriesEngine}; everything the orchestrator reads back is produced
+ * here so the children cannot drift apart in what they report.
+ */
+export async function runSeriesHarness(spec: SeriesHarnessSpec): Promise<void> {
+  console.log(spec.title);
+  console.log(
+    `  ${Object.entries(spec.banner ?? spec.options)
+      .map(([key, value]) => `${key}=${String(value)}`)
+      .join(' ')}`
+  );
+  if ((spec.forceGc ?? true) && !gcAvailable()) {
+    console.log('  (run with `node --expose-gc` to measure retained heap; continuing without it)');
+  }
+
+  const engine = await spec.setup();
+  const result = await runSeries(engine, spec);
+  printSeriesSummary(result, spec.saves);
+
+  if (spec.jsonOut) {
+    fs.writeFileSync(spec.jsonOut, JSON.stringify({ options: spec.options, ...result }, null, 2));
+    console.log(`  wrote ${spec.jsonOut}`);
+  }
+}
+
+/** Entry-point wrapper: any throw becomes a non-zero exit, which is how the orchestrator sees it. */
+export function harnessMain(run: () => Promise<void>): void {
+  run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bench/docgen-shared/stats.test.ts
+++ b/scripts/bench/docgen-shared/stats.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { leastSquaresSlope, mean, median } from './stats.ts';
+
+describe('median', () => {
+  it('returns the middle value for odd-length input', () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  it('averages the two middle values for even-length input', () => {
+    expect(median([4, 1, 3, 2])).toBe(2.5);
+  });
+
+  it('returns the value itself for a single sample', () => {
+    expect(median([7])).toBe(7);
+  });
+
+  it('does not mutate its input', () => {
+    const values = [3, 1, 2];
+    median(values);
+    expect(values).toEqual([3, 1, 2]);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => median([])).toThrow('median() requires at least one value');
+  });
+});
+
+describe('mean', () => {
+  it('averages the values', () => {
+    expect(mean([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => mean([])).toThrow('mean() requires at least one value');
+  });
+});
+
+describe('leastSquaresSlope', () => {
+  it('returns 0 for fewer than two points', () => {
+    expect(leastSquaresSlope([])).toBe(0);
+    expect(leastSquaresSlope([5])).toBe(0);
+  });
+
+  it('recovers the slope of a perfect line', () => {
+    expect(leastSquaresSlope([1, 3, 5, 7])).toBe(2);
+  });
+
+  it('returns 0 for a flat series', () => {
+    expect(leastSquaresSlope([4, 4, 4])).toBe(0);
+  });
+
+  it('fits noisy data to the least-squares line', () => {
+    expect(leastSquaresSlope([0, 2, 1, 3])).toBeCloseTo(0.8, 5);
+  });
+});

--- a/scripts/bench/docgen-shared/stats.ts
+++ b/scripts/bench/docgen-shared/stats.ts
@@ -1,0 +1,73 @@
+/** Statistics helpers shared by the docgen bench harnesses. */
+import type { MemorySample, SaveSample } from './samples.ts';
+
+/** Throws on an empty input so a missing series fails loudly. */
+export function median(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error('median() requires at least one value');
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** Throws on an empty input so a missing series fails loudly. */
+export function mean(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error('mean() requires at least one value');
+  }
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/** Least-squares slope of `values` vs index, in units-per-step. 0 for fewer than two points. */
+export function leastSquaresSlope(values: number[]): number {
+  const n = values.length;
+  if (n < 2) {
+    return 0;
+  }
+  const meanX = (n - 1) / 2;
+  const meanY = values.reduce((a, b) => a + b, 0) / n;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i++) {
+    num += (i - meanX) * (values[i] - meanY);
+    den += (i - meanX) ** 2;
+  }
+  return den === 0 ? 0 : num / den;
+}
+
+/** The retained- and transient-memory figures every series harness derives from its save series. */
+export interface SeriesSummary {
+  /** Least-squares slope of retained heap over the save series, MB per save. */
+  retainedSlope?: number;
+  /** Final retained sample minus the pre-series baseline, MB. */
+  retainedGrowth?: number;
+  /** Per-save allocation spike above the retained baseline, MB. */
+  transients: number[];
+  /** Mean of {@link transients}. */
+  avgTransient?: number;
+}
+
+/**
+ * Derive the retained/transient series figures shared by every series harness. Kept here so the
+ * memory harness and the per-engine harnesses cannot drift apart in how they compute them.
+ */
+export function summarizeSeries(samples: SaveSample[], baseline: MemorySample): SeriesSummary {
+  // Samples taken without --expose-gc carry no retained heap; dropping them keeps a missing reading
+  // from being averaged in as a zero.
+  const gcSampled = samples.filter(
+    (s): s is SaveSample & { retainedHeapMb: number } => s.retainedHeapMb !== undefined
+  );
+  const retained = gcSampled.map((s) => s.retainedHeapMb);
+  const transients = gcSampled.map((s) => s.heapUsedMb - s.retainedHeapMb);
+  const last = retained.at(-1);
+  return {
+    retainedSlope: retained.length ? leastSquaresSlope(retained) : undefined,
+    retainedGrowth:
+      last !== undefined && baseline.retainedHeapMb !== undefined
+        ? last - baseline.retainedHeapMb
+        : undefined,
+    transients,
+    avgTransient: transients.length ? mean(transients) : undefined,
+  };
+}


### PR DESCRIPTION
## What I did

`scripts/bench/docgen-memory/` is the memory benchmark that already runs as a daily CI gate for React docgen. It carried its own copies of the flag parsing, sampling, statistics, budgets, and output truncation that part 2 just moved into `docgen-shared/`. This deletes those copies and imports the shared ones.

The budgets and the assertions are unchanged — only where they come from. Three files, no new behavior.

One addition: `generate-project.ts` now also exports `componentRef` and `buildStoryRefs`. The React engine in part 5 generates the same synthetic projects and needs them.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`docgen-memory` has no unit tests, before or after this change. Its own gate run is the check — see below.

#### Manual testing

```bash
yarn install
cd scripts && yarn check && yarn lint
yarn bench:docgen-memory
```

The gate is the real test here. Confirm both halves still behave: the recycle-on case survives the save series inside its budgets, and the recycle-off negative control still runs out of memory. If the control stops failing, the gate has stopped being able to catch the regression it exists for.

### Documentation

- [ ] Add or update documentation reflecting your changes

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below: `build`
