### PR TITLE
Tests: Give the portable-react e2e suite a timeout its own waits fit in

### DIFF
--- a/test-storybooks/portable-stories-kitchen-sink/react/playwright-e2e.config.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/playwright-e2e.config.ts
@@ -7,8 +7,12 @@ import path from "node:path";
 export default defineConfig({
   testDir: "./e2e-tests",
   outputDir: "./test-results",
-  /* Maximum time one test can run for. */
-  timeout: (process.env.CI ? 60 : 30) * 1000,
+  /* Maximum time one test can run for. It caps the sum of a test's own waits, so it has to
+   * clear the longest chain any test declares - today 90s in component-testing.spec.ts, which
+   * waits up to 30s for a story to render and then up to 60s for its test results. At 60s
+   * those tests could time out while still making progress, which is how the coverage case
+   * kept flaking. Passing runs are unaffected; Playwright only spends what a test needs. */
+  timeout: (process.env.CI ? 120 : 30) * 1000,
   /* Run tests in files in parallel */
   fullyParallel: false,
 


### PR DESCRIPTION
## What I did

`test-storybooks-portable-react` fails intermittently, most often on `component testing › should collect coverage to testing module and HTML report`. It is not bad luck - the test's declared waits do not fit in the budget that caps them.

`playwright-e2e.config.ts` sets `timeout: 60s` on CI with `retries: 0`. The per-test timeout is an upper bound on the *sum* of a test's own waits, and `component-testing.spec.ts` routinely declares more than that:

| test | declared waits |
| --- | --- |
| `should show test results in the testing module` | 30s (story visible) + 60s (`Ran N tests`) = **90s** |
| `should collect coverage to testing module and HTML report` | 30s (story visible) + 2s (Vitest restart) + 30s (coverage report) = **62s** |

So a test can exhaust its budget while every individual assertion is still inside its own timeout and still making progress. The coverage case is the one that trips most often, because restarting Vitest with coverage instrumentation is the slowest step in the suite.

The file's history shows this creeping in: assertion timeouts were raised over several "attempt to fix flake" / "Fix a few flakes" commits, and the comments say so (`// For whatever reason, sometimes it takes longer for the story to load`, `// ...that causes flake`), but the test timeout capping them was never raised to match.

Raise the CI budget to 120s so it clears the longest declared chain with headroom. **Passing runs do not get slower** - a Playwright timeout is a ceiling, not a delay, so a test that finishes in 20s still finishes in 20s. `retries: 0` is deliberately left alone; retries would mask real failures, and this change fixes the arithmetic instead of hiding it.

Most recent occurrence: https://circleci.com/gh/storybookjs/storybook/1814985 (on #35574, a Vue docgen-harness PR that touches nothing this suite exercises).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

This changes the e2e suite's own configuration; the suite itself is the test.

#### Manual testing

No behavior change to Storybook - CI configuration for a test-only project.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below: `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gvCXfY6v5hGRDVNL11JXS
