### PR TITLE
Vue3: Support TypeScript enum props in vue-component-meta docgen

### DIFF
--- a/code/frameworks/vue3-vite/package.json
+++ b/code/frameworks/vue3-vite/package.json
@@ -53,7 +53,7 @@
     "@storybook/vue3": "workspace:*",
     "magic-string": "^1.1.0",
     "typescript": "^5.9.3",
-    "vue-component-meta": "^3.2.7",
+    "vue-component-meta": "^3.3.9",
     "vue-docgen-api": "^4.75.1"
   },
   "devDependencies": {

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -317,5 +317,9 @@ function removeNestedSchemas(schema: PropertyMetaSchema) {
     schema.schema?.forEach((enumSchema) => removeNestedSchemas(enumSchema));
     return;
   }
+  if (schema.kind === 'literal') {
+    // a TS enum member: a qualified name plus the runtime value it stands for, nothing nested
+    return;
+  }
   delete schema.schema;
 }

--- a/code/lib/docgen-harness/README.md
+++ b/code/lib/docgen-harness/README.md
@@ -84,7 +84,7 @@ Keeping that copy in step with `frameworks/vue3-vite/src/plugins/vue-component-m
 - Like the legacy recorder, it self-compares every committed baseline through the comparator, so a checker or plugin change that loses extraction quality fails with named violations instead of landing as an unremarkable diff.
   Whether the OSA Vue engine is also held to these baselines - rather than only to the legacy ones - is a separate, later decision.
 - Plugin and checker changes land here as reviewed snapshot diffs instead of silent drift - #35565 (`schema: true`) moved 17 of the 25 `cm-argtypes.snapshot` files and left every `cm-snippet-*` byte-identical.
-  The recorded state is whatever the lockfile resolves `vue-component-meta` to (3.3.2 today), so a dependency bump is a reviewed baseline change too.
+  The recorded state is whatever the lockfile resolves `vue-component-meta` to (3.3.9 today), so a dependency bump is a reviewed baseline change too.
 
 ## Adding a fixture
 
@@ -137,7 +137,7 @@ Each has a red marker in `vue3-legacy-gaps.test.ts`.
 - #20593 -> `runtime-proptype-cast/`: literal unions behind `PropType` casts must keep their options.
 - #24270 (partial) -> `define-slots-literal-bindings/`: `defineSlots` literal binding types must be extracted; the issue's own snippet repro is not covered here.
 - #26465 (partial) -> `slots/`: scoped-slot binding types must be extracted; the marker covers only this symptom, not the issue's `vue-component-meta` repro.
-- #26465 (not reproduced) -> `define-slots-with-props/`: the issue's own repro - documented `withDefaults` props plus `defineSlots` losing all prop meta under `vue-component-meta` - does not occur at 3.3.2.
+- #26465 (not reproduced) -> `define-slots-with-props/`: the issue's own repro - documented `withDefaults` props plus `defineSlots` losing all prop meta under `vue-component-meta` - does not occur at 3.3.9.
   `cm-argtypes.snapshot` records descriptions, defaults, and slot docs fully intact; a regression baseline, no marker.
   The issue's secondary HMR symptom is dev-server behavior outside this harness's reach.
 - #29354 -> `cross-file-union-alias/`: imported literal-union aliases must unfold to their options.

--- a/code/lib/docgen-harness/package.json
+++ b/code/lib/docgen-harness/package.json
@@ -38,7 +38,7 @@
     "rxjs": "^7.4.0",
     "typescript": "^6.0.3",
     "vue": "^3.2.47",
-    "vue-component-meta": "^3.2.7",
+    "vue-component-meta": "^3.3.9",
     "vue-docgen-api": "^4.75.1",
     "vue-tsc": "latest",
     "zone.js": "^0.16.2"

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/props-ts-enum/TsEnumProps.vue
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/props-ts-enum/TsEnumProps.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-// TypeScript enum props record only the bare enum NAME (sbType "other"), both for
-// an imported and for a locally declared enum - the members never reach Controls,
-// which fall back to a free-text input.
+// The legacy vue-docgen-api path records only the bare enum NAME (sbType "other"), both for
+// an imported and for a locally declared enum - the members never reach Controls, which fall
+// back to a free-text input. vue-component-meta enumerates them (see cm-argtypes.snapshot).
 import { Severity } from './severity.ts';
 
 enum Level {

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/props-ts-enum/cm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/props-ts-enum/cm-argtypes.snapshot
@@ -14,9 +14,19 @@
     },
   },
   "level": {
+    "control": {
+      "labels": {
+        "0": "Level.Low",
+        "1": "Level.High",
+      },
+    },
     "defaultValue": undefined,
     "description": "Priority, a locally declared numeric enum.",
     "name": "level",
+    "options": [
+      0,
+      1,
+    ],
     "table": {
       "category": "props",
       "defaultValue": undefined,
@@ -25,15 +35,30 @@
       },
     },
     "type": {
-      "name": "other",
+      "name": "enum",
       "required": false,
-      "value": "Level | undefined",
+      "value": [
+        0,
+        1,
+      ],
     },
   },
   "severity": {
+    "control": {
+      "labels": {
+        "error": "Severity.Error",
+        "info": "Severity.Info",
+        "warning": "Severity.Warning",
+      },
+    },
     "defaultValue": undefined,
     "description": "Alert severity, an imported string enum.",
     "name": "severity",
+    "options": [
+      "info",
+      "warning",
+      "error",
+    ],
     "table": {
       "category": "props",
       "defaultValue": undefined,
@@ -42,9 +67,13 @@
       },
     },
     "type": {
-      "name": "other",
+      "name": "enum",
       "required": true,
-      "value": "Severity",
+      "value": [
+        "info",
+        "warning",
+        "error",
+      ],
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
@@ -46,6 +46,9 @@ function removeNestedSchemas(schema: PropertyMetaSchema) {
     schema.schema?.forEach((enumSchema) => removeNestedSchemas(enumSchema));
     return;
   }
+  if (schema.kind === 'literal') {
+    return;
+  }
   delete schema.schema;
 }
 

--- a/code/renderers/vue3/src/__snapshots__/extractArgTypes.test.ts.snap
+++ b/code/renderers/vue3/src/__snapshots__/extractArgTypes.test.ts.snap
@@ -219,9 +219,21 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "enumValue": {
+    "control": {
+      "labels": {
+        "0": "MyEnum.Small",
+        "1": "MyEnum.Medium",
+        "2": "MyEnum.Large",
+      },
+    },
     "defaultValue": undefined,
     "description": "description enum value",
     "name": "enumValue",
+    "options": [
+      0,
+      1,
+      2,
+    ],
     "table": {
       "category": "props",
       "defaultValue": undefined,
@@ -230,9 +242,13 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
       },
     },
     "type": {
-      "name": "other",
+      "name": "enum",
       "required": true,
-      "value": "MyEnum",
+      "value": [
+        0,
+        1,
+        2,
+      ],
     },
   },
   "foo": {

--- a/code/renderers/vue3/src/__snapshots__/extractArgTypes.test.ts.snap
+++ b/code/renderers/vue3/src/__snapshots__/extractArgTypes.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`extractArgTypes (vue-docgen-api) > should extract events for Vue component 1`] = `
+exports[`extractArgTypes (vue-component-meta) > should extract events for Vue component 1`] = `
 {
   "bar": {
     "control": {
@@ -56,89 +56,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract events for Vue compon
 }
 `;
 
