### PR TITLE
ESLint Plugin: Add plugin meta and document oxlint usage

### DIFF
--- a/code/lib/eslint-plugin/README.md
+++ b/code/lib/eslint-plugin/README.md
@@ -172,6 +172,41 @@ export default [
 ];
 ```
 
+### Usage with oxlint
+
+[Oxlint](https://oxc.rs/docs/guide/usage/linter) can run this plugin through its [JS plugins support](https://oxc.rs/docs/guide/usage/linter/js-plugins.html) (an alpha oxlint feature). Reference the plugin in your `.oxlintrc.json` and enable rules for your stories files. The following mirrors the `flat/recommended` config:
+
+```jsonc
+{
+  "jsPlugins": ["eslint-plugin-storybook"],
+  "overrides": [
+    {
+      "files": ["**/*.stories.{ts,tsx,js,jsx,mjs,cjs}", "**/*.story.{ts,tsx,js,jsx,mjs,cjs}"],
+      "rules": {
+        "storybook/await-interactions": "error",
+        "storybook/context-in-play-function": "error",
+        "storybook/default-exports": "error",
+        "storybook/hierarchy-separator": "warn",
+        "storybook/no-redundant-story-name": "warn",
+        "storybook/no-renderer-packages": "error",
+        "storybook/prefer-pascal-case": "warn",
+        "storybook/story-exports": "error",
+        "storybook/use-storybook-expect": "error",
+        "storybook/use-storybook-testing-library": "error"
+      }
+    },
+    {
+      "files": [".storybook/main.{js,cjs,mjs,ts}"],
+      "rules": {
+        "storybook/no-uninstalled-addons": "error"
+      }
+    }
+  ]
+}
+```
+
+Note that oxlint's `files` patterns do not support ESLint's `@(ts|tsx)` extglob syntax — patterns using it are silently ignored. Use `{ts,tsx}` braces instead, as shown above.
+
 ### MDX Support
 
 This plugin does not support MDX files.

--- a/code/lib/eslint-plugin/scripts/update-lib-index.ts
+++ b/code/lib/eslint-plugin/scripts/update-lib-index.ts
@@ -21,6 +21,8 @@ export async function update() {
  * This file has been automatically generated,
  * in order to update its content execute "yarn update"
  */
+import { name, version } from '../package.json'
+
 // configs
 ${categoryIds
   .map((categoryId) => `import ${camelize(categoryId)} from './configs/${categoryId}.ts'`)
@@ -49,8 +51,14 @@ export const rules = {
     ${rules.map((rule) => `'${rule.name}': ${camelize(rule.name)}`).join(',\n')}
 };
 
+export const meta = {
+  name,
+  version,
+};
+
 export default {
   configs,
+  meta,
   rules,
 }
 `;

--- a/code/lib/eslint-plugin/src/index.test.ts
+++ b/code/lib/eslint-plugin/src/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { name, version } from '../package.json';
+import * as plugin from './index.ts';
+
+describe('plugin meta', () => {
+  it('exposes the package name and version', () => {
+    expect(plugin.meta).toEqual({ name, version });
+    expect(plugin.default.meta).toEqual({ name, version });
+  });
+});

--- a/code/lib/eslint-plugin/src/index.ts
+++ b/code/lib/eslint-plugin/src/index.ts
@@ -3,6 +3,8 @@
  * This file has been automatically generated,
  * in order to update its content execute "yarn update"
  */
+import { name, version } from '../package.json';
+
 // configs
 import csf from './configs/csf.ts';
 import csfStrict from './configs/csf-strict.ts';
@@ -64,7 +66,13 @@ export const rules = {
   'use-storybook-testing-library': useStorybookTestingLibrary,
 };
 
+export const meta = {
+  name,
+  version,
+};
+
 export default {
   configs,
+  meta,
   rules,
 };


### PR DESCRIPTION
## What I did

Added a `meta` object (`name`, `version`) to the plugin, following the [ESLint plugin convention](https://eslint.org/docs/latest/extend/plugins#meta-data-in-plugins). Tools that read plugin metadata — the ESLint config inspector, and linters with ESLint plugin compatibility such as [oxlint's JS plugins](https://oxc.rs/docs/guide/usage/linter/js-plugins.html) — use it to identify the plugin. The change is additive: ESLint v8 (`.eslintrc`) consumers ignore the extra key, and no existing exports or configs changed.

Also added a README section documenting how to run the plugin under oxlint via `jsPlugins`, mirroring the `flat/recommended` rule set. This includes a non-obvious caveat: oxlint's `files` override patterns don't support ESLint's `@(ts|tsx)` extglob syntax and silently match nothing, so the example uses `{ts,tsx}` braces.

The `meta` export is emitted by the `update-lib-index` codegen script, so `yarn update` keeps producing it. The version is read from `package.json` at build time.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Build the package: `cd code && yarn build eslint-plugin-storybook`
2. `node -e "import('./code/lib/eslint-plugin/dist/index.js').then((m) => console.log(m.default.meta))"` prints the package name and version.
3. In a project using oxlint (tested with oxlint 1.76): add `"jsPlugins": ["eslint-plugin-storybook"]` and the README's overrides to `.oxlintrc.json`, create a story file with a lowercase story export and no default export, and run `npx oxlint` — it reports `storybook/default-exports` and `storybook/prefer-pascal-case`.

### Documentation

- [x] Add or update documentation reflecting your changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ESLint plugin metadata now exposes its name and version through both named and default exports, improving compatibility with tooling that reads plugin information.
- **Documentation**
  - Added guidance for using the plugin with oxlint, including recommended configuration examples.
  - Clarified file-pattern syntax for TypeScript and TSX story files when configuring oxlint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->