### PR TITLE
Core: Truncate Testing Library DOM dumps in error messages

### DIFF
--- a/code/core/src/test/testing-library.test.ts
+++ b/code/core/src/test/testing-library.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+
+import { getConfig } from './testing-library.ts';
+
+describe('getElementError', () => {
+  it('truncates long DOM dumps and points at screen.debug()', () => {
+    const container = document.createElement('div');
+    for (let i = 0; i < 100; i += 1) {
+      const child = document.createElement('span');
+      child.textContent = `item ${i}`;
+      container.appendChild(child);
+    }
+
+    const error = getConfig().getElementError('Unable to find an element', container);
+
+    expect(error.name).toBe('TestingLibraryElementError');
+    expect(error.message).toContain('Unable to find an element');
+    expect(error.message).toContain('use screen.debug() to see the full DOM');
+    expect(error.message.split('\n').length).toBeLessThan(30);
+  });
+
+  it('leaves short DOM dumps intact', () => {
+    const container = document.createElement('div');
+    const button = document.createElement('button');
+    button.textContent = 'Click me';
+    container.appendChild(button);
+
+    const error = getConfig().getElementError('Unable to find an element', container);
+
+    expect(error.message).toContain('Click me');
+    expect(error.message).not.toContain('truncated');
+  });
+
+  it('returns the message alone when there is no container', () => {
+    const error = getConfig().getElementError('Unable to find an element', undefined as never);
+
+    expect(error.message).toBe('Unable to find an element');
+  });
+});

--- a/code/core/src/test/testing-library.test.ts
+++ b/code/core/src/test/testing-library.test.ts
@@ -16,8 +16,13 @@ describe('getElementError', () => {
 
     expect(error.name).toBe('TestingLibraryElementError');
     expect(error.message).toContain('Unable to find an element');
-    expect(error.message).toContain('use screen.debug() to see the full DOM');
-    expect(error.message.split('\n').length).toBeLessThan(30);
+
+    const [, dump] = error.message.split('\n\n');
+    const dumpLines = dump.split('\n');
+    expect(dumpLines).toHaveLength(21);
+    expect(dumpLines.at(-1)).toContain(
+      'DOM dump truncated at 20 lines, use screen.debug() to see the full DOM'
+    );
   });
 
   it('leaves short DOM dumps intact', () => {

--- a/code/core/src/test/testing-library.ts
+++ b/code/core/src/test/testing-library.ts
@@ -23,6 +23,27 @@ const testingLibrary = instrument(
   fireEvent: Promisify<FireFunction> & PromisifyObject<FireObject>;
 };
 
+// Testing Library appends a full prettyDOM dump to query and waitFor errors which buries the actual error when the container is the whole document
+// Keep a short excerpt and point at screen.debug() for the rest.
+const DOM_DUMP_LINE_LIMIT = 20;
+
+domTestingLibrary.configure({
+  getElementError(message, container) {
+    const prettifiedDOM = container && domTestingLibrary.prettyDOM(container);
+    const lines = prettifiedDOM ? prettifiedDOM.split('\n') : [];
+    const dump =
+      lines.length > DOM_DUMP_LINE_LIMIT
+        ? [
+            ...lines.slice(0, DOM_DUMP_LINE_LIMIT),
+            `... (DOM dump truncated at ${DOM_DUMP_LINE_LIMIT} lines, use screen.debug() to see the full DOM)`,
+          ].join('\n')
+        : prettifiedDOM;
+    const error = new Error([message, dump].filter(Boolean).join('\n\n'));
+    error.name = 'TestingLibraryElementError';
+    return error;
+  },
+});
+
 testingLibrary.screen = new Proxy(testingLibrary.screen, {
   get(target, prop, receiver) {
     if (typeof window !== 'undefined' && globalThis.location?.href?.includes('viewMode=docs')) {


### PR DESCRIPTION
Closes #34119

## What I did

Testing Library appends a `prettyDOM` dump of the container to query and `waitFor` errors and both error paths flow through one hook `config.getElementError`.

Storybook re exports the library without configuring it and as a result failures dump up to 7000 characters of DOM, usually the whole document dominated by Storybook's own wrapper markup. This buries the actual error in the browser console and floods CI terminals.

This registers a `getElementError` that keeps the first 20 lines of the dump and appends "DOM dump truncated at 20 lines, use screen.debug() to see the
full DOM". 

Why truncation rather than removal? The first lines often show which state the canvas was in and `screen.debug()` remains available for the full output. Because the hook is upstream of both the browser console and CLI reporters both symptoms from the issue are addressed.

Measured on a deliberately failing story test with an 80 element canvas run through the addon-vitest browser project which had 697 lines of output before this change and 89 after.

If a user calls `configure({ getElementError })` themselves their setup runs after this import-time call so existing customisations still win.

One note for review: the `new Error` in the custom handler intentionally mirrors Testing Librarys own `TestingLibraryElementError` shape with name
included rather than using a categorised StorybookError, so downstream
consumers see the same error type they would from upstream. This trips the
`no-uncategorized-errors` lint warning.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

New `testing-library.test.ts` covers: long dumps truncated with the `screen.debug()` pointer, short dumps left intact, and the no-container case. The truncation tests fail without the change.

#### Manual testing

1. Run a sandbox: `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. Add a story with a `play` that queries something that doesn't exist, e.g. `await within(canvasElement).findByText('nope', undefined, { timeout: 500 })`, on a component with a large DOM
3. Run the story test (or open it in the browser console). Before this change the error contains the entire document markup; after it, the first 20 lines plus a truncation note.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No docs change needed as this only shortens error output formatting and nothing is
deprecated or removed and `screen.debug()` is existing documented behaviour.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for failed element queries by limiting lengthy DOM output and adding a truncation notice.
  * Included guidance to use `screen.debug()` for full DOM details when content is truncated.
  * Preserved full output for short DOM content and kept messages minimal when no container is provided.

* **Tests**
  * Added coverage to verify truncated, short, and container-free error message scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->