-exports[`extractArgTypes (vue-docgen-api) > should extract events for component 1`] = `
-{
-  "bar": {
-    "control": {
-      "disable": true,
-    },
-    "description": "Test description bar",
-    "name": "bar",
-    "table": {
-      "category": "events",
-      "defaultValue": undefined,
-      "jsDocTags": undefined,
-      "type": {
-        "summary": "{ year: number; title?: any }",
-      },
-    },
-    "type": {
-      "name": "other",
-      "required": false,
-      "value": "{ year: number; title?: any }",
-    },
-  },
-  "baz": {
-    "control": {
-      "disable": true,
-    },
-    "description": "Test description baz",
-    "name": "baz",
-    "table": {
-      "category": "events",
-      "defaultValue": undefined,
-      "jsDocTags": undefined,
-      "type": undefined,
-    },
-    "type": {
-      "name": "other",
-      "required": false,
-      "value": "",
-    },
-  },
-}
-`;
-
-exports[`extractArgTypes (vue-docgen-api) > should extract expose for component 1`] = `
-{
-  "count": {
-    "control": {
-      "disable": true,
-    },
-    "description": "a count number",
-    "name": "count",
-    "table": {
-      "category": "expose",
-      "defaultValue": undefined,
-      "jsDocTags": undefined,
-      "type": undefined,
-    },
-    "type": {
-      "name": "other",
-      "value": "",
-    },
-  },
-  "label": {
-    "control": {
-      "disable": true,
-    },
-    "description": "a label string",
-    "name": "label",
-    "table": {
-      "category": "expose",
-      "defaultValue": undefined,
-      "jsDocTags": undefined,
-      "type": undefined,
-    },
-    "type": {
-      "name": "other",
-      "value": "",
-    },
-  },
-}
-`;
-
-exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1`] = `
+exports[`extractArgTypes (vue-component-meta) > should extract props for component 1`] = `
 {
   "array": {
     "defaultValue": undefined,
@@ -470,7 +388,150 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
 }
 `;
 
-exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2`] = `
+exports[`extractArgTypes (vue-component-meta) > should extract slots type for Vue component 1`] = `
+{
+  "default": {
+    "description": "",
+    "name": "default",
+    "table": {
+      "category": "slots",
+      "type": {
+        "summary": "{ num: number; }",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "{ num: number; }",
+    },
+  },
+  "named": {
+    "description": "",
+    "name": "named",
+    "table": {
+      "category": "slots",
+      "type": {
+        "summary": "{ str: string; }",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "{ str: string; }",
+    },
+  },
+  "no-bind": {
+    "description": "",
+    "name": "no-bind",
+    "table": {
+      "category": "slots",
+      "type": {
+        "summary": "{}",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "{}",
+    },
+  },
+  "vbind": {
+    "description": "",
+    "name": "vbind",
+    "table": {
+      "category": "slots",
+      "type": {
+        "summary": "{ num: number; str: string; }",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "{ num: number; str: string; }",
+    },
+  },
+}
+`;
+
+exports[`extractArgTypes (vue-docgen-api) > should extract events for component 1`] = `
+{
+  "bar": {
+    "control": {
+      "disable": true,
+    },
+    "description": "Test description bar",
+    "name": "bar",
+    "table": {
+      "category": "events",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": {
+        "summary": "{ year: number; title?: any }",
+      },
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "{ year: number; title?: any }",
+    },
+  },
+  "baz": {
+    "control": {
+      "disable": true,
+    },
+    "description": "Test description baz",
+    "name": "baz",
+    "table": {
+      "category": "events",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+}
+`;
+
+exports[`extractArgTypes (vue-docgen-api) > should extract expose for component 1`] = `
+{
+  "count": {
+    "control": {
+      "disable": true,
+    },
+    "description": "a count number",
+    "name": "count",
+    "table": {
+      "category": "expose",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "value": "",
+    },
+  },
+  "label": {
+    "control": {
+      "disable": true,
+    },
+    "description": "a label string",
+    "name": "label",
+    "table": {
+      "category": "expose",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "value": "",
+    },
+  },
+}
+`;
+
+exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1`] = `
 {
   "array": {
     "description": "description required array object",
@@ -828,67 +889,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1
       "name": "other",
       "required": false,
       "value": "{ num: unknown; str: unknown }",
-    },
-  },
-}
-`;
-
-exports[`extractArgTypes (vue-docgen-api) > should extract slots type for Vue component 1`] = `
-{
-  "default": {
-    "description": "",
-    "name": "default",
-    "table": {
-      "category": "slots",
-      "type": {
-        "summary": "{ num: number; }",
-      },
-    },
-    "type": {
-      "name": "other",
-      "value": "{ num: number; }",
-    },
-  },
-  "named": {
-    "description": "",
-    "name": "named",
-    "table": {
-      "category": "slots",
-      "type": {
-        "summary": "{ str: string; }",
-      },
-    },
-    "type": {
-      "name": "other",
-      "value": "{ str: string; }",
-    },
-  },
-  "no-bind": {
-    "description": "",
-    "name": "no-bind",
-    "table": {
-      "category": "slots",
-      "type": {
-        "summary": "{}",
-      },
-    },
-    "type": {
-      "name": "other",
-      "value": "{}",
-    },
-  },
-  "vbind": {
-    "description": "",
-    "name": "vbind",
-    "table": {
-      "category": "slots",
-      "type": {
-        "summary": "{ num: number; str: string; }",
-      },
-    },
-    "type": {
-      "name": "other",
-      "value": "{ num: number; str: string; }",
     },
   },
 }

