### PR TITLE
Core: Accept legacy addon namespaces in CSF factories

### DIFF
--- a/code/core/src/csf/csf-factories.test.ts
+++ b/code/core/src/csf/csf-factories.test.ts
@@ -19,6 +19,13 @@ interface Addon2Types {
 const addon2 = definePreviewAddon<Addon2Types>({});
 
 const preview = definePreview({ addons: [addon, addon2], renderToCanvas: () => {} });
+const legacyAnnotations = {
+  default: {
+    parameters: {
+      legacyAddon: true,
+    },
+  },
+};
 
 const meta = preview.type<{ args: { label: string } }>().meta({
   args: { label: 'foo' },
@@ -47,6 +54,33 @@ test('addon parameters are inferred', () => {
         value: 1,
       },
     },
+  });
+});
+
+test('legacy annotation namespaces are composed without collapsing factory addon types', () => {
+  const previewWithLegacyAnnotations = definePreview({
+    addons: [legacyAnnotations, addon],
+    renderToCanvas: () => {},
+  });
+  const meta = previewWithLegacyAnnotations.meta({
+    parameters: {
+      foo: {
+        value: 'typed',
+      },
+    },
+  });
+
+  meta.story({
+    parameters: {
+      foo: {
+        // @ts-expect-error factory addon parameter types remain enforced
+        value: 1,
+      },
+    },
+  });
+
+  expect(previewWithLegacyAnnotations.composed.parameters).toMatchObject({
+    legacyAddon: true,
   });
 });
 

--- a/code/core/src/csf/csf-factories.ts
+++ b/code/core/src/csf/csf-factories.ts
@@ -10,7 +10,7 @@ import type {
   TestFunction,
 } from 'storybook/internal/types';
 
