### PR TITLE
Core: Allow to send options to docGen worker

### DIFF
--- a/code/core/src/shared/open-service/services/docgen/types.ts
+++ b/code/core/src/shared/open-service/services/docgen/types.ts
@@ -94,6 +94,7 @@ export type DocgenMiddleware = (nextDocgen: DocgenProvider) => DocgenProvider;
 export interface DocgenProviderDescriptor {
   /** Absolute path to a module that exports {@link DocgenWorkerModule.createDocgenProvider}. */
   moduleSpecifier: string;
+  options?: Record<string, unknown>;
 }
 
 /**
@@ -102,5 +103,7 @@ export interface DocgenProviderDescriptor {
  * the provider chain. Integrations implement only this factory — they never touch threading.
  */
 export interface DocgenWorkerModule {
-  createDocgenProvider: () => DocgenMiddleware | Promise<DocgenMiddleware>;
+  createDocgenProvider: (
+    options?: DocgenProviderDescriptor['options']
+  ) => DocgenMiddleware | Promise<DocgenMiddleware>;
 }

--- a/code/core/src/shared/open-service/services/docgen/worker/docgen-worker.ts
+++ b/code/core/src/shared/open-service/services/docgen/worker/docgen-worker.ts
@@ -45,7 +45,7 @@ async function composeProvider(descriptors: DocgenProviderDescriptor[]): Promise
         `docgen worker module "${descriptor.moduleSpecifier}" does not export createDocgenProvider`
       );
     }
-    const middleware: DocgenMiddleware = await mod.createDocgenProvider();
+    const middleware: DocgenMiddleware = await mod.createDocgenProvider(descriptor.options);
     provider = middleware(provider);
   }
   return provider;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR allows to pass options to docgen worker 

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

-- 



> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document generation providers can now receive optional configuration options.
  * Provider-specific options are applied when initializing document generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->