### PR TITLE
Vue: Expose docgen provider, inject in manifest and gate behind vue-component-meta only

### DIFF
--- a/code/core/src/common/index.ts
+++ b/code/core/src/common/index.ts
@@ -42,6 +42,7 @@ export * from './utils/formatter.ts';
 export * from './utils/get-story-id.ts';
 export * from './utils/component-id.ts';
 export * from './utils/select-component-entry.ts';
+export * from './utils/lazy-docgen-middleware.ts';
 export * from './utils/posix.ts';
 export * from './utils/sync-main-preview-addons.ts';
 export * from './utils/setup-addon-in-config.ts';

--- a/code/core/src/common/utils/lazy-docgen-middleware.ts
+++ b/code/core/src/common/utils/lazy-docgen-middleware.ts
@@ -1,0 +1,50 @@
+import type {
+  DocgenMiddleware,
+  DocgenPayload,
+  DocgenProvider,
+  DocgenProviderInput,
+} from '../../shared/open-service/services/docgen/types.ts';
+import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from './select-component-entry.ts';
+
+export interface LazyDocgenMiddlewareOptions<TManager> {
+  /**
+   * Builds the renderer's extraction manager.
+   * Called once, lazily, on the first eligible request and memoized for the worker's lifetime.
+   * Return `undefined` to permanently pass through to the rest of the chain.
+   */
+  createManager: () => Promise<TManager | undefined>;
+  /**
+   * Extracts one payload
+   * Returns `undefined` to delegate the request downstream
+   */
+  extract: (manager: TManager, input: DocgenProviderInput) => Promise<DocgenPayload | undefined>;
+}
+
+export function createLazyDocgenMiddleware<TManager>({
+  createManager,
+  extract,
+}: LazyDocgenMiddlewareOptions<TManager>): DocgenMiddleware {
+  let managerPromise: Promise<TManager | undefined> | undefined;
+  const getManager = () => (managerPromise ??= createManager());
+
+  return (nextDocgen: DocgenProvider): DocgenProvider =>
+    async (input) => {
+      const storyImportPath = getStoryImportPathFromEntry(input.entry);
+      if (!storyImportPath || !STORY_FILE_TEST_REGEXP.test(storyImportPath)) {
+        return nextDocgen(input);
+      }
+
+      const manager = await getManager();
+      if (!manager) {
+        return nextDocgen(input);
+      }
+
+      const ours = await extract(manager, input);
+      if (!ours) {
+        return nextDocgen(input);
+      }
+
+      const downstream = await nextDocgen(input);
+      return { ...downstream, ...ours };
+    };
+}

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -459,7 +459,11 @@ export interface ComponentsManifest {
   v: number;
   components: Record<string, ComponentManifest>;
   meta?: {
-    docgen: 'react-docgen' | 'react-docgen-typescript' | 'react-component-meta';
+    docgen:
+      | 'react-docgen'
+      | 'react-docgen-typescript'
+      | 'react-component-meta'
+      | 'vue-component-meta';
     durationMs: number;
   };
 }

--- a/code/frameworks/vue3-vite/src/docgen/errors.ts
+++ b/code/frameworks/vue3-vite/src/docgen/errors.ts
@@ -1,0 +1,14 @@
+import { Category, StorybookError } from 'storybook/internal/server-errors';
+
+export class Vue3ViteDocgenManifestError extends StorybookError {
+  constructor() {
+    super({
+      name: 'Vue3ViteDocgenManifestError',
+      category: Category.FRAMEWORK_VUE3_VITE,
+      code: 1,
+      message:
+        "The Vue docgen manifest currently requires `docgen: 'vue-component-meta'` in `framework.options`.\n" +
+        'Update the Vue framework configuration or disable `features.componentsManifest`.',
+    });
+  }
+}

--- a/code/frameworks/vue3-vite/src/docgen/options.ts
+++ b/code/frameworks/vue3-vite/src/docgen/options.ts
@@ -1,12 +1,35 @@
-import type { Options } from 'storybook/internal/types';
+import type { Options, StorybookConfigRaw } from 'storybook/internal/types';
 
 import type { FrameworkOptions, VueDocgenPlugin } from '../types.ts';
 
+export const VUE_COMPONENT_META = 'vue-component-meta' satisfies VueDocgenPlugin;
+
 export type ResolvedDocgenOptions = false | { plugin: VueDocgenPlugin; tsconfig?: string };
 
