### PR TITLE
MCP: make addon-mcp aware of SB basePath

### DIFF
--- a/code/addons/mcp/src/auth/composition-auth.ts
+++ b/code/addons/mcp/src/auth/composition-auth.ts
@@ -119,18 +119,18 @@ export class CompositionAuth {
   }
 
   /** Build .well-known/oauth-protected-resource response. */
-  buildWellKnown(origin: string): object | null {
+  buildWellKnown(baseUrl: string): object | null {
     if (!this.#authRequirement) return null;
     return {
-      resource: `${origin}/mcp`,
+      resource: `${baseUrl}/mcp`,
       authorization_servers: this.#authRequirement.resourceMetadata.authorization_servers,
       scopes_supported: this.#authRequirement.resourceMetadata.scopes_supported,
     };
   }
 
   /** Build WWW-Authenticate header for 401 responses */
-  buildWwwAuthenticate(origin: string): string {
-    return `Bearer error="unauthorized", error_description="Authorization needed for composed Storybooks", resource_metadata="${origin}/.well-known/oauth-protected-resource"`;
+  buildWwwAuthenticate(baseUrl: string): string {
+    return `Bearer error="unauthorized", error_description="Authorization needed for composed Storybooks", resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`;
   }
 
   /** Build sources configuration: local first, then refs that have manifests. */

--- a/code/addons/mcp/src/mcp-handler.ts
+++ b/code/addons/mcp/src/mcp-handler.ts
@@ -1,27 +1,29 @@
-import { McpServer } from 'tmcp';
+import type { Source } from '@storybook/mcp';
 import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
 import { HttpTransport } from '@tmcp/transport-http';
-import pkgJson from '../package.json' with { type: 'json' };
-import type { Source } from '@storybook/mcp';
-import type { Options } from 'storybook/internal/types';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { buffer } from 'node:stream/consumers';
-import { collectTelemetry } from './telemetry.ts';
-import type { AddonContext, AddonOptionsOutput } from './types.ts';
 import { logger } from 'storybook/internal/node-logger';
+import type { Options } from 'storybook/internal/types';
+import { McpServer } from 'tmcp';
+import pkgJson from '../package.json' with { type: 'json' };
+import type { CompositionAuth } from './auth/index.ts';
+import { DEFAULT_MCP_ENDPOINT, STORYBOOK_MCP_PROXY_HEADER } from './constants.ts';
+import { buildServerInstructions } from './instructions/build-server-instructions.ts';
+import type { DocgenServerManifestAccess } from './manifests/in-process-provider.ts';
+import { collectTelemetry } from './telemetry.ts';
+import { registerAddonMcpTools } from './tools/tool-registry.ts';
+import type { AddonContext, AddonOptionsOutput } from './types.ts';
+import { resolveBaseUrl } from './utils/base-url.ts';
+import { estimateTokens } from './utils/estimate-tokens.ts';
 import {
   getEffectiveToolAvailability,
   getToolAvailability,
 } from './utils/get-tool-availability.ts';
-import { estimateTokens } from './utils/estimate-tokens.ts';
-import type { CompositionAuth } from './auth/index.ts';
-import { buildServerInstructions } from './instructions/build-server-instructions.ts';
-import { DEFAULT_MCP_ENDPOINT, STORYBOOK_MCP_PROXY_HEADER } from './constants.ts';
-import { registerAddonMcpTools } from './tools/tool-registry.ts';
-import type { DocgenServerManifestAccess } from './manifests/in-process-provider.ts';
 
 let transport: HttpTransport<AddonContext> | undefined;
 let origin: string | undefined;
+let basePath: string | undefined;
 // Promise that ensures single initialization, even with concurrent requests
 let initialize: Promise<McpServer<any, AddonContext>> | undefined;
 let disableTelemetry: boolean | undefined;
@@ -86,7 +88,8 @@ const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
   transport = new HttpTransport(server, { path: null });
 
   origin = `http://localhost:${options.port}`;
-  logger.debug(`MCP server origin: ${origin}`);
+  basePath = options.basePath;
+  logger.debug(`MCP server base URL: ${resolveBaseUrl({ origin, basePath })}`);
   return server;
 };
 
@@ -153,6 +156,7 @@ export const mcpServerHandler = async ({
     toolsets: getToolsets(webRequest, addonOptions),
     reviewEnabled: isReviewEnabledForRequest(webRequest, reviewGates!),
     origin: origin!,
+    basePath,
     disableTelemetry: disableTelemetry!,
     a11yEnabled,
     request: webRequest,
@@ -197,7 +201,9 @@ export const mcpServerHandler = async ({
           status: 401,
           headers: {
             'Content-Type': 'text/plain',
-            'WWW-Authenticate': compositionAuth.buildWwwAuthenticate(origin!),
+            'WWW-Authenticate': compositionAuth.buildWwwAuthenticate(
+              resolveBaseUrl({ origin: origin!, basePath })
+            ),
           },
         })
       : new Response(body, { status: response.status, headers: response.headers });

--- a/code/addons/mcp/src/preset.test.ts
+++ b/code/addons/mcp/src/preset.test.ts
@@ -269,6 +269,29 @@ describe('experimental_devServer', () => {
     );
   });
 
+  it('should advertise the basePath-prefixed resource metadata in the OAuth challenge', async () => {
+    vi.spyOn(mcpHandlerModule, 'mcpServerHandler').mockResolvedValue(undefined);
+    stubPrivateRefDiscovery();
+
+    await (experimental_devServer as any)(mockApp, {
+      ...createOptionsWithPrivateRef(),
+      port: 5173,
+      basePath: '/__storybook/',
+    } as unknown as Options);
+
+    const mockRes = { writeHead: vi.fn(), end: vi.fn() } as any;
+    await mcpHandler({ headers: {} }, mockRes);
+
+    expect(mockRes.writeHead).toHaveBeenCalledWith(
+      401,
+      expect.objectContaining({
+        'WWW-Authenticate': expect.stringContaining(
+          'resource_metadata="http://localhost:5173/__storybook/.well-known/oauth-protected-resource"'
+        ),
+      })
+    );
+  });
+
   it('should keep direct unauthenticated requests on the OAuth challenge path', async () => {
     const mcpServerHandler = vi
       .spyOn(mcpHandlerModule, 'mcpServerHandler')

--- a/code/addons/mcp/src/preset.ts
+++ b/code/addons/mcp/src/preset.ts
@@ -1,20 +1,21 @@
-import { mcpServerHandler } from './mcp-handler.ts';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import path from 'node:path';
+import { logger } from 'storybook/internal/node-logger';
 import type { PresetPropertyFn, StorybookConfigRaw } from 'storybook/internal/types';
-import { AddonOptions, type AddonOptionsInput } from './types.ts';
 import * as v from 'valibot';
+import { extractBearerToken, type ManifestProvider } from './auth/index.ts';
+import { resolveCompositionSources } from './auth/resolve-composition-sources.ts';
+import { DEFAULT_MCP_ENDPOINT } from './constants.ts';
+import { createDocgenServerManifestAccess } from './manifests/in-process-provider.ts';
+import { mcpServerHandler } from './mcp-handler.ts';
+import { buildStorybookAiMetadata, type StorybookAiMetadata } from './storybook-ai-metadata.ts';
+import htmlTemplate from './template.html';
+import { AddonOptions, type AddonOptionsInput } from './types.ts';
+import { resolveBaseUrl } from './utils/base-url.ts';
 import {
   getEffectiveToolAvailability,
   getToolAvailability,
 } from './utils/get-tool-availability.ts';
-import htmlTemplate from './template.html';
-import path from 'node:path';
-import { extractBearerToken, type ManifestProvider } from './auth/index.ts';
-import { resolveCompositionSources } from './auth/resolve-composition-sources.ts';
-import { logger } from 'storybook/internal/node-logger';
-import type { IncomingMessage, ServerResponse } from 'node:http';
-import { DEFAULT_MCP_ENDPOINT } from './constants.ts';
-import { buildStorybookAiMetadata, type StorybookAiMetadata } from './storybook-ai-metadata.ts';
-import { createDocgenServerManifestAccess } from './manifests/in-process-provider.ts';
 
 export const previewAnnotations: PresetPropertyFn<'previewAnnotations'> = async (
   existingAnnotations = []
@@ -35,6 +36,8 @@ export const experimental_devServer: PresetPropertyFn<
   });
 
   const origin = `http://localhost:${options.port}`;
+  const basePath = options.basePath ?? '/';
+  const baseUrl = resolveBaseUrl({ origin, basePath });
   const endpoint = addonOptions.endpoint ?? DEFAULT_MCP_ENDPOINT;
 
   const { refs, compositionAuth, sources, multiSource } = await resolveCompositionSources(options);
@@ -79,7 +82,7 @@ export const experimental_devServer: PresetPropertyFn<
 
   // Serve .well-known/oauth-protected-resource for MCP auth
   app!.get('/.well-known/oauth-protected-resource', (_req, res) => {
-    const wellKnown = compositionAuth.buildWellKnown(origin);
+    const wellKnown = compositionAuth.buildWellKnown(baseUrl);
     if (!wellKnown) {
       res.writeHead(404);
       res.end('Not found');
@@ -95,7 +98,7 @@ export const experimental_devServer: PresetPropertyFn<
     if (compositionAuth.requiresAuth && !token) {
       res.writeHead(401, {
         'Content-Type': 'text/plain',
-        'WWW-Authenticate': compositionAuth.buildWwwAuthenticate(origin),
+        'WWW-Authenticate': compositionAuth.buildWwwAuthenticate(baseUrl),
       });
       res.end('401 - Unauthorized');
       return true;
@@ -222,7 +225,7 @@ export const experimental_devServer: PresetPropertyFn<
       .replace(
         '{{MANIFEST_DEBUGGER_LINK}}',
         rawAvailability.docsEnabled
-          ? '<p>View the <a href="/manifests/components.html">component manifest debugger</a>.</p>'
+          ? `<p>View the <a href="${basePath}manifests/components.html">component manifest debugger</a>.</p>`
           : ''
       )
       .replace('{{A11Y_BADGE}}', a11yBadge);

--- a/code/addons/mcp/src/tools/display-review.test.ts
+++ b/code/addons/mcp/src/tools/display-review.test.ts
@@ -87,6 +87,22 @@ describe('buildReviewUrl', () => {
     ).toBe('http://localhost:6006/storybook/?path=/review/');
   });
 
+  it('includes the basePath Storybook is served from', () => {
+    expect(buildReviewUrl({ origin: 'http://localhost:5173', basePath: '/__storybook/' })).toBe(
+      'http://localhost:5173/__storybook/?path=/review/'
+    );
+  });
+
+  it('prefers the configured basePath over a request whose prefix was stripped by the proxy', () => {
+    expect(
+      buildReviewUrl({
+        origin: 'http://localhost:5173',
+        basePath: '/__storybook/',
+        request: new Request('http://127.0.0.1:41234/mcp'),
+      })
+    ).toBe('http://localhost:5173/__storybook/?path=/review/');
+  });
+
   it('strips a multi-segment endpoint with a trailing slash on the request', () => {
     expect(
       buildReviewUrl({

--- a/code/addons/mcp/src/tools/display-review.test.ts
+++ b/code/addons/mcp/src/tools/display-review.test.ts
@@ -204,6 +204,22 @@ describe('displayReviewTool', () => {
     expect(result?.content?.[0]?.text).toContain('http://localhost:6006/?path=/review/');
   });
 
+  it('uses the same proxied root for the review URL and the running-at message', async () => {
+    const response = await callTool(
+      sampleReview,
+      makeContext({ request: new Request('https://example.com/storybook/mcp') })
+    );
+    const result = getResult(response);
+
+    expect(result?.isError).toBeFalsy();
+    expect(result?.structuredContent?.reviewUrl).toBe(
+      'http://localhost:6006/storybook/?path=/review/'
+    );
+    expect(result?.content?.[0]?.text).toContain(
+      'already running at http://localhost:6006/storybook'
+    );
+  });
+
   it('uses singular nouns for a single collection and story', async () => {
     const response = await callTool(
       {

--- a/code/addons/mcp/src/tools/display-review.ts
+++ b/code/addons/mcp/src/tools/display-review.ts
@@ -117,7 +117,8 @@ function storybookRootFromRequest(
   }
 }
 
-export function buildReviewUrl(ctx: {
+/** The URL the local Storybook UI is reachable at, without a trailing slash. */
+export function resolveStorybookRoot(ctx: {
   origin: string;
   basePath?: string;
   request?: Request;
@@ -141,7 +142,11 @@ export function buildReviewUrl(ctx: {
           )) ||
         trustedOrigin
       : resolveBaseUrl({ origin: trustedOrigin, basePath });
-  return `${root.replace(/\/$/, '')}/?path=${REVIEW_PAGE_PATH}`;
+  return root.replace(/\/$/, '');
+}
+
+export function buildReviewUrl(ctx: Parameters<typeof resolveStorybookRoot>[0]): string {
+  return `${resolveStorybookRoot(ctx)}/?path=${REVIEW_PAGE_PATH}`;
 }
 
 export function getDisplayReviewToolMetadata() {
@@ -220,12 +225,13 @@ export async function addDisplayReviewTool(
           throw new Error(formatUnknownStoryIdsError(unknownIds));
         }
 
-        const reviewUrl = buildReviewUrl({
+        const storybookRoot = resolveStorybookRoot({
           origin: customContext.origin,
           basePath: customContext.basePath,
           request: customContext.request,
           endpoint: customContext.endpoint,
         });
+        const reviewUrl = `${storybookRoot}/?path=${REVIEW_PAGE_PATH}`;
 
         // Hand the payload off to core-server's review channel
         server.ctx.custom?.options?.channel?.emit(PUSH_REVIEW_EVENT, input);
@@ -248,7 +254,7 @@ export async function addDisplayReviewTool(
           content: [
             {
               type: 'text' as const,
-              text: `Review applied: ${collectionCount} collection${collectionCount === 1 ? '' : 's'}, ${storyCount} stor${storyCount === 1 ? 'y' : 'ies'}. Storybook is already running at ${resolveBaseUrl({ origin: customContext.origin, basePath: customContext.basePath })} — reuse it. Do NOT start another Storybook or change its port to view this review; the running instance already serves it.
+              text: `Review applied: ${collectionCount} collection${collectionCount === 1 ? '' : 's'}, ${storyCount} stor${storyCount === 1 ? 'y' : 'ies'}. Storybook is already running at ${storybookRoot} — reuse it. Do NOT start another Storybook or change its port to view this review; the running instance already serves it.
 
 Two things you must do now, both of them:
 1. **Open ${reviewUrl} yourself in your preview browser.** If you have any browser-preview or navigate tool in this session (e.g. preview_eval or an equivalent), call it on this URL so the review opens in your preview window immediately. Don't merely print the link and stop — actually open it.

--- a/code/addons/mcp/src/tools/display-review.ts
+++ b/code/addons/mcp/src/tools/display-review.ts
@@ -8,6 +8,7 @@ import type { Options } from 'storybook/internal/types';
 import { withFriendlyErrors } from '../utils/format-validation-issues.ts';
 import { DEFAULT_MCP_ENDPOINT, PUSH_REVIEW_EVENT, REVIEW_PAGE_PATH } from '../constants.ts';
 import { DISPLAY_REVIEW_TOOL_NAME } from './tool-names.ts';
+import { resolveBaseUrl } from '../utils/base-url.ts';
 
 export const DISPLAY_REVIEW_TOOL_DESCRIPTION = `Publish a curated review to Storybook's review page for spot-checking **visual impact**. Each call replaces the single active review — call it again whenever the user iterates on the changes.
 
@@ -118,6 +119,7 @@ function storybookRootFromRequest(
 
 export function buildReviewUrl(ctx: {
   origin: string;
+  basePath?: string;
   request?: Request;
   endpoint?: string;
 }): string {
@@ -125,10 +127,20 @@ export function buildReviewUrl(ctx: {
   if (!trustedOrigin) {
     throw new Error('Cannot resolve the Storybook URL: missing trusted origin in addon context.');
   }
-  const root = ctx.request
-    ? (storybookRootFromRequest(ctx.request, trustedOrigin, ctx.endpoint ?? DEFAULT_MCP_ENDPOINT) ??
-      trustedOrigin)
-    : trustedOrigin;
+  const basePath = ctx.basePath ?? '/';
+  // A configured basePath is authoritative. The request pathname is only mined for a root when
+  // there is none, because a proxy that mounts Storybook under a basePath strips the prefix
+  // before the request lands here — mining it then yields the bare origin.
+  const root =
+    basePath === '/'
+      ? (ctx.request &&
+          storybookRootFromRequest(
+            ctx.request,
+            trustedOrigin,
+            ctx.endpoint ?? DEFAULT_MCP_ENDPOINT
+          )) ||
+        trustedOrigin
+      : resolveBaseUrl({ origin: trustedOrigin, basePath });
   return `${root.replace(/\/$/, '')}/?path=${REVIEW_PAGE_PATH}`;
 }
 
@@ -210,6 +222,7 @@ export async function addDisplayReviewTool(
 
         const reviewUrl = buildReviewUrl({
           origin: customContext.origin,
+          basePath: customContext.basePath,
           request: customContext.request,
           endpoint: customContext.endpoint,
         });
@@ -235,7 +248,7 @@ export async function addDisplayReviewTool(
           content: [
             {
               type: 'text' as const,
-              text: `Review applied: ${collectionCount} collection${collectionCount === 1 ? '' : 's'}, ${storyCount} stor${storyCount === 1 ? 'y' : 'ies'}. Storybook is already running at ${customContext.origin} — reuse it. Do NOT start another Storybook or change its port to view this review; the running instance already serves it.
+              text: `Review applied: ${collectionCount} collection${collectionCount === 1 ? '' : 's'}, ${storyCount} stor${storyCount === 1 ? 'y' : 'ies'}. Storybook is already running at ${resolveBaseUrl({ origin: customContext.origin, basePath: customContext.basePath })} — reuse it. Do NOT start another Storybook or change its port to view this review; the running instance already serves it.
 
 Two things you must do now, both of them:
 1. **Open ${reviewUrl} yourself in your preview browser.** If you have any browser-preview or navigate tool in this session (e.g. preview_eval or an equivalent), call it on this URL so the review opens in your preview window immediately. Don't merely print the link and stop — actually open it.

--- a/code/addons/mcp/src/tools/preview-stories.test.ts
+++ b/code/addons/mcp/src/tools/preview-stories.test.ts
@@ -104,6 +104,35 @@ describe('previewStoriesTool', () => {
     expect(getStoryIndexSpy).toHaveBeenCalledWith(testContext.options);
   });
 
+  it('should return story URLs under the basePath Storybook is served from', async () => {
+    const request = {
+      jsonrpc: '2.0' as const,
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: PREVIEW_STORIES_TOOL_NAME,
+        arguments: {
+          stories: [{ storyId: 'button--primary' }],
+        },
+      },
+    };
+
+    const response = await server.receive(request, {
+      sessionId: 'test-session',
+      custom: { ...testContext, origin: 'http://localhost:5173', basePath: '/__storybook/' },
+    });
+
+    expect(response.result?.structuredContent).toEqual({
+      stories: [
+        {
+          title: 'Button',
+          name: 'Primary',
+          previewUrl: 'http://localhost:5173/__storybook/?path=/story/button--primary',
+        },
+      ],
+    });
+  });
+
   it('should return story URL when input uses storyId', async () => {
     const request = {
       jsonrpc: '2.0' as const,

--- a/code/addons/mcp/src/tools/preview-stories.ts
+++ b/code/addons/mcp/src/tools/preview-stories.ts
@@ -11,6 +11,7 @@ import { StoryInput, StoryInputArray } from '../types.ts';
 import appTemplate from './preview-stories/preview-stories-app-template.html';
 import fs from 'node:fs/promises';
 import { PREVIEW_STORIES_TOOL_NAME } from './tool-names.ts';
+import { resolveBaseUrl } from '../utils/base-url.ts';
 
 export const PREVIEW_STORIES_RESOURCE_URI = `ui://${PREVIEW_STORIES_TOOL_NAME}/preview.html`;
 
@@ -138,7 +139,7 @@ export async function addPreviewStoriesTool(
     },
     async (input) => {
       try {
-        const { origin, options, disableTelemetry } = server.ctx.custom ?? {};
+        const { origin, basePath, options, disableTelemetry } = server.ctx.custom ?? {};
 
         if (!origin) {
           throw new Error('Origin is required in addon context');
@@ -146,6 +147,8 @@ export async function addPreviewStoriesTool(
         if (!options) {
           throw new Error('Storybook options are required in addon context');
         }
+
+        const baseUrl = resolveBaseUrl({ origin, basePath });
 
         const index = await getStoryIndex(options);
         const resolvedStories = findStoryIds(index, input.stories);
@@ -173,7 +176,7 @@ export async function addPreviewStoriesTool(
             continue;
           }
 
-          let previewUrl = `${origin}/?path=/story/${story.id}`;
+          let previewUrl = `${baseUrl}/?path=/story/${story.id}`;
 
           // Add props as args query param if provided
           const argsParam = buildArgsParam(story.input.props ?? {});

--- a/code/addons/mcp/src/tools/run-story-tests.test.ts
+++ b/code/addons/mcp/src/tools/run-story-tests.test.ts
@@ -569,6 +569,62 @@ describe('runStoryTestsTool', () => {
 		`);
   });
 
+  it('should point a11y inspect links at the basePath Storybook is served from', async () => {
+    const testContext = {
+      ...createTestContext(),
+      origin: 'http://localhost:5173',
+      basePath: '/__storybook/',
+    };
+
+    setupChannelResponse({
+      status: 'completed',
+      result: {
+        triggeredBy: 'external:addon-mcp',
+        config: { coverage: false, a11y: true },
+        storyIds: ['button--primary'],
+        totalTestCount: 1,
+        startedAt: Date.now(),
+        finishedAt: Date.now(),
+        coverageSummary: undefined,
+        componentTestCount: { success: 1, error: 0 },
+        a11yCount: { success: 0, warning: 1, error: 1 },
+        componentTestStatuses: [],
+        a11yStatuses: [],
+        a11yReports: {
+          'button--primary': [
+            {
+              violations: [
+                {
+                  id: 'color-contrast',
+                  description: 'Color contrast ratio is insufficient',
+                  nodes: [
+                    {
+                      html: '<button>Click me</button>',
+                      impact: 'critical',
+                      failureSummary: '2.5:1 (required: 4.5:1)',
+                      linkPath: '/inspect/button--primary?inspectPath=button.0',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        reports: {},
+        unhandledErrors: [],
+      },
+    });
+
+    const response = await callTool(
+      [{ exportName: 'Primary', relativePath: 'src/Button.stories.tsx' }],
+      testContext
+    );
+
+    expect(response.result?.content[0].text).toContain(
+      '**Inspect**: http://localhost:5173/__storybook/inspect/button--primary?inspectPath=button.0'
+    );
+  });
+
   it('should include a11y violations when a11y input is omitted (defaults to true)', async () => {
     const testContext = createTestContext();
 

--- a/code/addons/mcp/src/tools/run-story-tests.ts
+++ b/code/addons/mcp/src/tools/run-story-tests.ts
@@ -15,6 +15,7 @@ import type Channel from 'storybook/internal/channels';
 import type { StoryId } from 'storybook/internal/csf';
 import type { A11yReport } from '@storybook/addon-a11y';
 import { RUN_STORY_TESTS_TOOL_NAME } from './tool-names.ts';
+import { resolveBaseUrl } from '../utils/base-url.ts';
 
 /**
  * Check if addon-vitest is available by trying to import its constants.
@@ -138,7 +139,7 @@ export async function addRunStoryTestsTool(
         done = await testRunQueue.wait();
         const runA11y = input.a11y ?? true;
 
-        const { origin, options, disableTelemetry } = server.ctx.custom ?? {};
+        const { origin, basePath, options, disableTelemetry } = server.ctx.custom ?? {};
 
         if (!origin) {
           throw new Error('Origin is required in addon context');
@@ -221,7 +222,7 @@ ${errorMessages}`,
         const { text, summary } = formatRunStoryTestResults({
           testResults,
           runA11y,
-          origin,
+          baseUrl: resolveBaseUrl({ origin, basePath }),
         });
 
         if (!disableTelemetry) {
@@ -386,11 +387,11 @@ type TestRunResult = NonNullable<TriggerTestRunResponsePayload['result']>;
 function formatRunStoryTestResults({
   testResults,
   runA11y,
-  origin,
+  baseUrl,
 }: {
   testResults: TestRunResult;
   runA11y: boolean;
-  origin: string;
+  baseUrl: string;
 }): { text: string; summary: RunStoryTestsSummary } {
   const sections: string[] = [];
   const componentTestStatuses = testResults.componentTestStatuses;
@@ -413,7 +414,7 @@ function formatRunStoryTestResults({
   const a11yReports = testResults.a11yReports as Record<StoryId, A11yReport[]>;
   const a11yViolationCount = runA11y ? countA11yViolations(a11yReports) : 0;
   if (runA11y && a11yReports && Object.keys(a11yReports).length > 0) {
-    const a11ySection = formatA11yReportsSection({ a11yReports, origin });
+    const a11ySection = formatA11yReportsSection({ a11yReports, baseUrl });
     if (a11ySection) {
       sections.push(a11ySection);
     }
@@ -457,10 +458,10 @@ ${entries.join('\n\n')}`;
 
 function formatA11yReportsSection({
   a11yReports,
-  origin,
+  baseUrl,
 }: {
   a11yReports: Record<StoryId, A11yReport[]>;
-  origin: string;
+  baseUrl: string;
 }): string | undefined {
   const a11yViolationSections: string[] = [];
 
@@ -481,7 +482,7 @@ ${report.error.message}`);
       for (const violation of violations) {
         const nodes = violation.nodes
           .map((node) => {
-            const inspectLink = node.linkPath ? `${origin}${node.linkPath}` : undefined;
+            const inspectLink = node.linkPath ? `${baseUrl}${node.linkPath}` : undefined;
             const parts = [] as string[];
 
             if (node.impact) {

--- a/code/addons/mcp/src/types.ts
+++ b/code/addons/mcp/src/types.ts
@@ -1,6 +1,6 @@
-import * as v from 'valibot';
-import type { Options } from 'storybook/internal/types';
 import { GET_TOOL_NAME, LIST_TOOL_NAME, type StorybookContext } from '@storybook/mcp';
+import type { Options } from 'storybook/internal/types';
+import * as v from 'valibot';
 import { GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME } from './tools/tool-names.ts';
 
 const isLiteralEndpointPathname = (endpoint: string) => {
@@ -58,6 +58,12 @@ export type AddonContext = StorybookContext & {
    * Typically http://localhost:{port}
    */
   origin: string;
+
+  /**
+   * The basePath the Storybook instance is served from, starting and ending with a slash.
+   * @default '/'
+   */
+  basePath?: string;
 
   /**
    * Whether telemetry collection is disabled.

--- a/code/addons/mcp/src/utils/base-url.test.ts
+++ b/code/addons/mcp/src/utils/base-url.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveBaseUrl } from './base-url.ts';
+
+describe('resolveBaseUrl', () => {
+  it('returns the bare origin for the default basePath', () => {
+    expect(resolveBaseUrl({ origin: 'http://localhost:6006' })).toBe('http://localhost:6006');
+    expect(resolveBaseUrl({ origin: 'http://localhost:6006', basePath: '/' })).toBe(
+      'http://localhost:6006'
+    );
+  });
+
+  it('appends the basePath without a trailing slash', () => {
+    expect(resolveBaseUrl({ origin: 'http://localhost:5173', basePath: '/__storybook/' })).toBe(
+      'http://localhost:5173/__storybook'
+    );
+    expect(
+      resolveBaseUrl({ origin: 'http://localhost:5173', basePath: '/design/storybook/' })
+    ).toBe('http://localhost:5173/design/storybook');
+  });
+
+  it('does not double up slashes when the origin carries one', () => {
+    expect(resolveBaseUrl({ origin: 'http://localhost:5173/', basePath: '/__storybook/' })).toBe(
+      'http://localhost:5173/__storybook'
+    );
+  });
+});

--- a/code/addons/mcp/src/utils/base-url.ts
+++ b/code/addons/mcp/src/utils/base-url.ts
@@ -1,0 +1,9 @@
+export function resolveBaseUrl({
+  origin,
+  basePath = '/',
+}: {
+  origin: string;
+  basePath?: string;
+}): string {
+  return `${origin.replace(/\/+$/, '')}${basePath}`.replace(/\/+$/, '');
+}


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR makes addon mcp use the basePath available from LoadOptions to call, listen and return correctly URLs for SB dev instances that may be served at a basePath.  

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing


- Ensure MCP is not broken with Chromatic hosted SB. 
- Ensure addon mcp is working with main storybook through CLI
- Test MCP with the vite plugin integration tools should:
  - return URL to agents includding the basePath. 

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
