### PR TITLE
Angular Vite: Respect Compodoc output directory

### DIFF
--- a/code/frameworks/angular-vite/src/builders/utils/run-compodoc.spec.ts
+++ b/code/frameworks/angular-vite/src/builders/utils/run-compodoc.spec.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { runCompodoc } from './run-compodoc.ts';
+import { resolve } from 'node:path';
+
+import { getCompodocOutputDir, runCompodoc } from './run-compodoc.ts';
 
 const mockRunScript = vi.fn().mockResolvedValue({ stdout: '' });
 
@@ -89,5 +91,42 @@ describe('runCompodoc', () => {
       args: ['compodoc', '-p', 'path/to/tsconfig.json', '-d', 'path/to/customFolder'],
       cwd: 'path/to/project',
     });
+  });
+});
+
+describe('getCompodocOutputDir', () => {
+  // Paths are wrapped in `resolve` so the expectations hold on Windows too.
+  const workspaceRoot = '/path/to/project';
+
+  it('defaults to the workspace root when no output flag is present', () => {
+    expect(getCompodocOutputDir([], workspaceRoot)).toBe(resolve(workspaceRoot));
+    expect(getCompodocOutputDir(['-e', 'json'], workspaceRoot)).toBe(resolve(workspaceRoot));
+  });
+
+  it('resolves a relative -d output directory against the workspace root', () => {
+    expect(getCompodocOutputDir(['-e', 'json', '-d', 'libs/storybook-host/'], workspaceRoot)).toBe(
+      resolve(workspaceRoot, 'libs/storybook-host')
+    );
+  });
+
+  it('resolves a relative --output directory against the workspace root', () => {
+    expect(getCompodocOutputDir(['--output', 'docs'], workspaceRoot)).toBe(
+      resolve(workspaceRoot, 'docs')
+    );
+  });
+
+  it('keeps an absolute -d output directory as-is', () => {
+    expect(getCompodocOutputDir(['-d', '/abs/docs'], workspaceRoot)).toBe(resolve('/abs/docs'));
+  });
+
+  it('uses the last output flag when several are given', () => {
+    expect(getCompodocOutputDir(['-d', 'first', '--output', 'second'], workspaceRoot)).toBe(
+      resolve(workspaceRoot, 'second')
+    );
+  });
+
+  it('falls back to the workspace root for a dangling output flag', () => {
+    expect(getCompodocOutputDir(['-d'], workspaceRoot)).toBe(resolve(workspaceRoot));
+    expect(getCompodocOutputDir(['--output', '-e'], workspaceRoot)).toBe(resolve(workspaceRoot));
   });
 });

--- a/code/frameworks/angular-vite/src/builders/utils/run-compodoc.spec.ts
+++ b/code/frameworks/angular-vite/src/builders/utils/run-compodoc.spec.ts
@@ -92,6 +92,32 @@ describe('runCompodoc', () => {
       cwd: 'path/to/project',
     });
   });
