### PR TITLE
Bench: Compare an engine against another release of itself

### DIFF
--- a/scripts/bench/PERF-METHODOLOGY.md
+++ b/scripts/bench/PERF-METHODOLOGY.md
@@ -56,6 +56,79 @@ One failure is specific to this shape. If both sides resolve to the same install
 
 A bump proposed in a pull request is fully covered by this. Catching a regression on the day it ships is not, because nothing here fetches the newest published version on its own, so moving the candidate forward still waits on a person or on a scheduled job that does not exist yet.
 
+#### Running a version comparison
+
+The pair that exists today is `vue-component-meta` against `vue-component-meta-next`, which are two installs of one package: the second is an alias in `scripts/package.json` pinned to an exact version.
+
+**1. Point the alias at the version you want to test.**
+Edit `scripts/package.json` and install, so the candidate is on disk:
+
+```jsonc
+"vue-component-meta": "^3.2.7",                          // the current side
+"vue-component-meta-next": "npm:vue-component-meta@3.3.8" // the candidate, pinned exactly
+```
+
+```bash
+yarn install
+```
+
+Pin the candidate exactly rather than with a range.
+A range on both sides can resolve to one install, and then the run compares an engine against itself.
+
+**2. Run both sides in one invocation, naming each explicitly.**
+From `scripts/`:
+
+```bash
+yarn bench:docgen-perf --engine vue-component-meta --engine vue-component-meta-next
+```
+
+Both ids are required.
+`vue-component-meta-next` is out of the default run because it carries no budget row, and a control pair only produces a ratio when both of its sides measured in the same invocation - naming one gives you a table row and no comparison.
+Add `--quick` for a smoke run that proves the wiring; its numbers are marked non-comparable and must not be read as a result.
+
+**3. Read the three guards on the ratio lines before reading the ratio.**
+A real run prints one cold and one warm line per scenario:
+
+```text
+ratio cold legacy/new (vue-component-meta-version/flat): 1.04  [documented members 70 vs 70]  [3.3.2 vs 3.3.8]
+ratio warm legacy/new (vue-component-meta-version/flat): 1.01  [documented members 15 vs 15]  [3.3.2 vs 3.3.8]
+```
+
+- **Two different versions.**
+  `[3.3.2 vs 3.3.8]` is what says two installs were actually compared.
+  `[both sides resolved 3.3.8 - NOT a comparison]` means the current side's range drifted onto the pin, and the roughly-1.00 ratio beside it means nothing.
+  Pin the current side too, or move the candidate.
+- **Equal work.**
+  A bare `[documented members 70 vs 70]` with no note after it is like-for-like.
+  A `NOT like-for-like` note means the two sides did not do equal work, and the note says which way: `documented more` / `documented less` is a difference in member counts, while `same members, but ...` is the subtler one, where the counts agree and the two versions resolved different amounts of the type graph behind them.
+  Either way the ratio is measuring a behaviour change rather than a cost change, and that behaviour change is the finding.
+- **Above 1.00 is the candidate winning.**
+  The ratio is the current side's median over the candidate's, so `1.04` means the candidate was 4% faster on that scenario.
+  A number below 1.00 is the candidate costing more.
+
+An engine whose package does not resolve is reported as skipped with a reason rather than measured, so a forgotten `yarn install` cannot quietly turn into a missing comparison.
+
+#### Adding a version pair for another engine
+
+This works only for an engine whose child imports the versioned package directly, the way `engines/vue-component-meta.ts` does.
+Where the harness reaches the engine through repo source instead - `react-legacy` goes via `loadReactRendererModule` into `code/renderers/react`, which imports `react-docgen` by bare specifier - no child flag can redirect that import, and a version pair needs a different approach entirely.
+
+Four data edits:
+
+1. An alias in `scripts/package.json` pinned to the candidate version.
+2. The new id added to the `EngineId` union in `docgen-shared/engine-ids.ts`, which is hand-maintained: a registry entry naming an id that is not in the union does not compile.
+3. A second registry entry in `docgen-perf/registry.ts` reusing the same child, with `inDefaultRun: false`, `versionPackage` naming the alias, and the flag that tells the child which install to load.
+4. An entry in `CONTROL_PAIRS` in `docgen-perf/ratios.ts` naming the current side as `legacy` and the alias as `next`.
+
+Plus one code edit, unless the child already has it: the child needs a flag that selects the install, which is what `--pin` is on the vue-component-meta child.
+That took a small union of allowed values, an extension of the shared option schema, a per-pin scratch directory so the two runs do not share a generated project, and a conditional import of the aliased package.
+
+One easily-missed prerequisite: the *current* side's existing registry entry must declare `versionPackage` too.
+`versionNote` prints nothing unless both sides resolved a version, so without it every ratio line silently loses its version note - and with it the guard against both sides being the same install.
+
+Nothing else changes: aggregation, member counts and the ordering alternation are already shared by every pair.
+A pair that shares an engine with another pair is fine, because the alternation reverses the whole engine list and so flips every pair at once.
+
 ## Budget shape
 
 Timing budgets are ratios or slopes rather than absolute milliseconds because absolute wall clock on a shared CI executor is far too noisy to gate on. A timing ratio divides the median of one side by the median of another. An engine that has a second implementation to compare against (for example, `vue-docgen-api` against `vue-component-meta`) uses that pair as its reference. An engine without one has its reference picked when its baselines are recorded.

--- a/scripts/bench/PERF-METHODOLOGY.md
+++ b/scripts/bench/PERF-METHODOLOGY.md
@@ -52,7 +52,10 @@ There is a third comparison that follows the same two rules: two installs of one
 
 Like-for-like still applies here, and it earns its keep. A newer version that legitimately documents more members costs more, and we want that to show up as a member count mismatch rather than as a regression.
 
