### PR TITLE
CI: Name release-branch workflow steps for readability

### DIFF
--- a/.github/workflows/handle-release-branches.yml
+++ b/.github/workflows/handle-release-branches.yml
@@ -71,7 +71,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - env:
+      - name: Force-push next release branch
+        env:
           TARGET_BRANCH: ${{ needs.get-next-release-branch.outputs.branch }}
           SOURCE_BRANCH: ${{ needs.branch-checks.outputs.branch }}
         run: |
@@ -98,7 +99,8 @@ jobs:
         if: ${{ steps.is-next-release-branch.outputs.result == 'true' }}
         run: echo "relevant-base-branch=next" >> $GITHUB_OUTPUT
 
-      - if: ${{ steps.is-next-release-branch.outputs.result == 'true' }}
+      - name: Reject direct pushes to next release branch
+        if: ${{ steps.is-next-release-branch.outputs.result == 'true' }}
         run: |
           echo 'WARNING: Do not push directly to the `${{ needs.branch-checks.outputs.branch }}` branch. This branch is created and force-pushed over after pushing to the `${{ steps.relevant-base-branch.outputs.relevant-base-branch }}` branch and the changes you just pushed will be lost.'
           exit 1


### PR DESCRIPTION
## Problem

In `.github/workflows/handle-release-branches.yml`, two helper `run` steps are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when next-release branch sync or push guards fail.

## Changes

Semantics are unchanged: same env vars, same `if:` conditions, and the same git / exit commands.

- Add `name: Force-push next release branch` in `create-next-release-branch`
- Add `name: Reject direct pushes to next release branch` in `next-release-branch-check`

## Test plan

- [ ] Confirm force-push still uses the same source/target branch env vars
- [ ] Confirm the reject step still runs only when `steps.is-next-release-branch.outputs.result == 'true'`
- [ ] Confirm the steps show the new names in the Actions UI

#### Manual testing

1. Open the diff for `.github/workflows/handle-release-branches.yml` and confirm only `name:` keys were added to the two existing `run` steps.
2. Confirm the force-push step still uses the same `SOURCE_BRANCH` / `TARGET_BRANCH` env vars and `git push --force` command.
3. Confirm the reject step still has `if: steps.is-next-release-branch.outputs.result == 'true'` and the same exit / messaging behavior.
4. In a future Actions run of this workflow, verify the two steps appear in the UI as:
   - `Force-push next release branch`
   - `Reject direct pushes to next release branch`