### PR TITLE
Bench: Add the docgen perf engine framework and the compodoc engine

### DIFF
--- a/scripts/bench/PERF-METHODOLOGY.md
+++ b/scripts/bench/PERF-METHODOLOGY.md
@@ -1,0 +1,141 @@
+# Docgen performance methodology
+
+This note is the measurement contract for the per-engine docgen performance suite.
+It fixes the metric set, the determinism method, the budget shape, and the CI tiers that the harness and its budgets implement.
+The suite measures; it never optimizes.
+
+## Scope
+
+The gated suite runs in plain Node: no browser, no dev server, no Vite.
+Where an engine only runs inside a builder plugin in production, the harness calls its extraction logic directly, so the numbers describe the engine rather than the plugin around it.
+The budgets table at the end of this note names every engine and its role.
+
+An engine whose cost moves between versions is pinned to one exact version, and its numbers only hold at the version recorded beside them.
+`react-docgen-typescript` is measured through the same wrapper as `react-docgen` but carries no budget of its own.
+Svelte and web components join when their harnesses land.
+
+## Metrics
+
+Five metrics per engine, all candidates for gating:
+
+- **Cold extraction**: time for the first full extraction in a fresh process.
+  For engines that build a TypeScript program, this includes building it.
+- **Warm extraction**: time to re-extract one changed component after a simulated save, once the process is warm.
+- **Whole-project scan**: time for one batch pass over the entire project.
+  Only Compodoc works this way, so this metric applies to Compodoc alone; per-component engines record it as n/a rather than a faked equivalent.
+- **Peak memory (transient)**: the memory a save claims above the retained baseline and then gives back, sampled around a forced garbage collection.
+- **Leak detection**: how much retained heap is left after the save series, plus how steeply it climbed per save across it.
+
+Compodoc maps onto these differently because it is a fresh CLI process per run: cold extraction and whole-project scan are the same full-project measurement, warm extraction is a second full run after touching one file, and peak memory is the child's peak RSS sampled from outside the process.
+Whether the retained-series metrics mean anything for a fresh-process engine is settled when its baselines are recorded; until then its leak cells stay placeholders.
+
+Two harnesses implement this.
+`scripts/bench/docgen-memory/` (`yarn bench:docgen-memory`) gates React memory and is the only tier that fails a build today.
+`scripts/bench/docgen-perf/` (`yarn bench:docgen-perf`) records all five metrics for every engine and gates nothing yet, because no budget values exist.
+
+## Determinism method
+
+- **Fixed synthetic projects.**
+  Inputs come from a generator with fixed parameters (component count, props per component, type-heaviness levers), never from real-world checkouts.
+  The existing generator is `scripts/bench/docgen-memory/generate-project.ts`.
+- **Warmup.**
+  Every run starts with one full cold pass.
+  That pass is the cold-extraction sample and is excluded from all warm samples.
+  This exists today in the refresh mode of `scripts/bench/docgen-memory/memory-harness.ts`; live mode skips it by design.
+- **Median-of-N for latency.**
+  Each latency metric records a median, never a single-run number.
+  Cold extraction and whole-project scan yield one sample per fresh process, so their N samples come from N spawns.
+  Warm extraction records the median of the per-save durations inside a single run's save series.
+  That run is the repetition whose cold sample is the median, never the first: repetition 1 pays for a cold module graph and a cold page cache, and measures several times slower than the rest.
+  The harness pins one N for all engines and records it with the results; numbers taken at different N are not comparable.
+  An engine that fails part-way through its repetitions is reported as failed, never as measured at an N it did not reach.
+  `scripts/bench/docgen-perf/aggregate.ts` implements this; the memory gate still runs each configuration exactly once.
+- **Series statistics for leak metrics.**
+  Retained slope is the slope of a straight line drawn through the whole save series, so no single noisy sample can swing it; retained growth is the difference between the last retained sample and the baseline taken before the run.
+  Both read one run's series instead of repeated runs.
+  This exists today.
+- **Series mean for transient memory.**
+  Peak memory (transient) is the mean of the per-save spikes across the save series - not repeated and medianed like cold latency, and not fitted to a line like retained slope.
+  Warm latency, transient memory, and the leak metrics all read the same fixed-length series from the same run.
+  This exists today in `scripts/bench/docgen-memory/memory-harness.ts`.
+- **Fresh process per measurement.**
+  Every measured process is spawned fresh so it starts from a clean heap.
+  This exists today in `scripts/bench/docgen-memory/gate.ts`.
+- **Relative comparison on the same machine.**
+  Perf questions are answered by ratios between runs executed sequentially inside a single CI job on one executor, or on one local machine.
+  "Same machine" means exactly that; comparing across jobs, runs or PRs is not a comparison at all, because each CI executor is thrown away after its run and the next one is not guaranteed to match it.
+  The two standing comparisons are docgen-server flag on vs off, and new engine vs legacy engine, both measured in the same run.
+  Paired runs alternate their order across repetitions, so neither a warm cache nor a machine that has heated up consistently favors one side.
+
+## Budget shape
+
+Timing budgets are ratios or slopes, never absolute milliseconds; absolute wall-clock on shared CI executors is too noisy to gate.
+A timing ratio divides the median of one side by the median of the other, both measured in the same job.
+An engine with a second implementation to compare against uses that pair as its reference; an engine without one gets its reference picked when its baselines are recorded, and until then its timing budget stays a placeholder.
+
+A ratio only means something when both sides did the same work.
+Engines resolve types to different depths, and a shallower one finishes faster while documenting less, so speed and thoroughness are easy to mistake for each other.
+Every engine therefore reports how many members it documented, the suite prints those counts beside every ratio, warm as well as cold, and a pair whose counts disagree is marked not like-for-like.
+A ratio marked not like-for-like must not become a budget.
+
+A member count alone is not always enough.
+An engine that records a type's name without ever looking through it documents exactly as many members as one that expands the whole chain, at a fraction of the cost.
+Such an engine also reports how many of its documented members carry a type it never resolved, and that count has to agree too before a pair counts as like-for-like.
+
+A ratio also has to be shaped like production before it describes a saving anyone would feel.
+Where the harness gives both sides equal work but production would give them unequal work, the ratio compares the engines and nothing else, and that has to be said beside the number.
+Where an engine's warm measurement covers the whole project instead of the one member that changed, it is not comparable with a per-member warm count at all.
+
+Not every difference between engines is a timing question.
+An engine that takes a shortcut costing fidelity rather than time produces two rows nobody can tell apart, so it belongs in the docgen-harness fixtures that pin engine behavior, not in a bench scenario.
+
+The baseline work records the figures; quoting any here would pin numbers taken at one profile on one machine.
+Memory budgets stay absolute megabytes with generous headroom: budgets sit well above observed values so the gate is not flaky, while still failing hard on a real regression.
+Every engine must also carry its own negative control - a configuration that must fail, proving the gate can still catch the kind of regression it exists for.
+A control names its lever and the one metric it must trip; it does not need to trip every metric, and where no credible lever exists the gap is recorded instead of inventing a control that proves nothing.
+The only worked example today is the memory gate's out-of-memory control, and the budgets table below says which engine it covers.
+Budgets and controls are derived per engine from that engine's own baseline runs; nothing is ported between engines.
+
+## CI tiers
+
+- **Per PR: report-only.**
+  Per-PR perf jobs run in the part of the generated CircleCI config (`scripts/ci/main.ts`) that runs on every build, alongside the package benchmark, which already reports there without gating.
+  They report numbers and never fail the build.
+- **Daily: the only gating tier.**
+  "Daily" names the CircleCI `workflow=daily` pipeline parameter (tier order `normal < merged < daily`, `scripts/ci/utils/types.ts`); daily-only jobs attach in `scripts/ci/main.ts`, where the docgen memory gate already runs.
+- **How often daily runs is unproven.**
+  The only trigger for the daily tier in version control is the `ci:daily` PR label (`.github/workflows/trigger-circle-ci-workflow.yml`); no scheduled trigger exists in the repo, and no CircleCI-side schedule is confirmed to exist.
+  Until that is resolved, gating on the daily tier means gating when someone applies the label.
+  The baseline-and-budget work must settle how often it runs before this gate can be called nightly protection.
+
+## User-perceived metrics
+
+Three user-perceived metrics join the suite as report-only extensions of the sandbox bench task; none joins the gated floor.
+They need a real dev server and Chromium, so their numbers jump around a lot; they exist to show user-visible impact, not to gate.
+All three build on existing tooling and add no new dependencies:
+
+- **Dev-server startup, with the feature on and off.**
+  Run the sandbox bench task (`scripts/tasks/bench.ts` driving `scripts/bench/browse.ts` over Playwright/Chromium, with dev-server readiness timings from `scripts/tasks/dev.ts`) twice, docgen-server feature on and off, and report the difference.
+  Today only the internal Storybook config reads the on/off switch (`code/.storybook/main.ts`); generated sandboxes do not, so the harness work must inject the feature toggle into the sandbox config before the difference can be measured there.
+  No first-class on/off comparison mode exists yet; today this is two runs diffed by hand.
+- **Time-to-Controls-populated.**
+  Adapt the existing Playwright flow that selects a story, opens the Controls panel, and waits for an args-table cell (`code/e2e-internal/docgen-hot-update.spec.ts`) into a timing measurement, using the elapsed-time pattern from `browse.ts`.
+  Today that flow is a pass/fail assertion and records no elapsed time.
+- **Docs-page props-table render.**
+  `benchAutodocs` in `scripts/bench/browse.ts` times the docs page today, but it only builds a locator for the component description and never waits on it, so the recorded number mostly reflects page load.
+  The replacement waits for a props-table element to actually appear; it does not exist yet.
+
+## Budgets table skeleton
+
+The baseline work fills in the values; until then every cell is a placeholder.
+The exception is react-osa's memory row, which the docgen memory gate already enforces from `scripts/bench/docgen-shared/budgets.ts`.
+
+| Engine                                    | Cold extraction | Warm extraction | Whole-project scan | Peak memory (transient) | Retained growth | Retained slope | Negative control | Tier       |
+| ----------------------------------------- | --------------- | --------------- | ------------------ | ----------------------- | --------------- | -------------- | ---------------- | ---------- |
+| react-legacy (react-docgen, control)      | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| react-osa (ComponentMetaManager, control)  | TBD (1.12)      | TBD (1.12)      | n/a                | 90MB                    | 60MB            | 3MB/save       | OOM (gate.ts)    | daily      |
+| vue-docgen-api (legacy, current default)  | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| vue-component-meta                        | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| compodoc                                  | TBD (1.12)      | TBD (1.12)      | TBD (1.12)         | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| svelte (stretch)                          | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |
+| cem (stretch)                             | TBD (1.12)      | TBD (1.12)      | n/a                | TBD (1.12)              | TBD (1.12)      | TBD (1.12)     | TBD (1.12)       | TBD (1.12) |

