### PR TITLE
Docs: Document that CSF story names must be string literals

### DIFF
--- a/docs/api/csf/index.mdx
+++ b/docs/api/csf/index.mdx
@@ -62,7 +62,7 @@ We recommend that all export names to start with a capital letter.
 
 Story objects can be annotated with a few different fields to define story-level [decorators](../../writing-stories/decorators.mdx) and [parameters](../../writing-stories/parameters.mdx), and also to define the `name` of the story.
 
-Storybook's `name` configuration element is helpful in specific circumstances. Common use cases are names with special characters or Javascript restricted words. If not specified, Storybook defaults to the named export. To appear in the sidebar, the value must be a plain string literal. See [Rename stories](../../writing-stories/index.mdx#rename-stories).
+Storybook's `name` configuration element is helpful in specific circumstances. Common use cases are names with special characters or Javascript restricted words. If not specified, Storybook defaults to the named export. For non-Svelte renderers, the value must be a plain string literal to appear in the sidebar. See [Rename stories](../../writing-stories/index.mdx#rename-stories).
 
 <CodeSnippets path="my-component-story-with-storyname.md" />
 

--- a/docs/api/csf/index.mdx
+++ b/docs/api/csf/index.mdx
@@ -62,7 +62,7 @@ We recommend that all export names to start with a capital letter.
 
 Story objects can be annotated with a few different fields to define story-level [decorators](../../writing-stories/decorators.mdx) and [parameters](../../writing-stories/parameters.mdx), and also to define the `name` of the story.
 
-Storybook's `name` configuration element is helpful in specific circumstances. Common use cases are names with special characters or Javascript restricted words. If not specified, Storybook defaults to the named export.
+Storybook's `name` configuration element is helpful in specific circumstances. Common use cases are names with special characters or Javascript restricted words. If not specified, Storybook defaults to the named export. To appear in the sidebar, the value must be a plain string literal. See [Rename stories](../../writing-stories/index.mdx#rename-stories).
 
 <CodeSnippets path="my-component-story-with-storyname.md" />
 

--- a/docs/writing-stories/index.mdx
+++ b/docs/writing-stories/index.mdx
@@ -254,6 +254,12 @@ If you're using Svelte CSF, the `name` property is usually fairly descriptive an
 
 Your story will now be shown in the sidebar with the given text.
 
+<Callout variant="info">
+
+The `name` value is read statically as part of the build process, so it must be a plain string literal. A variable, a template literal, a cast such as `name: 'I am the primary' as const`, or an assignment made after the export such as `Primary.name = 'I am the primary'` cannot be read statically, and the sidebar keeps the name derived from the export.
+
+</Callout>
+
 </If>
 
 {/* Maintaining a prior heading */}


### PR DESCRIPTION
Closes #31786

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

A story's `name` is only honored when it's written as a plain string literal. Any other form is silently ignored and the sidebar falls back to the name derived from the export, with no error or warning. #31786 confirmed this is intentional — story files are analyzed statically so the sidebar stays fast — and asked for it to be documented.

Two changes:

- **`docs/writing-stories/index.mdx`** — a `<Callout variant="info">` in the "Rename stories" section, listing the forms that can't be read statically.
- **`docs/api/csf/index.mdx`** — one sentence in the `name` paragraph pointing at that section, since the CSF reference is where people look up `name` and currently gives no hint of the constraint.

Two details worth flagging for review:

- The cast example is written at the property-value level (`name: 'I am the primary' as const`) rather than as a bare `as const`. The indexer unwraps `TSAsExpression` / `TSSatisfiesExpression` on the story declaration, so `export const Primary = { … } satisfies Story` reads normally — only a cast on the `name` value itself fails. Writing it the other way would have warned people off a pattern that works.
- The wording reuses the vocabulary already used for `title` and `id` earlier on the same page ("read statically", "as part of the build process") rather than introducing a second vocabulary for the same rule.

The Callout sits inside the existing `<If notRenderer="svelte">` block. Svelte CSF declares `name` as an attribute through a different compiler path, and I couldn't verify that it behaves the same way, so I scoped the claim rather than guessing.

## Open questions

- **A warning was also requested.** In the issue thread, @malt03 suggested warning when a non-literal `name` is used, by analogy with the `storyName` deprecation. The precedent is right next to the relevant code (`CsfFile.ts` already warns on `storyName` in a CSF3 object), so it's cheap — but it changes indexer output for everyone, and no maintainer weighed in. I left it out of this PR. Happy to open a follow-up if you want it.
- **The indexer and the runtime disagree.** `normalizeStory` reads `name` off the loaded story object, so a dynamic name *does* surface at runtime (`storyContext.name`, portable stories, test names) while the sidebar shows the export-derived name. The same inconsistency was raised on #22689 in 2023 and never resolved. The Callout is deliberately worded to describe only what the sidebar does, so it stays accurate either way. Let me know if you'd rather it said so explicitly.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Documentation-only change, so no automated test covers it. I ran `yarn docs:check` and `cd code && yarn fmt:check`, both clean, and confirmed the behavior it documents against `code/core/src/csf-tools/CsfFile.test.ts` (108 passed, 2 skipped).

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

This is a documentation-only change, so there is nothing to run.

To review the wording:

1. Open `docs/writing-stories/index.mdx` and find the "Rename stories" section.
2. Confirm the new Callout follows the `<CodeSnippets path="button-story-rename-story.md" />` example, which uses `name: 'I am the primary'` — the Callout's counter-examples reuse those names on purpose.
3. Open `docs/api/csf/index.mdx` and confirm the `name` paragraph now links to that section.

To confirm the documented behavior, in any sandbox:

1. Add a story whose `name` is a template literal rather than a string literal:

   ```js
   export const Dynamic = { name: `Dynamic name` };
   ```

2. Start Storybook and look at the sidebar.
3. The story is listed as "Dynamic", derived from the export name — the template literal is ignored, with nothing logged.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

---

AI disclosure, per CONTRIBUTING.md: I used Claude Code (Opus 5) while investigating the indexer behavior and drafting this change. I've reviewed and verified every line and can answer questions about it.
