### PR TITLE
Core: Add lazy-docgen-middleware

### DIFF
--- a/code/core/src/common/index.ts
+++ b/code/core/src/common/index.ts
@@ -42,6 +42,7 @@ export * from './utils/formatter.ts';
 export * from './utils/get-story-id.ts';
 export * from './utils/component-id.ts';
 export * from './utils/select-component-entry.ts';
+export * from './utils/lazy-docgen-middleware.ts';
 export * from './utils/posix.ts';
 export * from './utils/sync-main-preview-addons.ts';
 export * from './utils/setup-addon-in-config.ts';

--- a/code/core/src/common/utils/lazy-docgen-middleware.ts
+++ b/code/core/src/common/utils/lazy-docgen-middleware.ts
@@ -1,0 +1,50 @@
+import type {
+  DocgenMiddleware,
+  DocgenPayload,
+  DocgenProvider,
+  DocgenProviderInput,
+} from '../../shared/open-service/services/docgen/types.ts';
+import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from './select-component-entry.ts';
+
+export interface LazyDocgenMiddlewareOptions<TManager> {
+  /**
+   * Builds the renderer's extraction manager.
+   * Called once, lazily, on the first eligible request and memoized for the worker's lifetime.
+   * Return `undefined` to permanently pass through to the rest of the chain.
+   */
+  createManager: () => Promise<TManager | undefined>;
+  /**
+   * Extracts one payload
+   * Returns `undefined` to delegate the request downstream
+   */
+  extract: (manager: TManager, input: DocgenProviderInput) => Promise<DocgenPayload | undefined>;
+}
+
+export function createLazyDocgenMiddleware<TManager>({
+  createManager,
+  extract,
+}: LazyDocgenMiddlewareOptions<TManager>): DocgenMiddleware {
+  let managerPromise: Promise<TManager | undefined> | undefined;
+  const getManager = () => (managerPromise ??= createManager());
+
+  return (nextDocgen: DocgenProvider): DocgenProvider =>
+    async (input) => {
+      const storyImportPath = getStoryImportPathFromEntry(input.entry);
+      if (!storyImportPath || !STORY_FILE_TEST_REGEXP.test(storyImportPath)) {
+        return nextDocgen(input);
+      }
+
+      const manager = await getManager();
+      if (!manager) {
+        return nextDocgen(input);
+      }
+
+      const ours = await extract(manager, input);
+      if (!ours) {
+        return nextDocgen(input);
+      }
+
+      const downstream = await nextDocgen(input);
+      return { ...downstream, ...ours };
+    };
+}

--- a/code/renderers/react/src/docgen/docgen-worker.ts
+++ b/code/renderers/react/src/docgen/docgen-worker.ts
@@ -13,8 +13,8 @@
  * docgen-relevant TS option (`reactDocgenTypescriptOptions`, including `propFilter`) applies solely
  * to the `react-docgen-typescript` engine used by the legacy manifest path — not here.
  */
-import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
-import type { DocgenMiddleware, DocgenProvider } from 'storybook/internal/types';
+import { createLazyDocgenMiddleware } from 'storybook/internal/common';
+import type { DocgenMiddleware } from 'storybook/internal/types';
 
 import { ComponentMetaManager } from '../componentManifest/componentMeta/ComponentMetaManager.ts';
 import { buildDocgenPayload } from './buildDocgen.ts';
@@ -25,41 +25,15 @@ import { buildDocgenPayload } from './buildDocgen.ts';
  * created lazily on the first eligible request and memoized; when TypeScript is unavailable the
  * middleware passes through to the rest of the chain.
  */
