### PR TITLE
fix(TestingWidget): allow collapsing testing module after crash

### DIFF
--- a/code/core/src/manager/components/sidebar/TestingWidget.tsx
+++ b/code/core/src/manager/components/sidebar/TestingWidget.tsx
@@ -230,12 +230,6 @@ export const TestingWidget = ({
   );
   const hasTestProviders = Object.values(registeredTestProviders).length > 0;
 
-  useEffect(() => {
-    if (isCrashed && isCollapsed) {
-      toggleCollapsed(undefined, false);
-    }
-  }, [isCrashed, isCollapsed, toggleCollapsed]);
-
   useDynamicFavicon(
     isCrashed
       ? 'critical'


### PR DESCRIPTION
Fixes #32237

## Problem

When a testing module provider crashes, the module is forced open by a `useEffect` that calls `toggleCollapsed(undefined, false)` whenever `isCrashed && isCollapsed` is true. This means users can never collapse the module after a crash — every time they try, the effect re-opens it.

## Solution

Remove the `useEffect` that auto-expands the module on crash. Users can still see the crash indicator via the favicon, outline color, and status count, but they can also collapse the module to continue using the sidebar.

## Testing

- The crash indicator is still shown via `useDynamicFavicon` and the card `outlineColor`
- Users can now collapse and expand the testing widget freely, even after a crash