### PR TITLE
feat: expose forceInitialArgs as public prop on Story, Source, Canvas blocks

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Canvas.tsx
+++ b/code/addons/docs/src/blocks/blocks/Canvas.tsx
@@ -60,7 +60,7 @@ type CanvasProps = Pick<PurePreviewProps, 'withToolbar' | 'additionalActions' | 
   /** @see {SourceProps} */
   source?: Omit<SourceProps, 'dark'>;
   /** @see {StoryProps} */
-  story?: Pick<StoryProps, 'inline' | 'height' | 'autoplay' | '__forceInitialArgs' | '__primary'>;
+  story?: Pick<StoryProps, 'inline' | 'height' | 'autoplay' | 'forceInitialArgs' | '__forceInitialArgs' | '__primary'>;
 };
 
 const CanvasImpl: FC<CanvasProps> = (props) => {

--- a/code/addons/docs/src/blocks/blocks/DocsStory.tsx
+++ b/code/addons/docs/src/blocks/blocks/DocsStory.tsx
@@ -15,8 +15,12 @@ const DocsStoryImpl: FC<DocsStoryProps> = ({
   withToolbar: withToolbarProp = false,
   __forceInitialArgs = false,
   __primary = false,
+  forceInitialArgs,
 }) => {
   const { story } = useOf(of || 'story', ['story']);
+
+  // Public forceInitialArgs prop takes precedence over deprecated __forceInitialArgs
+  const effectiveForceInitialArgs = forceInitialArgs ?? __forceInitialArgs;
 
   // use withToolbar from parameters or default to true in autodocs
   const withToolbar = story.parameters.docs?.canvas?.withToolbar ?? withToolbarProp;
@@ -32,8 +36,8 @@ const DocsStoryImpl: FC<DocsStoryProps> = ({
       <Canvas
         of={of}
         withToolbar={withToolbar}
-        story={{ __forceInitialArgs, __primary }}
-        source={{ __forceInitialArgs }}
+        story={{ forceInitialArgs: effectiveForceInitialArgs, __primary }}
+        source={{ forceInitialArgs: effectiveForceInitialArgs }}
       />
     </Anchor>
   );

--- a/code/addons/docs/src/blocks/blocks/Source.tsx
+++ b/code/addons/docs/src/blocks/blocks/Source.tsx
@@ -40,7 +40,16 @@ export type SourceProps = SourceParameters & {
    */
   of?: ModuleExport;
 
-  /** Internal prop to control if a story re-renders on args updates */
+  /**
+   * Control if the source uses initial args. When true, the source reflects the
+   * story's initial args rather than current args. Set to false to show source
+   * based on current (possibly user-modified) args.
+   *
+   * @default false
+   */
+  forceInitialArgs?: boolean;
+
+  /** @deprecated Use `forceInitialArgs` instead */
   __forceInitialArgs?: boolean;
 };
 
@@ -129,7 +138,7 @@ export const useSourceProps = (
 
   const storyContext = story ? docsContext.getStoryContext(story) : {};
 
-  const argsForSource = props.__forceInitialArgs
+  const argsForSource = (props.forceInitialArgs ?? props.__forceInitialArgs)
     ? storyContext.initialArgs
     : storyContext.unmappedArgs;
 

--- a/code/addons/docs/src/blocks/blocks/Stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Stories.tsx
@@ -14,6 +14,7 @@ import type { DocsParameters } from '../../types.ts';
 interface StoriesProps {
   title?: ReactElement | string;
   includePrimary?: boolean;
+  forceInitialArgs?: boolean;
 }
 
 const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
@@ -32,7 +33,7 @@ const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
   },
 }));
 
