### PR TITLE
Builder-Webpack5: Use strict mtime equality for mock cache reuse

### DIFF
--- a/code/builders/builder-webpack5/src/plugins/webpack-mock-plugin.ts
+++ b/code/builders/builder-webpack5/src/plugins/webpack-mock-plugin.ts
@@ -70,9 +70,9 @@ export class WebpackMockPlugin {
     const updateMocks = () => {
       const mTimePreviewConfig = this.getPreviewConfigMtime(compiler);
       if (
-        this.lastPreviewMtime &&
-        mTimePreviewConfig &&
-        mTimePreviewConfig <= this.lastPreviewMtime
+        this.lastPreviewMtime !== undefined &&
+        mTimePreviewConfig !== undefined &&
+        mTimePreviewConfig === this.lastPreviewMtime
       ) {
         return; // unchanged
       }


### PR DESCRIPTION
## What I did

`WebpackMockPlugin`'s mock-cache check uses `mTimePreviewConfig <= this.lastPreviewMtime` to decide whether to skip re-extracting `sb.mock()` calls from the preview config. That treats a preview config mtime moving **backward** (e.g. `git checkout` to an older commit, a restored backup, some CI checkout tools) as "unchanged" — silently reusing a stale `mockMap`/`candidateSpecifiers` built from whatever content was previously observed, even though the file's actual content has changed. Filesystem mtimes aren't guaranteed to be monotonically increasing, so `<=` isn't a safe "unchanged" check. Only exact equality is.

This was found while porting this plugin's earlier fix (#33169) to the rsbuild builder (rstackjs/storybook-rsbuild#524), where a reviewer (CodeRabbit) flagged the same comparison — confirmed the identical logic exists here too.

**AI assistance disclosure:** This fix and PR description were prepared with Claude (Anthropic) assistance, surfaced via automated review feedback on the linked sibling PR. I've reviewed the change and stand behind it.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

No automated test covers this plugin currently — the original fix (#33169) also shipped without one, since `WebpackMockPlugin.apply()` wires into webpack's compiler hooks in a way that isn't practically unit-testable without a real compiler instance.

#### Manual testing

This is a 3-line, mechanically-obvious correctness fix (comparison operator only, no behavioral restructuring), verified by code inspection rather than a live monorepo build. To verify directly:
1. Add an `sb.mock()` call to a sandbox's `preview.ts`, run `storybook dev`.
2. Note the resolved mock's mtime is cached (`lastPreviewMtime`).
3. Replace `preview.ts` with different content but force an **older** mtime (e.g. `touch -d "1 hour ago" preview.ts` after editing) to simulate a checkout/restore scenario.
4. Trigger a rebuild (save any file) — before this fix, the stale mock map would be reused despite the content change; after, `updateMocks` re-extracts correctly.

### Documentation
- [ ] Add or update documentation reflecting your changes — not applicable, internal-only comparison fix.