### PR TITLE
Docs: Cover CSF Factories Manual Migration Fixes

### DIFF
--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -451,6 +451,61 @@ type CustomProps = React.ComponentProps<typeof Button> & { customProp: string };
 
 </details>
 
+#### Manual fixes after automatic migration
+
+The automigration covers the standard CSF 3 patterns. If your stories use custom
+args or import meta from another story file, make the following adjustments after
+running it.
+
+<details>
+<summary>Preserving custom args</summary>
+
+If a story used `satisfies Meta<CustomArgs>` to add args that are not component
+props, add the same type through `preview.type()` after the migration:
+
+```diff title="Button.stories.js|ts"
++ import preview from '../.storybook/preview';
+- import type { Meta } from '@storybook/your-framework';
+
+type StoryArgs = {
+  pageIcon: Icon;
+};
+
++ const meta = preview.type<{ args: StoryArgs }>().meta({
+- const meta = {
+  component: MyComponent,
+  args: {
+    pageIcon: DeactivatedOrg,
+  },
++ });
+- } satisfies Meta<StoryArgs>;
+```
+
+</details>
+
+<details>
+<summary>Reusing meta from another story file</summary>
+
+When another story file imports a meta object, explicitly export it as the
+default export from the source story file:
+
+```ts title="Button.stories.js|ts"
+const meta = preview.meta({ component: Button });
+
+export default meta;
+```
+
+This export is only needed for cross-file imports. It is not required for a
+regular CSF Next story file.
+
+```ts title="OtherButton.stories.js|ts"
+import ButtonMeta from './Button.stories';
+
+const meta = preview.meta({ ...ButtonMeta.input });
+```
+
+</details>
+
 **3.1 Reusing story properties**
 
 <Callout variant="info" icon="💡">


### PR DESCRIPTION
Closes #33528.

## What I did

Documented the two manual steps that can remain after the CSF Factories automigration:

- Preserve custom args with `preview.type<{ args: ... }>()`.
- Export meta by default when another story file imports it.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No runtime behavior changes. Review `docs/api/csf/csf-next.mdx` and confirm the new examples match the existing `preview.type()` and `preview.meta()` patterns. Whitespace checks and code-fence balance pass locally. The full docs check was not run because this environment does not have Storybook's required Node 22 and Yarn workspace dependencies installed.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update MIGRATION.MD

AI assistance: Codex helped prepare this documentation change. The diff and the issue's two requested cases were reviewed before submission.