--- a/code/renderers/vue3/src/docs/tests-meta-components/meta-components.ts
+++ b/code/renderers/vue3/src/docs/tests-meta-components/meta-components.ts
@@ -523,7 +523,11 @@ export const referenceTypeProps: TestComponent = normalizeComponentMetaFixture({
         schema: {
           kind: 'enum',
           type: 'MyEnum',
-          schema: ['MyEnum.Small', 'MyEnum.Medium', 'MyEnum.Large'],
+          schema: [
+            { kind: 'literal', type: 'MyEnum.Small', value: '0' },
+            { kind: 'literal', type: 'MyEnum.Medium', value: '1' },
+            { kind: 'literal', type: 'MyEnum.Large', value: '2' },
+          ],
         },
       },
       {
@@ -1223,7 +1227,11 @@ export const mockExtractComponentPropsReturn = [
       schema: {
         kind: 'enum',
         type: 'MyEnum',
-        schema: ['MyEnum.Small', 'MyEnum.Medium', 'MyEnum.Large'],
+        schema: [
+          { kind: 'literal', type: 'MyEnum.Small', value: '0' },
+          { kind: 'literal', type: 'MyEnum.Medium', value: '1' },
+          { kind: 'literal', type: 'MyEnum.Large', value: '2' },
+        ],
       },
     },
     typeSystem: TypeSystem.JAVASCRIPT,

--- a/code/renderers/vue3/src/extractArgTypes.test.ts
+++ b/code/renderers/vue3/src/extractArgTypes.test.ts
@@ -12,7 +12,11 @@ import {
   templateSlots,
   vueDocgenMocks,
 } from './docs/tests-meta-components/meta-components.ts';
-import { convertVueComponentMetaProp, extractArgTypes } from './extractArgTypes.ts';
+import {
+  convertVueComponentMetaProp,
+  extractArgTypes,
+  extractFromVueComponentMeta,
+} from './extractArgTypes.ts';
 
 vitest.mock('storybook/internal/docs-tools', async (importOriginal) => {
   const module: Record<string, unknown> = await importOriginal();
@@ -146,9 +150,7 @@ describe('convertVueComponentMetaProp', () => {
     ).toEqual({ name: 'enum', value: ['small', 'medium', 'large'], required: true });
   });
 
-  it('should not convert TS enum member references to an enum sbType', () => {
-    // the schema only carries the member names, not their runtime values; an enum
-    // sbType would make Controls inject the name string instead of the value
+  it('should convert TS enum members to an enum sbType of their runtime values', () => {
     expect(
       convertVueComponentMetaProp({
         type: 'Severity',
@@ -156,13 +158,17 @@ describe('convertVueComponentMetaProp', () => {
         schema: {
           kind: 'enum',
           type: 'Severity',
-          schema: ['Severity.Info', 'Severity.Warning', 'Severity.Error'],
+          schema: [
+            { kind: 'literal', type: 'Severity.Info', value: '"info"' },
+            { kind: 'literal', type: 'Severity.Warning', value: '"warning"' },
+            { kind: 'literal', type: 'Severity.Error', value: '"error"' },
+          ],
         },
       })
-    ).toEqual({ name: 'other', value: 'Severity', required: true });
+    ).toEqual({ name: 'enum', value: ['info', 'warning', 'error'], required: true });
   });
 
-  it('should not convert numeric TS enum member references either', () => {
+  it('should keep numeric TS enum members numeric', () => {
     expect(
       convertVueComponentMetaProp({
         type: 'Level | undefined',
@@ -170,9 +176,107 @@ describe('convertVueComponentMetaProp', () => {
         schema: {
           kind: 'enum',
           type: 'Level | undefined',
-          schema: ['undefined', 'Level.Low', 'Level.High'],
+          schema: [
+            'undefined',
+            { kind: 'literal', type: 'Level.Low', value: '0' },
+            { kind: 'literal', type: 'Level.High', value: '1' },
+          ],
         },
       })
-    ).toEqual({ name: 'other', value: 'Level | undefined', required: false });
+    ).toEqual({ name: 'enum', value: [0, 1], required: false });
+  });
+
+  it('should convert a union mixing TS enum members and string literals', () => {
+    expect(
+      convertVueComponentMetaProp({
+        type: 'Severity | "custom"',
+        required: true,
+        schema: {
+          kind: 'enum',
+          type: 'Severity | "custom"',
+          schema: [{ kind: 'literal', type: 'Severity.Info', value: '"info"' }, '"custom"'],
+        },
+      })
+    ).toEqual({ name: 'enum', value: ['info', 'custom'], required: true });
+  });
+
+  it('should not convert qualified type names that stand for no value', () => {
+    // "typeof Config.alpha" stringifies with a dot but carries nothing selectable;
+    // an enum sbType would make Controls inject that name verbatim
+    expect(
+      convertVueComponentMetaProp({
+        type: 'typeof Config.alpha | typeof Config.beta',
+        required: true,
+        schema: {
+          kind: 'enum',
+          type: 'typeof Config.alpha | typeof Config.beta',
+          schema: ['typeof Config.alpha', 'typeof Config.beta'],
+        },
+      })
+    ).toEqual({
+      name: 'other',
+      value: 'typeof Config.alpha | typeof Config.beta',
+      required: true,
+    });
+  });
+});
+
+describe('extractFromVueComponentMeta', () => {
+  const propInfo = (overrides: Record<string, unknown>) =>
+    ({
+      name: 'severity',
+      global: false,
+      description: '',
+      tags: [],
+      required: true,
+      ...overrides,
+    }) as any;
+
+  it('should label TS enum options with the member names they are written as', () => {
+    const argType = extractFromVueComponentMeta(
+      propInfo({
+        type: 'Severity',
+        schema: {
+          kind: 'enum',
+          type: 'Severity',
+          schema: [
+            { kind: 'literal', type: 'Severity.Info', value: '"info"' },
+            { kind: 'literal', type: 'Severity.Warning', value: '"warning"' },
+          ],
+        },
+      }),
+      'props'
+    );
+
+    expect(argType).toMatchObject({
+      type: { name: 'enum', value: ['info', 'warning'] },
+      options: ['info', 'warning'],
+      control: { labels: { info: 'Severity.Info', warning: 'Severity.Warning' } },
+      // the docs table documents the enum, not the values behind it
+      table: { type: { summary: 'Severity' } },
+    });
+  });
+
+  it('should leave a plain literal union unlabelled', () => {
+    const argType = extractFromVueComponentMeta(
+      propInfo({
+        name: 'size',
+        type: '"small" | "large"',
+        schema: { kind: 'enum', type: '"small" | "large"', schema: ['"small"', '"large"'] },
+      }),
+      'props'
+    );
+
+    expect(argType).toEqual({
+      name: 'size',
+      description: '',
+      defaultValue: undefined,
+      type: { name: 'enum', value: ['small', 'large'], required: true },
+      table: {
+        type: { summary: '"small" | "large"' },
+        defaultValue: undefined,
+        category: 'props',
+      },
+    });
   });
 });

--- a/code/renderers/vue3/src/extractArgTypes.test.ts
+++ b/code/renderers/vue3/src/extractArgTypes.test.ts
@@ -2,6 +2,7 @@ import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi, vitest } from 'vitest';
 
 import { extractComponentProps, hasDocgen } from 'storybook/internal/docs-tools';
+import { inferControls } from 'storybook/internal/preview-api';
 
 import {
   mockExtractComponentEventsReturn,
@@ -254,6 +255,38 @@ describe('extractFromVueComponentMeta', () => {
       control: { labels: { info: 'Severity.Info', warning: 'Severity.Warning' } },
       // the docs table documents the enum, not the values behind it
       table: { type: { summary: 'Severity' } },
+    });
+  });
+
+  it('should hand Controls a labelled option set once inferControls has run', () => {
+    // the labels are only useful if they survive next to the control type inferControls picks,
+    // which is what lets a TS enum reach the same radio/select treatment as a literal union
+    const argType = extractFromVueComponentMeta(
+      propInfo({
+        type: 'Severity',
+        schema: {
+          kind: 'enum',
+          type: 'Severity',
+          schema: [
+            { kind: 'literal', type: 'Severity.Info', value: '"info"' },
+            { kind: 'literal', type: 'Severity.Warning', value: '"warning"' },
+          ],
+        },
+      }),
+      'props'
+    );
+
+    const inferred = inferControls({
+      argTypes: { severity: argType } as any,
+      parameters: { __isArgsStory: true } as any,
+    });
+
+    expect(inferred.severity).toMatchObject({
+      control: {
+        type: 'radio',
+        labels: { info: 'Severity.Info', warning: 'Severity.Warning' },
+      },
+      options: ['info', 'warning'],
     });
   });
 

--- a/code/renderers/vue3/src/extractArgTypes.test.ts
+++ b/code/renderers/vue3/src/extractArgTypes.test.ts
@@ -28,7 +28,11 @@ vitest.mock('storybook/internal/docs-tools', async (importOriginal) => {
   };
 });
 
-describe('extractArgTypes (vue-docgen-api)', () => {
+// referenceTypeProps/Events and templateSlots are vue-component-meta fixtures. This block used
+// to be named after the other engine, which put its snapshots in the same namespace as the real
+// vue-docgen-api block below - both spell "should extract props for component", so the two
+// engines' props snapshots were told apart only by a trailing 1/2.
+describe('extractArgTypes (vue-component-meta)', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });

--- a/code/renderers/vue3/src/extractArgTypes.ts
+++ b/code/renderers/vue3/src/extractArgTypes.ts
@@ -165,12 +165,20 @@ export const extractFromVueComponentMeta = (
   if (section === 'props') {
     const propInfo = docgenInfo as VueDocgenInfoEntry<'vue-component-meta', 'props'>;
     const defaultValue = propInfo.default ? { summary: propInfo.default } : undefined;
+    const type = convertVueComponentMetaProp(propInfo);
+    const enumLabels = getEnumMemberLabels(propInfo.schema);
 
     return {
       name: propInfo.name,
       description: formatDescriptionWithTags(propInfo.description, propInfo.tags),
       defaultValue,
-      type: convertVueComponentMetaProp(propInfo),
+      type,
+      // A TS enum member is selected by its runtime value, so the qualified name it is written
+      // as can only be a label. "control.type" is left to inferControls, which picks radio or
+      // select by option count just like it does for a plain literal union.
+      ...(enumLabels && type.name === 'enum'
+        ? { options: type.value, control: { labels: enumLabels } }
+        : {}),
       table: {
         type: tableType,
         defaultValue,
@@ -214,16 +222,14 @@ export const convertVueComponentMetaProp = (
         return { name: 'boolean', required };
       }
 
-      if (isLiteralUnionSchema(definedSchemas)) {
-        // remove quotes from literals
-        const literals = definedSchemas.map((literal) => literal.replace(/"/g, ''));
-        return { name: 'enum', value: literals, required };
+      if (isSelectableUnionSchema(definedSchemas)) {
+        return { name: 'enum', value: definedSchemas.map(selectableValue), required };
       }
 
-      // TS enum members arrive as reference strings ("MyEnum.Foo") without their runtime
-      // values, and an enum sbType would make Controls inject those names verbatim
-      // (the string "MyEnum.Foo" instead of the member's value). Keep the type documented
-      // via the table but not selectable until the values are available.
+      // Some unresolved type references stringify with a dot ("typeof Config.alpha") without
+      // standing for any value, and an enum sbType would make Controls inject that name
+      // verbatim. Keep them documented via the table but not selectable. TS enum members no
+      // longer reach this branch - they arrive as "literal" schemas carrying their value.
       if (isEnumSchema(definedSchemas)) {
         return fallbackSbType;
       }
@@ -332,20 +338,54 @@ const formatDescriptionWithTags = (
 };
 
 /**
- * Checks whether the given schemas are all literal union schemas.
+ * A TS enum member. It stringifies to its qualified name ("Severity.Info"), which says nothing
+ * about what gets passed to the component, so vue-component-meta carries the runtime value it
+ * stands for alongside - JSON-encoded, as `"info"` or `0`.
  *
- * @example Foo | "bar" | "baz"
+ * @see https://github.com/vuejs/language-tools/pull/6131 (vue-component-meta >= 3.3.9)
  */
-const isLiteralUnionSchema = (schemas: PropertyMetaSchema[]): schemas is `"${string}"`[] => {
-  return schemas.every(
-    (schema) => typeof schema === 'string' && schema.startsWith('"') && schema.endsWith('"')
-  );
+type LiteralSchema = Extract<PropertyMetaSchema, { kind: 'literal' }>;
+
+const isLiteralSchema = (schema: PropertyMetaSchema): schema is LiteralSchema =>
+  typeof schema === 'object' && schema.kind === 'literal';
+
+/** A quoted string literal, e.g. `"bar"` from `Foo | "bar" | "baz"`. */
+const isQuotedLiteral = (schema: PropertyMetaSchema): schema is `"${string}"` =>
+  typeof schema === 'string' && schema.startsWith('"') && schema.endsWith('"');
+
+type SelectableSchema = `"${string}"` | LiteralSchema;
+
+/**
+ * Checks whether every schema stands for one concrete value, which is what makes the union
+ * offerable as a set of Controls options. Both string literals and TS enum members qualify, and
+ * they can mix (`Severity | "custom"`).
+ */
+const isSelectableUnionSchema = (schemas: PropertyMetaSchema[]): schemas is SelectableSchema[] =>
+  schemas.every((schema) => isQuotedLiteral(schema) || isLiteralSchema(schema));
+
+/** The runtime value a selectable schema stands for. */
+const selectableValue = (schema: SelectableSchema): string | number =>
+  isLiteralSchema(schema) ? JSON.parse(schema.value) : schema.replace(/"/g, '');
+
+/**
+ * Maps each TS enum member's runtime value to the qualified name it is written as, so Controls
+ * can label the option `Severity.Info` while passing `'info'` to the component. Returns undefined
+ * when the schema holds no enum members, which is every plain literal union.
+ */
+const getEnumMemberLabels = (schema: PropertyMetaSchema): Record<string, string> | undefined => {
+  if (typeof schema !== 'object' || schema.kind !== 'enum') {
+    return undefined;
+  }
+  const members = (schema.schema ?? []).filter(isLiteralSchema);
+  return members.length
+    ? Object.fromEntries(members.map((member) => [selectableValue(member), member.type]))
+    : undefined;
 };
 
 /**
- * Checks whether the given schemas are all enums.
+ * Checks whether the given schemas are all qualified type names.
  *
- * @example MyEnum.Foo, MyEnum.Bar
+ * @example MyNamespace.Foo, MyNamespace.Bar
  */
 const isEnumSchema = (schemas: PropertyMetaSchema[]): schemas is string[] => {
   return schemas.every((schema) => typeof schema === 'string' && schema.includes('.'));

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/TsEnumProps.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/TsEnumProps.stories.ts
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import Component from './ts-enum-props/component.vue';
+import { Severity } from './ts-enum-props/severity';
+
+const meta = {
+  component: Component,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Component>;
+
+type Story = StoryObj<typeof meta>;
+export default meta;
+
+/**
+ * Under the "vue-component-meta" docgen plugin, the enum-backed props get a Controls dropdown
+ * listing the member names (Severity.Info, Level.Low) while setting the runtime values they
+ * stand for ('info', 0). The literal-union prop next to them is the unlabelled comparison.
+ */
+export const TsEnumProps: Story = {
+  args: {
+    severity: Severity.Warning,
+    level: 1,
+    size: 'medium',
+  },
+};

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/ts-enum-props/component.vue
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/ts-enum-props/component.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { Severity } from './severity';
+
+/** Locally declared numeric enum, to cover the member values that are not strings. */
+enum Level {
+  Low,
+  High,
+}
+
+defineProps<{
+  /** Alert severity, an imported string enum. */
+  severity: Severity;
+  /** Priority, a locally declared numeric enum. */
+  level?: Level;
+  /** A plain literal union, for comparison with the enum-backed props above. */
+  size?: 'small' | 'medium' | 'large';
+}>();
+</script>
+
+<template>
+  <div :class="`severity-${severity}`">
+    <span>severity: {{ severity }}</span>
+    <span>level: {{ level }}</span>
+    <span>size: {{ size }}</span>
+  </div>
+</template>

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/ts-enum-props/severity.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/ts-enum-props/severity.ts
@@ -1,0 +1,5 @@
+export enum Severity {
+  Info = 'info',
+  Warning = 'warning',
+  Error = 'error',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12186,7 +12186,7 @@ __metadata:
     rxjs: "npm:^7.4.0"
     typescript: "npm:^6.0.3"
     vue: "npm:^3.2.47"
-    vue-component-meta: "npm:^3.2.7"
+    vue-component-meta: "npm:^3.3.9"
     vue-docgen-api: "npm:^4.75.1"
     vue-tsc: "npm:latest"
     zone.js: "npm:^0.16.2"
@@ -12890,7 +12890,7 @@ __metadata:
     magic-string: "npm:^1.1.0"
     typescript: "npm:^6.0.3"
     vite: "npm:^7.0.4"
-    vue-component-meta: "npm:^3.2.7"
+    vue-component-meta: "npm:^3.3.9"
     vue-docgen-api: "npm:^4.75.1"
   peerDependencies:
     storybook: "workspace:^"
@@ -16361,21 +16361,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/language-core@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@vue/language-core@npm:3.3.2"
-  dependencies:
-    "@volar/language-core": "npm:2.4.28"
-    "@vue/compiler-dom": "npm:^3.5.0"
-    "@vue/shared": "npm:^3.5.0"
-    alien-signals: "npm:^3.2.0"
-    muggle-string: "npm:^0.4.1"
-    path-browserify: "npm:^1.0.1"
-    picomatch: "npm:^4.0.4"
-  checksum: 10c0/f80870a9383c8721b50281e54c5b9f3513d082e71fb6654c7da11de07b2dafa666c0bdadabee559f5284fcd44825ba2064c148fd22f230f3e6646debb5a69fbe
-  languageName: node
-  linkType: hard
-
 "@vue/language-core@npm:3.3.7":
   version: 3.3.7
   resolution: "@vue/language-core@npm:3.3.7"
@@ -16388,6 +16373,21 @@ __metadata:
     path-browserify: "npm:^1.0.1"
     picomatch: "npm:^4.0.4"
   checksum: 10c0/9f8128c2b71f83750af69d240e898fadcbd825c9749fc7b72b1b68e5c7d231462a9482ae469dbaa66104641adb57314678cbc591bb0a931c57e53af19cf938bd
+  languageName: node
+  linkType: hard
+
+"@vue/language-core@npm:3.3.9":
+  version: 3.3.9
+  resolution: "@vue/language-core@npm:3.3.9"
+  dependencies:
+    "@volar/language-core": "npm:2.4.28"
+    "@vue/compiler-dom": "npm:^3.5.0"
+    "@vue/shared": "npm:^3.5.0"
+    alien-signals: "npm:^3.2.1"
+    muggle-string: "npm:^0.4.1"
+    path-browserify: "npm:^1.0.1"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/bff339e8ce218d32b8db7a372c1f958db52950e74bbedff527e928b68e52fad30c14e0652dc2626673a579cab15b47d8106eac0deefc7898f370da7889122bba
   languageName: node
   linkType: hard
 
@@ -16988,7 +16988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"alien-signals@npm:^3.2.0, alien-signals@npm:^3.2.1":
+"alien-signals@npm:^3.2.1":
   version: 3.2.1
   resolution: "alien-signals@npm:3.2.1"
   checksum: 10c0/4c4064faa208126177224d1ed6a2310687d452dec0771994e276d9af4c72e853fcb969ae4a7fcd034b1d1b9accb9500f4941178326eeea1cb8f64ec612853ef8
@@ -39334,19 +39334,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-component-meta@npm:^3.2.7":
-  version: 3.3.2
-  resolution: "vue-component-meta@npm:3.3.2"
+"vue-component-meta@npm:^3.3.9":
+  version: 3.3.9
+  resolution: "vue-component-meta@npm:3.3.9"
   dependencies:
     "@volar/typescript": "npm:2.4.28"
-    "@vue/language-core": "npm:3.3.2"
+    "@vue/language-core": "npm:3.3.9"
     path-browserify: "npm:^1.0.1"
   peerDependencies:
     typescript: "*"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/d78dd5c19474605e96812b6a81987c4163de29a704c3dc3ae7aaf627e9533af4e0af0db6323e0295e46d98c2146abb21912428e6f27c11051ef5876573f21d3d
+  checksum: 10c0/9164add9aa1e13dd089f2958bd926e7a6dba6cf952619e6a99281c86c7f481f6e7f17991631236e7396c52df7994fa69b5ca69ee5becc13ae81040511256dc86
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

Closes the TS-enum gap that #35565 had to leave open.

`vue-component-meta` stringifies a TypeScript enum member to its *qualified name* (`Severity.Info`), which says nothing about the value the component actually receives. That is why #35565, when it enabled `schema: true`, had to explicitly keep TS enums **out** of Controls ([86a1ea5](https://github.com/storybookjs/storybook/pull/35565/commits/86a1ea5b4b4ca51a1a66771ea8e89cc2c9b43ca6)): an `enum` sbType would have rendered a dropdown that injects the literal string `"Severity.Info"` instead of `'info'`.

[vuejs/language-tools#6131](https://github.com/vuejs/language-tools/pull/6131) - merged and released in `vue-component-meta@3.3.9` - adds a `literal` schema node that carries the runtime value alongside the member name:

```ts
{ kind: 'enum', type: 'Severity', schema: [
  { kind: 'literal', type: 'Severity.Info',    value: '"info"' },
  { kind: 'literal', type: 'Severity.Warning', value: '"warning"' },
] }
```

This PR bumps to `^3.3.9` and consumes it.

### Before / after

```ts
// enum Severity { Info = 'info', Warning = 'warning', Error = 'error' }
// props: { severity: Severity }

// before (#35565): documented, but not selectable
{ type: { name: 'other', value: 'Severity' } }

// after
{
  type:    { name: 'enum', value: ['info', 'warning', 'error'], required: true },
  options: ['info', 'warning', 'error'],
  control: { labels: { info: 'Severity.Info', warning: 'Severity.Warning', error: 'Severity.Error' } },
  table:   { type: { summary: 'Severity' } },
}
```

The dropdown shows `Severity.Info` and passes `'info'`. Numeric enums (`enum Level { Low, High }`) pass `0` and `1` under the labels `Level.Low` / `Level.High`. `table.type.summary` keeps the enum name in both cases, so the docs table is unchanged.

### Notes on the implementation

- **`control.type` is deliberately not set.** `inferControls` already picks `radio` vs `select` by option count, and `combineParameters` merges it with the `labels` set here. TS enums therefore behave exactly like plain literal unions instead of being force-fed a `select`.
- **Mixed unions work**: `Severity | 'custom'` resolves to `['info', 'warning', 'error', 'custom']`, with labels only on the enum members.
- **The dotted-string guard stays**, narrowed to what it actually catches now. I verified against 3.3.9 that unresolved qualified type names can still produce all-dotted schemas (`typeof Config.alpha | typeof Config.beta`) - those carry no value and must not become selectable. TS enum members no longer reach that branch.
- `removeNestedSchemas` in the vite plugin gained an explicit terminal case for `literal` nodes (they have nothing nested, and the previous `delete schema.schema` no longer type-checks against the widened `PropertyMetaSchema`).
- The `MyEnum` fixture in `meta-components.ts` was a hand-maintained capture of checker output still in the pre-3.3.9 shape; it is updated so the mock matches what the dependency now produces.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Unit tests in `code/renderers/vue3/src/extractArgTypes.test.ts` cover string enums, numeric enums, mixed enum/literal unions, the qualified-name guard, and the `options` + `control.labels` output. The docgen harness (#35574) re-records `props-ts-enum` and shows the change as a reviewed baseline diff - it is the only fixture that moves, and the harness comparator certifies it as an improvement rather than a regression.

#### Manual testing

1. `yarn task sandbox --template vue3-vite/default-ts --start-from auto`
2. Set `docgen: 'vue-component-meta'` in the framework options
3. Add a component with a TS enum prop and open its Controls panel: the dropdown lists the member names and sets the member values.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below: `bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gvCXfY6v5hGRDVNL11JXS