--- a/scripts/bench/docgen-memory/gate.ts
+++ b/scripts/bench/docgen-memory/gate.ts
@@ -2,18 +2,15 @@
  * CI regression gate for the docgen-server memory behavior
  * (https://github.com/storybookjs/storybook/issues/35260).
  *
- * Runs {@link file://./memory-harness.ts} in fresh child processes (so each measurement starts from a
- * clean heap) and asserts two independent things:
+ * Runs {@link file://./memory-harness.ts} in fresh child processes (one clean heap per measurement)
+ * and asserts two independent things:
  *
- *   1. Steady-state churn/leak-freeness (`changed-scope` metric config): post-GC `heapUsed` must not
- *      climb across saves, and the per-save transient working set must stay under budget. A regression
- *      that re-extracts the whole index would blow past these.
- *   2. The OOM fix itself, as a **crash → survive negative control** (`live` configs): the live path
- *      (many per-component `batchExtract` calls on the shared program) is run under a tight heap cap
- *      both WITH and WITHOUT program recycling.
- *        - recycle OFF (`--recycle off`, ratio Infinity) MUST OOM.
- *        - recycle ON (default) MUST survive.
- *      Asserting the flip (not just survival) is what guards the fix rather than the cap.
+ *   1. Steady-state leak-freeness (`changed-scope` metric config): post-GC `heapUsed` must not
+ *      climb across saves, and the per-save transient working set must stay under budget.
+ *   2. The OOM fix itself, as a **crash → survive negative control** (`live` configs): the live
+ *      path is run under a tight heap cap both WITH and WITHOUT program recycling - recycle OFF
+ *      (`--recycle off`, ratio Infinity) MUST OOM, recycle ON (default) MUST survive. Asserting
+ *      the flip, not just survival, is what guards the fix rather than the cap.
  *
  * Run:
  *   yarn bench:docgen-memory          # from scripts/
@@ -23,6 +20,8 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { type MemoryBudgets, memoryBudgetsFor } from '../docgen-shared/budgets.ts';
+import { outputTail } from '../docgen-shared/child-output.ts';
 import { SANDBOX_DIRECTORY } from '../../utils/constants.ts';
 
 interface HarnessResult {
@@ -33,15 +32,6 @@ interface HarnessResult {
   avgTransient?: number;
 }
 
-interface MetricBudgets {
-  /** Max allowed post-GC retained growth (MB) across the run. */
-  maxRetainedGrowthMb: number;
-  /** Max allowed average transient working set added per save (MB). */
-  maxTransientMb: number;
-  /** Max allowed post-GC retained-heap slope (MB/save). */
-  maxRetainedSlopeMb: number;
-}
-
 interface GateConfig {
   name: string;
   args: string[];
@@ -50,12 +40,12 @@ interface GateConfig {
   /** `--max-old-space-size` cap (MB) for the child. Omit to run uncapped. */
   capMb?: number;
   /**
-   * Crash → survive negative control. `true` ⇒ the child MUST OOM (recycle disabled); `false` ⇒ it
-   * MUST survive (recycle on). Omit for metric-only configs.
+   * Crash → survive negative control: `true` ⇒ MUST OOM (recycle disabled), `false` ⇒ MUST
+   * survive (recycle on). Omit for metric-only configs.
    */
   expectOom?: boolean;
   /** Post-GC metric budgets, asserted from `result.json` (metric configs only). */
-  budgets?: MetricBudgets;
+  budgets?: MemoryBudgets;
 }
 
 const HARNESS = path.join(import.meta.dirname, 'memory-harness.ts');
@@ -78,7 +68,7 @@ const CONFIGS: GateConfig[] = [
       '--scope', 'changed',
     ],
     outSubdir: 'changed-scope',
-    budgets: { maxRetainedGrowthMb: 60, maxTransientMb: 90, maxRetainedSlopeMb: 3 },
+    budgets: memoryBudgetsFor('react-osa'),
   },
   {
     // Positive control: the live per-edit workload survives under a tight cap BECAUSE the shared
@@ -153,15 +143,7 @@ function runHarness(config: GateConfig): RunOutcome {
 
   const proc = spawnSync(process.execPath, nodeArgs, { encoding: 'utf8' });
   const output = `${proc.stdout ?? ''}${proc.stderr ?? ''}`;
-  // Echo a compact tail so CI logs show what happened without the full V8 crash dump.
-  console.log(
-    output
-      .trim()
-      .split('\n')
-      .slice(-8)
-      .map((line) => `    ${line}`)
-      .join('\n')
-  );
+  console.log(outputTail(output, 8));
 
   const result = fs.existsSync(jsonPath)
     ? (JSON.parse(fs.readFileSync(jsonPath, 'utf8')) as HarnessResult)

--- a/scripts/bench/docgen-memory/generate-project.ts
+++ b/scripts/bench/docgen-memory/generate-project.ts
@@ -19,6 +19,11 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { z } from 'zod';
+
+import { countOption, parseHarnessOptions } from '../docgen-shared/args.ts';
+import type { ComponentRefLike, StoryRefLike } from '../docgen-shared/react-renderer-module.ts';
+
 const require = createRequire(import.meta.url);
 
 export interface GenerateOptions {
@@ -239,6 +244,26 @@ ${variantExports}
 `;
 }
 
+/** The renderer-side reference for the generated `Comp{i}`, matching the naming used above. */
+export function componentRef(i: number, componentPath: string): ComponentRefLike {
+  return {
+    componentName: `Comp${i}`,
+    importName: `Comp${i}`,
+    localImportName: `Comp${i}`,
+    importId: `./Comp${i}`,
+    isPackage: false,
+    path: componentPath,
+  };
+}
+
+/** Pairs {@link GeneratedProject.componentPaths} with `storyPaths`, which share an index. */
+export function buildStoryRefs(componentPaths: string[], storyPaths: string[]): StoryRefLike[] {
+  return componentPaths.map((componentPath, i) => ({
+    storyPath: storyPaths[i],
+    component: componentRef(i, componentPath),
+  }));
+}
+
 export function generateProject(options: GenerateOptions): GeneratedProject {
   const outDir = path.resolve(options.outDir);
   fs.rmSync(outDir, { recursive: true, force: true });
@@ -275,25 +300,40 @@ export function generateProject(options: GenerateOptions): GeneratedProject {
   return { outDir, configPath, componentPaths, storyPaths };
 }
 
-function parseArgs(argv: string[]): GenerateOptions {
-  const get = (flag: string, fallback: string) => {
-    const idx = argv.indexOf(flag);
-    return idx >= 0 && argv[idx + 1] ? argv[idx + 1] : fallback;
-  };
-  return {
-    outDir: get('--out', '../storybook-sandboxes/docgen-memory-stress'),
-    components: Number(get('--components', '500')),
-    variants: Number(get('--variants', '4')),
-    props: Number(get('--props', '8')),
-    heavyTypes: argv.includes('--heavy'),
-    heavyFactor: Number(get('--heavy-factor', '1')),
-    base64Kb: Number(get('--base64-kb', '0')),
-    withNodeModules: !argv.includes('--no-node-modules'),
-  };
+function parseOptions(argv: string[]): GenerateOptions {
+  return parseHarnessOptions<GenerateOptions>(
+    argv,
+    {
+      out: { type: 'string' },
+      components: { type: 'string' },
+      variants: { type: 'string' },
+      props: { type: 'string' },
+      heavy: { type: 'boolean' },
+      'heavy-factor': { type: 'string' },
+      'base64-kb': { type: 'string' },
+      'no-node-modules': { type: 'boolean' },
+    } as const,
+    z.object({
+      outDir: z.string().default('../storybook-sandboxes/docgen-memory-stress'),
+      components: countOption(500),
+      variants: countOption(4),
+      props: countOption(8),
+      heavyTypes: z.boolean().default(false),
+      heavyFactor: countOption(1),
+      base64Kb: countOption(0),
+      withNodeModules: z.boolean().default(true),
+    }),
+    (values) => ({
+      ...values,
+      outDir: values.out,
+      heavyTypes: values.heavy,
+      withNodeModules: !values.noNodeModules,
+    })
+  );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const options = parseArgs(process.argv.slice(2));
+  const options = parseOptions(process.argv.slice(2));
   const start = Date.now();
   const result = generateProject(options);
   console.log(

--- a/scripts/bench/docgen-memory/memory-harness.ts
+++ b/scripts/bench/docgen-memory/memory-harness.ts
@@ -2,22 +2,21 @@
  * Deterministic in-process memory harness for the docgen-server OOM
  * (https://github.com/storybookjs/storybook/issues/35260).
  *
- * It reproduces the "re-extract on every save" behavior without a browser or dev server, so it runs
- * fast and is fully deterministic. It drives the real {@link ComponentMetaManager} against a
- * generated project of N components, then simulates K file saves and samples memory after each one.
+ * Drives the real {@link ComponentMetaManager} against a generated project of N components, then
+ * simulates K file saves and samples memory after each one.
  *
- * Two failure signals are measured independently:
- *   - RETAINED growth: post-GC `heapUsed` trend across saves. A rising trend ⇒ a true leak (memory
- *     held between saves). A flat trend ⇒ the cost is transient allocation, not retained state.
- *   - PEAK pressure: pre-GC `rss` per save. With `--no-force-gc` and a `--max-old-space-size` cap at
- *     launch, this is what crashes the process when saves outpace GC (the reported OOM).
+ * Two independent failure signals:
+ *   - RETAINED growth: post-GC `heapUsed` trend across saves. Rising ⇒ a true leak (memory held
+ *     between saves), flat ⇒ transient allocation.
+ *   - PEAK pressure: pre-GC `rss` per save. Under `--no-force-gc` and a `--max-old-space-size` cap,
+ *     this is what crashes the process when saves outpace GC (the reported OOM).
  *
  * Modes:
- *   --mode refresh  call manager.batchExtract(allEntries) synchronously each save. Mirrors the docgen
+ *   --mode refresh  synchronous manager.batchExtract(allEntries) each save. Mirrors the docgen
  *                   open-service "refresh all extracted components" path (server.ts).
  *   --mode live     many per-component batchExtract calls on the shared program, mirroring the
- *                   docs-addon per-edit wave that drives the #35260 OOM. The program-recycle fix bounds
- *                   this path. Use --recycle off to assert the OOM still happens without the fix.
+ *                   docs-addon per-edit wave that drives the #35260 OOM. The program-recycle fix
+ *                   bounds this path; use --recycle off to assert the OOM still happens without it.
  *
  * Run (diagnose retained vs transient):
  *   node --expose-gc --import jiti/register scripts/bench/docgen-memory/memory-harness.ts \
@@ -36,28 +35,23 @@ import * as path from 'node:path';
 
 import ts from 'typescript';
 
-import { SANDBOX_DIRECTORY } from '../../utils/constants.ts';
-import { componentSource, generateProject } from './generate-project.ts';
+import { z } from 'zod';
 
-/**
- * Minimal structural view of the entry shape consumed by `ComponentMetaManager.batchExtract`. Kept
- * local so the `scripts` typecheck does not descend into `code/renderers` internals; the real types
- * live in `code/renderers/react/src/componentManifest`.
- */
-interface StoryRef {
-  storyPath: string;
-  component: {
-    componentName: string;
-    importName: string;
-    localImportName: string;
-    importId: string;
-    isPackage: boolean;
-    path: string;
-  };
-}
+import { countOption, parseHarnessOptions } from '../docgen-shared/args.ts';
+import { SANDBOX_DIRECTORY } from '../docgen-shared/paths.ts';
+import { type StoryRefLike, loadReactRendererModule } from '../docgen-shared/react-renderer-module.ts';
+import { MB, gcAvailable } from '../docgen-shared/sampling.ts';
+import {
+  type SeriesEngine,
+  harnessMain,
+  printSeriesSummary,
+  runSeries,
+} from '../docgen-shared/series.ts';
+import { leastSquaresSlope } from '../docgen-shared/stats.ts';
+import { buildStoryRefs, componentSource, generateProject } from './generate-project.ts';
 
 interface ComponentMetaManagerLike {
-  batchExtract(entries: StoryRef[]): void;
+  batchExtract(entries: StoryRefLike[]): void;
   onFilesChanged(changes: Array<{ filePath: string; type: 'changed' | 'created' | 'deleted' }>): void;
   dispose(): void;
 }
@@ -67,35 +61,24 @@ type ComponentMetaManagerCtor = new (
   recycleHeapPressureRatio?: number
 ) => ComponentMetaManagerLike;
 
+const MODES = ['refresh', 'live'] as const;
 /**
- * Load the real `ComponentMetaManager` at runtime. The specifier is built with `new URL` so the
- * static `scripts` typecheck does not pull `code/renderers` source into its program.
+ * Which entries to re-extract per save: `all` re-extracts every component (the docgen service
+ * refreshing on an empty change hint), `changed` re-extracts only the component whose file changed.
  */
-async function loadComponentMetaManager(): Promise<ComponentMetaManagerCtor> {
-  const url = new URL(
-    '../../../code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts',
-    import.meta.url
-  ).href;
-  const mod = (await import(url)) as { ComponentMetaManager: ComponentMetaManagerCtor };
-  return mod.ComponentMetaManager;
-}
+const SCOPES = ['all', 'changed'] as const;
+const RECYCLE = ['on', 'off'] as const;
 
 interface HarnessOptions {
   components: number;
   variants: number;
   props: number;
   saves: number;
-  mode: 'refresh' | 'live';
+  mode: (typeof MODES)[number];
   heavyTypes: boolean;
   heavyFactor: number;
   base64Kb: number;
-  /**
-   * Which entries to re-extract per save.
-   *   all     – re-extract every component each save (the docgen service refreshing all extracted
-   *             components on an empty change hint).
-   *   changed – re-extract only the component whose file changed.
-   */
-  scope: 'all' | 'changed';
+  scope: (typeof SCOPES)[number];
   forceGc: boolean;
   outDir: string;
   reuse: boolean;
@@ -104,120 +87,114 @@ interface HarnessOptions {
   maxRetainedGrowthMb: number;
   /**
    * Heap-pressure ratio forwarded to `ComponentMetaManager`. `Infinity` disables program recycling
-   * (the negative control: assert the OOM happens without the fix). `undefined` uses the product
-   * default.
+   * (negative control), `undefined` uses the product default.
    */
   recycleHeapPressureRatio?: number;
 }
 
-interface Sample {
-  save: number;
-  rssMb: number;
-  heapUsedMb: number;
-  retainedHeapMb?: number;
-}
+const OPTIONS = {
+  components: { type: 'string' },
+  variants: { type: 'string' },
+  props: { type: 'string' },
+  saves: { type: 'string' },
+  mode: { type: 'string' },
+  scope: { type: 'string' },
+  recycle: { type: 'string' },
+  heavy: { type: 'boolean' },
+  'heavy-factor': { type: 'string' },
+  'base64-kb': { type: 'string' },
+  'no-force-gc': { type: 'boolean' },
+  out: { type: 'string' },
+  reuse: { type: 'boolean' },
+  json: { type: 'string' },
+  'max-retained-growth': { type: 'string' },
+} as const;
 
-const MB = 1024 * 1024;
+const SCHEMA = z.object({
+  components: countOption(600),
+  variants: countOption(4),
+  props: countOption(8),
+  saves: countOption(25),
+  mode: z.enum(MODES).default('refresh'),
+  scope: z.enum(SCOPES).default('all'),
+  // `Infinity` disables program recycling; `undefined` leaves the product default in place.
+  recycleHeapPressureRatio: z
+    .enum(RECYCLE)
+    .default('on')
+    .transform((recycle) => (recycle === 'off' ? Number.POSITIVE_INFINITY : undefined)),
+  heavyTypes: z.boolean().default(false),
+  heavyFactor: countOption(1),
+  base64Kb: countOption(0),
+  forceGc: z.boolean().default(true),
+  outDir: z.string().default(path.join(SANDBOX_DIRECTORY, 'docgen-memory-stress')),
+  reuse: z.boolean().default(false),
+  jsonOut: z.string().optional(),
+  maxRetainedGrowthMb: countOption(400),
+});
 
-function parseArgs(argv: string[]): HarnessOptions {
-  const get = (flag: string, fallback: string) => {
-    const idx = argv.indexOf(flag);
-    return idx >= 0 && argv[idx + 1] ? argv[idx + 1] : fallback;
-  };
-  const mode = get('--mode', 'refresh');
-  if (mode !== 'refresh' && mode !== 'live') {
-    throw new Error(`--mode must be "refresh" or "live", got "${mode}"`);
-  }
-  const scope = get('--scope', 'all');
-  if (scope !== 'all' && scope !== 'changed') {
-    throw new Error(`--scope must be "all" or "changed", got "${scope}"`);
-  }
-  const recycle = get('--recycle', 'on');
-  if (recycle !== 'on' && recycle !== 'off') {
-    throw new Error(`--recycle must be "on" or "off", got "${recycle}"`);
-  }
-  return {
-    components: Number(get('--components', '600')),
-    variants: Number(get('--variants', '4')),
-    props: Number(get('--props', '8')),
-    saves: Number(get('--saves', '25')),
-    mode,
-    scope: scope as 'all' | 'changed',
-    recycleHeapPressureRatio: recycle === 'off' ? Number.POSITIVE_INFINITY : undefined,
-    heavyTypes: argv.includes('--heavy'),
-    heavyFactor: Number(get('--heavy-factor', '1')),
-    base64Kb: Number(get('--base64-kb', '0')),
-    forceGc: !argv.includes('--no-force-gc'),
-    outDir: get('--out', path.join(SANDBOX_DIRECTORY, 'docgen-memory-stress')),
-    reuse: argv.includes('--reuse'),
-    jsonOut: argv.indexOf('--json') >= 0 ? get('--json', '') : undefined,
-    maxRetainedGrowthMb: Number(get('--max-retained-growth', '400')),
-  };
-}
-
-function gc(): void {
-  if (typeof global.gc === 'function') {
-    global.gc();
-    global.gc();
-  }
-}
-
-function sampleMemory(forceGc: boolean): { rssMb: number; heapUsedMb: number; retainedHeapMb?: number } {
-  const pre = process.memoryUsage();
-  let retainedHeapMb: number | undefined;
-  if (forceGc) {
-    gc();
-    retainedHeapMb = process.memoryUsage().heapUsed / MB;
-  }
-  return { rssMb: pre.rss / MB, heapUsedMb: pre.heapUsed / MB, retainedHeapMb };
-}
-
-/** Least-squares slope of `values` vs index, in units-per-save. */
-function slopePerSave(values: number[]): number {
-  const n = values.length;
-  if (n < 2) {
-    return 0;
-  }
-  const meanX = (n - 1) / 2;
-  const meanY = values.reduce((a, b) => a + b, 0) / n;
-  let num = 0;
-  let den = 0;
-  for (let i = 0; i < n; i++) {
-    num += (i - meanX) * (values[i] - meanY);
-    den += (i - meanX) ** 2;
-  }
-  return den === 0 ? 0 : num / den;
-}
-
-function buildEntries(componentPaths: string[], storyPaths: string[]): StoryRef[] {
-  return componentPaths.map((componentPath, i) => ({
-    storyPath: storyPaths[i],
-    component: {
-      componentName: `Comp${i}`,
-      importName: `Comp${i}`,
-      localImportName: `Comp${i}`,
-      importId: `./Comp${i}`,
-      isPackage: false,
-      path: componentPath,
-    },
+function parseOptions(argv: string[]): HarnessOptions {
+  return parseHarnessOptions<HarnessOptions>(argv, OPTIONS, SCHEMA, (values) => ({
+    ...values,
+    recycleHeapPressureRatio: values.recycle,
+    heavyTypes: values.heavy,
+    forceGc: !values.noForceGc,
+    outDir: values.out,
+    jsonOut: values.json,
+    // The schema key carries the unit the flag name leaves off, so camel-casing alone misses it.
+    maxRetainedGrowthMb: values.maxRetainedGrowth,
   }));
 }
 
 /**
- * Live-path mode: mirrors the docs-addon per-edit "waves" that drive the #35260 OOM — many
- * individual per-component `batchExtract` calls on the ONE shared program, whose type-resolution
- * cache accumulates across calls. This is the exact shape the program-recycle fix bounds (the
- * recycle check runs between calls), unlike the `--scope all` single-call cold pass which OOMs
- * within one call regardless of recycling.
- *
- * Run under a `--max-old-space-size` cap:
- *   - recycle on (default): the heap sawtooths as the shared program is recycled, and survives.
- *   - `--recycle off` (ratio Infinity): the type cache climbs to the cap and the process OOMs —
- *     the negative control the gate asserts.
+ * Loaded via `new URL` at runtime, not a static import, so the `scripts` typecheck does not pull
+ * `code/renderers` source into its program.
+ */
+async function loadComponentMetaManager(): Promise<ComponentMetaManagerCtor> {
+  const mod = await loadReactRendererModule<{ ComponentMetaManager: ComponentMetaManagerCtor }>(
+    'componentMeta/ComponentMetaManager.ts'
+  );
+  return mod.ComponentMetaManager;
+}
+
+function resolveProject(options: HarnessOptions): ReturnType<typeof generateProject> {
+  const outDir = path.resolve(options.outDir);
+  const configPath = path.join(outDir, 'tsconfig.json');
+
+  if (options.reuse && fs.existsSync(configPath)) {
+    const componentPaths: string[] = [];
+    const storyPaths: string[] = [];
+    for (let i = 0; i < options.components; i++) {
+      componentPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.tsx`));
+      storyPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.stories.tsx`));
+    }
+    console.log(`  reusing generated project at ${outDir}`);
+    return { outDir, configPath, componentPaths, storyPaths };
+  }
+
+  const genStart = Date.now();
+  const project = generateProject({
+    outDir: options.outDir,
+    components: options.components,
+    variants: options.variants,
+    props: options.props,
+    heavyTypes: options.heavyTypes,
+    heavyFactor: options.heavyFactor,
+    base64Kb: options.base64Kb,
+    withNodeModules: true,
+  });
+  console.log(`  generated project in ${Date.now() - genStart}ms at ${project.outDir}`);
+  return project;
+}
+
+/**
+ * Unlike the `--scope all` single-call cold pass (which OOMs within one call regardless of
+ * recycling), the recycle check runs between the per-component calls here, so under a heap cap:
+ * recycle on sawtooths and survives, `--recycle off` climbs to the cap and OOMs (the negative
+ * control the gate asserts).
  */
 function runLiveMode(
   manager: ComponentMetaManagerLike,
-  entries: StoryRef[],
+  entries: StoryRefLike[],
   options: HarnessOptions
 ): void {
   const recycleEnabled = options.recycleHeapPressureRatio === undefined;
@@ -257,157 +234,101 @@ function runLiveMode(
   }
 }
 
-async function main() {
-  const options = parseArgs(process.argv.slice(2));
-  const gcAvailable = typeof global.gc === 'function';
+/**
+ * The cold pass is the *identical* operation a `scope=all` refresh save performs
+ * (extractPropsFromStories over every entry), so an OOM there is the same OOM every refresh-all
+ * save would hit.
+ */
+function refreshEngine(
+  manager: ComponentMetaManagerLike,
+  entries: StoryRefLike[],
+  project: ReturnType<typeof generateProject>,
+  options: HarnessOptions
+): SeriesEngine {
+  // Track how many extra props each component currently has, so each save grows the type.
+  const extraByComponent = new Array<number>(options.components).fill(options.props);
+  const changedIndex = (save: number) => (save - 1) % options.components;
+
+  return {
+    async cold() {
+      manager.batchExtract(entries);
+      return undefined;
+    },
+    async applySave(save) {
+      const i = changedIndex(save);
+      const componentPath = project.componentPaths[i];
+      // Mutate the component's props interface on disk so the type genuinely changes.
+      extraByComponent[i] += 1;
+      fs.writeFileSync(
+        componentPath,
+        componentSource(i, extraByComponent[i], {
+          heavyTypes: options.heavyTypes,
+          heavyFactor: options.heavyFactor,
+          base64Kb: options.base64Kb,
+        })
+      );
+      // Must run after the write, or the program serves a stale snapshot for this file.
+      manager.onFilesChanged([{ filePath: componentPath, type: 'changed' }]);
+    },
+    async reextract(save) {
+      manager.batchExtract(options.scope === 'changed' ? [entries[changedIndex(save)]] : entries);
+      return undefined;
+    },
+    dispose: () => manager.dispose(),
+  };
+}
+
+harnessMain(async () => {
+  const options = parseOptions(process.argv.slice(2));
 
   console.log('docgen-memory harness');
   console.log(
     `  components=${options.components} variants=${options.variants} props=${options.props} ` +
-      `saves=${options.saves} mode=${options.mode} scope=${options.scope} forceGc=${options.forceGc && gcAvailable}`
+      `saves=${options.saves} mode=${options.mode} scope=${options.scope} ` +
+      `forceGc=${options.forceGc && gcAvailable()}`
   );
-  if (options.forceGc && !gcAvailable) {
+  if (options.forceGc && !gcAvailable()) {
     console.log('  (run with `node --expose-gc` to measure retained heap; continuing without it)');
   }
 
-  const genStart = Date.now();
-  let project: ReturnType<typeof generateProject>;
-  if (options.reuse && fs.existsSync(path.join(path.resolve(options.outDir), 'tsconfig.json'))) {
-    const outDir = path.resolve(options.outDir);
-    const componentPaths: string[] = [];
-    const storyPaths: string[] = [];
-    for (let i = 0; i < options.components; i++) {
-      componentPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.tsx`));
-      storyPaths.push(path.join(outDir, 'src', `Comp${i}`, `Comp${i}.stories.tsx`));
-    }
-    project = { outDir, configPath: path.join(outDir, 'tsconfig.json'), componentPaths, storyPaths };
-    console.log(`  reusing generated project at ${outDir}`);
-  } else {
-    project = generateProject({
-      outDir: options.outDir,
-      components: options.components,
-      variants: options.variants,
-      props: options.props,
-      heavyTypes: options.heavyTypes,
-      heavyFactor: options.heavyFactor,
-      base64Kb: options.base64Kb,
-      withNodeModules: true,
-    });
-    console.log(`  generated project in ${Date.now() - genStart}ms at ${project.outDir}`);
-  }
-
+  const project = resolveProject(options);
   const ComponentMetaManager = await loadComponentMetaManager();
   const manager = new ComponentMetaManager(ts, options.recycleHeapPressureRatio);