-One failure is specific to this shape. If both sides resolve to the same install, and a single caret range is enough for that to happen, then we compare an engine against itself and get a ratio of roughly one, which reads exactly like a clean result. So both resolved versions are printed beside every ratio, and two equal ones are called out as not being a comparison at all.
+One failure is specific to this shape.
+The two aliases are always separate installs, but they can still resolve to the same published version, and a single caret range is enough for that to happen.
+Then we compare a version against itself and get a ratio of roughly one, which reads exactly like a clean result.
+So both resolved versions are printed beside every ratio, and two equal ones are called out as not being a comparison at all.
 
 A bump proposed in a pull request is fully covered by this. Catching a regression on the day it ships is not, because nothing here fetches the newest published version on its own, so moving the candidate forward still waits on a person or on a scheduled job that does not exist yet.
 
@@ -95,7 +98,7 @@ ratio warm legacy/new (vue-component-meta-version/flat): 1.01  [documented membe
 ```
 
 - **Two different versions.**
-  `[3.3.2 vs 3.3.8]` is what says two installs were actually compared.
+  `[3.3.2 vs 3.3.8]` is what says two different versions were actually compared.
   `[both sides resolved 3.3.8 - NOT a comparison]` means the current side's range drifted onto the pin, and the roughly-1.00 ratio beside it means nothing.
   Pin the current side too, or move the candidate.
 - **Equal work.**
@@ -124,7 +127,7 @@ Plus one code edit, unless the child already has it: the child needs a flag that
 That took a small union of allowed values, an extension of the shared option schema, a per-pin scratch directory so the two runs do not share a generated project, and a conditional import of the aliased package.
 
 One easily-missed prerequisite: the *current* side's existing registry entry must declare `versionPackage` too.
-`versionNote` prints nothing unless both sides resolved a version, so without it every ratio line silently loses its version note - and with it the guard against both sides being the same install.
+`versionNote` prints nothing unless both sides resolved a version, so without it every ratio line silently loses its version note - and with it the guard against both sides resolving to the same version.
 
 Nothing else changes: aggregation, member counts and the ordering alternation are already shared by every pair.
 A pair that shares an engine with another pair is fine, because the alternation reverses the whole engine list and so flips every pair at once.

--- a/scripts/bench/PERF-METHODOLOGY.md
+++ b/scripts/bench/PERF-METHODOLOGY.md
@@ -46,6 +46,16 @@ The pinned N has to be even for that alternation to cancel anything.
 Each side leads on half the repetitions, so an odd N gives one of them the lead once more than the other, and the cold figure is a median, which then lands on a repetition from whichever side led more often.
 That would turn the very effect the alternation exists to remove into a systematic bias on the ratio, so the parity is asserted in `ratios.test.ts` rather than left to whoever next edits the constant.
 
+### Comparing an engine against another release of itself
+
+There is a third comparison that follows the same two rules: two installs of one engine, measured against each other rather than against a different engine. This is how we check a version bump, because storing last week's milliseconds and diffing against them today would break the same-machine rule. Both sides run inside the same invocation, in the same alternating order, through the same control pair machinery, so nothing new was needed to compare them.
+
+Like-for-like still applies here, and it earns its keep. A newer version that legitimately documents more members costs more, and we want that to show up as a member count mismatch rather than as a regression.
+
+One failure is specific to this shape. If both sides resolve to the same install, and a single caret range is enough for that to happen, then we compare an engine against itself and get a ratio of roughly one, which reads exactly like a clean result. So both resolved versions are printed beside every ratio, and two equal ones are called out as not being a comparison at all.
+
+A bump proposed in a pull request is fully covered by this. Catching a regression on the day it ships is not, because nothing here fetches the newest published version on its own, so moving the candidate forward still waits on a person or on a scheduled job that does not exist yet.
+
 ## Budget shape
 
 Timing budgets are ratios or slopes rather than absolute milliseconds because absolute wall clock on a shared CI executor is far too noisy to gate on. A timing ratio divides the median of one side by the median of another. An engine that has a second implementation to compare against (for example, `vue-docgen-api` against `vue-component-meta`) uses that pair as its reference. An engine without one has its reference picked when its baselines are recorded.

--- a/scripts/bench/docgen-perf/engine.ts
+++ b/scripts/bench/docgen-perf/engine.ts
@@ -123,6 +123,20 @@ export class SeriesChildEngine extends BenchEngine<SeriesResult> {
     return this.#config.scenarios(profile);
   }
 
+  /**
+   * A declared `versionPackage` is one the child imports, so failing to resolve it means a partial
+   * install. Skipping here rather than letting `version()` quietly answer undefined is what keeps a
+   * version pair from running with no way to tell its two installs apart - the one failure that
+   * comparison exists to catch.
+   */
+  preflight(): string | undefined {
+    const { versionPackage } = this.#config;
+    if (versionPackage && resolvePackageVersion(versionPackage) === undefined) {
+      return `${versionPackage} did not resolve; it is pinned in scripts/package.json, so run yarn install`;
+    }
+    return undefined;
+  }
+
   version(): string | undefined {
     return this.#config.versionPackage ? resolvePackageVersion(this.#config.versionPackage) : undefined;
   }

--- a/scripts/bench/docgen-perf/engine.ts
+++ b/scripts/bench/docgen-perf/engine.ts
@@ -2,6 +2,8 @@
  * What the orchestrator knows about an engine. Engines differ only in how one repetition is
  * produced; everything downstream (aggregation, member counts) follows from that choice.
  */
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
 
 import type { SeriesResult } from '../docgen-shared/series.ts';
@@ -9,6 +11,17 @@ import { designatedRep, seriesMetrics } from './aggregate.ts';
 import type { SuiteProfile } from './config.ts';
 import type { SeriesChildSpec } from './spawn.ts';
 import type { EngineId, EngineMetrics, MemberCounts, ScenarioResult } from './types.ts';
+
+const require = createRequire(import.meta.url);
+
+function resolvePackageVersion(packageName: string): string | undefined {
+  try {
+    const packagePath = require.resolve(`${packageName}/package.json`);
+    return (JSON.parse(fs.readFileSync(packagePath, 'utf8')) as { version: string }).version;
+  } catch {
+    return undefined;
+  }
+}
 
 export interface ScenarioSpec {
   name: string;
@@ -86,6 +99,8 @@ export interface SeriesChildConfig {
   /** Only the reused docgen-memory harness runs under the jiti loader. */
   jiti?: boolean;
   inDefaultRun?: boolean;
+  /** The npm package name whose resolved `package.json#version` should be reported for this engine. */
+  versionPackage?: string;
 }
 
 /**
@@ -106,6 +121,10 @@ export class SeriesChildEngine extends BenchEngine<SeriesResult> {
 
   scenarios(profile: SuiteProfile): ScenarioSpec[] {
     return this.#config.scenarios(profile);
+  }
+
+  version(): string | undefined {
+    return this.#config.versionPackage ? resolvePackageVersion(this.#config.versionPackage) : undefined;
   }
 
   async measure(ctx: MeasureContext, scenario: ScenarioSpec, rep: number): Promise<SeriesResult> {

--- a/scripts/bench/docgen-perf/engines/vue-component-meta.ts
+++ b/scripts/bench/docgen-perf/engines/vue-component-meta.ts
@@ -12,7 +12,7 @@
  */
 import * as fs from 'node:fs';
 