-const StoriesImpl: FC<StoriesProps> = ({ title = 'Stories', includePrimary = true }) => {
+const StoriesImpl: FC<StoriesProps> = ({ title = 'Stories', includePrimary = true, forceInitialArgs }) => {
   const { componentStories, projectAnnotations, getStoryContext } = useContext(DocsContext);
 
   let stories = componentStories();
@@ -62,12 +63,19 @@ const StoriesImpl: FC<StoriesProps> = ({ title = 'Stories', includePrimary = tru
   if (!stories || stories.length === 0) {
     return null;
   }
+
+  // Resolve forceInitialArgs: block prop > parameter > default true
+  const paramForceInitialArgs =
+    (projectAnnotations.parameters as DocsParameters | undefined)?.docs?.stories
+      ?.forceInitialArgs;
+  const effectiveForceInitialArgs = forceInitialArgs ?? paramForceInitialArgs ?? true;
+
   return (
     <>
       {typeof title === 'string' ? <StyledHeading>{title}</StyledHeading> : title}
       {stories.map(
         (story) =>
-          story && <DocsStory key={story.id} of={story.moduleExport} expanded __forceInitialArgs />
+          story && <DocsStory key={story.id} of={story.moduleExport} expanded forceInitialArgs={effectiveForceInitialArgs} />
       )}
     </>
   );

--- a/code/addons/docs/src/blocks/blocks/Story.stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Story.stories.tsx
@@ -193,6 +193,6 @@ export const ForceInitialArgs: Story = {
   args: {
     of: ButtonStories.Primary,
     storyExport: ButtonStories.Primary,
-    __forceInitialArgs: true,
+    forceInitialArgs: true,
   } as any,
 };

--- a/code/addons/docs/src/blocks/blocks/Story.tsx
+++ b/code/addons/docs/src/blocks/blocks/Story.tsx
@@ -52,7 +52,14 @@ type StoryParameters = {
   height?: string;
   /** Whether to run the story's play function */
   autoplay?: boolean;
-  /** Internal prop to control if a story re-renders on args updates */
+  /**
+   * Control if a story re-renders on args updates. When true, args are frozen at
+   * their initial values. Set to false to make stories fully interactive.
+   *
+   * @default false
+   */
+  forceInitialArgs?: boolean;
+  /** @deprecated Use `forceInitialArgs` instead */
   __forceInitialArgs?: boolean;
   /** Internal prop if this story is the primary story */
   __primary?: boolean;
@@ -94,12 +101,14 @@ export const getStoryProps = <TFramework extends Renderer>(
   if (inline) {
     const height = props.height ?? storyParameters.height;
     const autoplay = props.autoplay ?? storyParameters.autoplay ?? false;
+    // Public forceInitialArgs prop takes precedence over deprecated __forceInitialArgs
+    const forceInitialArgs = props.forceInitialArgs ?? props.__forceInitialArgs ?? false;
     return {
       story: story as any,
       inline: true,
       height,
       autoplay,
-      forceInitialArgs: !!props.__forceInitialArgs,
+      forceInitialArgs: !!forceInitialArgs,
       primary: !!props.__primary,
       renderStoryToElement: context.renderStoryToElement as any,
     };
@@ -115,7 +124,7 @@ export const getStoryProps = <TFramework extends Renderer>(
   };
 };
 
-const StoryImpl: FC<StoryProps> = (props = { __forceInitialArgs: false, __primary: false }) => {
+const StoryImpl: FC<StoryProps> = (props = { forceInitialArgs: false, __primary: false }) => {
   const context = useContext(DocsContext);
   const storyId = getStoryId(props, context);
   const story = useStory(storyId, context);

--- a/code/addons/docs/src/blocks/blocks/types.ts
+++ b/code/addons/docs/src/blocks/blocks/types.ts
@@ -10,6 +10,7 @@ export type DocsStoryProps = {
   of: ModuleExport;
   expanded?: boolean;
   withToolbar?: boolean;
+  forceInitialArgs?: boolean;
   __forceInitialArgs?: boolean;
   __primary?: boolean;
 };

--- a/code/addons/docs/src/types.ts
+++ b/code/addons/docs/src/types.ts
@@ -36,6 +36,14 @@ type StoryBlockParameters = {
    * attached, the primary (first) story will be rendered.
    */
   of: ModuleExport;
+  /**
+   * When true, story args are frozen at their initial values so the story does not re-render
+   * when the user changes controls. Set to false to make stories fully interactive.
+   *
+   * @default false
+   * @see https://github.com/storybookjs/storybook/issues/22195
+   */
+  forceInitialArgs?: boolean;
 };
 
 type StoriesBlockParameters = {


### PR DESCRIPTION
Closes #22195

Rename internal `__forceInitialArgs` to `forceInitialArgs` across all doc blocks, keeping `__forceInitialArgs` as a deprecated alias.

## Changes
- Add `forceInitialArgs` prop to `Story`, `Source`, `Canvas`, `Stories` blocks
- Add `StoryBlockParameters.forceInitialArgs` for parameter-level config
- `Stories` block resolves: block prop > parameter > default true
- `DocsStory` passes `forceInitialArgs` (not `__forceInitialArgs`) to `Canvas`
- Keep `__forceInitialArgs` as deprecated fallback in `Story`, `Source`, `Canvas`