-  const entries = buildEntries(project.componentPaths, project.storyPaths);
+  const entries = buildStoryRefs(project.componentPaths, project.storyPaths);
 
   if (options.mode === 'live') {
     runLiveMode(manager, entries, options);
     return;
   }
 
-  // Initial extraction — builds the full TS program once (the cold path). This is the *identical*
-  // operation a `scope=all` refresh save performs (extractPropsFromStories over every entry), so an
-  // OOM here is the same OOM every refresh-all save would hit; it simply lands on the first pass when
-  // the full-extraction working set already exceeds the heap cap.
-  const initialStart = Date.now();
-  console.log(`  full extraction over ${entries.length} components (cold pass == refresh-all save)…`);
-  manager.batchExtract(entries);
-  console.log(`  initial batchExtract: ${Date.now() - initialStart}ms`);
+  const series = await runSeries(refreshEngine(manager, entries, project, options), {
+    saves: options.saves,
+    coldLabel: `${entries.length} components`,
+    forceGc: options.forceGc,
+  });
 
-  const baseline = sampleMemory(options.forceGc && gcAvailable);
-  console.log(
-    `  baseline: rss=${baseline.rssMb.toFixed(0)}MB heapUsed=${baseline.heapUsedMb.toFixed(0)}MB` +
-      (baseline.retainedHeapMb !== undefined
-        ? ` retained=${baseline.retainedHeapMb.toFixed(0)}MB`
-        : '')
-  );
+  const rssValues = series.samples.map((s) => s.rssMb);
+  const peakRss = Math.max(series.baseline.rssMb, ...rssValues);
+  const finalRss = rssValues.at(-1) ?? series.baseline.rssMb;
+  const rssSlope = leastSquaresSlope(rssValues);
+  const { retainedGrowth } = series;
 
-  const samples: Sample[] = [];
-  // Track how many extra props each component currently has, so each save grows the type.
-  const extraByComponent = new Array(options.components).fill(options.props);
-
-  for (let save = 1; save <= options.saves; save++) {
-    const i = (save - 1) % options.components;
-    const componentPath = project.componentPaths[i];
-
-    // Mutate the component's props interface on disk so the type genuinely changes.
-    extraByComponent[i] += 1;
-    fs.writeFileSync(
-      componentPath,
-      componentSource(i, extraByComponent[i], {
-        heavyTypes: options.heavyTypes,
-        heavyFactor: options.heavyFactor,
-        base64Kb: options.base64Kb,
-      })
-    );
-    // Bump project versions so the next extraction re-reads the mutated file (matches the dev
-    // server's file-watcher → onFilesChanged flow); without this the program serves stale snapshots.
-    manager.onFilesChanged([{ filePath: componentPath, type: 'changed' }]);
-
-    const saveStart = Date.now();
-    const toExtract = options.scope === 'changed' ? [entries[i]] : entries;
-    manager.batchExtract(toExtract);
-    const durMs = Date.now() - saveStart;
-
-    const mem = sampleMemory(options.forceGc && gcAvailable);
-    samples.push({ save, ...mem });
-    console.log(
-      `  save ${String(save).padStart(3)}: ${String(durMs).padStart(5)}ms  ` +
-        `rss=${mem.rssMb.toFixed(0).padStart(5)}MB  heapUsed=${mem.heapUsedMb.toFixed(0).padStart(5)}MB` +
-        (mem.retainedHeapMb !== undefined
-          ? `  retained=${mem.retainedHeapMb.toFixed(0).padStart(5)}MB`
-          : '')
-    );
-  }
-
-  manager.dispose();
-
-  const rssValues = samples.map((s) => s.rssMb);
-  const peakRss = Math.max(baseline.rssMb, ...rssValues);
-  const finalRss = rssValues.at(-1) ?? baseline.rssMb;
-  const rssSlope = slopePerSave(rssValues);
-
-  const retainedValues = samples
-    .map((s) => s.retainedHeapMb)
-    .filter((v): v is number => v !== undefined);
-  const retainedSlope = retainedValues.length ? slopePerSave(retainedValues) : undefined;
-  const retainedGrowth =
-    retainedValues.length && baseline.retainedHeapMb !== undefined
-      ? (retainedValues.at(-1) as number) - baseline.retainedHeapMb
-      : undefined;
-
-  const transients = samples
-    .map((s) => (s.retainedHeapMb !== undefined ? s.heapUsedMb - s.retainedHeapMb : undefined))
-    .filter((v): v is number => v !== undefined);
-  const avgTransient = transients.length
-    ? transients.reduce((a, b) => a + b, 0) / transients.length
-    : undefined;
-
-  console.log('\nsummary');
+  printSeriesSummary(series, options.saves);
   console.log(`  peak rss:            ${peakRss.toFixed(0)}MB`);
-  if (avgTransient !== undefined) {
-    console.log(`  avg transient/save:  ${avgTransient.toFixed(0)}MB (pre-GC heapUsed − post-GC heapUsed)`);
-  }
   console.log(`  final rss:           ${finalRss.toFixed(0)}MB`);
   console.log(`  rss slope:           ${rssSlope.toFixed(1)}MB/save`);
-  if (retainedSlope !== undefined) {
-    console.log(`  retained slope:      ${retainedSlope.toFixed(2)}MB/save (post-GC heapUsed)`);
-    console.log(`  retained growth:     ${retainedGrowth!.toFixed(0)}MB over ${options.saves} saves`);
+  if (retainedGrowth !== undefined) {
     console.log(
-      retainedGrowth! > 5
+      retainedGrowth > 5
         ? '  → classification:    RETAINED leak (memory held between saves)'
-        : '  → classification:    TRANSIENT pressure (post-GC heap flat; OOM is GC-can\'t-keep-up)'
+        : "  → classification:    TRANSIENT pressure (post-GC heap flat; OOM is GC-can't-keep-up)"
     );
   }
 
   if (options.jsonOut) {
     fs.writeFileSync(
       options.jsonOut,
-      JSON.stringify(
-        { options, baseline, samples, peakRss, finalRss, rssSlope, retainedSlope, retainedGrowth, avgTransient },
-        null,
-        2
-      )
+      JSON.stringify({ options, ...series, peakRss, finalRss, rssSlope }, null, 2)
     );
     console.log(`  wrote ${options.jsonOut}`);
   }
@@ -418,9 +339,4 @@ async function main() {
     );
     process.exitCode = 1;
   }
-}
-
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
 });

--- a/scripts/bench/docgen-perf/aggregate.test.ts
+++ b/scripts/bench/docgen-perf/aggregate.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MemorySample, SaveSample } from '../docgen-shared/samples.ts';
+import type { SeriesResult } from '../docgen-shared/series.ts';
+import { summarizeSeries } from '../docgen-shared/stats.ts';
+import { designatedRep, oneShotMetrics, seriesMetrics } from './aggregate.ts';
+
+function sample(save: number, durMs: number, heapUsedMb = 20, retainedHeapMb = 10): SaveSample {
+  return { save, durMs, rssMb: 100, heapUsedMb, retainedHeapMb };
+}
+
+/** Built through summarizeSeries, so the fixture cannot claim figures a real run would not produce. */
+function repOf(coldMs: number, samples: SaveSample[], baseline: MemorySample): SeriesResult {
+  return { coldMs, baseline, samples, ...summarizeSeries(samples, baseline) };
+}
+
+function rep(coldMs: number, durations: number[]): SeriesResult {
+  return repOf(
+    coldMs,
+    durations.map((d, i) => sample(i + 1, d)),
+    { rssMb: 90, heapUsedMb: 12, retainedHeapMb: 10 }
+  );
+}
+
+describe('designatedRep', () => {
+  it('picks the repetition whose cold sample is the median', () => {
+    const reps = [rep(900, [1]), rep(100, [2]), rep(300, [3]), rep(200, [4]), rep(250, [5])];
+    expect(designatedRep(reps).coldMs).toBe(250);
+  });
+
+  it('never picks the slow first repetition just because it came first', () => {
+    const reps = [rep(5000, [999]), rep(100, [10]), rep(110, [11]), rep(120, [12]), rep(130, [13])];
+    expect(designatedRep(reps).coldMs).not.toBe(5000);
+    expect(designatedRep(reps).coldMs).toBe(120);
+  });
+
+  it('takes the lower middle for an even count', () => {
+    const reps = [rep(10, [1]), rep(20, [2]), rep(30, [3]), rep(40, [4])];
+    expect(designatedRep(reps).coldMs).toBe(20);
+  });
+
+  it('does not mutate its input', () => {
+    const reps = [rep(30, [1]), rep(10, [2]), rep(20, [3])];
+    designatedRep(reps);
+    expect(reps.map((r) => r.coldMs)).toEqual([30, 10, 20]);
+  });
+});
+
+describe('seriesMetrics', () => {
+  const reps = [rep(300, [9, 9, 9]), rep(100, [1, 2, 3]), rep(200, [4, 5, 6])];
+
+  it('medians cold across every repetition', () => {
+    expect(seriesMetrics(reps, 3).coldExtractionMs).toMatchObject({
+      samples: [300, 100, 200],
+      median: 200,
+    });
+  });
+
+  it('reads warm from the designated repetition, not the first', () => {
+    expect(seriesMetrics(reps, 3).warmExtractionMs).toMatchObject({ samples: [4, 5, 6], median: 5 });
+  });
+
+  it('marks whole-project scan as not applicable rather than faking one', () => {
+    expect(seriesMetrics(reps, 3).wholeProjectScanMs).toEqual({ status: 'n/a' });
+  });
+
+  it('derives transient memory from the same repetition warm came from', () => {
+    expect(seriesMetrics(reps, 3).peakTransientMb).toMatchObject({ mean: 10 });
+  });
+
+  it('rejects a repetition count below the pinned N', () => {
+    expect(() => seriesMetrics(reps, 5)).toThrow('recorded 3 repetitions, expected the pinned 5');
+  });
+
+  it('rejects an empty set of repetitions', () => {
+    expect(() => seriesMetrics([], 5)).toThrow('no completed repetition recorded');
+  });
+
+  it('rejects a run with no retained samples', () => {
+    const noGc = repOf(100, [{ save: 1, durMs: 5, rssMb: 100, heapUsedMb: 20 }], {
+      rssMb: 90,
+      heapUsedMb: 12,
+    });
+    expect(() => seriesMetrics([noGc], 1)).toThrow('retained metrics missing');
+  });
+});
+
+describe('oneShotMetrics', () => {
+  const reps = [
+    { coldMs: 300, warmMs: 280, peakRssMb: 500 },
+    { coldMs: 100, warmMs: 120, peakRssMb: 400 },
+    { coldMs: 200, warmMs: 200, peakRssMb: 450 },
+  ];
+
+  it('reports cold and whole-project scan as the same measurement', () => {
+    const metrics = oneShotMetrics(reps, 3);
+    expect(metrics.wholeProjectScanMs).toEqual(metrics.coldExtractionMs);
+  });
+
+  it('has no retained series to report', () => {
+    const metrics = oneShotMetrics(reps, 3);
+    expect(metrics.retainedGrowthMb).toEqual({ status: 'n/a' });
+    expect(metrics.retainedSlopeMbPerSave).toEqual({ status: 'n/a' });
+  });
+
+  it('enforces the pinned repetition count', () => {
+    expect(() => oneShotMetrics(reps, 5)).toThrow('expected the pinned 5');
+  });
+});

--- a/scripts/bench/docgen-perf/aggregate.ts
+++ b/scripts/bench/docgen-perf/aggregate.ts
@@ -1,0 +1,87 @@
+/**
+ * Turns N repetitions into the five floor metrics (see scripts/bench/PERF-METHODOLOGY.md). Warm
+ * latency and all three memory metrics read the same designated repetition's save series, so those
+ * four figures always describe one run; cold latency is a median across every repetition instead.
+ */
+import type { SeriesResult } from '../docgen-shared/series.ts';
+import { mean, median } from '../docgen-shared/stats.ts';
+import { type EngineMetrics, NOT_APPLICABLE } from './types.ts';
+
+/**
+ * Repetition 1 is systematically the slowest - it pays for a cold module graph and a cold OS page
+ * cache - so taking it would bias warm latency and all three memory metrics at once. Cold latency
+ * needs no such protection: it is already a median across every repetition.
+ */
+export function designatedRep<T extends { coldMs: number }>(reps: T[]): T {
+  const byCold = [...reps].sort((a, b) => a.coldMs - b.coldMs);
+  return byCold[Math.floor((byCold.length - 1) / 2)];
+}
+
+/**
+ * An engine that failed part-way through holds fewer samples than expectedN. Reporting those would
+ * put numbers taken at an unrecorded N into the results file, which the comparison method rests on
+ * not happening.
+ */
+function assertRepetitionCount(reps: unknown[], expectedN: number): void {
+  if (reps.length === 0) {
+    throw new Error('no completed repetition recorded');
+  }
+  if (reps.length !== expectedN) {
+    throw new Error(`recorded ${reps.length} repetitions, expected the pinned ${expectedN}`);
+  }
+}
+
+export function seriesMetrics(reps: SeriesResult[], expectedN: number): EngineMetrics {
+  assertRepetitionCount(reps, expectedN);
+  const designated = designatedRep(reps);
+  const coldSamples = reps.map((r) => r.coldMs);
+  const warmSamples = designated.samples.map((s) => s.durMs);
+  const { transients, avgTransient } = designated;
+
+  if (
+    avgTransient === undefined ||
+    designated.retainedGrowth === undefined ||
+    designated.retainedSlope === undefined
+  ) {
+    throw new Error('retained metrics missing (child must run under --expose-gc)');
+  }
+
+  return {
+    coldExtractionMs: { status: 'measured', samples: coldSamples, median: median(coldSamples) },
+    warmExtractionMs: { status: 'measured', samples: warmSamples, median: median(warmSamples) },
+    // Per-component engines have no batch pass; recording one would be a faked equivalent.
+    wholeProjectScanMs: NOT_APPLICABLE,
+    peakTransientMb: { status: 'measured', samples: transients, mean: avgTransient },
+    retainedGrowthMb: { status: 'measured', value: designated.retainedGrowth },
+    retainedSlopeMbPerSave: { status: 'measured', value: designated.retainedSlope },
+  };
+}
+
+export interface OneShotRepetition {
+  coldMs: number;
+  warmMs: number;
+  peakRssMb: number;
+  coldMembers?: number;
+  warmMembers?: number;
+  /** Of the cold pass's members, how many carry a type the engine never resolved. */
+  coldOpaqueTypes?: number;
+}
+
+/**
+ * Metrics for a one-shot CLI engine: a fresh process per run, so cold extraction and the
+ * whole-project scan are the same full-project measurement, and there is no retained series to read.
+ */
+export function oneShotMetrics(reps: OneShotRepetition[], expectedN: number): EngineMetrics {
+  assertRepetitionCount(reps, expectedN);
+  const coldSamples = reps.map((r) => r.coldMs);
+  const warmSamples = reps.map((r) => r.warmMs);
+  const peaks = reps.map((r) => r.peakRssMb);
+  return {
+    coldExtractionMs: { status: 'measured', samples: coldSamples, median: median(coldSamples) },
+    warmExtractionMs: { status: 'measured', samples: warmSamples, median: median(warmSamples) },
+    wholeProjectScanMs: { status: 'measured', samples: coldSamples, median: median(coldSamples) },
+    peakTransientMb: { status: 'measured', samples: peaks, mean: mean(peaks) },
+    retainedGrowthMb: NOT_APPLICABLE,
+    retainedSlopeMbPerSave: NOT_APPLICABLE,
+  };
+}