-import type { SetOptional } from 'type-fest';
+import type { SetOptional, UnionToIntersection } from 'type-fest';
 
 import {
   combineParameters,
@@ -25,7 +25,7 @@ import { getCoreAnnotations, markAsComposedWithCoreAnnotations } from './core-an
 
 export interface Preview<TRenderer extends Renderer = Renderer> {
   readonly _tag: 'Preview';
-  input: ProjectAnnotations<TRenderer> & { addons?: PreviewAddon<never>[] };
+  input: ProjectAnnotations<TRenderer> & { addons?: PreviewAddonEntry[] };
   composed: NormalizedProjectAnnotations<TRenderer>;
 
   meta<
@@ -38,11 +38,20 @@ export interface Preview<TRenderer extends Renderer = Renderer> {
   type<T>(): Preview<TRenderer & T>;
 }
 
-export type InferTypes<T extends PreviewAddon<never>[]> = T extends PreviewAddon<infer C>[]
-  ? C & { csf4: true }
-  : never;
+/**
+ * An addon entry can be a typed CSF factory addon or a legacy preview annotations namespace.
+ * Legacy namespaces are composed at runtime but do not contribute additional inferred types.
+ */
+export type PreviewAddonEntry = object;
 
-export function definePreview<TRenderer extends Renderer, Addons extends PreviewAddon<never>[]>(
+type InferAddonTypes<T> = T extends PreviewAddon<infer C> ? C : never;
+
+export type InferTypes<T extends PreviewAddonEntry[]> = AddonTypes &
+  ([T[number]] extends [never] ? unknown : UnionToIntersection<InferAddonTypes<T[number]>>) & {
+    csf4: true;
+  };
+
+export function definePreview<TRenderer extends Renderer, Addons extends PreviewAddonEntry[] = []>(
   input: ProjectAnnotations<TRenderer> & { addons?: Addons }
 ): Preview<TRenderer & InferTypes<Addons>> {
   let composed: NormalizedProjectAnnotations<TRenderer & InferTypes<Addons>>;
@@ -75,9 +84,13 @@ export function definePreview<TRenderer extends Renderer, Addons extends Preview
   return preview;
 }
 
+declare const previewAddonTypes: unique symbol;
+
 export interface PreviewAddon<
   in TExtraContext extends AddonTypes = AddonTypes,
-> extends ProjectAnnotations<Renderer> {}
+> extends ProjectAnnotations<Renderer> {
+  readonly [previewAddonTypes]?: (types: TExtraContext) => void;
+}
 
 export function definePreviewAddon<TExtraContext extends AddonTypes = AddonTypes>(
   preview: ProjectAnnotations<Renderer>

--- a/code/frameworks/angular-vite/src/client/preview.ts
+++ b/code/frameworks/angular-vite/src/client/preview.ts
@@ -3,7 +3,7 @@ import type {
   InferTypes,
   Meta,
   Preview,
-  PreviewAddon,
+  PreviewAddonEntry,
   Story,
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
@@ -42,8 +42,8 @@ import { type AngularRenderer } from './types.ts';
  * });
  * ```
  */
-export function __definePreview<Addons extends PreviewAddon<never>[]>(
-  input: { addons: Addons } & ProjectAnnotations<AngularRenderer & InferTypes<Addons>>
+export function __definePreview<Addons extends PreviewAddonEntry[] = []>(
+  input: { addons?: Addons } & ProjectAnnotations<AngularRenderer & InferTypes<Addons>>
 ): AngularPreview<AngularRenderer & InferTypes<Addons>> {
   const preview = definePreviewBase({
     ...input,

--- a/code/frameworks/angular/src/client/preview.ts
+++ b/code/frameworks/angular/src/client/preview.ts
@@ -3,7 +3,7 @@ import type {
   InferTypes,
   Meta,
   Preview,
-  PreviewAddon,
+  PreviewAddonEntry,
   Story,
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
@@ -42,8 +42,8 @@ import { type AngularRenderer } from './types.ts';
  * });
  * ```
  */
-export function __definePreview<Addons extends PreviewAddon<never>[]>(
-  input: { addons: Addons } & ProjectAnnotations<AngularRenderer & InferTypes<Addons>>
+export function __definePreview<Addons extends PreviewAddonEntry[] = []>(
+  input: { addons?: Addons } & ProjectAnnotations<AngularRenderer & InferTypes<Addons>>
 ): AngularPreview<AngularRenderer & InferTypes<Addons>> {
   const preview = definePreviewBase({
     ...input,

--- a/code/frameworks/nextjs-vite/src/index.ts
+++ b/code/frameworks/nextjs-vite/src/index.ts
@@ -1,4 +1,4 @@
-import type { AddonTypes, InferTypes, PreviewAddon } from 'storybook/internal/csf';
+import type { AddonTypes, InferTypes, PreviewAddonEntry } from 'storybook/internal/csf';
 import type { ProjectAnnotations } from 'storybook/internal/types';
 
 import type { ReactPreview } from '@storybook/react';
@@ -13,7 +13,7 @@ export * from '@storybook/react';
 export * from './portable-stories.ts';
 export * from './types.ts';
 
-export function definePreview<Addons extends PreviewAddon<never>[]>(
+export function definePreview<Addons extends PreviewAddonEntry[] = []>(
   preview: { addons?: Addons } & ProjectAnnotations<ReactTypes & NextJsTypes & InferTypes<Addons>>
 ): NextPreview<InferTypes<Addons>> {
   // @ts-expect-error hard

--- a/code/frameworks/nextjs/src/index.ts
+++ b/code/frameworks/nextjs/src/index.ts
@@ -1,4 +1,4 @@
-import type { AddonTypes, InferTypes, PreviewAddon } from 'storybook/internal/csf';
+import type { AddonTypes, InferTypes, PreviewAddonEntry } from 'storybook/internal/csf';
 import type { ProjectAnnotations } from 'storybook/internal/types';
 
 import type { ReactPreview } from '@storybook/react';
@@ -13,7 +13,7 @@ export * from './types.ts';
 // @ts-expect-error (double exports)
 export * from './portable-stories.ts';
 
-export function definePreview<Addons extends PreviewAddon<never>[]>(
+export function definePreview<Addons extends PreviewAddonEntry[] = []>(
   preview: { addons?: Addons } & ProjectAnnotations<ReactTypes & NextJsTypes & InferTypes<Addons>>
 ): NextPreview<InferTypes<Addons>> {
   // @ts-expect-error hard

--- a/code/frameworks/tanstack-react/src/index.ts
+++ b/code/frameworks/tanstack-react/src/index.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from 'react';
 
-import type { AddonTypes, InferTypes, PreviewAddon } from 'storybook/internal/csf';
+import type { AddonTypes, InferTypes, PreviewAddonEntry } from 'storybook/internal/csf';
 import type {
   Args,
   ArgsStoryFn,
@@ -57,7 +57,7 @@ export type Preview<TRoute extends AnyRoute | undefined = undefined> = ProjectAn
 export function definePreview<
   TRoute extends AnyRoute | undefined = undefined,
   const TPath extends DefaultStoryPath<TRoute> = DefaultStoryPath<TRoute>,
-  Addons extends PreviewAddon<never>[] = [],
+  Addons extends PreviewAddonEntry[] = [],
 >(
   preview: {
     addons?: Addons;

--- a/code/renderers/react/src/csf-factories.test.tsx
+++ b/code/renderers/react/src/csf-factories.test.tsx
@@ -23,6 +23,14 @@ const preview = __definePreview({
   addons: [],
 });
 
+const legacyAnnotations = {
+  default: {
+    parameters: {
+      legacyAddon: true,
+    },
+  },
+};
+
 test('csf factories', () => {
   const meta = preview.meta({ component: Button, args: { disabled: true } });
 
@@ -33,6 +41,27 @@ test('csf factories', () => {
   });
 
   expect(MyStory.input.args?.label).toBe('Hello world');
+});
+
+test('addons can be omitted without collapsing preview types', () => {
+  const previewWithoutAddons = __definePreview({});
+  const meta = previewWithoutAddons.meta({
+    component: Button,
+    args: { disabled: false },
+  });
+  const story = meta.story({ args: { label: 'No addons' } });
+
+  expect(story.input.args?.label).toBe('No addons');
+});
+
+test('legacy annotation namespaces are accepted as addons', () => {
+  const previewWithLegacyAnnotations = __definePreview({
+    addons: [legacyAnnotations],
+  });
+
+  expect(previewWithLegacyAnnotations.composed.parameters).toMatchObject({
+    legacyAddon: true,
+  });
 });
 
 describe('Args can be provided in multiple ways', () => {

--- a/code/renderers/react/src/preview.tsx
+++ b/code/renderers/react/src/preview.tsx
@@ -1,8 +1,14 @@
 import type { ComponentType } from 'react';
 
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
-import type { AddonTypes, InferTypes, Meta, Preview, Story } from 'storybook/internal/csf';
-import type { PreviewAddon } from 'storybook/internal/csf';
+import type {
+  AddonTypes,
+  InferTypes,
+  Meta,
+  Preview,
+  PreviewAddonEntry,
+  Story,
+} from 'storybook/internal/csf';
 import type {
   Args,
   ArgsStoryFn,
@@ -52,8 +58,8 @@ type InferReactTypes<T, TArgs, Decorators> = ReactTypes &
  * });
  * ```
  */
-export function __definePreview<Addons extends PreviewAddon<never>[]>(
-  input: { addons: Addons } & ProjectAnnotations<ReactTypes & InferTypes<Addons>>
+export function __definePreview<Addons extends PreviewAddonEntry[] = []>(
+  input: { addons?: Addons } & ProjectAnnotations<ReactTypes & InferTypes<Addons>>
 ): ReactPreview<ReactTypes & InferTypes<Addons>> {
   const preview = definePreviewBase({
     ...input,

--- a/code/renderers/vue3/src/preview.ts
+++ b/code/renderers/vue3/src/preview.ts
@@ -3,7 +3,7 @@ import type {
   InferTypes,
   Meta,
   Preview,
-  PreviewAddon,
+  PreviewAddonEntry,
   Story,
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
@@ -42,8 +42,8 @@ import { type VueTypes } from './types.ts';
  * });
  * ```
  */
-export function __definePreview<Addons extends PreviewAddon<never>[]>(
-  input: { addons: Addons } & ProjectAnnotations<VueTypes & InferTypes<Addons>>
+export function __definePreview<Addons extends PreviewAddonEntry[] = []>(
+  input: { addons?: Addons } & ProjectAnnotations<VueTypes & InferTypes<Addons>>
 ): VuePreview<VueTypes & InferTypes<Addons>> {
   const preview = definePreviewBase({
     ...input,

--- a/code/renderers/web-components/src/preview.ts
+++ b/code/renderers/web-components/src/preview.ts
@@ -3,7 +3,7 @@ import type {
   InferTypes,
   Meta,
   Preview,
-  PreviewAddon,
+  PreviewAddonEntry,
   Story,
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
@@ -41,8 +41,8 @@ import { type WebComponentsTypes } from './types.ts';
  * });
  * ```
  */
-export function __definePreview<Addons extends PreviewAddon<never>[]>(
-  input: { addons: Addons } & ProjectAnnotations<WebComponentsTypes & InferTypes<Addons>>
+export function __definePreview<Addons extends PreviewAddonEntry[] = []>(
+  input: { addons?: Addons } & ProjectAnnotations<WebComponentsTypes & InferTypes<Addons>>
 ): WebComponentsPreview<WebComponentsTypes & InferTypes<Addons>> {
   const preview = definePreviewBase({
     ...input,


### PR DESCRIPTION
Closes #35571

## What I did

- Allow CSF factory addon arrays to accept legacy preview annotation namespace objects while preserving type inference from factory-based addons.
- Make `addons` optional across the core, renderer, and framework `definePreview` wrappers so an omitted array no longer collapses preview types to `never`.
- Add regression coverage for legacy namespace composition, mixed legacy/factory addon inference, and previews without an `addons` field.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. In a React Storybook project using CSF factories, register a third-party addon whose `/preview` entry is imported as a namespace.
2. Run `npx storybook automigrate csf-factories`.
3. Run the project's TypeScript check and confirm the generated `definePreview({ addons: [...] })` configuration no longer collapses decorators, render functions, and parameters to `never`.
4. Start Storybook and confirm the third-party preview annotations are still composed at runtime.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation change is needed because this makes the public types accept an annotation shape that Storybook already supports at runtime.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains one of the required release labels.

AI assistance disclosure: Codex was used to implement and validate this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Preview factories now preserve type information from addon entries, improving type safety for addon-provided context and parameters.
  - Preview definitions can omit the `addons` option when no addons are needed.
  - Legacy annotation namespaces remain compatible while retaining typed addon parameters.

- **Tests**
  - Added coverage for optional addons, legacy annotations, and invalid parameter type detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->