+
+  it('should not inject a default -d when an attached -d value is present', async () => {
+    await runCompodoc({
+      compodocArgs: ['-e', 'json', '-ddocs'],
+      tsconfig: 'path/to/tsconfig.json',
+      workspaceRoot,
+    });
+
+    expect(mockRunScript).toHaveBeenCalledWith({
+      args: ['compodoc', '-p', 'path/to/tsconfig.json', '-e', 'json', '-ddocs'],
+      cwd: 'path/to/project',
+    });
+  });
+
+  it('should not inject a default -d when a long --output=value is present', async () => {
+    await runCompodoc({
+      compodocArgs: ['--output=docs'],
+      tsconfig: 'path/to/tsconfig.json',
+      workspaceRoot,
+    });
+
+    expect(mockRunScript).toHaveBeenCalledWith({
+      args: ['compodoc', '-p', 'path/to/tsconfig.json', '--output=docs'],
+      cwd: 'path/to/project',
+    });
+  });
 });
 
 describe('getCompodocOutputDir', () => {
@@ -128,5 +154,21 @@ describe('getCompodocOutputDir', () => {
   it('falls back to the workspace root for a dangling output flag', () => {
     expect(getCompodocOutputDir(['-d'], workspaceRoot)).toBe(resolve(workspaceRoot));
     expect(getCompodocOutputDir(['--output', '-e'], workspaceRoot)).toBe(resolve(workspaceRoot));
+  });
+
+  it('resolves an attached -d value (-ddocs)', () => {
+    expect(getCompodocOutputDir(['-ddocs'], workspaceRoot)).toBe(resolve(workspaceRoot, 'docs'));
+  });
+
+  it('resolves an inline long --output=value', () => {
+    expect(getCompodocOutputDir(['--output=docs'], workspaceRoot)).toBe(
+      resolve(workspaceRoot, 'docs')
+    );
+  });
+
+  it('does not treat an attached long flag (--outputdocs) as an output option', () => {
+    // Commander parses `--outputdocs` as an unknown flag, so it must not be
+    // mistaken for the output directory.
+    expect(getCompodocOutputDir(['--outputdocs'], workspaceRoot)).toBe(resolve(workspaceRoot));
   });
 });

--- a/code/frameworks/angular-vite/src/builders/utils/run-compodoc.ts
+++ b/code/frameworks/angular-vite/src/builders/utils/run-compodoc.ts
@@ -52,7 +52,7 @@ export const getCompodocOutputDir = (compodocArgs: string[], workspaceRoot: stri
 };
 
 // relative is necessary to workaround a compodoc issue with
-// absolute paths on windows machines
+// absolute paths on Windows machines
 const toRelativePath = (pathToTsConfig: string) => {
   return isAbsolute(pathToTsConfig) ? relative('.', pathToTsConfig) : pathToTsConfig;
 };

--- a/code/frameworks/angular-vite/src/builders/utils/run-compodoc.ts
+++ b/code/frameworks/angular-vite/src/builders/utils/run-compodoc.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 import { JsPackageManagerFactory } from 'storybook/internal/common';
 
@@ -7,6 +7,29 @@ import { prompt } from 'storybook/internal/node-logger';
 const hasTsConfigArg = (args: string[]) => args.indexOf('-p') !== -1;
 const hasOutputArg = (args: string[]) =>
   args.indexOf('-d') !== -1 || args.indexOf('--output') !== -1;
+
+// Compodoc writes documentation.json to the directory given by its output
+// flag (-d / --output), resolved against the directory it runs from (the
+// workspace root). Falls back to the workspace root when no output flag is
+// present, matching the `-d ${workspaceRoot || '.'}` default injected below.
+// Only the space-separated forms are recognized, mirroring `hasOutputArg`.
+export const getCompodocOutputDir = (compodocArgs: string[], workspaceRoot: string): string => {
+  let outputDir = resolve(workspaceRoot);
+  for (let i = 0; i < compodocArgs.length; i++) {
+    const arg = compodocArgs[i];
+    if (arg !== '-d' && arg !== '--output') {
+      continue;
+    }
+    const value = compodocArgs[i + 1];
+    // A dangling output flag (e.g. '-d' as the last argument) has no path;
+    // skip it so a following flag is never misread as the output directory.
+    // Compodoc rejects such malformed invocations itself.
+    if (value && !value.startsWith('-')) {
+      outputDir = resolve(workspaceRoot, value);
+    }
+  }
+  return outputDir;
+};
 
 // relative is necessary to workaround a compodoc issue with
 // absolute paths on windows machines

--- a/code/frameworks/angular-vite/src/builders/utils/run-compodoc.ts
+++ b/code/frameworks/angular-vite/src/builders/utils/run-compodoc.ts
@@ -5,27 +5,47 @@ import { JsPackageManagerFactory } from 'storybook/internal/common';
 import { prompt } from 'storybook/internal/node-logger';
 
 const hasTsConfigArg = (args: string[]) => args.indexOf('-p') !== -1;
-const hasOutputArg = (args: string[]) =>
-  args.indexOf('-d') !== -1 || args.indexOf('--output') !== -1;
+
+// Whether an argument is Compodoc's output flag, matching the forms the
+// Commander-based CLI actually parses: the separated `-d value` / `--output
+// value` and the inline `-ddocs` / `--output=docs`. An inline `-d=value` is
+// also matched because Commander reads it as the output flag (with value
+// `=value`); `--outputdocs` is not, because Commander treats it as an unknown
+// flag rather than the output option.
+const isOutputArg = (arg: string): boolean => {
+  if (arg === '-d' || arg === '--output') {
+    return true;
+  }
+  if (arg.startsWith('-d') && arg.length > 2) {
+    return true;
+  }
+  return arg.startsWith('--output=');
+};
+
+const hasOutputArg = (args: string[]) => args.some(isOutputArg);
 
 // Compodoc writes documentation.json to the directory given by its output
 // flag (-d / --output), resolved against the directory it runs from (the
 // workspace root). Falls back to the workspace root when no output flag is
 // present, matching the `-d ${workspaceRoot || '.'}` default injected below.
-// Only the space-separated forms are recognized, mirroring `hasOutputArg`.
 export const getCompodocOutputDir = (compodocArgs: string[], workspaceRoot: string): string => {
   let outputDir = resolve(workspaceRoot);
   for (let i = 0; i < compodocArgs.length; i++) {
     const arg = compodocArgs[i];
-    if (arg !== '-d' && arg !== '--output') {
-      continue;
-    }
-    const value = compodocArgs[i + 1];
-    // A dangling output flag (e.g. '-d' as the last argument) has no path;
-    // skip it so a following flag is never misread as the output directory.
-    // Compodoc rejects such malformed invocations itself.
-    if (value && !value.startsWith('-')) {
-      outputDir = resolve(workspaceRoot, value);
+    if (arg === '-d' || arg === '--output') {
+      const value = compodocArgs[i + 1];
+      // A dangling output flag (e.g. '-d' as the last argument) has no path;
+      // skip it so a following flag is never misread as the output directory.
+      // Compodoc rejects such malformed invocations itself.
+      if (value && !value.startsWith('-')) {
+        outputDir = resolve(workspaceRoot, value);
+      }
+    } else if (arg.startsWith('-d') && arg.length > 2) {
+      // Inline short value (-ddocs, -d=value), matching Commander.
+      outputDir = resolve(workspaceRoot, arg.slice(2));
+    } else if (arg.startsWith('--output=')) {
+      // Inline long `=` value (--output=docs), matching Commander.
+      outputDir = resolve(workspaceRoot, arg.slice('--output='.length));
     }
   }
   return outputDir;

--- a/code/frameworks/angular-vite/src/preset-compodoc.test.ts
+++ b/code/frameworks/angular-vite/src/preset-compodoc.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolve } from 'node:path';
+
+// Keep runCompodoc's real implementation available (the output-dir helper is
+// still exercised) while recording whether the guard actually invokes it.
+const { runCompodoc } = vi.hoisted(() => ({ runCompodoc: vi.fn() }));
+
+vi.mock('vite', () => ({
+  mergeConfig: (base: Record<string, unknown>, override: Record<string, unknown>) => ({
+    ...base,
+    ...override,
+  }),
+  normalizePath: (p: string) => p,
+}));
+vi.mock('@analogjs/vite-plugin-angular', () => ({ default: (): unknown[] => [] }));
+vi.mock('node:fs', { spy: true });
+vi.mock('./builders/utils/run-compodoc.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./builders/utils/run-compodoc.ts')>()),
+  runCompodoc,
+}));
+// The preset's `angularOptionsPlugin` looks up the preview file on disk and
+// the mock-reapply plugin reads its mocks from config; none of that runs
+// during `viteFinal`, so stub these imports (which would otherwise need the
+// `storybook` package to be built) to keep the test hermetic.
+vi.mock('storybook/internal/common', () => ({
+  findConfigFile: (): string | undefined => undefined,
+}));
+vi.mock('storybook/internal/mocking-utils', () => ({
+  babelParser: {},
+  extractMockCalls: (): unknown[] => [],
+  findMockRedirect: (): string | undefined => undefined,
+  getAutomockCode: (): Record<string, unknown> => ({}),
+  getRealPath: (p: string) => p,
+}));
+
+import { existsSync } from 'node:fs';
+
+import { viteFinal } from './preset.ts';
+import type { StandaloneOptions } from './builders/utils/standalone-options.ts';
+
+const WORKSPACE_ROOT = '/workspace';
+const CUSTOM_OUTPUT_DIR = 'libs/storybook-host/';
+
+function makeOptions(frameworkOptions: Record<string, unknown>): StandaloneOptions {
+  return {
+    presets: {
+      apply: async (name: string) => (name === 'framework' ? { options: frameworkOptions } : {}),
+    },
+    angularBuilderContext: { workspaceRoot: WORKSPACE_ROOT },
+  } as unknown as StandaloneOptions;
+}
+
+const customDocumentationJson = resolve(
+  WORKSPACE_ROOT,
+  'libs/storybook-host',
+  'documentation.json'
+);
+const rootDocumentationJson = resolve(WORKSPACE_ROOT, 'documentation.json');
+
+describe('viteFinal compodoc skip-check', () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReset();
+    runCompodoc.mockReset();
+  });
+
+  afterEach(() => {
+    vi.mocked(existsSync).mockRestore();
+  });
+
+  it('runs compodoc when no documentation.json exists anywhere', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await viteFinal({ root: WORKSPACE_ROOT }, makeOptions({ compodoc: true }));
+
+    expect(runCompodoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips compodoc when documentation.json exists in the default output directory', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => p === rootDocumentationJson);
+
+    await viteFinal({ root: WORKSPACE_ROOT }, makeOptions({ compodoc: true }));
+
+    expect(runCompodoc).not.toHaveBeenCalled();
+  });
+
+  it('checks the -d output location rather than the workspace root', async () => {
+    // The custom output dir is populated, but the workspace root is not.
+    vi.mocked(existsSync).mockImplementation((p) => p === customDocumentationJson);
+
+    await viteFinal(
+      { root: WORKSPACE_ROOT },
+      makeOptions({ compodoc: true, compodocArgs: ['-e', 'json', '-d', CUSTOM_OUTPUT_DIR] })
+    );
+
+    expect(existsSync).toHaveBeenCalledWith(customDocumentationJson);
+    expect(runCompodoc).not.toHaveBeenCalled();
+  });
+
+  it('runs compodoc when only a stray root documentation.json exists', async () => {
+    // A stale file at the workspace root must not suppress regeneration when
+    // the real output lives in the configured -d directory.
+    vi.mocked(existsSync).mockImplementation((p) => p === rootDocumentationJson);
+
+    await viteFinal(
+      { root: WORKSPACE_ROOT },
+      makeOptions({ compodoc: true, compodocArgs: ['-e', 'json', '-d', CUSTOM_OUTPUT_DIR] })
+    );
+
+    expect(runCompodoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects the long-form --output flag when locating documentation.json', async () => {
+    const longFormDocumentationJson = resolve(WORKSPACE_ROOT, 'docs', 'documentation.json');
+    vi.mocked(existsSync).mockImplementation((p) => p === longFormDocumentationJson);
+
+    await viteFinal(
+      { root: WORKSPACE_ROOT },
+      makeOptions({ compodoc: true, compodocArgs: ['-e', 'json', '--output', 'docs'] })
+    );
+
+    expect(existsSync).toHaveBeenCalledWith(longFormDocumentationJson);
+    expect(runCompodoc).not.toHaveBeenCalled();
+  });
+
+  it('does not run compodoc when framework.options.compodoc is false', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await viteFinal({ root: WORKSPACE_ROOT }, makeOptions({ compodoc: false }));
+
+    expect(runCompodoc).not.toHaveBeenCalled();
+  });
+});