--- a/scripts/bench/docgen-perf/config.ts
+++ b/scripts/bench/docgen-perf/config.ts
@@ -1,0 +1,39 @@
+/**
+ * Fixed measurement parameters for the per-engine docgen performance suite.
+ *
+ * N is pinned here for every engine and recorded with the results; numbers taken at different N are
+ * not comparable. The --quick profile exists for smoke runs only and marks its results
+ * non-comparable.
+ */
+
+/** Fresh-process spawns per cold/scan median. One value for all engines. */
+export const PINNED_N = 5;
+
+/** Spawns for --quick smoke runs. Never comparable with PINNED_N results. */
+export const QUICK_N = 2;
+
+/** Sampling interval for the compodoc child's externally-polled peak RSS. */
+export const RSS_POLL_INTERVAL_MS = 100;
+
+export interface AngularScenarioConfig {
+  components: number;
+  props: number;
+}
+
+export interface SuiteProfile {
+  n: number;
+  comparable: boolean;
+  angular: AngularScenarioConfig;
+}
+
+export const DEFAULT_PROFILE: SuiteProfile = {
+  n: PINNED_N,
+  comparable: true,
+  angular: { components: 100, props: 8 },
+};
+
+export const QUICK_PROFILE: SuiteProfile = {
+  n: QUICK_N,
+  comparable: false,
+  angular: { components: 10, props: 4 },
+};

--- a/scripts/bench/docgen-perf/engine.ts
+++ b/scripts/bench/docgen-perf/engine.ts
@@ -1,0 +1,127 @@
+/**
+ * What the orchestrator knows about an engine. Engines differ only in how one repetition is
+ * produced; everything downstream (aggregation, member counts) follows from that choice.
+ */
+import * as path from 'node:path';
+
+import type { SeriesResult } from '../docgen-shared/series.ts';
+import { seriesMetrics } from './aggregate.ts';
+import type { SuiteProfile } from './config.ts';
+import type { SeriesChildSpec } from './spawn.ts';
+import type { EngineId, EngineMetrics } from './types.ts';
+
+export interface ScenarioSpec {
+  name: string;
+  /** Recorded verbatim in the results so a stored run is self-describing. */
+  params: Record<string, number | string | boolean>;
+}
+
+export interface MeasureContext {
+  /** Scratch directory for this engine/scenario: generated project and per-repetition JSON. */
+  scenarioDir: string;
+  rssPollIntervalMs: number;
+  runSeriesChild(spec: SeriesChildSpec, outDir: string, jsonPath: string): SeriesResult;
+}
+
+/** `Sample` is whatever one repetition of this engine produces. */
+export abstract class BenchEngine<Sample = unknown> {
+  abstract readonly id: EngineId;
+
+  /** Engines outside the default run only measure when named with `--engine`. */
+  inDefaultRun = true;
+
+  abstract scenarios(profile: SuiteProfile): ScenarioSpec[];
+
+  abstract measure(ctx: MeasureContext, scenario: ScenarioSpec, rep: number): Promise<Sample>;
+
+  abstract aggregate(samples: Sample[], expectedN: number): EngineMetrics;
+
+  /**
+   * Anything that must resolve before the run starts. A returned string is the skip reason: a
+   * missing external tool is a partial install, not a regression, so it is reported as skipped
+   * rather than failed.
+   */
+  preflight(): string | undefined {
+    return undefined;
+  }
+
+  /** The resolved version of an externally installed engine, recorded with the results. */
+  version(): string | undefined {
+    return undefined;
+  }
+
+  /** Members the cold pass documented. Undefined when the engine cannot report a count. */
+  coldMembers(_sample: Sample): number | undefined {
+    return undefined;
+  }
+
+  /** Members the timed re-extraction documented. */
+  warmMembers(_sample: Sample): number | undefined {
+    return undefined;
+  }
+
+  /**
+   * Of the cold pass's members, how many the engine documented under a type name it never resolved.
+   * Two engines can agree on {@link coldMembers} and still have done entirely different work, so a
+   * member count alone does not establish like-for-like; this is what separates them.
+   */
+  coldOpaqueTypes(_sample: Sample): number | undefined {
+    return undefined;
+  }
+}
+
+export interface SeriesChildConfig {
+  id: EngineId;
+  /** Child entry point, relative to this directory. */
+  child: string;
+  scenarios(profile: SuiteProfile): ScenarioSpec[];
+  args(scenario: ScenarioSpec): string[];
+  /** Only the reused docgen-memory harness runs under the jiti loader. */
+  jiti?: boolean;
+  inDefaultRun?: boolean;
+}
+
+/**
+ * An engine measured by spawning a series-harness child, one fresh process per repetition. All
+ * engines of this kind share the series harness, so aggregation and member counts are the same
+ * for each.
+ */
+export class SeriesChildEngine extends BenchEngine<SeriesResult> {
+  readonly id: EngineId;
+  readonly #config: SeriesChildConfig;
+
+  constructor(config: SeriesChildConfig) {
+    super();
+    this.id = config.id;
+    this.inDefaultRun = config.inDefaultRun ?? true;
+    this.#config = config;
+  }
+
+  scenarios(profile: SuiteProfile): ScenarioSpec[] {
+    return this.#config.scenarios(profile);
+  }
+
+  async measure(ctx: MeasureContext, scenario: ScenarioSpec, rep: number): Promise<SeriesResult> {
+    return ctx.runSeriesChild(
+      {
+        childPath: path.join(import.meta.dirname, this.#config.child),
+        args: this.#config.args(scenario),
+        jiti: this.#config.jiti,
+      },
+      path.join(ctx.scenarioDir, 'project'),
+      path.join(ctx.scenarioDir, `rep${rep}.json`)
+    );
+  }
+
+  aggregate(samples: SeriesResult[], expectedN: number): EngineMetrics {
+    return seriesMetrics(samples, expectedN);
+  }
+
+  coldMembers(sample: SeriesResult): number | undefined {
+    return sample.coldMembers;
+  }
+
+  warmMembers(sample: SeriesResult): number | undefined {
+    return sample.warmMembers;
+  }
+}

--- a/scripts/bench/docgen-perf/engines/compodoc-doc.test.ts
+++ b/scripts/bench/docgen-perf/engines/compodoc-doc.test.ts
@@ -1,0 +1,53 @@
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { countDocumentation } from './compodoc-doc.ts';
+
+/** Real compodoc output, committed as the Angular docgen baselines. */
+const fixture = (name: string) =>
+  countDocumentation(
+    path.join(
+      import.meta.dirname,
+      '../../../../code/lib/docgen-harness/src/angular/__testfixtures__',
+      name,
+      'compodoc-input.json'
+    )
+  );
+
+describe('countDocumentation', () => {
+  it('counts an inherited member once, not once per class that lists it', () => {
+    // The component declares `heading` and `dismissed` and inherits `dismissible`, which compodoc
+    // also lists separately under `classes`. Counting `classes` too would report it twice.
+    expect(fixture('cross-file-inheritance').members).toBe(3);
+  });
+
+  it('counts signal inputs and outputs like decorator ones', () => {
+    expect(fixture('signal-io').members).toBe(6);
+  });
+
+  describe('opaque types', () => {
+    it('separates a union written inline from the same union behind an alias', () => {
+      // This component's three inputs are `ButtonKind`, `"small" | "large"` and `ToneOption`. The
+      // inline one describes itself; the two aliases are names compodoc never looked through, and
+      // an engine that resolved them would document the same three members off far more work.
+      const counts = fixture('decorator-union-enum');
+      expect(counts.members).toBe(3);
+      expect(counts.opaqueTypes).toBe(2);
+    });
+
+    it('counts an unresolved generic parameter', () => {
+      expect(fixture('decorator-generic')).toEqual({ members: 2, opaqueTypes: 2 });
+    });
+
+    it('counts an output whose payload type was dropped', () => {
+      // compodoc records `EventEmitter`, losing the emitted shape.
+      expect(fixture('decorator-io-basics')).toEqual({ members: 5, opaqueTypes: 1 });
+    });
+
+    it('reports none when every member describes itself', () => {
+      expect(fixture('properties-methods-noise').opaqueTypes).toBe(0);
+      expect(fixture('jsdoc-tags').opaqueTypes).toBe(0);
+    });
+  });
+});

--- a/scripts/bench/docgen-perf/engines/compodoc-doc.ts
+++ b/scripts/bench/docgen-perf/engines/compodoc-doc.ts
@@ -1,0 +1,76 @@
+/**
+ * Reading compodoc's `documentation.json`.
+ *
+ * Compodoc records how much it documented and how much of it it actually resolved, which is what
+ * makes its timings readable: it never expands a named type, so a chain of aliases costs it nothing
+ * and it still reports every member. Counting members alone would let it look equal to an engine
+ * that did far more work.
+ */
+import * as fs from 'node:fs';
+
+interface MemberEntry {
+  type?: string;
+  subProperties?: unknown[];
+}
+
+interface MemberHolder {
+  inputsClass?: MemberEntry[];
+  outputsClass?: MemberEntry[];
+  propertiesClass?: MemberEntry[];
+  methodsClass?: MemberEntry[];
+}
+
+interface Documentation {
+  components?: MemberHolder[];
+  directives?: MemberHolder[];
+}
+
+const MEMBER_ARRAYS = ['inputsClass', 'outputsClass', 'propertiesClass', 'methodsClass'] as const;
+
+/**
+ * `classes` is deliberately left out. Compodoc copies an ancestor's members into every descendant's
+ * own arrays, so a base class documented under `classes` would be counted a second time. This also
+ * matches what Storybook reads, which is a component's own four arrays.
+ */
+function documentedMembers(doc: Documentation): MemberEntry[] {
+  return [...(doc.components ?? []), ...(doc.directives ?? [])].flatMap((holder) =>
+    MEMBER_ARRAYS.flatMap((key) => holder[key] ?? [])
+  );
+}
+
+/**
+ * Names that describe themselves, so recording one is not a resolution an engine skipped. Keyword
+ * spellings are lowercase as compodoc emits them (`function`, not `Function`); both are listed
+ * because the two spellings reach the same member field.
+ */
+const RESOLVED_TYPES = new Set([
+  'string', 'number', 'boolean', 'any', 'unknown', 'void', 'never', 'null', 'undefined',
+  'object', 'symbol', 'bigint', 'function', 'Date', 'Function', 'Array', 'Object',
+]);
+
+/**
+ * A member whose type is a bare name the engine never looked through — `Hop19Shape`, not
+ * `{ x: string }`. Inline object literals, primitives and literal unions are all self-describing,
+ * so only a lone identifier counts.
+ *
+ * This is a floor: wrapped forms such as `Partial<Shape>` are equally unresolved but do not match,
+ * so the true share of unresolved types is at least what this reports.
+ */
+function isOpaque(entry: MemberEntry): boolean {
+  if (entry.subProperties?.length || !entry.type) {
+    return false;
+  }
+  const named = entry.type.replace(/\[\]$/, '').trim();
+  return /^[A-Za-z_$][\w$]*$/.test(named) && !RESOLVED_TYPES.has(named);
+}
+
+export interface DocumentationCounts {
+  members: number;
+  opaqueTypes: number;
+}
+
+export function countDocumentation(documentationJsonPath: string): DocumentationCounts {
+  const doc = JSON.parse(fs.readFileSync(documentationJsonPath, 'utf8')) as Documentation;
+  const members = documentedMembers(doc);
+  return { members: members.length, opaqueTypes: members.filter(isOpaque).length };
+}

--- a/scripts/bench/docgen-perf/engines/compodoc.ts
+++ b/scripts/bench/docgen-perf/engines/compodoc.ts
@@ -1,0 +1,179 @@
+import { spawn, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+
+import { outputTail } from '../../docgen-shared/child-output.ts';
+import { type OneShotRepetition, oneShotMetrics } from '../aggregate.ts';
+import { type DocumentationCounts, countDocumentation } from './compodoc-doc.ts';
+import type { AngularScenarioConfig, SuiteProfile } from '../config.ts';
+import { BenchEngine, type MeasureContext, type ScenarioSpec } from '../engine.ts';
+import { angularComponentSource, generateAngularProject } from '../generators/angular.ts';
+import type { EngineId, EngineMetrics } from '../types.ts';
+
+const require = createRequire(import.meta.url);
+
+interface ResolvedCompodoc {
+  /** The CLI entry point, run as `node <cli>` so no shell shim or exec bit is involved. */
+  cli: string;
+  version: string;
+}
+
+function resolveCompodoc(): ResolvedCompodoc | undefined {
+  try {
+    const packagePath = require.resolve('@compodoc/compodoc/package.json');
+    const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    return {
+      cli: path.join(path.dirname(packagePath), pkg.bin.compodoc),
+      version: pkg.version,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+interface CompodocRun extends DocumentationCounts {
+  durMs: number;
+  peakRssMb: number;
+}
+
+function runCompodocOnce(
+  cli: string,
+  projectDir: string,
+  docsOutDir: string,
+  pollIntervalMs: number
+): Promise<CompodocRun> {
+  fs.rmSync(docsOutDir, { recursive: true, force: true });
+  const args = [cli, '-p', 'tsconfig.json', '-e', 'json', '-d', docsOutDir, '--silent'];
+
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const child = spawn(process.execPath, args, { cwd: projectDir });
+    let peakRssKb = 0;
+    let output = '';
+    child.stdout.on('data', (chunk: Buffer) => (output += chunk.toString()));
+    child.stderr.on('data', (chunk: Buffer) => (output += chunk.toString()));
+
+    const poll = setInterval(() => {
+      if (child.pid === undefined) {
+        return;
+      }
+
+      const ps = spawnSync('ps', ['-o', 'rss=', '-p', String(child.pid)], { encoding: 'utf8' });
+      if (ps.error || typeof ps.stdout !== 'string') {
+        return;
+      }
+      const rssKb = Number(ps.stdout.trim());
+      if (Number.isFinite(rssKb) && rssKb > peakRssKb) {
+        peakRssKb = rssKb;
+      }
+    }, pollIntervalMs);
+
+    child.on('error', (err) => {
+      clearInterval(poll);
+      reject(err);
+    });
+    child.on('close', (status) => {
+      clearInterval(poll);
+      const durMs = Date.now() - start;
+      if (status !== 0) {
+        reject(new Error(`compodoc exited with status ${status}:\n${outputTail(output, 8)}`));
+        return;
+      }
+      const documentationJson = path.join(docsOutDir, 'documentation.json');
+      if (!fs.existsSync(documentationJson)) {
+        reject(new Error('compodoc run produced no documentation.json'));
+        return;
+      }
+      // Counted before the next run overwrites the file, which both runs share.
+      const counts = countDocumentation(documentationJson);
+      // The polled peak misses spikes shorter than the interval; the recorded value is a floor.
+      resolve({ durMs, peakRssMb: peakRssKb / 1024, ...counts });
+    });
+  });
+}
+
+/**
+ * One repetition: fresh project, cold full run, touch one component, warm full run. Both runs are
+ * fresh compodoc processes, matching the one-sample-per-fresh-process topology.
+ */
+export async function runCompodocRepetition(
+  cli: string,
+  scenario: AngularScenarioConfig,
+  workDir: string,
+  pollIntervalMs: number
+): Promise<OneShotRepetition> {
+  const projectDir = path.join(workDir, 'project');
+  const docsOutDir = path.join(workDir, 'docs');
+  const project = generateAngularProject({
+    outDir: projectDir,
+    components: scenario.components,
+    props: scenario.props,
+  });
+
+  const cold = await runCompodocOnce(cli, project.outDir, docsOutDir, pollIntervalMs);
+
+  // Touch one component so the warm run sees a genuinely changed file.
+  fs.writeFileSync(project.componentPaths[0], angularComponentSource(0, scenario.props + 1));
+  const warm = await runCompodocOnce(cli, project.outDir, docsOutDir, pollIntervalMs);
+
+  return {
+    coldMs: cold.durMs,
+    warmMs: warm.durMs,
+    peakRssMb: Math.max(cold.peakRssMb, warm.peakRssMb),
+    coldMembers: cold.members,
+    // A second whole-project pass, so this counts the project, not the one file that changed. It is
+    // not comparable with a series engine's warm count, which covers only the re-extracted member.
+    warmMembers: warm.members,
+    coldOpaqueTypes: cold.opaqueTypes,
+  };
+}
+
+export class CompodocEngine extends BenchEngine<OneShotRepetition> {
+  readonly id: EngineId = 'compodoc';
+
+  #resolved: ResolvedCompodoc | undefined;
+
+  scenarios(profile: SuiteProfile): ScenarioSpec[] {
+    return [{ name: 'default', params: { ...profile.angular } }];
+  }
+
+  preflight(): string | undefined {
+    this.#resolved = resolveCompodoc();
+    return this.#resolved
+      ? undefined
+      : '@compodoc/compodoc did not resolve; it is pinned in scripts/package.json, so run yarn install';
+  }
+
+  version(): string | undefined {
+    return this.#resolved?.version;
+  }
+
+  async measure(ctx: MeasureContext, scenario: ScenarioSpec): Promise<OneShotRepetition> {
+    if (!this.#resolved) {
+      throw new Error('compodoc unresolved; preflight must run first');
+    }
+    return runCompodocRepetition(
+      this.#resolved.cli,
+      { components: Number(scenario.params.components), props: Number(scenario.params.props) },
+      ctx.scenarioDir,
+      ctx.rssPollIntervalMs
+    );
+  }
+
+  aggregate(samples: OneShotRepetition[], expectedN: number): EngineMetrics {
+    return oneShotMetrics(samples, expectedN);
+  }
+
+  coldMembers(sample: OneShotRepetition): number | undefined {
+    return sample.coldMembers;
+  }
+
+  warmMembers(sample: OneShotRepetition): number | undefined {
+    return sample.warmMembers;
+  }
+
+  coldOpaqueTypes(sample: OneShotRepetition): number | undefined {
+    return sample.coldOpaqueTypes;
+  }
+}

--- a/scripts/bench/docgen-perf/generators/angular.ts
+++ b/scripts/bench/docgen-perf/generators/angular.ts
@@ -1,0 +1,142 @@
+/**
+ * Generator for a synthetic Angular project consumable by a standalone Compodoc CLI run.
+ *
+ * Ships a minimal fake `(at)angular/core` type surface inside its own node_modules so the tree is
+ * hermetic - no npm install of the real framework is needed for type resolution.
+ *
+ * Run directly:
+ *   node scripts/bench/docgen-perf/generators/angular.ts --out ../storybook-sandboxes/docgen-perf-angular --components 100
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { z } from 'zod';
+
+import { countOption, parseHarnessOptions } from '../../docgen-shared/args.ts';
+
+export interface AngularGenerateOptions {
+  outDir: string;
+  components: number;
+  /** Extra `@Input()` members per component on top of the fixed baseline set. */
+  props: number;
+}
+
+export interface GeneratedAngularProject {
+  outDir: string;
+  /** Absolute component file paths, in component order. */
+  componentPaths: string[];
+}
+
+const FAKE_ANGULAR_CORE = `export declare function Component(metadata: {
+  selector?: string;
+  template?: string;
+  standalone?: boolean;
+}): ClassDecorator;
+export declare function Input(bindingPropertyName?: string): PropertyDecorator;
+export declare function Output(bindingPropertyName?: string): PropertyDecorator;
+export declare class EventEmitter<T> {
+  emit(value?: T): void;
+  subscribe(next: (value: T) => void): { unsubscribe(): void };
+}
+`;
+
+function emitFakeAngularCore(projectDir: string): void {
+  const dir = path.join(projectDir, 'node_modules', '@angular', 'core');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: '@angular/core', version: '0.0.0-bench', types: 'index.d.ts' }, null, 2)
+  );
+  fs.writeFileSync(path.join(dir, 'index.d.ts'), FAKE_ANGULAR_CORE);
+}
+
+/**
+ * `extraProps` grows the input surface by one per warm-run touch, so the second Compodoc run sees
+ * a genuinely changed file.
+ */
+export function angularComponentSource(i: number, extraProps: number): string {
+  const extras = Array.from(
+    { length: extraProps },
+    (_, p) => `  /** Extra input ${p} for component ${i}. */
+  @Input() extra${p}?: ${p % 3 === 0 ? `'a' | 'b' | 'c'` : p % 3 === 1 ? 'number' : 'string'};`
+  ).join('\n');
+
+  return `import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+/**
+ * Comp${i} - generated bench component.
+ */
+@Component({
+  selector: 'bench-comp${i}',
+  template: '<div>{{ label }}</div>',
+})
+export class Comp${i}Component {
+  /** Primary label shown to the user. */
+  @Input() label = '';
+  /** Numeric size token. */
+  @Input() size?: number;
+  /** Visual variant. */
+  @Input() variant?: 'primary' | 'secondary' | 'tertiary';
+  /** Disable interaction. */
+  @Input() disabled = false;
+${extras ? `${extras}\n` : ''}  /** Emits when the user acts on the component. */
+  @Output() action = new EventEmitter<{ id: string; value: number }>();
+}
+`;
+}
+
+const TSCONFIG = {
+  compilerOptions: {
+    target: 'ES2020',
+    module: 'ESNext',
+    moduleResolution: 'Bundler',
+    strict: true,
+    skipLibCheck: true,
+    experimentalDecorators: true,
+    emitDecoratorMetadata: false,
+  },
+  include: ['src/**/*.ts'],
+};
+
+export function generateAngularProject(options: AngularGenerateOptions): GeneratedAngularProject {
+  const outDir = path.resolve(options.outDir);
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.mkdirSync(path.join(outDir, 'src', 'app'), { recursive: true });
+
+  emitFakeAngularCore(outDir);
+
+  // The compodoc adapter passes `-p tsconfig.json` with the project dir as cwd.
+  fs.writeFileSync(path.join(outDir, 'tsconfig.json'), JSON.stringify(TSCONFIG, null, 2));
+
+  const componentPaths: string[] = [];
+  for (let i = 0; i < options.components; i++) {
+    const componentPath = path.join(outDir, 'src', 'app', `comp${i}.component.ts`);
+    fs.writeFileSync(componentPath, angularComponentSource(i, options.props));
+    componentPaths.push(componentPath);
+  }
+
+  return { outDir, componentPaths };
+}
+
+function parseOptions(argv: string[]): AngularGenerateOptions {
+  return parseHarnessOptions<AngularGenerateOptions>(
+    argv,
+    { out: { type: 'string' }, components: { type: 'string' }, props: { type: 'string' } } as const,
+    z.object({
+      outDir: z.string().default('../storybook-sandboxes/docgen-perf-angular'),
+      components: countOption(100),
+      props: countOption(8),
+    }),
+    (values) => ({ ...values, outDir: values.out })
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const options = parseOptions(process.argv.slice(2));
+  const start = Date.now();
+  const result = generateAngularProject(options);
+  console.log(
+    `Generated ${options.components} Angular components into ${result.outDir} in ${Date.now() - start}ms`
+  );
+}

--- a/scripts/bench/docgen-perf/spawn.ts
+++ b/scripts/bench/docgen-perf/spawn.ts
@@ -1,0 +1,59 @@
+/**
+ * Spawning one measured child process and reading its result back.
+ *
+ * Every measurement runs in a fresh process so it starts from a clean heap; an engine measured after
+ * another engine's garbage would report that garbage as its own.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { outputTail } from '../docgen-shared/child-output.ts';
+import type { SeriesResult } from '../docgen-shared/series.ts';
+
+export interface SeriesChildSpec {
+  childPath: string;
+  args: string[];
+  /**
+   * Run the child under the jiti loader. Only the reused docgen-memory harness needs it: under
+   * jiti, react-docgen's browserslist dependency fails on its JSON data require
+   * ("jsReleases.map is not a function"), so the legacy child must run on native type stripping.
+   */
+  jiti?: boolean;
+}
+
+/**
+ * Run one series-harness child and parse its result JSON. A non-zero exit, or a missing or
+ * unreadable result, is a failure - never a silently empty measurement.
+ */
+export function runSeriesChild(
+  spec: SeriesChildSpec,
+  outDir: string,
+  jsonPath: string
+): SeriesResult {
+  fs.mkdirSync(path.dirname(jsonPath), { recursive: true });
+  // Remove any stale result so a crashed run cannot be mistaken for a prior success.
+  fs.rmSync(jsonPath, { force: true });
+
+  const nodeArgs = [
+    '--expose-gc',
+    ...(spec.jiti ? ['--import', 'jiti/register'] : []),
+    spec.childPath,
+    ...spec.args,
+    '--out',
+    outDir,
+    '--json',
+    jsonPath,
+  ];
+
+  const proc = spawnSync(process.execPath, nodeArgs, { encoding: 'utf8' });
+  const output = `${proc.stdout ?? ''}${proc.stderr ?? ''}`;
+
+  if (proc.status !== 0) {
+    throw new Error(`child exited with status ${proc.status}:\n${outputTail(output, 4)}`);
+  }
+  if (!fs.existsSync(jsonPath)) {
+    throw new Error(`child wrote no result JSON at ${jsonPath}:\n${outputTail(output, 4)}`);
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, 'utf8')) as SeriesResult;
+}