-import { type MetaCheckerOptions, createChecker, createCheckerByJson } from 'vue-component-meta';
+import type { MetaCheckerOptions } from 'vue-component-meta';
 
 import { type SeriesEngine, harnessMain, runSeriesHarness } from '../../docgen-shared/series.ts';
 import {
@@ -22,7 +22,9 @@ import {
   vueBanner,
 } from './vue-scenario.ts';
 
-type Checker = ReturnType<typeof createCheckerByJson>;
+/** Both pins are the same package, so the current one's types describe either install. */
+type CheckerModule = typeof import('vue-component-meta');
+type Checker = ReturnType<CheckerModule['createCheckerByJson']>;
 
 /** Mirrors the production Vite plugin's checker options. */
 const CHECKER_OPTIONS: MetaCheckerOptions = {
@@ -30,6 +32,32 @@ const CHECKER_OPTIONS: MetaCheckerOptions = {
   noDeclarations: true,
   printer: { newLine: 1 },
 };
+
+const PINS = ['current', 'next'] as const;
+type Pin = (typeof PINS)[number];
+
+/** Pulls --pin out of argv before the shared parseVueOptions ever sees it, so vue-scenario.ts
+ * and vue-docgen-api.ts stay unaware this flag exists. */
+function parsePin(argv: string[]): { pin: Pin; rest: string[] } {
+  const idx = argv.indexOf('--pin');
+  if (idx === -1) {
+    return { pin: 'current', rest: argv };
+  }
+  const value = argv[idx + 1];
+  if (!PINS.includes(value as Pin)) {
+    throw new Error(`invalid --pin value: ${value}`);
+  }
+  return { pin: value as Pin, rest: [...argv.slice(0, idx), ...argv.slice(idx + 2)] };
+}
+
+/**
+ * Only the pin being measured is loaded. Importing both copies would leave the other one's module
+ * graph on the heap of every run, including the runs that feed the standing vue pair, which would
+ * shift a memory number that has nothing to do with this comparison.
+ */
+function loadCheckers(pin: Pin): Promise<CheckerModule> {
+  return pin === 'next' ? import('vue-component-meta-next') : import('vue-component-meta');
+}
 
 /**
  * Both checker calls stay inside the timed path on purpose, re-extraction included. The production
@@ -52,8 +80,9 @@ function extractOne(checker: Checker, sfcPath: string): number {
   return meta.props.length + meta.events.length + meta.slots.length + meta.exposed.length;
 }
 
-function createEngine(options: VueHarnessOptions): SeriesEngine {
+async function createEngine(options: VueHarnessOptions, pin: Pin): Promise<SeriesEngine> {
   const scenario = setUpVueScenario(options);
+  const fns = await loadCheckers(pin);
   let checker: Checker | undefined;
   let measuredPath = scenario.targetPaths[0];
 
@@ -61,8 +90,11 @@ function createEngine(options: VueHarnessOptions): SeriesEngine {
     async cold() {
       checker =
         options.scenario === 'flat'
-          ? createCheckerByJson(scenario.project.outDir, { include: ['**/*'] }, CHECKER_OPTIONS)
-          : createChecker(scenario.project.packageConfigPaths[scenario.targetPackage], CHECKER_OPTIONS);
+          ? fns.createCheckerByJson(scenario.project.outDir, { include: ['**/*'] }, CHECKER_OPTIONS)
+          : fns.createChecker(
+              scenario.project.packageConfigPaths[scenario.targetPackage],
+              CHECKER_OPTIONS
+            );
       let members = 0;
       for (const sfcPath of scenario.targetPaths) {
         members += extractOne(checker, sfcPath);
@@ -82,14 +114,15 @@ function createEngine(options: VueHarnessOptions): SeriesEngine {
 }
 
 harnessMain(async () => {
-  const options = parseVueOptions(process.argv.slice(2), 'vue-component-meta');
+  const { pin, rest } = parsePin(process.argv.slice(2));
+  const options = parseVueOptions(rest, pin === 'next' ? 'vue-component-meta-next' : 'vue-component-meta');
   await runSeriesHarness({
-    title: `vue-component-meta harness (${options.scenario})`,
+    title: `vue-component-meta harness (${options.scenario}, pin=${pin})`,
     options,
     banner: vueBanner(options),
     saves: options.saves,
     coldLabel: `${options.componentsPerPackage} components, checker creation included`,
     jsonOut: options.jsonOut,
-    setup: async () => createEngine(options),
+    setup: async () => createEngine(options, pin),
   });
 });

--- a/scripts/bench/docgen-perf/engines/vue-component-meta.ts
+++ b/scripts/bench/docgen-perf/engines/vue-component-meta.ts
@@ -13,13 +13,19 @@
 import * as fs from 'node:fs';
 
 import type { MetaCheckerOptions } from 'vue-component-meta';
+import { z } from 'zod';
 
+import { parseHarnessOptions } from '../../docgen-shared/args.ts';
 import { type SeriesEngine, harnessMain, runSeriesHarness } from '../../docgen-shared/series.ts';
 import {
+  VUE_OPTIONS,
+  VUE_SCHEMA,
   type VueHarnessOptions,
-  parseVueOptions,
+  type VueOptionsInput,
   setUpVueScenario,
   vueBanner,
+  vueOutDir,
+  vueToInput,
 } from './vue-scenario.ts';
 
 /** Both pins are the same package, so the current one's types describe either install. */
@@ -36,18 +42,27 @@ const CHECKER_OPTIONS: MetaCheckerOptions = {
 const PINS = ['current', 'next'] as const;
 type Pin = (typeof PINS)[number];
 
-/** Pulls --pin out of argv before the shared parseVueOptions ever sees it, so vue-scenario.ts
- * and vue-docgen-api.ts stay unaware this flag exists. */
-function parsePin(argv: string[]): { pin: Pin; rest: string[] } {
-  const idx = argv.indexOf('--pin');
-  if (idx === -1) {
-    return { pin: 'current', rest: argv };
-  }
-  const value = argv[idx + 1];
-  if (!PINS.includes(value as Pin)) {
-    throw new Error(`invalid --pin value: ${value}`);
-  }
-  return { pin: value as Pin, rest: [...argv.slice(0, idx), ...argv.slice(idx + 2)] };
+/** Each pin is a separate install, so each gets its own scratch directory. */
+const PIN_DIR: Record<Pin, string> = {
+  current: 'vue-component-meta',
+  next: 'vue-component-meta-next',
+};
+
+/**
+ * `--pin` is this harness's only flag of its own, so it extends the shared Vue table rather than
+ * being read out of argv beforehand: it is validated by the same strict parser as every other flag,
+ * accepts `--pin=next` like they do, and lands in the options the result JSON records.
+ */
+const SCHEMA = VUE_SCHEMA.extend({ pin: z.enum(PINS).default('current') });
+
+function parseOptions(argv: string[]): VueHarnessOptions & { pin: Pin } {
+  const parsed = parseHarnessOptions<VueOptionsInput & { pin: Pin }>(
+    argv,
+    { ...VUE_OPTIONS, pin: { type: 'string' } },
+    SCHEMA,
+    vueToInput
+  );
+  return { ...parsed, outDir: parsed.outDir ?? vueOutDir(PIN_DIR[parsed.pin]) };
 }
 
 /**
@@ -114,15 +129,14 @@ async function createEngine(options: VueHarnessOptions, pin: Pin): Promise<Serie
 }
 
 harnessMain(async () => {
-  const { pin, rest } = parsePin(process.argv.slice(2));
-  const options = parseVueOptions(rest, pin === 'next' ? 'vue-component-meta-next' : 'vue-component-meta');
+  const options = parseOptions(process.argv.slice(2));
   await runSeriesHarness({
-    title: `vue-component-meta harness (${options.scenario}, pin=${pin})`,
+    title: `vue-component-meta harness (${options.scenario}, pin=${options.pin})`,
     options,
     banner: vueBanner(options),
     saves: options.saves,
     coldLabel: `${options.componentsPerPackage} components, checker creation included`,
     jsonOut: options.jsonOut,
-    setup: async () => createEngine(options, pin),
+    setup: async () => createEngine(options, options.pin),
   });
 });

--- a/scripts/bench/docgen-perf/engines/vue-scenario.ts
+++ b/scripts/bench/docgen-perf/engines/vue-scenario.ts
@@ -26,7 +26,11 @@ import {
 
 export const VUE_SCENARIOS = ['flat', 'workspace', 'base-type-touch'] as const;
 
-const OPTIONS = {
+/**
+ * The flags both Vue harnesses accept. A harness with a flag of its own spreads this and extends
+ * {@link VUE_SCHEMA}, so every flag still reaches one strict parser and one schema.
+ */
+export const VUE_OPTIONS = {
   scenario: { type: 'string' },
   packages: { type: 'string' },
   'components-per-package': { type: 'string' },
@@ -38,30 +42,39 @@ const OPTIONS = {
   json: { type: 'string' },
 } as const;
 
-/** `engineDirName` only supplies the default scratch directory, so it is bound per harness. */
-const schemaFor = (engineDirName: string) =>
-  z.object({
-    scenario: z.enum(VUE_SCENARIOS).default('workspace'),
-    packages: countOption(4),
-    componentsPerPackage: countOption(10),
-    chainDepth: countOption(3),
-    fanOut: countOption(4),
-    heavyLib: z.boolean().default(false),
-    saves: countOption(15),
-    outDir: z
-      .string()
-      .default(path.join(SANDBOX_DIRECTORY, 'docgen-perf', engineDirName, 'project')),
-    jsonOut: z.string().optional(),
-  });
+export const VUE_SCHEMA = z.object({
+  scenario: z.enum(VUE_SCENARIOS).default('workspace'),
+  packages: countOption(4),
+  componentsPerPackage: countOption(10),
+  chainDepth: countOption(3),
+  fanOut: countOption(4),
+  heavyLib: z.boolean().default(false),
+  saves: countOption(15),
+  // Resolved after parsing, because a harness can only know which scratch directory it defaults to
+  // once its own flags are parsed - the pinned vue-component-meta install being the case in point.
+  outDir: z.string().optional(),
+  jsonOut: z.string().optional(),
+});
 
-export type VueHarnessOptions = z.infer<ReturnType<typeof schemaFor>>;
+/** parseArgs keys these as written; the schema names them as the harnesses read them. */
+export const vueToInput = (values: Record<string, unknown>) => ({
+  ...values,
+  outDir: values.out,
+  jsonOut: values.json,
+});
+
+/** Where a harness generates its project when `--out` was not given. */
+export const vueOutDir = (engineDirName: string): string =>
+  path.join(SANDBOX_DIRECTORY, 'docgen-perf', engineDirName, 'project');
+
+/** Straight off the shared flags, before a harness has resolved its scratch directory. */
+export type VueOptionsInput = z.infer<typeof VUE_SCHEMA>;
+
+export type VueHarnessOptions = VueOptionsInput & { outDir: string };
 
 export function parseVueOptions(argv: string[], engineDirName: string): VueHarnessOptions {
-  return parseHarnessOptions<VueHarnessOptions>(argv, OPTIONS, schemaFor(engineDirName), (values) => ({
-    ...values,
-    outDir: values.out,
-    jsonOut: values.json,
-  }));
+  const parsed = parseHarnessOptions<VueOptionsInput>(argv, VUE_OPTIONS, VUE_SCHEMA, vueToInput);
+  return { ...parsed, outDir: parsed.outDir ?? vueOutDir(engineDirName) };
 }
 
 export function vueBanner(options: VueHarnessOptions): Record<string, unknown> {

--- a/scripts/bench/docgen-perf/ratios.ts
+++ b/scripts/bench/docgen-perf/ratios.ts
@@ -26,6 +26,7 @@ interface ControlPair {
 export const CONTROL_PAIRS: ControlPair[] = [
   { name: 'react', legacy: 'react-legacy', next: 'react-osa' },
   { name: 'vue', legacy: 'vue-docgen-api', next: 'vue-component-meta' },
+  { name: 'vue-component-meta-version', legacy: 'vue-component-meta', next: 'vue-component-meta-next' },
 ];
 
 /**
@@ -81,7 +82,11 @@ function comparability(
   return nextOpaque > legacyOpaque ? 'next-resolves-less' : 'next-resolves-more';
 }
 
-function ratioFor(legacy: ScenarioResult, next: ScenarioResult): RatioEntry {
+function ratioFor(
+  legacy: ScenarioResult,
+  next: ScenarioResult,
+  versions: PairVersions
+): RatioEntry {
   return {
     cold: medianRatio(legacy.metrics.coldExtractionMs, next.metrics.coldExtractionMs),
     warm: medianRatio(legacy.metrics.warmExtractionMs, next.metrics.warmExtractionMs),
@@ -97,14 +102,27 @@ function ratioFor(legacy: ScenarioResult, next: ScenarioResult): RatioEntry {
     ),
     // No engine reports opaque types for the re-extracted member, so warm is judged on counts alone.
     warmComparability: comparability(legacy.warmMembers, next.warmMembers),
+    ...versions,
   };
+}
+
+interface PairVersions {
+  legacyVersion?: string;
+  nextVersion?: string;
 }
 
 /**
  * Ratios for every control pair whose two engines both measured in this invocation. A pair with one
  * failed or skipped side yields nothing: dividing a fresh median by a stale one is not a comparison.
+ *
+ * Resolved versions ride along because a pair can have both sides land on the same version - a
+ * range on one side is enough - and a ratio of one taken against itself must not read as a clean
+ * result.
  */
-export function computeRatios(results: Partial<Record<EngineId, EngineResult>>): Ratios {
+export function computeRatios(
+  results: Partial<Record<EngineId, EngineResult>>,
+  engineVersions: Partial<Record<EngineId, string>> = {}
+): Ratios {
   const ratios: Ratios = {};
 
   for (const pair of CONTROL_PAIRS) {
@@ -113,13 +131,17 @@ export function computeRatios(results: Partial<Record<EngineId, EngineResult>>):
     if (legacy?.status !== 'measured' || next?.status !== 'measured') {
       continue;
     }
+    const versions: PairVersions = {
+      legacyVersion: engineVersions[pair.legacy],
+      nextVersion: engineVersions[pair.next],
+    };
     for (const [scenarioName, legacyScenario] of Object.entries(legacy.scenarios)) {
       const nextScenario = next.scenarios[scenarioName];
       if (!nextScenario) {
         continue;
       }
       ratios[pair.name] ??= {};
-      ratios[pair.name][scenarioName] = ratioFor(legacyScenario, nextScenario);
+      ratios[pair.name][scenarioName] = ratioFor(legacyScenario, nextScenario, versions);
     }
   }
 

--- a/scripts/bench/docgen-perf/registry.test.ts
+++ b/scripts/bench/docgen-perf/registry.test.ts
@@ -142,8 +142,21 @@ describe('what the series engines spawn', () => {
     }
   });
 
-  it('resolves a real version for both sides of the version pair', () => {
-    expect(engineById('vue-component-meta').version()).toMatch(/^\d+\.\d+\.\d+/);
-    expect(engineById('vue-component-meta-next').version()).toBe('3.3.8');
+  it('resolves the two sides of the version pair to two different installs', () => {
+    // The invariant, rather than the literal the alias happens to pin today: a caret range on the
+    // current side is enough for both sides to land on one release, and the pair then compares an
+    // engine against itself for a ratio of 1.00 that reads exactly like a clean result.
+    const current = engineById('vue-component-meta').version();
+    const next = engineById('vue-component-meta-next').version();
+    expect(current).toMatch(/^\d+\.\d+\.\d+/);
+    expect(next).toMatch(/^\d+\.\d+\.\d+/);
+    expect(next).not.toBe(current);
+  });
+
+  it('skips a version-pinned engine whose install is missing, rather than losing its provenance', () => {
+    // Both sides must report a version or the run cannot say whether it compared two installs.
+    for (const id of ['vue-component-meta', 'vue-component-meta-next'] as EngineId[]) {
+      expect(engineById(id).preflight(), id).toBeUndefined();
+    }
   });
 });

--- a/scripts/bench/docgen-perf/registry.test.ts
+++ b/scripts/bench/docgen-perf/registry.test.ts
@@ -28,6 +28,9 @@ async function specFor(id: EngineId, scenario: ScenarioSpec, rep = 1) {
 }
 
 const reactScenario = engineById('react-legacy').scenarios(QUICK_PROFILE)[0];
+const vueFlatScenario = engineById('vue-component-meta')
+  .scenarios(QUICK_PROFILE)
+  .find((s) => s.name === 'flat')!;
 
 describe('the engine table', () => {
   it('registers each id exactly once', () => {
@@ -59,9 +62,12 @@ describe('the engine table', () => {
     }
   });
 
-  it('runs both sides of every control pair by default', () => {
+  it('runs both sides of every control pair that is on by default', () => {
     // A ratio needs both sides measured in the same invocation.
     for (const pair of CONTROL_PAIRS) {
+      if (!DEFAULT_ENGINE_IDS.includes(pair.next)) {
+        continue; // e.g. vue-component-meta-version: opt-in, no budget row yet
+      }
       expect(DEFAULT_ENGINE_IDS, pair.name).toContain(pair.legacy);
       expect(DEFAULT_ENGINE_IDS, pair.name).toContain(pair.next);
     }
@@ -118,5 +124,26 @@ describe('what the series engines spawn', () => {
 
   it('writes each repetition to its own result file', async () => {
     expect((await specFor('react-legacy', reactScenario, 3)).jsonPath).toMatch(/rep3\.json$/);
+  });
+
+  it('sends the two vue-component-meta versions to one child with different pins', async () => {
+    const pinned = await specFor('vue-component-meta', vueFlatScenario);
+    const next = await specFor('vue-component-meta-next', vueFlatScenario);
+    expect(next.spec.childPath).toBe(pinned.spec.childPath);
+    expect(pinned.spec.args).not.toContain('next');
+    expect(next.spec.args.slice(-2)).toEqual(['--pin', 'next']);
+  });
+
+  it('gives both vue-component-meta versions identical flags apart from --pin', async () => {
+    for (const scenario of engineById('vue-component-meta').scenarios(QUICK_PROFILE)) {
+      const pinned = await specFor('vue-component-meta', scenario);
+      const next = await specFor('vue-component-meta-next', scenario);
+      expect(next.spec.args.slice(0, -2)).toEqual(pinned.spec.args);
+    }
+  });
+
+  it('resolves a real version for both sides of the version pair', () => {
+    expect(engineById('vue-component-meta').version()).toMatch(/^\d+\.\d+\.\d+/);
+    expect(engineById('vue-component-meta-next').version()).toBe('3.3.8');
   });
 });

--- a/scripts/bench/docgen-perf/registry.ts
+++ b/scripts/bench/docgen-perf/registry.ts
@@ -71,6 +71,18 @@ export const ENGINES: BenchEngine[] = [
     child: 'engines/vue-component-meta.ts',
     scenarios: vueScenarios,
     args: vueArgs,
+    versionPackage: 'vue-component-meta',
+  }),
+  // Same child, pinned to a second, explicitly-versioned copy of the package - a version-pair
+  // control rather than an engine-vs-engine one. No budget row yet, so it stays out of the
+  // default run; a contributor testing a bump runs both ids with --engine explicitly.
+  new SeriesChildEngine({
+    id: 'vue-component-meta-next',
+    child: 'engines/vue-component-meta.ts',
+    scenarios: vueScenarios,
+    inDefaultRun: false,
+    args: (scenario) => [...vueArgs(scenario), '--pin', 'next'],
+    versionPackage: 'vue-component-meta-next',
   }),
   new CompodocEngine(),
 ];

--- a/scripts/bench/docgen-perf/report.test.ts
+++ b/scripts/bench/docgen-perf/report.test.ts
@@ -181,6 +181,68 @@ describe('renderRatios', () => {
   it('says so when there is no ratio at all', () => {
     expect(block(renderRatios({}))).toMatchInlineSnapshot(`"  no calibration ratio: it needs both sides of a control pair measured in one run"`);
   });
+
+  it('names both versions when a pair compares one package against another release of it', () => {
+    expect(
+      block(
+        renderRatios({
+          'vue-component-meta-version': {
+            flat: {
+              cold: 1.08,
+              legacyVersion: '3.3.2',
+              nextVersion: '3.3.8',
+              coldComparability: 'like-for-like',
+              warmComparability: 'like-for-like',
+            },
+          },
+        })
+      )
+    ).toMatchInlineSnapshot(`"  ratio cold legacy/new (vue-component-meta-version/flat): 1.08  [3.3.2 vs 3.3.8]"`);
+  });
+
+  it('says a pair measured nothing when both sides resolved the same version', () => {
+    // A range on the current side is enough to let both land on one release. The ratio is then 1.00
+    // against itself, which is the one failure a version pair must never report as a clean result.
+    expect(
+      block(
+        renderRatios({
+          'vue-component-meta-version': {
+            flat: {
+              cold: 1.0,
+              legacyVersion: '3.3.8',
+              nextVersion: '3.3.8',
+              coldComparability: 'like-for-like',
+              warmComparability: 'like-for-like',
+            },
+          },
+        })
+      )
+    ).toMatchInlineSnapshot(`"  ratio cold legacy/new (vue-component-meta-version/flat): 1.00  [both sides resolved 3.3.8 - NOT a comparison]"`);
+  });
+
+  it('carries the versions onto the warm line as well as the cold one', () => {
+    expect(
+      block(
+        renderRatios({
+          'vue-component-meta-version': {
+            flat: {
+              cold: 1.08,
+              warm: 0.97,
+              legacyColdMembers: 320,
+              nextColdMembers: 320,
+              legacyVersion: '3.3.2',
+              nextVersion: '3.3.8',
+              coldComparability: 'like-for-like',
+              warmComparability: 'unknown',
+            },
+          },
+        })
+      )
+    ).toMatchInlineSnapshot(`
+      "  ratio cold legacy/new (vue-component-meta-version/flat): 1.08  [documented members 320 vs 320]  [3.3.2 vs 3.3.8]
+        ratio warm legacy/new (vue-component-meta-version/flat): 0.97  [3.3.2 vs 3.3.8]"
+    `);
+  });
 });
 
 describe('renderResults', () => {

--- a/scripts/bench/docgen-perf/report.ts
+++ b/scripts/bench/docgen-perf/report.ts
@@ -1,5 +1,12 @@
 /** Renders the suite's terminal output. Pure string building, so it is testable without a runner. */
-import type { Comparability, EngineId, EngineMetrics, EngineResult, Ratios } from './types.ts';
+import type {
+  Comparability,
+  EngineId,
+  EngineMetrics,
+  EngineResult,
+  RatioEntry,
+  Ratios,
+} from './types.ts';
 
 const HEADER = ['engine/scenario', 'cold', 'warm', 'scan', 'peak', 'ret-growth', 'ret-slope'];
 
@@ -86,17 +93,20 @@ export function renderRatios(ratios: Ratios): string[] {
   for (const [pairName, scenarios] of Object.entries(ratios)) {
     for (const [scenarioName, entry] of Object.entries(scenarios)) {
       const label = `${pairName}/${scenarioName}`;
+      const versions = versionNote(entry);
 
       if (entry.cold !== undefined) {
         lines.push(
           `  ratio cold legacy/new (${label}): ${entry.cold.toFixed(2)}` +
-            memberNote(entry.legacyColdMembers, entry.nextColdMembers, entry.coldComparability)
+            memberNote(entry.legacyColdMembers, entry.nextColdMembers, entry.coldComparability) +
+            versions
         );
       }
       if (entry.warm !== undefined) {
         lines.push(
           `  ratio warm legacy/new (${label}): ${entry.warm.toFixed(2)}` +
-            memberNote(entry.legacyWarmMembers, entry.nextWarmMembers, entry.warmComparability)
+            memberNote(entry.legacyWarmMembers, entry.nextWarmMembers, entry.warmComparability) +
+            versions
         );
       }
     }
@@ -133,4 +143,17 @@ function memberNote(
     return note ? `  [${note}]` : '';
   }
   return `  [documented members ${legacy} vs ${next}${note ? ` - ${note}` : ''}]`;
+}
+
+/**
+ * Two sides on the same version compare an engine against itself, which reads as a clean 1.00 and
+ * means nothing. Saying so beside the ratio is what stops it being read as "no regression".
+ */
+function versionNote({ legacyVersion, nextVersion }: RatioEntry): string {
+  if (legacyVersion === undefined || nextVersion === undefined) {
+    return '';
+  }
+  return legacyVersion === nextVersion
+    ? `  [both sides resolved ${legacyVersion} - NOT a comparison]`
+    : `  [${legacyVersion} vs ${nextVersion}]`;
 }

--- a/scripts/bench/docgen-perf/run.ts
+++ b/scripts/bench/docgen-perf/run.ts
@@ -135,7 +135,7 @@ async function main() {
     comparable: profile.comparable,
     engineVersions,
     engines: engineResults,
-    ratios: computeRatios(engineResults),
+    ratios: computeRatios(engineResults, engineVersions),
   };
 
   console.log('\nresults');

--- a/scripts/bench/docgen-perf/types.ts
+++ b/scripts/bench/docgen-perf/types.ts
@@ -108,6 +108,12 @@ export interface RatioEntry {
   nextWarmMembers?: number;
   coldComparability: Comparability;
   warmComparability: Comparability;
+  /**
+   * The versions the two sides resolved to. Only meaningful for a pair whose sides are the same
+   * package, where two equal versions mean nothing was compared at all.
+   */
+  legacyVersion?: string;
+  nextVersion?: string;
 }
 
 /** Keyed by control-pair name, then by scenario name. */

--- a/scripts/bench/docgen-shared/engine-ids.ts
+++ b/scripts/bench/docgen-shared/engine-ids.ts
@@ -7,4 +7,5 @@ export type EngineId =
   | 'react-osa'
   | 'vue-docgen-api'
   | 'vue-component-meta'
+  | 'vue-component-meta-next'
   | 'compodoc';

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -157,6 +157,7 @@
     "vitest": "^4.1.5",
     "vue": "^3.2.47",
     "vue-component-meta": "^3.2.7",
+    "vue-component-meta-next": "npm:vue-component-meta@3.3.8",
     "vue-docgen-api": "^4.75.1",
     "wait-on": "^8.0.3",
     "window-size": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12869,6 +12869,7 @@ __metadata:
     vitest: "npm:^4.1.5"
     vue: "npm:^3.2.47"
     vue-component-meta: "npm:^3.2.7"
+    vue-component-meta-next: "npm:vue-component-meta@3.3.8"
     vue-docgen-api: "npm:^4.75.1"
     wait-on: "npm:^8.0.3"
     window-size: "npm:^1.1.1"
@@ -16527,6 +16528,21 @@ __metadata:
     path-browserify: "npm:^1.0.1"
     picomatch: "npm:^4.0.4"
   checksum: 10c0/9f8128c2b71f83750af69d240e898fadcbd825c9749fc7b72b1b68e5c7d231462a9482ae469dbaa66104641adb57314678cbc591bb0a931c57e53af19cf938bd
+  languageName: node
+  linkType: hard
+
+"@vue/language-core@npm:3.3.8":
+  version: 3.3.8
+  resolution: "@vue/language-core@npm:3.3.8"
+  dependencies:
+    "@volar/language-core": "npm:2.4.28"
+    "@vue/compiler-dom": "npm:^3.5.0"
+    "@vue/shared": "npm:^3.5.0"
+    alien-signals: "npm:^3.2.1"
+    muggle-string: "npm:^0.4.1"
+    path-browserify: "npm:^1.0.1"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/2e321f027dfb10f28cb6052629e1f1fba3e12b659284c68755097aa678ea56c190dd43aad2da1fb237debc399fd7ab2922d7e576a4eb072c5f094cdaea412b2d
   languageName: node
   linkType: hard
 
@@ -39711,6 +39727,22 @@ __metadata:
   version: 3.1.0
   resolution: "vscode-uri@npm:3.1.0"
   checksum: 10c0/5f6c9c10fd9b1664d71fab4e9fbbae6be93c7f75bb3a1d9d74399a88ab8649e99691223fd7cef4644376cac6e94fa2c086d802521b9a8e31c5af3e60f0f35624
+  languageName: node
+  linkType: hard
+
+"vue-component-meta-next@npm:vue-component-meta@3.3.8":
+  version: 3.3.8
+  resolution: "vue-component-meta@npm:3.3.8"
+  dependencies:
+    "@volar/typescript": "npm:2.4.28"
+    "@vue/language-core": "npm:3.3.8"
+    path-browserify: "npm:^1.0.1"
+  peerDependencies:
+    typescript: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/699ec4617bc587d1c36a9feb033c0e1e84e4238f65dd836914032ca6c02e951501ae0d6c32e8721f3cc4cd7bfc8a4ef2b2f5b98bb886cd7c4a6a27bdf82a6ae7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

The suite as it stands answers "is the new engine faster than the legacy one, right now, on this machine". It has no answer for the regression that actually reaches users: **the engine we already ship getting slower when we bump it.** If `vue-component-meta` 3.3.8 is 40% slower than the 3.3.2 we resolve today, nothing notices.

The obvious fix is not available. Storing last week's numbers and diffing against them breaks the rule part 1 sets out — each CI executor is thrown away after its run, so those two numbers were never comparable in the first place.

So both versions are installed side by side and measured back to back in one run. That is structurally the control pair we already have, except both sides are the same engine at two releases, which means `CONTROL_PAIRS`, `engineOrderForRep`, `medianRatio` and `likeForLike` are all reused unchanged.

A yarn npm-alias installs the second copy, the same trick `typescript-native` already uses for TS 7:

```json
"vue-component-meta": "^3.2.7",
"vue-component-meta-next": "npm:vue-component-meta@3.3.8",
```

One `--pin` flag picks which copy the child loads. The new engine stays out of the default run until it has a budget, so testing a bump means naming both ids:

```bash
yarn bench:docgen-perf --engine vue-component-meta --engine vue-component-meta-next
```

**Like-for-like earns its keep here.** A newer version that legitimately documents more members costs more, and that has to read as a member-count mismatch rather than as a regression. The existing machinery already does this, for free.

Two things I fixed after the first cut, both worth knowing about:

**Only the copy under measurement is loaded.** The first version imported both statically, which added the other one's module graph — about 2.8 MB RSS — to *every* run, including the plain `vue-component-meta` runs that feed the standing Vue pair. That would have shifted a memory number that has nothing to do with this comparison.

**Both resolved versions now print beside every ratio.** This matters most when they come out equal. `vue-component-meta` is a caret range, so both sides can land on the same release, and an engine compared against itself scores about 1.00 — which reads exactly like a clean result. That case is now called out rather than reported as a pass.

```
ratio cold legacy/new (vue-component-meta-version/workspace): 1.28  [documented members 63 vs 63]  [3.3.2 vs 3.3.8]
```

## What this does not do

It does not fetch the newest published version by itself, because a network install inside a benchmark both breaks reproducibility and pollutes the timing. So a bump proposed in a PR is fully covered; catching a regression on the day it ships still needs someone to move the candidate pin forward. The note says so plainly rather than implying protection that is not there.

No budget and no gate — report-only, exactly like the existing Vue pair, until baseline figures are recorded.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

84 tests, up from 79. The new ones cover the registry wiring and both version-note cases, including the same-version one.

#### Manual testing

```bash
yarn install          # pulls in the second vue-component-meta copy
cd scripts && yarn check && yarn lint && yarn test bench/docgen
yarn bench:docgen-perf --quick --engine vue-component-meta --engine vue-component-meta-next
```

Expect a `vue-component-meta-version` ratio per scenario, each carrying matching member counts and `[3.3.2 vs 3.3.8]`.

To see the guard fire, point the alias at whatever the caret range already resolves to, re-run, and confirm the line says `NOT a comparison` instead of showing a clean 1.00.

### Documentation

- [x] Add or update documentation reflecting your changes

The methodology note gains a short section on this third comparison shape, including what it does not cover.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below: `build`