### PR TITLE
Bench: Gate the docgen perf suite on budgets in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ scripts/eval/results
 
 # Vercel CLI link/pull output for the agent-eval playground (CI runs from the repo root)
 .vercel
+
+# Perf suite results written by the docgen perf jobs
+code/lib/docgen-harness/perf-results

--- a/code/lib/docgen-harness/README.md
+++ b/code/lib/docgen-harness/README.md
@@ -210,7 +210,7 @@ The React engines run every scenario twice, because Storybook documents componen
 - `whole-index` - one batch over every component, what the manifest generator does.
 - `first-story` - the single component a request asks for, what the docgen server does. This is the number a developer waits for before Controls populate.
 
-The cold ratio between the React engines is around 0.7 over the index and 0.1 over the first story; reading only one of them gives a misleading picture of the engine's cost.
+The cold ratio between the React engines is 0.73 over the index and 0.08 over the first story; reading only one of them gives a misleading picture of the engine's cost.
 
 ### Comparing two releases of one engine
 

--- a/code/lib/docgen-harness/README.md
+++ b/code/lib/docgen-harness/README.md
@@ -180,8 +180,8 @@ All commands run from `code/lib/docgen-harness`:
 ```bash
 yarn bench:docgen-perf            # per-engine cold/warm latency and memory, full profile (~1 min)
 yarn bench:docgen-perf --quick    # smoke profile; its numbers are marked non-comparable
-yarn bench:docgen-perf-gate       # the same suite, plus budget assertions - what CI runs daily
-yarn bench:docgen-memory          # the docgen-server memory regression gate CI runs daily
+yarn bench:docgen-perf-gate       # the same suite, plus budget assertions - what the CI gate runs
+yarn bench:docgen-memory          # the docgen-server memory regression gate
 ```
 
 `bench:docgen-perf` generates synthetic projects under the shared sandbox directory, runs each engine in its own child process, and writes a results JSON next to them.
@@ -226,6 +226,8 @@ The suite prints both resolved versions beside every ratio and calls out two equ
 `PERF-METHODOLOGY.md` walks through reading those guard lines, and through adding a pair for another engine.
 
 ### The gate and its budgets
+
+Both gates run on CircleCI's daily tier, which is triggered on demand by the `ci:daily` label on a pull request - nothing schedules it, so this is not nightly protection.
 
 `bench:docgen-perf-gate` runs the suite at the pinned profile, asserts the budgets in `src/perf/docgen-shared/budgets.ts`, and then proves its own failure detection by running a deliberately failing engine and requiring that run to come back non-zero.
 It writes into the sandbox directory by default; CI passes `--out ./perf-results` so the results can be stored as a build artifact.

--- a/code/lib/docgen-harness/README.md
+++ b/code/lib/docgen-harness/README.md
@@ -223,6 +223,9 @@ yarn bench:docgen-perf --engine vue-component-meta --engine vue-component-meta-n
 
 Pin the candidate exactly rather than with a range - two caret ranges can resolve to one install, and then the run compares an engine against itself.
 The suite prints both resolved versions beside every ratio and calls out two equal ones as not being a comparison at all.
+
+The mechanism is not Vue-specific: an engine entry declares which install it measures, the child imports that specifier instead of a hard-coded package, and a pair is two entries differing only in that field.
+`PERF-METHODOLOGY.md` has the steps for setting one up on another engine, and the one case it does not cover.
 `PERF-METHODOLOGY.md` walks through reading those guard lines, and through adding a pair for another engine.
 
 ### The gate and its budgets

--- a/code/lib/docgen-harness/README.md
+++ b/code/lib/docgen-harness/README.md
@@ -175,19 +175,68 @@ Each has a red marker in `vue3-legacy-gaps.test.ts`.
 `src/perf/` measures how fast the docgen engines are and how much memory they hold, which is the other half of the "docgen beyond React" question the snapshot comparator above answers for correctness.
 It is a set of CLIs rather than part of this package's exported API, so nothing in `src/perf/` is re-exported from `src/index.ts`.
 
-Both commands run from `code/lib/docgen-harness`:
+All commands run from `code/lib/docgen-harness`:
 
 ```bash
-yarn bench:docgen-perf            # per-engine cold/warm latency and memory, full profile
+yarn bench:docgen-perf            # per-engine cold/warm latency and memory, full profile (~1 min)
 yarn bench:docgen-perf --quick    # smoke profile; its numbers are marked non-comparable
+yarn bench:docgen-perf-gate       # the same suite, plus budget assertions - what CI runs daily
 yarn bench:docgen-memory          # the docgen-server memory regression gate CI runs daily
 ```
 
 `bench:docgen-perf` generates synthetic projects under the shared sandbox directory, runs each engine in its own child process, and writes a results JSON next to them.
+The generated trees are left on disk so you can open what was measured, and each engine/scenario owns one directory that the generator wipes before it writes.
+That makes two bench runs at once clobber each other - one wipes a tree the other is mid-way through reading - so run them one at a time.
 `bench:docgen-memory` asserts both that re-extraction is leak-free and that the program-recycle fix still flips a tight-heap run from OOM to survival.
 
+### Running one engine, or one that is out of the default run
+
+```bash
+yarn bench:docgen-perf --engine react-osa                       # one engine
+yarn bench:docgen-perf --engine react-legacy --engine react-osa # a control pair, one invocation
+yarn bench:docgen-perf --json /tmp/results.json                 # where the results land
+```
+
+The default run is `react-legacy`, `react-osa`, `vue-docgen-api`, `vue-component-meta` and `compodoc`.
+Two ids sit outside it and only measure when named: `react-legacy-rdt` (the `react-docgen-typescript` parser) and `vue-component-meta-next` (the version-pair alias).
+A ratio only appears when both sides of a control pair measured in the same invocation, so naming one side gives you a table row and no comparison.
+
+Compodoc is skipped with a message when its CLI does not resolve; every other engine reads from the workspace, so a missing one is a failure rather than a skip.
+
+### The two React shapes
+
+The React engines run every scenario twice, because Storybook documents components in two shapes that cost very different things:
+
+- `whole-index` - one batch over every component, what the manifest generator does.
+- `first-story` - the single component a request asks for, what the docgen server does. This is the number a developer waits for before Controls populate.
+
+The cold ratio between the React engines is around 0.7 over the index and 0.1 over the first story; reading only one of them gives a misleading picture of the engine's cost.
+
+### Comparing two releases of one engine
+
+`vue-component-meta-next` is an alias in this package's `package.json`, pinned to an exact version.
+Point it at the version you want to test, `yarn install`, then run both sides in one invocation:
+
+```bash
+yarn bench:docgen-perf --engine vue-component-meta --engine vue-component-meta-next
+```
+
+Pin the candidate exactly rather than with a range - two caret ranges can resolve to one install, and then the run compares an engine against itself.
+The suite prints both resolved versions beside every ratio and calls out two equal ones as not being a comparison at all.
+`PERF-METHODOLOGY.md` walks through reading those guard lines, and through adding a pair for another engine.
+
+### The gate and its budgets
+
+`bench:docgen-perf-gate` runs the suite at the pinned profile, asserts the budgets in `src/perf/docgen-shared/budgets.ts`, and then proves its own failure detection by running a deliberately failing engine and requiring that run to come back non-zero.
+It writes into the sandbox directory by default; CI passes `--out ./perf-results` so the results can be stored as a build artifact.
+
+It refuses to report a green gate on a `--quick` run, on an empty budget table, or when a budgeted engine skipped or failed - each of those would look like protection while asserting nothing.
+
+Budgets are ratios and absolute megabytes, never raw milliseconds, because wall clock on a shared CI executor is far too noisy to gate on.
+Change one only against numbers measured on CI, and record where they came from in `PERF-METHODOLOGY.md`.
+
 Read `src/perf/PERF-METHODOLOGY.md` before changing a metric, a budget, or a version pair.
-It is the contract the numbers are only meaningful under.
+It is the contract these numbers are only meaningful under.
 
 The bench also carries unit tests for its own aggregation, reporting and generator logic, so `yarn test code/lib/docgen-harness` runs those alongside the fixture comparisons.
 