--- a/scripts/bench/docgen-perf/types.ts
+++ b/scripts/bench/docgen-perf/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Result shapes for the per-engine docgen performance suite. The measurement contract behind these
+ * shapes is scripts/bench/PERF-METHODOLOGY.md.
+ */
+import type { EngineId } from '../docgen-shared/engine-ids.ts';
+
+export type { EngineId };
+
+/** A latency metric: median of repeated samples (fresh process each, for cold/scan). */
+export interface LatencyMetric {
+  status: 'measured';
+  samples: number[];
+  median: number;
+}
+
+/** A memory metric aggregated as the mean of a per-save (or per-run) series. */
+export interface SeriesMeanMetric {
+  status: 'measured';
+  samples: number[];
+  mean: number;
+}
+
+/** A single-valued metric read from one run's series (retained growth, retained slope). */
+export interface ValueMetric {
+  status: 'measured';
+  value: number;
+}
+
+/** The explicit marker for a metric that does not apply to an engine; never a faked equivalent. */
+export interface NotApplicable {
+  status: 'n/a';
+}
+
+export const NOT_APPLICABLE: NotApplicable = { status: 'n/a' };
+
+export interface EngineMetrics {
+  coldExtractionMs: LatencyMetric | NotApplicable;
+  warmExtractionMs: LatencyMetric | NotApplicable;
+  wholeProjectScanMs: LatencyMetric | NotApplicable;
+  peakTransientMb: SeriesMeanMetric | NotApplicable;
+  retainedGrowthMb: ValueMetric | NotApplicable;
+  retainedSlopeMbPerSave: ValueMetric | NotApplicable;
+}
+
+export interface ScenarioResult {
+  params: Record<string, number | string | boolean>;
+  metrics: EngineMetrics;
+  /**
+   * Members the cold pass documented, when the engine reports it. Two engines over the same project
+   * can differ by an order of magnitude here, and a timing ratio between them means nothing without
+   * it.
+   */
+  coldMembers?: number;
+  /** Members the timed re-extraction documented. Warm ratios need this for the same reason. */
+  warmMembers?: number;
+  /**
+   * Of {@link coldMembers}, how many the engine documented under a type name it never resolved.
+   * An engine that prints `Hop19Shape` and one that expands it into its fields report the same
+   * member count off very different work, so equal counts alone do not make a ratio like-for-like.
+   */
+  coldOpaqueTypes?: number;
+}
+
+export type EngineResult =
+  | { status: 'measured'; scenarios: Record<string, ScenarioResult> }
+  | { status: 'skipped'; reason: string }
+  | { status: 'failed'; reason: string };
+
+/**
+ * One control pair's comparison for one scenario: the legacy engine's median over the new engine's,
+ * both measured in the same invocation.
+ *
+ * `likeForLike` is false when the two engines documented different numbers of members, which means
+ * they did not do the same work and the ratio measures resolution depth as much as speed. A ratio
+ * whose `likeForLike` is false must not become a budget.
+ */
+export interface RatioEntry {
+  cold?: number;
+  warm?: number;
+  legacyColdMembers?: number;
+  nextColdMembers?: number;
+  legacyWarmMembers?: number;
+  nextWarmMembers?: number;
+  likeForLike?: boolean;
+}
+
+/** Keyed by control-pair name, then by scenario name. */
+export type Ratios = Record<string, Record<string, RatioEntry>>;
+
+export interface SuiteResults {
+  generatedAt: string;
+  nodeVersion: string;
+  /** The one pinned N; numbers taken at different N are not comparable. */
+  pinnedN: number;
+  /** False for --quick smoke runs, whose numbers must never be compared against real runs. */
+  comparable: boolean;
+  /** Sampling interval for the compodoc child's externally-polled peak RSS. */
+  rssPollIntervalMs: number;
+  /** Resolved versions of externally-installed engines, when they ran. */
+  engineVersions: Partial<Record<EngineId, string>>;
+  engines: Partial<Record<EngineId, EngineResult>>;
+  ratios: Ratios;
+}

--- a/scripts/bench/docgen-shared/args.test.ts
+++ b/scripts/bench/docgen-shared/args.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { countOption, parseHarnessOptions } from './args.ts';
+
+const OPTIONS = {
+  components: { type: 'string' },
+  scope: { type: 'string' },
+  heavy: { type: 'boolean' },
+  out: { type: 'string' },
+  'components-per-package': { type: 'string' },
+  'max-retained-growth': { type: 'string' },
+} as const;
+
+const SCHEMA = z.object({
+  components: countOption(300),
+  scope: z.enum(['all', 'changed']).default('changed'),
+  heavy: z.boolean().default(false),
+  outDir: z.string().default('/default'),
+  componentsPerPackage: countOption(10),
+  maxRetainedGrowthMb: countOption(400),
+});
+
+interface Options {
+  components: number;
+  scope: 'all' | 'changed';
+  heavy: boolean;
+  outDir: string;
+  componentsPerPackage: number;
+  maxRetainedGrowthMb: number;
+}
+
+const parse = (argv: string[]) =>
+  parseHarnessOptions<Options>(argv, OPTIONS, SCHEMA, (values) => ({
+    ...values,
+    outDir: values.out,
+    maxRetainedGrowthMb: values.maxRetainedGrowth,
+  }));
+
+describe('parseHarnessOptions', () => {
+  it('applies defaults when nothing is passed', () => {
+    expect(parse([])).toEqual({
+      components: 300,
+      scope: 'changed',
+      heavy: false,
+      outDir: '/default',
+      componentsPerPackage: 10,
+      maxRetainedGrowthMb: 400,
+    });
+  });
+
+  it('coerces numeric flags', () => {
+    expect(parse(['--components', '20']).components).toBe(20);
+  });
+
+  it('maps kebab-case flags onto the schema shape', () => {
+    expect(parse(['--components-per-package', '5']).componentsPerPackage).toBe(5);
+  });
+
+  it('carries a flag whose schema key is not its camelCase', () => {
+    // `--max-retained-growth` camel-cases to `maxRetainedGrowth`, but the schema names the unit.
+    // Without the rename in `toInput` the flag is accepted and then silently ignored, which is how
+    // the memory harness lost its threshold flag once already.
+    expect(parse(['--max-retained-growth', '50']).maxRetainedGrowthMb).toBe(50);
+  });
+
+  it('reads boolean flags', () => {
+    expect(parse(['--heavy']).heavy).toBe(true);
+  });
+
+  it('rejects an unknown flag', () => {
+    // The reason for strict mode: `--component 5` would otherwise be dropped silently and the
+    // harness would benchmark 300 components while reporting a run someone asked for at 5.
+    expect(() => parse(['--component', '5'])).toThrow(/Unknown option/);
+  });
+
+  it('rejects a flag whose value is another flag', () => {
+    expect(() => parse(['--components', '--out', 'x'])).toThrow(/ambiguous/);
+  });
+
+  it('rejects a flag with no value at all', () => {
+    expect(() => parse(['--components'])).toThrow(/argument missing/);
+  });
+
+  it('rejects a value outside an enum, naming the flag', () => {
+    expect(() => parse(['--scope', 'some'])).toThrow(/--scope/);
+  });
+
+  describe('countOption', () => {
+    it('rejects a non-numeric value', () => {
+      expect(() => parse(['--components', 'lots'])).toThrow(/--components/);
+    });
+
+    it('rejects a fraction', () => {
+      expect(() => parse(['--components', '2.5'])).toThrow(/--components/);
+    });
+
+    it('rejects a negative', () => {
+      expect(() => parse(['--components', '-3'])).toThrow(/--components/);
+    });
+  });
+});

--- a/scripts/bench/docgen-shared/args.ts
+++ b/scripts/bench/docgen-shared/args.ts
@@ -1,0 +1,38 @@
+import { type ParseArgsConfig, parseArgs } from 'node:util';
+
+import { z } from 'zod';
+
+type OptionsConfig = NonNullable<ParseArgsConfig['options']>;
+
+/** parseArgs yields strings, so numeric flags are coerced here */
+export const countOption = (fallback: number) =>
+  z.coerce.number().int().nonnegative().default(fallback);
+
+/**
+ * parseArgs keys flags as written, so `--fan-out` arrives as `fan-out`; schema keys are camelCase.
+ * A schema key that is not exactly its flag's camelCase — `maxRetainedGrowthMb` for
+ * `--max-retained-growth` — must still be renamed in `toInput`, or Zod silently uses its default.
+ */
+function toCamelCase(flag: string): string {
+  return flag.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+export function parseHarnessOptions<Out>(
+  argv: string[],
+  options: OptionsConfig,
+  schema: z.ZodTypeAny,
+  toInput?: (values: Record<string, unknown>) => Record<string, unknown>
+): Out {
+  const { values } = parseArgs({ args: argv, options, strict: true });
+  const flags = Object.fromEntries(
+    Object.entries(values).map(([flag, value]) => [toCamelCase(flag), value])
+  );
+  const result = schema.safeParse(toInput ? toInput(flags) : flags);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `  --${issue.path.join('.')}: ${issue.message}`)
+      .join('\n');
+    throw new Error(`invalid options:\n${issues}`);
+  }
+  return result.data as Out;
+}

--- a/scripts/bench/docgen-shared/budgets.ts
+++ b/scripts/bench/docgen-shared/budgets.ts
@@ -1,0 +1,22 @@
+import type { EngineId } from './engine-ids.ts';
+
+export interface MemoryBudgets {
+  /** Max allowed post-GC retained growth (MB) across the run. */
+  maxRetainedGrowthMb: number;
+  /** Max allowed average transient working set added per save (MB). */
+  maxTransientMb: number;
+  /** Max allowed post-GC retained-heap slope (MB/save). */
+  maxRetainedSlopeMb: number;
+}
+
+const MEMORY_BUDGETS: Partial<Record<EngineId, MemoryBudgets>> = {
+  'react-osa': { maxRetainedGrowthMb: 60, maxTransientMb: 90, maxRetainedSlopeMb: 3 },
+};
+
+export function memoryBudgetsFor(engine: EngineId): MemoryBudgets {
+  const budgets = MEMORY_BUDGETS[engine];
+  if (!budgets) {
+    throw new Error(`no memory budgets recorded for "${engine}"`);
+  }
+  return budgets;
+}

