### PR TITLE
Core: Extract ComponentMetaManager to Core

### DIFF
--- a/code/core/build-config.ts
+++ b/code/core/build-config.ts
@@ -89,6 +89,10 @@ const config: BuildEntries = {
         entryPoint: './src/common/index.ts',
       },
       {
+        exportEntries: ['./internal/component-meta'],
+        entryPoint: './src/component-meta/index.ts',
+      },
+      {
         entryPoint: './src/cli/index.ts',
         exportEntries: ['./internal/cli'],
       },

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -93,6 +93,11 @@
       "code": "./src/common/index.ts",
       "default": "./dist/common/index.js"
     },
+    "./internal/component-meta": {
+      "types": "./dist/component-meta/index.d.ts",
+      "code": "./src/component-meta/index.ts",
+      "default": "./dist/component-meta/index.js"
+    },
     "./internal/components": {
       "types": "./dist/components/index.d.ts",
       "code": "./src/components/index.ts",

--- a/code/core/src/component-meta/ComponentMetaManager.ts
+++ b/code/core/src/component-meta/ComponentMetaManager.ts
@@ -1,11 +1,4 @@
 /**
- * ComponentMetaManager — multi-project manager for component metadata extraction.
- *
- * Generic over the project type: renderers supply a {@link ComponentMetaProjectFactory} that turns
- * tsconfigs into projects (React: a TS LanguageService project; Vue: a `vue-component-meta`
- * checker), while everything below — tsconfig discovery and matching, project-reference chains,
- * configured/inferred project lifecycle, file watching, heap-pressure recycling — is shared.
- *
  * Mirrors Volar-style project management patterns:
  *
  * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L18-L390

--- a/code/core/src/component-meta/ComponentMetaManager.ts
+++ b/code/core/src/component-meta/ComponentMetaManager.ts
@@ -1,0 +1,631 @@
+/**
+ * ComponentMetaManager — multi-project manager for component metadata extraction.
+ *
+ * Generic over the project type: renderers supply a {@link ComponentMetaProjectFactory} that turns
+ * tsconfigs into projects (React: a TS LanguageService project; Vue: a `vue-component-meta`
+ * checker), while everything below — tsconfig discovery and matching, project-reference chains,
+ * configured/inferred project lifecycle, file watching, heap-pressure recycling — is shared.
+ *
+ * Mirrors Volar-style project management patterns:
+ *
+ * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L18-L390
+ * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L262-L353
+ * - ConfigProjects / inferredProject / rootTsConfigs / searchedDirs
+ * - FindMatchTSConfig → prepareClosestRootCommandLine / findDirectIncludeTsconfig /
+ *   findIndirectReferenceTsconfig / findTSConfig / getReferencesChains / getCommandLine
+ * - GetOrCreateConfiguredProject / getOrCreateInferredProject
+ * - SortTSConfigs / isFileInDir
+ * - Config change handler (Created / Changed+Deleted dispose pattern)
+ *
+ * Plus our own file watching layer (fs.watch + debounce) since we're a standalone Node.js process,
+ * not running inside an IDE.
+ */
+import { logger, once } from 'storybook/internal/node-logger';
+
+import { type FSWatcher, existsSync, watch } from 'fs';
+import * as path from 'path';
+import { dedent } from 'ts-dedent';
+import type ts from 'typescript';
+import * as v8 from 'v8';
+
+import type { ComponentMetaProjectBase, ComponentMetaProjectFactory, FileChange } from './types.ts';
+
+// Adapted from:
+// https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L18
+const rootTsConfigNames = ['tsconfig.json', 'jsconfig.json'];
+
+/**
+ * Recycle (dispose + lazily rebuild) the shared TS program(s) once heap usage crosses this fraction
+ * of the V8 heap limit.
+ */
+const RECYCLE_HEAP_PRESSURE_RATIO = 0.7;
+
+export class ComponentMetaManager<P extends ComponentMetaProjectBase> {
+  // Adapted from:
+  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L34-L37
+  private configProjects = new Map<string, P>();
+  private inferredProject: P | undefined;
+  private rootTsConfigs = new Set<string>();
+  private searchedDirs = new Set<string>();
+
+  // Our own file watching layer
+  private watching = false;
+  private watchersByDir = new Map<string, FSWatcher>();
+  private pendingEvents = new Map<string, ReturnType<typeof setTimeout>>();
+
+  // Heap-pressure recycle: bytes of `heapUsed` past which the TS program(s) are disposed and rebuilt.
+  private readonly heapRecycleThresholdBytes: number;
+
+  /**
+   * @param recycleHeapPressureRatio Fraction of the V8 heap limit at which the shared program(s) are
+   *   recycled (see {@link RECYCLE_HEAP_PRESSURE_RATIO}). Exposed for tuning and for the memory
+   *   regression gate, which passes `Infinity` to disable recycling and assert the OOM still happens
+   *   without the fix. Defaults to {@link RECYCLE_HEAP_PRESSURE_RATIO}.
+   */
+  constructor(
+    private typescript: typeof ts,
+    private factory: ComponentMetaProjectFactory<P>,
+    recycleHeapPressureRatio: number = RECYCLE_HEAP_PRESSURE_RATIO
+  ) {
+    this.heapRecycleThresholdBytes = Math.floor(
+      v8.getHeapStatistics().heap_size_limit * recycleHeapPressureRatio
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Adapted from:
+  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L70-L79
+  // ---------------------------------------------------------------------------
+
+  getProjectForFile(fileName: string): P {
+    const tsconfig = this.findMatchTSConfig(fileName);
+    if (tsconfig) {
+      // Adapted from:
+      // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L71-L77
+      // Always go through getOrCreateConfiguredProject — never raw map lookup.
+      return (
+        this.getOrCreateConfiguredProject(tsconfig) ?? this.getOrCreateInferredProject(fileName)
+      );
+    }
+    return this.getOrCreateInferredProject(fileName);
+  }
+
+  /**
+   * Reclaim the shared program(s)' resident type-resolution cache when heap usage approaches the V8
+   * limit, preventing the next extraction's spike from OOMing the dev server. Callers with a
+   * batch-extraction surface invoke this after each batch.
+   */
+  protected recycleProjectsIfHeapPressured(): void {
+    if (this.configProjects.size === 0 && !this.inferredProject) {
+      return;
+    }
+    if (process.memoryUsage().heapUsed < this.heapRecycleThresholdBytes) {
+      return;
+    }
+
+    // We crossed the heap-pressure threshold. Recycling reclaims the type cache and usually prevents
+    // the crash, but a single extraction can still exceed the cap — warn once so the user can raise
+    // their memory limit rather than silently paying repeated rebuilds (or eventually crashing).
+    const heapLimitMb = Math.round(v8.getHeapStatistics().heap_size_limit / (1024 * 1024));
+    once.warn(dedent`
+      Storybook's experimental docgen server is nearing the Node.js memory limit (~${heapLimitMb} MB) while extracting component types, and recycled its TypeScript program to avoid an out-of-memory crash. This can briefly slow down the docs and Controls panels.
+
+      If this happens often, raise Node's memory limit before starting Storybook, for example:
+        NODE_OPTIONS="--max-old-space-size=${heapLimitMb * 2}"
+    `);
+
+    for (const project of this.configProjects.values()) {
+      project.dispose();
+    }
+    this.inferredProject?.dispose();
+    this.configProjects.clear();
+    this.inferredProject = undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Adapted from:
+  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L101-L234
+  // ---------------------------------------------------------------------------
+
+  private findMatchTSConfig(filePath: string): string | null {
+    const fileName = filePath.replace(/\\/g, '/');
+
+    // Adapted from:
+    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L104-L118
+    let dir = path.dirname(fileName);
+    while (true) {
+      if (this.searchedDirs.has(dir)) {
+        break;
+      }
+      this.searchedDirs.add(dir);
+      for (const tsConfigName of rootTsConfigNames) {
+        const tsconfigPath = path.join(dir, tsConfigName).replace(/\\/g, '/');
+        if (this.typescript.sys.fileExists(tsconfigPath)) {
+          this.rootTsConfigs.add(tsconfigPath);
+        }
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) {
+        break;
+      }
+      dir = parent;
+    }
+
+    if (this.rootTsConfigs.size === 0) {
+      return null;
+    }
+
+    // Adapted from:
+    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L124-L138
+    // Side-effect only: pre-creates the closest project via getCommandLine() so that
+    // findIndirectReferenceTsconfig below can inspect its project references.
+    const prepareClosestRootCommandLine = () => {
+      let matches: string[] = [];
+      for (const rootTsConfig of this.rootTsConfigs) {
+        if (isFileInDir(fileName, path.dirname(rootTsConfig))) {
+          matches.push(rootTsConfig);
+        }
+      }
+      matches = matches.sort((a, b) => sortTSConfigs(fileName, a, b));
+      if (matches.length) {
+        getCommandLine(matches[0]);
+      }
+    };
+
+    // Adapted from:
+    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L139-L147
+    const findIndirectReferenceTsconfig = () => {
+      return findTSConfig((tsconfig) => {
+        const project = this.configProjects.get(tsconfig);
+        return !!project?.hasSourceFile(fileName);
+      });
+    };
+
+    // Adapted from:
+    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L149-L158
+    const findDirectIncludeTsconfig = () => {
+      return findTSConfig((tsconfig) => {
+        const commandLine = getCommandLine(tsconfig);
+        const fileNames = new Set(commandLine?.fileNames ?? []);
+        return fileNames.has(fileName);
+      });
+    };
+
+    // Adapted from:
+    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L160-L188
+    const findTSConfig = (match: (tsconfig: string) => boolean): string | null => {
+      const checked = new Set<string>();
+
+      for (const rootTsConfig of [...this.rootTsConfigs].sort((a, b) =>
+        sortTSConfigs(fileName, a, b)
+      )) {
+        const project = this.configProjects.get(rootTsConfig);
+        if (project) {
+          let chains = getReferencesChains(project.getCommandLine(), rootTsConfig, []);
+
+          // This is to be consistent with tsserver behavior
+          chains = chains.reverse();
+
+          for (const chain of chains) {
+            for (let i = chain.length - 1; i >= 0; i--) {
+              const tsconfig = chain[i];
+
+              if (checked.has(tsconfig)) {
+                continue;
+              }
+              checked.add(tsconfig);
+
+              if (match(tsconfig)) {
+                return tsconfig;
+              }
+            }
+          }
+        }
+      }
+
+      return null;
+    };
+
+    // Adapted from:
+    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L189-L229
+    const getReferencesChains = (
+      commandLine: ts.ParsedCommandLine,
+      tsConfig: string,
+      before: string[]
+    ): string[][] => {
+      if (commandLine.projectReferences?.length) {
+        const newChains: string[][] = [];
+
+        for (const projectReference of commandLine.projectReferences) {
+          let tsConfigPath = projectReference.path.replace(/\\/g, '/');
+
+          // fix https://github.com/johnsoncodehk/volar/issues/712
+          if (this.typescript.sys.directoryExists(tsConfigPath)) {
+            const newTsConfigPath = path.join(tsConfigPath, 'tsconfig.json');
+            const newJsConfigPath = path.join(tsConfigPath, 'jsconfig.json');
+            if (this.typescript.sys.fileExists(newTsConfigPath)) {
+              tsConfigPath = newTsConfigPath;
+            } else if (this.typescript.sys.fileExists(newJsConfigPath)) {
+              tsConfigPath = newJsConfigPath;
+            }
+          }
+
+          const beforeIndex = before.indexOf(tsConfigPath); // cycle
+          if (beforeIndex >= 0) {
+            newChains.push(before.slice(0, Math.max(beforeIndex, 1)));
+          } else {
+            const referenceCommandLine = getCommandLine(tsConfigPath);
+            if (referenceCommandLine) {
+              for (const chain of getReferencesChains(referenceCommandLine, tsConfigPath, [
+                ...before,
+                tsConfig,
+              ])) {
+                newChains.push(chain);
+              }
+            }
+          }
+        }
+
+        return newChains;
+      } else {
+        return [[...before, tsConfig]];
+      }
+    };
+
+    // Adapted from:
+    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L230-L233
+    const getCommandLine = (tsConfig: string) => {
+      const project = this.getOrCreateConfiguredProject(tsConfig);
+      return project?.getCommandLine();
+    };
+
+    prepareClosestRootCommandLine();
+
+    return findDirectIncludeTsconfig() ?? findIndirectReferenceTsconfig();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Adapted from:
+  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L236-L256
+  // ---------------------------------------------------------------------------
+
+  private getOrCreateConfiguredProject(tsconfig: string): P | null {
+    tsconfig = tsconfig.replace(/\\/g, '/');
+    let project = this.configProjects.get(tsconfig);
+    if (!project) {
+      try {
+        const getCommandLine = () => this.factory.parseCommandLine(tsconfig);
+        project = this.factory.createConfiguredProject(getCommandLine(), tsconfig, getCommandLine);
+        this.configProjects.set(tsconfig, project);
+
+        // Auto-watch the project's directories if watching is active.
+        // This covers projects discovered after initial startWatching().
+        if (this.watching) {
+          this.watchDirectory(path.dirname(tsconfig));
+          this.watchProgramSourceDirs(project);
+        }
+      } catch (err) {
+        logger.debug(`[component-meta] Failed to parse tsconfig ${tsconfig}: ${err}`);
+        return null;
+      }
+    }
+    return project;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Adapted from:
+  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L258-L284
+  // ---------------------------------------------------------------------------
+
+  private getOrCreateInferredProject(fileName: string): P {
+    if (!this.inferredProject) {
+      this.inferredProject = this.factory.createInferredProject();
+    }
+
+    this.inferredProject.ensureFiles([fileName]);
+
+    return this.inferredProject;
+  }
+
+  // ---------------------------------------------------------------------------
+  // File events
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Broadcast file changes to all projects. Each project selectively bumps projectVersion.
+   *
+   * Adapted from:
+   * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L409-L432
+   */
+  onFilesChanged(changes: FileChange[]) {
+    for (const project of this.configProjects.values()) {
+      project.onFilesChanged(changes);
+    }
+    this.inferredProject?.onFilesChanged(changes);
+  }
+
+  /**
+   * Adapted from:
+   * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L43-L68
+   */
+  onConfigChanged(configPath: string, type: 'created' | 'changed' | 'deleted') {
+    configPath = configPath.replace(/\\/g, '/');
+    if (type === 'created') {
+      this.rootTsConfigs.add(configPath);
+    } else if ((type === 'changed' || type === 'deleted') && this.configProjects.has(configPath)) {
+      if (type === 'deleted') {
+        this.rootTsConfigs.delete(configPath);
+      }
+      const project = this.configProjects.get(configPath);
+      this.configProjects.delete(configPath);
+      project?.dispose();
+    }
+    // Clear searchedDirs so findMatchTSConfig re-scans directories.
+    // Without this, new tsconfigs in previously-scanned dirs would be invisible.
+    this.searchedDirs.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Our own file watching layer (no Volar equivalent — we're standalone)
+  // ---------------------------------------------------------------------------
+
+  startWatching(): void {
+    if (this.watching) {
+      return;
+    }
+    this.watching = true;
+
+    // Retroactively create watchers for projects that were created before
+    // watching was enabled (the first manifest request creates projects
+    // eagerly, but startWatching() is only called once the manager is ready).
+    for (const tsconfig of this.configProjects.keys()) {
+      this.watchDirectory(path.dirname(tsconfig));
+    }
+
+    // Also watch directories containing source files resolved by the TS program.
+    // This covers files reached via path aliases (e.g. monorepos where stories
+    // live in apps/storybook/ but components live in packages/ui/).
+    this.watchProgramSourceDirs();
+  }
+
+  /**
+   * Watch directories that contain source files from all TS programs. This covers monorepo setups
+   * where stories import components via path aliases (e.g. apps/storybook/ imports from
+   * packages/ui/ via tsconfig paths).
+   */
+  private watchProgramSourceDirs(singleProject?: P): void {
+    const dirs = new Set<string>();
+
+    if (singleProject) {
+      for (const filePath of singleProject.getSourceFilePaths()) {
+        dirs.add(path.dirname(filePath));
+      }
+    } else {
+      for (const project of this.configProjects.values()) {
+        for (const filePath of project.getSourceFilePaths()) {
+          dirs.add(path.dirname(filePath));
+        }
+      }
+      if (this.inferredProject) {
+        for (const filePath of this.inferredProject.getSourceFilePaths()) {
+          dirs.add(path.dirname(filePath));
+        }
+      }
+    }
+
+    // Walk up from each source file dir to find package roots (package.json or tsconfig.json).
+    // This avoids creating hundreds of individual watchers for each subdirectory.
+    const roots = new Set<string>();
+    for (const dir of dirs) {
+      let candidate = dir;
+      while (candidate !== path.dirname(candidate)) {
+        // If already covered by an existing watcher, skip
+        const normalized = candidate.replace(/\\/g, '/');
+        let alreadyWatched = false;
+        for (const watched of this.watchersByDir.keys()) {
+          if (normalized === watched || normalized.startsWith(watched + '/')) {
+            alreadyWatched = true;
+            break;
+          }
+        }
+        if (alreadyWatched) {
+          break;
+        }
+
+        // Use package root as watch boundary
+        if (
+          this.typescript.sys.fileExists(path.join(candidate, 'package.json')) ||
+          this.typescript.sys.fileExists(path.join(candidate, 'tsconfig.json'))
+        ) {
+          roots.add(candidate);
+          break;
+        }
+        candidate = path.dirname(candidate);
+      }
+    }
+
+    for (const root of roots) {
+      this.watchDirectory(root);
+    }
+  }
+
+  private watchDirectory(dir: string): void {
+    if (!this.watching) {
+      return;
+    }
+
+    const normalized = dir.replace(/\\/g, '/');
+
+    for (const watched of this.watchersByDir.keys()) {
+      // Already covered by an existing broader watcher
+      if (normalized === watched || normalized.startsWith(watched + '/')) {
+        return;
+      }
+    }
+
+    // Close and remove narrower watchers that this broader directory subsumes.
+    // The new recursive watcher covers them, so keeping both wastes file descriptors
+    // and produces duplicate events.
+    for (const [watched, watcher] of this.watchersByDir) {
+      if (watched.startsWith(normalized + '/')) {
+        watcher.close();
+        this.watchersByDir.delete(watched);
+      }
+    }
+
+    try {
+      const watcher = watch(dir, { recursive: true }, (eventType, filename) => {
+        if (!filename) {
+          return;
+        }
+        const filePath = path.resolve(dir, filename).replace(/\\/g, '/');
+
+        if (filePath.includes('/node_modules/') || filePath.includes('/.git/')) {
+          return;
+        }
+
+        const existing = this.pendingEvents.get(filePath);
+        if (existing) {
+          clearTimeout(existing);
+        }
+
+        this.pendingEvents.set(
+          filePath,
+          setTimeout(() => {
+            this.pendingEvents.delete(filePath);
+
+            if (eventType === 'rename') {
+              if (existsSync(filePath)) {
+                this.handleFileEvent(filePath, 'created');
+              } else {
+                this.handleFileEvent(filePath, 'deleted');
+              }
+            } else {
+              this.handleFileEvent(filePath, 'changed');
+            }
+          }, 50)
+        );
+      });
+      watcher.unref();
+      this.watchersByDir.set(normalized, watcher);
+    } catch (err) {
+      logger.debug(`[component-meta] Failed to watch directory ${normalized}: ${err}`);
+    }
+  }
+
+  stopWatching(): void {
+    for (const timeout of this.pendingEvents.values()) {
+      clearTimeout(timeout);
+    }
+    this.pendingEvents.clear();
+    for (const watcher of this.watchersByDir.values()) {
+      watcher.close();
+    }
+    this.watchersByDir.clear();
+    this.watching = false;
+  }
+
+  /**
+   * Map raw fs.watch events to LSP-style FileChangeType before broadcasting.
+   *
+   * Fs.watch reports atomic saves (sed -i, editors) as `rename` → we classify as `created` (file
+   * exists after rename). But an IDE/LSP would report an atomic save of an _existing_ file as
+   * `Changed`, not `Created`.
+   *
+   * We reclassify here so that onFilesChanged stays 1:1 with Volar Kit.
+   */
+  private handleFileEvent(filePath: string, type: 'created' | 'changed' | 'deleted') {
+    // Reclassify: atomic save of tracked file → 'changed' (LSP Changed)
+    if (type === 'created') {
+      for (const project of this.configProjects.values()) {
+        if (project.hasSourceFile(filePath)) {
+          type = 'changed';
+          break;
+        }
+      }
+      if (type === 'created' && this.inferredProject?.hasSourceFile(filePath)) {
+        type = 'changed';
+      }
+    }
+
+    const basename = path.basename(filePath);
+    if (rootTsConfigNames.includes(basename)) {
+      this.onConfigChanged(filePath, type);
+      return;
+    }
+
+    this.onFilesChanged([{ filePath, type }]);
+  }
+
+  dispose() {
+    this.stopWatching();
+    for (const project of this.configProjects.values()) {
+      project.dispose();
+    }
+    this.inferredProject?.dispose();
+    this.configProjects.clear();
+    this.inferredProject = undefined;
+    this.factory.dispose?.();
+    this.searchedDirs.clear();
+    this.rootTsConfigs.clear();
+  }
+}
+
+/**
+ * Parse a tsconfig with TypeScript's own machinery, the way `tsc` would. The default
+ * `parseCommandLine` for factories whose components are plain TS/TSX; renderers with their own
+ * file types (Vue SFCs) must parse with their own machinery instead so the manager's
+ * file-to-tsconfig matching sees those files in `fileNames`.
+ *
+ * Adapted from:
+ * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L262-L353
+ */
+export function parseTsconfigCommandLine(
+  typescript: typeof ts,
+  tsconfig: string
+): ts.ParsedCommandLine {
+  const config = typescript.readJsonConfigFile(tsconfig, typescript.sys.readFile);
+  const content = typescript.parseJsonSourceFileConfigFileContent(
+    config,
+    typescript.sys,
+    path.dirname(tsconfig),
+    {},
+    tsconfig
+  );
+  // fix https://github.com/johnsoncodehk/volar/issues/1786
+  // https://github.com/microsoft/TypeScript/issues/30457
+  content.options.outDir = undefined;
+  content.fileNames = content.fileNames.map((fileName) => fileName.replace(/\\/g, '/'));
+  return content;
+}
+
+// Adapted from:
+// https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L365-L385
+export function sortTSConfigs(file: string, a: string, b: string) {
+  const inA = isFileInDir(file, path.dirname(a));
+  const inB = isFileInDir(file, path.dirname(b));
+
+  if (inA !== inB) {
+    const aWeight = inA ? 1 : 0;
+    const bWeight = inB ? 1 : 0;
+    return bWeight - aWeight;
+  }
+
+  const aLength = a.split('/').length;
+  const bLength = b.split('/').length;
+
+  if (aLength === bLength) {
+    const aWeight = path.basename(a) === 'tsconfig.json' ? 1 : 0;
+    const bWeight = path.basename(b) === 'tsconfig.json' ? 1 : 0;
+    return bWeight - aWeight;
+  }
+
+  return bLength - aLength;
+}
+
+// Adapted from:
+// https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L387-L390
+export function isFileInDir(fileName: string, dir: string) {
+  const relative = path.relative(dir, fileName);
+  return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}

--- a/code/core/src/component-meta/ComponentMetaManager.ts
+++ b/code/core/src/component-meta/ComponentMetaManager.ts
@@ -25,10 +25,15 @@ import { logger, once } from 'storybook/internal/node-logger';
 import { type FSWatcher, existsSync, watch } from 'fs';
 import * as path from 'path';
 import { dedent } from 'ts-dedent';
-import type ts from 'typescript';
 import * as v8 from 'v8';
 
-import type { ComponentMetaProjectBase, ComponentMetaProjectFactory, FileChange } from './types.ts';
+import type {
+  ComponentMetaFileSystem,
+  ComponentMetaProjectBase,
+  ComponentMetaProjectFactory,
+  FileChange,
+  ProjectCommandLine,
+} from './types.ts';
 
 // Adapted from:
 // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L18
@@ -40,7 +45,10 @@ const rootTsConfigNames = ['tsconfig.json', 'jsconfig.json'];
  */
 const RECYCLE_HEAP_PRESSURE_RATIO = 0.7;
 
-export class ComponentMetaManager<P extends ComponentMetaProjectBase> {
+export class ComponentMetaManager<
+  P extends ComponentMetaProjectBase,
+  CL extends ProjectCommandLine = ProjectCommandLine,
+> {
   // Adapted from:
   // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L34-L37
   private configProjects = new Map<string, P>();
@@ -63,8 +71,11 @@ export class ComponentMetaManager<P extends ComponentMetaProjectBase> {
    *   without the fix. Defaults to {@link RECYCLE_HEAP_PRESSURE_RATIO}.
    */
   constructor(
-    private typescript: typeof ts,
-    private factory: ComponentMetaProjectFactory<P>,
+    // Structural host rather than `typeof ts`: naming the `typescript` package here would couple
+    // every consumer to core's copy of it (see the rationale on ComponentMetaFileSystem). Callers
+    // pass their own `typescript` module, which satisfies the shape via `ts.sys`.
+    private typescript: ComponentMetaFileSystem,
+    private factory: ComponentMetaProjectFactory<P, CL>,
     recycleHeapPressureRatio: number = RECYCLE_HEAP_PRESSURE_RATIO
   ) {
     this.heapRecycleThresholdBytes = Math.floor(
@@ -229,7 +240,7 @@ export class ComponentMetaManager<P extends ComponentMetaProjectBase> {
     // Adapted from:
     // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L189-L229
     const getReferencesChains = (
-      commandLine: ts.ParsedCommandLine,
+      commandLine: ProjectCommandLine,
       tsConfig: string,
       before: string[]
     ): string[][] => {
@@ -569,34 +580,6 @@ export class ComponentMetaManager<P extends ComponentMetaProjectBase> {
     this.searchedDirs.clear();
     this.rootTsConfigs.clear();
   }
-}
-
-/**
- * Parse a tsconfig with TypeScript's own machinery, the way `tsc` would. The default
- * `parseCommandLine` for factories whose components are plain TS/TSX; renderers with their own
- * file types (Vue SFCs) must parse with their own machinery instead so the manager's
- * file-to-tsconfig matching sees those files in `fileNames`.
- *
- * Adapted from:
- * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L262-L353
- */
-export function parseTsconfigCommandLine(
-  typescript: typeof ts,
-  tsconfig: string
-): ts.ParsedCommandLine {
-  const config = typescript.readJsonConfigFile(tsconfig, typescript.sys.readFile);
-  const content = typescript.parseJsonSourceFileConfigFileContent(
-    config,
-    typescript.sys,
-    path.dirname(tsconfig),
-    {},
-    tsconfig
-  );
-  // fix https://github.com/johnsoncodehk/volar/issues/1786
-  // https://github.com/microsoft/TypeScript/issues/30457
-  content.options.outDir = undefined;
-  content.fileNames = content.fileNames.map((fileName) => fileName.replace(/\\/g, '/'));
-  return content;
 }
 
 // Adapted from:

--- a/code/core/src/component-meta/index.ts
+++ b/code/core/src/component-meta/index.ts
@@ -1,11 +1,4 @@
 export { ComponentMetaManager, isFileInDir, sortTSConfigs } from './ComponentMetaManager.ts';
 export { parseTsconfigCommandLine } from './parse-tsconfig.ts';
 export type { FileExtensionInfo, TsconfigParserModule } from './parse-tsconfig.ts';
-export type {
-  ComponentMetaFileSystem,
-  ComponentMetaProjectBase,
-  ComponentMetaProjectFactory,
-  FileChange,
-  FileChangeType,
-  ProjectCommandLine,
-} from './types.ts';
+export type { ComponentMetaProjectBase, ComponentMetaProjectFactory, FileChange } from './types.ts';

--- a/code/core/src/component-meta/index.ts
+++ b/code/core/src/component-meta/index.ts
@@ -1,0 +1,12 @@
+export {
+  ComponentMetaManager,
+  isFileInDir,
+  parseTsconfigCommandLine,
+  sortTSConfigs,
+} from './ComponentMetaManager.ts';
+export type {
+  ComponentMetaProjectBase,
+  ComponentMetaProjectFactory,
+  FileChange,
+  FileChangeType,
+} from './types.ts';

--- a/code/core/src/component-meta/index.ts
+++ b/code/core/src/component-meta/index.ts
@@ -1,4 +1,6 @@
 export { ComponentMetaManager, isFileInDir, sortTSConfigs } from './ComponentMetaManager.ts';
+export { parseTsconfigCommandLine } from './parse-tsconfig.ts';
+export type { FileExtensionInfo, TsconfigParserModule } from './parse-tsconfig.ts';
 export type {
   ComponentMetaFileSystem,
   ComponentMetaProjectBase,

--- a/code/core/src/component-meta/index.ts
+++ b/code/core/src/component-meta/index.ts
@@ -1,12 +1,9 @@
-export {
-  ComponentMetaManager,
-  isFileInDir,
-  parseTsconfigCommandLine,
-  sortTSConfigs,
-} from './ComponentMetaManager.ts';
+export { ComponentMetaManager, isFileInDir, sortTSConfigs } from './ComponentMetaManager.ts';
 export type {
+  ComponentMetaFileSystem,
   ComponentMetaProjectBase,
   ComponentMetaProjectFactory,
   FileChange,
   FileChangeType,
+  ProjectCommandLine,
 } from './types.ts';

--- a/code/core/src/component-meta/parse-tsconfig.ts
+++ b/code/core/src/component-meta/parse-tsconfig.ts
@@ -1,0 +1,69 @@
+import { dirname } from 'node:path';
+
+import type { ProjectCommandLine } from './types.ts';
+
+/**
+ * The tsconfig-parsing surface of the `typescript` module this helper drives.
+ */
+export interface TsconfigParserModule {
+  sys: {
+    readFile(path: string): string | undefined;
+  };
+  readJsonConfigFile(fileName: string, readFile: (path: string) => string | undefined): unknown;
+  /**
+   * Incidental parameters are `any`, not `unknown`: the consumer's function is a plain declaration
+   * (no method bivariance), so under `strictFunctionTypes` these positions are checked
+   * contravariantly against the consumer's own `TsConfigSourceFile`/`CompilerOptions`/… — the exact
+   * cross-instance comparison this contract exists to avoid. `any` is assignable in both
+   * directions and keeps the check shallow.
+   */
+  parseJsonSourceFileConfigFileContent(
+    // oxlint-disable no-explicit-any
+    json: any,
+    host: any,
+    basePath: string,
+    existingOptions: any,
+    configFileName: string,
+    resolutionStack: any,
+    extraFileExtensions: any
+    // oxlint-enable no-explicit-any
+  ): ProjectCommandLine & { options: { outDir?: unknown } };
+}
+
+/** Structural `ts.FileExtensionInfo`; `scriptKind` is the numeric `ts.ScriptKind` enum value. */
+export interface FileExtensionInfo {
+  extension: string;
+  isMixedContent: boolean;
+  scriptKind?: number;
+}
+
+/**
+ * Parse a tsconfig with TypeScript's own machinery, the way `tsc` would, with the two fixes every
+ * component-meta project needs: `outDir` neutralized (volar#1786 / TS#30457) and separators
+ * normalized for the manager's path comparisons.
+ *
+ * Adapted from:
+ * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L262-L353
+ */
+export function parseTsconfigCommandLine<CL extends ProjectCommandLine = ProjectCommandLine>(
+  typescript: TsconfigParserModule,
+  tsconfig: string,
+  extraFileExtensions?: readonly FileExtensionInfo[]
+): CL {
+  const config = typescript.readJsonConfigFile(tsconfig, typescript.sys.readFile);
+  const content = typescript.parseJsonSourceFileConfigFileContent(
+    config,
+    typescript.sys,
+    dirname(tsconfig),
+    {},
+    tsconfig,
+    undefined,
+    extraFileExtensions
+  );
+  // fix https://github.com/johnsoncodehk/volar/issues/1786
+  // https://github.com/microsoft/TypeScript/issues/30457
+  content.options.outDir = undefined;
+  content.fileNames = content.fileNames.map((fileName) => fileName.replace(/\\/g, '/'));
+  // The runtime value is whatever the caller's own module produced; core only typed the subset.
+  return content as unknown as CL;
+}

--- a/code/core/src/component-meta/types.ts
+++ b/code/core/src/component-meta/types.ts
@@ -1,11 +1,37 @@
-import type ts from 'typescript';
-
 /** LSP-style file change type broadcast to projects (Volar Kit checker vocabulary). */
 export type FileChangeType = 'changed' | 'created' | 'deleted';
 
 export interface FileChange {
   filePath: string;
   type: FileChangeType;
+}
+
+/**
+ * Structural subset of `ts.ParsedCommandLine` the manager reads: `fileNames` for direct-include
+ * matching and `projectReferences` for reference-chain walking.
+ *
+ * Deliberately not `ts.ParsedCommandLine`: this module's contract must not name types from the
+ * `typescript` package. Renderers resolve their own `typescript` copy (frameworks even pin their
+ * own versions), and a cross-instance `ts.ParsedCommandLine` comparison walks the entire
+ * compiler-API graph (`errors` → `Diagnostic` → `SourceFile` → …), which both couples consumers to
+ * core's instance (TS2345) and blows the checker's comparison stack (TS2321). A real
+ * `ts.ParsedCommandLine` remains assignable to this shape.
+ */
+export interface ProjectCommandLine {
+  fileNames: string[];
+  projectReferences?: readonly { path: string }[];
+}
+
+/**
+ * The two filesystem probes the manager needs during tsconfig discovery and watching. `typeof ts`
+ * satisfies this (via `ts.sys`), so callers pass their own `typescript` module — without this
+ * module ever naming the `typescript` package (see {@link ProjectCommandLine} for why).
+ */
+export interface ComponentMetaFileSystem {
+  sys: {
+    fileExists(path: string): boolean;
+    directoryExists(path: string): boolean;
+  };
 }
 
 /**
@@ -17,7 +43,7 @@ export interface FileChange {
  * — a TypeScript language service, a Volar checker — is the renderer's business.
  */
 export interface ComponentMetaProjectBase {
-  getCommandLine(): ts.ParsedCommandLine;
+  getCommandLine(): ProjectCommandLine;
   hasSourceFile(fileName: string): boolean;
   /** Add files to the project's root set (used for inferred projects and on-demand inclusion). */
   ensureFiles(fileNames: string[]): void;
@@ -33,14 +59,17 @@ export interface ComponentMetaProjectBase {
  * `parseCommandLine` matters beyond project creation: the manager matches files to tsconfigs by the
  * parsed `fileNames`, so a renderer whose components are not plain TS must parse with its own
  * machinery (Vue's `createParsedCommandLine` includes `.vue` files; plain TS parsing would not).
+ *
+ * `CL` lets the factory keep full command-line fidelity internally (e.g. React's real
+ * `ts.ParsedCommandLine`): whatever `parseCommandLine` returns is what `createConfiguredProject`
+ * receives, while the manager itself only reads the {@link ProjectCommandLine} subset.
  */
-export interface ComponentMetaProjectFactory<P extends ComponentMetaProjectBase> {
-  parseCommandLine(tsconfig: string): ts.ParsedCommandLine;
-  createConfiguredProject(
-    commandLine: ts.ParsedCommandLine,
-    tsconfig: string,
-    getCommandLine: () => ts.ParsedCommandLine
-  ): P;
+export interface ComponentMetaProjectFactory<
+  P extends ComponentMetaProjectBase,
+  CL extends ProjectCommandLine = ProjectCommandLine,
+> {
+  parseCommandLine(tsconfig: string): CL;
+  createConfiguredProject(commandLine: CL, tsconfig: string, getCommandLine: () => CL): P;
   /** Project for files no discovered tsconfig covers; owns its own default compiler options. */
   createInferredProject(): P;
   /** Called from the manager's `dispose()` so factory-owned caches die with the manager. */

--- a/code/core/src/component-meta/types.ts
+++ b/code/core/src/component-meta/types.ts
@@ -1,0 +1,48 @@
+import type ts from 'typescript';
+
+/** LSP-style file change type broadcast to projects (Volar Kit checker vocabulary). */
+export type FileChangeType = 'changed' | 'created' | 'deleted';
+
+export interface FileChange {
+  filePath: string;
+  type: FileChangeType;
+}
+
+/**
+ * Contract a per-tsconfig project must satisfy for {@link ../ComponentMetaManager} to manage it.
+ *
+ * The manager only needs enough surface to match files to tsconfigs (parsed command lines,
+ * `hasSourceFile`), keep projects fresh (`onFilesChanged`, `ensureFiles`), watch their source
+ * directories (`getSourceFilePaths`), and reclaim memory (`dispose`). What a "project" actually is
+ * — a TypeScript language service, a Volar checker — is the renderer's business.
+ */
+export interface ComponentMetaProjectBase {
+  getCommandLine(): ts.ParsedCommandLine;
+  hasSourceFile(fileName: string): boolean;
+  /** Add files to the project's root set (used for inferred projects and on-demand inclusion). */
+  ensureFiles(fileNames: string[]): void;
+  onFilesChanged(changes: FileChange[]): void;
+  /** Non-node_modules source file paths of the current program, for directory watching. */
+  getSourceFilePaths(): string[];
+  dispose(): void;
+}
+
+/**
+ * How a renderer turns tsconfigs into projects.
+ *
+ * `parseCommandLine` matters beyond project creation: the manager matches files to tsconfigs by the
+ * parsed `fileNames`, so a renderer whose components are not plain TS must parse with its own
+ * machinery (Vue's `createParsedCommandLine` includes `.vue` files; plain TS parsing would not).
+ */
+export interface ComponentMetaProjectFactory<P extends ComponentMetaProjectBase> {
+  parseCommandLine(tsconfig: string): ts.ParsedCommandLine;
+  createConfiguredProject(
+    commandLine: ts.ParsedCommandLine,
+    tsconfig: string,
+    getCommandLine: () => ts.ParsedCommandLine
+  ): P;
+  /** Project for files no discovered tsconfig covers; owns its own default compiler options. */
+  createInferredProject(): P;
+  /** Called from the manager's `dispose()` so factory-owned caches die with the manager. */
+  dispose?(): void;
+}

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
@@ -11,10 +11,10 @@
 import {
   ComponentMetaManager as BaseComponentMetaManager,
   type ComponentMetaProjectFactory,
+  parseTsconfigCommandLine,
 } from 'storybook/internal/component-meta';
 import { logger } from 'storybook/internal/node-logger';
 
-import * as path from 'path';
 import type ts from 'typescript';
 
 import type { StoryRef } from '../getComponentImports.ts';
@@ -34,31 +34,6 @@ const DEFAULT_INFERRED_OPTIONS: ts.CompilerOptions = {
 type FsFileSnapshots = Map<string, [number | undefined, ts.IScriptSnapshot | undefined]>;
 
 /**
- * Parse a tsconfig with TypeScript's own machinery, the way `tsc` would. Lives here rather than in
- * core because core's component-meta module deliberately names no types from the `typescript`
- * package — its consumers each resolve their own copy, and `typeof ts` across two copies is not
- * assignable (nor cheaply comparable).
- *
- * Adapted from:
- * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L262-L353
- */
-function parseTsconfigCommandLine(typescript: typeof ts, tsconfig: string): ts.ParsedCommandLine {
-  const config = typescript.readJsonConfigFile(tsconfig, typescript.sys.readFile);
-  const content = typescript.parseJsonSourceFileConfigFileContent(
-    config,
-    typescript.sys,
-    path.dirname(tsconfig),
-    {},
-    tsconfig
-  );
-  // fix https://github.com/johnsoncodehk/volar/issues/1786
-  // https://github.com/microsoft/TypeScript/issues/30457
-  content.options.outDir = undefined;
-  content.fileNames = content.fileNames.map((fileName) => fileName.replace(/\\/g, '/'));
-  return content;
-}
-
-/**
  * Builds the React project factory plus the snapshot cache it closes over. The cache is shared
  * across every project the factory creates (Volar Kit checker pattern) and returned separately so
  * the manager can expose it to tests; it is cleared through the factory's `dispose`.
@@ -74,7 +49,8 @@ function createReactProjectFactory(typescript: typeof ts): {
   return {
     fsFileSnapshots,
     factory: {
-      parseCommandLine: (tsconfig) => parseTsconfigCommandLine(typescript, tsconfig),
+      parseCommandLine: (tsconfig) =>
+        parseTsconfigCommandLine<ts.ParsedCommandLine>(typescript, tsconfig),
       createConfiguredProject: (commandLine, tsconfig, getCommandLine) =>
         new ComponentMetaProject(
           typescript,

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
@@ -1,35 +1,28 @@
 /**
- * ComponentMetaManager — multi-project manager for component metadata extraction.
+ * React specialization of core's generic {@link BaseComponentMetaManager}.
  *
- * Mirrors Volar-style project management patterns:
- *
- * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L18-L390
- * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L262-L353
- * - ConfigProjects / inferredProject / rootTsConfigs / searchedDirs
- * - FindMatchTSConfig → prepareClosestRootCommandLine / findDirectIncludeTsconfig /
- *   findIndirectReferenceTsconfig / findTSConfig / getReferencesChains / getCommandLine
- * - GetOrCreateConfiguredProject / getOrCreateInferredProject
- * - SortTSConfigs / isFileInDir
- * - Config change handler (Created / Changed+Deleted dispose pattern)
- *
- * Plus our own file watching layer (fs.watch + debounce) since we're a standalone Node.js process,
- * not running inside an IDE.
+ * The tsconfig discovery/matching, project-reference chains, file watching, and heap-pressure
+ * recycling all live in `storybook/internal/component-meta`; this file contributes what is
+ * React-specific: a {@link ComponentMetaProjectFactory} that builds {@link ComponentMetaProject}s
+ * (one TS LanguageService per tsconfig, sharing one mtime-cached snapshot map), React-flavored
+ * inferred-project compiler options, and the {@link ComponentMetaManager.batchExtract} surface the
+ * manifest generator and docgen provider drive.
  */
-import { logger, once } from 'storybook/internal/node-logger';
+import {
+  ComponentMetaManager as BaseComponentMetaManager,
+  type ComponentMetaProjectFactory,
+  parseTsconfigCommandLine,
+} from 'storybook/internal/component-meta';
+import { logger } from 'storybook/internal/node-logger';
 
-import { type FSWatcher, existsSync, watch } from 'fs';
-import * as path from 'path';
-import { dedent } from 'ts-dedent';
 import type ts from 'typescript';
-import * as v8 from 'v8';
 
 import type { StoryRef } from '../getComponentImports.ts';
 import { groupByToMap } from '../utils.ts';
 import { ComponentMetaProject } from './ComponentMetaProject.ts';
 
-// Adapted from:
-// https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L18
-const rootTsConfigNames = ['tsconfig.json', 'jsconfig.json'];
+// The manager's tsconfig-matching helpers are re-exported for existing consumers and tests.
+export { isFileInDir, sortTSConfigs } from 'storybook/internal/component-meta';
 
 const DEFAULT_INFERRED_OPTIONS: ts.CompilerOptions = {
   strict: true,
@@ -38,66 +31,68 @@ const DEFAULT_INFERRED_OPTIONS: ts.CompilerOptions = {
   skipLibCheck: true,
 };
 
+type FsFileSnapshots = Map<string, [number | undefined, ts.IScriptSnapshot | undefined]>;
+
 /**
- * Recycle (dispose + lazily rebuild) the shared TS program(s) once heap usage crosses this fraction
- * of the V8 heap limit.
+ * Builds the React project factory plus the snapshot cache it closes over. The cache is shared
+ * across every project the factory creates (Volar Kit checker pattern) and returned separately so
+ * the manager can expose it to tests; it is cleared through the factory's `dispose`.
  */
-const RECYCLE_HEAP_PRESSURE_RATIO = 0.7;
-
-export class ComponentMetaManager {
-  // Adapted from:
-  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L34-L37
-  private configProjects = new Map<string, ComponentMetaProject>();
-  private inferredProject: ComponentMetaProject | undefined;
-  private rootTsConfigs = new Set<string>();
-  private searchedDirs = new Set<string>();
-
-  // Our own file watching layer
-  private watching = false;
-  private watchersByDir = new Map<string, FSWatcher>();
-  private pendingEvents = new Map<string, ReturnType<typeof setTimeout>>();
-
+function createReactProjectFactory(typescript: typeof ts): {
+  factory: ComponentMetaProjectFactory<ComponentMetaProject>;
+  fsFileSnapshots: FsFileSnapshots;
+} {
   // Adapted from:
   // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L83
-  readonly fsFileSnapshots = new Map<
-    string,
-    [number | undefined, ts.IScriptSnapshot | undefined]
-  >();
+  const fsFileSnapshots: FsFileSnapshots = new Map();
 
-  // Heap-pressure recycle: bytes of `heapUsed` past which the TS program(s) are disposed and rebuilt.
-  private readonly heapRecycleThresholdBytes: number;
+  return {
+    fsFileSnapshots,
+    factory: {
+      parseCommandLine: (tsconfig) => parseTsconfigCommandLine(typescript, tsconfig),
+      createConfiguredProject: (commandLine, tsconfig, getCommandLine) =>
+        new ComponentMetaProject(
+          typescript,
+          commandLine,
+          tsconfig,
+          fsFileSnapshots,
+          getCommandLine
+        ),
+      createInferredProject: () =>
+        new ComponentMetaProject(
+          typescript,
+          {
+            options: {
+              ...DEFAULT_INFERRED_OPTIONS,
+              target: typescript.ScriptTarget.Latest,
+              module: typescript.ModuleKind.ESNext,
+              moduleResolution: typescript.ModuleResolutionKind.Bundler,
+              jsx: typescript.JsxEmit.ReactJSX,
+            },
+            fileNames: [],
+            errors: [],
+          },
+          undefined,
+          fsFileSnapshots
+        ),
+      dispose: () => fsFileSnapshots.clear(),
+    },
+  };
+}
+
+export class ComponentMetaManager extends BaseComponentMetaManager<ComponentMetaProject> {
+  /** Shared mtime-cached file snapshots, exposed for tests; owned by the factory. */
+  readonly fsFileSnapshots: FsFileSnapshots;
 
   /**
-   * @param recycleHeapPressureRatio Fraction of the V8 heap limit at which the shared program(s) are
-   *   recycled (see {@link RECYCLE_HEAP_PRESSURE_RATIO}). Exposed for tuning and for the memory
-   *   regression gate, which passes `Infinity` to disable recycling and assert the OOM still happens
-   *   without the fix. Defaults to {@link RECYCLE_HEAP_PRESSURE_RATIO}.
+   * @param recycleHeapPressureRatio Fraction of the V8 heap limit at which the shared program(s)
+   *   are recycled. Exposed for tuning and for the memory regression gate, which passes `Infinity`
+   *   to disable recycling and assert the OOM still happens without the fix.
    */
-  constructor(
-    private typescript: typeof ts,
-    recycleHeapPressureRatio: number = RECYCLE_HEAP_PRESSURE_RATIO
-  ) {
-    this.heapRecycleThresholdBytes = Math.floor(
-      v8.getHeapStatistics().heap_size_limit * recycleHeapPressureRatio
-    );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Adapted from:
-  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L70-L79
-  // ---------------------------------------------------------------------------
-
-  getProjectForFile(fileName: string): ComponentMetaProject {
-    const tsconfig = this.findMatchTSConfig(fileName);
-    if (tsconfig) {
-      // Adapted from:
-      // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L71-L77
-      // Always go through getOrCreateConfiguredProject — never raw map lookup.
-      return (
-        this.getOrCreateConfiguredProject(tsconfig) ?? this.getOrCreateInferredProject(fileName)
-      );
-    }
-    return this.getOrCreateInferredProject(fileName);
+  constructor(typescript: typeof ts, recycleHeapPressureRatio?: number) {
+    const { factory, fsFileSnapshots } = createReactProjectFactory(typescript);
+    super(typescript, factory, recycleHeapPressureRatio);
+    this.fsFileSnapshots = fsFileSnapshots;
   }
 
   /**
@@ -122,556 +117,4 @@ export class ComponentMetaManager {
 
     this.recycleProjectsIfHeapPressured();
   }
-
-  /**
-   * Reclaim the shared program(s)' resident type-resolution cache when heap usage approaches the V8
-   * limit, preventing the next extraction's spike from OOMing the dev server.
-   */
-  private recycleProjectsIfHeapPressured(): void {
-    if (this.configProjects.size === 0 && !this.inferredProject) {
-      return;
-    }
-    if (process.memoryUsage().heapUsed < this.heapRecycleThresholdBytes) {
-      return;
-    }
-
-    // We crossed the heap-pressure threshold. Recycling reclaims the type cache and usually prevents
-    // the crash, but a single extraction can still exceed the cap — warn once so the user can raise
-    // their memory limit rather than silently paying repeated rebuilds (or eventually crashing).
-    const heapLimitMb = Math.round(v8.getHeapStatistics().heap_size_limit / (1024 * 1024));
-    once.warn(dedent`
-      Storybook's experimental docgen server is nearing the Node.js memory limit (~${heapLimitMb} MB) while extracting component types, and recycled its TypeScript program to avoid an out-of-memory crash. This can briefly slow down the docs and Controls panels.
-
-      If this happens often, raise Node's memory limit before starting Storybook, for example:
-        NODE_OPTIONS="--max-old-space-size=${heapLimitMb * 2}"
-    `);
-
-    for (const project of this.configProjects.values()) {
-      project.dispose();
-    }
-    this.inferredProject?.dispose();
-    this.configProjects.clear();
-    this.inferredProject = undefined;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Adapted from:
-  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L101-L234
-  // ---------------------------------------------------------------------------
-
-  private findMatchTSConfig(filePath: string): string | null {
-    const fileName = filePath.replace(/\\/g, '/');
-
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L104-L118
-    let dir = path.dirname(fileName);
-    while (true) {
-      if (this.searchedDirs.has(dir)) {
-        break;
-      }
-      this.searchedDirs.add(dir);
-      for (const tsConfigName of rootTsConfigNames) {
-        const tsconfigPath = path.join(dir, tsConfigName).replace(/\\/g, '/');
-        if (this.typescript.sys.fileExists(tsconfigPath)) {
-          this.rootTsConfigs.add(tsconfigPath);
-        }
-      }
-      const parent = path.dirname(dir);
-      if (parent === dir) {
-        break;
-      }
-      dir = parent;
-    }
-
-    if (this.rootTsConfigs.size === 0) {
-      return null;
-    }
-
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L124-L138
-    // Side-effect only: pre-creates the closest project via getCommandLine() so that
-    // findIndirectReferenceTsconfig below can inspect its project references.
-    const prepareClosestRootCommandLine = () => {
-      let matches: string[] = [];
-      for (const rootTsConfig of this.rootTsConfigs) {
-        if (isFileInDir(fileName, path.dirname(rootTsConfig))) {
-          matches.push(rootTsConfig);
-        }
-      }
-      matches = matches.sort((a, b) => sortTSConfigs(fileName, a, b));
-      if (matches.length) {
-        getCommandLine(matches[0]);
-      }
-    };
-
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L139-L147
-    const findIndirectReferenceTsconfig = () => {
-      return findTSConfig((tsconfig) => {
-        const project = this.configProjects.get(tsconfig);
-        return !!project?.hasSourceFile(fileName);
-      });
-    };
-
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L149-L158
-    const findDirectIncludeTsconfig = () => {
-      return findTSConfig((tsconfig) => {
-        const commandLine = getCommandLine(tsconfig);
-        const fileNames = new Set(commandLine?.fileNames ?? []);
-        return fileNames.has(fileName);
-      });
-    };
-
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L160-L188
-    const findTSConfig = (match: (tsconfig: string) => boolean): string | null => {
-      const checked = new Set<string>();
-
-      for (const rootTsConfig of [...this.rootTsConfigs].sort((a, b) =>
-        sortTSConfigs(fileName, a, b)
-      )) {
-        const project = this.configProjects.get(rootTsConfig);
-        if (project) {
-          let chains = getReferencesChains(project.getCommandLine(), rootTsConfig, []);
-
-          // This is to be consistent with tsserver behavior
-          chains = chains.reverse();
-
-          for (const chain of chains) {
-            for (let i = chain.length - 1; i >= 0; i--) {
-              const tsconfig = chain[i];
-
-              if (checked.has(tsconfig)) {
-                continue;
-              }
-              checked.add(tsconfig);
-
-              if (match(tsconfig)) {
-                return tsconfig;
-              }
-            }
-          }
-        }
-      }
-
-      return null;
-    };
-
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L189-L229
-    const getReferencesChains = (
-      commandLine: ts.ParsedCommandLine,
-      tsConfig: string,
-      before: string[]
-    ): string[][] => {
-      if (commandLine.projectReferences?.length) {
-        const newChains: string[][] = [];
-
-        for (const projectReference of commandLine.projectReferences) {
-          let tsConfigPath = projectReference.path.replace(/\\/g, '/');
-
-          // fix https://github.com/johnsoncodehk/volar/issues/712
-          if (this.typescript.sys.directoryExists(tsConfigPath)) {
-            const newTsConfigPath = path.join(tsConfigPath, 'tsconfig.json');
-            const newJsConfigPath = path.join(tsConfigPath, 'jsconfig.json');
-            if (this.typescript.sys.fileExists(newTsConfigPath)) {
-              tsConfigPath = newTsConfigPath;
-            } else if (this.typescript.sys.fileExists(newJsConfigPath)) {
-              tsConfigPath = newJsConfigPath;
-            }
-          }
-
-          const beforeIndex = before.indexOf(tsConfigPath); // cycle
-          if (beforeIndex >= 0) {
-            newChains.push(before.slice(0, Math.max(beforeIndex, 1)));
-          } else {
-            const referenceCommandLine = getCommandLine(tsConfigPath);
-            if (referenceCommandLine) {
-              for (const chain of getReferencesChains(referenceCommandLine, tsConfigPath, [
-                ...before,
-                tsConfig,
-              ])) {
-                newChains.push(chain);
-              }
-            }
-          }
-        }
-
-        return newChains;
-      } else {
-        return [[...before, tsConfig]];
-      }
-    };
-
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L230-L233
-    const getCommandLine = (tsConfig: string) => {
-      const project = this.getOrCreateConfiguredProject(tsConfig);
-      return project?.getCommandLine();
-    };
-
-    prepareClosestRootCommandLine();
-
-    return findDirectIncludeTsconfig() ?? findIndirectReferenceTsconfig();
-  }
-
-  // ---------------------------------------------------------------------------
-  // Adapted from:
-  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L236-L256
-  // ---------------------------------------------------------------------------
-
-  private getOrCreateConfiguredProject(tsconfig: string): ComponentMetaProject | null {
-    tsconfig = tsconfig.replace(/\\/g, '/');
-    let project = this.configProjects.get(tsconfig);
-    if (!project) {
-      try {
-        const getCommandLine = () => this.parseConfigWorker(tsconfig);
-        project = new ComponentMetaProject(
-          this.typescript,
-          getCommandLine(),
-          tsconfig,
-          this.fsFileSnapshots,
-          getCommandLine
-        );
-        this.configProjects.set(tsconfig, project);
-
-        // Auto-watch the project's directories if watching is active.
-        // This covers projects discovered after initial startWatching().
-        if (this.watching) {
-          this.watchDirectory(path.dirname(tsconfig));
-          this.watchProgramSourceDirs(project);
-        }
-      } catch (err) {
-        logger.debug(`[reactComponentMeta] Failed to parse tsconfig ${tsconfig}: ${err}`);
-        return null;
-      }
-    }
-    return project;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Adapted from:
-  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L258-L284
-  // ---------------------------------------------------------------------------
-
-  private getOrCreateInferredProject(fileName: string): ComponentMetaProject {
-    if (!this.inferredProject) {
-      this.inferredProject = new ComponentMetaProject(
-        this.typescript,
-        {
-          options: {
-            ...DEFAULT_INFERRED_OPTIONS,
-            target: this.typescript.ScriptTarget.Latest,
-            module: this.typescript.ModuleKind.ESNext,
-            moduleResolution: this.typescript.ModuleResolutionKind.Bundler,
-            jsx: this.typescript.JsxEmit.ReactJSX,
-          },
-          fileNames: [],
-          errors: [],
-        },
-        undefined,
-        this.fsFileSnapshots
-      );
-    }
-
-    this.inferredProject.ensureFiles([fileName]);
-
-    return this.inferredProject;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Adapted from:
-  // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L262-L353
-  // ---------------------------------------------------------------------------
-
-  private parseConfigWorker(tsconfig: string): ts.ParsedCommandLine {
-    const config = this.typescript.readJsonConfigFile(tsconfig, this.typescript.sys.readFile);
-    const content = this.typescript.parseJsonSourceFileConfigFileContent(
-      config,
-      this.typescript.sys,
-      path.dirname(tsconfig),
-      {},
-      tsconfig
-    );
-    // fix https://github.com/johnsoncodehk/volar/issues/1786
-    // https://github.com/microsoft/TypeScript/issues/30457
-    content.options.outDir = undefined;
-    content.fileNames = content.fileNames.map((fileName) => fileName.replace(/\\/g, '/'));
-    return content;
-  }
-
-  // ---------------------------------------------------------------------------
-  // File events
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Broadcast file changes to all projects. Each project selectively bumps projectVersion.
-   *
-   * Adapted from:
-   * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L409-L432
-   */
-  onFilesChanged(changes: Array<{ filePath: string; type: 'changed' | 'created' | 'deleted' }>) {
-    for (const project of this.configProjects.values()) {
-      project.onFilesChanged(changes);
-    }
-    this.inferredProject?.onFilesChanged(changes);
-  }
-
-  /**
-   * Adapted from:
-   * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L43-L68
-   */
-  onConfigChanged(configPath: string, type: 'created' | 'changed' | 'deleted') {
-    configPath = configPath.replace(/\\/g, '/');
-    if (type === 'created') {
-      this.rootTsConfigs.add(configPath);
-    } else if ((type === 'changed' || type === 'deleted') && this.configProjects.has(configPath)) {
-      if (type === 'deleted') {
-        this.rootTsConfigs.delete(configPath);
-      }
-      const project = this.configProjects.get(configPath);
-      this.configProjects.delete(configPath);
-      project?.dispose();
-    }
-    // Clear searchedDirs so findMatchTSConfig re-scans directories.
-    // Without this, new tsconfigs in previously-scanned dirs would be invisible.
-    this.searchedDirs.clear();
-  }
-
-  // ---------------------------------------------------------------------------
-  // Our own file watching layer (no Volar equivalent — we're standalone)
-  // ---------------------------------------------------------------------------
-
-  startWatching(): void {
-    if (this.watching) {
-      return;
-    }
-    this.watching = true;
-
-    // Retroactively create watchers for projects that were created before
-    // watching was enabled (the first manifest request creates projects
-    // eagerly, but startWatching() is only called once the manager is ready).
-    for (const tsconfig of this.configProjects.keys()) {
-      this.watchDirectory(path.dirname(tsconfig));
-    }
-
-    // Also watch directories containing source files resolved by the TS program.
-    // This covers files reached via path aliases (e.g. monorepos where stories
-    // live in apps/storybook/ but components live in packages/ui/).
-    this.watchProgramSourceDirs();
-  }
-
-  /**
-   * Watch directories that contain source files from all TS programs. This covers monorepo setups
-   * where stories import components via path aliases (e.g. apps/storybook/ imports from
-   * packages/ui/ via tsconfig paths).
-   */
-  private watchProgramSourceDirs(singleProject?: ComponentMetaProject): void {
-    const dirs = new Set<string>();
-
-    if (singleProject) {
-      for (const filePath of singleProject.getSourceFilePaths()) {
-        dirs.add(path.dirname(filePath));
-      }
-    } else {
-      for (const project of this.configProjects.values()) {
-        for (const filePath of project.getSourceFilePaths()) {
-          dirs.add(path.dirname(filePath));
-        }
-      }
-      if (this.inferredProject) {
-        for (const filePath of this.inferredProject.getSourceFilePaths()) {
-          dirs.add(path.dirname(filePath));
-        }
-      }
-    }
-
-    // Walk up from each source file dir to find package roots (package.json or tsconfig.json).
-    // This avoids creating hundreds of individual watchers for each subdirectory.
-    const roots = new Set<string>();
-    for (const dir of dirs) {
-      let candidate = dir;
-      while (candidate !== path.dirname(candidate)) {
-        // If already covered by an existing watcher, skip
-        const normalized = candidate.replace(/\\/g, '/');
-        let alreadyWatched = false;
-        for (const watched of this.watchersByDir.keys()) {
-          if (normalized === watched || normalized.startsWith(watched + '/')) {
-            alreadyWatched = true;
-            break;
-          }
-        }
-        if (alreadyWatched) {
-          break;
-        }
-
-        // Use package root as watch boundary
-        if (
-          this.typescript.sys.fileExists(path.join(candidate, 'package.json')) ||
-          this.typescript.sys.fileExists(path.join(candidate, 'tsconfig.json'))
-        ) {
-          roots.add(candidate);
-          break;
-        }
-        candidate = path.dirname(candidate);
-      }
-    }
-
-    for (const root of roots) {
-      this.watchDirectory(root);
-    }
-  }
-
-  private watchDirectory(dir: string): void {
-    if (!this.watching) {
-      return;
-    }
-
-    const normalized = dir.replace(/\\/g, '/');
-
-    for (const watched of this.watchersByDir.keys()) {
-      // Already covered by an existing broader watcher
-      if (normalized === watched || normalized.startsWith(watched + '/')) {
-        return;
-      }
-    }
-
-    // Close and remove narrower watchers that this broader directory subsumes.
-    // The new recursive watcher covers them, so keeping both wastes file descriptors
-    // and produces duplicate events.
-    for (const [watched, watcher] of this.watchersByDir) {
-      if (watched.startsWith(normalized + '/')) {
-        watcher.close();
-        this.watchersByDir.delete(watched);
-      }
-    }
-
-    try {
-      const watcher = watch(dir, { recursive: true }, (eventType, filename) => {
-        if (!filename) {
-          return;
-        }
-        const filePath = path.resolve(dir, filename).replace(/\\/g, '/');
-
-        if (filePath.includes('/node_modules/') || filePath.includes('/.git/')) {
-          return;
-        }
-
-        const existing = this.pendingEvents.get(filePath);
-        if (existing) {
-          clearTimeout(existing);
-        }
-
-        this.pendingEvents.set(
-          filePath,
-          setTimeout(() => {
-            this.pendingEvents.delete(filePath);
-
-            if (eventType === 'rename') {
-              if (existsSync(filePath)) {
-                this.handleFileEvent(filePath, 'created');
-              } else {
-                this.handleFileEvent(filePath, 'deleted');
-              }
-            } else {
-              this.handleFileEvent(filePath, 'changed');
-            }
-          }, 50)
-        );
-      });
-      watcher.unref();
-      this.watchersByDir.set(normalized, watcher);
-    } catch (err) {
-      logger.debug(`[reactComponentMeta] Failed to watch directory ${normalized}: ${err}`);
-    }
-  }
-
-  stopWatching(): void {
-    for (const timeout of this.pendingEvents.values()) {
-      clearTimeout(timeout);
-    }
-    this.pendingEvents.clear();
-    for (const watcher of this.watchersByDir.values()) {
-      watcher.close();
-    }
-    this.watchersByDir.clear();
-    this.watching = false;
-  }
-
-  /**
-   * Map raw fs.watch events to LSP-style FileChangeType before broadcasting.
-   *
-   * Fs.watch reports atomic saves (sed -i, editors) as `rename` → we classify as `created` (file
-   * exists after rename). But an IDE/LSP would report an atomic save of an _existing_ file as
-   * `Changed`, not `Created`.
-   *
-   * We reclassify here so that onFilesChanged stays 1:1 with Volar Kit.
-   */
-  private handleFileEvent(filePath: string, type: 'created' | 'changed' | 'deleted') {
-    // Reclassify: atomic save of tracked file → 'changed' (LSP Changed)
-    if (type === 'created') {
-      for (const project of this.configProjects.values()) {
-        if (project.hasSourceFile(filePath)) {
-          type = 'changed';
-          break;
-        }
-      }
-      if (type === 'created' && this.inferredProject?.hasSourceFile(filePath)) {
-        type = 'changed';
-      }
-    }
-
-    const basename = path.basename(filePath);
-    if (rootTsConfigNames.includes(basename)) {
-      this.onConfigChanged(filePath, type);
-      return;
-    }
-
-    this.onFilesChanged([{ filePath, type }]);
-  }
-
-  dispose() {
-    this.stopWatching();
-    for (const project of this.configProjects.values()) {
-      project.dispose();
-    }
-    this.inferredProject?.dispose();
-    this.configProjects.clear();
-    this.inferredProject = undefined;
-    this.fsFileSnapshots.clear();
-    this.searchedDirs.clear();
-    this.rootTsConfigs.clear();
-  }
-}
-
-// Adapted from:
-// https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L365-L385
-export function sortTSConfigs(file: string, a: string, b: string) {
-  const inA = isFileInDir(file, path.dirname(a));
-  const inB = isFileInDir(file, path.dirname(b));
-
-  if (inA !== inB) {
-    const aWeight = inA ? 1 : 0;
-    const bWeight = inB ? 1 : 0;
-    return bWeight - aWeight;
-  }
-
-  const aLength = a.split('/').length;
-  const bLength = b.split('/').length;
-
-  if (aLength === bLength) {
-    const aWeight = path.basename(a) === 'tsconfig.json' ? 1 : 0;
-    const bWeight = path.basename(b) === 'tsconfig.json' ? 1 : 0;
-    return bWeight - aWeight;
-  }
-
-  return bLength - aLength;
-}
-
-// Adapted from:
-// https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L387-L390
-export function isFileInDir(fileName: string, dir: string) {
-  const relative = path.relative(dir, fileName);
-  return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
 }

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
@@ -11,10 +11,10 @@
 import {
   ComponentMetaManager as BaseComponentMetaManager,
   type ComponentMetaProjectFactory,
-  parseTsconfigCommandLine,
 } from 'storybook/internal/component-meta';
 import { logger } from 'storybook/internal/node-logger';
 
+import * as path from 'path';
 import type ts from 'typescript';
 
 import type { StoryRef } from '../getComponentImports.ts';
@@ -34,12 +34,37 @@ const DEFAULT_INFERRED_OPTIONS: ts.CompilerOptions = {
 type FsFileSnapshots = Map<string, [number | undefined, ts.IScriptSnapshot | undefined]>;
 
 /**
+ * Parse a tsconfig with TypeScript's own machinery, the way `tsc` would. Lives here rather than in
+ * core because core's component-meta module deliberately names no types from the `typescript`
+ * package — its consumers each resolve their own copy, and `typeof ts` across two copies is not
+ * assignable (nor cheaply comparable).
+ *
+ * Adapted from:
+ * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L262-L353
+ */
+function parseTsconfigCommandLine(typescript: typeof ts, tsconfig: string): ts.ParsedCommandLine {
+  const config = typescript.readJsonConfigFile(tsconfig, typescript.sys.readFile);
+  const content = typescript.parseJsonSourceFileConfigFileContent(
+    config,
+    typescript.sys,
+    path.dirname(tsconfig),
+    {},
+    tsconfig
+  );
+  // fix https://github.com/johnsoncodehk/volar/issues/1786
+  // https://github.com/microsoft/TypeScript/issues/30457
+  content.options.outDir = undefined;
+  content.fileNames = content.fileNames.map((fileName) => fileName.replace(/\\/g, '/'));
+  return content;
+}
+
+/**
  * Builds the React project factory plus the snapshot cache it closes over. The cache is shared
  * across every project the factory creates (Volar Kit checker pattern) and returned separately so
  * the manager can expose it to tests; it is cleared through the factory's `dispose`.
  */
 function createReactProjectFactory(typescript: typeof ts): {
-  factory: ComponentMetaProjectFactory<ComponentMetaProject>;
+  factory: ComponentMetaProjectFactory<ComponentMetaProject, ts.ParsedCommandLine>;
   fsFileSnapshots: FsFileSnapshots;
 } {
   // Adapted from:
@@ -80,7 +105,10 @@ function createReactProjectFactory(typescript: typeof ts): {
   };
 }
 
-export class ComponentMetaManager extends BaseComponentMetaManager<ComponentMetaProject> {
+export class ComponentMetaManager extends BaseComponentMetaManager<
+  ComponentMetaProject,
+  ts.ParsedCommandLine
+> {
   /** Shared mtime-cached file snapshots, exposed for tests; owned by the factory. */
   readonly fsFileSnapshots: FsFileSnapshots;
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR extracts `ComponentMetaManager` from React renderer to Core for reusability across different renderer intergrzeation. 

- ComponentMetaProjectBase is the interface that the manager needs from every project
- ComponentMetaProjectFactory truns tsconfigs into projects -> owns `parseCommandLine` and `createInferredProject` (fallback for file that no config covers)
- ComponentM%etaManager is just the remaining implementation from react moved into Core

For React:
- ComponentMetaPorject builds its own TS languager service

For Vue:
- `ComponentMetaProject` would wrap a `vueComponentMeta.createChecker()` per tsconfig

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Check that nothing broke with react-component-meta

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved component metadata handling across multiple TypeScript projects, including inferred project support when no match is found.
  * Added a shared component-metadata manager API (including file-change broadcasting and TypeScript command-line abstractions) for reuse across renderers.
* **Bug Fixes**
  * Improved detection and propagation of tsconfig and file changes (including save/rename edge cases), keeping metadata extraction up to date.
  * Reduced memory pressure during long sessions via automatic project recycling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->