--- a/code/frameworks/angular-vite/src/preset-compodoc.test.ts
+++ b/code/frameworks/angular-vite/src/preset-compodoc.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resolve } from 'node:path';
 
@@ -42,6 +42,17 @@ import type { StandaloneOptions } from './builders/utils/standalone-options.ts';
 const WORKSPACE_ROOT = '/workspace';
 const CUSTOM_OUTPUT_DIR = 'libs/storybook-host/';
 
+const customDocumentationJson = resolve(
+  WORKSPACE_ROOT,
+  'libs/storybook-host',
+  'documentation.json'
+);
+const rootDocumentationJson = resolve(WORKSPACE_ROOT, 'documentation.json');
+const longFormDocumentationJson = resolve(WORKSPACE_ROOT, 'docs', 'documentation.json');
+
+// Shared filesystem state: each test seeds the paths that "exist" on disk.
+let existingFiles: string[];
+
 function makeOptions(frameworkOptions: Record<string, unknown>): StandaloneOptions {
   return {
     presets: {
@@ -51,33 +62,23 @@ function makeOptions(frameworkOptions: Record<string, unknown>): StandaloneOptio
   } as unknown as StandaloneOptions;
 }
 
-const customDocumentationJson = resolve(
-  WORKSPACE_ROOT,
-  'libs/storybook-host',
-  'documentation.json'
-);
-const rootDocumentationJson = resolve(WORKSPACE_ROOT, 'documentation.json');
-
 describe('viteFinal compodoc skip-check', () => {
   beforeEach(() => {
+    existingFiles = [];
     vi.mocked(existsSync).mockReset();
-    runCompodoc.mockReset();
-  });
-
-  afterEach(() => {
-    vi.mocked(existsSync).mockRestore();
+    vi.mocked(existsSync).mockImplementation((p) => existingFiles.includes(String(p)));
+    vi.mocked(runCompodoc).mockReset();
+    vi.mocked(runCompodoc).mockResolvedValue(undefined);
   });
 
   it('runs compodoc when no documentation.json exists anywhere', async () => {
-    vi.mocked(existsSync).mockReturnValue(false);
-
     await viteFinal({ root: WORKSPACE_ROOT }, makeOptions({ compodoc: true }));
 
     expect(runCompodoc).toHaveBeenCalledTimes(1);
   });
 
   it('skips compodoc when documentation.json exists in the default output directory', async () => {
-    vi.mocked(existsSync).mockImplementation((p) => p === rootDocumentationJson);
+    existingFiles = [rootDocumentationJson];
 
     await viteFinal({ root: WORKSPACE_ROOT }, makeOptions({ compodoc: true }));
 
@@ -86,7 +87,7 @@ describe('viteFinal compodoc skip-check', () => {
 
   it('checks the -d output location rather than the workspace root', async () => {
     // The custom output dir is populated, but the workspace root is not.
-    vi.mocked(existsSync).mockImplementation((p) => p === customDocumentationJson);
+    existingFiles = [customDocumentationJson];
 
     await viteFinal(
       { root: WORKSPACE_ROOT },
@@ -100,7 +101,7 @@ describe('viteFinal compodoc skip-check', () => {
   it('runs compodoc when only a stray root documentation.json exists', async () => {
     // A stale file at the workspace root must not suppress regeneration when
     // the real output lives in the configured -d directory.
-    vi.mocked(existsSync).mockImplementation((p) => p === rootDocumentationJson);
+    existingFiles = [rootDocumentationJson];
 
     await viteFinal(
       { root: WORKSPACE_ROOT },
@@ -111,8 +112,7 @@ describe('viteFinal compodoc skip-check', () => {
   });
 
   it('respects the long-form --output flag when locating documentation.json', async () => {
-    const longFormDocumentationJson = resolve(WORKSPACE_ROOT, 'docs', 'documentation.json');
-    vi.mocked(existsSync).mockImplementation((p) => p === longFormDocumentationJson);
+    existingFiles = [longFormDocumentationJson];
 
     await viteFinal(
       { root: WORKSPACE_ROOT },
@@ -124,8 +124,6 @@ describe('viteFinal compodoc skip-check', () => {
   });
 
   it('does not run compodoc when framework.options.compodoc is false', async () => {
-    vi.mocked(existsSync).mockReturnValue(false);
-
     await viteFinal({ root: WORKSPACE_ROOT }, makeOptions({ compodoc: false }));
 
     expect(runCompodoc).not.toHaveBeenCalled();

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -114,14 +114,23 @@ export const viteFinal = async (config: UserConfig, options?: StandaloneOptions)
 
   // Generate compodoc's documentation.json on cold start when no builder
   // path has produced it yet (e.g. addon-vitest child, ng run without the
-  // Angular CLI builder). Skipped when the file already exists or when the
-  // user opts out via framework.options.compodoc === false.
+  // Angular CLI builder). Skipped when the file already exists at the output
+  // directory configured via compodocArgs (-d / --output) or when the user
+  // opts out via framework.options.compodoc === false. Checking the
+  // configured location (rather than the workspace root) keeps a custom
+  // output dir from regenerating on every launch and stops a stray root
+  // documentation.json from suppressing regeneration.
   if (framework.options?.compodoc !== false) {
     const { existsSync } = await import('node:fs');
     const path = await import('node:path');
     const workspaceRoot =
       (options as any)?.angularBuilderContext?.workspaceRoot ?? config?.root ?? process.cwd();
-    const documentationJsonPath = path.resolve(workspaceRoot, 'documentation.json');
+    const compodocArgs = framework.options?.compodocArgs ?? ['-e', 'json', '-d', '.'];
+    const { getCompodocOutputDir } = await import('./builders/utils/run-compodoc.ts');
+    const documentationJsonPath = path.resolve(
+      getCompodocOutputDir(compodocArgs, workspaceRoot),
+      'documentation.json'
+    );
     if (!existsSync(documentationJsonPath)) {
       const { runCompodoc } = await import('./builders/utils/run-compodoc.ts');
       const tsconfig =
@@ -129,7 +138,6 @@ export const viteFinal = async (config: UserConfig, options?: StandaloneOptions)
         (options as any)?.tsConfig ??
         (options as any)?.angularBuilderOptions?.tsConfig ??
         path.resolve(workspaceRoot, 'tsconfig.json');
-      const compodocArgs = framework.options?.compodocArgs ?? ['-e', 'json', '-d', '.'];
       try {
         await runCompodoc({ compodocArgs, tsconfig, workspaceRoot });
       } catch (err) {


### PR DESCRIPTION
## Summary

`@storybook/angular-vite` decides whether to run Compodoc on cold start by checking `existsSync(<workspaceRoot>/documentation.json)`, regardless of where `compodocArgs`' `-d` / `--output` actually writes. This mismatch had two effects:

1. A custom output directory (e.g. `-d libs/storybook-host/`) made Compodoc regenerate on every launch, because the guard never saw the file.
2. A stray root `documentation.json` silently suppressed regeneration of the real, configured output.

This PR makes the existence check use the output directory derived from `compodocArgs` (via a new `getCompodocOutputDir` helper) instead of always the workspace root.

## Why

The guard is an intentional design that avoids re-running Compodoc when the file already exists (e.g. across the addon-vitest child process), and it is relied on by CI. The defect was only the path it checked. Preserving the skip-when-the-correct-file-exists behavior is deliberate — this change does **not** make Compodoc regenerate after every source change or on every separate launch.

## Testing

- Added `getCompodocOutputDir` unit tests (default output dir, relative `-d`, long-form `--output`, absolute path, repeated flags, dangling flags, and the Commander-supported inline forms `-ddocs` / `--output=docs`).
- Added `viteFinal` regression tests: a custom `-d` output location is checked (not the workspace root), a stray root `documentation.json` no longer suppresses generation, long-form `--output` is honored, and `framework.options.compodoc === false` still prevents execution.
- `runCompodoc` no longer injects a duplicate default `-d` when an inline output flag is present.
- The new tests fail against the previous implementation and pass with this change.
- Ran the full `@storybook/angular-vite` Vitest suite (199 passed), package typecheck, lint, formatting check, and package compile.

#### Manual testing

1. Configure `@storybook/angular-vite` with a custom Compodoc output dir:

   ```ts
   framework: {
     name: '@storybook/angular-vite',
     options: {
       compodoc: true,
       compodocArgs: ['-e', 'json', '-d', 'libs/storybook-host/'],
     },
   },
   ```

2. `rm -f documentation.json libs/storybook-host/documentation.json`, then run `build-storybook` twice. The first run generates `documentation.json` in `libs/storybook-host/`; the second run skips Compodoc because the file already exists at the configured location (no regeneration on every launch).
3. `touch documentation.json` at the workspace root and run `build-storybook` again. Compodoc still runs, because the real output lives in `libs/storybook-host/` — the stray root file must not suppress generation.

Closes #35674

🤖 Generated with [Claude Code](https://claude.com/claude-code)