--- a/scripts/bench/docgen-shared/child-output.ts
+++ b/scripts/bench/docgen-shared/child-output.ts
@@ -1,0 +1,8 @@
+export function outputTail(output: string, count: number): string {
+  return output
+    .trim()
+    .split('\n')
+    .slice(-count)
+    .map((line) => `    ${line}`)
+    .join('\n');
+}

--- a/scripts/bench/docgen-shared/engine-ids.ts
+++ b/scripts/bench/docgen-shared/engine-ids.ts
@@ -1,4 +1,4 @@
 /**
  * The docgen engines under measurement. Each engine adds its own id when it lands.
  */
-export type EngineId = 'react-osa';
+export type EngineId = 'react-osa' | 'compodoc';

--- a/scripts/bench/docgen-shared/engine-ids.ts
+++ b/scripts/bench/docgen-shared/engine-ids.ts
@@ -1,0 +1,4 @@
+/**
+ * The docgen engines under measurement. Each engine adds its own id when it lands.
+ */
+export type EngineId = 'react-osa';

--- a/scripts/bench/docgen-shared/paths.ts
+++ b/scripts/bench/docgen-shared/paths.ts
@@ -1,0 +1,13 @@
+/**
+ * Mirrors SANDBOX_DIRECTORY from scripts/utils/constants.ts. That module deliberately stays on the
+ * CJS-only `__dirname` global for Playwright compatibility, so the native-Node harness entry points
+ * here cannot import it.
+ */
+import * as path from 'node:path';
+
+const ROOT_DIRECTORY = path.join(import.meta.dirname, '..', '..', '..');
+
+export const SANDBOX_DIRECTORY =
+  process.env.STORYBOOK_SANDBOX_ROOT && path.isAbsolute(process.env.STORYBOOK_SANDBOX_ROOT)
+    ? process.env.STORYBOOK_SANDBOX_ROOT
+    : path.join(ROOT_DIRECTORY, process.env.STORYBOOK_SANDBOX_ROOT || '../storybook-sandboxes');

--- a/scripts/bench/docgen-shared/react-renderer-module.ts
+++ b/scripts/bench/docgen-shared/react-renderer-module.ts
@@ -1,0 +1,20 @@
+const COMPONENT_MANIFEST = '../../../code/renderers/react/src/componentManifest/';
+
+export async function loadReactRendererModule<T>(relativePath: string): Promise<T> {
+  const url = new URL(`${COMPONENT_MANIFEST}${relativePath}`, import.meta.url).href;
+  return (await import(url)) as T;
+}
+
+export interface ComponentRefLike {
+  componentName: string;
+  importName: string;
+  localImportName: string;
+  importId: string;
+  isPackage: boolean;
+  path: string;
+}
+
+export interface StoryRefLike {
+  storyPath: string;
+  component: ComponentRefLike;
+}

--- a/scripts/bench/docgen-shared/samples.ts
+++ b/scripts/bench/docgen-shared/samples.ts
@@ -1,0 +1,15 @@
+export interface MemorySample {
+  /** Resident Set Size, the total memory allocated for the process. */
+  rssMb: number;
+  /** The V8 heap used by the process. */
+  heapUsedMb: number;
+  /** Post-GC heap. Present only when the child runs under `node --expose-gc`. */
+  retainedHeapMb?: number;
+}
+
+export interface SaveSample extends MemorySample {
+  /** The save number, counting from 1. */
+  save: number;
+  /** The duration of the save's re-extraction, in milliseconds. */
+  durMs: number;
+}

--- a/scripts/bench/docgen-shared/sampling.ts
+++ b/scripts/bench/docgen-shared/sampling.ts
@@ -1,0 +1,39 @@
+/**
+ * Memory sampling shared by every docgen bench harness: pre-GC rss/heapUsed is the transient-pressure
+ * signal, post-GC heapUsed (only under `node --expose-gc`) is the retained signal.
+ */
+import type { MemorySample } from './samples.ts';
+
+export const MB = 1024 * 1024;
+
+export function gc(): void {
+  if (typeof global.gc === 'function') {
+    global.gc();
+    global.gc();
+  }
+}
+
+export function gcAvailable(): boolean {
+  return typeof global.gc === 'function';
+}
+
+export function sampleMemory(forceGc: boolean): MemorySample {
+  const pre = process.memoryUsage();
+  let retainedHeapMb: number | undefined;
+  if (forceGc && gcAvailable()) {
+    gc();
+    retainedHeapMb = process.memoryUsage().heapUsed / MB;
+  }
+  return { rssMb: pre.rss / MB, heapUsedMb: pre.heapUsed / MB, retainedHeapMb };
+}
+
+/** The one per-save log line every harness prints, so their output stays comparable by eye. */
+export function formatSampleLine(save: number, durMs: number, mem: MemorySample): string {
+  return (
+    `  save ${String(save).padStart(3)}: ${String(durMs).padStart(5)}ms  ` +
+    `rss=${mem.rssMb.toFixed(0).padStart(5)}MB  heapUsed=${mem.heapUsedMb.toFixed(0).padStart(5)}MB` +
+    (mem.retainedHeapMb !== undefined
+      ? `  retained=${mem.retainedHeapMb.toFixed(0).padStart(5)}MB`
+      : '')
+  );
+}

