### PR TITLE
Bench: Make the docgen perf suite runnable

### DIFF
--- a/scripts/bench/PERF-METHODOLOGY.md
+++ b/scripts/bench/PERF-METHODOLOGY.md
@@ -1,6 +1,6 @@
 # Docgen performance methodology
 
-This document sets out how the per-engine docgen performance suite measures things. It elaborates on the metrics we record, the rules that make a run repeatable, the shape a budget may take, and the CI tier that gates.
+This document sets out how the per-engine docgen performance suite measures things. It elaborates on the metrics we record, the rules that make a run repeatable, the shape a budget may take, and the CI tier a budget is intended to gate once baselines exist.
 
 ## Scope
 

--- a/scripts/bench/PERF-METHODOLOGY.md
+++ b/scripts/bench/PERF-METHODOLOGY.md
@@ -1,6 +1,6 @@
 # Docgen performance methodology
 
-This document sets out how the per-engine docgen performance suite measures things. It elaborates on the metrics we record, the rules that make a run repeatable, the shape a budget may take, and the CIT at that gate.
+This document sets out how the per-engine docgen performance suite measures things. It elaborates on the metrics we record, the rules that make a run repeatable, the shape a budget may take, and the CI tier that gates.
 
 ## Scope
 
@@ -12,7 +12,7 @@ We are collecting five metrics per engine:
 
 1. Cold extraction: that's the time a fresh process takes over its full extraction, including starting the typescript program where an engine needs one.
 2. Warm extraction: the time to re-extract one changed component after a simulated save once the process is warm. In theory, an already booted typescript program's delay shouldn't be visible in the warm extraction anymore, and therefore warm extractions are faster than cold ones.
-3. Whole project scan: that's the time for one batch pass over the entire project. Currently, only CompuDoc works this way, so the metric applies to CompuDoc for Angular alone.
+3. Whole project scan: that's the time for one batch pass over the entire project. Currently, only Compodoc works this way, so the metric applies to Compodoc for Angular alone.
 4. Peak memory: the memory a save claims above the retained baseline
 5. Leak detection: How much retained heap is still held after the save series, together with how steeply it climbed from one save to the next?
 
@@ -44,17 +44,19 @@ Performance questions are answered by ratios between runs executed on one machin
 
 ## Budget shape
 
-Timing budgets are ratios or slopes rather than absolute milliseconds because absolute wall clock on a shared CI executor is far too noisy to gate on. A timing ratio divides the median of one side by the median of another. An engine that has a second implementation to compare against (for example, ViewDocktion API vs. ViewComponent meta) uses that pair as its reference. An engine without one has its reference picked when its baselines are recorded.
+Timing budgets are ratios or slopes rather than absolute milliseconds because absolute wall clock on a shared CI executor is far too noisy to gate on. A timing ratio divides the median of one side by the median of another. An engine that has a second implementation to compare against (for example, `vue-docgen-api` against `vue-component-meta`) uses that pair as its reference. An engine without one has its reference picked when its baselines are recorded.
 
-### Like-to-Like comparison
+### Like-for-like comparison
 
-Ratio only means something when both sides did the same amount of work. Engines, for example, resolve types to different depths, and a shallower one finishes sooner precisely because it documented less, which makes speed and thoroughness very easy to mistake for one another.
+A ratio only means something when both sides did the same amount of work. Engines resolve types to different depths, and a shallower one finishes sooner precisely because it documented less, which makes speed and thoroughness very easy to mistake for one another.
 
-Therefore, every engine reports how many members it documented. The suit prints those counts, besides every ratio, warm as well as cold, and any pair whose counts disagree is marked not like-to-like.
+Therefore, every engine reports how many members it documented, and the suite prints those counts beside every ratio, warm as well as cold. Where the two sides disagree, we do not just flag the ratio, we say which way it went, because the direction is what tells you how to read the number. An engine that documented less is fast for the wrong reason and its ratio is worthless. An engine that documented more and still won has a ratio that undersells it. Only a pair that did equal work may ever become a budget.
 