--- a/code/lib/docgen-harness/package.json
+++ b/code/lib/docgen-harness/package.json
@@ -27,7 +27,8 @@
   },
   "scripts": {
     "bench:docgen-memory": "node --import jiti/register ./src/perf/docgen-memory/gate.ts",
-    "bench:docgen-perf": "node ./src/perf/docgen-perf/run.ts"
+    "bench:docgen-perf": "node ./src/perf/docgen-perf/run.ts",
+    "bench:docgen-perf-gate": "node ./src/perf/docgen-perf/gate.ts"
   },
   "devDependencies": {
     "@angular/common": "^21.2.14",

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -143,15 +143,19 @@ Declaring `@storybook/react` as a dependency of `@storybook/docgen-harness` is w
 
 Four data edits:
 
-1. An alias in `code/lib/docgen-harness/package.json` pinned to the candidate version.
+1. An alias in `code/lib/docgen-harness/package.json` pinned to the candidate version, named `<package>-<suffix>`.
 2. The new id added to the `EngineId` union in `docgen-shared/engine-ids.ts`, which is hand-maintained: a registry entry naming an id that is not in the union does not compile.
-3. A second registry entry in `docgen-perf/registry.ts` reusing the same child, with `inDefaultRun: false`, `versionPackage` naming the alias, and the flag that tells the child which install to load.
+3. A second registry entry in `docgen-perf/registry.ts` reusing the same child, with `inDefaultRun: false` and `pin` naming the alias.
 4. An entry in `CONTROL_PAIRS` in `docgen-perf/ratios.ts` naming the current side as `legacy` and the alias as `next`.
 
-Plus one code edit, unless the child already has it: the child needs a flag that selects the install, which is what `--pin` is on the vue-component-meta child.
-That took a small union of allowed values, an extension of the shared option schema, a per-pin scratch directory so the two runs do not share a generated project, and a conditional import of the aliased package.
+The registry's `pin` is the whole mechanism: it reaches the child as `--pin <specifier>`, is what `preflight` resolves, and is the version reported with the results.
+Nothing about it is engine-specific.
 
-One easily-missed prerequisite: the *current* side's existing registry entry must declare `versionPackage` too.
+Plus one code edit, unless the child already has it: the child has to accept `--pin` and import that specifier rather than a hard-coded one.
+`docgen-shared/pin.ts` is that, in three lines at the child - the flag, `pinOption(<canonical package>)` extending its option schema, and `importPinned` in place of a static import.
+Only the named install is ever imported, so the other copy never sits on the measured heap, and the resolved specifier also names the scratch directory so the two runs do not share a generated project.
+
+One easily-missed prerequisite: the *current* side's existing registry entry must declare `pin` too, naming the canonical package.
 `versionNote` prints nothing unless both sides resolved a version, so without it every ratio line silently loses its version note - and with it the guard against both sides resolving to the same version.
 
 Nothing else changes: aggregation, member counts and the ordering alternation are already shared by every pair.

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -20,6 +20,7 @@ The slope is fitted over the save series with the first save excluded.
 An engine that re-extracts one component per save releases its whole-project state on that first save, and a fit that includes the step measures the cold-to-steady-state transition instead of the leak trend.
 For `react-osa` that is the difference between a strongly negative slope, which hides any leak smaller than the step, and the small positive trend its steady state actually shows in the table below.
 One excluded sample is enough: that engine is the only one with a step, and it lands entirely inside the first save.
+A scenario therefore needs at least three saves to produce a slope at all - the excluded one, plus the two a line needs - and a scenario configured below that reports no retained metrics and fails its engine rather than quietly reporting a flat trend.
 
 ### The two React shapes
 
@@ -114,9 +115,11 @@ Add `--quick` for a smoke run that proves the wiring; its numbers are marked non
 A real run prints one cold and one warm line per scenario:
 
 ```text
-ratio cold legacy/new (vue-component-meta-version/flat): 1.04  [documented members 70 vs 70]  [3.3.2 vs 3.3.8]
-ratio warm legacy/new (vue-component-meta-version/flat): 1.01  [documented members 15 vs 15]  [3.3.2 vs 3.3.8]
+ratio cold (vue-component-meta over vue-component-meta-next, flat): 1.04  [documented members 70 vs 70]  [3.3.2 vs 3.3.8]
+ratio warm (vue-component-meta over vue-component-meta-next, flat): 1.01  [documented members 15 vs 15]  [3.3.2 vs 3.3.8]
 ```
+
+Both engines are named on the line, and a header above the block says which way the division goes, so no one has to remember which side of a pair is which.
 
 - **Two different versions.**
   `[3.3.2 vs 3.3.8]` is what says two different versions were actually compared.

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -153,7 +153,8 @@ Nothing about it is engine-specific.
 
 Plus one code edit, unless the engine already takes a pin.
 A spawned-CLI engine resolves its pin itself and needs nothing more; `CompodocEngine` takes one in its constructor.
-A child-harness engine has to accept `--pin` and import that specifier rather than a hard-coded one, which is three lines at the child - the flag, `pinOption(<canonical package>)` extending its option schema, and `importPinned` in place of a static import.
+A child-harness engine has to accept `--pin` and import that specifier rather than a hard-coded one, which is three lines at the child - the flag, one schema entry, and `importPinned` in place of a static import.
+`importPinned` checks the pin resolves to the package the harness measures before loading it, since an alias keeps the aliased package's own name.
 Only the named install is ever imported, so the other copy never sits on the measured heap, and the resolved specifier also names the scratch directory so the two runs do not share a generated project.
 
 One easily-missed prerequisite: the *current* side's existing registry entry must declare `pin` too, naming the canonical package.

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -147,7 +147,39 @@ Cold and warm get their own verdict, since a pair can document the same members 
 
 Even the member count is not enough on its own. An engine that records a type's name without ever looking through it documents exactly as many members as one that expanded the whole chain, and it does so at a fraction of the cost. So an engine that works that way also reports how many of its documented members carry a type it never resolved, and that second count has to agree as well before the two sides count as having done equal work.
 
-What we do not have yet is the gate. Once baselines exist, a ratio that moves the wrong way should fail CI, so that a human intercepts and decides what to do next.
+A cross-engine ratio therefore only becomes a budget once the suite has certified the pair as like-for-like, and today none of the pairs qualifies.
+The Vue pair is genuinely unequal: `vue-component-meta` documents several times the members `vue-docgen-api` does, so its higher cost is thoroughness rather than slowness.
+The React pair is undecided rather than unequal, because neither React engine reports a member count, and a missing count is not agreement.
+Making that pair gateable means teaching both React children to count what they documented, which is worth doing and has not been done.
+
+### The incrementality ratio
+
+There is one timing budget that needs no second engine.
+Warm over cold, for a single engine, compares two figures from the same process over the same project, which makes it like-for-like by construction and immune to the member-count question entirely.
+
+It also measures the thing users feel.
+A cold extraction happens once at startup; a warm one happens on every save, and it is only fast because the engine re-extracts the component that changed instead of redoing the whole project.
+When that breaks, the warm figure climbs toward the cold one, and the ratio catches it whatever the absolute numbers on the day happen to be.
+
+## The gate
+
+`yarn bench:docgen-perf-gate` runs the suite once at the pinned profile and asserts every recorded budget against the results.
+
+Four rules exist so that a green gate means something:
+
+- A run marked non-comparable - the `--quick` smoke profile - fails rather than passing on numbers that were never meant to be compared.
+- An empty budget table fails, because a gate that asserts nothing should not report success.
+- An engine that carries a budget but skipped or failed fails the gate. Skipping is legitimate on a laptop missing an optional tool; on the gate it means the thing being protected did not run.
+- A cross-engine ratio the suite did not certify as like-for-like fails rather than being gated on, and the failure names which way the two sides differed.
+
+The gate then proves its own failure detection: it runs the suite a second time with an engine that always fails, and requires that run to come back non-zero.
+Without that, a gate whose failure path had silently broken would be indistinguishable from a gate that keeps passing because nothing is wrong.
+
+### When it runs
+
+On CircleCI's daily tier, which is triggered by the `ci:daily` label on a pull request.
+Nothing schedules that tier, so this is on-demand protection rather than nightly protection.
+A regression that lands on a Tuesday is caught whenever someone next asks for a daily run, not overnight.
 
 ### Memory budgets
 

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -250,7 +250,8 @@ None of them is gated on, for the reasons under "Like-for-like comparison" above
 | vue-docgen-api over vue-component-meta | workspace       | 0.10 | 0.04 | no - 50 vs 350 cold, 0 vs 37 warm               |
 | vue-docgen-api over vue-component-meta | base-type-touch | 0.10 | 0.07 | no - 50 vs 350 cold, 5 vs 45 warm               |
 
-The Vue rows are all `NOT like-for-like` in the new engine's favour: it documents four to seven times as many members, so every one of those ratios understates it.
+The Vue rows are all `NOT like-for-like` in the new engine's favour: it documents four to seven times as many members on the cold pass, and more still on the save each was timed on - 5 against 45 on `base-type-touch`, and 0 against 17 and 37 on the other two, where `vue-docgen-api` documented nothing at all.
+So every one of those ratios understates the new engine.
 The React rows say `unknown` rather than agreeing, because neither React engine reports a member count at all.
 Nothing in the version-pair row appears here: `vue-component-meta-next` is out of the default run, so a version comparison only exists in the output of the run that explicitly asked for it.
 
@@ -260,16 +261,18 @@ Four things in these tables are worth reading twice.
 Compodoc's warm figure is its cold figure, because it re-runs the whole project on every invocation.
 That is what it does by design, so it carries no incrementality budget; its peak memory, an order of magnitude above every other engine, is the number worth watching.
 
-`react-osa` reports negative retained growth, and that is the engine working correctly rather than a measurement artefact.
+`react-osa` reports negative retained growth on `whole-index`, and that is the engine working correctly rather than a measurement artefact.
 The baseline is sampled straight after the cold pass, when the engine still holds state sized for the whole project.
 The first save re-extracts a single component, that whole-project state is released, and retained heap drops by around 83MB in one step and then stays flat.
-So the growth figure measures the distance from the cold-pass peak down to the steady state, and it is negative for every engine that re-extracts incrementally.
+So the growth figure measures the distance from the cold-pass peak down to the steady state, and it is negative wherever the cold pass built whole-project state that the first save then releases.
+That is the two `whole-index` rows and nothing else: the `first-story` rows never build that state, and the Vue engines hold little enough of it that the growing component type outweighs whatever they release.
 
 The React pair's cold ratio depends entirely on which shape you ask about.
 Over `whole-index` it sits at 0.73 - the two engines are within half an order of magnitude when documenting everything.
 Over `first-story` it drops to 0.08, because `react-docgen` answers one component without building a program at all while `react-osa` has to construct one first.
 That gap is the startup cost of the new engine, and it was invisible while the suite only measured the whole-index shape.
-The warm ratios run the other way round: 0.29 over the index against 0.40 over the first story, because once a program exists `react-osa` re-extracts more cheaply than the legacy parser re-parses.
+The warm ratios move the other way between shapes, 0.29 over the index against 0.40 over the first story, but both stay well under 1.00: `react-legacy` re-parses one component in 13ms and 19ms against `react-osa`'s 45ms and 48ms, so the legacy parser is the cheaper warm path in either shape.
+What the first-story warm ratio says is that `react-osa` loses far less ground once its program exists than the 0.08 cold ratio suggests.
 
 And the retained slope is higher on `first-story` for both engines (0.12 and 0.19, against 0.01 and 0.10) without either of them leaking.
 Every save adds a prop to the component it touches, and in this shape that is the same component every time, so its type genuinely grows across the run.
@@ -281,13 +284,13 @@ Recorded in `docgen-shared/budgets.ts`, keyed by engine and scenario, above the 
 
 | Engine / scenario                  | Warm/cold ratio | Peak transient | Retained growth | Retained slope | Tier  |
 | ---------------------------------- | --------------- | -------------- | --------------- | -------------- | ----- |
-| react-legacy/whole-index           | 0.05            | 15MB           | 30MB            | 1MB/save       | daily |
+| react-legacy/whole-index           | 0.05            | 15MB           | 2MB             | 0.1MB/save     | daily |
 | react-legacy/first-story           | 0.60            | 15MB           | 10MB            | 1MB/save       | daily |
-| react-osa/whole-index              | 0.08            | 45MB           | 60MB            | 0.5MB/save     | daily |
+| react-osa/whole-index              | 0.08            | 45MB           | -50MB           | 0.5MB/save     | daily |
 | react-osa/first-story              | 0.15            | 30MB           | 10MB            | 1MB/save       | daily |
-| vue-docgen-api/flat                | 0.08            | 8MB            | 10MB            | 1MB/save       | daily |
-| vue-docgen-api/workspace           | 0.10            | 8MB            | 10MB            | 1MB/save       | daily |
-| vue-docgen-api/base-type-touch     | 0.25            | 8MB            | 10MB            | 1MB/save       | daily |
+| vue-docgen-api/flat                | 0.08            | 4MB            | 3MB             | 0.2MB/save     | daily |
+| vue-docgen-api/workspace           | 0.10            | 4MB            | 3MB             | 0.2MB/save     | daily |
+| vue-docgen-api/base-type-touch     | 0.25            | 4MB            | 3MB             | 0.2MB/save     | daily |
 | vue-component-meta/flat            | 0.20            | 40MB           | 20MB            | 1.5MB/save     | daily |
 | vue-component-meta/workspace       | 0.22            | 40MB           | 20MB            | 1.5MB/save     | daily |
 | vue-component-meta/base-type-touch | 0.25            | 40MB           | 20MB            | 1.5MB/save     | daily |
@@ -295,7 +298,12 @@ Recorded in `docgen-shared/budgets.ts`, keyed by engine and scenario, above the 
 | svelte (stretch)                   | TBD             | TBD            | TBD             | TBD            | TBD   |
 | cem (stretch)                      | TBD             | TBD            | TBD             | TBD            | TBD   |
 
+Retained growth is a signed ceiling rather than a multiple of what was observed, because the number it bounds can be negative.
+`react-osa/whole-index` measures -82.9MB, and the regression worth catching there is the engine no longer releasing its whole-project state, which would land near 0MB and pass any positive budget.
+Its budget is therefore -50MB: the run has to still drop at least that far to be green.
+
 `react-legacy-rdt` and `vue-component-meta-next` are measurable but carry no budget: neither runs by default, and a budget on something CI never runs would be decoration.
 The two stretch rows wait on engines that do not exist yet.
 
-The docgen-memory gate keeps its own, heavier `react-osa` row (90MB transient, 60MB growth, 3MB/save) covering the whole-index workload; the row above covers the incremental one this suite measures.
+The docgen-memory gate keeps its own, heavier `react-osa` row (90MB transient, 60MB growth, 3MB/save) over a 600-component project.
+It measures the same shape and the same save scope as `react-osa/whole-index` above; only the project size differs, which is why its budgets sit so much higher.

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -16,6 +16,10 @@ We are collecting five metrics per engine:
 4. Peak memory: the memory a save claims above the retained baseline
 5. Leak detection: How much retained heap is still held after the save series, together with how steeply it climbed from one save to the next?
 
+The slope is fitted over the save series with the first save excluded.
+An engine that re-extracts one component per save releases its whole-project state on that first save, and a fit that includes the step measures the cold-to-steady-state transition instead of the leak trend - for `react-osa` that alone is the difference between a reported -1.16MB/save and the true +0.06MB/save.
+One excluded sample is enough: that engine is the only one with a step, and it lands entirely inside the first save.
+
 ## Determinism method
 
 ### Fixed synthetic projects
@@ -195,7 +199,7 @@ Milliseconds are context, never a budget: the same suite runs three to four time
 | Engine / scenario                  | Cold    | Warm   | Scan   | Peak transient | Retained growth | Retained slope |
 | ---------------------------------- | ------- | ------ | ------ | -------------- | --------------- | -------------- |
 | react-legacy/default               | 1917ms  | 14ms   | n/a    | 2.4MB          | -4.1MB          | 0.01MB/save    |
-| react-osa/default                  | 2701ms  | 44ms   | n/a    | 13.8MB         | -83.0MB         | -1.13MB/save   |
+| react-osa/default                  | 2701ms  | 44ms   | n/a    | 13.8MB         | -83.0MB         | pending        |
 | vue-docgen-api/flat                | 155ms   | 3ms    | n/a    | 0.4MB          | 0.2MB           | 0.02MB/save    |
 | vue-docgen-api/workspace           | 121ms   | 3ms    | n/a    | 0.4MB          | 0.3MB           | 0.02MB/save    |
 | vue-docgen-api/base-type-touch     | 123ms   | 10ms   | n/a    | 0.9MB          | 0.1MB           | 0.01MB/save    |
@@ -209,8 +213,10 @@ Two things in that table are worth reading twice.
 Compodoc's warm figure is its cold figure, because it re-runs the whole project on every invocation.
 That is what it does by design, so it carries no incrementality budget; its peak memory, an order of magnitude above every other engine, is the number worth watching.
 
-`react-osa` reports negative retained growth and a negative slope: it ends the series holding less than it started with, because the run's forced collections settle the heap below the baseline taken before any extraction happened.
-A leak would show up as a positive slope, so the budget is a ceiling and the negative value passes it comfortably.
+`react-osa` reports negative retained growth, and that is the engine working correctly rather than a measurement artefact.
+The baseline is sampled straight after the cold pass, when the engine still holds state sized for the whole project.
+The first save re-extracts a single component, that whole-project state is released, and retained heap drops by around 85MB in one step and then stays flat.
+So the growth figure measures the distance from the cold-pass peak down to the steady state, and it is negative for every engine that re-extracts incrementally.
 
 The reference ratios stand at 0.71 cold and 0.31 warm for react-legacy over react-osa, and around 0.10-0.14 cold for vue-docgen-api over vue-component-meta.
 None of them is gated on, for the reasons under "Like-for-like comparison" above.
@@ -222,7 +228,7 @@ Recorded in `docgen-shared/budgets.ts`, keyed by engine and scenario, at roughly
 | Engine / scenario                  | Warm/cold ratio | Peak transient | Retained growth | Retained slope | Tier  |
 | ---------------------------------- | --------------- | -------------- | --------------- | -------------- | ----- |
 | react-legacy/default               | 0.05            | 15MB           | 30MB            | 1MB/save       | daily |
-| react-osa/default                  | 0.08            | 45MB           | 60MB            | 3MB/save       | daily |
+| react-osa/default                  | 0.08            | 45MB           | 60MB            | 0.5MB/save     | daily |
 | vue-docgen-api/flat                | 0.08            | 8MB            | 10MB            | 1MB/save       | daily |
 | vue-docgen-api/workspace           | 0.10            | 8MB            | 10MB            | 1MB/save       | daily |
 | vue-docgen-api/base-type-touch     | 0.25            | 8MB            | 10MB            | 1MB/save       | daily |

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -199,6 +199,7 @@ Four rules exist so that a green gate means something:
 
 - A run marked non-comparable - the `--quick` smoke profile - fails rather than passing on numbers that were never meant to be compared.
 - An empty budget table fails, because a gate that asserts nothing should not report success.
+- A scenario the run measured with no budget row fails. The gate can only assert the rows it has, so without this a new scenario would run every night protected by nothing. It fails until its baseline is recorded, which is the run that produces the number to budget.
 - An engine that carries a budget but skipped or failed fails the gate. Skipping is legitimate on a laptop missing an optional tool; on the gate it means the thing being protected did not run.
 
 Cross-engine ratios are printed on every run but gated on by nothing, because no pair has been certified as doing equal work.
@@ -219,52 +220,71 @@ Memory budgets stay in absolute megabytes, with enough headroom on CI so that th
 
 ## Recorded baselines
 
-Measured on a CircleCI `sb_node_22_classic` medium+ executor, Node 22.22.1, at the pinned profile (N=6).
+Measured on a CircleCI `sb_node_22_classic` medium+ executor at the pinned profile (N=6); the exact Node version is recorded in the run's own `results.json`.
 Milliseconds are context, never a budget: the same suite runs three to four times faster on an Apple-silicon laptop, which is exactly why nothing gates on them.
 
-| Engine / scenario                  | Cold    | Warm   | Scan   | Peak transient | Retained growth | Retained slope |
-| ---------------------------------- | ------- | ------ | ------ | -------------- | --------------- | -------------- |
-| react-legacy/whole-index           | 1917ms  | 14ms   | n/a    | 2.4MB          | -4.1MB          | 0.01MB/save    |
-| react-osa/whole-index              | 2701ms  | 44ms   | n/a    | 13.8MB         | -83.0MB         | 0.10MB/save    |
-| react-legacy/first-story           | pending | pending| n/a    | pending        | pending         | pending        |
-| react-osa/first-story              | pending | pending| n/a    | pending        | pending         | pending        |
-| vue-docgen-api/flat                | 155ms   | 3ms    | n/a    | 0.4MB          | 0.2MB           | 0.02MB/save    |
-| vue-docgen-api/workspace           | 121ms   | 3ms    | n/a    | 0.4MB          | 0.3MB           | 0.02MB/save    |
-| vue-docgen-api/base-type-touch     | 123ms   | 10ms   | n/a    | 0.9MB          | 0.1MB           | 0.02MB/save    |
-| vue-component-meta/flat            | 1145ms  | 80ms   | n/a    | 9.4MB          | 3.7MB           | 0.19MB/save    |
-| vue-component-meta/workspace       | 1067ms  | 84ms   | n/a    | 12.7MB         | 3.6MB           | 0.19MB/save    |
-| vue-component-meta/base-type-touch | 1182ms  | 96ms   | n/a    | 12.1MB         | 3.0MB           | 0.25MB/save    |
-| compodoc/default                   | 1434ms  | 1537ms | 1434ms | 213.8MB        | n/a             | n/a            |
+| Engine / scenario                  | Cold   | Warm   | Scan   | Peak transient | Retained growth | Retained slope |
+| ---------------------------------- | ------ | ------ | ------ | -------------- | --------------- | -------------- |
+| react-legacy/whole-index           | 1722ms | 13ms   | n/a    | 2.3MB          | -4.1MB          | 0.01MB/save    |
+| react-legacy/first-story           | 96ms   | 19ms   | n/a    | 2.6MB          | 1.6MB           | 0.12MB/save    |
+| react-osa/whole-index              | 2353ms | 45ms   | n/a    | 13.8MB         | -82.9MB         | 0.10MB/save    |
+| react-osa/first-story              | 1142ms | 48ms   | n/a    | 9.8MB          | 1.3MB           | 0.19MB/save    |
+| vue-docgen-api/flat                | 153ms  | 3ms    | n/a    | 0.4MB          | 0.2MB           | 0.01MB/save    |
+| vue-docgen-api/workspace           | 105ms  | 3ms    | n/a    | 0.4MB          | 0.2MB           | 0.02MB/save    |
+| vue-docgen-api/base-type-touch     | 109ms  | 6ms    | n/a    | 0.9MB          | 0.1MB           | 0.02MB/save    |
+| vue-component-meta/flat            | 997ms  | 79ms   | n/a    | 9.4MB          | 3.7MB           | 0.20MB/save    |
+| vue-component-meta/workspace       | 1060ms | 84ms   | n/a    | 12.8MB         | 3.6MB           | 0.19MB/save    |
+| vue-component-meta/base-type-touch | 1044ms | 84ms   | n/a    | 12.9MB         | 3.0MB           | 0.25MB/save    |
+| compodoc/default                   | 1315ms | 1336ms | 1315ms | 216.0MB        | n/a             | n/a            |
 
-The `first-story` rows land with the next daily run; the shape was added after the run above.
-Locally they read 33ms and 341ms cold against 463ms and 678ms for `whole-index`, which is the shape of the finding rather than a number to quote.
+### Pair ratios from the same run
 
-Three things in that table are worth reading twice.
+Each ratio divides the first engine's median by the second's, so above 1.00 means the second engine was faster.
+None of them is gated on, for the reasons under "Like-for-like comparison" above.
+
+| Pair (first over second)               | Scenario        | Cold | Warm | Equal work?                                     |
+| -------------------------------------- | --------------- | ---- | ---- | ----------------------------------------------- |
+| react-legacy over react-osa            | whole-index     | 0.73 | 0.29 | unknown - neither React engine reports counts   |
+| react-legacy over react-osa            | first-story     | 0.08 | 0.40 | unknown - neither React engine reports counts   |
+| vue-docgen-api over vue-component-meta | flat            | 0.15 | 0.04 | no - 80 vs 320 cold, 0 vs 17 warm               |
+| vue-docgen-api over vue-component-meta | workspace       | 0.10 | 0.04 | no - 50 vs 350 cold, 0 vs 37 warm               |
+| vue-docgen-api over vue-component-meta | base-type-touch | 0.10 | 0.07 | no - 50 vs 350 cold, 5 vs 45 warm               |
+
+The Vue rows are all `NOT like-for-like` in the new engine's favour: it documents four to seven times as many members, so every one of those ratios understates it.
+The React rows say `unknown` rather than agreeing, because neither React engine reports a member count at all.
+Nothing in the version-pair row appears here: `vue-component-meta-next` is out of the default run, so a version comparison only exists in the output of the run that explicitly asked for it.
+
+Four things in these tables are worth reading twice.
+
 
 Compodoc's warm figure is its cold figure, because it re-runs the whole project on every invocation.
 That is what it does by design, so it carries no incrementality budget; its peak memory, an order of magnitude above every other engine, is the number worth watching.
 
 `react-osa` reports negative retained growth, and that is the engine working correctly rather than a measurement artefact.
 The baseline is sampled straight after the cold pass, when the engine still holds state sized for the whole project.
-The first save re-extracts a single component, that whole-project state is released, and retained heap drops by around 85MB in one step and then stays flat.
+The first save re-extracts a single component, that whole-project state is released, and retained heap drops by around 83MB in one step and then stays flat.
 So the growth figure measures the distance from the cold-pass peak down to the steady state, and it is negative for every engine that re-extracts incrementally.
 
-And the React pair's cold ratio depends entirely on which shape you ask about.
-Over `whole-index` it sits near 0.7 - the two engines are within half an order of magnitude when documenting everything.
-Over `first-story` it drops to about 0.10, because `react-docgen` answers one component without building a program at all while `react-osa` has to construct one first.
+The React pair's cold ratio depends entirely on which shape you ask about.
+Over `whole-index` it sits at 0.73 - the two engines are within half an order of magnitude when documenting everything.
+Over `first-story` it drops to 0.08, because `react-docgen` answers one component without building a program at all while `react-osa` has to construct one first.
 That gap is the startup cost of the new engine, and it was invisible while the suite only measured the whole-index shape.
+The warm ratios run the other way round: 0.29 over the index against 0.40 over the first story, because once a program exists `react-osa` re-extracts more cheaply than the legacy parser re-parses.
 
-The reference ratios stand at 0.71 cold and 0.31 warm for react-legacy over react-osa on `whole-index`, and around 0.10-0.14 cold for vue-docgen-api over vue-component-meta.
-None of them is gated on, for the reasons under "Like-for-like comparison" above.
+And the retained slope is higher on `first-story` for both engines (0.12 and 0.19, against 0.01 and 0.10) without either of them leaking.
+Every save adds a prop to the component it touches, and in this shape that is the same component every time, so its type genuinely grows across the run.
+The slope there measures that growth as well as any leak, which is why its budget is no tighter than the whole-index one.
 
 ### Budgets
 
-Recorded in `docgen-shared/budgets.ts`, keyed by engine and scenario, at roughly three to seven times the observed value so a busy executor cannot turn the gate into a flake.
+Recorded in `docgen-shared/budgets.ts`, keyed by engine and scenario, above the observed value by whatever margin that metric's own noise demands.
 
 | Engine / scenario                  | Warm/cold ratio | Peak transient | Retained growth | Retained slope | Tier  |
 | ---------------------------------- | --------------- | -------------- | --------------- | -------------- | ----- |
 | react-legacy/whole-index           | 0.05            | 15MB           | 30MB            | 1MB/save       | daily |
+| react-legacy/first-story           | 0.60            | 15MB           | 10MB            | 1MB/save       | daily |
 | react-osa/whole-index              | 0.08            | 45MB           | 60MB            | 0.5MB/save     | daily |
+| react-osa/first-story              | 0.15            | 30MB           | 10MB            | 1MB/save       | daily |
 | vue-docgen-api/flat                | 0.08            | 8MB            | 10MB            | 1MB/save       | daily |
 | vue-docgen-api/workspace           | 0.10            | 8MB            | 10MB            | 1MB/save       | daily |
 | vue-docgen-api/base-type-touch     | 0.25            | 8MB            | 10MB            | 1MB/save       | daily |

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -137,7 +137,7 @@ An engine whose package does not resolve is reported as skipped with a reason ra
 
 #### Adding a version pair for another engine
 
-This works only for an engine whose child imports the versioned package directly, the way `engines/vue-component-meta.ts` does.
+This works for an engine that reaches its docgen package by specifier: a child that imports it, the way `engines/vue-component-meta.ts` does, or a CLI the engine spawns, the way `engines/compodoc.ts` does.
 Where the harness reaches the engine through repo source instead - `react-legacy` goes via `loadReactRendererModule` into `code/renderers/react`, which imports `react-docgen` by bare specifier - no child flag can redirect that import, and a version pair needs a different approach entirely.
 Declaring `@storybook/react` as a dependency of `@storybook/docgen-harness` is what makes that source reachable in the first place, but it does not make the specifier redirectable: pointing the renderer at a second `react-docgen` would take a module resolution hook registered in the child, which is not built.
 
@@ -151,8 +151,9 @@ Four data edits:
 The registry's `pin` is the whole mechanism: it reaches the child as `--pin <specifier>`, is what `preflight` resolves, and is the version reported with the results.
 Nothing about it is engine-specific.
 
-Plus one code edit, unless the child already has it: the child has to accept `--pin` and import that specifier rather than a hard-coded one.
-`docgen-shared/pin.ts` is that, in three lines at the child - the flag, `pinOption(<canonical package>)` extending its option schema, and `importPinned` in place of a static import.
+Plus one code edit, unless the engine already takes a pin.
+A spawned-CLI engine resolves its pin itself and needs nothing more; `CompodocEngine` takes one in its constructor.
+A child-harness engine has to accept `--pin` and import that specifier rather than a hard-coded one, which is three lines at the child - the flag, `pinOption(<canonical package>)` extending its option schema, and `importPinned` in place of a static import.
 Only the named install is ever imported, so the other copy never sits on the measured heap, and the resolved specifier also names the scratch directory so the two runs do not share a generated project.
 
 One easily-missed prerequisite: the *current* side's existing registry entry must declare `pin` too, naming the canonical package.

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -21,6 +21,22 @@ An engine that re-extracts one component per save releases its whole-project sta
 For `react-osa` that is the difference between a strongly negative slope, which hides any leak smaller than the step, and the small positive trend its steady state actually shows in the table below.
 One excluded sample is enough: that engine is the only one with a step, and it lands entirely inside the first save.
 
+### The two React shapes
+
+Storybook documents React components in two different shapes, and they cost very different things, so the suite measures both rather than averaging them into one misleading number.
+
+`whole-index` is the manifest generator: one batch over every component in the index.
+`first-story` is the docgen server's per-request path, where the manager is created on the first eligible request and extracts only the component that story needs; every save then re-extracts that same component.
+Both run over the identical generated project, so the only difference is how much of it the cold pass documents.
+
+The save target differs deliberately.
+Walking round-robin under `first-story` would document a component the cold pass never touched, so retained heap would climb for the honest reason that the run keeps documenting more - which is indistinguishable from a leak.
+Re-touching the one documented component keeps the steady state comparable between the shapes.
+
+Reading both rows together is the point.
+`whole-index` is what a full manifest build costs, which is what agent and MCP consumers need.
+`first-story` is what a developer waits for before Controls populate, and it is the number to watch when judging whether the docgen server feels fast.
+
 ## Determinism method
 
 ### Fixed synthetic projects
@@ -199,8 +215,10 @@ Milliseconds are context, never a budget: the same suite runs three to four time
 
 | Engine / scenario                  | Cold    | Warm   | Scan   | Peak transient | Retained growth | Retained slope |
 | ---------------------------------- | ------- | ------ | ------ | -------------- | --------------- | -------------- |
-| react-legacy/default               | 1917ms  | 14ms   | n/a    | 2.4MB          | -4.1MB          | 0.01MB/save    |
-| react-osa/default                  | 2701ms  | 44ms   | n/a    | 13.8MB         | -83.0MB         | 0.10MB/save    |
+| react-legacy/whole-index           | 1917ms  | 14ms   | n/a    | 2.4MB          | -4.1MB          | 0.01MB/save    |
+| react-osa/whole-index              | 2701ms  | 44ms   | n/a    | 13.8MB         | -83.0MB         | 0.10MB/save    |
+| react-legacy/first-story           | pending | pending| n/a    | pending        | pending         | pending        |
+| react-osa/first-story              | pending | pending| n/a    | pending        | pending         | pending        |
 | vue-docgen-api/flat                | 155ms   | 3ms    | n/a    | 0.4MB          | 0.2MB           | 0.02MB/save    |
 | vue-docgen-api/workspace           | 121ms   | 3ms    | n/a    | 0.4MB          | 0.3MB           | 0.02MB/save    |
 | vue-docgen-api/base-type-touch     | 123ms   | 10ms   | n/a    | 0.9MB          | 0.1MB           | 0.02MB/save    |
@@ -209,7 +227,10 @@ Milliseconds are context, never a budget: the same suite runs three to four time
 | vue-component-meta/base-type-touch | 1182ms  | 96ms   | n/a    | 12.1MB         | 3.0MB           | 0.25MB/save    |
 | compodoc/default                   | 1434ms  | 1537ms | 1434ms | 213.8MB        | n/a             | n/a            |
 
-Two things in that table are worth reading twice.
+The `first-story` rows land with the next daily run; the shape was added after the run above.
+Locally they read 33ms and 341ms cold against 463ms and 678ms for `whole-index`, which is the shape of the finding rather than a number to quote.
+
+Three things in that table are worth reading twice.
 
 Compodoc's warm figure is its cold figure, because it re-runs the whole project on every invocation.
 That is what it does by design, so it carries no incrementality budget; its peak memory, an order of magnitude above every other engine, is the number worth watching.
@@ -219,7 +240,12 @@ The baseline is sampled straight after the cold pass, when the engine still hold
 The first save re-extracts a single component, that whole-project state is released, and retained heap drops by around 85MB in one step and then stays flat.
 So the growth figure measures the distance from the cold-pass peak down to the steady state, and it is negative for every engine that re-extracts incrementally.
 
-The reference ratios stand at 0.71 cold and 0.31 warm for react-legacy over react-osa, and around 0.10-0.14 cold for vue-docgen-api over vue-component-meta.
+And the React pair's cold ratio depends entirely on which shape you ask about.
+Over `whole-index` it sits near 0.7 - the two engines are within half an order of magnitude when documenting everything.
+Over `first-story` it drops to about 0.10, because `react-docgen` answers one component without building a program at all while `react-osa` has to construct one first.
+That gap is the startup cost of the new engine, and it was invisible while the suite only measured the whole-index shape.
+
+The reference ratios stand at 0.71 cold and 0.31 warm for react-legacy over react-osa on `whole-index`, and around 0.10-0.14 cold for vue-docgen-api over vue-component-meta.
 None of them is gated on, for the reasons under "Like-for-like comparison" above.
 
 ### Budgets
@@ -228,8 +254,8 @@ Recorded in `docgen-shared/budgets.ts`, keyed by engine and scenario, at roughly
 
 | Engine / scenario                  | Warm/cold ratio | Peak transient | Retained growth | Retained slope | Tier  |
 | ---------------------------------- | --------------- | -------------- | --------------- | -------------- | ----- |
-| react-legacy/default               | 0.05            | 15MB           | 30MB            | 1MB/save       | daily |
-| react-osa/default                  | 0.08            | 45MB           | 60MB            | 0.5MB/save     | daily |
+| react-legacy/whole-index           | 0.05            | 15MB           | 30MB            | 1MB/save       | daily |
+| react-osa/whole-index              | 0.08            | 45MB           | 60MB            | 0.5MB/save     | daily |
 | vue-docgen-api/flat                | 0.08            | 8MB            | 10MB            | 1MB/save       | daily |
 | vue-docgen-api/workspace           | 0.10            | 8MB            | 10MB            | 1MB/save       | daily |
 | vue-docgen-api/base-type-touch     | 0.25            | 8MB            | 10MB            | 1MB/save       | daily |

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -170,7 +170,9 @@ Four rules exist so that a green gate means something:
 - A run marked non-comparable - the `--quick` smoke profile - fails rather than passing on numbers that were never meant to be compared.
 - An empty budget table fails, because a gate that asserts nothing should not report success.
 - An engine that carries a budget but skipped or failed fails the gate. Skipping is legitimate on a laptop missing an optional tool; on the gate it means the thing being protected did not run.
-- A cross-engine ratio the suite did not certify as like-for-like fails rather than being gated on, and the failure names which way the two sides differed.
+
+Cross-engine ratios are printed on every run but gated on by nothing, because no pair has been certified as doing equal work.
+The rule that only a like-for-like pair may become a budget lives here rather than in the gate; the check that enforces it belongs with the first pair that earns one.
 
 The gate then proves its own failure detection: it runs the suite a second time with an engine that always fails, and requires that run to come back non-zero.
 Without that, a gate whose failure path had silently broken would be indistinguishable from a gate that keeps passing because nothing is wrong.

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -17,7 +17,8 @@ We are collecting five metrics per engine:
 5. Leak detection: How much retained heap is still held after the save series, together with how steeply it climbed from one save to the next?
 
 The slope is fitted over the save series with the first save excluded.
-An engine that re-extracts one component per save releases its whole-project state on that first save, and a fit that includes the step measures the cold-to-steady-state transition instead of the leak trend - for `react-osa` that alone is the difference between a reported -1.16MB/save and the true +0.06MB/save.
+An engine that re-extracts one component per save releases its whole-project state on that first save, and a fit that includes the step measures the cold-to-steady-state transition instead of the leak trend.
+For `react-osa` that is the difference between a strongly negative slope, which hides any leak smaller than the step, and the small positive trend its steady state actually shows in the table below.
 One excluded sample is enough: that engine is the only one with a step, and it lands entirely inside the first save.
 
 ## Determinism method
@@ -199,13 +200,13 @@ Milliseconds are context, never a budget: the same suite runs three to four time
 | Engine / scenario                  | Cold    | Warm   | Scan   | Peak transient | Retained growth | Retained slope |
 | ---------------------------------- | ------- | ------ | ------ | -------------- | --------------- | -------------- |
 | react-legacy/default               | 1917ms  | 14ms   | n/a    | 2.4MB          | -4.1MB          | 0.01MB/save    |
-| react-osa/default                  | 2701ms  | 44ms   | n/a    | 13.8MB         | -83.0MB         | pending        |
+| react-osa/default                  | 2701ms  | 44ms   | n/a    | 13.8MB         | -83.0MB         | 0.10MB/save    |
 | vue-docgen-api/flat                | 155ms   | 3ms    | n/a    | 0.4MB          | 0.2MB           | 0.02MB/save    |
 | vue-docgen-api/workspace           | 121ms   | 3ms    | n/a    | 0.4MB          | 0.3MB           | 0.02MB/save    |
-| vue-docgen-api/base-type-touch     | 123ms   | 10ms   | n/a    | 0.9MB          | 0.1MB           | 0.01MB/save    |
-| vue-component-meta/flat            | 1145ms  | 80ms   | n/a    | 9.4MB          | 3.7MB           | 0.21MB/save    |
-| vue-component-meta/workspace       | 1067ms  | 84ms   | n/a    | 12.7MB         | 3.6MB           | 0.20MB/save    |
-| vue-component-meta/base-type-touch | 1182ms  | 96ms   | n/a    | 12.1MB         | 3.0MB           | 0.26MB/save    |
+| vue-docgen-api/base-type-touch     | 123ms   | 10ms   | n/a    | 0.9MB          | 0.1MB           | 0.02MB/save    |
+| vue-component-meta/flat            | 1145ms  | 80ms   | n/a    | 9.4MB          | 3.7MB           | 0.19MB/save    |
+| vue-component-meta/workspace       | 1067ms  | 84ms   | n/a    | 12.7MB         | 3.6MB           | 0.19MB/save    |
+| vue-component-meta/base-type-touch | 1182ms  | 96ms   | n/a    | 12.1MB         | 3.0MB           | 0.25MB/save    |
 | compodoc/default                   | 1434ms  | 1537ms | 1434ms | 213.8MB        | n/a             | n/a            |
 
 Two things in that table are worth reading twice.

--- a/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
+++ b/code/lib/docgen-harness/src/perf/PERF-METHODOLOGY.md
@@ -185,14 +185,53 @@ A regression that lands on a Tuesday is caught whenever someone next asks for a 
 
 Memory budgets stay in absolute megabytes, with enough headroom on CI so that the gate is not flaky while still failing hard on real regressions.
 
-## Budgets table skeleton
+## Recorded baselines
 
-| Engine                                    | Cold extraction | Warm extraction | Whole-project scan | Peak memory (transient) | Retained growth | Retained slope | Tier  |
-| ----------------------------------------- | --------------- | --------------- | ------------------ | ----------------------- | --------------- | -------------- | ----- |
-| react-legacy (react-docgen, control)      | TBD             | TBD             | n/a                | TBD                     | TBD             | TBD            | TBD   |
-| react-osa (ComponentMetaManager, control) | TBD             | TBD             | n/a                | 90MB                    | 60MB            | 3MB/save       | daily |
-| vue-docgen-api (legacy, current default)  | TBD             | TBD             | n/a                | TBD                     | TBD             | TBD            | TBD   |
-| vue-component-meta                        | TBD             | TBD             | n/a                | TBD                     | TBD             | TBD            | TBD   |
-| compodoc                                  | TBD             | TBD             | TBD                | TBD                     | TBD             | TBD            | TBD   |
-| svelte (stretch)                          | TBD             | TBD             | n/a                | TBD                     | TBD             | TBD            | TBD   |
-| cem (stretch)                             | TBD             | TBD             | n/a                | TBD                     | TBD             | TBD            | TBD   |
+Measured on a CircleCI `sb_node_22_classic` medium+ executor, Node 22.22.1, at the pinned profile (N=6).
+Milliseconds are context, never a budget: the same suite runs three to four times faster on an Apple-silicon laptop, which is exactly why nothing gates on them.
+
+| Engine / scenario                  | Cold    | Warm   | Scan   | Peak transient | Retained growth | Retained slope |
+| ---------------------------------- | ------- | ------ | ------ | -------------- | --------------- | -------------- |
+| react-legacy/default               | 1917ms  | 14ms   | n/a    | 2.4MB          | -4.1MB          | 0.01MB/save    |
+| react-osa/default                  | 2701ms  | 44ms   | n/a    | 13.8MB         | -83.0MB         | -1.13MB/save   |
+| vue-docgen-api/flat                | 155ms   | 3ms    | n/a    | 0.4MB          | 0.2MB           | 0.02MB/save    |
+| vue-docgen-api/workspace           | 121ms   | 3ms    | n/a    | 0.4MB          | 0.3MB           | 0.02MB/save    |
+| vue-docgen-api/base-type-touch     | 123ms   | 10ms   | n/a    | 0.9MB          | 0.1MB           | 0.01MB/save    |
+| vue-component-meta/flat            | 1145ms  | 80ms   | n/a    | 9.4MB          | 3.7MB           | 0.21MB/save    |
+| vue-component-meta/workspace       | 1067ms  | 84ms   | n/a    | 12.7MB         | 3.6MB           | 0.20MB/save    |
+| vue-component-meta/base-type-touch | 1182ms  | 96ms   | n/a    | 12.1MB         | 3.0MB           | 0.26MB/save    |
+| compodoc/default                   | 1434ms  | 1537ms | 1434ms | 213.8MB        | n/a             | n/a            |
+
+Two things in that table are worth reading twice.
+
+Compodoc's warm figure is its cold figure, because it re-runs the whole project on every invocation.
+That is what it does by design, so it carries no incrementality budget; its peak memory, an order of magnitude above every other engine, is the number worth watching.
+
+`react-osa` reports negative retained growth and a negative slope: it ends the series holding less than it started with, because the run's forced collections settle the heap below the baseline taken before any extraction happened.
+A leak would show up as a positive slope, so the budget is a ceiling and the negative value passes it comfortably.
+
+The reference ratios stand at 0.71 cold and 0.31 warm for react-legacy over react-osa, and around 0.10-0.14 cold for vue-docgen-api over vue-component-meta.
+None of them is gated on, for the reasons under "Like-for-like comparison" above.
+
+### Budgets
+
+Recorded in `docgen-shared/budgets.ts`, keyed by engine and scenario, at roughly three to seven times the observed value so a busy executor cannot turn the gate into a flake.
+
+| Engine / scenario                  | Warm/cold ratio | Peak transient | Retained growth | Retained slope | Tier  |
+| ---------------------------------- | --------------- | -------------- | --------------- | -------------- | ----- |
+| react-legacy/default               | 0.05            | 15MB           | 30MB            | 1MB/save       | daily |
+| react-osa/default                  | 0.08            | 45MB           | 60MB            | 3MB/save       | daily |
+| vue-docgen-api/flat                | 0.08            | 8MB            | 10MB            | 1MB/save       | daily |
+| vue-docgen-api/workspace           | 0.10            | 8MB            | 10MB            | 1MB/save       | daily |
+| vue-docgen-api/base-type-touch     | 0.25            | 8MB            | 10MB            | 1MB/save       | daily |
+| vue-component-meta/flat            | 0.20            | 40MB           | 20MB            | 1.5MB/save     | daily |
+| vue-component-meta/workspace       | 0.22            | 40MB           | 20MB            | 1.5MB/save     | daily |
+| vue-component-meta/base-type-touch | 0.25            | 40MB           | 20MB            | 1.5MB/save     | daily |
+| compodoc/default                   | none            | 400MB          | n/a             | n/a            | daily |
+| svelte (stretch)                   | TBD             | TBD            | TBD             | TBD            | TBD   |
+| cem (stretch)                      | TBD             | TBD            | TBD             | TBD            | TBD   |
+
+`react-legacy-rdt` and `vue-component-meta-next` are measurable but carry no budget: neither runs by default, and a budget on something CI never runs would be decoration.
+The two stretch rows wait on engines that do not exist yet.
+
+The docgen-memory gate keeps its own, heavier `react-osa` row (90MB transient, 60MB growth, 3MB/save) covering the whole-index workload; the row above covers the incremental one this suite measures.

--- a/code/lib/docgen-harness/src/perf/docgen-memory/memory-harness.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-memory/memory-harness.ts
@@ -76,8 +76,7 @@ const SCOPES = ['all', 'changed'] as const;
  * Which shape of docgen work the run reproduces.
  *
  *   whole-index - cold documents every component, saves walk round-robin. The manifest generator.
- *   first-story - cold documents one component, every save re-extracts that same one. The docgen
- *                 server's per-request path, where nothing is documented until a story asks for it.
+ *   first-story - cold documents one component and every save re-extracts it. The docgen server.
  */
 const SHAPES = ['whole-index', 'first-story'] as const;
 const RECYCLE = ['on', 'off'] as const;
@@ -238,9 +237,8 @@ function refreshEngine(
   // Track how many extra props each component currently has, so each save grows the type.
   const extraByComponent = new Array<number>(options.components).fill(options.props);
   const firstStory = options.shape === 'first-story';
-  // Round-robin would document a component the cold pass never touched, so retained heap would
-  // climb for the honest reason that the run keeps documenting more - indistinguishable from a leak.
-  // Re-touching the one documented component keeps the steady state comparable with the other shape.
+  // Round-robin would document components the cold pass never touched, so retained heap would climb
+  // for an honest reason that reads exactly like a leak.
   const changedIndex = (save: number) => (firstStory ? 0 : (save - 1) % options.components);
 
   return {
@@ -285,9 +283,8 @@ harnessMain(async () => {
     console.log('  (run with `node --expose-gc` to measure retained heap; continuing without it)');
   }
 
+  // Re-extracting everything after a save is the other shape wearing this one's name.
   if (options.shape === 'first-story' && options.scope === 'all') {
-    // Re-extracting everything after a save would document the whole project anyway, which is the
-    // other shape wearing this one's name.
     throw new Error('--shape first-story requires --scope changed');
   }
 

--- a/code/lib/docgen-harness/src/perf/docgen-memory/memory-harness.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-memory/memory-harness.ts
@@ -72,6 +72,14 @@ const MODES = ['refresh', 'live'] as const;
  * refreshing on an empty change hint), `changed` re-extracts only the component whose file changed.
  */
 const SCOPES = ['all', 'changed'] as const;
+/**
+ * Which shape of docgen work the run reproduces.
+ *
+ *   whole-index - cold documents every component, saves walk round-robin. The manifest generator.
+ *   first-story - cold documents one component, every save re-extracts that same one. The docgen
+ *                 server's per-request path, where nothing is documented until a story asks for it.
+ */
+const SHAPES = ['whole-index', 'first-story'] as const;
 const RECYCLE = ['on', 'off'] as const;
 
 const OPTIONS = {
@@ -81,6 +89,7 @@ const OPTIONS = {
   saves: { type: 'string' },
   mode: { type: 'string' },
   scope: { type: 'string' },
+  shape: { type: 'string' },
   recycle: { type: 'string' },
   heavy: { type: 'boolean' },
   'heavy-factor': { type: 'string' },
@@ -98,6 +107,7 @@ const SCHEMA = z.object({
   saves: countOption(25),
   mode: z.enum(MODES).default('refresh'),
   scope: z.enum(SCOPES).default('all'),
+  shape: z.enum(SHAPES).default('whole-index'),
   // `Infinity` disables program recycling; `undefined` leaves the product default in place.
   recycleHeapPressureRatio: z
     .enum(RECYCLE)
@@ -227,11 +237,15 @@ function refreshEngine(
 ): SeriesEngine {
   // Track how many extra props each component currently has, so each save grows the type.
   const extraByComponent = new Array<number>(options.components).fill(options.props);
-  const changedIndex = (save: number) => (save - 1) % options.components;
+  const firstStory = options.shape === 'first-story';
+  // Round-robin would document a component the cold pass never touched, so retained heap would
+  // climb for the honest reason that the run keeps documenting more - indistinguishable from a leak.
+  // Re-touching the one documented component keeps the steady state comparable with the other shape.
+  const changedIndex = (save: number) => (firstStory ? 0 : (save - 1) % options.components);
 
   return {
     async cold() {
-      manager.batchExtract(entries);
+      manager.batchExtract(firstStory ? [entries[0]] : entries);
       return undefined;
     },
     async applySave(save) {
@@ -264,11 +278,17 @@ harnessMain(async () => {
   console.log('docgen-memory harness');
   console.log(
     `  components=${options.components} variants=${options.variants} props=${options.props} ` +
-      `saves=${options.saves} mode=${options.mode} scope=${options.scope} ` +
+      `saves=${options.saves} mode=${options.mode} scope=${options.scope} shape=${options.shape} ` +
       `forceGc=${options.forceGc && gcAvailable()}`
   );
   if (options.forceGc && !gcAvailable()) {
     console.log('  (run with `node --expose-gc` to measure retained heap; continuing without it)');
+  }
+
+  if (options.shape === 'first-story' && options.scope === 'all') {
+    // Re-extracting everything after a save would document the whole project anyway, which is the
+    // other shape wearing this one's name.
+    throw new Error('--shape first-story requires --scope changed');
   }
 
   const project = resolveProject(options);
@@ -283,7 +303,10 @@ harnessMain(async () => {
 
   const series = await runSeries(refreshEngine(manager, entries, project, options), {
     saves: options.saves,
-    coldLabel: `${entries.length} components`,
+    coldLabel:
+      options.shape === 'first-story'
+        ? `1 of ${entries.length} components`
+        : `${entries.length} components`,
     forceGc: options.forceGc,
   });
 

--- a/code/lib/docgen-harness/src/perf/docgen-perf/aggregate.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/aggregate.test.ts
@@ -52,14 +52,14 @@ describe('seriesMetrics', () => {
   it('medians cold across every repetition', () => {
     expect(seriesMetrics(reps, 3).coldExtractionMs).toMatchObject({
       samples: [300, 100, 200],
-      median: 200,
+      value: 200,
     });
   });
 
   it('reads warm from the designated repetition, not the first', () => {
     expect(seriesMetrics(reps, 3).warmExtractionMs).toMatchObject({
       samples: [4, 5, 6],
-      median: 5,
+      value: 5,
     });
   });
 
@@ -68,7 +68,7 @@ describe('seriesMetrics', () => {
   });
 
   it('derives transient memory from the same repetition warm came from', () => {
-    expect(seriesMetrics(reps, 3).peakTransientMb).toMatchObject({ mean: 10 });
+    expect(seriesMetrics(reps, 3).peakTransientMb).toMatchObject({ value: 10 });
   });
 
   it('rejects a repetition count below the pinned N', () => {

--- a/code/lib/docgen-harness/src/perf/docgen-perf/aggregate.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/aggregate.ts
@@ -49,11 +49,11 @@ export function seriesMetrics(reps: SeriesResult[], expectedN: number): EngineMe
   }
 
   return {
-    coldExtractionMs: { status: 'measured', samples: coldSamples, median: median(coldSamples) },
-    warmExtractionMs: { status: 'measured', samples: warmSamples, median: median(warmSamples) },
+    coldExtractionMs: { status: 'measured', samples: coldSamples, value: median(coldSamples) },
+    warmExtractionMs: { status: 'measured', samples: warmSamples, value: median(warmSamples) },
     // Per-component engines have no batch pass; recording one would be a faked equivalent.
     wholeProjectScanMs: NOT_APPLICABLE,
-    peakTransientMb: { status: 'measured', samples: transients, mean: avgTransient },
+    peakTransientMb: { status: 'measured', samples: transients, value: avgTransient },
     retainedGrowthMb: { status: 'measured', value: designated.retainedGrowth },
     retainedSlopeMbPerSave: { status: 'measured', value: designated.retainedSlope },
   };
@@ -82,12 +82,12 @@ export function oneShotMetrics(reps: OneShotRepetition[], expectedN: number): En
   // recorded. A partially-sampled series is reported as no measurement rather than as a low one.
   const peaks = reps.map((r) => r.peakRssMb).filter((mb) => mb !== undefined);
   return {
-    coldExtractionMs: { status: 'measured', samples: coldSamples, median: median(coldSamples) },
-    warmExtractionMs: { status: 'measured', samples: warmSamples, median: median(warmSamples) },
-    wholeProjectScanMs: { status: 'measured', samples: coldSamples, median: median(coldSamples) },
+    coldExtractionMs: { status: 'measured', samples: coldSamples, value: median(coldSamples) },
+    warmExtractionMs: { status: 'measured', samples: warmSamples, value: median(warmSamples) },
+    wholeProjectScanMs: { status: 'measured', samples: coldSamples, value: median(coldSamples) },
     peakTransientMb:
       peaks.length === reps.length
-        ? { status: 'measured', samples: peaks, mean: mean(peaks) }
+        ? { status: 'measured', samples: peaks, value: mean(peaks) }
         : NOT_APPLICABLE,
     retainedGrowthMb: NOT_APPLICABLE,
     retainedSlopeMbPerSave: NOT_APPLICABLE,

--- a/code/lib/docgen-harness/src/perf/docgen-perf/config.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { MIN_SAVES_FOR_SLOPE } from '../docgen-shared/stats.ts';
+import { DEFAULT_PROFILE, PINNED_N, QUICK_PROFILE, type SuiteProfile } from './config.ts';
+
+const savesPerScenario = (profile: SuiteProfile): Array<{ name: string; saves: number }> => [
+  ...profile.react.map((scenario) => ({ name: `react/${scenario.shape}`, saves: scenario.saves })),
+  ...profile.vue.map((scenario) => ({ name: `vue/${scenario.name}`, saves: scenario.saves })),
+];
+
+describe.each([
+  ['default', DEFAULT_PROFILE],
+  ['quick', QUICK_PROFILE],
+])('%s profile', (_name, profile) => {
+  // The slope fit drops the settle save, so a scenario configured below this floor reports no
+  // retained metrics and the aggregation fails the whole engine - a smoke run that cannot smoke.
+  it('runs enough saves for every scenario to produce a retained slope', () => {
+    for (const { name, saves } of savesPerScenario(profile)) {
+      expect(saves, name).toBeGreaterThanOrEqual(MIN_SAVES_FOR_SLOPE);
+    }
+  });
+});
+
+describe('the pinned profile', () => {
+  it('measures at the pinned N and says its numbers are comparable', () => {
+    expect(DEFAULT_PROFILE.n).toBe(PINNED_N);
+    expect(DEFAULT_PROFILE.comparable).toBe(true);
+  });
+
+  it('marks the quick profile non-comparable, so its numbers can never become a baseline', () => {
+    expect(QUICK_PROFILE.comparable).toBe(false);
+  });
+});

--- a/code/lib/docgen-harness/src/perf/docgen-perf/config.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { MIN_SAVES_FOR_SLOPE } from '../docgen-shared/stats.ts';
-import { DEFAULT_PROFILE, PINNED_N, QUICK_PROFILE, type SuiteProfile } from './config.ts';
+import { DEFAULT_PROFILE, QUICK_PROFILE, type SuiteProfile } from './config.ts';
 
 const savesPerScenario = (profile: SuiteProfile): Array<{ name: string; saves: number }> => [
   ...profile.react.map((scenario) => ({ name: `react/${scenario.shape}`, saves: scenario.saves })),
@@ -20,13 +20,8 @@ describe.each([
   });
 });
 
-describe('the pinned profile', () => {
-  it('measures at the pinned N and says its numbers are comparable', () => {
-    expect(DEFAULT_PROFILE.n).toBe(PINNED_N);
-    expect(DEFAULT_PROFILE.comparable).toBe(true);
-  });
-
-  it('marks the quick profile non-comparable, so its numbers can never become a baseline', () => {
-    expect(QUICK_PROFILE.comparable).toBe(false);
-  });
+// The gate asserts `comparable` before anything else, so this flag is the only thing standing
+// between a smoke run's numbers and a recorded baseline.
+it('marks the quick profile non-comparable, so its numbers can never become a baseline', () => {
+  expect(QUICK_PROFILE.comparable).toBe(false);
 });

--- a/code/lib/docgen-harness/src/perf/docgen-perf/config.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/config.test.ts
@@ -12,8 +12,7 @@ describe.each([
   ['default', DEFAULT_PROFILE],
   ['quick', QUICK_PROFILE],
 ])('%s profile', (_name, profile) => {
-  // The slope fit drops the settle save, so a scenario configured below this floor reports no
-  // retained metrics and the aggregation fails the whole engine - a smoke run that cannot smoke.
+  // Below the floor the run reports no retained metrics and fails the engine outright.
   it('runs enough saves for every scenario to produce a retained slope', () => {
     for (const { name, saves } of savesPerScenario(profile)) {
       expect(saves, name).toBeGreaterThanOrEqual(MIN_SAVES_FOR_SLOPE);

--- a/code/lib/docgen-harness/src/perf/docgen-perf/config.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/config.ts
@@ -29,7 +29,18 @@ export const RSS_POLL_INTERVAL_MS = 100;
  */
 export const COMPODOC_TIMEOUT_MS = 10 * 60 * 1000;
 
+/**
+ * How much of the project the cold pass documents, which is the difference between the two shapes
+ * Storybook actually runs.
+ *
+ *   whole-index - one batch over every component, what the manifest generator does.
+ *   first-story - the single component a request asked for, what the docgen server does; every save
+ *                 then re-extracts that same component, so the steady state stays comparable.
+ */
+export type ReactScenarioShape = 'whole-index' | 'first-story';
+
 export interface ReactScenarioConfig {
+  shape: ReactScenarioShape;
   components: number;
   variants: number;
   props: number;
@@ -54,7 +65,7 @@ export interface AngularScenarioConfig {
 export interface SuiteProfile {
   n: number;
   comparable: boolean;
-  react: ReactScenarioConfig;
+  react: ReactScenarioConfig[];
   vue: VueScenarioConfig[];
   angular: AngularScenarioConfig;
 }
@@ -62,7 +73,12 @@ export interface SuiteProfile {
 export const DEFAULT_PROFILE: SuiteProfile = {
   n: PINNED_N,
   comparable: true,
-  react: { components: 300, variants: 4, props: 10, saves: 20 },
+  react: [
+    { shape: 'whole-index', components: 300, variants: 4, props: 10, saves: 20 },
+    // The project is the same size; only the cold pass and the save target differ, so the two rows
+    // are directly comparable.
+    { shape: 'first-story', components: 300, variants: 4, props: 10, saves: 10 },
+  ],
   vue: [
     {
       name: 'flat',
@@ -98,7 +114,10 @@ export const DEFAULT_PROFILE: SuiteProfile = {
 export const QUICK_PROFILE: SuiteProfile = {
   n: QUICK_N,
   comparable: false,
-  react: { components: 20, variants: 2, props: 4, saves: 4 },
+  react: [
+    { shape: 'whole-index', components: 20, variants: 2, props: 4, saves: 4 },
+    { shape: 'first-story', components: 20, variants: 2, props: 4, saves: 3 },
+  ],
   vue: [
     {
       name: 'flat',

--- a/code/lib/docgen-harness/src/perf/docgen-perf/config.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/config.ts
@@ -30,12 +30,11 @@ export const RSS_POLL_INTERVAL_MS = 100;
 export const COMPODOC_TIMEOUT_MS = 10 * 60 * 1000;
 
 /**
- * How much of the project the cold pass documents, which is the difference between the two shapes
- * Storybook actually runs.
+ * How much of the project the cold pass documents - the two shapes Storybook actually runs.
  *
  *   whole-index - one batch over every component, what the manifest generator does.
- *   first-story - the single component a request asked for, what the docgen server does; every save
- *                 then re-extracts that same component, so the steady state stays comparable.
+ *   first-story - the one component a request asked for, what the docgen server does; saves then
+ *                 re-extract that same component.
  */
 export type ReactScenarioShape = 'whole-index' | 'first-story';
 
@@ -75,8 +74,7 @@ export const DEFAULT_PROFILE: SuiteProfile = {
   comparable: true,
   react: [
     { shape: 'whole-index', components: 300, variants: 4, props: 10, saves: 20 },
-    // The project is the same size; only the cold pass and the save target differ, so the two rows
-    // are directly comparable.
+    // Same project size; only the cold pass and save target differ, so the rows are comparable.
     { shape: 'first-story', components: 300, variants: 4, props: 10, saves: 10 },
   ],
   vue: [

--- a/code/lib/docgen-harness/src/perf/docgen-perf/config.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/config.ts
@@ -144,7 +144,7 @@ export const QUICK_PROFILE: SuiteProfile = {
       chainDepth: 2,
       fanOut: 2,
       heavyLib: true,
-      saves: 2,
+      saves: 3,
     },
   ],
   angular: { components: 10, props: 4 },

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engine.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engine.ts
@@ -2,26 +2,14 @@
  * What the orchestrator knows about an engine. Engines differ only in how one repetition is
  * produced; everything downstream (aggregation, member counts) follows from that choice.
  */
-import * as fs from 'node:fs';
-import { createRequire } from 'node:module';
 import * as path from 'node:path';
 
+import { resolvePin } from '../docgen-shared/pin.ts';
 import type { SeriesResult } from '../docgen-shared/series.ts';
 import { designatedRep, seriesMetrics } from './aggregate.ts';
 import type { SuiteProfile } from './config.ts';
 import type { SeriesChildSpec } from './spawn.ts';
 import type { EngineId, EngineMetrics, MemberCounts, ScenarioResult } from './types.ts';
-
-const require = createRequire(import.meta.url);
-
-function resolvePackageVersion(packageName: string): string | undefined {
-  try {
-    const packagePath = require.resolve(`${packageName}/package.json`);
-    return (JSON.parse(fs.readFileSync(packagePath, 'utf8')) as { version: string }).version;
-  } catch {
-    return undefined;
-  }
-}
 
 export interface ScenarioSpec {
   name: string;
@@ -136,28 +124,24 @@ export class SeriesChildEngine extends BenchEngine<SeriesResult> {
    */
   preflight(): string | undefined {
     const { pin } = this.#config;
-    if (pin && resolvePackageVersion(pin) === undefined) {
+    if (pin && !resolvePin(pin)) {
       return `${pin} did not resolve; it is pinned in code/lib/docgen-harness/package.json, so run yarn install`;
     }
     return undefined;
   }
 
   version(): string | undefined {
-    return this.#config.pin ? resolvePackageVersion(this.#config.pin) : undefined;
-  }
-
-  /** The pin reaches the child as a flag, so no engine has to spell it out in its own `args`. */
-  #args(scenario: ScenarioSpec): string[] {
-    const { args, pin } = this.#config;
-    return pin ? [...args(scenario), '--pin', pin] : args(scenario);
+    return this.#config.pin ? resolvePin(this.#config.pin)?.version : undefined;
   }
 
   async measure(ctx: MeasureContext, scenario: ScenarioSpec, rep: number): Promise<SeriesResult> {
+    const { args, child, jiti, pin } = this.#config;
     return ctx.runSeriesChild(
       {
-        childPath: path.join(import.meta.dirname, this.#config.child),
-        args: this.#args(scenario),
-        jiti: this.#config.jiti,
+        childPath: path.join(import.meta.dirname, child),
+        // The pin reaches the child as a flag, so no engine spells it out in its own `args`.
+        args: pin ? [...args(scenario), '--pin', pin] : args(scenario),
+        jiti,
       },
       path.join(ctx.scenarioDir, 'project'),
       path.join(ctx.scenarioDir, `rep${rep}.json`)

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engine.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engine.ts
@@ -99,8 +99,13 @@ export interface SeriesChildConfig {
   /** Only the reused docgen-memory harness runs under the jiti loader. */
   jiti?: boolean;
   inDefaultRun?: boolean;
-  /** The npm package name whose resolved `package.json#version` should be reported for this engine. */
-  versionPackage?: string;
+  /**
+   * The install this engine measures: the canonical package name, or the alias of a second,
+   * explicitly-versioned copy of it. Passed to the child as `--pin` and reported as the engine's
+   * version, so a version pair is two entries differing only in this field. Only for children that
+   * accept `--pin`; see docgen-shared/pin.ts.
+   */
+  pin?: string;
 }
 
 /**
@@ -124,30 +129,34 @@ export class SeriesChildEngine extends BenchEngine<SeriesResult> {
   }
 
   /**
-   * A declared `versionPackage` is one the child imports, so failing to resolve it means a partial
-   * install. Skipping here rather than letting `version()` quietly answer undefined is what keeps a
-   * version pair from running with no way to tell its two installs apart - the one failure that
-   * comparison exists to catch.
+   * A declared `pin` is what the child imports, so failing to resolve it means a partial install.
+   * Skipping here rather than letting `version()` quietly answer undefined is what keeps a version
+   * pair from running with no way to tell its two installs apart - the one failure that comparison
+   * exists to catch.
    */
   preflight(): string | undefined {
-    const { versionPackage } = this.#config;
-    if (versionPackage && resolvePackageVersion(versionPackage) === undefined) {
-      return `${versionPackage} did not resolve; it is pinned in code/lib/docgen-harness/package.json, so run yarn install`;
+    const { pin } = this.#config;
+    if (pin && resolvePackageVersion(pin) === undefined) {
+      return `${pin} did not resolve; it is pinned in code/lib/docgen-harness/package.json, so run yarn install`;
     }
     return undefined;
   }
 
   version(): string | undefined {
-    return this.#config.versionPackage
-      ? resolvePackageVersion(this.#config.versionPackage)
-      : undefined;
+    return this.#config.pin ? resolvePackageVersion(this.#config.pin) : undefined;
+  }
+
+  /** The pin reaches the child as a flag, so no engine has to spell it out in its own `args`. */
+  #args(scenario: ScenarioSpec): string[] {
+    const { args, pin } = this.#config;
+    return pin ? [...args(scenario), '--pin', pin] : args(scenario);
   }
 
   async measure(ctx: MeasureContext, scenario: ScenarioSpec, rep: number): Promise<SeriesResult> {
     return ctx.runSeriesChild(
       {
         childPath: path.join(import.meta.dirname, this.#config.child),
-        args: this.#config.args(scenario),
+        args: this.#args(scenario),
         jiti: this.#config.jiti,
       },
       path.join(ctx.scenarioDir, 'project'),

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/compodoc.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/compodoc.ts
@@ -1,10 +1,9 @@
 import { spawn, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import { createRequire } from 'node:module';
 import * as path from 'node:path';
 
 import { outputTail } from '../../docgen-shared/child-output.ts';
-import { assertPin } from '../../docgen-shared/pin.ts';
+import { resolvePin } from '../../docgen-shared/pin.ts';
 import { type OneShotRepetition, oneShotMetrics } from '../aggregate.ts';
 import { type DocumentationCounts, countDocumentation } from './compodoc-doc.ts';
 import {
@@ -17,8 +16,6 @@ import { BenchEngine, type MeasureContext, type ScenarioSpec } from '../engine.t
 import { angularComponentSource, generateAngularProject } from '../generators/angular.ts';
 import type { EngineId, EngineMetrics, MemberCounts } from '../types.ts';
 
-const require = createRequire(import.meta.url);
-
 interface ResolvedCompodoc {
   /** The CLI entry point, run as `node <cli>` so no shell shim or exec bit is involved. */
   cli: string;
@@ -28,17 +25,16 @@ interface ResolvedCompodoc {
 /** The canonical install. A pin names an alias of it - see docgen-shared/pin.ts. */
 const COMPODOC_PACKAGE = '@compodoc/compodoc';
 
+/**
+ * An alias keeps the aliased package's own name, so the name check is what stops a pin naming some
+ * other package from being measured as compodoc.
+ */
 function resolveCompodoc(specifier: string): ResolvedCompodoc | undefined {
-  try {
-    const packagePath = require.resolve(`${specifier}/package.json`);
-    const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
-    return {
-      cli: path.join(path.dirname(packagePath), pkg.bin.compodoc),
-      version: pkg.version,
-    };
-  } catch {
+  const found = resolvePin(specifier);
+  if (found?.name !== COMPODOC_PACKAGE || !found.bin?.compodoc) {
     return undefined;
   }
+  return { cli: path.join(found.dir, found.bin.compodoc), version: found.version };
 }
 
 interface CompodocRun extends DocumentationCounts {
@@ -194,7 +190,7 @@ export class CompodocEngine extends BenchEngine<OneShotRepetition> {
     super();
     this.id = config.id;
     this.inDefaultRun = config.inDefaultRun ?? true;
-    this.#pin = assertPin(COMPODOC_PACKAGE, config.pin);
+    this.#pin = config.pin;
   }
 
   scenarios(profile: SuiteProfile): ScenarioSpec[] {

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/compodoc.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/compodoc.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import * as path from 'node:path';
 
 import { outputTail } from '../../docgen-shared/child-output.ts';
+import { assertPin } from '../../docgen-shared/pin.ts';
 import { type OneShotRepetition, oneShotMetrics } from '../aggregate.ts';
 import { type DocumentationCounts, countDocumentation } from './compodoc-doc.ts';
 import {
@@ -24,9 +25,12 @@ interface ResolvedCompodoc {
   version: string;
 }
 
-function resolveCompodoc(): ResolvedCompodoc | undefined {
+/** The canonical install. A pin names an alias of it - see docgen-shared/pin.ts. */
+const COMPODOC_PACKAGE = '@compodoc/compodoc';
+
+function resolveCompodoc(specifier: string): ResolvedCompodoc | undefined {
   try {
-    const packagePath = require.resolve('@compodoc/compodoc/package.json');
+    const packagePath = require.resolve(`${specifier}/package.json`);
     const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
     return {
       cli: path.join(path.dirname(packagePath), pkg.bin.compodoc),
@@ -169,10 +173,29 @@ export async function runCompodocRepetition(
   };
 }
 
+/**
+ * Compodoc is a spawned CLI rather than an imported module, so its pin selects which CLI to run.
+ * A version pair is two entries differing only in `pin`, as it is for the series engines.
+ */
+export interface CompodocConfig {
+  id: EngineId;
+  pin: string;
+  inDefaultRun?: boolean;
+}
+
 export class CompodocEngine extends BenchEngine<OneShotRepetition> {
-  readonly id: EngineId = 'compodoc';
+  readonly id: EngineId;
+
+  readonly #pin: string;
 
   #resolved: ResolvedCompodoc | undefined;
+
+  constructor(config: CompodocConfig = { id: 'compodoc', pin: COMPODOC_PACKAGE }) {
+    super();
+    this.id = config.id;
+    this.inDefaultRun = config.inDefaultRun ?? true;
+    this.#pin = assertPin(COMPODOC_PACKAGE, config.pin);
+  }
 
   scenarios(profile: SuiteProfile): ScenarioSpec[] {
     // The poll interval rides in params because it qualifies the peak this engine reports: the
@@ -184,10 +207,10 @@ export class CompodocEngine extends BenchEngine<OneShotRepetition> {
   }
 
   preflight(): string | undefined {
-    this.#resolved = resolveCompodoc();
+    this.#resolved = resolveCompodoc(this.#pin);
     return this.#resolved
       ? undefined
-      : '@compodoc/compodoc did not resolve; it is pinned in code/lib/docgen-harness/package.json, so run yarn install';
+      : `${this.#pin} did not resolve; it is pinned in code/lib/docgen-harness/package.json, so run yarn install`;
   }
 
   version(): string | undefined {

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/crash-control.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/crash-control.ts
@@ -1,0 +1,11 @@
+/**
+ * An engine that always fails, used as the perf gate's negative control.
+ *
+ * A gate that has never failed is not known to work, so the gate runs the suite once with this
+ * engine named and requires that run to come back non-zero. If it ever passes, the gate's own
+ * failure detection is broken and the job must say so rather than reporting green.
+ *
+ * It is out of the default engine set, so a normal suite run never touches it.
+ */
+console.error('crash-control: failing deliberately, this is the gate negative control');
+process.exit(1);

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/crash-control.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/crash-control.ts
@@ -1,11 +1,8 @@
 /**
- * An engine that always fails, used as the perf gate's negative control.
+ * An engine that always fails: the perf gate's negative control.
  *
- * A gate that has never failed is not known to work, so the gate runs the suite once with this
- * engine named and requires that run to come back non-zero. If it ever passes, the gate's own
- * failure detection is broken and the job must say so rather than reporting green.
- *
- * It is out of the default engine set, so a normal suite run never touches it.
+ * The gate runs the suite once with this engine named and requires a non-zero exit. If that ever
+ * passes, the gate's failure detection is broken. Out of the default run, so nothing else hits it.
  */
 console.error('crash-control: failing deliberately, this is the gate negative control');
 process.exit(1);

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/react-legacy.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/react-legacy.ts
@@ -55,9 +55,18 @@ const PARSERS = ['react-docgen', 'react-docgen-typescript'] as const;
  *   changed - re-extract only the component whose file changed.
  */
 const SCOPES = ['all', 'changed'] as const;
+/**
+ * Which shape of docgen work the run reproduces - the same two shapes the OSA harness runs, so the
+ * legacy engine can be compared against it on either.
+ *
+ *   whole-index - cold documents every component, saves walk round-robin.
+ *   first-story - cold documents one component, every save re-extracts that same one.
+ */
+const SHAPES = ['whole-index', 'first-story'] as const;
 
 const OPTIONS = {
   parser: { type: 'string' },
+  shape: { type: 'string' },
   components: { type: 'string' },
   variants: { type: 'string' },
   props: { type: 'string' },
@@ -74,6 +83,7 @@ const SCHEMA = z.object({
   props: countOption(10),
   saves: countOption(20),
   scope: z.enum(SCOPES).default('changed'),
+  shape: z.enum(SHAPES).default('whole-index'),
   outDir: z
     .string()
     .default(path.join(SANDBOX_DIRECTORY, 'docgen-perf', 'react-legacy', 'project')),
@@ -158,11 +168,18 @@ async function createEngine(options: HarnessOptions): Promise<SeriesEngine> {
 
   // Track how many extra props each component currently has, so each save grows its type.
   const extraByComponent = new Array<number>(options.components).fill(options.props);
-  const changedIndex = (save: number) => (save - 1) % options.components;
+  const firstStory = options.shape === 'first-story';
+  // Fixed at the one component the cold pass documented, for the reason the OSA harness pins it:
+  // walking round-robin would keep documenting components the cold pass never saw.
+  const changedIndex = (save: number) => (firstStory ? 0 : (save - 1) % options.components);
 
   return {
     async cold() {
-      await extractAll();
+      if (firstStory) {
+        await extractOne(0);
+      } else {
+        await extractAll();
+      }
       return undefined;
     },
     async applySave(save) {
@@ -194,9 +211,13 @@ harnessMain(async () => {
       props: options.props,
       saves: options.saves,
       scope: options.scope,
+      shape: options.shape,
     },
     saves: options.saves,
-    coldLabel: `${options.components} components`,
+    coldLabel:
+      options.shape === 'first-story'
+        ? `1 of ${options.components} components`
+        : `${options.components} components`,
     jsonOut: options.jsonOut,
     setup: () => createEngine(options),
   });

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/react-legacy.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/react-legacy.ts
@@ -139,6 +139,11 @@ async function loadParser(options: HarnessOptions, project: GeneratedProject): P
 }
 
 async function createEngine(options: HarnessOptions): Promise<SeriesEngine> {
+  // Re-extracting everything after a save is the other shape wearing this one's name.
+  if (options.shape === 'first-story' && options.scope === 'all') {
+    throw new Error('--shape first-story requires --scope changed');
+  }
+
   const genStart = Date.now();
   const project = generateProject({
     outDir: options.outDir,

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/react-legacy.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/react-legacy.ts
@@ -55,13 +55,7 @@ const PARSERS = ['react-docgen', 'react-docgen-typescript'] as const;
  *   changed - re-extract only the component whose file changed.
  */
 const SCOPES = ['all', 'changed'] as const;
-/**
- * Which shape of docgen work the run reproduces - the same two shapes the OSA harness runs, so the
- * legacy engine can be compared against it on either.
- *
- *   whole-index - cold documents every component, saves walk round-robin.
- *   first-story - cold documents one component, every save re-extracts that same one.
- */
+/** The two shapes the OSA harness runs, so the legacy engine can be compared on either. */
 const SHAPES = ['whole-index', 'first-story'] as const;
 
 const OPTIONS = {
@@ -169,8 +163,7 @@ async function createEngine(options: HarnessOptions): Promise<SeriesEngine> {
   // Track how many extra props each component currently has, so each save grows its type.
   const extraByComponent = new Array<number>(options.components).fill(options.props);
   const firstStory = options.shape === 'first-story';
-  // Fixed at the one component the cold pass documented, for the reason the OSA harness pins it:
-  // walking round-robin would keep documenting components the cold pass never saw.
+  // Fixed at the component the cold pass documented; round-robin would keep documenting new ones.
   const changedIndex = (save: number) => (firstStory ? 0 : (save - 1) % options.components);
 
   return {

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/vue-component-meta.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/vue-component-meta.ts
@@ -13,9 +13,9 @@
 import * as fs from 'node:fs';
 
 import type { MetaCheckerOptions } from 'vue-component-meta';
-import { z } from 'zod';
 
 import { parseHarnessOptions } from '../../docgen-shared/args.ts';
+import { PIN_OPTION, importPinned, pinOption } from '../../docgen-shared/pin.ts';
 import { type SeriesEngine, harnessMain, runSeriesHarness } from '../../docgen-shared/series.ts';
 import {
   VUE_OPTIONS,
@@ -28,7 +28,8 @@ import {
   vueToInput,
 } from './vue-scenario.ts';
 
-/** Both pins are the same package, so the current one's types describe either install. */
+/** The canonical install. A pin is an alias of the same package, so these types describe either. */
+const PACKAGE = 'vue-component-meta';
 type CheckerModule = typeof import('vue-component-meta');
 type Checker = ReturnType<CheckerModule['createCheckerByJson']>;
 
@@ -39,39 +40,21 @@ const CHECKER_OPTIONS: MetaCheckerOptions = {
   printer: { newLine: 1 },
 };
 
-const PINS = ['current', 'next'] as const;
-type Pin = (typeof PINS)[number];
-
-/** Each pin is a separate install, so each gets its own scratch directory. */
-const PIN_DIR: Record<Pin, string> = {
-  current: 'vue-component-meta',
-  next: 'vue-component-meta-next',
-};
+const SCHEMA = VUE_SCHEMA.extend({ pin: pinOption(PACKAGE) });
 
 /**
- * `--pin` is this harness's only flag of its own, so it extends the shared Vue table rather than
- * being read out of argv beforehand: it is validated by the same strict parser as every other flag,
- * accepts `--pin=next` like they do, and lands in the options the result JSON records.
+ * `--pin` extends the shared Vue table rather than being read out of argv beforehand, so it reaches
+ * the same strict parser as every other flag and lands in the options the result JSON records. Each
+ * install gets its own scratch directory, so the two runs never share a generated project.
  */
-const SCHEMA = VUE_SCHEMA.extend({ pin: z.enum(PINS).default('current') });
-
-function parseOptions(argv: string[]): VueHarnessOptions & { pin: Pin } {
-  const parsed = parseHarnessOptions<VueOptionsInput & { pin: Pin }>(
+function parseOptions(argv: string[]): VueHarnessOptions & { pin: string } {
+  const parsed = parseHarnessOptions<VueOptionsInput & { pin: string }>(
     argv,
-    { ...VUE_OPTIONS, pin: { type: 'string' } },
+    { ...VUE_OPTIONS, ...PIN_OPTION },
     SCHEMA,
     vueToInput
   );
-  return { ...parsed, outDir: parsed.outDir ?? vueOutDir(PIN_DIR[parsed.pin]) };
-}
-
-/**
- * Only the pin being measured is loaded. Importing both copies would leave the other one's module
- * graph on the heap of every run, including the runs that feed the standing vue pair, which would
- * shift a memory number that has nothing to do with this comparison.
- */
-function loadCheckers(pin: Pin): Promise<CheckerModule> {
-  return pin === 'next' ? import('vue-component-meta-next') : import('vue-component-meta');
+  return { ...parsed, outDir: parsed.outDir ?? vueOutDir(parsed.pin) };
 }
 
 /**
@@ -95,9 +78,9 @@ function extractOne(checker: Checker, sfcPath: string): number {
   return meta.props.length + meta.events.length + meta.slots.length + meta.exposed.length;
 }
 
-async function createEngine(options: VueHarnessOptions, pin: Pin): Promise<SeriesEngine> {
+async function createEngine(options: VueHarnessOptions, pin: string): Promise<SeriesEngine> {
   const scenario = setUpVueScenario(options);
-  const fns = await loadCheckers(pin);
+  const fns = await importPinned<CheckerModule>(pin);
   let checker: Checker | undefined;
   let measuredPath = scenario.targetPaths[0];
 

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/vue-component-meta.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/vue-component-meta.ts
@@ -13,9 +13,10 @@
 import * as fs from 'node:fs';
 
 import type { MetaCheckerOptions } from 'vue-component-meta';
+import { z } from 'zod';
 
 import { parseHarnessOptions } from '../../docgen-shared/args.ts';
-import { PIN_OPTION, importPinned, pinOption } from '../../docgen-shared/pin.ts';
+import { PIN_OPTION, importPinned } from '../../docgen-shared/pin.ts';
 import { type SeriesEngine, harnessMain, runSeriesHarness } from '../../docgen-shared/series.ts';
 import {
   VUE_OPTIONS,
@@ -40,7 +41,7 @@ const CHECKER_OPTIONS: MetaCheckerOptions = {
   printer: { newLine: 1 },
 };
 
-const SCHEMA = VUE_SCHEMA.extend({ pin: pinOption(PACKAGE) });
+const SCHEMA = VUE_SCHEMA.extend({ pin: z.string().default(PACKAGE) });
 
 /**
  * `--pin` extends the shared Vue table rather than being read out of argv beforehand, so it reaches
@@ -80,7 +81,7 @@ function extractOne(checker: Checker, sfcPath: string): number {
 
 async function createEngine(options: VueHarnessOptions, pin: string): Promise<SeriesEngine> {
   const scenario = setUpVueScenario(options);
-  const fns = await importPinned<CheckerModule>(pin);
+  const fns = await importPinned<CheckerModule>(pin, PACKAGE);
   let checker: Checker | undefined;
   let measuredPath = scenario.targetPaths[0];
 

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { PerfBudget } from '../docgen-shared/budgets.ts';
+import type { PerfBudget, PerfBudgetKey } from '../docgen-shared/budgets.ts';
 import { assertBudgets } from './gate-assertions.ts';
 import {
   type EngineMetrics,
@@ -61,10 +61,10 @@ const failures = (assertions: ReturnType<typeof assertBudgets>) => assertions.fi
 
 describe('assertBudgets', () => {
   it('passes when every budgeted metric is within its budget', () => {
-    const budgets: Record<string, PerfBudget> = {
+    const budgets: Partial<Record<PerfBudgetKey, PerfBudget>> = {
       'vue-component-meta/flat': {
         maxWarmColdRatio: 0.3,
-        memory: { maxPeakTransientMb: 60, maxRetainedSlopeMbPerSave: 1 },
+        memory: { maxTransientMb: 60, maxRetainedSlopeMb: 1 },
       },
     };
     expect(failures(assertBudgets(results(), budgets))).toEqual([]);
@@ -82,7 +82,7 @@ describe('assertBudgets', () => {
   it('fails a memory metric over budget', () => {
     const found = failures(
       assertBudgets(results(), {
-        'vue-component-meta/flat': { memory: { maxPeakTransientMb: 10 } },
+        'vue-component-meta/flat': { memory: { maxTransientMb: 10 } },
       })
     );
     expect(found).toHaveLength(1);
@@ -122,48 +122,5 @@ describe('assertBudgets', () => {
     );
     expect(found).toHaveLength(1);
     expect(found[0].detail).toBe('not measured in this run');
-  });
-
-  it('refuses to gate on a cross-engine ratio the suite did not certify as like-for-like', () => {
-    const withRatio = results({
-      ratios: {
-        vue: {
-          flat: {
-            cold: 0.15,
-            warm: 0.04,
-            coldComparability: 'next-documents-more',
-            warmComparability: 'next-documents-more',
-          },
-        },
-      },
-    });
-    const found = failures(
-      assertBudgets(withRatio, {
-        'vue-component-meta/flat': { reference: { pair: 'vue', minColdRatio: 0.1 } },
-      })
-    );
-    expect(found).toHaveLength(1);
-    expect(found[0].detail).toContain('did not do equal work');
-  });
-
-  it('passes a like-for-like reference ratio at or above its floor', () => {
-    const withRatio = results({
-      ratios: {
-        vue: {
-          flat: {
-            cold: 1.2,
-            coldComparability: 'like-for-like',
-            warmComparability: 'like-for-like',
-          },
-        },
-      },
-    });
-    expect(
-      failures(
-        assertBudgets(withRatio, {
-          'vue-component-meta/flat': { reference: { pair: 'vue', minColdRatio: 1.0 } },
-        })
-      )
-    ).toEqual([]);
   });
 });

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.test.ts
@@ -4,15 +4,15 @@ import type { PerfBudget, PerfBudgetKey } from '../docgen-shared/budgets.ts';
 import { assertBudgets } from './gate-assertions.ts';
 import {
   type EngineMetrics,
-  type LatencyMetric,
+  type MeasuredMetric,
   NOT_APPLICABLE,
   type SuiteResults,
 } from './types.ts';
 
-const measuredLatency = (median: number): LatencyMetric => ({
+const measuredLatency = (value: number): MeasuredMetric => ({
   status: 'measured',
-  samples: [median],
-  median,
+  samples: [value],
+  value,
 });
 
 function results(overrides: Partial<SuiteResults> = {}): SuiteResults {
@@ -32,7 +32,7 @@ function results(overrides: Partial<SuiteResults> = {}): SuiteResults {
               coldExtractionMs: measuredLatency(200),
               warmExtractionMs: measuredLatency(20),
               wholeProjectScanMs: NOT_APPLICABLE,
-              peakTransientMb: { status: 'measured', samples: [20], mean: 20 },
+              peakTransientMb: { status: 'measured', samples: [20], value: 20 },
               retainedGrowthMb: { status: 'measured', value: 3 },
               retainedSlopeMbPerSave: { status: 'measured', value: 0.2 },
             },

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.test.ts
@@ -113,6 +113,20 @@ describe('assertBudgets', () => {
     expect(found[0].detail).toContain('skipped');
   });
 
+  it('fails a scenario the run measured with no budget row, so a new one cannot land unprotected', () => {
+    const extra = results();
+    const measured = extra.engines['vue-component-meta'];
+    if (measured?.status !== 'measured') {
+      throw new Error('fixture must start from a measured engine');
+    }
+    measured.scenarios.workspace = measured.scenarios.flat;
+    const found = failures(
+      assertBudgets(extra, { 'vue-component-meta/flat': { maxWarmColdRatio: 0.3 } })
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].detail).toContain('vue-component-meta/workspace');
+  });
+
   it('fails a budgeted metric the run reported as n/a', () => {
     const partial = withMetrics({ retainedGrowthMb: NOT_APPLICABLE });
     const found = failures(

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PerfBudget } from '../docgen-shared/budgets.ts';
+import { assertBudgets } from './gate-assertions.ts';
+import {
+  type EngineMetrics,
+  type LatencyMetric,
+  NOT_APPLICABLE,
+  type SuiteResults,
+} from './types.ts';
+
+const measuredLatency = (median: number): LatencyMetric => ({
+  status: 'measured',
+  samples: [median],
+  median,
+});
+
+function results(overrides: Partial<SuiteResults> = {}): SuiteResults {
+  return {
+    generatedAt: '2026-08-03T00:00:00.000Z',
+    nodeVersion: 'v22.22.3',
+    pinnedN: 6,
+    comparable: true,
+    engineVersions: {},
+    engines: {
+      'vue-component-meta': {
+        status: 'measured',
+        scenarios: {
+          flat: {
+            params: {},
+            metrics: {
+              coldExtractionMs: measuredLatency(200),
+              warmExtractionMs: measuredLatency(20),
+              wholeProjectScanMs: NOT_APPLICABLE,
+              peakTransientMb: { status: 'measured', samples: [20], mean: 20 },
+              retainedGrowthMb: { status: 'measured', value: 3 },
+              retainedSlopeMbPerSave: { status: 'measured', value: 0.2 },
+            },
+          },
+        },
+      },
+    },
+    ratios: {},
+    ...overrides,
+  };
+}
+
+/** One measured scenario with some of its metrics replaced, which is what most cases here vary. */
+function withMetrics(patch: Partial<EngineMetrics>): SuiteResults {
+  const base = results();
+  const measured = base.engines['vue-component-meta'];
+  if (measured?.status !== 'measured') {
+    throw new Error('fixture must start from a measured engine');
+  }
+  const flat = measured.scenarios.flat;
+  measured.scenarios.flat = { ...flat, metrics: { ...flat.metrics, ...patch } };
+  return base;
+}
+
+const failures = (assertions: ReturnType<typeof assertBudgets>) => assertions.filter((a) => !a.ok);
+
+describe('assertBudgets', () => {
+  it('passes when every budgeted metric is within its budget', () => {
+    const budgets: Record<string, PerfBudget> = {
+      'vue-component-meta/flat': {
+        maxWarmColdRatio: 0.3,
+        memory: { maxPeakTransientMb: 60, maxRetainedSlopeMbPerSave: 1 },
+      },
+    };
+    expect(failures(assertBudgets(results(), budgets))).toEqual([]);
+  });
+
+  it('fails a warm/cold ratio that says re-extraction stopped being incremental', () => {
+    const slow = withMetrics({ warmExtractionMs: measuredLatency(190) });
+    const found = failures(
+      assertBudgets(slow, { 'vue-component-meta/flat': { maxWarmColdRatio: 0.3 } })
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].detail).toContain('no longer incremental');
+  });
+
+  it('fails a memory metric over budget', () => {
+    const found = failures(
+      assertBudgets(results(), {
+        'vue-component-meta/flat': { memory: { maxPeakTransientMb: 10 } },
+      })
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].detail).toContain('exceeds the budget');
+  });
+
+  it('rejects a non-comparable run outright', () => {
+    const found = failures(
+      assertBudgets(results({ comparable: false }), {
+        'vue-component-meta/flat': { maxWarmColdRatio: 0.3 },
+      })
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].label).toBe('run is comparable');
+  });
+
+  it('rejects an empty budget table rather than reporting a green gate', () => {
+    expect(failures(assertBudgets(results(), {}))).toHaveLength(1);
+  });
+
+  it('fails a budgeted engine that skipped, because the protected thing did not run', () => {
+    const skipped = results();
+    skipped.engines['vue-component-meta'] = { status: 'skipped', reason: 'not installed' };
+    const found = failures(
+      assertBudgets(skipped, { 'vue-component-meta/flat': { maxWarmColdRatio: 0.3 } })
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].detail).toContain('skipped');
+  });
+
+  it('fails a budgeted metric the run reported as n/a', () => {
+    const partial = withMetrics({ retainedGrowthMb: NOT_APPLICABLE });
+    const found = failures(
+      assertBudgets(partial, {
+        'vue-component-meta/flat': { memory: { maxRetainedGrowthMb: 10 } },
+      })
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].detail).toBe('not measured in this run');
+  });
+
+  it('refuses to gate on a cross-engine ratio the suite did not certify as like-for-like', () => {
+    const withRatio = results({
+      ratios: {
+        vue: {
+          flat: {
+            cold: 0.15,
+            warm: 0.04,
+            coldComparability: 'next-documents-more',
+            warmComparability: 'next-documents-more',
+          },
+        },
+      },
+    });
+    const found = failures(
+      assertBudgets(withRatio, {
+        'vue-component-meta/flat': { reference: { pair: 'vue', minColdRatio: 0.1 } },
+      })
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].detail).toContain('did not do equal work');
+  });
+
+  it('passes a like-for-like reference ratio at or above its floor', () => {
+    const withRatio = results({
+      ratios: {
+        vue: {
+          flat: {
+            cold: 1.2,
+            coldComparability: 'like-for-like',
+            warmComparability: 'like-for-like',
+          },
+        },
+      },
+    });
+    expect(
+      failures(
+        assertBudgets(withRatio, {
+          'vue-component-meta/flat': { reference: { pair: 'vue', minColdRatio: 1.0 } },
+        })
+      )
+    ).toEqual([]);
+  });
+});

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
@@ -5,7 +5,7 @@
  * instead of a full run.
  */
 import { PERF_BUDGETS, type PerfBudget, type PerfBudgetKey } from '../docgen-shared/budgets.ts';
-import type { EngineId, EngineMetrics, ScenarioResult, SuiteResults } from './types.ts';
+import type { EngineId, EngineMetrics, Metric, ScenarioResult, SuiteResults } from './types.ts';
 
 export interface Assertion {
   label: string;
@@ -36,8 +36,8 @@ function splitKey(key: PerfBudgetKey): { engine: EngineId; scenario: string } {
   };
 }
 
-function median(metric: EngineMetrics[keyof EngineMetrics]): number | undefined {
-  return metric.status === 'measured' && 'median' in metric ? metric.median : undefined;
+function valueOf(metric: Metric): number | undefined {
+  return metric.status === 'measured' ? metric.value : undefined;
 }
 
 /**
@@ -46,8 +46,8 @@ function median(metric: EngineMetrics[keyof EngineMetrics]): number | undefined 
  */
 function checkIncrementality(key: string, max: number, metrics: EngineMetrics): Assertion {
   const label = `${key} warm/cold ratio`;
-  const cold = median(metrics.coldExtractionMs);
-  const warm = median(metrics.warmExtractionMs);
+  const cold = valueOf(metrics.coldExtractionMs);
+  const warm = valueOf(metrics.warmExtractionMs);
 
   if (cold === undefined || warm === undefined || cold === 0) {
     return fail(label, 'cold and warm were not both measured');
@@ -70,18 +70,17 @@ function checkMemory(
   const checks = [
     {
       metric: 'peak transient (MB)',
-      value: peakTransientMb.status === 'measured' ? peakTransientMb.mean : undefined,
+      value: valueOf(peakTransientMb),
       max: memory.maxTransientMb,
     },
     {
       metric: 'retained growth (MB)',
-      value: retainedGrowthMb.status === 'measured' ? retainedGrowthMb.value : undefined,
+      value: valueOf(retainedGrowthMb),
       max: memory.maxRetainedGrowthMb,
     },
     {
       metric: 'retained slope (MB/save)',
-      value:
-        retainedSlopeMbPerSave.status === 'measured' ? retainedSlopeMbPerSave.value : undefined,
+      value: valueOf(retainedSlopeMbPerSave),
       max: memory.maxRetainedSlopeMb,
     },
   ];

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
@@ -118,8 +118,31 @@ function resolveScenario(
 }
 
 /**
- * Every assertion the gate makes about one run, in print order. The two whole-run rules come first
- * because either invalidates everything after it.
+ * The gate asserts the budget rows it has, so a scenario nobody wrote a row for would be measured
+ * every night and protected by nothing. Adding a scenario therefore fails the gate until its
+ * baseline is recorded, which is the point at which the number to budget exists.
+ */
+function checkEveryScenarioBudgeted(
+  results: SuiteResults,
+  budgets: Partial<Record<PerfBudgetKey, PerfBudget>>
+): Assertion {
+  const unbudgeted = Object.entries(results.engines).flatMap(([engine, result]) =>
+    result?.status === 'measured'
+      ? Object.keys(result.scenarios)
+          .filter((scenario) => budgets[`${engine as EngineId}/${scenario}`] === undefined)
+          .map((scenario) => `${engine}/${scenario}`)
+      : []
+  );
+
+  const label = 'every measured scenario has a budget';
+  return unbudgeted.length === 0
+    ? pass(label)
+    : fail(label, `${unbudgeted.join(', ')} measured with no budget row in budgets.ts`);
+}
+
+/**
+ * Every assertion the gate makes about one run, in print order. The whole-run rules come first
+ * because each invalidates everything after it.
  */
 export function assertBudgets(
   results: SuiteResults,
@@ -144,6 +167,7 @@ export function assertBudgets(
 
   return [
     pass('run is comparable'),
+    checkEveryScenarioBudgeted(results, budgets),
     ...entries.flatMap(([key, budget]) => {
       const scenario = resolveScenario(key, results);
       if ('missing' in scenario) {

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
@@ -1,8 +1,8 @@
 /**
  * Turns one suite run into a pass/fail verdict against the recorded budgets.
  *
- * Kept free of process and filesystem work so the rules below - which are the whole point of the
- * gate - can be tested against hand-built results instead of a full run.
+ * Free of process and filesystem work, so the rules can be tested against hand-built results
+ * instead of a full run.
  */
 import { PERF_BUDGETS, type PerfBudget, type PerfBudgetKey } from '../docgen-shared/budgets.ts';
 import type { EngineId, EngineMetrics, ScenarioResult, SuiteResults } from './types.ts';
@@ -41,11 +41,8 @@ function median(metric: EngineMetrics[keyof EngineMetrics]): number | undefined 
 }
 
 /**
- * Warm over cold, for one engine, from one run.
- *
- * Both figures come from the same process over the same project, which makes this like-for-like by
- * construction - no member-count comparison needed - and it rises exactly when re-extraction after
- * a save stops being incremental and starts redoing the cold pass's work.
+ * Warm over cold, for one engine, from one run: like-for-like by construction, and it rises when
+ * re-extraction after a save stops being incremental.
  */
 function checkIncrementality(key: string, max: number, metrics: EngineMetrics): Assertion {
   const label = `${key} warm/cold ratio`;
@@ -102,10 +99,8 @@ function checkMemory(
 }
 
 /**
- * The scenario a budget row names, or the reason there is nothing to assert it against.
- *
- * A budgeted engine that skipped is legitimate on a laptop missing an optional tool and never on
- * the gate: the thing being protected did not run, and a green result would claim otherwise.
+ * The scenario a budget row names, or why there is nothing to assert against. A budgeted engine
+ * that skipped is fine locally and never on the gate: the protected thing did not run.
  */
 function resolveScenario(
   key: PerfBudgetKey,
@@ -124,11 +119,8 @@ function resolveScenario(
 }
 
 /**
- * Every assertion the gate makes about one run, in the order it should be printed.
- *
- * Two whole-run rules come first, because either one invalidates everything after it: a run whose
- * numbers are marked non-comparable (the `--quick` smoke profile) must never report a green gate,
- * and a budget table with no rows asserts nothing while looking like protection.
+ * Every assertion the gate makes about one run, in print order. The two whole-run rules come first
+ * because either invalidates everything after it.
  */
 export function assertBudgets(
   results: SuiteResults,

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
@@ -1,0 +1,244 @@
+/**
+ * Turns one suite run into a pass/fail verdict against the recorded budgets.
+ *
+ * Kept free of process and filesystem work so the rules below - which are the whole point of the
+ * gate - can be tested against hand-built results instead of a full run.
+ */
+import { PERF_BUDGETS, type PerfBudget } from '../docgen-shared/budgets.ts';
+import type { Comparability, EngineId, EngineMetrics, SuiteResults } from './types.ts';
+
+export interface Assertion {
+  label: string;
+  ok: boolean;
+  /** Why it failed. Absent on a pass. */
+  detail?: string;
+}
+
+function splitKey(key: string): { engine: EngineId; scenario: string } {
+  const [engine, ...rest] = key.split('/');
+  return { engine: engine as EngineId, scenario: rest.join('/') };
+}
+
+/**
+ * A cross-engine ratio only becomes a verdict when both sides did equal work. Anything else is a
+ * behaviour change wearing a performance number, and passing it through as if it were comparable is
+ * how a regression gets waved past.
+ */
+function likeForLike(verdict: Comparability): boolean {
+  return verdict === 'like-for-like';
+}
+
+function measuredMedian(metric: EngineMetrics[keyof EngineMetrics]): number | undefined {
+  return metric.status === 'measured' && 'median' in metric ? metric.median : undefined;
+}
+
+/**
+ * Warm over cold, for one engine, from one run.
+ *
+ * This is the budget that does not need a second engine to mean something: both sides come from the
+ * same process on the same machine over the same project, so it is like-for-like by construction.
+ * It rises when re-extraction after a save stops being incremental and starts redoing the cold
+ * pass's work, which is the docgen regression that actually hurts users.
+ */
+function checkIncrementality(
+  key: string,
+  max: number,
+  metrics: EngineMetrics,
+  assertions: Assertion[]
+): void {
+  const label = `${key} warm/cold ratio`;
+  const cold = measuredMedian(metrics.coldExtractionMs);
+  const warm = measuredMedian(metrics.warmExtractionMs);
+
+  if (cold === undefined || warm === undefined || cold === 0) {
+    assertions.push({ label, ok: false, detail: 'cold and warm were not both measured' });
+    return;
+  }
+  const ratio = warm / cold;
+  assertions.push({
+    label,
+    ok: ratio <= max,
+    detail:
+      ratio <= max
+        ? undefined
+        : `${ratio.toFixed(3)} exceeds the budget of ${max}; re-extraction after a save is no longer incremental`,
+  });
+}
+
+function checkReference(
+  key: string,
+  scenario: string,
+  reference: NonNullable<PerfBudget['reference']>,
+  results: SuiteResults,
+  assertions: Assertion[]
+): void {
+  const entry = results.ratios[reference.pair]?.[scenario];
+  if (!entry) {
+    assertions.push({
+      label: `${key} reference ratio`,
+      ok: false,
+      detail: `control pair "${reference.pair}" produced no ratio for this scenario; both sides must measure in one run`,
+    });
+    return;
+  }
+
+  const checks = [
+    {
+      metric: 'cold',
+      ratio: entry.cold,
+      min: reference.minColdRatio,
+      verdict: entry.coldComparability,
+    },
+    {
+      metric: 'warm',
+      ratio: entry.warm,
+      min: reference.minWarmRatio,
+      verdict: entry.warmComparability,
+    },
+  ] as const;
+
+  for (const { metric, ratio, min, verdict } of checks) {
+    if (min === undefined) {
+      continue;
+    }
+    const label = `${key} ${metric} reference ratio`;
+    if (ratio === undefined) {
+      assertions.push({ label, ok: false, detail: 'not measured in this run' });
+      continue;
+    }
+    if (!likeForLike(verdict)) {
+      assertions.push({
+        label,
+        ok: false,
+        detail: `the two sides did not do equal work (${verdict}), so ${ratio.toFixed(2)} is not a cost comparison`,
+      });
+      continue;
+    }
+    assertions.push({
+      label,
+      ok: ratio >= min,
+      detail: ratio >= min ? undefined : `${ratio.toFixed(2)} is below the budget of ${min}`,
+    });
+  }
+}
+
+function checkMemory(
+  key: string,
+  memory: NonNullable<PerfBudget['memory']>,
+  metrics: EngineMetrics,
+  assertions: Assertion[]
+): void {
+  const peak = metrics.peakTransientMb;
+  const growth = metrics.retainedGrowthMb;
+  const slope = metrics.retainedSlopeMbPerSave;
+
+  const checks: Array<{ metric: string; value: number | undefined; max: number | undefined }> = [
+    {
+      metric: 'peak transient (MB)',
+      value: peak.status === 'measured' ? peak.mean : undefined,
+      max: memory.maxPeakTransientMb,
+    },
+    {
+      metric: 'retained growth (MB)',
+      value: growth.status === 'measured' ? growth.value : undefined,
+      max: memory.maxRetainedGrowthMb,
+    },
+    {
+      metric: 'retained slope (MB/save)',
+      value: slope.status === 'measured' ? slope.value : undefined,
+      max: memory.maxRetainedSlopeMbPerSave,
+    },
+  ];
+
+  for (const { metric, value, max } of checks) {
+    if (max === undefined) {
+      continue;
+    }
+    const label = `${key} ${metric}`;
+    if (value === undefined) {
+      // A budgeted metric reported n/a means the run did not produce the thing being gated on.
+      assertions.push({ label, ok: false, detail: 'not measured in this run' });
+      continue;
+    }
+    assertions.push({
+      label,
+      ok: value <= max,
+      detail: value <= max ? undefined : `${value.toFixed(1)} exceeds the budget of ${max}`,
+    });
+  }
+}
+
+/**
+ * Every assertion the gate makes about one run, in the order it should be printed.
+ *
+ * Two whole-run rules come first, because either one invalidates everything after it: a run whose
+ * numbers are marked non-comparable (the `--quick` smoke profile) must never report a green gate,
+ * and a budget table with no rows asserts nothing while looking like protection.
+ */
+export function assertBudgets(
+  results: SuiteResults,
+  budgets: Record<string, PerfBudget> = PERF_BUDGETS
+): Assertion[] {
+  const assertions: Assertion[] = [];
+
+  if (!results.comparable) {
+    return [
+      {
+        label: 'run is comparable',
+        ok: false,
+        detail: 'these are non-comparable smoke numbers; the gate needs a full-profile run',
+      },
+    ];
+  }
+  assertions.push({ label: 'run is comparable', ok: true });
+
+  const keys = Object.keys(budgets);
+  if (keys.length === 0) {
+    return [
+      ...assertions,
+      {
+        label: 'budgets recorded',
+        ok: false,
+        detail: 'no budget rows exist, so this gate asserts nothing',
+      },
+    ];
+  }
+
+  for (const key of keys) {
+    const { engine, scenario } = splitKey(key);
+    const budget = budgets[key];
+    const result = results.engines[engine];
+
+    // A budgeted engine that skipped is legitimate locally and never on the gate: the thing being
+    // protected did not run, and a green result would claim otherwise.
+    if (!result) {
+      assertions.push({ label: key, ok: false, detail: `engine "${engine}" did not run` });
+      continue;
+    }
+    if (result.status !== 'measured') {
+      assertions.push({
+        label: key,
+        ok: false,
+        detail: `engine "${engine}" ${result.status}: ${result.reason}`,
+      });
+      continue;
+    }
+    const scenarioResult = result.scenarios[scenario];
+    if (!scenarioResult) {
+      assertions.push({ label: key, ok: false, detail: `scenario "${scenario}" did not run` });
+      continue;
+    }
+
+    if (budget.maxWarmColdRatio !== undefined) {
+      checkIncrementality(key, budget.maxWarmColdRatio, scenarioResult.metrics, assertions);
+    }
+    if (budget.reference) {
+      checkReference(key, scenario, budget.reference, results, assertions);
+    }
+    if (budget.memory) {
+      checkMemory(key, budget.memory, scenarioResult.metrics, assertions);
+    }
+  }
+
+  return assertions;
+}

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate-assertions.ts
@@ -4,8 +4,8 @@
  * Kept free of process and filesystem work so the rules below - which are the whole point of the
  * gate - can be tested against hand-built results instead of a full run.
  */
-import { PERF_BUDGETS, type PerfBudget } from '../docgen-shared/budgets.ts';
-import type { Comparability, EngineId, EngineMetrics, SuiteResults } from './types.ts';
+import { PERF_BUDGETS, type PerfBudget, type PerfBudgetKey } from '../docgen-shared/budgets.ts';
+import type { EngineId, EngineMetrics, ScenarioResult, SuiteResults } from './types.ts';
 
 export interface Assertion {
   label: string;
@@ -14,158 +14,113 @@ export interface Assertion {
   detail?: string;
 }
 
-function splitKey(key: string): { engine: EngineId; scenario: string } {
-  const [engine, ...rest] = key.split('/');
-  return { engine: engine as EngineId, scenario: rest.join('/') };
+function pass(label: string): Assertion {
+  return { label, ok: true };
 }
 
-/**
- * A cross-engine ratio only becomes a verdict when both sides did equal work. Anything else is a
- * behaviour change wearing a performance number, and passing it through as if it were comparable is
- * how a regression gets waved past.
- */
-function likeForLike(verdict: Comparability): boolean {
-  return verdict === 'like-for-like';
+function fail(label: string, detail: string): Assertion {
+  return { label, ok: false, detail };
 }
 
-function measuredMedian(metric: EngineMetrics[keyof EngineMetrics]): number | undefined {
+function within(label: string, value: number, max: number): Assertion {
+  return value <= max
+    ? pass(label)
+    : fail(label, `${value.toFixed(2)} exceeds the budget of ${max}`);
+}
+
+function splitKey(key: PerfBudgetKey): { engine: EngineId; scenario: string } {
+  const separator = key.indexOf('/');
+  return {
+    engine: key.slice(0, separator) as EngineId,
+    scenario: key.slice(separator + 1),
+  };
+}
+
+function median(metric: EngineMetrics[keyof EngineMetrics]): number | undefined {
   return metric.status === 'measured' && 'median' in metric ? metric.median : undefined;
 }
 
 /**
  * Warm over cold, for one engine, from one run.
  *
- * This is the budget that does not need a second engine to mean something: both sides come from the
- * same process on the same machine over the same project, so it is like-for-like by construction.
- * It rises when re-extraction after a save stops being incremental and starts redoing the cold
- * pass's work, which is the docgen regression that actually hurts users.
+ * Both figures come from the same process over the same project, which makes this like-for-like by
+ * construction - no member-count comparison needed - and it rises exactly when re-extraction after
+ * a save stops being incremental and starts redoing the cold pass's work.
  */
-function checkIncrementality(
-  key: string,
-  max: number,
-  metrics: EngineMetrics,
-  assertions: Assertion[]
-): void {
+function checkIncrementality(key: string, max: number, metrics: EngineMetrics): Assertion {
   const label = `${key} warm/cold ratio`;
-  const cold = measuredMedian(metrics.coldExtractionMs);
-  const warm = measuredMedian(metrics.warmExtractionMs);
+  const cold = median(metrics.coldExtractionMs);
+  const warm = median(metrics.warmExtractionMs);
 
   if (cold === undefined || warm === undefined || cold === 0) {
-    assertions.push({ label, ok: false, detail: 'cold and warm were not both measured' });
-    return;
+    return fail(label, 'cold and warm were not both measured');
   }
   const ratio = warm / cold;
-  assertions.push({
-    label,
-    ok: ratio <= max,
-    detail:
-      ratio <= max
-        ? undefined
-        : `${ratio.toFixed(3)} exceeds the budget of ${max}; re-extraction after a save is no longer incremental`,
-  });
-}
-
-function checkReference(
-  key: string,
-  scenario: string,
-  reference: NonNullable<PerfBudget['reference']>,
-  results: SuiteResults,
-  assertions: Assertion[]
-): void {
-  const entry = results.ratios[reference.pair]?.[scenario];
-  if (!entry) {
-    assertions.push({
-      label: `${key} reference ratio`,
-      ok: false,
-      detail: `control pair "${reference.pair}" produced no ratio for this scenario; both sides must measure in one run`,
-    });
-    return;
-  }
-
-  const checks = [
-    {
-      metric: 'cold',
-      ratio: entry.cold,
-      min: reference.minColdRatio,
-      verdict: entry.coldComparability,
-    },
-    {
-      metric: 'warm',
-      ratio: entry.warm,
-      min: reference.minWarmRatio,
-      verdict: entry.warmComparability,
-    },
-  ] as const;
-
-  for (const { metric, ratio, min, verdict } of checks) {
-    if (min === undefined) {
-      continue;
-    }
-    const label = `${key} ${metric} reference ratio`;
-    if (ratio === undefined) {
-      assertions.push({ label, ok: false, detail: 'not measured in this run' });
-      continue;
-    }
-    if (!likeForLike(verdict)) {
-      assertions.push({
+  return ratio <= max
+    ? pass(label)
+    : fail(
         label,
-        ok: false,
-        detail: `the two sides did not do equal work (${verdict}), so ${ratio.toFixed(2)} is not a cost comparison`,
-      });
-      continue;
-    }
-    assertions.push({
-      label,
-      ok: ratio >= min,
-      detail: ratio >= min ? undefined : `${ratio.toFixed(2)} is below the budget of ${min}`,
-    });
-  }
+        `${ratio.toFixed(3)} exceeds the budget of ${max}; re-extraction after a save is no longer incremental`
+      );
 }
 
 function checkMemory(
   key: string,
   memory: NonNullable<PerfBudget['memory']>,
-  metrics: EngineMetrics,
-  assertions: Assertion[]
-): void {
-  const peak = metrics.peakTransientMb;
-  const growth = metrics.retainedGrowthMb;
-  const slope = metrics.retainedSlopeMbPerSave;
-
-  const checks: Array<{ metric: string; value: number | undefined; max: number | undefined }> = [
+  metrics: EngineMetrics
+): Assertion[] {
+  const { peakTransientMb, retainedGrowthMb, retainedSlopeMbPerSave } = metrics;
+  const checks = [
     {
       metric: 'peak transient (MB)',
-      value: peak.status === 'measured' ? peak.mean : undefined,
-      max: memory.maxPeakTransientMb,
+      value: peakTransientMb.status === 'measured' ? peakTransientMb.mean : undefined,
+      max: memory.maxTransientMb,
     },
     {
       metric: 'retained growth (MB)',
-      value: growth.status === 'measured' ? growth.value : undefined,
+      value: retainedGrowthMb.status === 'measured' ? retainedGrowthMb.value : undefined,
       max: memory.maxRetainedGrowthMb,
     },
     {
       metric: 'retained slope (MB/save)',
-      value: slope.status === 'measured' ? slope.value : undefined,
-      max: memory.maxRetainedSlopeMbPerSave,
+      value:
+        retainedSlopeMbPerSave.status === 'measured' ? retainedSlopeMbPerSave.value : undefined,
+      max: memory.maxRetainedSlopeMb,
     },
   ];
 
-  for (const { metric, value, max } of checks) {
+  return checks.flatMap(({ metric, value, max }) => {
     if (max === undefined) {
-      continue;
+      return [];
     }
     const label = `${key} ${metric}`;
-    if (value === undefined) {
-      // A budgeted metric reported n/a means the run did not produce the thing being gated on.
-      assertions.push({ label, ok: false, detail: 'not measured in this run' });
-      continue;
-    }
-    assertions.push({
-      label,
-      ok: value <= max,
-      detail: value <= max ? undefined : `${value.toFixed(1)} exceeds the budget of ${max}`,
-    });
+    // A budgeted metric reported n/a means the run did not produce the thing being gated on.
+    return [
+      value === undefined ? fail(label, 'not measured in this run') : within(label, value, max),
+    ];
+  });
+}
+
+/**
+ * The scenario a budget row names, or the reason there is nothing to assert it against.
+ *
+ * A budgeted engine that skipped is legitimate on a laptop missing an optional tool and never on
+ * the gate: the thing being protected did not run, and a green result would claim otherwise.
+ */
+function resolveScenario(
+  key: PerfBudgetKey,
+  results: SuiteResults
+): ScenarioResult | { missing: string } {
+  const { engine, scenario } = splitKey(key);
+  const result = results.engines[engine];
+
+  if (!result) {
+    return { missing: `engine "${engine}" did not run` };
   }
+  if (result.status !== 'measured') {
+    return { missing: `engine "${engine}" ${result.status}: ${result.reason}` };
+  }
+  return result.scenarios[scenario] ?? { missing: `scenario "${scenario}" did not run` };
 }
 
 /**
@@ -177,68 +132,38 @@ function checkMemory(
  */
 export function assertBudgets(
   results: SuiteResults,
-  budgets: Record<string, PerfBudget> = PERF_BUDGETS
+  budgets: Partial<Record<PerfBudgetKey, PerfBudget>> = PERF_BUDGETS
 ): Assertion[] {
-  const assertions: Assertion[] = [];
-
   if (!results.comparable) {
     return [
-      {
-        label: 'run is comparable',
-        ok: false,
-        detail: 'these are non-comparable smoke numbers; the gate needs a full-profile run',
-      },
+      fail(
+        'run is comparable',
+        'these are non-comparable smoke numbers; the gate needs a full-profile run'
+      ),
     ];
   }
-  assertions.push({ label: 'run is comparable', ok: true });
 
-  const keys = Object.keys(budgets);
-  if (keys.length === 0) {
+  const entries = Object.entries(budgets) as Array<[PerfBudgetKey, PerfBudget]>;
+  if (entries.length === 0) {
     return [
-      ...assertions,
-      {
-        label: 'budgets recorded',
-        ok: false,
-        detail: 'no budget rows exist, so this gate asserts nothing',
-      },
+      pass('run is comparable'),
+      fail('budgets recorded', 'no budget rows exist, so this gate asserts nothing'),
     ];
   }
 
-  for (const key of keys) {
-    const { engine, scenario } = splitKey(key);
-    const budget = budgets[key];
-    const result = results.engines[engine];
-
-    // A budgeted engine that skipped is legitimate locally and never on the gate: the thing being
-    // protected did not run, and a green result would claim otherwise.
-    if (!result) {
-      assertions.push({ label: key, ok: false, detail: `engine "${engine}" did not run` });
-      continue;
-    }
-    if (result.status !== 'measured') {
-      assertions.push({
-        label: key,
-        ok: false,
-        detail: `engine "${engine}" ${result.status}: ${result.reason}`,
-      });
-      continue;
-    }
-    const scenarioResult = result.scenarios[scenario];
-    if (!scenarioResult) {
-      assertions.push({ label: key, ok: false, detail: `scenario "${scenario}" did not run` });
-      continue;
-    }
-
-    if (budget.maxWarmColdRatio !== undefined) {
-      checkIncrementality(key, budget.maxWarmColdRatio, scenarioResult.metrics, assertions);
-    }
-    if (budget.reference) {
-      checkReference(key, scenario, budget.reference, results, assertions);
-    }
-    if (budget.memory) {
-      checkMemory(key, budget.memory, scenarioResult.metrics, assertions);
-    }
-  }
-
-  return assertions;
+  return [
+    pass('run is comparable'),
+    ...entries.flatMap(([key, budget]) => {
+      const scenario = resolveScenario(key, results);
+      if ('missing' in scenario) {
+        return [fail(key, scenario.missing)];
+      }
+      return [
+        ...(budget.maxWarmColdRatio === undefined
+          ? []
+          : [checkIncrementality(key, budget.maxWarmColdRatio, scenario.metrics)]),
+        ...(budget.memory ? checkMemory(key, budget.memory, scenario.metrics) : []),
+      ];
+    }),
+  ];
 }

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate.ts
@@ -25,14 +25,15 @@ import type { SuiteResults } from './types.ts';
 
 const SUITE = path.join(import.meta.dirname, 'run.ts');
 
-/** CI points this inside the checkout so the results can be stored as a build artifact. */
-const { outDir: GATE_DIR } = parseHarnessOptions<{ outDir: string }>(
-  process.argv.slice(2),
-  { out: { type: 'string' } },
-  z.object({ outDir: z.string().default(path.join(SANDBOX_DIRECTORY, 'docgen-perf-gate')) }),
-  (values) => ({ outDir: values.out })
-);
-const RESULTS_PATH = path.join(GATE_DIR, 'results.json');
+/** CI points `--out` inside the checkout so the results can be stored as a build artifact. */
+function parseOptions(argv: string[]): { outDir: string } {
+  return parseHarnessOptions<{ outDir: string }>(
+    argv,
+    { out: { type: 'string' } },
+    z.object({ outDir: z.string().default(path.join(SANDBOX_DIRECTORY, 'docgen-perf-gate')) }),
+    (values) => ({ outDir: values.out })
+  );
+}
 
 interface SuiteRun {
   status: number | null;
@@ -73,9 +74,9 @@ function report(assertions: Assertion[]): string[] {
  * control and still succeeds means failures are being swallowed somewhere between the child and
  * the job's exit status.
  */
-function checkNegativeControl(): string[] {
+function checkNegativeControl(gateDir: string): string[] {
   console.log('\n=== negative control: a failing engine must fail the gate ===');
-  const controlPath = path.join(GATE_DIR, 'crash-control.json');
+  const controlPath = path.join(gateDir, 'crash-control.json');
   const { status } = runSuite(['--quick', '--engine', 'crash-control'], controlPath);
 
   if (status !== 0) {
@@ -89,8 +90,11 @@ function checkNegativeControl(): string[] {
 }
 
 function main(): void {
+  const { outDir } = parseOptions(process.argv.slice(2));
+  const resultsPath = path.join(outDir, 'results.json');
+
   console.log('=== docgen perf suite (pinned profile) ===');
-  const { status, results } = runSuite([], RESULTS_PATH);
+  const { status, results } = runSuite([], resultsPath);
 
   const failures: string[] = [];
 
@@ -98,13 +102,13 @@ function main(): void {
     failures.push(`the suite exited with status ${status}; see its output above`);
   }
   if (!results) {
-    failures.push(`the suite wrote no results at ${RESULTS_PATH}`);
+    failures.push(`the suite wrote no results at ${resultsPath}`);
   } else {
     console.log('\n=== budgets ===');
     failures.push(...report(assertBudgets(results)));
   }
 
-  failures.push(...checkNegativeControl());
+  failures.push(...checkNegativeControl(outDir));
 
   console.log('');
   if (failures.length > 0) {
@@ -117,7 +121,7 @@ function main(): void {
     process.exitCode = 1;
     return;
   }
-  console.log(`docgen perf gate passed. Results: ${RESULTS_PATH}`);
+  console.log(`docgen perf gate passed. Results: ${resultsPath}`);
 }
 
 main();

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate.ts
@@ -1,0 +1,123 @@
+/**
+ * CI regression gate for the per-engine docgen performance suite.
+ *
+ * Runs the suite once at the pinned profile, asserts every recorded budget against the results it
+ * wrote, and then proves its own failure detection with a negative control: a second, tiny run that
+ * includes a deliberately failing engine and MUST come back non-zero.
+ *
+ * The measurement contract is ../PERF-METHODOLOGY.md; the budgets are
+ * ../docgen-shared/budgets.ts.
+ *
+ * Run from code/lib/docgen-harness:
+ *   yarn bench:docgen-perf-gate
+ *   yarn bench:docgen-perf-gate --out <dir>   # where the results are written
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+import { parseHarnessOptions } from '../docgen-shared/args.ts';
+import { SANDBOX_DIRECTORY } from '../docgen-shared/paths.ts';
+import { type Assertion, assertBudgets } from './gate-assertions.ts';
+import type { SuiteResults } from './types.ts';
+
+const SUITE = path.join(import.meta.dirname, 'run.ts');
+
+/** CI points this inside the checkout so the results can be stored as a build artifact. */
+const { outDir: GATE_DIR } = parseHarnessOptions<{ outDir: string }>(
+  process.argv.slice(2),
+  { out: { type: 'string' } },
+  z.object({ outDir: z.string().default(path.join(SANDBOX_DIRECTORY, 'docgen-perf-gate')) }),
+  (values) => ({ outDir: values.out })
+);
+const RESULTS_PATH = path.join(GATE_DIR, 'results.json');
+
+interface SuiteRun {
+  status: number | null;
+  results?: SuiteResults;
+}
+
+function runSuite(args: string[], jsonPath: string): SuiteRun {
+  fs.mkdirSync(path.dirname(jsonPath), { recursive: true });
+  // Remove any stale results so a crashed run cannot be asserted against a previous success.
+  fs.rmSync(jsonPath, { force: true });
+
+  const proc = spawnSync(process.execPath, [SUITE, ...args, '--json', jsonPath], {
+    encoding: 'utf8',
+    // The suite's own table is the record of what was measured, so it belongs in the job log in
+    // full rather than as a tail after the fact.
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+
+  const results = fs.existsSync(jsonPath)
+    ? (JSON.parse(fs.readFileSync(jsonPath, 'utf8')) as SuiteResults)
+    : undefined;
+  return { status: proc.status, results };
+}
+
+function report(assertions: Assertion[]): string[] {
+  const failures: string[] = [];
+  for (const { label, ok, detail } of assertions) {
+    console.log(`  ${ok ? '✓' : '✗'} ${label}${detail ? `: ${detail}` : ''}`);
+    if (!ok) {
+      failures.push(`${label}: ${detail ?? 'failed'}`);
+    }
+  }
+  return failures;
+}
+
+/**
+ * The suite reports a failing engine by exiting non-zero, so a gate run that includes the crash
+ * control and still succeeds means failures are being swallowed somewhere between the child and
+ * the job's exit status.
+ */
+function checkNegativeControl(): string[] {
+  console.log('\n=== negative control: a failing engine must fail the gate ===');
+  const controlPath = path.join(GATE_DIR, 'crash-control.json');
+  const { status } = runSuite(['--quick', '--engine', 'crash-control'], controlPath);
+
+  if (status !== 0) {
+    console.log(`  ✓ suite exited ${status} on a failing engine`);
+    return [];
+  }
+  console.log('  ✗ suite exited 0 despite a deliberately failing engine');
+  return [
+    'negative control: the suite reported success for a failing engine, so the gate cannot be trusted to catch a real one',
+  ];
+}
+
+function main(): void {
+  console.log('=== docgen perf suite (pinned profile) ===');
+  const { status, results } = runSuite([], RESULTS_PATH);
+
+  const failures: string[] = [];
+
+  if (status !== 0) {
+    failures.push(`the suite exited with status ${status}; see its output above`);
+  }
+  if (!results) {
+    failures.push(`the suite wrote no results at ${RESULTS_PATH}`);
+  } else {
+    console.log('\n=== budgets ===');
+    failures.push(...report(assertBudgets(results)));
+  }
+
+  failures.push(...checkNegativeControl());
+
+  console.log('');
+  if (failures.length > 0) {
+    console.error('docgen perf gate FAILED:');
+    for (const failure of failures) {
+      console.error(`  - ${failure}`);
+    }
+    // Not process.exit: writes to a pipe are async, and exiting here can truncate the very reasons
+    // someone is reading when the gate fails.
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`docgen perf gate passed. Results: ${RESULTS_PATH}`);
+}
+
+main();

--- a/code/lib/docgen-harness/src/perf/docgen-perf/gate.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/gate.ts
@@ -1,12 +1,11 @@
 /**
  * CI regression gate for the per-engine docgen performance suite.
  *
- * Runs the suite once at the pinned profile, asserts every recorded budget against the results it
- * wrote, and then proves its own failure detection with a negative control: a second, tiny run that
- * includes a deliberately failing engine and MUST come back non-zero.
+ * Runs the suite at the pinned profile, asserts the recorded budgets, then proves its own failure
+ * detection with a negative control: a second run including a deliberately failing engine, which
+ * MUST come back non-zero.
  *
- * The measurement contract is ../PERF-METHODOLOGY.md; the budgets are
- * ../docgen-shared/budgets.ts.
+ * Contract: ../PERF-METHODOLOGY.md. Budgets: ../docgen-shared/budgets.ts.
  *
  * Run from code/lib/docgen-harness:
  *   yarn bench:docgen-perf-gate
@@ -47,8 +46,7 @@ function runSuite(args: string[], jsonPath: string): SuiteRun {
 
   const proc = spawnSync(process.execPath, [SUITE, ...args, '--json', jsonPath], {
     encoding: 'utf8',
-    // The suite's own table is the record of what was measured, so it belongs in the job log in
-    // full rather than as a tail after the fact.
+    // The suite's table is the record of what was measured, so it belongs in the job log in full.
     stdio: ['ignore', 'inherit', 'inherit'],
   });
 
@@ -69,11 +67,7 @@ function report(assertions: Assertion[]): string[] {
   return failures;
 }
 
-/**
- * The suite reports a failing engine by exiting non-zero, so a gate run that includes the crash
- * control and still succeeds means failures are being swallowed somewhere between the child and
- * the job's exit status.
- */
+/** A run including the crash control that still succeeds means failures are being swallowed. */
 function checkNegativeControl(gateDir: string): string[] {
   console.log('\n=== negative control: a failing engine must fail the gate ===');
   const controlPath = path.join(gateDir, 'crash-control.json');
@@ -116,8 +110,7 @@ function main(): void {
     for (const failure of failures) {
       console.error(`  - ${failure}`);
     }
-    // Not process.exit: writes to a pipe are async, and exiting here can truncate the very reasons
-    // someone is reading when the gate fails.
+    // Not process.exit: writes to a pipe are async and would truncate the reasons printed above.
     process.exitCode = 1;
     return;
   }

--- a/code/lib/docgen-harness/src/perf/docgen-perf/ratios.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/ratios.test.ts
@@ -16,8 +16,8 @@ function scenario(
     warmMembers: members?.[1],
     coldOpaqueTypes,
     metrics: {
-      coldExtractionMs: { status: 'measured', samples: [cold], median: cold },
-      warmExtractionMs: { status: 'measured', samples: [warm], median: warm },
+      coldExtractionMs: { status: 'measured', samples: [cold], value: cold },
+      warmExtractionMs: { status: 'measured', samples: [warm], value: warm },
       wholeProjectScanMs: NOT_APPLICABLE,
       peakTransientMb: NOT_APPLICABLE,
       retainedGrowthMb: NOT_APPLICABLE,

--- a/code/lib/docgen-harness/src/perf/docgen-perf/ratios.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/ratios.ts
@@ -7,8 +7,7 @@ import type {
   Comparability,
   EngineId,
   EngineResult,
-  LatencyMetric,
-  NotApplicable,
+  Metric,
   RatioEntry,
   Ratios,
   ScenarioResult,
@@ -52,11 +51,11 @@ export function engineOrderForRep(engines: EngineId[], rep: number): EngineId[] 
  * A zero denominator is treated the same way. It means the new engine's median landed below the
  * clock's resolution, and Infinity would then be rendered and stored as if it were a ratio.
  */
-function medianRatio(legacy: LatencyMetric | NotApplicable, next: LatencyMetric | NotApplicable) {
+function medianRatio(legacy: Metric, next: Metric) {
   if (legacy.status !== 'measured' || next.status !== 'measured') {
     return undefined;
   }
-  const ratio = legacy.median / next.median;
+  const ratio = legacy.value / next.value;
   return Number.isFinite(ratio) ? ratio : undefined;
 }
 

--- a/code/lib/docgen-harness/src/perf/docgen-perf/ratios.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/ratios.ts
@@ -87,11 +87,14 @@ function comparability(
 }
 
 function ratioFor(
+  pair: ControlPair,
   legacy: ScenarioResult,
   next: ScenarioResult,
   versions: PairVersions
 ): RatioEntry {
   return {
+    legacyEngine: pair.legacy,
+    nextEngine: pair.next,
     cold: medianRatio(legacy.metrics.coldExtractionMs, next.metrics.coldExtractionMs),
     warm: medianRatio(legacy.metrics.warmExtractionMs, next.metrics.warmExtractionMs),
     legacyColdMembers: legacy.coldMembers,
@@ -145,7 +148,7 @@ export function computeRatios(
         continue;
       }
       ratios[pair.name] ??= {};
-      ratios[pair.name][scenarioName] = ratioFor(legacyScenario, nextScenario, versions);
+      ratios[pair.name][scenarioName] = ratioFor(pair, legacyScenario, nextScenario, versions);
     }
   }
 

--- a/code/lib/docgen-harness/src/perf/docgen-perf/registry.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/registry.test.ts
@@ -117,7 +117,28 @@ describe('what the series engines spawn', () => {
   it('passes the scenario size through to the child', async () => {
     const { spec } = await specFor('react-legacy', reactScenario);
     const components = spec.args[spec.args.indexOf('--components') + 1];
-    expect(components).toBe(String(QUICK_PROFILE.react.components));
+    expect(components).toBe(String(QUICK_PROFILE.react[0].components));
+  });
+
+  it('runs both React shapes, and tells the child which one it is measuring', async () => {
+    const shapes = engineById('react-osa')
+      .scenarios(QUICK_PROFILE)
+      .map((scenario) => scenario.name);
+    expect(shapes).toEqual(['whole-index', 'first-story']);
+
+    for (const scenario of engineById('react-osa').scenarios(QUICK_PROFILE)) {
+      const { spec } = await specFor('react-osa', scenario);
+      expect(spec.args[spec.args.indexOf('--shape') + 1], scenario.name).toBe(scenario.name);
+    }
+  });
+
+  it('gives the React engines identical flags per shape, so a ratio compares engines not shapes', async () => {
+    for (const scenario of engineById('react-osa').scenarios(QUICK_PROFILE)) {
+      const osa = await specFor('react-osa', scenario);
+      const legacy = await specFor('react-legacy', scenario);
+      const shapeOf = (args: string[]) => args[args.indexOf('--shape') + 1];
+      expect(shapeOf(osa.spec.args), scenario.name).toBe(shapeOf(legacy.spec.args));
+    }
   });
 
   it('passes --heavy-lib only for scenarios that ask for it', async () => {

--- a/code/lib/docgen-harness/src/perf/docgen-perf/registry.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/registry.test.ts
@@ -29,6 +29,12 @@ async function specFor(id: EngineId, scenario: ScenarioSpec, rep = 1) {
   return calls[0];
 }
 
+/** Everything that describes the generated project, which is what a flag comparison is about. */
+function withoutPin(args: string[]): string[] {
+  const pin = args.indexOf('--pin');
+  return pin === -1 ? args : [...args.slice(0, pin), ...args.slice(pin + 2)];
+}
+
 const reactScenario = engineById('react-legacy').scenarios(QUICK_PROFILE)[0];
 const vueFlatScenario = engineById('vue-component-meta')
   .scenarios(QUICK_PROFILE)
@@ -153,7 +159,7 @@ describe('what the series engines spawn', () => {
     for (const scenario of engineById('vue-docgen-api').scenarios(QUICK_PROFILE)) {
       const legacy = await specFor('vue-docgen-api', scenario);
       const meta = await specFor('vue-component-meta', scenario);
-      expect(meta.spec.args, scenario.name).toEqual(legacy.spec.args);
+      expect(withoutPin(meta.spec.args), scenario.name).toEqual(withoutPin(legacy.spec.args));
       expect(meta.spec.childPath).not.toBe(legacy.spec.childPath);
     }
   });
@@ -163,18 +169,18 @@ describe('what the series engines spawn', () => {
   });
 
   it('sends the two vue-component-meta versions to one child with different pins', async () => {
-    const pinned = await specFor('vue-component-meta', vueFlatScenario);
+    const current = await specFor('vue-component-meta', vueFlatScenario);
     const next = await specFor('vue-component-meta-next', vueFlatScenario);
-    expect(next.spec.childPath).toBe(pinned.spec.childPath);
-    expect(pinned.spec.args).not.toContain('next');
-    expect(next.spec.args.slice(-2)).toEqual(['--pin', 'next']);
+    expect(next.spec.childPath).toBe(current.spec.childPath);
+    expect(current.spec.args.slice(-2)).toEqual(['--pin', 'vue-component-meta']);
+    expect(next.spec.args.slice(-2)).toEqual(['--pin', 'vue-component-meta-next']);
   });
 
   it('gives both vue-component-meta versions identical flags apart from --pin', async () => {
     for (const scenario of engineById('vue-component-meta').scenarios(QUICK_PROFILE)) {
-      const pinned = await specFor('vue-component-meta', scenario);
+      const current = await specFor('vue-component-meta', scenario);
       const next = await specFor('vue-component-meta-next', scenario);
-      expect(next.spec.args.slice(0, -2)).toEqual(pinned.spec.args);
+      expect(withoutPin(next.spec.args)).toEqual(withoutPin(current.spec.args));
     }
   });
 

--- a/code/lib/docgen-harness/src/perf/docgen-perf/registry.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/registry.ts
@@ -8,14 +8,15 @@ import { type BenchEngine, type ScenarioSpec, SeriesChildEngine } from './engine
 import { CompodocEngine } from './engines/compodoc.ts';
 import type { EngineId } from './types.ts';
 
-const reactScenarios = (profile: SuiteProfile): ScenarioSpec[] => [
-  { name: 'default', params: { ...profile.react } },
-];
+const reactScenarios = (profile: SuiteProfile): ScenarioSpec[] =>
+  profile.react.map((scenario) => ({ name: scenario.shape, params: { ...scenario } }));
 
 const vueScenarios = (profile: SuiteProfile): ScenarioSpec[] =>
   profile.vue.map((scenario) => ({ name: scenario.name, params: { ...scenario } }));
 
 const reactArgs = ({ params }: ScenarioSpec): string[] => [
+  '--shape',
+  String(params.shape),
   '--components',
   String(params.components),
   '--variants',

--- a/code/lib/docgen-harness/src/perf/docgen-perf/registry.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/registry.ts
@@ -97,6 +97,15 @@ export const ENGINES: BenchEngine[] = [
     versionPackage: 'vue-component-meta-next',
   }),
   new CompodocEngine(),
+  // Always fails. The gate names it explicitly to prove the gate reports a failing engine as a
+  // failure; nothing else ever runs it.
+  new SeriesChildEngine({
+    id: 'crash-control',
+    child: 'engines/crash-control.ts',
+    scenarios: () => [{ name: 'default', params: {} }],
+    inDefaultRun: false,
+    args: () => [],
+  }),
 ];
 
 export const ALL_ENGINE_IDS: EngineId[] = ENGINES.map((engine) => engine.id);

--- a/code/lib/docgen-harness/src/perf/docgen-perf/registry.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/registry.ts
@@ -84,7 +84,7 @@ export const ENGINES: BenchEngine[] = [
     child: 'engines/vue-component-meta.ts',
     scenarios: vueScenarios,
     args: vueArgs,
-    versionPackage: 'vue-component-meta',
+    pin: 'vue-component-meta',
   }),
   // Same child, pinned to a second, explicitly-versioned copy of the package - a version-pair
   // control rather than an engine-vs-engine one. No budget row yet, so it stays out of the
@@ -94,8 +94,8 @@ export const ENGINES: BenchEngine[] = [
     child: 'engines/vue-component-meta.ts',
     scenarios: vueScenarios,
     inDefaultRun: false,
-    args: (scenario) => [...vueArgs(scenario), '--pin', 'next'],
-    versionPackage: 'vue-component-meta-next',
+    args: vueArgs,
+    pin: 'vue-component-meta-next',
   }),
   new CompodocEngine(),
   // Always fails. The gate names it explicitly to prove the gate reports a failing engine as a

--- a/code/lib/docgen-harness/src/perf/docgen-perf/report.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/report.test.ts
@@ -44,6 +44,8 @@ describe('renderRatios', () => {
         renderRatios({
           vue: {
             flat: {
+              legacyEngine: 'vue-docgen-api',
+              nextEngine: 'vue-component-meta',
               cold: 18.48,
               warm: 22.5,
               legacyColdMembers: 6,
@@ -57,8 +59,9 @@ describe('renderRatios', () => {
         })
       )
     ).toMatchInlineSnapshot(`
-      "  ratio cold legacy/new (vue/flat): 18.48  [documented members 6 vs 320 - NOT like-for-like - new engine documented more, so this ratio undersells it]
-        ratio warm legacy/new (vue/flat): 22.50  [documented members 0 vs 32 - NOT like-for-like - new engine documented more, so this ratio undersells it]"
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (vue-docgen-api over vue-component-meta, flat): 18.48  [documented members 6 vs 320 - NOT like-for-like - new engine documented more, so this ratio undersells it]
+        ratio warm (vue-docgen-api over vue-component-meta, flat): 22.50  [documented members 0 vs 32 - NOT like-for-like - new engine documented more, so this ratio undersells it]"
     `);
   });
 
@@ -69,6 +72,8 @@ describe('renderRatios', () => {
         renderRatios({
           vue: {
             flat: {
+              legacyEngine: 'vue-docgen-api',
+              nextEngine: 'vue-component-meta',
               cold: 0.05,
               legacyColdMembers: 320,
               nextColdMembers: 6,
@@ -79,7 +84,10 @@ describe('renderRatios', () => {
         })
       )
     ).toMatchInlineSnapshot(
-      `"  ratio cold legacy/new (vue/flat): 0.05  [documented members 320 vs 6 - NOT like-for-like - new engine documented less, so it is fast for the wrong reason]"`
+      `
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (vue-docgen-api over vue-component-meta, flat): 0.05  [documented members 320 vs 6 - NOT like-for-like - new engine documented less, so it is fast for the wrong reason]"
+    `
     );
   });
 
@@ -90,6 +98,8 @@ describe('renderRatios', () => {
         renderRatios({
           vue: {
             flat: {
+              legacyEngine: 'vue-docgen-api',
+              nextEngine: 'vue-component-meta',
               cold: 4.1,
               legacyColdMembers: 90,
               nextColdMembers: 90,
@@ -100,7 +110,10 @@ describe('renderRatios', () => {
         })
       )
     ).toMatchInlineSnapshot(
-      `"  ratio cold legacy/new (vue/flat): 4.10  [documented members 90 vs 90 - NOT like-for-like - same members, but the new engine left more types unresolved]"`
+      `
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (vue-docgen-api over vue-component-meta, flat): 4.10  [documented members 90 vs 90 - NOT like-for-like - same members, but the new engine left more types unresolved]"
+    `
     );
   });
 
@@ -110,6 +123,8 @@ describe('renderRatios', () => {
         renderRatios({
           vue: {
             flat: {
+              legacyEngine: 'vue-docgen-api',
+              nextEngine: 'vue-component-meta',
               cold: 1.2,
               warm: 1.1,
               legacyColdMembers: 50,
@@ -121,8 +136,9 @@ describe('renderRatios', () => {
         })
       )
     ).toMatchInlineSnapshot(`
-      "  ratio cold legacy/new (vue/flat): 1.20  [documented members 50 vs 50]
-        ratio warm legacy/new (vue/flat): 1.10"
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (vue-docgen-api over vue-component-meta, flat): 1.20  [documented members 50 vs 50]
+        ratio warm (vue-docgen-api over vue-component-meta, flat): 1.10"
     `);
   });
 
@@ -133,6 +149,8 @@ describe('renderRatios', () => {
         renderRatios({
           react: {
             default: {
+              legacyEngine: 'react-legacy',
+              nextEngine: 'react-osa',
               cold: 4,
               warm: 2,
               coldComparability: 'unknown',
@@ -142,8 +160,9 @@ describe('renderRatios', () => {
         })
       )
     ).toMatchInlineSnapshot(`
-      "  ratio cold legacy/new (react/default): 4.00
-        ratio warm legacy/new (react/default): 2.00"
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (react-legacy over react-osa, default): 4.00
+        ratio warm (react-legacy over react-osa, default): 2.00"
     `);
   });
 
@@ -152,17 +171,28 @@ describe('renderRatios', () => {
       block(
         renderRatios({
           react: {
-            default: { cold: 4, coldComparability: 'unknown', warmComparability: 'unknown' },
+            default: {
+              legacyEngine: 'react-legacy',
+              nextEngine: 'react-osa',
+              cold: 4,
+              coldComparability: 'unknown',
+              warmComparability: 'unknown',
+            },
           },
         })
       )
-    ).toMatchInlineSnapshot(`"  ratio cold legacy/new (react/default): 4.00"`);
+    ).toMatchInlineSnapshot(`
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (react-legacy over react-osa, default): 4.00"
+    `);
   });
 
   it('renders every scenario of every pair', () => {
     const ratios: Ratios = {
       react: {
         default: {
+          legacyEngine: 'react-legacy',
+          nextEngine: 'react-osa',
           cold: 3.9,
           warm: 2.1,
           coldComparability: 'unknown',
@@ -170,15 +200,28 @@ describe('renderRatios', () => {
         },
       },
       vue: {
-        flat: { cold: 18.5, coldComparability: 'unknown', warmComparability: 'unknown' },
-        workspace: { cold: 21.2, coldComparability: 'unknown', warmComparability: 'unknown' },
+        flat: {
+          legacyEngine: 'vue-docgen-api',
+          nextEngine: 'vue-component-meta',
+          cold: 18.5,
+          coldComparability: 'unknown',
+          warmComparability: 'unknown',
+        },
+        workspace: {
+          legacyEngine: 'vue-docgen-api',
+          nextEngine: 'vue-component-meta',
+          cold: 21.2,
+          coldComparability: 'unknown',
+          warmComparability: 'unknown',
+        },
       },
     };
     expect(block(renderRatios(ratios))).toMatchInlineSnapshot(`
-      "  ratio cold legacy/new (react/default): 3.90
-        ratio warm legacy/new (react/default): 2.10
-        ratio cold legacy/new (vue/flat): 18.50
-        ratio cold legacy/new (vue/workspace): 21.20"
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (react-legacy over react-osa, default): 3.90
+        ratio warm (react-legacy over react-osa, default): 2.10
+        ratio cold (vue-docgen-api over vue-component-meta, flat): 18.50
+        ratio cold (vue-docgen-api over vue-component-meta, workspace): 21.20"
     `);
   });
 
@@ -194,6 +237,8 @@ describe('renderRatios', () => {
         renderRatios({
           'vue-component-meta-version': {
             flat: {
+              legacyEngine: 'vue-docgen-api',
+              nextEngine: 'vue-component-meta',
               cold: 1.08,
               legacyVersion: '3.3.2',
               nextVersion: '3.3.8',
@@ -204,7 +249,10 @@ describe('renderRatios', () => {
         })
       )
     ).toMatchInlineSnapshot(
-      `"  ratio cold legacy/new (vue-component-meta-version/flat): 1.08  [3.3.2 vs 3.3.8]"`
+      `
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (vue-docgen-api over vue-component-meta, flat): 1.08  [3.3.2 vs 3.3.8]"
+    `
     );
   });
 
@@ -216,6 +264,8 @@ describe('renderRatios', () => {
         renderRatios({
           'vue-component-meta-version': {
             flat: {
+              legacyEngine: 'vue-docgen-api',
+              nextEngine: 'vue-component-meta',
               cold: 1.0,
               legacyVersion: '3.3.8',
               nextVersion: '3.3.8',
@@ -226,7 +276,10 @@ describe('renderRatios', () => {
         })
       )
     ).toMatchInlineSnapshot(
-      `"  ratio cold legacy/new (vue-component-meta-version/flat): 1.00  [both sides resolved 3.3.8 - NOT a comparison]"`
+      `
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (vue-docgen-api over vue-component-meta, flat): 1.00  [both sides resolved 3.3.8 - NOT a comparison]"
+    `
     );
   });
 
@@ -236,6 +289,8 @@ describe('renderRatios', () => {
         renderRatios({
           'vue-component-meta-version': {
             flat: {
+              legacyEngine: 'vue-docgen-api',
+              nextEngine: 'vue-component-meta',
               cold: 1.08,
               warm: 0.97,
               legacyColdMembers: 320,
@@ -249,8 +304,9 @@ describe('renderRatios', () => {
         })
       )
     ).toMatchInlineSnapshot(`
-      "  ratio cold legacy/new (vue-component-meta-version/flat): 1.08  [documented members 320 vs 320]  [3.3.2 vs 3.3.8]
-        ratio warm legacy/new (vue-component-meta-version/flat): 0.97  [3.3.2 vs 3.3.8]"
+      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
+        ratio cold (vue-docgen-api over vue-component-meta, flat): 1.08  [documented members 320 vs 320]  [3.3.2 vs 3.3.8]
+        ratio warm (vue-docgen-api over vue-component-meta, flat): 0.97  [3.3.2 vs 3.3.8]"
     `);
   });
 });

--- a/code/lib/docgen-harness/src/perf/docgen-perf/report.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/report.test.ts
@@ -12,20 +12,20 @@ const block = (lines: string[]) => lines.join('\n');
 
 /** A series engine: per-component, so it has no whole-project scan. */
 const seriesMetrics: EngineMetrics = {
-  coldExtractionMs: { status: 'measured', samples: [1204, 1180, 1191], median: 1191 },
-  warmExtractionMs: { status: 'measured', samples: [42.4, 39.8, 41.1], median: 41.1 },
+  coldExtractionMs: { status: 'measured', samples: [1204, 1180, 1191], value: 1191 },
+  warmExtractionMs: { status: 'measured', samples: [42.4, 39.8, 41.1], value: 41.1 },
   wholeProjectScanMs: NOT_APPLICABLE,
-  peakTransientMb: { status: 'measured', samples: [61, 58, 63], mean: 60.7 },
+  peakTransientMb: { status: 'measured', samples: [61, 58, 63], value: 60.7 },
   retainedGrowthMb: { status: 'measured', value: 12.4 },
   retainedSlopeMbPerSave: { status: 'measured', value: 0.62 },
 };
 
 /** A one-shot CLI engine: a fresh process per run, so no retained series to report. */
 const oneShotMetrics: EngineMetrics = {
-  coldExtractionMs: { status: 'measured', samples: [8420, 8110, 8300], median: 8300 },
-  warmExtractionMs: { status: 'measured', samples: [8290, 8050, 8180], median: 8180 },
-  wholeProjectScanMs: { status: 'measured', samples: [8420, 8110, 8300], median: 8300 },
-  peakTransientMb: { status: 'measured', samples: [980, 1010, 995], mean: 995 },
+  coldExtractionMs: { status: 'measured', samples: [8420, 8110, 8300], value: 8300 },
+  warmExtractionMs: { status: 'measured', samples: [8290, 8050, 8180], value: 8180 },
+  wholeProjectScanMs: { status: 'measured', samples: [8420, 8110, 8300], value: 8300 },
+  peakTransientMb: { status: 'measured', samples: [980, 1010, 995], value: 995 },
   retainedGrowthMb: NOT_APPLICABLE,
   retainedSlopeMbPerSave: NOT_APPLICABLE,
 };
@@ -166,27 +166,6 @@ describe('renderRatios', () => {
     `);
   });
 
-  it('omits the half of the pair that did not measure', () => {
-    expect(
-      block(
-        renderRatios({
-          react: {
-            default: {
-              legacyEngine: 'react-legacy',
-              nextEngine: 'react-osa',
-              cold: 4,
-              coldComparability: 'unknown',
-              warmComparability: 'unknown',
-            },
-          },
-        })
-      )
-    ).toMatchInlineSnapshot(`
-      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
-        ratio cold (react-legacy over react-osa, default): 4.00"
-    `);
-  });
-
   it('renders every scenario of every pair', () => {
     const ratios: Ratios = {
       react: {
@@ -228,31 +207,6 @@ describe('renderRatios', () => {
   it('says so when there is no ratio at all', () => {
     expect(block(renderRatios({}))).toMatchInlineSnapshot(
       `"  no calibration ratio: it needs both sides of a control pair measured in one run"`
-    );
-  });
-
-  it('names both versions when a pair compares one package against another release of it', () => {
-    expect(
-      block(
-        renderRatios({
-          'vue-component-meta-version': {
-            flat: {
-              legacyEngine: 'vue-docgen-api',
-              nextEngine: 'vue-component-meta',
-              cold: 1.08,
-              legacyVersion: '3.3.2',
-              nextVersion: '3.3.8',
-              coldComparability: 'like-for-like',
-              warmComparability: 'like-for-like',
-            },
-          },
-        })
-      )
-    ).toMatchInlineSnapshot(
-      `
-      "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
-        ratio cold (vue-docgen-api over vue-component-meta, flat): 1.08  [3.3.2 vs 3.3.8]"
-    `
     );
   });
 
@@ -329,10 +283,10 @@ describe('renderResults', () => {
       }
     );
     expect(block(table)).toMatchInlineSnapshot(`
-      "  engine/scenario       cold    warm    scan    peak   ret-growth  ret-slope
-        react-legacy/default  1191ms  41ms    n/a     61MB   12.4MB      0.62MB/save
-        react-osa/default     1191ms  41ms    n/a     61MB   12.4MB      0.62MB/save
-        compodoc/default      8300ms  8180ms  8300ms  995MB  n/a         n/a"
+      "  engine/scenario       cold    warm    scan    peak     ret-growth  ret-slope
+        react-legacy/default  1191ms  41ms    n/a     60.7MB   12.4MB      0.62MB/save
+        react-osa/default     1191ms  41ms    n/a     60.7MB   12.4MB      0.62MB/save
+        compodoc/default      8300ms  8180ms  8300ms  995.0MB  n/a         n/a"
     `);
     // Only the first line of a reason: a stack trace would push the table off the screen.
     expect(block(statusLines)).toMatchInlineSnapshot(`
@@ -353,10 +307,10 @@ describe('renderResults', () => {
       },
     });
     expect(block(table)).toMatchInlineSnapshot(`
-      "  engine/scenario                     cold    warm  scan  peak  ret-growth  ret-slope
-        vue-component-meta/flat             1191ms  41ms  n/a   61MB  12.4MB      0.62MB/save
-        vue-component-meta/workspace        1191ms  41ms  n/a   61MB  12.4MB      0.62MB/save
-        vue-component-meta/base-type-touch  1191ms  41ms  n/a   61MB  12.4MB      0.62MB/save"
+      "  engine/scenario                     cold    warm  scan  peak    ret-growth  ret-slope
+        vue-component-meta/flat             1191ms  41ms  n/a   60.7MB  12.4MB      0.62MB/save
+        vue-component-meta/workspace        1191ms  41ms  n/a   60.7MB  12.4MB      0.62MB/save
+        vue-component-meta/base-type-touch  1191ms  41ms  n/a   60.7MB  12.4MB      0.62MB/save"
     `);
   });
 

--- a/code/lib/docgen-harness/src/perf/docgen-perf/report.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/report.ts
@@ -90,21 +90,23 @@ export function renderResults(
 export function renderRatios(ratios: Ratios): string[] {
   const lines: string[] = [];
 
-  for (const [pairName, scenarios] of Object.entries(ratios)) {
+  for (const scenarios of Object.values(ratios)) {
     for (const [scenarioName, entry] of Object.entries(scenarios)) {
-      const label = `${pairName}/${scenarioName}`;
+      // Naming both engines rather than their roles: "legacy/new" tells a reader which side is
+      // which only if they already know the pair, which is exactly what they came here to find out.
+      const label = `${entry.legacyEngine} over ${entry.nextEngine}, ${scenarioName}`;
       const versions = versionNote(entry);
 
       if (entry.cold !== undefined) {
         lines.push(
-          `  ratio cold legacy/new (${label}): ${entry.cold.toFixed(2)}` +
+          `  ratio cold (${label}): ${entry.cold.toFixed(2)}` +
             memberNote(entry.legacyColdMembers, entry.nextColdMembers, entry.coldComparability) +
             versions
         );
       }
       if (entry.warm !== undefined) {
         lines.push(
-          `  ratio warm legacy/new (${label}): ${entry.warm.toFixed(2)}` +
+          `  ratio warm (${label}): ${entry.warm.toFixed(2)}` +
             memberNote(entry.legacyWarmMembers, entry.nextWarmMembers, entry.warmComparability) +
             versions
         );
@@ -113,9 +115,14 @@ export function renderRatios(ratios: Ratios): string[] {
   }
 
   if (lines.length === 0) {
-    lines.push('  no calibration ratio: it needs both sides of a control pair measured in one run');
+    return ['  no calibration ratio: it needs both sides of a control pair measured in one run'];
   }
-  return lines;
+  // Which way the number points is the first thing a reader needs, and it is not guessable from a
+  // bare decimal.
+  return [
+    "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster",
+    ...lines,
+  ];
 }
 
 /**

--- a/code/lib/docgen-harness/src/perf/docgen-perf/report.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/report.ts
@@ -1,35 +1,16 @@
 /** Renders the suite's terminal output. Pure string building, so it is testable without a runner. */
-import type {
-  Comparability,
-  EngineId,
-  EngineMetrics,
-  EngineResult,
-  RatioEntry,
-  Ratios,
-} from './types.ts';
+import type { Comparability, EngineId, EngineResult, Metric, RatioEntry, Ratios } from './types.ts';
 
 const HEADER = ['engine/scenario', 'cold', 'warm', 'scan', 'peak', 'ret-growth', 'ret-slope'];
 
 /**
- * Decimals for a single-valued metric, per unit. A slope needs two to say anything at all, while a
- * sub-millisecond difference between two aggregates is noise.
+ * Decimals per unit. A slope needs two to say anything at all, while a sub-millisecond difference
+ * between two aggregates is noise.
  */
 const VALUE_PRECISION = { ms: 0, MB: 1, 'MB/save': 2 } as const;
 
-export function formatCell(
-  metric: EngineMetrics[keyof EngineMetrics],
-  unit: keyof typeof VALUE_PRECISION
-): string {
-  if (metric.status === 'n/a') {
-    return 'n/a';
-  }
-  if ('median' in metric) {
-    return `${metric.median.toFixed(0)}${unit}`;
-  }
-  if ('mean' in metric) {
-    return `${metric.mean.toFixed(0)}${unit}`;
-  }
-  return `${metric.value.toFixed(VALUE_PRECISION[unit])}${unit}`;
+export function formatCell(metric: Metric, unit: keyof typeof VALUE_PRECISION): string {
+  return metric.status === 'n/a' ? 'n/a' : `${metric.value.toFixed(VALUE_PRECISION[unit])}${unit}`;
 }
 
 export interface RenderedResults {

--- a/code/lib/docgen-harness/src/perf/docgen-perf/report.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/report.ts
@@ -92,8 +92,7 @@ export function renderRatios(ratios: Ratios): string[] {
 
   for (const scenarios of Object.values(ratios)) {
     for (const [scenarioName, entry] of Object.entries(scenarios)) {
-      // Naming both engines rather than their roles: "legacy/new" tells a reader which side is
-      // which only if they already know the pair, which is exactly what they came here to find out.
+      // Naming both engines: "legacy/new" only helps a reader who already knows the pair.
       const label = `${entry.legacyEngine} over ${entry.nextEngine}, ${scenarioName}`;
       const versions = versionNote(entry);
 
@@ -117,8 +116,7 @@ export function renderRatios(ratios: Ratios): string[] {
   if (lines.length === 0) {
     return ['  no calibration ratio: it needs both sides of a control pair measured in one run'];
   }
-  // Which way the number points is the first thing a reader needs, and it is not guessable from a
-  // bare decimal.
+  // Which way the number points is not guessable from a bare decimal.
   return [
     "  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster",
     ...lines,

--- a/code/lib/docgen-harness/src/perf/docgen-perf/types.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/types.ts
@@ -6,24 +6,15 @@ import type { EngineId } from '../docgen-shared/engine-ids.ts';
 
 export type { EngineId };
 
-/** A latency metric: median of repeated samples (fresh process each, for cold/scan). */
-export interface LatencyMetric {
-  status: 'measured';
-  samples: number[];
-  median: number;
-}
-
-/** A memory metric aggregated as the mean of a per-save (or per-run) series. */
-export interface SeriesMeanMetric {
-  status: 'measured';
-  samples: number[];
-  mean: number;
-}
-
-/** A single-valued metric read from one run's series (retained growth, retained slope). */
-export interface ValueMetric {
+/**
+ * A measured number. Which statistic it is belongs to the field that holds it - a median across
+ * repetitions for latency, a mean of a series for peak memory - and every reader wants the number.
+ */
+export interface MeasuredMetric {
   status: 'measured';
   value: number;
+  /** What it was aggregated from; absent for a figure read straight off one run's series. */
+  samples?: number[];
 }
 
 /** The explicit marker for a metric that does not apply to an engine; never a faked equivalent. */
@@ -33,13 +24,15 @@ export interface NotApplicable {
 
 export const NOT_APPLICABLE: NotApplicable = { status: 'n/a' };
 
+export type Metric = MeasuredMetric | NotApplicable;
+
 export interface EngineMetrics {
-  coldExtractionMs: LatencyMetric | NotApplicable;
-  warmExtractionMs: LatencyMetric | NotApplicable;
-  wholeProjectScanMs: LatencyMetric | NotApplicable;
-  peakTransientMb: SeriesMeanMetric | NotApplicable;
-  retainedGrowthMb: ValueMetric | NotApplicable;
-  retainedSlopeMbPerSave: ValueMetric | NotApplicable;
+  coldExtractionMs: Metric;
+  warmExtractionMs: Metric;
+  wholeProjectScanMs: Metric;
+  peakTransientMb: Metric;
+  retainedGrowthMb: Metric;
+  retainedSlopeMbPerSave: Metric;
 }
 
 /**

--- a/code/lib/docgen-harness/src/perf/docgen-perf/types.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/types.ts
@@ -100,9 +100,9 @@ export type Comparability =
  * document the same members cold and different ones on the save it was timed on.
  */
 export interface RatioEntry {
-  /** The engine whose median is the numerator. */
+  /** Numerator of the ratio. */
   legacyEngine: EngineId;
-  /** The engine whose median is the denominator - the one a budget would protect. */
+  /** Denominator of the ratio - the engine a budget would protect. */
   nextEngine: EngineId;
   cold?: number;
   warm?: number;

--- a/code/lib/docgen-harness/src/perf/docgen-perf/types.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/types.ts
@@ -100,6 +100,10 @@ export type Comparability =
  * document the same members cold and different ones on the save it was timed on.
  */
 export interface RatioEntry {
+  /** The engine whose median is the numerator. */
+  legacyEngine: EngineId;
+  /** The engine whose median is the denominator - the one a budget would protect. */
+  nextEngine: EngineId;
   cold?: number;
   warm?: number;
   legacyColdMembers?: number;

--- a/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
@@ -38,13 +38,23 @@ export interface PerfBudget {
 /** `engine/scenario`, exactly as the suite reports a result, with the engine id checked. */
 export type PerfBudgetKey = `${EngineId}/${string}`;
 
+/** Observed at 0.4-0.9MB transient, 0.1-0.2MB growth and 0.01-0.02MB/save across the three scenarios. */
+const VUE_DOCGEN_API_MEMORY = {
+  maxTransientMb: 4,
+  maxRetainedGrowthMb: 3,
+  maxRetainedSlopeMb: 0.2,
+};
+
 /** Measured on CI with headroom; the run is recorded in PERF-METHODOLOGY.md. */
 export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
   // Warm is ~13ms against a ~1.7s cold pass, so the ratio moves easily on a noisy executor; the
   // budget sits far enough above it to survive that.
+  //
+  // Growth is a ceiling, not a multiple of the observed -4.1MB: what is worth catching is this run
+  // ending above the baseline it started from, so the budget sits just above zero.
   'react-legacy/whole-index': {
     maxWarmColdRatio: 0.05,
-    memory: { maxTransientMb: 15, maxRetainedGrowthMb: 30, maxRetainedSlopeMb: 1 },
+    memory: { maxTransientMb: 15, maxRetainedGrowthMb: 2, maxRetainedSlopeMb: 0.1 },
   },
   // A one-component cold pass is only ~96ms, so warm/cold sits an order of magnitude higher than
   // the index shape's without anything being wrong; the ratio still catches a warm pass that stops
@@ -56,9 +66,13 @@ export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
   },
   // Growth is negative here: the engine releases its whole-project state on the first save and
   // settles ~83MB below the cold pass, so the slope is what carries the leak signal.
+  //
+  // The growth budget is negative for that reason. A positive ceiling would pass the very
+  // regression this row exists to catch - an engine that stopped releasing that state lands near
+  // 0MB growth - so the budget asserts the drop still happens rather than bounding a rise.
   'react-osa/whole-index': {
     maxWarmColdRatio: 0.08,
-    memory: { maxTransientMb: 45, maxRetainedGrowthMb: 60, maxRetainedSlopeMb: 0.5 },
+    memory: { maxTransientMb: 45, maxRetainedGrowthMb: -50, maxRetainedSlopeMb: 0.5 },
   },
   // The engine still builds a program for one component, so cold stays ~1.1s and the ratio looks
   // like the index shape's. Its cold cost against react-legacy's is the finding, not this budget.
@@ -66,18 +80,21 @@ export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
     maxWarmColdRatio: 0.15,
     memory: { maxTransientMb: 30, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
   },
+  // This engine keeps no cache, so every figure is a fraction of a megabyte and the budgets are
+  // set against the largest of the three scenarios rather than each row's own number. Even so they
+  // fail long before anything at this scale matters: a leak here would be tens of megabytes.
   'vue-docgen-api/flat': {
     maxWarmColdRatio: 0.08,
-    memory: { maxTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
+    memory: VUE_DOCGEN_API_MEMORY,
   },
   'vue-docgen-api/workspace': {
     maxWarmColdRatio: 0.1,
-    memory: { maxTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
+    memory: VUE_DOCGEN_API_MEMORY,
   },
   // Touching a widely-imported base type costs more per save, so this ratio sits higher.
   'vue-docgen-api/base-type-touch': {
     maxWarmColdRatio: 0.25,
-    memory: { maxTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
+    memory: VUE_DOCGEN_API_MEMORY,
   },
   'vue-component-meta/flat': {
     maxWarmColdRatio: 0.2,
@@ -93,6 +110,10 @@ export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
   },
   // No incrementality budget: compodoc re-runs the whole project every invocation by design, so its
   // warm figure is its cold figure. Peak memory is what is worth watching.
+  //
+  // The tightest row in the table at under twice its observation, because this is a whole-process
+  // RSS peak rather than a delta: two CI runs read 213.8MB and 216.0MB. Loosen it only against a
+  // run that actually flaked, not on the grounds that the multiple looks small.
   'compodoc/default': {
     memory: { maxTransientMb: 400 },
   },

--- a/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
@@ -1,16 +1,20 @@
 import type { EngineId } from './engine-ids.ts';
 
+/**
+ * Absolute memory ceilings, in megabytes. Shared by both gates: a megabyte is a megabyte regardless
+ * of how busy the machine is, which is what makes memory safe to gate on where wall clock is not.
+ */
 export interface MemoryBudgets {
-  /** Max allowed post-GC retained growth (MB) across the run. */
-  maxRetainedGrowthMb: number;
   /** Max allowed average transient working set added per save (MB). */
   maxTransientMb: number;
+  /** Max allowed post-GC retained growth (MB) across the run. */
+  maxRetainedGrowthMb: number;
   /** Max allowed post-GC retained-heap slope (MB/save). */
   maxRetainedSlopeMb: number;
 }
 
 const MEMORY_BUDGETS: Partial<Record<EngineId, MemoryBudgets>> = {
-  'react-osa': { maxRetainedGrowthMb: 60, maxTransientMb: 90, maxRetainedSlopeMb: 3 },
+  'react-osa': { maxTransientMb: 90, maxRetainedGrowthMb: 60, maxRetainedSlopeMb: 3 },
 };
 
 export function memoryBudgetsFor(engine: EngineId): MemoryBudgets {
@@ -25,11 +29,13 @@ export function memoryBudgetsFor(engine: EngineId): MemoryBudgets {
  * What the perf suite's gate asserts, for one engine on one scenario.
  *
  * Timing never appears as a ceiling on milliseconds: wall clock on a shared executor is far too
- * noisy to gate on (PERF-METHODOLOGY.md, "Budget shape"). It appears as a ratio between two figures
- * from the same run on the same machine, which is the only comparison the methodology allows.
+ * noisy to gate on (PERF-METHODOLOGY.md, "Budget shape"). The one timing budget here is a ratio
+ * between two figures from the same run on the same machine, which is the only comparison the
+ * methodology allows.
  *
- * Memory stays absolute, with headroom, for the same reason the docgen-memory gate does: a megabyte
- * is a megabyte regardless of how busy the machine is.
+ * Cross-engine ratios carry no budget today, because no control pair has been certified as doing
+ * equal work; PERF-METHODOLOGY.md records why. That check belongs with the first pair that earns
+ * it, not with a placeholder here.
  */
 export interface PerfBudget {
   /**
@@ -38,74 +44,61 @@ export interface PerfBudget {
    * re-extracted incrementally.
    */
   maxWarmColdRatio?: number;
-  /**
-   * Floor on the cross-engine ratio from a control pair, for an engine that has a reference
-   * implementation to be measured against. Only a pair the suite certified as like-for-like may
-   * carry one, so an engine whose pair documents different amounts of the type graph has no row
-   * here and the gap is recorded in PERF-METHODOLOGY.md instead.
-   */
-  reference?: {
-    pair: string;
-    minColdRatio?: number;
-    minWarmRatio?: number;
-  };
-  memory?: {
-    maxPeakTransientMb?: number;
-    maxRetainedGrowthMb?: number;
-    maxRetainedSlopeMbPerSave?: number;
-  };
+  memory?: Partial<MemoryBudgets>;
 }
 
+/** `engine/scenario`, exactly as the suite reports a result, with the engine id checked. */
+export type PerfBudgetKey = `${EngineId}/${string}`;
+
 /**
- * Keyed `engine/scenario`, matching how the suite reports its results. Every number here was
- * measured on CI, with headroom over the observed value; the run they came from is recorded in
- * PERF-METHODOLOGY.md.
+ * Every number here was measured on CI, with headroom over the observed value; the run they came
+ * from is recorded in PERF-METHODOLOGY.md.
  */
-export const PERF_BUDGETS: Record<string, PerfBudget> = {
+export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
   // Warm here is ~14ms against a ~1.9s cold pass, so the ratio has room to move on a noisy
   // executor without meaning anything; the budget sits far enough above it to survive that and
   // still catch a save that stopped being re-extracted incrementally.
   'react-legacy/default': {
     maxWarmColdRatio: 0.05,
-    memory: { maxPeakTransientMb: 15, maxRetainedGrowthMb: 30, maxRetainedSlopeMbPerSave: 1 },
+    memory: { maxTransientMb: 15, maxRetainedGrowthMb: 30, maxRetainedSlopeMb: 1 },
   },
   // The docgen-memory gate protects this engine's retained heap under its own, much heavier
   // workload; what this row adds is the incremental re-extraction the suite measures.
   'react-osa/default': {
     maxWarmColdRatio: 0.08,
-    memory: { maxPeakTransientMb: 45, maxRetainedGrowthMb: 60, maxRetainedSlopeMbPerSave: 3 },
+    memory: { maxTransientMb: 45, maxRetainedGrowthMb: 60, maxRetainedSlopeMb: 3 },
   },
   'vue-docgen-api/flat': {
     maxWarmColdRatio: 0.08,
-    memory: { maxPeakTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMbPerSave: 1 },
+    memory: { maxTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
   },
   'vue-docgen-api/workspace': {
     maxWarmColdRatio: 0.1,
-    memory: { maxPeakTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMbPerSave: 1 },
+    memory: { maxTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
   },
   // Touching a widely-imported base type costs every engine more per save, so this scenario's
   // ratio is allowed to sit higher than the same engine's other two.
   'vue-docgen-api/base-type-touch': {
     maxWarmColdRatio: 0.25,
-    memory: { maxPeakTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMbPerSave: 1 },
+    memory: { maxTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
   },
   'vue-component-meta/flat': {
     maxWarmColdRatio: 0.2,
-    memory: { maxPeakTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMbPerSave: 1.5 },
+    memory: { maxTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMb: 1.5 },
   },
   'vue-component-meta/workspace': {
     maxWarmColdRatio: 0.22,
-    memory: { maxPeakTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMbPerSave: 1.5 },
+    memory: { maxTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMb: 1.5 },
   },
   'vue-component-meta/base-type-touch': {
     maxWarmColdRatio: 0.25,
-    memory: { maxPeakTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMbPerSave: 1.5 },
+    memory: { maxTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMb: 1.5 },
   },
   // No incrementality budget: compodoc re-runs the whole project on every invocation by design, so
   // its warm figure is its cold figure and a ratio around one is correct behaviour, not a
   // regression. Peak memory is the thing worth watching - it is an order of magnitude above every
   // other engine here.
   'compodoc/default': {
-    memory: { maxPeakTransientMb: 400 },
+    memory: { maxTransientMb: 400 },
   },
 };

--- a/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
@@ -1,9 +1,6 @@
 import type { EngineId } from './engine-ids.ts';
 
-/**
- * Absolute memory ceilings, in megabytes. Shared by both gates: a megabyte is a megabyte regardless
- * of how busy the machine is, which is what makes memory safe to gate on where wall clock is not.
- */
+/** Absolute memory ceilings, in megabytes. Shared by both gates. */
 export interface MemoryBudgets {
   /** Max allowed average transient working set added per save (MB). */
   maxTransientMb: number;
@@ -26,23 +23,14 @@ export function memoryBudgetsFor(engine: EngineId): MemoryBudgets {
 }
 
 /**
- * What the perf suite's gate asserts, for one engine on one scenario.
+ * What the perf gate asserts for one engine on one scenario.
  *
- * Timing never appears as a ceiling on milliseconds: wall clock on a shared executor is far too
- * noisy to gate on (PERF-METHODOLOGY.md, "Budget shape"). The one timing budget here is a ratio
- * between two figures from the same run on the same machine, which is the only comparison the
- * methodology allows.
- *
- * Cross-engine ratios carry no budget today, because no control pair has been certified as doing
- * equal work; PERF-METHODOLOGY.md records why. That check belongs with the first pair that earns
- * it, not with a placeholder here.
+ * Timing is never a ceiling on milliseconds: wall clock on a shared executor is too noisy to gate
+ * on (PERF-METHODOLOGY.md, "Budget shape"). Cross-engine ratios carry no budget today because no
+ * control pair does equal work; that check belongs with the first pair that earns one.
  */
 export interface PerfBudget {
-  /**
-   * Ceiling on warm median over cold median for this engine. Like-for-like by construction - both
-   * figures come from one process over one project - and it rises exactly when a save stops being
-   * re-extracted incrementally.
-   */
+  /** Ceiling on warm median over cold median: it rises when a save stops re-extracting incrementally. */
   maxWarmColdRatio?: number;
   memory?: Partial<MemoryBudgets>;
 }
@@ -50,27 +38,18 @@ export interface PerfBudget {
 /** `engine/scenario`, exactly as the suite reports a result, with the engine id checked. */
 export type PerfBudgetKey = `${EngineId}/${string}`;
 
-/**
- * Every number here was measured on CI, with headroom over the observed value; the run they came
- * from is recorded in PERF-METHODOLOGY.md.
- */
+/** Measured on CI with headroom; the run is recorded in PERF-METHODOLOGY.md. */
 export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
-  // No first-story rows yet: that shape lands with this change and its budgets follow the first CI
-  // run that measures it, rather than being guessed from a laptop.
+  // No first-story rows yet: those budgets follow the first CI run that measures the shape.
   //
-  // Warm here is ~14ms against a ~1.9s cold pass, so the ratio has room to move on a noisy
-  // executor without meaning anything; the budget sits far enough above it to survive that and
-  // still catch a save that stopped being re-extracted incrementally.
+  // Warm is ~14ms against a ~1.9s cold pass, so the ratio moves easily on a noisy executor; the
+  // budget sits far enough above it to survive that.
   'react-legacy/whole-index': {
     maxWarmColdRatio: 0.05,
     memory: { maxTransientMb: 15, maxRetainedGrowthMb: 30, maxRetainedSlopeMb: 1 },
   },
-  // The docgen-memory gate protects this engine's retained heap under its own, much heavier
-  // workload; what this row adds is the incremental re-extraction the suite measures.
-  //
-  // Growth is negative here - the engine releases its whole-project state on the first save and
-  // settles ~85MB below the cold pass - so the ceiling is only ever met from far below. The slope
-  // is what carries the leak signal, and it is tight because the steady state is genuinely flat.
+  // Growth is negative here: the engine releases its whole-project state on the first save and
+  // settles ~85MB below the cold pass, so the slope is what carries the leak signal.
   'react-osa/whole-index': {
     maxWarmColdRatio: 0.08,
     memory: { maxTransientMb: 45, maxRetainedGrowthMb: 60, maxRetainedSlopeMb: 0.5 },
@@ -83,8 +62,7 @@ export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
     maxWarmColdRatio: 0.1,
     memory: { maxTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
   },
-  // Touching a widely-imported base type costs every engine more per save, so this scenario's
-  // ratio is allowed to sit higher than the same engine's other two.
+  // Touching a widely-imported base type costs more per save, so this ratio sits higher.
   'vue-docgen-api/base-type-touch': {
     maxWarmColdRatio: 0.25,
     memory: { maxTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
@@ -101,10 +79,8 @@ export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
     maxWarmColdRatio: 0.25,
     memory: { maxTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMb: 1.5 },
   },
-  // No incrementality budget: compodoc re-runs the whole project on every invocation by design, so
-  // its warm figure is its cold figure and a ratio around one is correct behaviour, not a
-  // regression. Peak memory is the thing worth watching - it is an order of magnitude above every
-  // other engine here.
+  // No incrementality budget: compodoc re-runs the whole project every invocation by design, so its
+  // warm figure is its cold figure. Peak memory is what is worth watching.
   'compodoc/default': {
     memory: { maxTransientMb: 400 },
   },

--- a/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
@@ -61,4 +61,51 @@ export interface PerfBudget {
  * measured on CI, with headroom over the observed value; the run they came from is recorded in
  * PERF-METHODOLOGY.md.
  */
-export const PERF_BUDGETS: Record<string, PerfBudget> = {};
+export const PERF_BUDGETS: Record<string, PerfBudget> = {
+  // Warm here is ~14ms against a ~1.9s cold pass, so the ratio has room to move on a noisy
+  // executor without meaning anything; the budget sits far enough above it to survive that and
+  // still catch a save that stopped being re-extracted incrementally.
+  'react-legacy/default': {
+    maxWarmColdRatio: 0.05,
+    memory: { maxPeakTransientMb: 15, maxRetainedGrowthMb: 30, maxRetainedSlopeMbPerSave: 1 },
+  },
+  // The docgen-memory gate protects this engine's retained heap under its own, much heavier
+  // workload; what this row adds is the incremental re-extraction the suite measures.
+  'react-osa/default': {
+    maxWarmColdRatio: 0.08,
+    memory: { maxPeakTransientMb: 45, maxRetainedGrowthMb: 60, maxRetainedSlopeMbPerSave: 3 },
+  },
+  'vue-docgen-api/flat': {
+    maxWarmColdRatio: 0.08,
+    memory: { maxPeakTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMbPerSave: 1 },
+  },
+  'vue-docgen-api/workspace': {
+    maxWarmColdRatio: 0.1,
+    memory: { maxPeakTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMbPerSave: 1 },
+  },
+  // Touching a widely-imported base type costs every engine more per save, so this scenario's
+  // ratio is allowed to sit higher than the same engine's other two.
+  'vue-docgen-api/base-type-touch': {
+    maxWarmColdRatio: 0.25,
+    memory: { maxPeakTransientMb: 8, maxRetainedGrowthMb: 10, maxRetainedSlopeMbPerSave: 1 },
+  },
+  'vue-component-meta/flat': {
+    maxWarmColdRatio: 0.2,
+    memory: { maxPeakTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMbPerSave: 1.5 },
+  },
+  'vue-component-meta/workspace': {
+    maxWarmColdRatio: 0.22,
+    memory: { maxPeakTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMbPerSave: 1.5 },
+  },
+  'vue-component-meta/base-type-touch': {
+    maxWarmColdRatio: 0.25,
+    memory: { maxPeakTransientMb: 40, maxRetainedGrowthMb: 20, maxRetainedSlopeMbPerSave: 1.5 },
+  },
+  // No incrementality budget: compodoc re-runs the whole project on every invocation by design, so
+  // its warm figure is its cold figure and a ratio around one is correct behaviour, not a
+  // regression. Peak memory is the thing worth watching - it is an order of magnitude above every
+  // other engine here.
+  'compodoc/default': {
+    memory: { maxPeakTransientMb: 400 },
+  },
+};

--- a/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
@@ -20,3 +20,45 @@ export function memoryBudgetsFor(engine: EngineId): MemoryBudgets {
   }
   return budgets;
 }
+
+/**
+ * What the perf suite's gate asserts, for one engine on one scenario.
+ *
+ * Timing never appears as a ceiling on milliseconds: wall clock on a shared executor is far too
+ * noisy to gate on (PERF-METHODOLOGY.md, "Budget shape"). It appears as a ratio between two figures
+ * from the same run on the same machine, which is the only comparison the methodology allows.
+ *
+ * Memory stays absolute, with headroom, for the same reason the docgen-memory gate does: a megabyte
+ * is a megabyte regardless of how busy the machine is.
+ */
+export interface PerfBudget {
+  /**
+   * Ceiling on warm median over cold median for this engine. Like-for-like by construction - both
+   * figures come from one process over one project - and it rises exactly when a save stops being
+   * re-extracted incrementally.
+   */
+  maxWarmColdRatio?: number;
+  /**
+   * Floor on the cross-engine ratio from a control pair, for an engine that has a reference
+   * implementation to be measured against. Only a pair the suite certified as like-for-like may
+   * carry one, so an engine whose pair documents different amounts of the type graph has no row
+   * here and the gap is recorded in PERF-METHODOLOGY.md instead.
+   */
+  reference?: {
+    pair: string;
+    minColdRatio?: number;
+    minWarmRatio?: number;
+  };
+  memory?: {
+    maxPeakTransientMb?: number;
+    maxRetainedGrowthMb?: number;
+    maxRetainedSlopeMbPerSave?: number;
+  };
+}
+
+/**
+ * Keyed `engine/scenario`, matching how the suite reports its results. Every number here was
+ * measured on CI, with headroom over the observed value; the run they came from is recorded in
+ * PERF-METHODOLOGY.md.
+ */
+export const PERF_BUDGETS: Record<string, PerfBudget> = {};

--- a/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
@@ -40,19 +40,31 @@ export type PerfBudgetKey = `${EngineId}/${string}`;
 
 /** Measured on CI with headroom; the run is recorded in PERF-METHODOLOGY.md. */
 export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
-  // No first-story rows yet: those budgets follow the first CI run that measures the shape.
-  //
-  // Warm is ~14ms against a ~1.9s cold pass, so the ratio moves easily on a noisy executor; the
+  // Warm is ~13ms against a ~1.7s cold pass, so the ratio moves easily on a noisy executor; the
   // budget sits far enough above it to survive that.
   'react-legacy/whole-index': {
     maxWarmColdRatio: 0.05,
     memory: { maxTransientMb: 15, maxRetainedGrowthMb: 30, maxRetainedSlopeMb: 1 },
   },
+  // A one-component cold pass is only ~96ms, so warm/cold sits an order of magnitude higher than
+  // the index shape's without anything being wrong; the ratio still catches a warm pass that stops
+  // being incremental. Growth and slope are positive here because every save grows the one
+  // component's type - see PERF-METHODOLOGY.md, "Recorded baselines".
+  'react-legacy/first-story': {
+    maxWarmColdRatio: 0.6,
+    memory: { maxTransientMb: 15, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
+  },
   // Growth is negative here: the engine releases its whole-project state on the first save and
-  // settles ~85MB below the cold pass, so the slope is what carries the leak signal.
+  // settles ~83MB below the cold pass, so the slope is what carries the leak signal.
   'react-osa/whole-index': {
     maxWarmColdRatio: 0.08,
     memory: { maxTransientMb: 45, maxRetainedGrowthMb: 60, maxRetainedSlopeMb: 0.5 },
+  },
+  // The engine still builds a program for one component, so cold stays ~1.1s and the ratio looks
+  // like the index shape's. Its cold cost against react-legacy's is the finding, not this budget.
+  'react-osa/first-story': {
+    maxWarmColdRatio: 0.15,
+    memory: { maxTransientMb: 30, maxRetainedGrowthMb: 10, maxRetainedSlopeMb: 1 },
   },
   'vue-docgen-api/flat': {
     maxWarmColdRatio: 0.08,

--- a/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
@@ -55,10 +55,13 @@ export type PerfBudgetKey = `${EngineId}/${string}`;
  * from is recorded in PERF-METHODOLOGY.md.
  */
 export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
+  // No first-story rows yet: that shape lands with this change and its budgets follow the first CI
+  // run that measures it, rather than being guessed from a laptop.
+  //
   // Warm here is ~14ms against a ~1.9s cold pass, so the ratio has room to move on a noisy
   // executor without meaning anything; the budget sits far enough above it to survive that and
   // still catch a save that stopped being re-extracted incrementally.
-  'react-legacy/default': {
+  'react-legacy/whole-index': {
     maxWarmColdRatio: 0.05,
     memory: { maxTransientMb: 15, maxRetainedGrowthMb: 30, maxRetainedSlopeMb: 1 },
   },
@@ -68,7 +71,7 @@ export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
   // Growth is negative here - the engine releases its whole-project state on the first save and
   // settles ~85MB below the cold pass - so the ceiling is only ever met from far below. The slope
   // is what carries the leak signal, and it is tight because the steady state is genuinely flat.
-  'react-osa/default': {
+  'react-osa/whole-index': {
     maxWarmColdRatio: 0.08,
     memory: { maxTransientMb: 45, maxRetainedGrowthMb: 60, maxRetainedSlopeMb: 0.5 },
   },

--- a/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/budgets.ts
@@ -64,9 +64,13 @@ export const PERF_BUDGETS: Partial<Record<PerfBudgetKey, PerfBudget>> = {
   },
   // The docgen-memory gate protects this engine's retained heap under its own, much heavier
   // workload; what this row adds is the incremental re-extraction the suite measures.
+  //
+  // Growth is negative here - the engine releases its whole-project state on the first save and
+  // settles ~85MB below the cold pass - so the ceiling is only ever met from far below. The slope
+  // is what carries the leak signal, and it is tight because the steady state is genuinely flat.
   'react-osa/default': {
     maxWarmColdRatio: 0.08,
-    memory: { maxTransientMb: 45, maxRetainedGrowthMb: 60, maxRetainedSlopeMb: 3 },
+    memory: { maxTransientMb: 45, maxRetainedGrowthMb: 60, maxRetainedSlopeMb: 0.5 },
   },
   'vue-docgen-api/flat': {
     maxWarmColdRatio: 0.08,

--- a/code/lib/docgen-harness/src/perf/docgen-shared/engine-ids.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/engine-ids.ts
@@ -8,4 +8,6 @@ export type EngineId =
   | 'vue-docgen-api'
   | 'vue-component-meta'
   | 'vue-component-meta-next'
-  | 'compodoc';
+  | 'compodoc'
+  // Not an engine: a deliberately failing entry the perf gate uses as its negative control.
+  | 'crash-control';

--- a/code/lib/docgen-harness/src/perf/docgen-shared/pin.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/pin.test.ts
@@ -1,33 +1,38 @@
 import { describe, expect, it } from 'vitest';
 
-import { assertPin, pinOption } from './pin.ts';
+import { importPinned, resolvePin } from './pin.ts';
 
-describe('pinOption', () => {
-  const schema = pinOption('vue-component-meta');
-
-  it('defaults to the canonical package, so an unpinned run loads it', () => {
-    expect(schema.parse(undefined)).toBe('vue-component-meta');
-  });
-
-  it('accepts an alias of the canonical package', () => {
-    expect(schema.parse('vue-component-meta-next')).toBe('vue-component-meta-next');
-  });
-
-  it('rejects a specifier that is not the canonical package or an alias of it', () => {
-    // Otherwise a typo would run the engine's name against a different package's numbers.
-    expect(() => schema.parse('vue-docgen-api')).toThrow();
-  });
-});
-
-describe('assertPin', () => {
-  it('accepts the canonical package and an alias of it', () => {
-    expect(assertPin('@compodoc/compodoc', '@compodoc/compodoc')).toBe('@compodoc/compodoc');
-    expect(assertPin('@compodoc/compodoc', '@compodoc/compodoc-next')).toBe(
-      '@compodoc/compodoc-next'
+describe('resolvePin', () => {
+  it('reports the package a pin actually installs, which an alias does not rename', () => {
+    // The whole mechanism rests on this: `vue-component-meta-next` is an alias, so it resolves to a
+    // second install of vue-component-meta at another version rather than to a package of its own.
+    expect(resolvePin('vue-component-meta-next')).toMatchObject({ name: 'vue-component-meta' });
+    expect(resolvePin('vue-component-meta')?.version).not.toBe(
+      resolvePin('vue-component-meta-next')?.version
     );
   });
 
-  it('rejects a pin naming a different package', () => {
-    expect(() => assertPin('@compodoc/compodoc', 'vue-component-meta')).toThrow(/@compodoc/);
+  it('answers undefined for an install that is not there', () => {
+    expect(resolvePin('vue-component-meta-not-installed')).toBeUndefined();
+  });
+
+  it('resolves a package whose exports map hides its own package.json', () => {
+    // vue-docgen-api is one, so asking for `<pkg>/package.json` throws and the walk-up path runs.
+    expect(resolvePin('vue-docgen-api')).toMatchObject({ name: 'vue-docgen-api' });
+  });
+});
+
+describe('importPinned', () => {
+  it('refuses a pin that resolves to a different package', async () => {
+    // Otherwise the run would measure vue-docgen-api under vue-component-meta's name.
+    await expect(importPinned('vue-docgen-api', 'vue-component-meta')).rejects.toThrow(
+      /resolves to "vue-docgen-api", not "vue-component-meta"/
+    );
+  });
+
+  it('refuses a pin that resolves to nothing', async () => {
+    await expect(importPinned('vue-component-meta-typo', 'vue-component-meta')).rejects.toThrow(
+      /resolves to nothing/
+    );
   });
 });

--- a/code/lib/docgen-harness/src/perf/docgen-shared/pin.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/pin.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { pinOption } from './pin.ts';
+import { assertPin, pinOption } from './pin.ts';
 
 describe('pinOption', () => {
   const schema = pinOption('vue-component-meta');
@@ -16,5 +16,18 @@ describe('pinOption', () => {
   it('rejects a specifier that is not the canonical package or an alias of it', () => {
     // Otherwise a typo would run the engine's name against a different package's numbers.
     expect(() => schema.parse('vue-docgen-api')).toThrow();
+  });
+});
+
+describe('assertPin', () => {
+  it('accepts the canonical package and an alias of it', () => {
+    expect(assertPin('@compodoc/compodoc', '@compodoc/compodoc')).toBe('@compodoc/compodoc');
+    expect(assertPin('@compodoc/compodoc', '@compodoc/compodoc-next')).toBe(
+      '@compodoc/compodoc-next'
+    );
+  });
+
+  it('rejects a pin naming a different package', () => {
+    expect(() => assertPin('@compodoc/compodoc', 'vue-component-meta')).toThrow(/@compodoc/);
   });
 });

--- a/code/lib/docgen-harness/src/perf/docgen-shared/pin.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/pin.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { pinOption } from './pin.ts';
+
+describe('pinOption', () => {
+  const schema = pinOption('vue-component-meta');
+
+  it('defaults to the canonical package, so an unpinned run loads it', () => {
+    expect(schema.parse(undefined)).toBe('vue-component-meta');
+  });
+
+  it('accepts an alias of the canonical package', () => {
+    expect(schema.parse('vue-component-meta-next')).toBe('vue-component-meta-next');
+  });
+
+  it('rejects a specifier that is not the canonical package or an alias of it', () => {
+    // Otherwise a typo would run the engine's name against a different package's numbers.
+    expect(() => schema.parse('vue-docgen-api')).toThrow();
+  });
+});

--- a/code/lib/docgen-harness/src/perf/docgen-shared/pin.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/pin.ts
@@ -12,17 +12,32 @@ import { z } from 'zod';
 export const PIN_OPTION = { pin: { type: 'string' } } as const;
 
 /**
- * `--pin` may only name the canonical package or an alias of it. Aliases are named
- * `<package>-<suffix>` by convention, and checking that here is what stops a typo in the registry
- * from silently measuring a different package under the engine's name.
+ * A pin may only name the canonical package or an alias of it, which are named
+ * `<package>-<suffix>` by convention. Checking that is what stops a typo in the registry from
+ * silently measuring a different package under the engine's name.
  */
+export const isPinOf = (canonical: string, specifier: string): boolean =>
+  specifier === canonical || specifier.startsWith(`${canonical}-`);
+
+const pinMessage = (canonical: string) =>
+  `must be "${canonical}" or an alias of it ("${canonical}-<suffix>")`;
+
+/** Extends a harness's option schema with `--pin`, defaulting to the canonical package. */
 export const pinOption = (canonical: string) =>
   z
     .string()
     .default(canonical)
-    .refine((specifier) => specifier === canonical || specifier.startsWith(`${canonical}-`), {
-      message: `must be "${canonical}" or an alias of it ("${canonical}-<suffix>")`,
+    .refine((specifier) => isPinOf(canonical, specifier), {
+      message: pinMessage(canonical),
     });
+
+/** For an engine that takes its pin straight from the registry rather than through a flag. */
+export function assertPin(canonical: string, specifier: string): string {
+  if (!isPinOf(canonical, specifier)) {
+    throw new Error(`pin "${specifier}" ${pinMessage(canonical)}`);
+  }
+  return specifier;
+}
 
 /**
  * Only the pinned copy is imported. Loading both would leave the unmeasured one's module graph on

--- a/code/lib/docgen-harness/src/perf/docgen-shared/pin.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/pin.ts
@@ -1,0 +1,33 @@
+/**
+ * Version pinning, for any engine whose child imports its docgen package by specifier.
+ *
+ * A pinned engine is the same child harness loading a second, explicitly-versioned copy of that
+ * package, installed under an alias in this package's `package.json`
+ * (`"vue-component-meta-next": "npm:vue-component-meta@3.3.8"`). `--pin` names the specifier to
+ * import; it defaults to the canonical package, so an unpinned run is unchanged.
+ */
+import { z } from 'zod';
+
+/** Add to a harness's `parseArgs` table to accept `--pin`. */
+export const PIN_OPTION = { pin: { type: 'string' } } as const;
+
+/**
+ * `--pin` may only name the canonical package or an alias of it. Aliases are named
+ * `<package>-<suffix>` by convention, and checking that here is what stops a typo in the registry
+ * from silently measuring a different package under the engine's name.
+ */
+export const pinOption = (canonical: string) =>
+  z
+    .string()
+    .default(canonical)
+    .refine((specifier) => specifier === canonical || specifier.startsWith(`${canonical}-`), {
+      message: `must be "${canonical}" or an alias of it ("${canonical}-<suffix>")`,
+    });
+
+/**
+ * Only the pinned copy is imported. Loading both would leave the unmeasured one's module graph on
+ * the heap of every run, shifting a memory number that has nothing to do with the comparison.
+ */
+export function importPinned<T>(specifier: string): Promise<T> {
+  return import(specifier) as Promise<T>;
+}

--- a/code/lib/docgen-harness/src/perf/docgen-shared/pin.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/pin.ts
@@ -1,48 +1,85 @@
 /**
- * Version pinning, for any engine whose child imports its docgen package by specifier.
+ * Version pinning, for any engine that reaches its docgen package by specifier.
  *
- * A pinned engine is the same child harness loading a second, explicitly-versioned copy of that
- * package, installed under an alias in this package's `package.json`
- * (`"vue-component-meta-next": "npm:vue-component-meta@3.3.8"`). `--pin` names the specifier to
- * import; it defaults to the canonical package, so an unpinned run is unchanged.
+ * A pinned engine measures a second, explicitly-versioned copy of that package, installed under an
+ * alias in this package's `package.json` (`"vue-component-meta-next": "npm:vue-component-meta@3.3.8"`).
+ * An engine declares which install it measures; `--pin` carries that to a child harness.
  */
-import { z } from 'zod';
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+
+const require = createRequire(import.meta.url);
 
 /** Add to a harness's `parseArgs` table to accept `--pin`. */
 export const PIN_OPTION = { pin: { type: 'string' } } as const;
 
-/**
- * A pin may only name the canonical package or an alias of it, which are named
- * `<package>-<suffix>` by convention. Checking that is what stops a typo in the registry from
- * silently measuring a different package under the engine's name.
- */
-export const isPinOf = (canonical: string, specifier: string): boolean =>
-  specifier === canonical || specifier.startsWith(`${canonical}-`);
+export interface ResolvedPin {
+  /** Install directory, for a package whose CLI is spawned rather than imported. */
+  dir: string;
+  /** The package's own name, which an alias does not change: how a pin is checked. */
+  name: string;
+  version: string;
+  bin?: Record<string, string>;
+}
 
-const pinMessage = (canonical: string) =>
-  `must be "${canonical}" or an alias of it ("${canonical}-<suffix>")`;
-
-/** Extends a harness's option schema with `--pin`, defaulting to the canonical package. */
-export const pinOption = (canonical: string) =>
-  z
-    .string()
-    .default(canonical)
-    .refine((specifier) => isPinOf(canonical, specifier), {
-      message: pinMessage(canonical),
-    });
-
-/** For an engine that takes its pin straight from the registry rather than through a flag. */
-export function assertPin(canonical: string, specifier: string): string {
-  if (!isPinOf(canonical, specifier)) {
-    throw new Error(`pin "${specifier}" ${pinMessage(canonical)}`);
+function readManifest(file: string): ResolvedPin | undefined {
+  try {
+    const { name, version, bin } = JSON.parse(fs.readFileSync(file, 'utf8'));
+    // An unnamed manifest is a loader hint like dist/package.json, not the package's own.
+    return name ? { dir: path.dirname(file), name, version, bin } : undefined;
+  } catch {
+    return undefined;
   }
-  return specifier;
 }
 
 /**
+ * A package whose `exports` map does not list `./package.json` cannot be asked for it directly -
+ * vue-docgen-api is one - so fall back to its entry point and take the manifest above it.
+ */
+function resolveInstall(specifier: string): string | undefined {
+  for (const request of [`${specifier}/package.json`, specifier]) {
+    try {
+      return require.resolve(request);
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+/** The install a pin names, or undefined when it did not resolve - a partial install. */
+export function resolvePin(specifier: string): ResolvedPin | undefined {
+  const entry = resolveInstall(specifier);
+  if (!entry) {
+    return undefined;
+  }
+  for (let dir = path.dirname(entry); ; dir = path.dirname(dir)) {
+    const manifest = readManifest(path.join(dir, 'package.json'));
+    if (manifest) {
+      return manifest;
+    }
+    if (path.dirname(dir) === dir) {
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Loads the pinned copy, having checked it really is `canonical` under another name - an alias keeps
+ * the aliased package's own name, so a pin that resolves elsewhere is a typo about to be measured
+ * under this engine's name.
+ *
  * Only the pinned copy is imported. Loading both would leave the unmeasured one's module graph on
  * the heap of every run, shifting a memory number that has nothing to do with the comparison.
  */
-export function importPinned<T>(specifier: string): Promise<T> {
+export async function importPinned<T>(specifier: string, canonical: string): Promise<T> {
+  const resolved = resolvePin(specifier);
+  if (resolved?.name !== canonical) {
+    throw new Error(
+      `--pin ${specifier} resolves to ${resolved ? `"${resolved.name}"` : 'nothing'}, ` +
+        `not "${canonical}": a pin must name an install of the package this harness measures`
+    );
+  }
   return import(specifier) as Promise<T>;
 }

--- a/code/lib/docgen-harness/src/perf/docgen-shared/stats.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/stats.test.ts
@@ -69,9 +69,9 @@ describe('summarizeSeries', () => {
     }));
 
   it('excludes the settle save from the slope, so a cold-to-steady-state drop is not read as a trend', () => {
-    // react-osa's real shape: whole-project state is released on the first save, then flat.
+    // react-osa's real shape: the first save releases whole-project state, then it is flat.
     const summary = summarizeSeries(series([232.7, 147.4, 147.5, 147.6, 147.7]), baseline);
-    // Fitting the step in would give a steeply negative slope; the steady state creeps up slightly.
+    // Fitting the step would give a steeply negative slope; the steady state creeps up slightly.
     expect(summary.retainedSlope).toBeCloseTo(0.1, 5);
   });
 

--- a/code/lib/docgen-harness/src/perf/docgen-shared/stats.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/stats.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { leastSquaresSlope, mean, median } from './stats.ts';
+import type { MemorySample, SaveSample } from './samples.ts';
+import { leastSquaresSlope, mean, median, summarizeSeries } from './stats.ts';
 
 describe('median', () => {
   it('returns the middle value for odd-length input', () => {
@@ -52,5 +53,39 @@ describe('leastSquaresSlope', () => {
 
   it('fits noisy data to the least-squares line', () => {
     expect(leastSquaresSlope([0, 2, 1, 3])).toBeCloseTo(0.8, 5);
+  });
+});
+
+describe('summarizeSeries', () => {
+  const baseline: MemorySample = { rssMb: 500, heapUsedMb: 250, retainedHeapMb: 231.6 };
+
+  const series = (retained: number[]): SaveSample[] =>
+    retained.map((retainedHeapMb, i) => ({
+      save: i + 1,
+      durMs: 20,
+      rssMb: 500,
+      heapUsedMb: retainedHeapMb + 15,
+      retainedHeapMb,
+    }));
+
+  it('excludes the settle save from the slope, so a cold-to-steady-state drop is not read as a trend', () => {
+    // react-osa's real shape: whole-project state is released on the first save, then flat.
+    const summary = summarizeSeries(series([232.7, 147.4, 147.5, 147.6, 147.7]), baseline);
+    // Fitting the step in would give a steeply negative slope; the steady state creeps up slightly.
+    expect(summary.retainedSlope).toBeCloseTo(0.1, 5);
+  });
+
+  it('still reports a real leak trend', () => {
+    const summary = summarizeSeries(series([100, 102, 104, 106, 108]), baseline);
+    expect(summary.retainedSlope).toBeCloseTo(2, 5);
+  });
+
+  it('measures growth from the baseline, including the settle drop', () => {
+    const summary = summarizeSeries(series([232.7, 147.4, 148.4]), baseline);
+    expect(summary.retainedGrowth).toBeCloseTo(148.4 - 231.6, 5);
+  });
+
+  it('reports no slope when too few saves remain after the settle save', () => {
+    expect(summarizeSeries(series([120, 118]), baseline).retainedSlope).toBeUndefined();
   });
 });

--- a/code/lib/docgen-harness/src/perf/docgen-shared/stats.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/stats.ts
@@ -65,6 +65,13 @@ export interface SeriesSummary {
 const SETTLE_SAVES = 1;
 
 /**
+ * Saves a scenario must run for a slope to exist: the excluded settle save, plus the two points a
+ * least-squares fit needs. A scenario configured below this reports no retained metrics at all,
+ * which the aggregation treats as a failed engine.
+ */
+export const MIN_SAVES_FOR_SLOPE = SETTLE_SAVES + 2;
+
+/**
  * Derive the retained/transient series figures shared by every series harness. Kept here so the
  * memory harness and the per-engine harnesses cannot drift apart in how they compute them.
  */

--- a/code/lib/docgen-harness/src/perf/docgen-shared/stats.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/stats.ts
@@ -38,7 +38,10 @@ export function leastSquaresSlope(values: number[]): number {
 
 /** The retained- and transient-memory figures every series harness derives from its save series. */
 export interface SeriesSummary {
-  /** Least-squares slope of retained heap over the save series, MB per save. */
+  /**
+   * Least-squares slope of retained heap over the save series, MB per save, excluding the settle
+   * sample. This is the leak signal: a positive slope means each save leaves something behind.
+   */
   retainedSlope?: number;
   /** Final retained sample minus the pre-series baseline, MB. */
   retainedGrowth?: number;
@@ -47,6 +50,19 @@ export interface SeriesSummary {
   /** Mean of {@link transients}. */
   avgTransient?: number;
 }
+
+/**
+ * Saves excluded from the slope fit.
+ *
+ * The baseline is sampled straight after the cold pass, so an engine still holds whole-project
+ * state going into the first save. Where a save re-extracts one component, that state is released
+ * on the first one - `react-osa` drops ~85MB between save 1 and save 2 and is then flat - and a fit
+ * that includes the step measures the cold-to-steady-state transition rather than the leak trend.
+ *
+ * One is enough: that engine is the only one with a step, and it lands entirely inside the first
+ * save. Every other engine is flat from save 1, so dropping one sample costs them nothing.
+ */
+const SETTLE_SAVES = 1;
 
 /**
  * Derive the retained/transient series figures shared by every series harness. Kept here so the
@@ -61,10 +77,11 @@ export function summarizeSeries(samples: SaveSample[], baseline: MemorySample): 
   const retained = gcSampled.map((s) => s.retainedHeapMb);
   const transients = gcSampled.map((s) => s.heapUsedMb - s.retainedHeapMb);
   const last = retained.at(-1);
+  const settled = retained.slice(SETTLE_SAVES);
   return {
     // A slope needs two points. `leastSquaresSlope` answers 0 for a shorter series, which is
     // indistinguishable from a measured flat one, so a series that short reports nothing instead.
-    retainedSlope: retained.length >= 2 ? leastSquaresSlope(retained) : undefined,
+    retainedSlope: settled.length >= 2 ? leastSquaresSlope(settled) : undefined,
     retainedGrowth:
       last !== undefined && baseline.retainedHeapMb !== undefined
         ? last - baseline.retainedHeapMb

--- a/code/lib/docgen-harness/src/perf/docgen-shared/stats.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/stats.ts
@@ -52,7 +52,7 @@ export interface SeriesSummary {
  * Saves excluded from the slope fit.
  *
  * The baseline is sampled after the cold pass, so an engine still holds whole-project state going
- * into the first save and releases it there - `react-osa` drops ~85MB between save 1 and 2, then is
+ * into the first save and releases it there - `react-osa` drops ~83MB between save 1 and 2, then is
  * flat. Fitting that step measures the transition, not the leak trend. Every other engine is flat
  * from save 1, so one excluded sample costs them nothing.
  */

--- a/code/lib/docgen-harness/src/perf/docgen-shared/stats.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/stats.ts
@@ -38,10 +38,7 @@ export function leastSquaresSlope(values: number[]): number {
 
 /** The retained- and transient-memory figures every series harness derives from its save series. */
 export interface SeriesSummary {
-  /**
-   * Least-squares slope of retained heap over the save series, MB per save, excluding the settle
-   * sample. This is the leak signal: a positive slope means each save leaves something behind.
-   */
+  /** Least-squares slope of retained heap per save, excluding the settle sample: the leak signal. */
   retainedSlope?: number;
   /** Final retained sample minus the pre-series baseline, MB. */
   retainedGrowth?: number;
@@ -54,20 +51,16 @@ export interface SeriesSummary {
 /**
  * Saves excluded from the slope fit.
  *
- * The baseline is sampled straight after the cold pass, so an engine still holds whole-project
- * state going into the first save. Where a save re-extracts one component, that state is released
- * on the first one - `react-osa` drops ~85MB between save 1 and save 2 and is then flat - and a fit
- * that includes the step measures the cold-to-steady-state transition rather than the leak trend.
- *
- * One is enough: that engine is the only one with a step, and it lands entirely inside the first
- * save. Every other engine is flat from save 1, so dropping one sample costs them nothing.
+ * The baseline is sampled after the cold pass, so an engine still holds whole-project state going
+ * into the first save and releases it there - `react-osa` drops ~85MB between save 1 and 2, then is
+ * flat. Fitting that step measures the transition, not the leak trend. Every other engine is flat
+ * from save 1, so one excluded sample costs them nothing.
  */
 const SETTLE_SAVES = 1;
 
 /**
- * Saves a scenario must run for a slope to exist: the excluded settle save, plus the two points a
- * least-squares fit needs. A scenario configured below this reports no retained metrics at all,
- * which the aggregation treats as a failed engine.
+ * Saves a scenario needs for a slope: the excluded settle save plus the two points a fit needs.
+ * Below this the run reports no retained metrics, which fails the engine.
  */
 export const MIN_SAVES_FOR_SLOPE = SETTLE_SAVES + 2;
 

--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -433,6 +433,9 @@ export const defineCircleciCompletion = (requires: JobOrNoOpJob[]) =>
     requires
   );
 
+const DOCGEN_HARNESS_DIR = 'code/lib/docgen-harness';
+const DOCGEN_PERF_RESULTS_DIR = 'perf-results';
+
 export const docgenMemoryGate = defineJob(
   'Docgen memory gate',
   () => ({
@@ -445,7 +448,7 @@ export const docgenMemoryGate = defineJob(
       {
         run: {
           name: 'Docgen-server re-extraction memory gate',
-          working_directory: 'code/lib/docgen-harness',
+          working_directory: DOCGEN_HARNESS_DIR,
           command: 'yarn bench:docgen-memory',
         },
       },
@@ -453,12 +456,6 @@ export const docgenMemoryGate = defineJob(
   }),
   [commonJobsNoOpJob]
 );
-
-/**
- * Wall clock is roughly a minute per engine at the pinned profile, plus the compodoc child's own
- * ten-minute kill if it hangs, so the job needs headroom well above a normal run.
- */
-const DOCGEN_PERF_RESULTS_DIR = 'code/lib/docgen-harness/perf-results';
 
 export const docgenPerfGate = defineJob(
   'Docgen perf gate',
@@ -472,13 +469,15 @@ export const docgenPerfGate = defineJob(
       {
         run: {
           name: 'Per-engine docgen perf budgets',
-          working_directory: 'code/lib/docgen-harness',
-          command: 'yarn bench:docgen-perf-gate --out ./perf-results',
+          working_directory: DOCGEN_HARNESS_DIR,
+          command: `yarn bench:docgen-perf-gate --out ./${DOCGEN_PERF_RESULTS_DIR}`,
+          // A full run is ~5 minutes, but the compodoc child alone may sit for its own ten-minute
+          // kill before the suite can report it, so the ceiling sits well above the normal case.
           no_output_timeout: '30m',
         },
       },
       artifact.persist(
-        join(LINUX_ROOT_DIR, WORKING_DIR, DOCGEN_PERF_RESULTS_DIR),
+        join(LINUX_ROOT_DIR, WORKING_DIR, DOCGEN_HARNESS_DIR, DOCGEN_PERF_RESULTS_DIR),
         'docgen-perf-results'
       ),
     ],

--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -471,8 +471,7 @@ export const docgenPerfGate = defineJob(
           name: 'Per-engine docgen perf budgets',
           working_directory: DOCGEN_HARNESS_DIR,
           command: `yarn bench:docgen-perf-gate --out ./${DOCGEN_PERF_RESULTS_DIR}`,
-          // A full run is ~5 minutes, but the compodoc child alone may sit for its own ten-minute
-          // kill before the suite can report it, so the ceiling sits well above the normal case.
+          // A full run is ~5 minutes; the ceiling covers a hung compodoc child's ten-minute kill.
           no_output_timeout: '30m',
         },
       },

--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -454,6 +454,71 @@ export const docgenMemoryGate = defineJob(
   [commonJobsNoOpJob]
 );
 
+/**
+ * Wall clock is roughly a minute per engine at the pinned profile, plus the compodoc child's own
+ * ten-minute kill if it hangs, so the job needs headroom well above a normal run.
+ */
+const DOCGEN_PERF_RESULTS_DIR = 'code/lib/docgen-harness/perf-results';
+
+export const docgenPerfGate = defineJob(
+  'Docgen perf gate',
+  () => ({
+    executor: {
+      name: 'sb_node_22_classic',
+      class: 'medium+',
+    },
+    steps: [
+      ...workflow.restoreLinux(),
+      {
+        run: {
+          name: 'Per-engine docgen perf budgets',
+          working_directory: 'code/lib/docgen-harness',
+          command: 'yarn bench:docgen-perf-gate --out ./perf-results',
+          no_output_timeout: '30m',
+        },
+      },
+      artifact.persist(
+        join(LINUX_ROOT_DIR, WORKING_DIR, DOCGEN_PERF_RESULTS_DIR),
+        'docgen-perf-results'
+      ),
+    ],
+  }),
+  [commonJobsNoOpJob]
+);
+
+/**
+ * TEMPORARY - delete before this branch merges.
+ *
+ * Runs the perf suite on CI hardware so the budgets in the harness can be set from CI numbers
+ * rather than from a laptop. It never gates: it reports. Once the budgets are recorded, this job
+ * and its entry in the always-on workflow go away and the daily gate above is the only perf job.
+ */
+export const docgenPerfBaselineCapture = defineJob(
+  'Docgen perf baseline capture (temporary)',
+  () => ({
+    executor: {
+      name: 'sb_node_22_classic',
+      class: 'medium+',
+    },
+    steps: [
+      ...workflow.restoreLinux(),
+      {
+        run: {
+          name: 'Per-engine docgen perf suite (report only)',
+          working_directory: 'code/lib/docgen-harness',
+          command: 'yarn bench:docgen-perf --json ./perf-results/results.json',
+          no_output_timeout: '30m',
+        },
+      },
+      artifact.persist(
+        join(LINUX_ROOT_DIR, WORKING_DIR, DOCGEN_PERF_RESULTS_DIR),
+        'docgen-perf-baseline'
+      ),
+    ],
+  }),
+  [commonJobsNoOpJob]
+);
+
 export const benchmarkPackages = defineJob(
   'Benchmark packages',
   () => ({

--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -486,39 +486,6 @@ export const docgenPerfGate = defineJob(
   [commonJobsNoOpJob]
 );
 
-/**
- * TEMPORARY - delete before this branch merges.
- *
- * Runs the perf suite on CI hardware so the budgets in the harness can be set from CI numbers
- * rather than from a laptop. It never gates: it reports. Once the budgets are recorded, this job
- * and its entry in the always-on workflow go away and the daily gate above is the only perf job.
- */
-export const docgenPerfBaselineCapture = defineJob(
-  'Docgen perf baseline capture (temporary)',
-  () => ({
-    executor: {
-      name: 'sb_node_22_classic',
-      class: 'medium+',
-    },
-    steps: [
-      ...workflow.restoreLinux(),
-      {
-        run: {
-          name: 'Per-engine docgen perf suite (report only)',
-          working_directory: 'code/lib/docgen-harness',
-          command: 'yarn bench:docgen-perf --json ./perf-results/results.json',
-          no_output_timeout: '30m',
-        },
-      },
-      artifact.persist(
-        join(LINUX_ROOT_DIR, WORKING_DIR, DOCGEN_PERF_RESULTS_DIR),
-        'docgen-perf-baseline'
-      ),
-    ],
-  }),
-  [commonJobsNoOpJob]
-);
-
 export const benchmarkPackages = defineJob(
   'Benchmark packages',
   () => ({

--- a/scripts/ci/main.ts
+++ b/scripts/ci/main.ts
@@ -12,7 +12,6 @@ import {
   commonJobsNoOpJob,
   defineCircleciCompletion,
   docgenMemoryGate,
-  docgenPerfBaselineCapture,
   docgenPerfGate,
   knip,
   lint,
@@ -76,7 +75,6 @@ function generateConfig(workflow: Workflow) {
       internalStorybookBuildE2e,
       benchmarkPackages,
       // TEMPORARY: remove together with the job definition once the perf budgets are recorded.
-      docgenPerfBaselineCapture,
 
       sandboxesNoOpJob,
       ...sandboxes,

--- a/scripts/ci/main.ts
+++ b/scripts/ci/main.ts
@@ -74,7 +74,6 @@ function generateConfig(workflow: Workflow) {
       internalStorybookE2e,
       internalStorybookBuildE2e,
       benchmarkPackages,
-      // TEMPORARY: remove together with the job definition once the perf budgets are recorded.
 
       sandboxesNoOpJob,
       ...sandboxes,

--- a/scripts/ci/main.ts
+++ b/scripts/ci/main.ts
@@ -12,6 +12,8 @@ import {
   commonJobsNoOpJob,
   defineCircleciCompletion,
   docgenMemoryGate,
+  docgenPerfBaselineCapture,
+  docgenPerfGate,
   knip,
   lint,
   fmt,
@@ -55,7 +57,7 @@ function generateConfig(workflow: Workflow) {
     const initEmpty = getInitEmpty(workflow);
 
     if (isWorkflowOrAbove(workflow, 'daily')) {
-      jobs.push(build_windows, testUnit_windows, docgenMemoryGate);
+      jobs.push(build_windows, testUnit_windows, docgenMemoryGate, docgenPerfGate);
     }
 
     jobs.push(
@@ -73,6 +75,8 @@ function generateConfig(workflow: Workflow) {
       internalStorybookE2e,
       internalStorybookBuildE2e,
       benchmarkPackages,
+      // TEMPORARY: remove together with the job definition once the perf budgets are recorded.
+      docgenPerfBaselineCapture,
 
       sandboxesNoOpJob,
       ...sandboxes,


### PR DESCRIPTION
## What I did

Storybook measures how expensive each framework's docgen engine is, but nothing checked those numbers - a change that made prop extraction twice as slow would land unnoticed.

This adds a gate that runs the per-engine perf suite, checks the results against recorded budgets, and fails when one is breached. Because a check that has never failed is not known to work, the gate also runs a deliberately failing engine and requires that run to come back red.

Budgets are ratios and megabytes, never raw milliseconds: wall clock on a shared CI machine is far too noisy to make decisions from. The main timing budget is the cost of re-extracting after a save relative to a cold start, which is what rises when incremental docgen quietly breaks.

The gate runs on the `ci:daily` label. It is not scheduled, so this is on-demand protection rather than nightly.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

From `code/lib/docgen-harness`:

1. `yarn bench:docgen-perf-gate` - runs the suite, prints every budget check, and ends with the negative control confirming that a failing engine turns the gate red.
2. Tighten any budget in the harness's budget table and re-run: the gate must fail and name the metric that breached.
3. `yarn bench:docgen-memory` still passes unchanged.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