--- a/scripts/bench/docgen-shared/series.ts
+++ b/scripts/bench/docgen-shared/series.ts
@@ -1,0 +1,140 @@
+/**
+ * The save-series harness every docgen engine child runs:
+ * one timed cold pass, then K simulated saves that mutate the project on disk, invalidate the
+ * engine's caches, and re-extract, with memory sampled around forced GC after every save. Engines
+ * differ only in what those steps mean, so they implement {@link SeriesEngine} and this module owns
+ * the timing.
+ */
+import * as fs from 'node:fs';
+
+import type { MemorySample, SaveSample } from './samples.ts';
+import { formatSampleLine, gcAvailable, sampleMemory } from './sampling.ts';
+import { type SeriesSummary, summarizeSeries } from './stats.ts';
+
+export interface SeriesEngine {
+  /**
+   * One full extraction over the measured set, from a cold start. Returns how many members it
+   * documented, when the engine can report that; two engines over one project can differ by an order
+   * of magnitude, and a timing ratio between them means nothing without it.
+   */
+  cold(): Promise<number | undefined>;
+  /** Mutate the project on disk for save `save` and invalidate the engine's caches. Never timed. */
+  applySave(save: number): Promise<void>;
+  /** Re-extract after save `save`. This call, and only this call, is the warm sample. */
+  reextract(save: number): Promise<number | undefined>;
+  dispose?(): void;
+}
+
+export interface SeriesResult extends SeriesSummary {
+  coldMs: number;
+  coldMembers?: number;
+  /** Members documented by the last timed re-extraction. */
+  warmMembers?: number;
+  baseline: MemorySample;
+  samples: SaveSample[];
+}
+
+export interface SeriesOptions {
+  saves: number;
+  /** Describes the measured set for the cold-pass log line, e.g. "300 components". */
+  coldLabel: string;
+  /** Off only for the memory harness's uncapped pressure configs, which measure pre-GC rss. */
+  forceGc?: boolean;
+}
+
+export async function runSeries(
+  engine: SeriesEngine,
+  options: SeriesOptions
+): Promise<SeriesResult> {
+  const forceGc = options.forceGc ?? true;
+
+  console.log(`  full extraction over ${options.coldLabel} (cold pass)…`);
+  const coldStart = Date.now();
+  const coldMembers = await engine.cold();
+  const coldMs = Date.now() - coldStart;
+  console.log(
+    `  cold pass: ${coldMs}ms` + (coldMembers !== undefined ? ` (${coldMembers} documented members)` : '')
+  );
+
+  const baseline = sampleMemory(forceGc);
+  const samples: SaveSample[] = [];
+  let warmMembers: number | undefined;
+
+  for (let save = 1; save <= options.saves; save++) {
+    await engine.applySave(save);
+
+    const saveStart = Date.now();
+    warmMembers = await engine.reextract(save);
+    const durMs = Date.now() - saveStart;
+
+    const mem = sampleMemory(forceGc);
+    samples.push({ save, durMs, ...mem });
+    console.log(formatSampleLine(save, durMs, mem));
+  }
+
+  engine.dispose?.();
+
+  return { coldMs, coldMembers, warmMembers, baseline, samples, ...summarizeSeries(samples, baseline) };
+}
+
+export function printSeriesSummary(result: SeriesResult, saves: number): void {
+  console.log('\nsummary');
+  console.log(`  cold pass:           ${result.coldMs}ms`);
+  if (result.coldMembers !== undefined) {
+    console.log(
+      `  documented members:  ${result.coldMembers} cold, ${result.warmMembers ?? 0} on the last save`
+    );
+  }
+  if (result.avgTransient !== undefined) {
+    console.log(`  avg transient/save:  ${result.avgTransient.toFixed(0)}MB`);
+  }
+  if (result.retainedSlope !== undefined && result.retainedGrowth !== undefined) {
+    console.log(`  retained slope:      ${result.retainedSlope.toFixed(2)}MB/save`);
+    console.log(`  retained growth:     ${result.retainedGrowth.toFixed(0)}MB over ${saves} saves`);
+  }
+}
+
+export interface SeriesHarnessSpec extends SeriesOptions {
+  /** Banner line, e.g. `vue-component-meta harness (workspace)`. */
+  title: string;
+  /** The resolved options, recorded in the result JSON so a stored run is self-describing. */
+  options: object;
+  /** The subset echoed under the banner. Defaults to {@link options}. */
+  banner?: Record<string, unknown>;
+  jsonOut?: string;
+  /** Build the project and the engine. Runs before the cold pass, so its cost is not measured. */
+  setup(): Promise<SeriesEngine>;
+}
+
+/**
+ * Children own only their {@link SeriesEngine}; everything the orchestrator reads back is produced
+ * here so the children cannot drift apart in what they report.
+ */
+export async function runSeriesHarness(spec: SeriesHarnessSpec): Promise<void> {
+  console.log(spec.title);
+  console.log(
+    `  ${Object.entries(spec.banner ?? spec.options)
+      .map(([key, value]) => `${key}=${String(value)}`)
+      .join(' ')}`
+  );
+  if ((spec.forceGc ?? true) && !gcAvailable()) {
+    console.log('  (run with `node --expose-gc` to measure retained heap; continuing without it)');
+  }
+
+  const engine = await spec.setup();
+  const result = await runSeries(engine, spec);
+  printSeriesSummary(result, spec.saves);
+
+  if (spec.jsonOut) {
+    fs.writeFileSync(spec.jsonOut, JSON.stringify({ options: spec.options, ...result }, null, 2));
+    console.log(`  wrote ${spec.jsonOut}`);
+  }
+}
+
+/** Entry-point wrapper: any throw becomes a non-zero exit, which is how the orchestrator sees it. */
+export function harnessMain(run: () => Promise<void>): void {
+  run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bench/docgen-shared/stats.test.ts
+++ b/scripts/bench/docgen-shared/stats.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { leastSquaresSlope, mean, median } from './stats.ts';
+
+describe('median', () => {
+  it('returns the middle value for odd-length input', () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  it('averages the two middle values for even-length input', () => {
+    expect(median([4, 1, 3, 2])).toBe(2.5);
+  });
+
+  it('returns the value itself for a single sample', () => {
+    expect(median([7])).toBe(7);
+  });
+
+  it('does not mutate its input', () => {
+    const values = [3, 1, 2];
+    median(values);
+    expect(values).toEqual([3, 1, 2]);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => median([])).toThrow('median() requires at least one value');
+  });
+});
+
+describe('mean', () => {
+  it('averages the values', () => {
+    expect(mean([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => mean([])).toThrow('mean() requires at least one value');
+  });
+});
+
+describe('leastSquaresSlope', () => {
+  it('returns 0 for fewer than two points', () => {
+    expect(leastSquaresSlope([])).toBe(0);
+    expect(leastSquaresSlope([5])).toBe(0);
+  });
+
+  it('recovers the slope of a perfect line', () => {
+    expect(leastSquaresSlope([1, 3, 5, 7])).toBe(2);
+  });
+
+  it('returns 0 for a flat series', () => {
+    expect(leastSquaresSlope([4, 4, 4])).toBe(0);
+  });
+
+  it('fits noisy data to the least-squares line', () => {
+    expect(leastSquaresSlope([0, 2, 1, 3])).toBeCloseTo(0.8, 5);
+  });
+});

--- a/scripts/bench/docgen-shared/stats.ts
+++ b/scripts/bench/docgen-shared/stats.ts
@@ -1,0 +1,73 @@
+/** Statistics helpers shared by the docgen bench harnesses. */
+import type { MemorySample, SaveSample } from './samples.ts';
+
+/** Throws on an empty input so a missing series fails loudly. */
+export function median(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error('median() requires at least one value');
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** Throws on an empty input so a missing series fails loudly. */
+export function mean(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error('mean() requires at least one value');
+  }
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/** Least-squares slope of `values` vs index, in units-per-step. 0 for fewer than two points. */
+export function leastSquaresSlope(values: number[]): number {
+  const n = values.length;
+  if (n < 2) {
+    return 0;
+  }
+  const meanX = (n - 1) / 2;
+  const meanY = values.reduce((a, b) => a + b, 0) / n;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i++) {
+    num += (i - meanX) * (values[i] - meanY);
+    den += (i - meanX) ** 2;
+  }
+  return den === 0 ? 0 : num / den;
+}
+
+/** The retained- and transient-memory figures every series harness derives from its save series. */
+export interface SeriesSummary {
+  /** Least-squares slope of retained heap over the save series, MB per save. */
+  retainedSlope?: number;
+  /** Final retained sample minus the pre-series baseline, MB. */
+  retainedGrowth?: number;
+  /** Per-save allocation spike above the retained baseline, MB. */
+  transients: number[];
+  /** Mean of {@link transients}. */
+  avgTransient?: number;
+}
+
+/**
+ * Derive the retained/transient series figures shared by every series harness. Kept here so the
+ * memory harness and the per-engine harnesses cannot drift apart in how they compute them.
+ */
+export function summarizeSeries(samples: SaveSample[], baseline: MemorySample): SeriesSummary {
+  // Samples taken without --expose-gc carry no retained heap; dropping them keeps a missing reading
+  // from being averaged in as a zero.
+  const gcSampled = samples.filter(
+    (s): s is SaveSample & { retainedHeapMb: number } => s.retainedHeapMb !== undefined
+  );
+  const retained = gcSampled.map((s) => s.retainedHeapMb);
+  const transients = gcSampled.map((s) => s.heapUsedMb - s.retainedHeapMb);
+  const last = retained.at(-1);
+  return {
+    retainedSlope: retained.length ? leastSquaresSlope(retained) : undefined,
+    retainedGrowth:
+      last !== undefined && baseline.retainedHeapMb !== undefined
+        ? last - baseline.retainedHeapMb
+        : undefined,
+    transients,
+    avgTransient: transients.length ? mean(transients) : undefined,
+  };
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@anthropic-ai/claude-agent-sdk": "^0.2.85",
+    "@compodoc/compodoc": "2.0.0",
     "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
     "@google-cloud/bigquery": "^6.2.1",
     "@octokit/graphql": "^5.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,6 +48,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aduh95/viz.js@npm:3.4.0":
+  version: 3.4.0
+  resolution: "@aduh95/viz.js@npm:3.4.0"
+  checksum: 10c0/6acb40e881dc0b7ac7a6800a1508e8c420e1f6b09bd42e3289aa2199345729af8aec6ffc52dc72cfe678476fcc341f4a83bc2c3d59cd223232e8495f3a414ab0
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:2.3.0, @ampproject/remapping@npm:^2.2.0, @ampproject/remapping@npm:^2.3.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -431,6 +438,38 @@ __metadata:
     chokidar:
       optional: true
   checksum: 10c0/0ee6c9515d05acb0f6872608030630b0e2d9291f9bcbce9a6101630a9a5ed2888da0ea29f12c476b5a05426935922bbe5c367ae2b1b8d9e04c8bcc74d87d828a
+  languageName: node
+  linkType: hard
+
+"@angular-devkit/core@npm:22.0.4":
+  version: 22.0.4
+  resolution: "@angular-devkit/core@npm:22.0.4"
+  dependencies:
+    ajv: "npm:8.20.0"
+    ajv-formats: "npm:3.0.1"
+    jsonc-parser: "npm:3.3.1"
+    picomatch: "npm:4.0.4"
+    rxjs: "npm:7.8.2"
+    source-map: "npm:0.7.6"
+  peerDependencies:
+    chokidar: ^5.0.0
+  peerDependenciesMeta:
+    chokidar:
+      optional: true
+  checksum: 10c0/0d84969ad31113a48202c644038386f7dd120af950490125d7b8d56c4ebc9ca362cff56be70f90eb3c3be1c15cbcec11aad648e46caebabba82efc91e75dff20
+  languageName: node
+  linkType: hard
+
+"@angular-devkit/schematics@npm:22.0.4":
+  version: 22.0.4
+  resolution: "@angular-devkit/schematics@npm:22.0.4"
+  dependencies:
+    "@angular-devkit/core": "npm:22.0.4"
+    jsonc-parser: "npm:3.3.1"
+    magic-string: "npm:0.30.21"
+    ora: "npm:9.4.0"
+    rxjs: "npm:7.8.2"
+  checksum: 10c0/02288bf8f636d3517d03e97942ac1fab4ec8e4448d0d918abd96b06b1a8d0e043482993b51fc69e6c2fe43a3459fb4bbf8c3cccc803f17649ebc2f61c656d94d
   languageName: node
   linkType: hard
 
@@ -852,6 +891,13 @@ __metadata:
     "@img/sharp-win32-x64":
       optional: true
   checksum: 10c0/5bb31712460b03b264b489c38a2ddcac62ba60aad50da8cd6d3cebdaf46fae84c37473f25b7a4e20a6bda6f2310b4cc9f3574bc3f2e8f73a4a6e6bd0e04bd827
+  languageName: node
+  linkType: hard
+
+"@arr/every@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@arr/every@npm:1.0.1"
+  checksum: 10c0/f9769bc97eca37d1c0dedfda4c17506c0e1269d95c15a7478a49c4d84d43512a3f350b71c95e045cf4113d3398ebd6d298f2eea09196a1ed61c311bc4e6964e7
   languageName: node
   linkType: hard
 
@@ -2641,6 +2687,69 @@ __metadata:
     picocolors: "npm:^1.0.0"
     sisteransi: "npm:^1.0.5"
   checksum: 10c0/21f657868fe538e260f0c79026cca909b51013ad8017a6951869c976dded786383b604db616fed2a799b40c300f7df672fa3e7f4c2e1484819c7fc482b2bd9bb
+  languageName: node
+  linkType: hard
+
+"@compodoc/compodoc@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@compodoc/compodoc@npm:2.0.0"
+  dependencies:
+    "@angular-devkit/schematics": "npm:22.0.4"
+    "@compodoc/ngd-transformer": "npm:^2.1.3"
+    body-parser: "npm:^2.3.0"
+    bootstrap.native: "npm:^5.1.10"
+    cheerio: "npm:1.2.0"
+    chokidar: "npm:^5.0.0"
+    commander: "npm:^15.0.0"
+    cosmiconfig: "npm:^9.0.2"
+    es6-shim: "npm:^0.35.8"
+    fs-extra: "npm:^11.3.5"
+    handlebars: "npm:^4.7.9"
+    html-entities: "npm:^2.6.0"
+    i18next: "npm:26.3.3"
+    json5: "npm:^2.2.3"
+    loglevel: "npm:^1.9.2"
+    loglevel-plugin-prefix: "npm:^0.8.4"
+    lunr: "npm:^2.3.9"
+    marked: "npm:18.0.5"
+    neotraverse: "npm:^1.0.1"
+    picocolors: "npm:^1.1.1"
+    polka: "npm:^0.5.2"
+    prismjs: "npm:^1.30.0"
+    semver: "npm:^7.8.5"
+    sirv: "npm:^3.0.2"
+    svg-pan-zoom: "npm:^3.6.2"
+    tablesort: "npm:^5.7.1"
+    tinyglobby: "npm:^0.2.17"
+    ts-morph: "npm:^28.0.0"
+    uuid: "npm:14.0.1"
+    vis-network: "npm:^10.1.0"
+  bin:
+    compodoc: bin/index-cli.js
+  checksum: 10c0/327e6b7d173f75be1996b59b89d3832467599782530f1e2b1ff8bcc73e977833e69e35e5ab57bfd79ddfb02e31ea58e5ee9a58201829751b330601f74af0efc8
+  languageName: node
+  linkType: hard
+
+"@compodoc/ngd-core@npm:~2.1.1":
+  version: 2.1.1
+  resolution: "@compodoc/ngd-core@npm:2.1.1"
+  dependencies:
+    ansi-colors: "npm:^4.1.3"
+    fancy-log: "npm:^2.0.0"
+    typescript: "npm:^5.0.4"
+  checksum: 10c0/f78f4231e39d96e397bb39614cfbe8dfc6b985eb9b2795cd5188a40f65eb60eb096dc29de61baa6d914fbc86ec7f21b5a2d02e6000b26d82ae3cd682aea79275
+  languageName: node
+  linkType: hard
+
+"@compodoc/ngd-transformer@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@compodoc/ngd-transformer@npm:2.1.3"
+  dependencies:
+    "@aduh95/viz.js": "npm:3.4.0"
+    "@compodoc/ngd-core": "npm:~2.1.1"
+    dot: "npm:^2.0.0-beta.1"
+    fs-extra: "npm:^11.1.1"
+  checksum: 10c0/fb7b13860fc022cda284ca0bae55f8c6610621a060c943740838b5fa2f6be7957c99c2750024cf949b2c8f1c5f41bc64cd8e28ab333f985627f5991bcaf5cdcf
   languageName: node
   linkType: hard
 
@@ -6484,6 +6593,13 @@ __metadata:
   version: 1.0.0-next.28
   resolution: "@polka/parse@npm:1.0.0-next.28"
   checksum: 10c0/42c53dfdc4b39a3b516fbd4358b2472b22f36e6038e25d463afb3f133fb1d5af84d7eb4d245ab66bc5793d6414299fdd9093803e5214e560f0693f2176fc58b6
+  languageName: node
+  linkType: hard
+
+"@polka/url@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@polka/url@npm:0.5.0"
+  checksum: 10c0/76324126e1608f4cdc5c6b11b618ca67612c37d45401f3fbcce4967294093761b7568cc6ae74ade8afbe744547e72e9d50bc38f690ddea0904a1d66a6b8a0093
   languageName: node
   linkType: hard
 
@@ -10404,6 +10520,7 @@ __metadata:
   dependencies:
     "@actions/core": "npm:^1.11.1"
     "@anthropic-ai/claude-agent-sdk": "npm:^0.2.85"
+    "@compodoc/compodoc": "npm:2.0.0"
     "@fal-works/esbuild-plugin-global-externals": "npm:^2.1.2"
     "@google-cloud/bigquery": "npm:^6.2.1"
     "@octokit/graphql": "npm:^5.0.6"
@@ -11195,6 +11312,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@thednp/event-listener@npm:^2.0.15":
+  version: 2.0.15
+  resolution: "@thednp/event-listener@npm:2.0.15"
+  checksum: 10c0/02ce4402985f72af44049b6557443dd96a47f37301ea2dbc82f009aa56f22d9d5f06b45e4cb07f6c3bc5ff30c0faadd118095212f908b40b9521348aee231c39
+  languageName: node
+  linkType: hard
+
+"@thednp/position-observer@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@thednp/position-observer@npm:1.1.3"
+  dependencies:
+    "@thednp/shorty": "npm:^2.0.14"
+  checksum: 10c0/1fc95a4d8a67e5accab98a6aac571053190bd491702d09759242357d35d3b7d035998470d86abe6f113304b1a5ea44722e5caa1832ef51c36d8654e3890d1951
+  languageName: node
+  linkType: hard
+
+"@thednp/shorty@npm:^2.0.14":
+  version: 2.0.14
+  resolution: "@thednp/shorty@npm:2.0.14"
+  checksum: 10c0/72a4ecdbdbeb05953649721f412c1301f950450906fe5914cf4225b83e49f18dc0573f3526aa6efaaff2e442753b5e5b897ed91f5be0792ad4766c3462a0277d
+  languageName: node
+  linkType: hard
+
 "@tmcp/adapter-valibot@npm:^0.1.5":
   version: 0.1.6
   resolution: "@tmcp/adapter-valibot@npm:0.1.6"
@@ -11257,6 +11397,17 @@ __metadata:
     mkdirp: "npm:^3.0.1"
     path-browserify: "npm:^1.0.1"
   checksum: 10c0/1f1ff7fee54414e09803b1ba559ff51881b821c19bc97cb19d06fc46c58957dea4a58e6a83e9f2e30e08c8179d6d142e45be329d9242f410323795b5c1e04806
+  languageName: node
+  linkType: hard
+
+"@ts-morph/common@npm:~0.29.0":
+  version: 0.29.0
+  resolution: "@ts-morph/common@npm:0.29.0"
+  dependencies:
+    minimatch: "npm:^10.0.1"
+    path-browserify: "npm:^1.0.1"
+    tinyglobby: "npm:^0.2.14"
+  checksum: 10c0/97ab8ca66558b817e5475a8893ee1476ab760a3ac71fa9868413d95ddbaaf909eda81716e3a8d14291cbf449e624af66de81bcddd3ec2e36525728b4edf5e8ee
   languageName: node
   linkType: hard
 
@@ -13675,6 +13826,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv@npm:8.20.0":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
+  languageName: node
+  linkType: hard
+
 "ajv@npm:^6.10.0, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.12.5, ajv@npm:^6.12.6":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
@@ -13711,7 +13874,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:4.1.3, ansi-colors@npm:^4.1.1":
+"ansi-colors@npm:4.1.3, ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
   checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
@@ -14819,6 +14982,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "body-parser@npm:2.3.0"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^2.0.0"
+    debug: "npm:^4.4.3"
+    http-errors: "npm:^2.0.1"
+    iconv-lite: "npm:^0.7.2"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.15.2"
+    raw-body: "npm:^3.0.2"
+    type-is: "npm:^2.1.0"
+  checksum: 10c0/2a8fbbdc471b588338555a3e1a597d1eb0ad0c21cf20fdc3bac5d3f8d9c3a4b19b4163575ab852a43a5dfc0df7770ced5284f979e561f1a24c2f851ce89e695a
+  languageName: node
+  linkType: hard
+
 "body-parser@npm:~1.20.5":
   version: 1.20.5
   resolution: "body-parser@npm:1.20.5"
@@ -14853,6 +15033,17 @@ __metadata:
   version: 1.0.0
   resolution: "boolbase@npm:1.0.0"
   checksum: 10c0/e4b53deb4f2b85c52be0e21a273f2045c7b6a6ea002b0e139c744cb6f95e9ec044439a52883b0d74dedd1ff3da55ed140cfdddfed7fb0cccbed373de5dce1bcf
+  languageName: node
+  linkType: hard
+
+"bootstrap.native@npm:^5.1.10":
+  version: 5.1.10
+  resolution: "bootstrap.native@npm:5.1.10"
+  dependencies:
+    "@thednp/event-listener": "npm:^2.0.15"
+    "@thednp/position-observer": "npm:^1.1.3"
+    "@thednp/shorty": "npm:^2.0.14"
+  checksum: 10c0/6484411fc4ba5b7d1bdd9da039d07efc32c30b5b216b1442cea4ef235b6398b22ccf721b7216258113f8e9cca86558bf6155abb98ebe7ff55a51e4345130e997
   languageName: node
   linkType: hard
 
@@ -15315,7 +15506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.1.2, bytes@npm:~3.1.2":
+"bytes@npm:3.1.2, bytes@npm:^3.1.2, bytes@npm:~3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
@@ -15635,7 +15826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio@npm:^1.0.0":
+"cheerio@npm:1.2.0, cheerio@npm:^1.0.0":
   version: 1.2.0
   resolution: "cheerio@npm:1.2.0"
   dependencies:
@@ -15991,6 +16182,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"code-block-writer@npm:^13.0.3":
+  version: 13.0.3
+  resolution: "code-block-writer@npm:13.0.3"
+  checksum: 10c0/87db97b37583f71cfd7eced8bf3f0a0a0ca53af912751a734372b36c08cd27f3e8a4878ec05591c0cd9ae11bea8add1423e132d660edd86aab952656dd41fd66
+  languageName: node
+  linkType: hard
+
 "code-point-at@npm:^1.0.0":
   version: 1.1.0
   resolution: "code-point-at@npm:1.1.0"
@@ -16109,6 +16307,13 @@ __metadata:
   version: 14.0.3
   resolution: "commander@npm:14.0.3"
   checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
+  languageName: node
+  linkType: hard
+
+"commander@npm:^15.0.0":
+  version: 15.0.0
+  resolution: "commander@npm:15.0.0"
+  checksum: 10c0/539229c171914ea1ccd45ee5f10d924289a12a684ea3a7a44147abe54003c35ed6de9ae4ad198d88c29fdf403dca0428451a388234e6dc01b6faa978fb207206
   languageName: node
   linkType: hard
 
@@ -16277,6 +16482,13 @@ __metadata:
   dependencies:
     safe-buffer: "npm:5.2.1"
   checksum: 10c0/bac0316ebfeacb8f381b38285dc691c9939bf0a78b0b7c2d5758acadad242d04783cee5337ba7d12a565a19075af1b3c11c728e1e4946de73c6ff7ce45f3f1bb
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "content-type@npm:2.0.0"
+  checksum: 10c0/491539fff707d7594b0ca4fabcc084bef2a31ffa754ff0a4f80c4377e3963cff0394317f9271c24087596c97fa675bc123d61fa34ffe65b4904e7d3d3098de72
   languageName: node
   linkType: hard
 
@@ -16504,6 +16716,23 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/1c1703be4f02a250b1d6ca3267e408ce16abfe8364193891afc94c2d5c060b69611fdc8d97af74b7e6d5d1aac0ab2fb94d6b079573146bc2d756c2484ce5f0ee
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^9.0.2":
+  version: 9.0.2
+  resolution: "cosmiconfig@npm:9.0.2"
+  dependencies:
+    env-paths: "npm:^2.2.1"
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/132d32863c0b3d9ace7010a10011e09089532b36e3b11e02004d671dcbd8b8f2f16293b82d510d9c15890f30358baf8722127c7b1c011449c90b6a178f9c6594
   languageName: node
   linkType: hard
 
@@ -17511,6 +17740,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dot@npm:^2.0.0-beta.1":
+  version: 2.0.0-beta.1
+  resolution: "dot@npm:2.0.0-beta.1"
+  checksum: 10c0/28876e214576210384fd49bcf2f3c4afc6478cec7de18e923c07a085dd1f3c565ff162c53911040267fc9ff96fa732dde8676c503ffd60d5a522101bc1ad1e21
+  languageName: node
+  linkType: hard
+
 "dotenv-expand@npm:^10.0.0":
   version: 10.0.0
   resolution: "dotenv-expand@npm:10.0.0"
@@ -18308,6 +18544,13 @@ __metadata:
     prettier-plugin-sort-re-exports@0.0.1:
       unplugged: true
   checksum: 10c0/bbff0b591fd01be9f37a34dad7964b590e4952fc594c1230140771687f05136caa6ab21962a6e9cde7c4b529a149171ed5179d6379d4a8e656dbf7e8d126999c
+  languageName: node
+  linkType: hard
+
+"es6-shim@npm:^0.35.8":
+  version: 0.35.8
+  resolution: "es6-shim@npm:0.35.8"
+  checksum: 10c0/e54e147677b9cd57c96bbc2332c3096ab861040b22daa27728204cacf9aa656d6a3eeb5367a037b276bfbe442ec866938a95b4612accf0cd24d01c209e48eaf9
   languageName: node
   linkType: hard
 
@@ -19309,6 +19552,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fancy-log@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fancy-log@npm:2.0.0"
+  dependencies:
+    color-support: "npm:^1.1.3"
+  checksum: 10c0/a6e116f3346756a7363eea343b551c1375d2cd2afc2a92d224feb78589b6b3cff85db9dc5d5df89792a0f7c1e17f731f52cb3d2807302f0516422be6269b95a8
+  languageName: node
+  linkType: hard
+
 "fast-content-type-parse@npm:^2.0.0":
   version: 2.0.1
   resolution: "fast-content-type-parse@npm:2.0.1"
@@ -19963,6 +20215,17 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 10c0/5f579466e7109719d162a9249abbeffe7f426eb133ea486e020b89bc6d67a741134076bf439983f2eb79276ceaf6bd7b7c1e43c3fd67fe889863e69072fb0a5e
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^11.1.1, fs-extra@npm:^11.3.5":
+  version: 11.4.0
+  resolution: "fs-extra@npm:11.4.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/1e311eca820a12d3d795f2043dcd5628d017f4d21e634f3f9ef314ae68bee9979758262fb9cb35ffa6f26454c3fffe8b15558733e91e8fc729b07b10bb98d8b6
   languageName: node
   linkType: hard
 
@@ -20710,6 +20973,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"handlebars@npm:^4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
+  dependencies:
+    minimist: "npm:^1.2.5"
+    neo-async: "npm:^2.6.2"
+    source-map: "npm:^0.6.1"
+    uglify-js: "npm:^3.1.4"
+    wordwrap: "npm:^1.0.0"
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
+  languageName: node
+  linkType: hard
+
 "happy-dom@npm:^17.6.3":
   version: 17.6.3
   resolution: "happy-dom@npm:17.6.3"
@@ -21095,7 +21376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-entities@npm:^2.1.0":
+"html-entities@npm:^2.1.0, html-entities@npm:^2.6.0":
   version: 2.6.0
   resolution: "html-entities@npm:2.6.0"
   checksum: 10c0/7c8b15d9ea0cd00dc9279f61bab002ba6ca8a7a0f3c36ed2db3530a67a9621c017830d1d2c1c65beb9b8e3436ea663e9cf8b230472e0e413359399413b27c8b7
@@ -21217,19 +21498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:~1.6.2":
-  version: 1.6.3
-  resolution: "http-errors@npm:1.6.3"
-  dependencies:
-    depd: "npm:~1.1.2"
-    inherits: "npm:2.0.3"
-    setprototypeof: "npm:1.1.0"
-    statuses: "npm:>= 1.4.0 < 2"
-  checksum: 10c0/17ec4046ee974477778bfdd525936c254b872054703ec2caa4d6f099566b8adade636ae6aeeacb39302c5cd6e28fb407ebd937f500f5010d0b6850750414ff78
-  languageName: node
-  linkType: hard
-
-"http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
+"http-errors@npm:^2.0.1, http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
   version: 2.0.1
   resolution: "http-errors@npm:2.0.1"
   dependencies:
@@ -21239,6 +21508,18 @@ __metadata:
     statuses: "npm:~2.0.2"
     toidentifier: "npm:~1.0.1"
   checksum: 10c0/fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
+  languageName: node
+  linkType: hard
+
+"http-errors@npm:~1.6.2":
+  version: 1.6.3
+  resolution: "http-errors@npm:1.6.3"
+  dependencies:
+    depd: "npm:~1.1.2"
+    inherits: "npm:2.0.3"
+    setprototypeof: "npm:1.1.0"
+    statuses: "npm:>= 1.4.0 < 2"
+  checksum: 10c0/17ec4046ee974477778bfdd525936c254b872054703ec2caa4d6f099566b8adade636ae6aeeacb39302c5cd6e28fb407ebd937f500f5010d0b6850750414ff78
   languageName: node
   linkType: hard
 
@@ -21440,6 +21721,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"i18next@npm:26.3.3":
+  version: 26.3.3
+  resolution: "i18next@npm:26.3.3"
+  peerDependencies:
+    typescript: ^5 || ^6
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/7a6676a8bade1683d23c3187b92d571528eeadf9f3d6776b4ef1bd27789d2ee7594a9aa7ca05394d8e11c931c8c8f224d85b2b5059a5613cb79b04b8d46a291e
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.4.24, iconv-lite@npm:~0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -21455,6 +21748,15 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.7.2, iconv-lite@npm:~0.7.0":
+  version: 0.7.3
+  resolution: "iconv-lite@npm:0.7.3"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/be2fd2414f7e94be3a63063fa0ad5919c16bc7b6e00c77eea0765ced6db405739f38dd51016583058fba25cc1d0106ba30b83fbb7a7e32f824d4db76f23d8d33
   languageName: node
   linkType: hard
 
@@ -23852,6 +24154,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loglevel-plugin-prefix@npm:^0.8.4":
+  version: 0.8.4
+  resolution: "loglevel-plugin-prefix@npm:0.8.4"
+  checksum: 10c0/357524eec4c165ff823b5bbf72e8373ff529e5cb95c1f4b20749847bd5b5b16ab328d6d33d1a9019f1a2dc52e28fca5d595e52f2ee20e24986182a6f9552a9ec
+  languageName: node
+  linkType: hard
+
+"loglevel@npm:^1.9.2":
+  version: 1.9.2
+  resolution: "loglevel@npm:1.9.2"
+  checksum: 10c0/1e317fa4648fe0b4a4cffef6de037340592cee8547b07d4ce97a487abe9153e704b98451100c799b032c72bb89c9366d71c9fb8192ada8703269263ae77acdc7
+  languageName: node
+  linkType: hard
+
 "longest-streak@npm:^3.0.0":
   version: 3.1.0
   resolution: "longest-streak@npm:3.1.0"
@@ -23952,6 +24268,13 @@ __metadata:
   version: 8.0.5
   resolution: "lru-cache@npm:8.0.5"
   checksum: 10c0/cd95a9c38497611c5a6453de39a881f6eb5865851a2a01b5f14104ff3fee515362a7b1e7de28606028f423802910ba05bdb8ae1aa7b0d54eae70c92f0cec10b2
+  languageName: node
+  linkType: hard
+
+"lunr@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "lunr@npm:2.3.9"
+  checksum: 10c0/77d7dbb4fbd602aac161e2b50887d8eda28c0fa3b799159cee380fbb311f1e614219126ecbbd2c3a9c685f1720a8109b3c1ca85cc893c39b6c9cc6a62a1d8a8b
   languageName: node
   linkType: hard
 
@@ -24121,6 +24444,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"marked@npm:18.0.5":
+  version: 18.0.5
+  resolution: "marked@npm:18.0.5"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/22763935a0a243c41851b010a086ea85a09951e379948b6aa629b6cecdcd66e3a5e8c4acac2f6b29c183c20609d3e5102495270207dfd5f4c46ddd773a4ddb9b
+  languageName: node
+  linkType: hard
+
 "matcher-collection@npm:^1.0.0, matcher-collection@npm:^1.1.1":
   version: 1.1.2
   resolution: "matcher-collection@npm:1.1.2"
@@ -24137,6 +24469,15 @@ __metadata:
     "@types/minimatch": "npm:^3.0.3"
     minimatch: "npm:^3.0.2"
   checksum: 10c0/409aad220000e2041672f900883ec66ffdd04814b133b428a8d35e055495fc09bb9024ca6ad7a63ebe6ed9e480e01db02c3edf3587ae1ba2627727a3d896ff96
+  languageName: node
+  linkType: hard
+
+"matchit@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "matchit@npm:1.1.0"
+  dependencies:
+    "@arr/every": "npm:^1.0.0"
+  checksum: 10c0/f2cd8702ea37dd9859cf1df762581c822180eb72372b9240397a80320cb4ffb4828b3d8ed0beff2429daf500d1ec746c2963dbb3c6386f1b5b9eb969e0f1caaa
   languageName: node
   linkType: hard
 
@@ -24296,6 +24637,13 @@ __metadata:
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
   checksum: 10c0/d160f31246907e79fed398470285f21bafb45a62869dc469b1c8877f3f064f5eabc4bcc122f9479b8b605bc5c76187d7871cf84c4ee3ecd3e487da1993279928
+  languageName: node
+  linkType: hard
+
+"media-typer@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "media-typer@npm:1.1.1"
+  checksum: 10c0/924644de220c3107fc53ec0299b7c1488503470265d32f1492535bd798cc369ba7ceaf9c2a4533361590dcf7208d1cc7b7032dbc1a5918773f5f5d912cab5211
   languageName: node
   linkType: hard
 
@@ -24773,6 +25121,15 @@ __metadata:
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "mime-types@npm:3.0.2"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10c0/35a0dd1035d14d185664f346efcdb72e93ef7a9b6e9ae808bd1f6358227010267fab52657b37562c80fc888ff76becb2b2938deb5e730818b7983bf8bd359767
   languageName: node
   linkType: hard
 
@@ -25331,6 +25688,13 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
+  languageName: node
+  linkType: hard
+
+"neotraverse@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "neotraverse@npm:1.0.1"
+  checksum: 10c0/98e5d2d1974f91d527851a9dcfceb62701a1d31970b324b9f35fbdd244d173edc7a379ea1773f64771a9dc282486e3d3b693b24e14b1e969291612b2ff6b5054
   languageName: node
   linkType: hard
 
@@ -26160,6 +26524,22 @@ __metadata:
     stdin-discarder: "npm:^0.3.1"
     string-width: "npm:^8.1.0"
   checksum: 10c0/1d25c0f43e20389757285f740686958bce78ccb9d03dda190ecc92ae585cbc498fa54cf13933fea2f96cb97a0be82e927cf0fd8c96217459f9c43d915a380531
+  languageName: node
+  linkType: hard
+
+"ora@npm:9.4.0":
+  version: 9.4.0
+  resolution: "ora@npm:9.4.0"
+  dependencies:
+    chalk: "npm:^5.6.2"
+    cli-cursor: "npm:^5.0.0"
+    cli-spinners: "npm:^3.2.0"
+    is-interactive: "npm:^2.0.0"
+    is-unicode-supported: "npm:^2.1.0"
+    log-symbols: "npm:^7.0.1"
+    stdin-discarder: "npm:^0.3.2"
+    string-width: "npm:^8.1.0"
+  checksum: 10c0/8f2d7a8869cd68607797ac0ffe9f5cdceeb6009437672510d9920aea794cdd055164e3fe804248624c4940a71b22f94f1ffd94ce8fecf0746baef97a5c121a91
   languageName: node
   linkType: hard
 
@@ -27489,6 +27869,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"polka@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "polka@npm:0.5.2"
+  dependencies:
+    "@polka/url": "npm:^0.5.0"
+    trouter: "npm:^2.0.1"
+  checksum: 10c0/113005fe146e1ee67bc6e1a5438c71e1b59ac05a8bc435d593be210e21f712e6b9ba4d163072e3c941f8efbb7516df9c55bf18934948f91623d03dc9657a1410
+  languageName: node
+  linkType: hard
+
 "polka@npm:^1.0.0-next.28":
   version: 1.0.0-next.28
   resolution: "polka@npm:1.0.0-next.28"
@@ -28243,6 +28633,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.15.2":
+  version: 6.15.3
+  resolution: "qs@npm:6.15.3"
+  dependencies:
+    es-define-property: "npm:^1.0.1"
+    side-channel: "npm:^1.1.1"
+  checksum: 10c0/8f3f6e45ece255347d57696628401cde29e9ec649fff698b53bd3150dea7cefdf33036e1bc1826b9f110bfa7cb0ec4ab9f5297eca628ce216c55af82c304e08e
+  languageName: node
+  linkType: hard
+
 "qs@npm:~6.5.2":
   version: 6.5.3
   resolution: "qs@npm:6.5.3"
@@ -28324,6 +28724,18 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: 10c0/b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "raw-body@npm:3.0.2"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.7.0"
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/d266678d08e1e7abea62c0ce5864344e980fa81c64f6b481e9842c5beaed2cdcf975f658a3ccd67ad35fc919c1f6664ccc106067801850286a6cbe101de89f29
   languageName: node
   linkType: hard
 
@@ -30366,6 +30778,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.8.5":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
+  languageName: node
+  linkType: hard
+
 "send@npm:0.19.0":
   version: 0.19.0
   resolution: "send@npm:0.19.0"
@@ -30720,6 +31141,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+  checksum: 10c0/d346c787fd2f9f1c2fdea14f00e8250118db0e7596d85a6cb9faa75f105d31a73a8f7a341c93d7df2a2429098c3d37a77bd3be9e88c37094b8c01807bc77c7a2
+  languageName: node
+  linkType: hard
+
 "side-channel-map@npm:^1.0.1":
   version: 1.0.1
   resolution: "side-channel-map@npm:1.0.1"
@@ -30755,6 +31186,19 @@ __metadata:
     side-channel-map: "npm:^1.0.1"
     side-channel-weakmap: "npm:^1.0.2"
   checksum: 10c0/cb20dad41eb032e6c24c0982e1e5a24963a28aa6122b4f05b3f3d6bf8ae7fd5474ef382c8f54a6a3ab86e0cac4d41a23bd64ede3970e5bfb50326ba02a7996e6
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "side-channel@npm:1.1.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+    side-channel-list: "npm:^1.0.1"
+    side-channel-map: "npm:^1.0.1"
+    side-channel-weakmap: "npm:^1.0.2"
+  checksum: 10c0/dc0ab81d67f61bda9247d053ce93f41c3fd8ad2bdcb9cf9d8d2f8540d488f26d87a5e99ebfc07eea49ec025867b2452b705442d974b1478f0395e69f6bfb3270
   languageName: node
   linkType: hard
 
@@ -31278,7 +31722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stdin-discarder@npm:^0.3.1":
+"stdin-discarder@npm:^0.3.1, stdin-discarder@npm:^0.3.2":
   version: 0.3.2
   resolution: "stdin-discarder@npm:0.3.2"
   checksum: 10c0/5dbaba9efbcb447a4450d5ae19794641ea9166abe96dc4b5547a109db1bb6e8bdb17bbe1029e02ca8d9d8ee996b7c7cbcce12b12c18c121871cd4f574292381a
@@ -32007,6 +32451,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"svg-pan-zoom@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "svg-pan-zoom@npm:3.6.2"
+  checksum: 10c0/dc05030bd6545d523de71e38d79d6830f780a74416a609269cc378fe8778796e794cb3e27f0f5b20bd7ee930597820e5b4463e4e4e0708127bed81e020339ec0
+  languageName: node
+  linkType: hard
+
 "symlink-or-copy@npm:^1.0.0, symlink-or-copy@npm:^1.0.1, symlink-or-copy@npm:^1.1.8, symlink-or-copy@npm:^1.2.0, symlink-or-copy@npm:^1.3.1":
   version: 1.3.1
   resolution: "symlink-or-copy@npm:1.3.1"
@@ -32033,6 +32484,13 @@ __metadata:
   dependencies:
     acorn-node: "npm:^1.2.0"
   checksum: 10c0/435763d011943df551caa5a3bb84e00b6d22d7375e4ae115a922ebc2a239f136979f78b6a81b89c92383834d752692dc068aee59c2448e3f7fce00a52d9162d8
+  languageName: node
+  linkType: hard
+
+"tablesort@npm:^5.7.1":
+  version: 5.7.1
+  resolution: "tablesort@npm:5.7.1"
+  checksum: 10c0/be69ec398438695b87589de702861d4ca126dba0c4a8c1f4bbc28ffa4ea257a623ee764abd769ec88d7f8347dc36b5157b9d36d282c181a8c43b19413cd88854
   languageName: node
   linkType: hard
 
@@ -32649,6 +33107,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"trouter@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "trouter@npm:2.0.1"
+  dependencies:
+    matchit: "npm:^1.0.0"
+  checksum: 10c0/9d294dbe74d45649d929d3abf0d4cb8e508985a2ea0f8be41b3b097a985352b14f65dd76b68ae651731128995eceddba375b15719356c419bbfe754c5fb5673c
+  languageName: node
+  linkType: hard
+
 "trouter@npm:^4.0.0":
   version: 4.0.0
   resolution: "trouter@npm:4.0.0"
@@ -32695,6 +33162,16 @@ __metadata:
     "@ts-morph/common": "npm:~0.22.0"
     code-block-writer: "npm:^12.0.0"
   checksum: 10c0/ed1d4ccdeba2300cfa236f2aaf64bb462aa386141e659a08d8a2eb96d3b4b274abc9d97b8dd06a0c13af79187b197f38f6a8baca709f99d11094a82c8abccf27
+  languageName: node
+  linkType: hard
+
+"ts-morph@npm:^28.0.0":
+  version: 28.0.0
+  resolution: "ts-morph@npm:28.0.0"
+  dependencies:
+    "@ts-morph/common": "npm:~0.29.0"
+    code-block-writer: "npm:^13.0.3"
+  checksum: 10c0/969570a5e983b4193735fff43878ce7b78787b4860bf3d23f330c86d7de707286969e5a82d486dce333eea27bf9d373a46f9de58a80c0bf86d2a462620563a55
   languageName: node
   linkType: hard
 
@@ -32864,6 +33341,17 @@ __metadata:
   dependencies:
     tagged-tag: "npm:^1.0.0"
   checksum: 10c0/5468a8ffda7f3904e6f7bbd8069eb8b6dd4bd9156e206df7a01d09a73e28cd1afedf74ead9d0fc12841c8c90074194859feca240511c50800962fde1bd9ddcbc
+  languageName: node
+  linkType: hard
+
+"type-is@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "type-is@npm:2.1.0"
+  dependencies:
+    content-type: "npm:^2.0.0"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10c0/a6018f8f509de48f2c7429305e3a920e73b374fa93127dd0877ae1c2df65a5d33907caac8afb0c37a9b9fc7c49f29e3f55d668963dc845d966930b667c07f50e
   languageName: node
   linkType: hard
 
@@ -33539,6 +34027,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:14.0.1":
+  version: 14.0.1
+  resolution: "uuid@npm:14.0.1"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/2d961289097cb68c37d93d1da0b5c3aafc1eb9948a455cca8d0ae53a099b2fe583b8933254a84097f700e6bac2e23033364904df0467c22551d5d9611febcaf6
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^11.1.0":
   version: 11.1.0
   resolution: "uuid@npm:11.1.0"
@@ -33753,6 +34250,20 @@ __metadata:
     "@types/unist": "npm:^3.0.0"
     vfile-message: "npm:^4.0.0"
   checksum: 10c0/e5d9eb4810623f23758cfc2205323e33552fb5972e5c2e6587babe08fe4d24859866277404fb9e2a20afb71013860d96ec806cb257536ae463c87d70022ab9ef
+  languageName: node
+  linkType: hard
+
+"vis-network@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "vis-network@npm:10.1.0"
+  peerDependencies:
+    "@egjs/hammerjs": ^2.0.0
+    component-emitter: ^1.3.0 || ^2.0.0
+    keycharm: ^0.2.0 || ^0.3.0 || ^0.4.0
+    uuid: ^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0
+    vis-data: ">=8.0.0"
+    vis-util: ">=6.0.0"
+  checksum: 10c0/c3f553f03f80e096c7f8cea4fb98011906dde67c65e7d1e8ca0ed5811dad0dc9f648dde93a6a61ce3ac24f153a7a4eb96e931104c8ad1801701a50db687f5bb6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

This is the base of the new per-engine docgen performance suite, plus its first engine.

The framework: metric types, the fixed measurement profiles, the aggregation that turns N repetitions into medians, the child-process spawn helper, and the `BenchEngine` base class every engine implements.

The engine: Compodoc, which is what Storybook shells out to for Angular docgen. It runs as a fresh CLI process, so cold extraction and whole-project scan are the same measurement, and peak memory is sampled from outside the child.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`aggregate.test.ts` and `compodoc-doc.test.ts`, on top of part 2's tests — 4 files, 43 tests.

#### Manual testing

```bash
yarn install          # pulls in @compodoc/compodoc
yarn dedupe --check
cd scripts && yarn check && yarn lint && yarn test bench/docgen
```

Expect 4 test files and 43 tests passing.
`compodoc-doc.test.ts` counts against the real Compodoc captures already committed in `code/lib/docgen-harness`, so it is checking the counter against output the tool actually produced, not against a hand-written fixture.

There is no runnable benchmark at this point in the stack — that first becomes possible in part 5.

### Documentation

- [ ] Add or update documentation reflecting your changes

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below: `build`