-A ratio marked that way must never become a budget. Rather, we should make sure that if the performance of an engine decreases (for example, by bumping the engine's version or introducing a new one), CI fails in these scenarios (so that a human can intercept and decide what to do next).
+Cold and warm get their own verdict, since a pair can document the same members on the cold pass and different ones on the save it was timed on. When either side reports no count at all we record that as unknown rather than treating it as agreement, because marking a pair equal on the strength of a number nobody measured is exactly how a bad ratio would slip through.
 
-But even a member count of properties is not always enough on its own. An engine that records a type's name but not the type's type doesn't contribute to a fair comparison. Therefore, a documented member's actual type will be recorded and is the second count to agree as well as a pair count for the like-for-like comparison.
+Even the member count is not enough on its own. An engine that records a type's name without ever looking through it documents exactly as many members as one that expanded the whole chain, and it does so at a fraction of the cost. So an engine that works that way also reports how many of its documented members carry a type it never resolved, and that second count has to agree as well before the two sides count as having done equal work.
+
+What we do not have yet is the gate. Once baselines exist, a ratio that moves the wrong way should fail CI, so that a human intercepts and decides what to do next.
 
 ### Memory budgets
 

--- a/scripts/bench/PERF-METHODOLOGY.md
+++ b/scripts/bench/PERF-METHODOLOGY.md
@@ -42,6 +42,10 @@ Performance questions are answered by ratios between runs executed on one machin
 - A new engine against its legacy counterpart
   Both are measured inside the same run. Paired runs also alternate their order across repetitions so that neither a warm cache nor a machine that has heated up can consistently favor one side.
 
+The pinned N has to be even for that alternation to cancel anything.
+Each side leads on half the repetitions, so an odd N gives one of them the lead once more than the other, and the cold figure is a median, which then lands on a repetition from whichever side led more often.
+That would turn the very effect the alternation exists to remove into a systematic bias on the ratio, so the parity is asserted in `ratios.test.ts` rather than left to whoever next edits the constant.
+
 ## Budget shape
 
 Timing budgets are ratios or slopes rather than absolute milliseconds because absolute wall clock on a shared CI executor is far too noisy to gate on. A timing ratio divides the median of one side by the median of another. An engine that has a second implementation to compare against (for example, `vue-docgen-api` against `vue-component-meta`) uses that pair as its reference. An engine without one has its reference picked when its baselines are recorded.

--- a/scripts/bench/docgen-perf/cli.ts
+++ b/scripts/bench/docgen-perf/cli.ts
@@ -1,0 +1,39 @@
+/** Command line for the docgen perf suite. */
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+import { parseHarnessOptions } from '../docgen-shared/args.ts';
+import { ALL_ENGINE_IDS, DEFAULT_ENGINE_IDS } from './registry.ts';
+import type { EngineId } from './types.ts';
+
+const OPTIONS = {
+  quick: { type: 'boolean' },
+  engine: { type: 'string', multiple: true },
+  json: { type: 'string' },
+} as const;
+
+export interface CliOptions {
+  quick: boolean;
+  engines: EngineId[];
+  jsonOut: string;
+}
+
+export function parseCliOptions(argv: string[], workRoot: string): CliOptions {
+  const schema = z.object({
+    quick: z.boolean().default(false),
+    // No --engine means the default set, which is why this defaults to empty rather than to
+    // DEFAULT_ENGINE_IDS: an explicit empty list and an absent flag are the same request.
+    engines: z.array(z.enum(ALL_ENGINE_IDS as [EngineId, ...EngineId[]])).default([]),
+    jsonOut: z.string().default(path.join(workRoot, 'results.json')),
+  });
+  const options = parseHarnessOptions<CliOptions>(argv, OPTIONS, schema, (values) => ({
+    ...values,
+    engines: values.engine,
+    jsonOut: values.json,
+  }));
+  return {
+    ...options,
+    engines: options.engines.length ? options.engines : DEFAULT_ENGINE_IDS,
+  };
+}

--- a/scripts/bench/docgen-perf/ratios.test.ts
+++ b/scripts/bench/docgen-perf/ratios.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import { CONTROL_PAIRS, computeRatios, engineOrderForRep } from './ratios.ts';
+import { type EngineId, type EngineResult, NOT_APPLICABLE, type ScenarioResult } from './types.ts';
+
+function scenario(
+  cold: number,
+  warm: number,
+  members?: [number, number],
+  coldOpaqueTypes?: number
+): ScenarioResult {
+  return {
+    params: {},
+    coldMembers: members?.[0],
+    warmMembers: members?.[1],
+    coldOpaqueTypes,
+    metrics: {
+      coldExtractionMs: { status: 'measured', samples: [cold], median: cold },
+      warmExtractionMs: { status: 'measured', samples: [warm], median: warm },
+      wholeProjectScanMs: NOT_APPLICABLE,
+      peakTransientMb: NOT_APPLICABLE,
+      retainedGrowthMb: NOT_APPLICABLE,
+      retainedSlopeMbPerSave: NOT_APPLICABLE,
+    },
+  };
+}
+
+function measured(scenarios: Record<string, ScenarioResult>): EngineResult {
+  return { status: 'measured', scenarios };
+}
+
+describe('engineOrderForRep', () => {
+  const engines: EngineId[] = ['react-legacy', 'react-osa', 'vue-docgen-api', 'vue-component-meta'];
+
+  it('keeps the listed order on odd repetitions', () => {
+    expect(engineOrderForRep(engines, 1)).toEqual(engines);
+    expect(engineOrderForRep(engines, 3)).toEqual(engines);
+  });
+
+  it('swaps every control pair on even repetitions', () => {
+    expect(engineOrderForRep(engines, 2)).toEqual([
+      'react-osa',
+      'react-legacy',
+      'vue-component-meta',
+      'vue-docgen-api',
+    ]);
+  });
+
+  it('leaves a pair alone when only one of its sides is running', () => {
+    expect(engineOrderForRep(['react-legacy', 'compodoc'], 2)).toEqual(['react-legacy', 'compodoc']);
+  });
+
+  it('does not mutate its input', () => {
+    const input: EngineId[] = ['react-legacy', 'react-osa'];
+    engineOrderForRep(input, 2);
+    expect(input).toEqual(['react-legacy', 'react-osa']);
+  });
+
+  it('gives each side of a pair the first slot at least once across the pinned five', () => {
+    const firsts = [1, 2, 3, 4, 5].map((rep) => engineOrderForRep(engines, rep)[0]);
+    expect(new Set(firsts)).toEqual(new Set(['react-legacy', 'react-osa']));
+  });
+});
+
+describe('computeRatios', () => {
+  it('divides the legacy median by the new engine median', () => {
+    const ratios = computeRatios({
+      'react-legacy': measured({ default: scenario(400, 40) }),
+      'react-osa': measured({ default: scenario(100, 20) }),
+    });
+    expect(ratios.react.default.cold).toBe(4);
+    expect(ratios.react.default.warm).toBe(2);
+  });
+
+  it('produces nothing when one side did not measure', () => {
+    expect(
+      computeRatios({
+        'react-legacy': measured({ default: scenario(400, 40) }),
+        'react-osa': { status: 'failed', reason: 'boom' },
+      })
+    ).toEqual({});
+  });
+
+  it('produces nothing when one side was skipped', () => {
+    expect(
+      computeRatios({
+        'vue-docgen-api': measured({ flat: scenario(20, 2) }),
+        'vue-component-meta': { status: 'skipped', reason: 'not installed' },
+      })
+    ).toEqual({});
+  });
+
+  it('pairs scenarios by name and ignores ones only one side ran', () => {
+    const ratios = computeRatios({
+      'vue-docgen-api': measured({ flat: scenario(20, 2), workspace: scenario(30, 3) }),
+      'vue-component-meta': measured({ flat: scenario(400, 40) }),
+    });
+    expect(Object.keys(ratios.vue)).toEqual(['flat']);
+  });
+
+  it('marks a pair like-for-like when both documented the same members', () => {
+    const ratios = computeRatios({
+      'vue-docgen-api': measured({ flat: scenario(20, 2, [50, 5]) }),
+      'vue-component-meta': measured({ flat: scenario(400, 40, [50, 5]) }),
+    });
+    expect(ratios.vue.flat.coldComparability).toBe('like-for-like');
+  });
+
+  it('marks a pair not like-for-like when the member counts disagree', () => {
+    // vue-docgen-api does not resolve tsconfig `paths` aliases, so it documents a fraction of what
+    // vue-component-meta does and is fast for the wrong reason.
+    const ratios = computeRatios({
+      'vue-docgen-api': measured({ flat: scenario(23, 1, [6, 0]) }),
+      'vue-component-meta': measured({ flat: scenario(425, 40, [320, 32]) }),
+    });
+    expect(ratios.vue.flat).toMatchObject({
+      coldComparability: 'next-documents-more',
+      warmComparability: 'next-documents-more',
+      legacyColdMembers: 6,
+      nextColdMembers: 320,
+      legacyWarmMembers: 0,
+      nextWarmMembers: 32,
+    });
+  });
+
+  it('separates a pair that documented more from one that documented less', () => {
+    // Same numbers, opposite meaning: the side that documented less is fast for the wrong reason,
+    // while the side that documented more has a ratio that undersells it. A boolean lost this.
+    const fewer = computeRatios({
+      'vue-docgen-api': measured({ flat: scenario(400, 40, [320, 32]) }),
+      'vue-component-meta': measured({ flat: scenario(23, 1, [6, 0]) }),
+    });
+    expect(fewer.vue.flat.coldComparability).toBe('next-documents-less');
+  });
+
+  it('catches a pair that documented the same members off different resolution work', () => {
+    // The Angular trap: an engine that records a type's name without looking through it documents
+    // exactly as many members as one that expanded the chain, so counts alone read as clean.
+    const ratios = computeRatios({
+      'vue-docgen-api': measured({ flat: scenario(400, 40, [90, 9], 0) }),
+      'vue-component-meta': measured({ flat: scenario(100, 10, [90, 9], 10) }),
+    });
+    expect(ratios.vue.flat.coldComparability).toBe('next-resolves-less');
+    expect(ratios.vue.flat.warmComparability).toBe('like-for-like');
+  });
+
+  it('reports comparability unknown when the engines report no member counts', () => {
+    // Unknown is not the same claim as unequal; a missing count must not read as agreement.
+    const ratios = computeRatios({
+      'react-legacy': measured({ default: scenario(400, 40) }),
+      'react-osa': measured({ default: scenario(100, 20) }),
+    });
+    expect(ratios.react.default.coldComparability).toBe('unknown');
+  });
+
+  it('names every pair it knows uniquely', () => {
+    const names = CONTROL_PAIRS.map((p) => p.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/scripts/bench/docgen-perf/ratios.test.ts
+++ b/scripts/bench/docgen-perf/ratios.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { PINNED_N } from './config.ts';
 import { CONTROL_PAIRS, computeRatios, engineOrderForRep } from './ratios.ts';
 import { type EngineId, type EngineResult, NOT_APPLICABLE, type ScenarioResult } from './types.ts';
 
@@ -32,22 +33,38 @@ function measured(scenarios: Record<string, ScenarioResult>): EngineResult {
 describe('engineOrderForRep', () => {
   const engines: EngineId[] = ['react-legacy', 'react-osa', 'vue-docgen-api', 'vue-component-meta'];
 
+  /**
+   * Every engine named by a control pair. The two properties below are asserted against this rather
+   * than a fixed list, so they keep holding as pairs are added - including a pair that shares an
+   * engine with another, which a pairwise swap cannot alternate.
+   */
+  const paired = [...new Set(CONTROL_PAIRS.flatMap((pair) => [pair.legacy, pair.next]))];
+
+  /** Which of the two runs first, which is the bias the alternation exists to cancel. */
+  const runsFirst = (order: EngineId[], pair: { legacy: EngineId; next: EngineId }) => {
+    const legacy = order.indexOf(pair.legacy);
+    const next = order.indexOf(pair.next);
+    if (legacy < 0 || next < 0) {
+      throw new Error(`${pair.legacy} and ${pair.next} must both be running to have an order`);
+    }
+    return legacy < next ? pair.legacy : pair.next;
+  };
+
   it('keeps the listed order on odd repetitions', () => {
     expect(engineOrderForRep(engines, 1)).toEqual(engines);
     expect(engineOrderForRep(engines, 3)).toEqual(engines);
   });
 
-  it('swaps every control pair on even repetitions', () => {
-    expect(engineOrderForRep(engines, 2)).toEqual([
-      'react-osa',
-      'react-legacy',
-      'vue-component-meta',
-      'vue-docgen-api',
-    ]);
+  it('reverses the order on even repetitions', () => {
+    expect(engineOrderForRep(engines, 2)).toEqual([...engines].reverse());
   });
 
-  it('leaves a pair alone when only one of its sides is running', () => {
-    expect(engineOrderForRep(['react-legacy', 'compodoc'], 2)).toEqual(['react-legacy', 'compodoc']);
+  it('flips which side of every control pair goes first', () => {
+    for (const pair of CONTROL_PAIRS) {
+      expect(runsFirst(engineOrderForRep(paired, 2), pair), pair.name).not.toBe(
+        runsFirst(engineOrderForRep(paired, 1), pair)
+      );
+    }
   });
 
   it('does not mutate its input', () => {
@@ -56,9 +73,19 @@ describe('engineOrderForRep', () => {
     expect(input).toEqual(['react-legacy', 'react-osa']);
   });
 
-  it('gives each side of a pair the first slot at least once across the pinned five', () => {
-    const firsts = [1, 2, 3, 4, 5].map((rep) => engineOrderForRep(engines, rep)[0]);
-    expect(new Set(firsts)).toEqual(new Set(['react-legacy', 'react-osa']));
+  it('gives each side of a pair the first slot equally often across the pinned N', () => {
+    // The alternation only cancels the ordering effect when both sides lead the same number of
+    // times. An odd N leaves a 3-2 split, and the cold median - the headline figure - then lands on
+    // a repetition from whichever side led more often. Driven off PINNED_N so making it odd fails
+    // here rather than silently biasing every ratio.
+    for (const pair of CONTROL_PAIRS) {
+      const firsts = Array.from({ length: PINNED_N }, (_, i) =>
+        runsFirst(engineOrderForRep(paired, i + 1), pair)
+      );
+      expect(firsts.filter((id) => id === pair.legacy).length, pair.name).toBe(
+        firsts.filter((id) => id === pair.next).length
+      );
+    }
   });
 });
 
@@ -70,6 +97,17 @@ describe('computeRatios', () => {
     });
     expect(ratios.react.default.cold).toBe(4);
     expect(ratios.react.default.warm).toBe(2);
+  });
+
+  it('produces no ratio when the new engine median rounded to zero', () => {
+    // A warm re-extraction can finish below the clock's resolution. Dividing by it yields Infinity,
+    // which would render as a ratio and serialize into the results file as null.
+    const ratios = computeRatios({
+      'react-legacy': measured({ default: scenario(400, 40) }),
+      'react-osa': measured({ default: scenario(100, 0) }),
+    });
+    expect(ratios.react.default.warm).toBeUndefined();
+    expect(ratios.react.default.cold).toBe(4);
   });
 
   it('produces nothing when one side did not measure', () => {

--- a/scripts/bench/docgen-perf/ratios.ts
+++ b/scripts/bench/docgen-perf/ratios.ts
@@ -1,0 +1,127 @@
+/**
+ * The calibration references: each framework's legacy-engine median divided by its new-engine
+ * median, both measured in the same invocation. Ratios stand in for absolute milliseconds because
+ * wall-clock on shared CI executors is too noisy to gate (PERF-METHODOLOGY.md, "Budget shape").
+ */
+import type {
+  Comparability,
+  EngineId,
+  EngineResult,
+  LatencyMetric,
+  NotApplicable,
+  RatioEntry,
+  Ratios,
+  ScenarioResult,
+} from './types.ts';
+
+interface ControlPair {
+  /** Key under which this pair's ratios appear in the results. */
+  name: string;
+  legacy: EngineId;
+  next: EngineId;
+}
+
+// A pair whose engines are not both registered yields no ratio, so a pair may be listed before the
+// engines behind it land.
+export const CONTROL_PAIRS: ControlPair[] = [
+  { name: 'react', legacy: 'react-legacy', next: 'react-osa' },
+  { name: 'vue', legacy: 'vue-docgen-api', next: 'vue-component-meta' },
+];
+
+/**
+ * Each control pair swaps sides on even repetitions so cache warming and thermal drift do not
+ * consistently favour whichever engine is listed first.
+ */
+export function engineOrderForRep(engines: EngineId[], rep: number): EngineId[] {
+  const order = [...engines];
+  if (rep % 2 !== 0) {
+    return order;
+  }
+  for (const { legacy, next } of CONTROL_PAIRS) {
+    const legacyIdx = order.indexOf(legacy);
+    const nextIdx = order.indexOf(next);
+    if (legacyIdx >= 0 && nextIdx >= 0) {
+      order[legacyIdx] = next;
+      order[nextIdx] = legacy;
+    }
+  }
+  return order;
+}
+
+/** Undefined unless both sides measured: dividing by a skipped or failed side is not a comparison. */
+function medianRatio(legacy: LatencyMetric | NotApplicable, next: LatencyMetric | NotApplicable) {
+  return legacy.status === 'measured' && next.status === 'measured'
+    ? legacy.median / next.median
+    : undefined;
+}
+
+/**
+ * Member counts decide first, and any difference there settles it. Only once they agree does the
+ * count of types an engine never looked through get a say, which is the case a member count on its
+ * own cannot see.
+ *
+ * A missing count on either side yields `unknown` rather than a verdict. Treating it as agreement
+ * would mark a pair like-for-like on the strength of a number nobody measured.
+ */
+function comparability(
+  legacyMembers: number | undefined,
+  nextMembers: number | undefined,
+  legacyOpaque?: number,
+  nextOpaque?: number
+): Comparability {
+  if (legacyMembers === undefined || nextMembers === undefined) {
+    return 'unknown';
+  }
+  if (nextMembers !== legacyMembers) {
+    return nextMembers > legacyMembers ? 'next-documents-more' : 'next-documents-less';
+  }
+  if (legacyOpaque === undefined || nextOpaque === undefined || nextOpaque === legacyOpaque) {
+    return 'like-for-like';
+  }
+  return nextOpaque > legacyOpaque ? 'next-resolves-less' : 'next-resolves-more';
+}
+
+function ratioFor(legacy: ScenarioResult, next: ScenarioResult): RatioEntry {
+  return {
+    cold: medianRatio(legacy.metrics.coldExtractionMs, next.metrics.coldExtractionMs),
+    warm: medianRatio(legacy.metrics.warmExtractionMs, next.metrics.warmExtractionMs),
+    legacyColdMembers: legacy.coldMembers,
+    nextColdMembers: next.coldMembers,
+    legacyWarmMembers: legacy.warmMembers,
+    nextWarmMembers: next.warmMembers,
+    coldComparability: comparability(
+      legacy.coldMembers,
+      next.coldMembers,
+      legacy.coldOpaqueTypes,
+      next.coldOpaqueTypes
+    ),
+    // No engine reports opaque types for the re-extracted member, so warm is judged on counts alone.
+    warmComparability: comparability(legacy.warmMembers, next.warmMembers),
+  };
+}
+
+/**
+ * Ratios for every control pair whose two engines both measured in this invocation. A pair with one
+ * failed or skipped side yields nothing: dividing a fresh median by a stale one is not a comparison.
+ */
+export function computeRatios(results: Partial<Record<EngineId, EngineResult>>): Ratios {
+  const ratios: Ratios = {};
+
+  for (const pair of CONTROL_PAIRS) {
+    const legacy = results[pair.legacy];
+    const next = results[pair.next];
+    if (legacy?.status !== 'measured' || next?.status !== 'measured') {
+      continue;
+    }
+    for (const [scenarioName, legacyScenario] of Object.entries(legacy.scenarios)) {
+      const nextScenario = next.scenarios[scenarioName];
+      if (!nextScenario) {
+        continue;
+      }
+      ratios[pair.name] ??= {};
+      ratios[pair.name][scenarioName] = ratioFor(legacyScenario, nextScenario);
+    }
+  }
+
+  return ratios;
+}

--- a/scripts/bench/docgen-perf/ratios.ts
+++ b/scripts/bench/docgen-perf/ratios.ts
@@ -29,30 +29,30 @@ export const CONTROL_PAIRS: ControlPair[] = [
 ];
 
 /**
- * Each control pair swaps sides on even repetitions so cache warming and thermal drift do not
- * consistently favour whichever engine is listed first.
+ * Even repetitions run the engines back to front, so cache warming and thermal drift do not
+ * consistently favour whichever side of a pair is listed first.
+ *
+ * Reversing the whole list rather than swapping each pair in place is what makes that hold for
+ * *every* pair at once. Pairs can share an engine - `vue-component-meta` is the new side of the vue
+ * pair and the legacy side of the version pair - and swapping such a chain pairwise moves the shared
+ * engine twice, which puts the first pair back in its original relative order.
  */
 export function engineOrderForRep(engines: EngineId[], rep: number): EngineId[] {
-  const order = [...engines];
-  if (rep % 2 !== 0) {
-    return order;
-  }
-  for (const { legacy, next } of CONTROL_PAIRS) {
-    const legacyIdx = order.indexOf(legacy);
-    const nextIdx = order.indexOf(next);
-    if (legacyIdx >= 0 && nextIdx >= 0) {
-      order[legacyIdx] = next;
-      order[nextIdx] = legacy;
-    }
-  }
-  return order;
+  return rep % 2 === 0 ? [...engines].reverse() : [...engines];
 }
 
-/** Undefined unless both sides measured: dividing by a skipped or failed side is not a comparison. */
+/**
+ * Undefined unless both sides measured: dividing by a skipped or failed side is not a comparison.
+ *
+ * A zero denominator is treated the same way. It means the new engine's median landed below the
+ * clock's resolution, and Infinity would then be rendered and stored as if it were a ratio.
+ */
 function medianRatio(legacy: LatencyMetric | NotApplicable, next: LatencyMetric | NotApplicable) {
-  return legacy.status === 'measured' && next.status === 'measured'
-    ? legacy.median / next.median
-    : undefined;
+  if (legacy.status !== 'measured' || next.status !== 'measured') {
+    return undefined;
+  }
+  const ratio = legacy.median / next.median;
+  return Number.isFinite(ratio) ? ratio : undefined;
 }
 
 /**

--- a/scripts/bench/docgen-perf/registry.test.ts
+++ b/scripts/bench/docgen-perf/registry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { QUICK_PROFILE } from './config.ts';
+import { ALL_ENGINE_IDS, ENGINES, engineById } from './registry.ts';
+import type { EngineId } from './types.ts';
+
+describe('the engine table', () => {
+  it('registers each id exactly once', () => {
+    expect(new Set(ALL_ENGINE_IDS).size).toBe(ALL_ENGINE_IDS.length);
+  });
+
+  it('names an engine that is not registered', () => {
+    expect(() => engineById('svelte' as EngineId)).toThrow('no engine registered for "svelte"');
+  });
+
+  it('gives every engine at least one scenario, with unique names', () => {
+    for (const engine of ENGINES) {
+      const names = engine.scenarios(QUICK_PROFILE).map((s) => s.name);
+      expect(names.length, engine.id).toBeGreaterThan(0);
+      expect(new Set(names).size, engine.id).toBe(names.length);
+    }
+  });
+});

--- a/scripts/bench/docgen-perf/registry.ts
+++ b/scripts/bench/docgen-perf/registry.ts
@@ -1,0 +1,21 @@
+/**
+ * The engine table. Adding an engine means adding one entry here; the orchestrator has no
+ * per-engine branches. Everything below is data: which child to spawn, with which flags, over
+ * which scenarios.
+ */
+import type { BenchEngine } from './engine.ts';
+import { CompodocEngine } from './engines/compodoc.ts';
+import type { EngineId } from './types.ts';
+
+export const ENGINES: BenchEngine[] = [new CompodocEngine()];
+
+export const ALL_ENGINE_IDS: EngineId[] = ENGINES.map((engine) => engine.id);
+export const DEFAULT_ENGINE_IDS: EngineId[] = ENGINES.filter((e) => e.inDefaultRun).map((e) => e.id);
+
+export function engineById(id: EngineId): BenchEngine {
+  const engine = ENGINES.find((candidate) => candidate.id === id);
+  if (!engine) {
+    throw new Error(`no engine registered for "${id}"`);
+  }
+  return engine;
+}

--- a/scripts/bench/docgen-perf/report.test.ts
+++ b/scripts/bench/docgen-perf/report.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderRatios, renderResults } from './report.ts';
+import { NOT_APPLICABLE, type Ratios } from './types.ts';
+
+describe('renderRatios', () => {
+  const notLikeForLike: Ratios = {
+    vue: {
+      flat: {
+        cold: 18.48,
+        warm: 22.5,
+        legacyColdMembers: 6,
+        nextColdMembers: 320,
+        legacyWarmMembers: 0,
+        nextWarmMembers: 32,
+        coldComparability: 'next-documents-more',
+        warmComparability: 'next-documents-more',
+      },
+    },
+  };
+
+  it('warns on the cold line when the engines documented different members', () => {
+    const [cold] = renderRatios(notLikeForLike);
+    expect(cold).toContain('documented members 6 vs 320');
+    expect(cold).toContain('NOT like-for-like');
+  });
+
+  it('warns on the warm line too', () => {
+    // The warm ratio is the more misleading of the two: the legacy Vue parser documented nothing
+    // on the save it was timed on, so a bare ratio reads as a 22x speed win over identical work.
+    const warm = renderRatios(notLikeForLike).find((line) => line.includes('warm'));
+    expect(warm).toContain('documented members 0 vs 32');
+    expect(warm).toContain('NOT like-for-like');
+  });
+
+  it('prints no warning when the engines did the same work', () => {
+    const lines = renderRatios({
+      vue: {
+        flat: { cold: 1.2, warm: 1.1, legacyColdMembers: 50, nextColdMembers: 50, coldComparability: 'like-for-like', warmComparability: 'like-for-like' },
+      },
+    });
+    expect(lines.every((line) => !line.includes('NOT like-for-like'))).toBe(true);
+    expect(lines[0]).toContain('documented members 50 vs 50');
+  });
+
+  it('prints a bare ratio when neither engine reports member counts', () => {
+    const lines = renderRatios({ react: { default: { cold: 4, warm: 2, coldComparability: 'unknown', warmComparability: 'unknown' } } });
+    expect(lines).toEqual([
+      '  ratio cold legacy/new (react/default): 4.00',
+      '  ratio warm legacy/new (react/default): 2.00',
+    ]);
+  });
+
+  it('says so when there is no ratio at all', () => {
+    expect(renderRatios({})).toEqual([
+      '  no calibration ratio: it needs both sides of a control pair measured in one run',
+    ]);
+  });
+
+  it('omits a half of the pair that did not measure', () => {
+    const lines = renderRatios({ react: { default: { cold: 4, coldComparability: 'unknown', warmComparability: 'unknown' } } });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('cold');
+  });
+});
+
+describe('renderResults', () => {
+  it('lists a failed engine as a status line rather than a table row', () => {
+    const { table, statusLines } = renderResults(['compodoc'], {
+      compodoc: { status: 'failed', reason: 'child exited with status 1:\nsecond line' },
+    });
+    expect(table).toHaveLength(1); // header only
+    expect(statusLines).toEqual(['  compodoc: FAILED - child exited with status 1:']);
+  });
+
+  it('renders n/a metrics as n/a rather than zero', () => {
+    const { table } = renderResults(['react-osa'], {
+      'react-osa': {
+        status: 'measured',
+        scenarios: {
+          default: {
+            params: {},
+            metrics: {
+              coldExtractionMs: { status: 'measured', samples: [100], median: 100 },
+              warmExtractionMs: { status: 'measured', samples: [10], median: 10 },
+              wholeProjectScanMs: NOT_APPLICABLE,
+              peakTransientMb: { status: 'measured', samples: [5], mean: 5 },
+              retainedGrowthMb: { status: 'measured', value: 3 },
+              retainedSlopeMbPerSave: { status: 'measured', value: 0.25 },
+            },
+          },
+        },
+      },
+    });
+    expect(table[1]).toContain('n/a');
+    expect(table[1]).toContain('0.25MB/save');
+  });
+});

--- a/scripts/bench/docgen-perf/report.test.ts
+++ b/scripts/bench/docgen-perf/report.test.ts
@@ -1,98 +1,242 @@
 import { describe, expect, it } from 'vitest';
 
 import { renderRatios, renderResults } from './report.ts';
-import { NOT_APPLICABLE, type Ratios } from './types.ts';
+import { type EngineMetrics, type EngineResult, NOT_APPLICABLE, type Ratios } from './types.ts';
+
+/**
+ * The report is read as a block of terminal output, not as an array of strings, so the snapshots
+ * below join it back into one. Column alignment and the notes that travel beside a ratio are the
+ * whole point of this module, and neither survives a per-line assertion.
+ */
+const block = (lines: string[]) => lines.join('\n');
+
+/** A series engine: per-component, so it has no whole-project scan. */
+const seriesMetrics: EngineMetrics = {
+  coldExtractionMs: { status: 'measured', samples: [1204, 1180, 1191], median: 1191 },
+  warmExtractionMs: { status: 'measured', samples: [42.4, 39.8, 41.1], median: 41.1 },
+  wholeProjectScanMs: NOT_APPLICABLE,
+  peakTransientMb: { status: 'measured', samples: [61, 58, 63], mean: 60.7 },
+  retainedGrowthMb: { status: 'measured', value: 12.4 },
+  retainedSlopeMbPerSave: { status: 'measured', value: 0.62 },
+};
+
+/** A one-shot CLI engine: a fresh process per run, so no retained series to report. */
+const oneShotMetrics: EngineMetrics = {
+  coldExtractionMs: { status: 'measured', samples: [8420, 8110, 8300], median: 8300 },
+  warmExtractionMs: { status: 'measured', samples: [8290, 8050, 8180], median: 8180 },
+  wholeProjectScanMs: { status: 'measured', samples: [8420, 8110, 8300], median: 8300 },
+  peakTransientMb: { status: 'measured', samples: [980, 1010, 995], mean: 995 },
+  retainedGrowthMb: NOT_APPLICABLE,
+  retainedSlopeMbPerSave: NOT_APPLICABLE,
+};
+
+const measured = (metrics: EngineMetrics): EngineResult => ({
+  status: 'measured',
+  scenarios: { default: { params: {}, metrics } },
+});
 
 describe('renderRatios', () => {
-  const notLikeForLike: Ratios = {
-    vue: {
-      flat: {
-        cold: 18.48,
-        warm: 22.5,
-        legacyColdMembers: 6,
-        nextColdMembers: 320,
-        legacyWarmMembers: 0,
-        nextWarmMembers: 32,
-        coldComparability: 'next-documents-more',
-        warmComparability: 'next-documents-more',
-      },
-    },
-  };
-
-  it('warns on the cold line when the engines documented different members', () => {
-    const [cold] = renderRatios(notLikeForLike);
-    expect(cold).toContain('documented members 6 vs 320');
-    expect(cold).toContain('NOT like-for-like');
+  it('spells out which side documented more, on the cold line and the warm one', () => {
+    // The warm line needs the note more than the cold one: the legacy Vue parser documents nothing
+    // on the save it is timed on, so a bare 22.50 would read as a clean win over identical work.
+    expect(
+      block(
+        renderRatios({
+          vue: {
+            flat: {
+              cold: 18.48,
+              warm: 22.5,
+              legacyColdMembers: 6,
+              nextColdMembers: 320,
+              legacyWarmMembers: 0,
+              nextWarmMembers: 32,
+              coldComparability: 'next-documents-more',
+              warmComparability: 'next-documents-more',
+            },
+          },
+        })
+      )
+    ).toMatchInlineSnapshot(`
+      "  ratio cold legacy/new (vue/flat): 18.48  [documented members 6 vs 320 - NOT like-for-like - new engine documented more, so this ratio undersells it]
+        ratio warm legacy/new (vue/flat): 22.50  [documented members 0 vs 32 - NOT like-for-like - new engine documented more, so this ratio undersells it]"
+    `);
   });
 
-  it('warns on the warm line too', () => {
-    // The warm ratio is the more misleading of the two: the legacy Vue parser documented nothing
-    // on the save it was timed on, so a bare ratio reads as a 22x speed win over identical work.
-    const warm = renderRatios(notLikeForLike).find((line) => line.includes('warm'));
-    expect(warm).toContain('documented members 0 vs 32');
-    expect(warm).toContain('NOT like-for-like');
+  it('reads a ratio the other way when the new engine documented less', () => {
+    // The same shape of mismatch, the opposite meaning: this one is fast for the wrong reason.
+    expect(
+      block(
+        renderRatios({
+          vue: {
+            flat: {
+              cold: 0.05,
+              legacyColdMembers: 320,
+              nextColdMembers: 6,
+              coldComparability: 'next-documents-less',
+              warmComparability: 'unknown',
+            },
+          },
+        })
+      )
+    ).toMatchInlineSnapshot(`"  ratio cold legacy/new (vue/flat): 0.05  [documented members 320 vs 6 - NOT like-for-like - new engine documented less, so it is fast for the wrong reason]"`);
   });
 
-  it('prints no warning when the engines did the same work', () => {
-    const lines = renderRatios({
-      vue: {
-        flat: { cold: 1.2, warm: 1.1, legacyColdMembers: 50, nextColdMembers: 50, coldComparability: 'like-for-like', warmComparability: 'like-for-like' },
-      },
-    });
-    expect(lines.every((line) => !line.includes('NOT like-for-like'))).toBe(true);
-    expect(lines[0]).toContain('documented members 50 vs 50');
+  it('warns when the counts agree but the resolution work did not', () => {
+    // Equal member counts off unequal work, which is the case a count alone cannot see.
+    expect(
+      block(
+        renderRatios({
+          vue: {
+            flat: {
+              cold: 4.1,
+              legacyColdMembers: 90,
+              nextColdMembers: 90,
+              coldComparability: 'next-resolves-less',
+              warmComparability: 'like-for-like',
+            },
+          },
+        })
+      )
+    ).toMatchInlineSnapshot(`"  ratio cold legacy/new (vue/flat): 4.10  [documented members 90 vs 90 - NOT like-for-like - same members, but the new engine left more types unresolved]"`);
+  });
+
+  it('prints the counts without a warning when both sides did the same work', () => {
+    expect(
+      block(
+        renderRatios({
+          vue: {
+            flat: {
+              cold: 1.2,
+              warm: 1.1,
+              legacyColdMembers: 50,
+              nextColdMembers: 50,
+              coldComparability: 'like-for-like',
+              warmComparability: 'like-for-like',
+            },
+          },
+        })
+      )
+    ).toMatchInlineSnapshot(`
+      "  ratio cold legacy/new (vue/flat): 1.20  [documented members 50 vs 50]
+        ratio warm legacy/new (vue/flat): 1.10"
+    `);
   });
 
   it('prints a bare ratio when neither engine reports member counts', () => {
-    const lines = renderRatios({ react: { default: { cold: 4, warm: 2, coldComparability: 'unknown', warmComparability: 'unknown' } } });
-    expect(lines).toEqual([
-      '  ratio cold legacy/new (react/default): 4.00',
-      '  ratio warm legacy/new (react/default): 2.00',
-    ]);
+    // Unknown earns no warning: it is not a claim of inequality, only an absence of counts.
+    expect(
+      block(
+        renderRatios({
+          react: {
+            default: {
+              cold: 4,
+              warm: 2,
+              coldComparability: 'unknown',
+              warmComparability: 'unknown',
+            },
+          },
+        })
+      )
+    ).toMatchInlineSnapshot(`
+      "  ratio cold legacy/new (react/default): 4.00
+        ratio warm legacy/new (react/default): 2.00"
+    `);
+  });
+
+  it('omits the half of the pair that did not measure', () => {
+    expect(
+      block(
+        renderRatios({
+          react: {
+            default: { cold: 4, coldComparability: 'unknown', warmComparability: 'unknown' },
+          },
+        })
+      )
+    ).toMatchInlineSnapshot(`"  ratio cold legacy/new (react/default): 4.00"`);
+  });
+
+  it('renders every scenario of every pair', () => {
+    const ratios: Ratios = {
+      react: {
+        default: {
+          cold: 3.9,
+          warm: 2.1,
+          coldComparability: 'unknown',
+          warmComparability: 'unknown',
+        },
+      },
+      vue: {
+        flat: { cold: 18.5, coldComparability: 'unknown', warmComparability: 'unknown' },
+        workspace: { cold: 21.2, coldComparability: 'unknown', warmComparability: 'unknown' },
+      },
+    };
+    expect(block(renderRatios(ratios))).toMatchInlineSnapshot(`
+      "  ratio cold legacy/new (react/default): 3.90
+        ratio warm legacy/new (react/default): 2.10
+        ratio cold legacy/new (vue/flat): 18.50
+        ratio cold legacy/new (vue/workspace): 21.20"
+    `);
   });
 
   it('says so when there is no ratio at all', () => {
-    expect(renderRatios({})).toEqual([
-      '  no calibration ratio: it needs both sides of a control pair measured in one run',
-    ]);
-  });
-
-  it('omits a half of the pair that did not measure', () => {
-    const lines = renderRatios({ react: { default: { cold: 4, coldComparability: 'unknown', warmComparability: 'unknown' } } });
-    expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('cold');
+    expect(block(renderRatios({}))).toMatchInlineSnapshot(`"  no calibration ratio: it needs both sides of a control pair measured in one run"`);
   });
 });
 
 describe('renderResults', () => {
-  it('lists a failed engine as a status line rather than a table row', () => {
-    const { table, statusLines } = renderResults(['compodoc'], {
-      compodoc: { status: 'failed', reason: 'child exited with status 1:\nsecond line' },
-    });
-    expect(table).toHaveLength(1); // header only
-    expect(statusLines).toEqual(['  compodoc: FAILED - child exited with status 1:']);
+  it('renders the table every run ends with', () => {
+    // One engine of each kind, plus a skip and a failure, because the column widths are computed
+    // across the whole table and a status line replaces a row rather than joining one.
+    const { table, statusLines } = renderResults(
+      ['react-legacy', 'react-osa', 'compodoc', 'vue-docgen-api', 'vue-component-meta'],
+      {
+        'react-legacy': measured(seriesMetrics),
+        'react-osa': measured(seriesMetrics),
+        compodoc: measured(oneShotMetrics),
+        'vue-docgen-api': { status: 'skipped', reason: 'vue-docgen-api did not resolve' },
+        'vue-component-meta': {
+          status: 'failed',
+          reason: 'child exited with status 1:\n    at createChecker (vue-component-meta)',
+        },
+      }
+    );
+    expect(block(table)).toMatchInlineSnapshot(`
+      "  engine/scenario       cold    warm    scan    peak   ret-growth  ret-slope
+        react-legacy/default  1191ms  41ms    n/a     61MB   12.4MB      0.62MB/save
+        react-osa/default     1191ms  41ms    n/a     61MB   12.4MB      0.62MB/save
+        compodoc/default      8300ms  8180ms  8300ms  995MB  n/a         n/a"
+    `);
+    // Only the first line of a reason: a stack trace would push the table off the screen.
+    expect(block(statusLines)).toMatchInlineSnapshot(`
+      "  vue-docgen-api: SKIPPED - vue-docgen-api did not resolve
+        vue-component-meta: FAILED - child exited with status 1:"
+    `);
   });
 
-  it('renders n/a metrics as n/a rather than zero', () => {
-    const { table } = renderResults(['react-osa'], {
-      'react-osa': {
+  it('renders one engine with several scenarios as a row each', () => {
+    const { table } = renderResults(['vue-component-meta'], {
+      'vue-component-meta': {
         status: 'measured',
         scenarios: {
-          default: {
-            params: {},
-            metrics: {
-              coldExtractionMs: { status: 'measured', samples: [100], median: 100 },
-              warmExtractionMs: { status: 'measured', samples: [10], median: 10 },
-              wholeProjectScanMs: NOT_APPLICABLE,
-              peakTransientMb: { status: 'measured', samples: [5], mean: 5 },
-              retainedGrowthMb: { status: 'measured', value: 3 },
-              retainedSlopeMbPerSave: { status: 'measured', value: 0.25 },
-            },
-          },
+          flat: { params: {}, metrics: seriesMetrics },
+          workspace: { params: {}, metrics: seriesMetrics },
+          'base-type-touch': { params: {}, metrics: seriesMetrics },
         },
       },
     });
-    expect(table[1]).toContain('n/a');
-    expect(table[1]).toContain('0.25MB/save');
+    expect(block(table)).toMatchInlineSnapshot(`
+      "  engine/scenario                     cold    warm  scan  peak  ret-growth  ret-slope
+        vue-component-meta/flat             1191ms  41ms  n/a   61MB  12.4MB      0.62MB/save
+        vue-component-meta/workspace        1191ms  41ms  n/a   61MB  12.4MB      0.62MB/save
+        vue-component-meta/base-type-touch  1191ms  41ms  n/a   61MB  12.4MB      0.62MB/save"
+    `);
+  });
+
+  it('renders the header alone when nothing measured', () => {
+    const { table, statusLines } = renderResults(['compodoc'], {
+      compodoc: { status: 'skipped', reason: '@compodoc/compodoc did not resolve' },
+    });
+    expect(block(table)).toMatchInlineSnapshot(`"  engine/scenario  cold  warm  scan  peak  ret-growth  ret-slope"`);
+    expect(block(statusLines)).toMatchInlineSnapshot(`"  compodoc: SKIPPED - @compodoc/compodoc did not resolve"`);
   });
 });

--- a/scripts/bench/docgen-perf/report.ts
+++ b/scripts/bench/docgen-perf/report.ts
@@ -1,0 +1,125 @@
+/** Renders the suite's terminal output. Pure string building, so it is testable without a runner. */
+import type { Comparability, EngineId, EngineMetrics, EngineResult, Ratios } from './types.ts';
+
+const HEADER = ['engine/scenario', 'cold', 'warm', 'scan', 'peak', 'ret-growth', 'ret-slope'];
+
+export function formatCell(metric: EngineMetrics[keyof EngineMetrics], unit: 'ms' | 'MB'): string {
+  if (metric.status === 'n/a') {
+    return 'n/a';
+  }
+  if ('median' in metric) {
+    return `${metric.median.toFixed(0)}${unit}`;
+  }
+  if ('mean' in metric) {
+    return `${metric.mean.toFixed(0)}${unit}`;
+  }
+  return `${metric.value.toFixed(unit === 'MB' ? 1 : 0)}${unit}`;
+}
+
+export interface RenderedResults {
+  /** Already padded into aligned lines. */
+  table: string[];
+  /** One line per engine that skipped or failed, in place of a table row. */
+  statusLines: string[];
+}
+
+export function renderResults(
+  engineIds: EngineId[],
+  results: Partial<Record<EngineId, EngineResult>>
+): RenderedResults {
+  const rows: string[][] = [HEADER];
+  const statusLines: string[] = [];
+
+  for (const engineId of engineIds) {
+    const result = results[engineId];
+    if (!result) {
+      continue;
+    }
+    if (result.status !== 'measured') {
+      statusLines.push(
+        `  ${engineId}: ${result.status.toUpperCase()} - ${result.reason.split('\n')[0]}`
+      );
+      continue;
+    }
+    for (const [scenarioName, scenario] of Object.entries(result.scenarios)) {
+      const m = scenario.metrics;
+      rows.push([
+        `${engineId}/${scenarioName}`,
+        formatCell(m.coldExtractionMs, 'ms'),
+        formatCell(m.warmExtractionMs, 'ms'),
+        formatCell(m.wholeProjectScanMs, 'ms'),
+        formatCell(m.peakTransientMb, 'MB'),
+        formatCell(m.retainedGrowthMb, 'MB'),
+        m.retainedSlopeMbPerSave.status === 'measured'
+          ? `${m.retainedSlopeMbPerSave.value.toFixed(2)}MB/save`
+          : 'n/a',
+      ]);
+    }
+  }
+
+  const widths = HEADER.map((_, col) => Math.max(...rows.map((row) => row[col].length)));
+  const table = rows.map((row) => `  ${row.map((cell, col) => cell.padEnd(widths[col])).join('  ')}`);
+  return { table, statusLines };
+}
+
+/**
+ * A ratio between engines that documented different numbers of members is not a speed comparison -
+ * the faster side was fast because it resolved less. Printing such a ratio bare reads as a clean
+ * win, so the member counts and the warning travel with it, on the warm line as much as the cold
+ * one. The warm line needs it more: the legacy Vue parser documents zero members on the save it is
+ * timed on, so a bare warm ratio would read as a clean win over identical work.
+ */
+export function renderRatios(ratios: Ratios): string[] {
+  const lines: string[] = [];
+
+  for (const [pairName, scenarios] of Object.entries(ratios)) {
+    for (const [scenarioName, entry] of Object.entries(scenarios)) {
+      const label = `${pairName}/${scenarioName}`;
+
+      if (entry.cold !== undefined) {
+        lines.push(
+          `  ratio cold legacy/new (${label}): ${entry.cold.toFixed(2)}` +
+            memberNote(entry.legacyColdMembers, entry.nextColdMembers, entry.coldComparability)
+        );
+      }
+      if (entry.warm !== undefined) {
+        lines.push(
+          `  ratio warm legacy/new (${label}): ${entry.warm.toFixed(2)}` +
+            memberNote(entry.legacyWarmMembers, entry.nextWarmMembers, entry.warmComparability)
+        );
+      }
+    }
+  }
+
+  if (lines.length === 0) {
+    lines.push('  no calibration ratio: it needs both sides of a control pair measured in one run');
+  }
+  return lines;
+}
+
+/**
+ * Spelled out rather than flagged, because the direction is what a reader needs: an engine that
+ * documented less is fast for the wrong reason, while one that documented more has a ratio that
+ * undersells it. A bare "NOT like-for-like" leaves those two looking the same.
+ */
+const VERDICT: Record<Comparability, string> = {
+  // No counts is not a claim of inequality, so it earns no warning - only a direction does.
+  unknown: '',
+  'like-for-like': '',
+  'next-documents-more': 'NOT like-for-like - new engine documented more, so this ratio undersells it',
+  'next-documents-less': 'NOT like-for-like - new engine documented less, so it is fast for the wrong reason',
+  'next-resolves-more': 'NOT like-for-like - same members, but the new engine resolved more of them',
+  'next-resolves-less': 'NOT like-for-like - same members, but the new engine left more types unresolved',
+};
+
+function memberNote(
+  legacy: number | undefined,
+  next: number | undefined,
+  verdict: Comparability
+): string {
+  const note = VERDICT[verdict];
+  if (legacy === undefined || next === undefined) {
+    return note ? `  [${note}]` : '';
+  }
+  return `  [documented members ${legacy} vs ${next}${note ? ` - ${note}` : ''}]`;
+}

--- a/scripts/bench/docgen-perf/report.ts
+++ b/scripts/bench/docgen-perf/report.ts
@@ -65,7 +65,11 @@ export function renderResults(
   }
 
   const widths = HEADER.map((_, col) => Math.max(...rows.map((row) => row[col].length)));
-  const table = rows.map((row) => `  ${row.map((cell, col) => cell.padEnd(widths[col])).join('  ')}`);
+  // trimEnd because the last column is padded like every other one, and a run's output should not
+  // carry trailing spaces on every line.
+  const table = rows.map(
+    (row) => `  ${row.map((cell, col) => cell.padEnd(widths[col])).join('  ')}`.trimEnd()
+  );
   return { table, statusLines };
 }
 

--- a/scripts/bench/docgen-perf/report.ts
+++ b/scripts/bench/docgen-perf/report.ts
@@ -3,7 +3,16 @@ import type { Comparability, EngineId, EngineMetrics, EngineResult, Ratios } fro
 
 const HEADER = ['engine/scenario', 'cold', 'warm', 'scan', 'peak', 'ret-growth', 'ret-slope'];
 
-export function formatCell(metric: EngineMetrics[keyof EngineMetrics], unit: 'ms' | 'MB'): string {
+/**
+ * Decimals for a single-valued metric, per unit. A slope needs two to say anything at all, while a
+ * sub-millisecond difference between two aggregates is noise.
+ */
+const VALUE_PRECISION = { ms: 0, MB: 1, 'MB/save': 2 } as const;
+
+export function formatCell(
+  metric: EngineMetrics[keyof EngineMetrics],
+  unit: keyof typeof VALUE_PRECISION
+): string {
   if (metric.status === 'n/a') {
     return 'n/a';
   }
@@ -13,7 +22,7 @@ export function formatCell(metric: EngineMetrics[keyof EngineMetrics], unit: 'ms
   if ('mean' in metric) {
     return `${metric.mean.toFixed(0)}${unit}`;
   }
-  return `${metric.value.toFixed(unit === 'MB' ? 1 : 0)}${unit}`;
+  return `${metric.value.toFixed(VALUE_PRECISION[unit])}${unit}`;
 }
 
 export interface RenderedResults {
@@ -50,9 +59,7 @@ export function renderResults(
         formatCell(m.wholeProjectScanMs, 'ms'),
         formatCell(m.peakTransientMb, 'MB'),
         formatCell(m.retainedGrowthMb, 'MB'),
-        m.retainedSlopeMbPerSave.status === 'measured'
-          ? `${m.retainedSlopeMbPerSave.value.toFixed(2)}MB/save`
-          : 'n/a',
+        formatCell(m.retainedSlopeMbPerSave, 'MB/save'),
       ]);
     }
   }

--- a/scripts/bench/docgen-perf/run.ts
+++ b/scripts/bench/docgen-perf/run.ts
@@ -156,7 +156,10 @@ async function main() {
     for (const [engineId, reason] of failed) {
       console.error(`  - ${engineId}: ${reason}`);
     }
-    process.exit(1);
+    // Not `process.exit`: writes to a pipe are async, so exiting here can truncate the reasons
+    // printed just above - exactly the output someone is reading when the suite fails under `tee`.
+    process.exitCode = 1;
+    return;
   }
   console.log('\ndocgen-perf suite completed.');
 }

--- a/scripts/bench/docgen-perf/run.ts
+++ b/scripts/bench/docgen-perf/run.ts
@@ -1,0 +1,186 @@
+/**
+ * Orchestrator for the per-engine docgen performance suite. See scripts/bench/PERF-METHODOLOGY.md
+ * for the measurement contract.
+ *
+ * Run:
+ *   yarn bench:docgen-perf                # from scripts/, full profile
+ *   yarn bench:docgen-perf --quick        # smoke profile; results marked non-comparable
+ *   yarn bench:docgen-perf --engine compodoc     # one engine
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { SANDBOX_DIRECTORY } from '../docgen-shared/paths.ts';
+import { designatedRep } from './aggregate.ts';
+import { parseCliOptions } from './cli.ts';
+import { DEFAULT_PROFILE, QUICK_PROFILE, type SuiteProfile } from './config.ts';
+import type { ScenarioSpec } from './engine.ts';
+import { computeRatios, engineOrderForRep } from './ratios.ts';
+import { engineById } from './registry.ts';
+import { renderRatios, renderResults } from './report.ts';
+import { runSeriesChild } from './spawn.ts';
+import type { EngineId, EngineResult, ScenarioResult, SuiteResults } from './types.ts';
+
+const WORK_ROOT = path.join(SANDBOX_DIRECTORY, 'docgen-perf');
+
+/** Raw repetition samples, keyed by `engine/scenario`. */
+type SampleStore = Map<string, unknown[]>;
+
+function scenarioKey(engineId: EngineId, scenarioName: string): string {
+  return `${engineId}/${scenarioName}`;
+}
+
+/** One repetition of one engine, across every scenario that engine runs. */
+async function measureEngine(
+  engineId: EngineId,
+  profile: SuiteProfile,
+  rep: number,
+  store: SampleStore
+): Promise<void> {
+  const engine = engineById(engineId);
+  for (const scenario of engine.scenarios(profile)) {
+    const key = scenarioKey(engineId, scenario.name);
+    console.log(`  ${key} (rep ${rep}/${profile.n})…`);
+    const sample = await engine.measure(
+      {
+        scenarioDir: path.join(WORK_ROOT, engineId, scenario.name),
+        runSeriesChild,
+      },
+      scenario,
+      rep
+    );
+    store.set(key, [...(store.get(key) ?? []), sample]);
+  }
+}
+
+function assembleScenario(
+  engineId: EngineId,
+  scenario: ScenarioSpec,
+  profile: SuiteProfile,
+  store: SampleStore
+): ScenarioResult {
+  const engine = engineById(engineId);
+  const samples = store.get(scenarioKey(engineId, scenario.name)) ?? [];
+  const metrics = engine.aggregate(samples, profile.n);
+  // Member counts come from the same repetition as the warm and memory metrics, so every figure
+  // reported for a scenario describes one run.
+  const designated = designatedRep(samples as Array<{ coldMs: number }>);
+  return {
+    params: scenario.params,
+    metrics,
+    coldMembers: engine.coldMembers(designated),
+    warmMembers: engine.warmMembers(designated),
+    coldOpaqueTypes: engine.coldOpaqueTypes(designated),
+  };
+}
+
+async function main() {
+  const options = parseCliOptions(process.argv.slice(2), WORK_ROOT);
+  const profile: SuiteProfile = options.quick ? QUICK_PROFILE : DEFAULT_PROFILE;
+
+  console.log('docgen-perf suite');
+  console.log(`  engines=${options.engines.join(',')} n=${profile.n} comparable=${profile.comparable}`);
+  if (!profile.comparable) {
+    console.log('  QUICK PROFILE: results are non-comparable smoke numbers');
+  }
+
+  const store: SampleStore = new Map();
+  const failed = new Map<EngineId, string>();
+  const skipped = new Map<EngineId, string>();
+
+  for (const engineId of options.engines) {
+    const reason = engineById(engineId).preflight();
+    if (reason) {
+      skipped.set(engineId, reason);
+      console.log(`  ${engineId}: SKIPPED - ${reason}`);
+    }
+  }
+
+  for (let rep = 1; rep <= profile.n; rep++) {
+    console.log(`\n=== repetition ${rep}/${profile.n} ===`);
+    for (const engineId of engineOrderForRep(options.engines, rep)) {
+      if (failed.has(engineId) || skipped.has(engineId)) {
+        continue;
+      }
+      try {
+        await measureEngine(engineId, profile, rep, store);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        failed.set(engineId, reason);
+        console.error(`  ${engineId} FAILED: ${reason}`);
+      }
+    }
+  }
+
+  const engineResults: SuiteResults['engines'] = {};
+  const engineVersions: SuiteResults['engineVersions'] = {};
+
+  for (const engineId of options.engines) {
+    const engine = engineById(engineId);
+    const version = engine.version();
+    if (version) {
+      engineVersions[engineId] = version;
+    }
+
+    const skipReason = skipped.get(engineId);
+    if (skipReason) {
+      engineResults[engineId] = { status: 'skipped', reason: skipReason };
+      continue;
+    }
+    // An engine that failed part-way holds fewer samples than the pinned N, so it stays failed
+    // rather than being reported as measured at an unrecorded N.
+    const failReason = failed.get(engineId);
+    if (failReason) {
+      engineResults[engineId] = { status: 'failed', reason: failReason };
+      continue;
+    }
+    try {
+      const scenarios: Record<string, ScenarioResult> = {};
+      for (const scenario of engine.scenarios(profile)) {
+        scenarios[scenario.name] = assembleScenario(engineId, scenario, profile, store);
+      }
+      engineResults[engineId] = { status: 'measured', scenarios } satisfies EngineResult;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      failed.set(engineId, reason);
+      engineResults[engineId] = { status: 'failed', reason };
+    }
+  }
+
+  const results: SuiteResults = {
+    generatedAt: new Date().toISOString(),
+    nodeVersion: process.version,
+    pinnedN: profile.n,
+    comparable: profile.comparable,
+    engineVersions,
+    engines: engineResults,
+    ratios: computeRatios(engineResults),
+  };
+
+  console.log('\nresults');
+  const { table, statusLines } = renderResults(options.engines, engineResults);
+  for (const line of [...table, ...statusLines, ...renderRatios(results.ratios)]) {
+    console.log(line);
+  }
+  if (!profile.comparable) {
+    console.log('  QUICK PROFILE: results are non-comparable smoke numbers');
+  }
+
+  fs.mkdirSync(path.dirname(options.jsonOut), { recursive: true });
+  fs.writeFileSync(options.jsonOut, JSON.stringify(results, null, 2));
+  console.log(`  wrote ${options.jsonOut}`);
+
+  if (failed.size > 0) {
+    console.error('\ndocgen-perf suite FAILED:');
+    for (const [engineId, reason] of failed) {
+      console.error(`  - ${engineId}: ${reason}`);
+    }
+    process.exit(1);
+  }
+  console.log('\ndocgen-perf suite completed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/bench/docgen-perf/run.ts
+++ b/scripts/bench/docgen-perf/run.ts
@@ -11,10 +11,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { SANDBOX_DIRECTORY } from '../docgen-shared/paths.ts';
-import { designatedRep } from './aggregate.ts';
 import { parseCliOptions } from './cli.ts';
 import { DEFAULT_PROFILE, QUICK_PROFILE, type SuiteProfile } from './config.ts';
-import type { ScenarioSpec } from './engine.ts';
 import { computeRatios, engineOrderForRep } from './ratios.ts';
 import { engineById } from './registry.ts';
 import { renderRatios, renderResults } from './report.ts';
@@ -23,8 +21,11 @@ import type { EngineId, EngineResult, ScenarioResult, SuiteResults } from './typ
 
 const WORK_ROOT = path.join(SANDBOX_DIRECTORY, 'docgen-perf');
 
-/** Raw repetition samples, keyed by `engine/scenario`. */
-type SampleStore = Map<string, unknown[]>;
+/**
+ * Raw repetition samples, keyed by `engine/scenario`. Only the cold duration is common to every
+ * engine's sample; the rest stays known to the engine that produced it, which is what reads it back.
+ */
+type SampleStore = Map<string, Array<{ coldMs: number }>>;
 
 function scenarioKey(engineId: EngineId, scenarioName: string): string {
   return `${engineId}/${scenarioName}`;
@@ -51,27 +52,6 @@ async function measureEngine(
     );
     store.set(key, [...(store.get(key) ?? []), sample]);
   }
-}
-
-function assembleScenario(
-  engineId: EngineId,
-  scenario: ScenarioSpec,
-  profile: SuiteProfile,
-  store: SampleStore
-): ScenarioResult {
-  const engine = engineById(engineId);
-  const samples = store.get(scenarioKey(engineId, scenario.name)) ?? [];
-  const metrics = engine.aggregate(samples, profile.n);
-  // Member counts come from the same repetition as the warm and memory metrics, so every figure
-  // reported for a scenario describes one run.
-  const designated = designatedRep(samples as Array<{ coldMs: number }>);
-  return {
-    params: scenario.params,
-    metrics,
-    coldMembers: engine.coldMembers(designated),
-    warmMembers: engine.warmMembers(designated),
-    coldOpaqueTypes: engine.coldOpaqueTypes(designated),
-  };
 }
 
 async function main() {
@@ -137,7 +117,8 @@ async function main() {
     try {
       const scenarios: Record<string, ScenarioResult> = {};
       for (const scenario of engine.scenarios(profile)) {
-        scenarios[scenario.name] = assembleScenario(engineId, scenario, profile, store);
+        const samples = store.get(scenarioKey(engineId, scenario.name)) ?? [];
+        scenarios[scenario.name] = engine.assemble(samples, profile.n, scenario);
       }
       engineResults[engineId] = { status: 'measured', scenarios } satisfies EngineResult;
     } catch (err) {

--- a/scripts/bench/docgen-shared/engine-ids.ts
+++ b/scripts/bench/docgen-shared/engine-ids.ts
@@ -1,4 +1,10 @@
 /**
- * The docgen engines under measurement. Each engine adds its own id when it lands.
+ * The docgen engines under measurement.
  */
-export type EngineId = 'react-osa' | 'compodoc';
+export type EngineId =
+  | 'react-legacy'
+  | 'react-legacy-rdt'
+  | 'react-osa'
+  | 'vue-docgen-api'
+  | 'vue-component-meta'
+  | 'compodoc';

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "bench-packages": "jiti ./bench/bench-packages.ts",
     "bench:docgen-memory": "node --import jiti/register ./bench/docgen-memory/gate.ts",
+    "bench:docgen-perf": "node ./bench/docgen-perf/run.ts",
     "build-package": "jiti ./build-package.ts",
     "check": "node ./check/check-package.ts",
     "check-package": "jiti ./check-package.ts",


### PR DESCRIPTION
**Part 5, stacked on #35636.** The React and Vue engines that used to sit in this PR now live in #35651.

## What I did

This makes the perf suite runnable.

- `run.ts` is the entry point behind the new `yarn bench:docgen-perf`.
- `registry.ts` is the table of which engine measures what, with which flags. Adding an engine means adding one row; the orchestrator has no per-engine branches.
- `ratios.ts` divides each framework's legacy median by its new-engine median, both taken in the same run.
- `report.ts` prints the result table.

Compodoc, from the PR under this one, is the only engine registered here, so a run measures Angular. The control pairs the React and Vue engines belong to are already listed in `ratios.ts`: a pair whose two engines are not both registered yields no ratio, which is what a run prints today.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`ratios.test.ts`, `registry.test.ts` and `report.test.ts`.

#### Manual testing

```bash
cd scripts && yarn check && yarn lint && yarn test bench/docgen

yarn bench:docgen-perf --quick --engine compodoc
```

`--quick` uses small projects and marks its own output non-comparable, so it is a smoke test, not a measurement. The run prints the Compodoc row, then says it has no calibration ratio, because a ratio needs both sides of a control pair measured in one invocation and only one engine is registered so far.

### Documentation

- [ ] Add or update documentation reflecting your changes

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below: `build`