-export async function getFrameworkOptions(options: Options): Promise<FrameworkOptions> {
-  const framework = await options.presets.apply('framework');
-  return typeof framework === 'string' ? {} : (framework.options ?? {});
+export interface DocgenContext {
+  docgen: ResolvedDocgenOptions;
+  features: StorybookConfigRaw['features'];
+  /**
+   * Only true if the docgen server is active and the `vue-component-meta` plugin is selected.
+   */
+  docgenServerActive: boolean;
+}
+
+export async function resolveDocgenContext(options: Options): Promise<DocgenContext> {
+  const [frameworkOptions, features] = await Promise.all([
+    options.presets.apply<FrameworkOptions | null>('frameworkOptions'),
+    options.presets.apply('features', {}),
+  ]);
+  const docgen = resolveDocgenOptions(frameworkOptions?.docgen);
+
+  return {
+    docgen,
+    features,
+    docgenServerActive:
+      features?.experimentalDocgenServer === true &&
+      docgen !== false &&
+      docgen.plugin === VUE_COMPONENT_META,
+  };
 }
 
 export function resolveDocgenOptions(docgen?: FrameworkOptions['docgen']): ResolvedDocgenOptions {

--- a/code/frameworks/vue3-vite/src/docgen/options.ts
+++ b/code/frameworks/vue3-vite/src/docgen/options.ts
@@ -1,6 +1,13 @@
+import type { Options } from 'storybook/internal/types';
+
 import type { FrameworkOptions, VueDocgenPlugin } from '../types.ts';
 
 export type ResolvedDocgenOptions = false | { plugin: VueDocgenPlugin; tsconfig?: string };
+
+export async function getFrameworkOptions(options: Options): Promise<FrameworkOptions> {
+  const framework = await options.presets.apply('framework');
+  return typeof framework === 'string' ? {} : (framework.options ?? {});
+}
 
 export function resolveDocgenOptions(docgen?: FrameworkOptions['docgen']): ResolvedDocgenOptions {
   if (docgen === false) {

--- a/code/frameworks/vue3-vite/src/docgen/preset.test.ts
+++ b/code/frameworks/vue3-vite/src/docgen/preset.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DocgenProviderDescriptor, Options } from 'storybook/internal/types';
+
+import type { FrameworkOptions } from '../types.ts';
+import { experimental_docgenProvider, experimental_manifests } from './preset.ts';
+
+const optionsWith = (docgen?: FrameworkOptions['docgen'], features: Record<string, boolean> = {}) =>
+  ({
+    presets: {
+      apply: async (key: string) => {
+        if (key === 'framework') {
+          return { name: '@storybook/vue3-vite', options: { docgen } };
+        }
+        return key === 'features' ? features : {};
+      },
+    },
+  }) as unknown as Options;
+
+const existing: DocgenProviderDescriptor[] = [{ moduleSpecifier: '/addon/docgen-worker.js' }];
+const docgenServerOn = { experimentalDocgenServer: true };
+const componentsManifestOn = { ...docgenServerOn, componentsManifest: true };
+
+describe('experimental_docgenProvider', () => {
+  it('appends a descriptor pointing at the renderer worker module', async () => {
+    const descriptors = await experimental_docgenProvider(
+      existing,
+      optionsWith('vue-component-meta', docgenServerOn)
+    );
+
+    expect(descriptors).toHaveLength(2);
+    // Appended, so addon providers stack on top of ours rather than replacing it.
+    expect(descriptors[0]).toBe(existing[0]);
+    expect(descriptors[1].moduleSpecifier).toMatch(/docgen-worker\.js$/);
+  });
+
+  // The worker extracts with vue-component-meta only. Registering for vue-docgen-api would
+  // silently swap the engine the project asked for; `docgen: false` opted out of extraction
+  // altogether and must stay opted out.
+  it.each(['vue-docgen-api' as const, undefined, false as const])(
+    'registers nothing for docgen: %s',
+    async (docgen) => {
+      await expect(
+        experimental_docgenProvider(existing, optionsWith(docgen, docgenServerOn))
+      ).resolves.toEqual(existing);
+    }
+  );
+});
+
+describe('experimental_manifests', () => {
+  const manifests = (docgen?: FrameworkOptions['docgen'], features?: Record<string, boolean>) =>
+    experimental_manifests({}, optionsWith(docgen, features) as never);
+
+  // Core asserts `components.meta.docgen` is present whenever the feature is on, so omitting it
+  // fails a Vue `storybook build` outright rather than degrading the debugger.
+  it('declares the engine so core can label the components debugger', async () => {
+    await expect(manifests('vue-component-meta', componentsManifestOn)).resolves.toEqual({
+      components: { v: 0, components: {}, meta: { docgen: 'vue-component-meta', durationMs: 0 } },
+    });
+  });
+
+  it.each(['vue-docgen-api' as const, undefined, false as const])(
+    'rejects the components manifest for docgen: %s',
+    async (docgen) => {
+      await expect(manifests(docgen, componentsManifestOn)).rejects.toThrow(
+        "The Vue docgen manifest currently requires `docgen: 'vue-component-meta'` in `framework.options`."
+      );
+    }
+  );
+
+  // The manifest is populated from docgen-service payloads. When another engine (or none) runs,
+  // there are no payloads, so claiming an engine here would report "0 components" against it.
+  it.each(['vue-docgen-api' as const, undefined, false as const])(
+    'contributes nothing for docgen: %s',
+    async (docgen) => {
+      await expect(manifests(docgen, docgenServerOn)).resolves.toEqual({});
+    }
+  );
+
+  // Vue has no legacy component manifest, so with the feature off there is nothing to contribute.
+  it('contributes nothing when the docgen service is off', async () => {
+    await expect(manifests('vue-component-meta')).resolves.toEqual({});
+  });
+});

--- a/code/frameworks/vue3-vite/src/docgen/preset.test.ts
+++ b/code/frameworks/vue3-vite/src/docgen/preset.test.ts
@@ -9,8 +9,8 @@ const optionsWith = (docgen?: FrameworkOptions['docgen'], features: Record<strin
   ({
     presets: {
       apply: async (key: string) => {
-        if (key === 'framework') {
-          return { name: '@storybook/vue3-vite', options: { docgen } };
+        if (key === 'frameworkOptions') {
+          return { docgen };
         }
         return key === 'features' ? features : {};
       },

--- a/code/frameworks/vue3-vite/src/docgen/preset.ts
+++ b/code/frameworks/vue3-vite/src/docgen/preset.ts
@@ -9,7 +9,7 @@ import type {
 } from 'storybook/internal/types';
 
 import { Vue3ViteDocgenManifestError } from './errors.ts';
-import { getFrameworkOptions, resolveDocgenOptions } from './options.ts';
+import { VUE_COMPONENT_META, resolveDocgenContext } from './options.ts';
 
 /**
  * Vue docgen provider.
@@ -20,17 +20,9 @@ export const experimental_docgenProvider = async (
   existing: DocgenProviderDescriptor[] = [],
   options: Options
 ): Promise<DocgenProviderDescriptor[]> => {
-  const [frameworkOptions, features] = await Promise.all([
-    getFrameworkOptions(options),
-    options.presets.apply('features', {}),
-  ]);
-  const docgen = resolveDocgenOptions(frameworkOptions.docgen);
+  const { docgenServerActive } = await resolveDocgenContext(options);
 
-  if (
-    !features?.experimentalDocgenServer ||
-    docgen === false ||
-    docgen.plugin !== 'vue-component-meta'
-  ) {
+  if (!docgenServerActive) {
     return existing;
   }
 
@@ -47,25 +39,17 @@ export const experimental_manifests: PresetPropertyFn<
   StorybookConfigRaw,
   { manifestEntries: IndexEntry[]; watch: boolean }
 > = async (existingManifests = {}, options) => {
-  const [frameworkOptions, features] = await Promise.all([
-    getFrameworkOptions(options),
-    options.presets.apply('features', {}),
-  ]);
-  const docgen = resolveDocgenOptions(frameworkOptions.docgen);
+  const { features, docgenServerActive } = await resolveDocgenContext(options);
 
   if (
     features?.experimentalDocgenServer === true &&
     features.componentsManifest === true &&
-    (docgen === false || docgen.plugin !== 'vue-component-meta')
+    !docgenServerActive
   ) {
     throw new Vue3ViteDocgenManifestError();
   }
 
-  if (
-    !features?.experimentalDocgenServer ||
-    docgen === false ||
-    docgen.plugin !== 'vue-component-meta'
-  ) {
+  if (!docgenServerActive) {
     return existingManifests;
   }
 
@@ -74,7 +58,7 @@ export const experimental_manifests: PresetPropertyFn<
     components: {
       v: 0,
       components: {},
-      meta: { docgen: 'vue-component-meta', durationMs: 0 },
+      meta: { docgen: VUE_COMPONENT_META, durationMs: 0 },
     },
   };
 };

--- a/code/frameworks/vue3-vite/src/docgen/preset.ts
+++ b/code/frameworks/vue3-vite/src/docgen/preset.ts
@@ -1,0 +1,80 @@
+import { fileURLToPath } from 'node:url';
+
+import type {
+  DocgenProviderDescriptor,
+  IndexEntry,
+  Options,
+  PresetPropertyFn,
+  StorybookConfigRaw,
+} from 'storybook/internal/types';
+
+import { Vue3ViteDocgenManifestError } from './errors.ts';
+import { getFrameworkOptions, resolveDocgenOptions } from './options.ts';
+
+/**
+ * Vue docgen provider.
+ *
+ * Contributes a {@link DocgenProviderDescriptor} pointing at `@storybook/vue3/internal/docgen-worker`
+ */
+export const experimental_docgenProvider = async (
+  existing: DocgenProviderDescriptor[] = [],
+  options: Options
+): Promise<DocgenProviderDescriptor[]> => {
+  const [frameworkOptions, features] = await Promise.all([
+    getFrameworkOptions(options),
+    options.presets.apply('features', {}),
+  ]);
+  const docgen = resolveDocgenOptions(frameworkOptions.docgen);
+
+  if (
+    !features?.experimentalDocgenServer ||
+    docgen === false ||
+    docgen.plugin !== 'vue-component-meta'
+  ) {
+    return existing;
+  }
+
+  return [
+    ...existing,
+    {
+      moduleSpecifier: fileURLToPath(import.meta.resolve('@storybook/vue3/internal/docgen-worker')),
+    },
+  ];
+};
+
+export const experimental_manifests: PresetPropertyFn<
+  'experimental_manifests',
+  StorybookConfigRaw,
+  { manifestEntries: IndexEntry[]; watch: boolean }
+> = async (existingManifests = {}, options) => {
+  const [frameworkOptions, features] = await Promise.all([
+    getFrameworkOptions(options),
+    options.presets.apply('features', {}),
+  ]);
+  const docgen = resolveDocgenOptions(frameworkOptions.docgen);
+
+  if (
+    features?.experimentalDocgenServer === true &&
+    features.componentsManifest === true &&
+    (docgen === false || docgen.plugin !== 'vue-component-meta')
+  ) {
+    throw new Vue3ViteDocgenManifestError();
+  }
+
+  if (
+    !features?.experimentalDocgenServer ||
+    docgen === false ||
+    docgen.plugin !== 'vue-component-meta'
+  ) {
+    return existingManifests;
+  }
+
+  return {
+    ...existingManifests,
+    components: {
+      v: 0,
+      components: {},
+      meta: { docgen: 'vue-component-meta', durationMs: 0 },
+    },
+  };
+};

--- a/code/frameworks/vue3-vite/src/preset.test.ts
+++ b/code/frameworks/vue3-vite/src/preset.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Options } from 'storybook/internal/types';
+
+import { vueComponentMeta } from './plugins/vue-component-meta.ts';
+import { vueDocgen } from './plugins/vue-docgen.ts';
+import { templateCompilation } from './plugins/vue-template.ts';
+import type { FrameworkOptions } from './types.ts';
+
+// The real plugin factories build a vue-component-meta checker / vue-docgen-api parser, which is
+// far too heavy for a preset test. Identify them by name instead.
+vi.mock('./plugins/vue-template.ts', { spy: true });
+vi.mock('./plugins/vue-component-meta.ts', { spy: true });
+vi.mock('./plugins/vue-docgen.ts', { spy: true });
+
+beforeEach(() => {
+  vi.mocked(templateCompilation).mockResolvedValue({ name: 'template' });
+  vi.mocked(vueComponentMeta).mockResolvedValue({ name: 'vue-component-meta' });
+  vi.mocked(vueDocgen).mockResolvedValue({ name: 'vue-docgen-api' });
+});
+
+const optionsWith = (docgen: FrameworkOptions['docgen'], features: Record<string, boolean> = {}) =>
+  ({
+    presets: {
+      apply: async (key: string) => {
+        if (key === 'framework') {
+          return { name: '@storybook/vue3-vite', options: { docgen } };
+        }
+        return key === 'features' ? features : {};
+      },
+    },
+  }) as unknown as Options;
+
+const pluginNames = async (
+  docgen: FrameworkOptions['docgen'],
+  features?: Record<string, boolean>
+) => {
+  const { viteFinal } = await import('./preset.ts');
+  const config = await viteFinal!({}, optionsWith(docgen, features));
+  return (config.plugins ?? []).map((plugin) => (plugin as { name: string }).name);
+};
+
+describe('viteFinal', () => {
+  it.each([
+    ['vue-component-meta' as const, 'vue-component-meta'],
+    [undefined, 'vue-docgen-api'],
+  ])('adds the %s docgen plugin when the docgen service is off', async (docgen, expected) => {
+    expect(await pluginNames(docgen)).toEqual(['template', expected]);
+  });
+
+  // The service extracts the same metadata, so leaving the plugin on would compile every component
+  // twice and put a `__docgenInfo` in the preview bundle that nothing reads.
+  it('omits the vue-component-meta plugin when the docgen service is on', async () => {
+    expect(await pluginNames('vue-component-meta', { experimentalDocgenServer: true })).toEqual([
+      'template',
+    ]);
+  });
+
+  // vue-docgen-api has no worker-side extractor, so the feature flag must not strip its plugin —
+  // that would leave these projects with no docgen at all.
+  it.each(['vue-docgen-api' as const, undefined])(
+    'keeps the docgen plugin for docgen: %s even when the docgen service is on',
+    async (docgen) => {
+      expect(await pluginNames(docgen, { experimentalDocgenServer: true })).toEqual([
+        'template',
+        'vue-docgen-api',
+      ]);
+    }
+  );
+
+  it('keeps template compilation when docgen is disabled', async () => {
+    expect(await pluginNames(false)).toEqual(['template']);
+  });
+});

--- a/code/frameworks/vue3-vite/src/preset.test.ts
+++ b/code/frameworks/vue3-vite/src/preset.test.ts
@@ -23,8 +23,8 @@ const optionsWith = (docgen: FrameworkOptions['docgen'], features: Record<string
   ({
     presets: {
       apply: async (key: string) => {
-        if (key === 'framework') {
-          return { name: '@storybook/vue3-vite', options: { docgen } };
+        if (key === 'frameworkOptions') {
+          return { docgen };
         }
         return key === 'features' ? features : {};
       },

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -2,7 +2,7 @@ import type { PresetProperty } from 'storybook/internal/types';
 
 import type { Plugin } from 'vite';
 
-import { getFrameworkOptions, resolveDocgenOptions } from './docgen/options.ts';
+import { VUE_COMPONENT_META, resolveDocgenContext } from './docgen/options.ts';
 import { type VueDocgenEngine, vueComponentMeta } from './plugins/vue-component-meta.ts';
 import { vueDocgen } from './plugins/vue-docgen.ts';
 import { templateCompilation } from './plugins/vue-template.ts';
@@ -18,18 +18,11 @@ export const core: PresetProperty<'core'> = {
 export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) => {
   const plugins: Plugin[] = [await templateCompilation()];
 
-  const [frameworkOptions, features] = await Promise.all([
-    getFrameworkOptions(options),
-    options.presets.apply('features', {}),
-  ]);
-  const docgen = resolveDocgenOptions(frameworkOptions.docgen);
+  const { docgen, docgenServerActive } = await resolveDocgenContext(options);
 
   // add docgen plugin depending on framework option
-  if (
-    docgen !== false &&
-    (!features?.experimentalDocgenServer || docgen.plugin !== 'vue-component-meta')
-  ) {
-    if (docgen.plugin === 'vue-component-meta') {
+  if (docgen !== false && !docgenServerActive) {
+    if (docgen.plugin === VUE_COMPONENT_META) {
       const engine: VueDocgenEngine = await options.presets.apply('experimental_vueDocgenEngine');
       plugins.push(await vueComponentMeta(engine, docgen.tsconfig));
     } else {

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -2,11 +2,13 @@ import type { PresetProperty } from 'storybook/internal/types';
 
 import type { Plugin } from 'vite';
 
-import { resolveDocgenOptions } from './docgen/options.ts';
+import { getFrameworkOptions, resolveDocgenOptions } from './docgen/options.ts';
 import { type VueDocgenEngine, vueComponentMeta } from './plugins/vue-component-meta.ts';
 import { vueDocgen } from './plugins/vue-docgen.ts';
 import { templateCompilation } from './plugins/vue-template.ts';
-import type { FrameworkOptions, StorybookConfig } from './types.ts';
+import type { StorybookConfig } from './types.ts';
+
+export { experimental_docgenProvider, experimental_manifests } from './docgen/preset.ts';
 
 export const core: PresetProperty<'core'> = {
   builder: import.meta.resolve('@storybook/builder-vite'),
@@ -16,14 +18,17 @@ export const core: PresetProperty<'core'> = {
 export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) => {
   const plugins: Plugin[] = [await templateCompilation()];
 
-  const framework = await options.presets.apply('framework');
-  const frameworkOptions: FrameworkOptions =
-    typeof framework === 'string' ? {} : (framework.options ?? {});
-
+  const [frameworkOptions, features] = await Promise.all([
+    getFrameworkOptions(options),
+    options.presets.apply('features', {}),
+  ]);
   const docgen = resolveDocgenOptions(frameworkOptions.docgen);
 
   // add docgen plugin depending on framework option
-  if (docgen !== false) {
+  if (
+    docgen !== false &&
+    (!features?.experimentalDocgenServer || docgen.plugin !== 'vue-component-meta')
+  ) {
     if (docgen.plugin === 'vue-component-meta') {
       const engine: VueDocgenEngine = await options.presets.apply('experimental_vueDocgenEngine');
       plugins.push(await vueComponentMeta(engine, docgen.tsconfig));

--- a/code/renderers/react/src/docgen/docgen-worker.ts
+++ b/code/renderers/react/src/docgen/docgen-worker.ts
@@ -13,8 +13,8 @@
  * docgen-relevant TS option (`reactDocgenTypescriptOptions`, including `propFilter`) applies solely
  * to the `react-docgen-typescript` engine used by the legacy manifest path — not here.
  */
-import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
-import type { DocgenMiddleware, DocgenProvider } from 'storybook/internal/types';
+import { createLazyDocgenMiddleware } from 'storybook/internal/common';
+import type { DocgenMiddleware } from 'storybook/internal/types';
 
 import { ComponentMetaManager } from '../componentManifest/componentMeta/ComponentMetaManager.ts';
 import { buildDocgenPayload } from './buildDocgen.ts';
@@ -25,41 +25,15 @@ import { buildDocgenPayload } from './buildDocgen.ts';
  * created lazily on the first eligible request and memoized; when TypeScript is unavailable the
  * middleware passes through to the rest of the chain.
  */
-export const createDocgenProvider = (): DocgenMiddleware => {
-  let managerPromise: Promise<ComponentMetaManager | undefined> | undefined;
-
-  const getManager = (): Promise<ComponentMetaManager | undefined> => {
-    if (!managerPromise) {
-      managerPromise = (async () => {
-        try {
-          const ts = await import('typescript');
-          return new ComponentMetaManager(ts);
-        } catch {
-          return undefined;
-        }
-      })();
-    }
-    return managerPromise;
-  };
-
-  return (nextDocgen: DocgenProvider): DocgenProvider =>
-    async (input) => {
-      const storyImportPath = getStoryImportPathFromEntry(input.entry);
-      if (!storyImportPath || !STORY_FILE_TEST_REGEXP.test(storyImportPath)) {
-        return nextDocgen(input);
+export const createDocgenProvider = (): DocgenMiddleware =>
+  createLazyDocgenMiddleware({
+    createManager: async () => {
+      try {
+        const ts = await import('typescript');
+        return new ComponentMetaManager(ts);
+      } catch {
+        return undefined;
       }
-
-      const componentMetaManager = await getManager();
-      if (!componentMetaManager) {
-        return nextDocgen(input);
-      }
-
-      const ours = await buildDocgenPayload(input, { componentMetaManager });
-      if (!ours) {
-        return nextDocgen(input);
-      }
-
-      const downstream = await nextDocgen(input);
-      return { ...downstream, ...ours };
-    };
-};
+    },
+    extract: (componentMetaManager, input) => buildDocgenPayload(input, { componentMetaManager }),
+  });

--- a/code/renderers/vue3/src/docgen/docgen-worker.ts
+++ b/code/renderers/vue3/src/docgen/docgen-worker.ts
@@ -9,9 +9,9 @@
  * The framework contributes the descriptor that points here; nothing in this module is bundler
  * specific, so it sits with the rest of the Vue docgen code in the renderer.
  */
-import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
+import { createLazyDocgenMiddleware } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
-import type { DocgenMiddleware, DocgenProvider } from 'storybook/internal/types';
+import type { DocgenMiddleware } from 'storybook/internal/types';
 
 import { buildDocgenPayload } from './build-docgen.ts';
 import { VueComponentMetaManager } from './vue-project-manager.ts';
@@ -23,11 +23,9 @@ import { VueComponentMetaManager } from './vue-project-manager.ts';
  * manager is created lazily on the first eligible request and memoized; when it cannot be created
  * the middleware passes through to the rest of the chain.
  */
-export const createDocgenProvider = (): DocgenMiddleware => {
-  let managerPromise: Promise<VueComponentMetaManager | undefined>;
-
-  const getManager = () => {
-    managerPromise ??= (async () => {
+export const createDocgenProvider = (): DocgenMiddleware =>
+  createLazyDocgenMiddleware({
+    createManager: async () => {
       try {
         const typescript = await import('typescript');
         const manager = new VueComponentMetaManager(typescript.default ?? typescript);
@@ -41,33 +39,14 @@ export const createDocgenProvider = (): DocgenMiddleware => {
         );
         return undefined;
       }
-    })();
-    return managerPromise;
-  };
-
-  return (nextDocgen: DocgenProvider): DocgenProvider =>
-    async (input) => {
-      const storyImportPath = getStoryImportPathFromEntry(input.entry);
-      if (!storyImportPath || !STORY_FILE_TEST_REGEXP.test(storyImportPath)) {
-        return nextDocgen(input);
-      }
-
-      const manager = await getManager();
-      if (!manager) {
-        return nextDocgen(input);
-      }
-
+    },
+    extract: async (manager, input) => {
       const ours = await buildDocgenPayload(input, {
         getChecker: (componentPath) => manager.getCheckerForFile(componentPath),
       });
       // Volar programs hold large type caches; check heap pressure after each extraction since Vue
       // has no batch surface to hang this on.
       manager.recycleIfHeapPressured();
-      if (!ours) {
-        return nextDocgen(input);
-      }
-
-      const downstream = await nextDocgen(input);
-      return { ...downstream, ...ours };
-    };
-};
+      return ours;
+    },
+  });

--- a/code/renderers/vue3/src/docgen/vue-project-manager.test.ts
+++ b/code/renderers/vue3/src/docgen/vue-project-manager.test.ts
@@ -1,14 +1,15 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
 
 import type { IndexEntry } from 'storybook/internal/types';
 
 import ts from 'typescript';
+import type { ComponentMetaChecker } from 'vue-component-meta';
 
 import { buildDocgenPayload } from './build-docgen.ts';
-import { VueComponentMetaManager } from './vue-project-manager.ts';
+import { VueComponentMetaManager, VueComponentMetaProject } from './vue-project-manager.ts';
 
 const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
 const referencesDir = join(fixturesDir, 'references');
@@ -94,5 +95,47 @@ describe('VueComponentMetaManager', () => {
     const project = manager.getProjectForFile(join(dir, 'Loose.vue'));
 
     expect(project.configFileName).toBeUndefined();
+  });
+
+  it('defers and batches created files until the project is next queried', () => {
+    const buttonPath = join(fixturesDir, 'Button.vue').replace(/\\/g, '/');
+    const refButtonPath = join(referencesDir, 'src/RefButton.vue').replace(/\\/g, '/');
+    const excludedPath = join(fixturesDir, 'excluded.vue').replace(/\\/g, '/');
+    const checker = {
+      updateFile: vi.fn(),
+      clearCache: vi.fn(),
+    } as unknown as ComponentMetaChecker;
+    const refreshedCommandLine = {
+      options: {},
+      fileNames: [buttonPath, refButtonPath],
+      errors: [],
+    } satisfies ts.ParsedCommandLine;
+    const getCommandLine = vi.fn(() => refreshedCommandLine);
+    const project = new VueComponentMetaProject(
+      checker,
+      { options: {}, fileNames: [], errors: [] },
+      join(fixturesDir, 'tsconfig.json'),
+      getCommandLine
+    );
+
+    project.onFilesChanged([
+      { filePath: buttonPath, type: 'created' },
+      { filePath: refButtonPath, type: 'created' },
+      { filePath: excludedPath, type: 'created' },
+    ]);
+
+    expect(getCommandLine).not.toHaveBeenCalled();
+    expect(checker.updateFile).not.toHaveBeenCalled();
+
+    expect(project.getCommandLine()).toBe(refreshedCommandLine);
+    expect(getCommandLine).toHaveBeenCalledOnce();
+    expect(checker.updateFile).toHaveBeenCalledTimes(2);
+    expect(checker.updateFile).toHaveBeenCalledWith(buttonPath, expect.any(String));
+    expect(checker.updateFile).toHaveBeenCalledWith(refButtonPath, expect.any(String));
+    expect(checker.updateFile).not.toHaveBeenCalledWith(excludedPath, expect.any(String));
+
+    project.getCommandLine();
+    expect(getCommandLine).toHaveBeenCalledOnce();
+    expect(checker.updateFile).toHaveBeenCalledTimes(2);
   });
 });

--- a/code/renderers/vue3/src/docgen/vue-project-manager.ts
+++ b/code/renderers/vue3/src/docgen/vue-project-manager.ts
@@ -57,6 +57,7 @@ export class VueComponentMetaProject implements ComponentMetaProjectBase {
    * so without this an extraction racing an editor save would serve stale docgen forever.
    */
   private readonly mtimes = new Map<string, number>();
+  private readonly pendingCreatedFiles = new Set<string>();
 
   constructor(
     public readonly checker: ComponentMetaChecker,
@@ -66,7 +67,34 @@ export class VueComponentMetaProject implements ComponentMetaProjectBase {
   ) {}
 
   getCommandLine(): ts.ParsedCommandLine {
+    this.replayPendingCreatedFiles();
     return this.commandLine;
+  }
+
+  private replayPendingCreatedFiles(): void {
+    if (this.pendingCreatedFiles.size === 0) {
+      return;
+    }
+
+    const pendingCreatedFiles = [...this.pendingCreatedFiles];
+    this.pendingCreatedFiles.clear();
+
+    const commandLine = this.getCommandLineFn?.();
+    if (!commandLine) {
+      return;
+    }
+
+    this.commandLine = commandLine;
+    const rootFiles = new Set(commandLine.fileNames);
+    for (const fileName of pendingCreatedFiles) {
+      if (!rootFiles.has(fileName)) {
+        continue;
+      }
+      const text = tryReadFile(fileName);
+      if (text !== undefined) {
+        this.checker.updateFile(fileName, text);
+      }
+    }
   }
 
   hasSourceFile(fileName: string): boolean {
@@ -124,6 +152,7 @@ export class VueComponentMetaProject implements ComponentMetaProjectBase {
       const fileName = normalize(filePath);
 
       if (type === 'deleted') {
+        this.pendingCreatedFiles.delete(fileName);
         if (this.hasSourceFile(fileName)) {
           this.checker.deleteFile(fileName);
         }
@@ -145,15 +174,8 @@ export class VueComponentMetaProject implements ComponentMetaProjectBase {
         continue;
       }
 
-      const commandLine = this.commandLine;
-      if (commandLine) {
-        this.commandLine = commandLine;
-        if (commandLine.fileNames.includes(fileName)) {
-          const text = tryReadFile(fileName);
-          if (text !== undefined) {
-            this.checker.updateFile(fileName, text);
-          }
-        }
+      if (this.getCommandLineFn) {
+        this.pendingCreatedFiles.add(fileName);
       }
     }
   }
@@ -172,6 +194,7 @@ export class VueComponentMetaProject implements ComponentMetaProjectBase {
   dispose(): void {
     this.checker.clearCache();
     this.mtimes.clear();
+    this.pendingCreatedFiles.clear();
   }
 }
 


### PR DESCRIPTION
 Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did


This pR makes vue renderer exposes dogenProvider and manifest in preset to:

- provide dogen when docgen is set to `vue-omponent-meta` and `experimentalDogenServer` is enabled
- inject the dogen result in manifest, in the `vuecomponentMeta` field

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing


- in a vue sandbix
  - manifest feature enabled --- docgen enabled --- vue-component-meta set for the Vue Framework options
    - run a build
      - expect docgen to be in the manifest
      - expect OSA file to contain docgen for each component
    - dev 
      - should see different docgen data in the OSA panel
  - manifest feature enabled --- docgen enabled --- vue-docgen-api set for the Vue Framework options
    - should be fully disabled

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