-export const createDocgenProvider = (): DocgenMiddleware => {
-  let managerPromise: Promise<ComponentMetaManager | undefined> | undefined;
-
-  const getManager = (): Promise<ComponentMetaManager | undefined> => {
-    if (!managerPromise) {
-      managerPromise = (async () => {
-        try {
-          const ts = await import('typescript');
-          return new ComponentMetaManager(ts);
-        } catch {
-          return undefined;
-        }
-      })();
-    }
-    return managerPromise;
-  };
-
-  return (nextDocgen: DocgenProvider): DocgenProvider =>
-    async (input) => {
-      const storyImportPath = getStoryImportPathFromEntry(input.entry);
-      if (!storyImportPath || !STORY_FILE_TEST_REGEXP.test(storyImportPath)) {
-        return nextDocgen(input);
+export const createDocgenProvider = (): DocgenMiddleware =>
+  createLazyDocgenMiddleware({
+    createManager: async () => {
+      try {
+        const ts = await import('typescript');
+        return new ComponentMetaManager(ts);
+      } catch {
+        return undefined;
       }
-
-      const componentMetaManager = await getManager();
-      if (!componentMetaManager) {
-        return nextDocgen(input);
-      }
-
-      const ours = await buildDocgenPayload(input, { componentMetaManager });
-      if (!ours) {
-        return nextDocgen(input);
-      }
-
-      const downstream = await nextDocgen(input);
-      return { ...downstream, ...ours };
-    };
-};
+    },
+    extract: (componentMetaManager, input) => buildDocgenPayload(input, { componentMetaManager }),
+  });

--- a/code/renderers/vue3/src/docgen/docgen-worker.ts
+++ b/code/renderers/vue3/src/docgen/docgen-worker.ts
@@ -9,9 +9,9 @@
  * The framework contributes the descriptor that points here; nothing in this module is bundler
  * specific, so it sits with the rest of the Vue docgen code in the renderer.
  */
-import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
+import { createLazyDocgenMiddleware } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
-import type { DocgenMiddleware, DocgenProvider } from 'storybook/internal/types';
+import type { DocgenMiddleware } from 'storybook/internal/types';
 
 import { buildDocgenPayload } from './build-docgen.ts';
 import { VueComponentMetaManager } from './vue-project-manager.ts';
@@ -23,11 +23,9 @@ import { VueComponentMetaManager } from './vue-project-manager.ts';
  * manager is created lazily on the first eligible request and memoized; when it cannot be created
  * the middleware passes through to the rest of the chain.
  */
-export const createDocgenProvider = (): DocgenMiddleware => {
-  let managerPromise: Promise<VueComponentMetaManager | undefined>;
-
-  const getManager = () => {
-    managerPromise ??= (async () => {
+export const createDocgenProvider = (): DocgenMiddleware =>
+  createLazyDocgenMiddleware({
+    createManager: async () => {
       try {
         const typescript = await import('typescript');
         const manager = new VueComponentMetaManager(typescript.default ?? typescript);
@@ -41,33 +39,14 @@ export const createDocgenProvider = (): DocgenMiddleware => {
         );
         return undefined;
       }
-    })();
-    return managerPromise;
-  };
-
-  return (nextDocgen: DocgenProvider): DocgenProvider =>
-    async (input) => {
-      const storyImportPath = getStoryImportPathFromEntry(input.entry);
-      if (!storyImportPath || !STORY_FILE_TEST_REGEXP.test(storyImportPath)) {
-        return nextDocgen(input);
-      }
-
-      const manager = await getManager();
-      if (!manager) {
-        return nextDocgen(input);
-      }
-
+    },
+    extract: async (manager, input) => {
       const ours = await buildDocgenPayload(input, {
         getChecker: (componentPath) => manager.getCheckerForFile(componentPath),
       });
       // Volar programs hold large type caches; check heap pressure after each extraction since Vue
       // has no batch surface to hang this on.
       manager.recycleIfHeapPressured();
-      if (!ours) {
-        return nextDocgen(input);
-      }
-
-      const downstream = await nextDocgen(input);
-      return { ...downstream, ...ours };
-    };
-};
+      return ours;
+    },
+  });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

this PR extracts the provider-middleware skeleton duplicated between the React and Vue docgen workers into core as createLazyDocgenMiddleware 

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

---

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
