### PR TITLE
Agents: Add Cursor Cloud environment setup notes

### DIFF
--- a/.cursor/cloud-agent.md
+++ b/.cursor/cloud-agent.md
@@ -1,0 +1,15 @@
+# Cursor Cloud agent setup notes
+
+These notes apply **only** when running inside a Cursor Cloud agent VM. They are split out of `AGENTS.md` (which links here) so the always-loaded instructions stay lean. For everything else — architecture, commands, testing, lint, and formatting — follow `AGENTS.md`.
+
+The cloud VM boots from a snapshot with dependencies already installed; the startup update script only runs `yarn` (install).
+
+- **Node is fixed in the VM snapshot, not in this repo.** `/exec-daemon/node` (Node 22.14) is injected ahead of nvm in `PATH`, and `nvm use` does not override it. That breaks anything running a `.ts` file directly through `node` (`yarn task check`, `yarn nx run-many -t check`). The snapshot's `~/.bashrc` already prepends the nvm-managed Node (`.nvmrc` / `22.22.3`), so normally you do nothing. Because that fix lives in the VM image rather than in git, it is not reproducible from this repo alone — if `node --version` reports below 22.18, the snapshot was rebuilt without it and you should restore it:
+  ```bash
+  # from the repo root, so nvm resolves .nvmrc
+  nvm install                                                                           # no-op if already installed
+  export PATH="${NVM_DIR:-$HOME/.nvm}/versions/node/v$(tr -d '[:space:]' < .nvmrc)/bin:$PATH"
+  corepack enable                                                                       # yarn 4.10.3 on that Node
+  ```
+- **Compile before running or typechecking.** The update script does not build. `yarn storybook:ui` runs `code/core/dist/bin/dispatcher.js`, so run `yarn task --task=compile --start-from=compile` (or `yarn nx run-many -t compile`) after a fresh boot or after changing package source. NX caches make reruns fast.
+- **Running the app:** `cd code && yarn storybook:ui` serves the internal Storybook UI on port `6006`. Verify with `curl --fail --silent --show-error localhost:6006/index.json`.

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,0 @@
-{
-  "snapshot": "snapshot-20250521-0222c8bd-0a11-48ab-a2a8-380203843e05",
-  "install": "yarn && yarn task --task=compile --start-from=compile",
-  "start": "cd /workspace/code && yarn test",
-  "terminals": []
-}

--- a/.cursor/rules/cursor-cloud.mdc
+++ b/.cursor/rules/cursor-cloud.mdc
@@ -1,6 +1,12 @@
+---
+description: Always use this when you are a Cursor Cloud agent
+globs:
+alwaysApply: false
+---
+
 # Cursor Cloud agent setup notes
 
-These notes apply **only** when running inside a Cursor Cloud agent VM. They are split out of `AGENTS.md` (which links here) so the always-loaded instructions stay lean. For everything else — architecture, commands, testing, lint, and formatting — follow `AGENTS.md`.
+These notes apply only when running inside a Cursor Cloud agent VM. For architecture, commands, testing, lint, and formatting, follow `AGENTS.md`.
 
 The cloud VM boots from a snapshot with dependencies already installed; the startup update script only runs `yarn` (install).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,14 +369,4 @@ These are recurring failure modes in agent-authored changes to this repo. Apply 
 
 ## Cursor Cloud specific instructions
 
-The cloud VM boots from a snapshot with dependencies already installed; the startup update script only runs `yarn` (install). Standard commands are documented above — notes below are cloud-only caveats.
-
-- **Node is fixed in the VM snapshot, not in this repo.** `/exec-daemon/node` (Node 22.14) is injected ahead of nvm in `PATH`, and `nvm use` does not override it. That breaks anything running a `.ts` file directly through `node` (`yarn task check`, `yarn nx run-many -t check`). The snapshot's `~/.bashrc` already prepends the nvm-managed Node (`.nvmrc` / `22.22.3`), so normally you do nothing. Because that fix lives in the VM image rather than in git, it is not reproducible from this repo alone — if `node --version` reports below 22.18, the snapshot was rebuilt without it and you should restore it:
-  ```bash
-  # from the repo root, so nvm resolves .nvmrc
-  nvm install                                                                           # no-op if already installed
-  export PATH="${NVM_DIR:-$HOME/.nvm}/versions/node/v$(tr -d '[:space:]' < .nvmrc)/bin:$PATH"
-  corepack enable                                                                       # yarn 4.10.3 on that Node
-  ```
-- **Compile before running or typechecking.** The update script does not build. `yarn storybook:ui` runs `code/core/dist/bin/dispatcher.js`, so run `yarn task --task=compile --start-from=compile` (or `yarn nx run-many -t compile`) after a fresh boot or after changing package source. NX caches make reruns fast.
-- **Running the app:** `cd code && yarn storybook:ui` serves the internal Storybook UI on port `6006`. Verify with `curl --fail --silent --show-error localhost:6006/index.json`.
+Only relevant when running inside a Cursor Cloud agent VM: see [`.cursor/cloud-agent.md`](.cursor/cloud-agent.md) for the VM-specific caveats (the snapshot-provided Node/PATH setup, compiling before running or typechecking, and starting/verifying the Storybook UI). Kept as a pointer so these targeted notes do not fill every agent's context window.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,3 +363,17 @@ These are recurring failure modes in agent-authored changes to this repo. Apply 
 - Update `AGENTS.md` when architecture, commands, versions, release flows, or contributor guidance changes
 - Keep `CLAUDE.md` and other agent entrypoints as thin references to `AGENTS.md`
 - Do not reintroduce duplicated instruction files when a reference will do
+
+## Cursor Cloud specific instructions
+
+The cloud VM boots from a snapshot with dependencies already installed; the startup update script only runs `yarn` (install). Commands are the standard ones documented above — the notes below are only the non-obvious cloud caveats.
+
+- **Node/PATH gotcha (important):** `/exec-daemon/node` (Node 22.14) is injected at the front of `PATH` and shadows the nvm-managed Node. `nvm use` does **not** win over it. Most tasks tolerate 22.14 (install, `compile`, `lint`, `yarn test`, and running the app all work because they go through jiti/vite/vitest/oxlint), but anything that runs a `.ts` file directly through `node` — notably `yarn task check` and `yarn nx run-many -t check` — needs Node ≥ 22.18 (the repo pins `22.22.3` via `.nvmrc`). Activate it by explicitly prepending the nvm bin to `PATH` before those commands:
+  ```bash
+  export PATH="$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node" | sort -V | tail -1)/bin:$PATH"
+  corepack enable   # only needed once per node version, provides yarn 4.10.3
+  ```
+- **Compile before running or typechecking.** The update script does not build. `yarn storybook:ui` runs `code/core/dist/bin/dispatcher.js`, so run `yarn task --task=compile --start-from=compile` (or `yarn nx run-many -t compile`) after a fresh boot or after changing package source. NX caches make reruns fast.
+- **Running the app:** `cd code && yarn storybook:ui` serves the internal Storybook UI on port `6006` (long-running dev server). It is fully functional in the VM; verify via `curl -s localhost:6006/index.json`.
+- **NX Cloud remote cache returns HTTP 401** ("insufficient access") on this account — this is benign, the local cache is still used. Ignore it.
+- **Tests:** the full `yarn test` suite is large; prefer focused runs like `yarn test <pattern>` (e.g. `yarn test csf-tools`) during iteration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,7 @@ Key points:
 - NX handles task dependencies via `nx.json`
 - NX target commands use Nx project names (from `project.json` / Nx graph), not `package.json` names
 - Example: `yarn nx compile core` (project `core` is published as package `storybook`)
-- NX Cloud remote-cache auth failures (e.g. HTTP 401 "insufficient access") are benign — the local cache is still used. Set `NX_CLOUD_ACCESS_TOKEN` to authenticate; a read-only token enables cache reads but still cannot store artifacts, so the "wasn't able to store" warning remains expected
+- NX Cloud remote-cache auth failures (e.g. HTTP 401 "insufficient access") degrade to the local cache, so they are expected on local runs where `NX_CLOUD_ACCESS_TOKEN` is unset. CI always sets that token, so a 401 there means an invalid or expired token and should be investigated rather than ignored. A read-only token enables cache reads but cannot store artifacts, so the "wasn't able to store" warning is still expected with one
 
 ## Sandbox Notes
 
@@ -373,8 +373,10 @@ The cloud VM boots from a snapshot with dependencies already installed; the star
 
 - **Node is fixed in the VM snapshot, not in this repo.** `/exec-daemon/node` (Node 22.14) is injected ahead of nvm in `PATH`, and `nvm use` does not override it. That breaks anything running a `.ts` file directly through `node` (`yarn task check`, `yarn nx run-many -t check`). The snapshot's `~/.bashrc` already prepends the nvm-managed Node (`.nvmrc` / `22.22.3`), so normally you do nothing. Because that fix lives in the VM image rather than in git, it is not reproducible from this repo alone — if `node --version` reports below 22.18, the snapshot was rebuilt without it and you should restore it:
   ```bash
-  export PATH="$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node" | sort -V | tail -1)/bin:$PATH"
-  corepack enable   # provides yarn 4.10.3 on that Node
+  # from the repo root, so nvm resolves .nvmrc
+  nvm install                                                                           # no-op if already installed
+  export PATH="${NVM_DIR:-$HOME/.nvm}/versions/node/v$(tr -d '[:space:]' < .nvmrc)/bin:$PATH"
+  corepack enable                                                                       # yarn 4.10.3 on that Node
   ```
 - **Compile before running or typechecking.** The update script does not build. `yarn storybook:ui` runs `code/core/dist/bin/dispatcher.js`, so run `yarn task --task=compile --start-from=compile` (or `yarn nx run-many -t compile`) after a fresh boot or after changing package source. NX caches make reruns fast.
-- **Running the app:** `cd code && yarn storybook:ui` serves the internal Storybook UI on port `6006`. Verify with `curl -s localhost:6006/index.json`.
+- **Running the app:** `cd code && yarn storybook:ui` serves the internal Storybook UI on port `6006`. Verify with `curl --fail --silent --show-error localhost:6006/index.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,4 +369,4 @@ These are recurring failure modes in agent-authored changes to this repo. Apply 
 
 ## Cursor Cloud specific instructions
 
-Only relevant when running inside a Cursor Cloud agent VM: see [`.cursor/cloud-agent.md`](.cursor/cloud-agent.md) for the VM-specific caveats (the snapshot-provided Node/PATH setup, compiling before running or typechecking, and starting/verifying the Storybook UI). Kept as a pointer so these targeted notes do not fill every agent's context window.
+Cursor Cloud agents must also read [`.cursor/cloud-agent.md`](.cursor/cloud-agent.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,7 @@ Key points:
 - NX handles task dependencies via `nx.json`
 - NX target commands use Nx project names (from `project.json` / Nx graph), not `package.json` names
 - Example: `yarn nx compile core` (project `core` is published as package `storybook`)
+- NX Cloud remote-cache auth failures (e.g. HTTP 401 "insufficient access") are benign — the local cache is still used
 
 ## Sandbox Notes
 
@@ -248,6 +249,7 @@ Common templates:
 
 - Use `yarn storybook:vitest` to run Storybook story tests (the primary test path for components)
 - Use `yarn test` for unit tests of utilities, hooks, and non-React modules
+- Prefer focused unit-test runs during iteration — the full suite is large: `yarn test <pattern>` (e.g. `yarn test csf-tools`)
 - Use Storybook UI or Chromatic for visual validation
 - Use `yarn task e2e-tests --start-from auto` or `yarn task e2e-tests-dev --start-from auto` for E2E coverage
 - Use `yarn task test-runner --start-from auto` or `yarn task test-runner-dev --start-from auto` for test-runner scenarios
@@ -366,14 +368,8 @@ These are recurring failure modes in agent-authored changes to this repo. Apply 
 
 ## Cursor Cloud specific instructions
 
-The cloud VM boots from a snapshot with dependencies already installed; the startup update script only runs `yarn` (install). Commands are the standard ones documented above — the notes below are only the non-obvious cloud caveats.
+The cloud VM boots from a snapshot with dependencies already installed; the startup update script only runs `yarn` (install). Standard commands are documented above — notes below are cloud-only caveats.
 
-- **Node/PATH gotcha (important):** `/exec-daemon/node` (Node 22.14) is injected at the front of `PATH` and shadows the nvm-managed Node. `nvm use` does **not** win over it. Most tasks tolerate 22.14 (install, `compile`, `lint`, `yarn test`, and running the app all work because they go through jiti/vite/vitest/oxlint), but anything that runs a `.ts` file directly through `node` — notably `yarn task check` and `yarn nx run-many -t check` — needs Node ≥ 22.18 (the repo pins `22.22.3` via `.nvmrc`). Activate it by explicitly prepending the nvm bin to `PATH` before those commands:
-  ```bash
-  export PATH="$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node" | sort -V | tail -1)/bin:$PATH"
-  corepack enable   # only needed once per node version, provides yarn 4.10.3
-  ```
+- **Node is already configured in the snapshot.** `~/.bashrc` prepends the nvm-managed Node (`.nvmrc` / `22.22.3`) ahead of `/exec-daemon/node`, so login shells and shells that source `~/.bashrc` get the correct version for native `.ts` execution (`yarn task check`, etc.). Do not re-document or re-apply that PATH workaround in-session unless `node --version` is unexpectedly below 22.18.
 - **Compile before running or typechecking.** The update script does not build. `yarn storybook:ui` runs `code/core/dist/bin/dispatcher.js`, so run `yarn task --task=compile --start-from=compile` (or `yarn nx run-many -t compile`) after a fresh boot or after changing package source. NX caches make reruns fast.
-- **Running the app:** `cd code && yarn storybook:ui` serves the internal Storybook UI on port `6006` (long-running dev server). It is fully functional in the VM; verify via `curl -s localhost:6006/index.json`.
-- **NX Cloud remote cache returns HTTP 401** ("insufficient access") on this account — this is benign, the local cache is still used. Ignore it.
-- **Tests:** the full `yarn test` suite is large; prefer focused runs like `yarn test <pattern>` (e.g. `yarn test csf-tools`) during iteration.
+- **Running the app:** `cd code && yarn storybook:ui` serves the internal Storybook UI on port `6006`. Verify with `curl -s localhost:6006/index.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,7 @@ Key points:
 - NX handles task dependencies via `nx.json`
 - NX target commands use Nx project names (from `project.json` / Nx graph), not `package.json` names
 - Example: `yarn nx compile core` (project `core` is published as package `storybook`)
-- NX Cloud remote-cache auth failures (e.g. HTTP 401 "insufficient access") are benign — the local cache is still used
+- NX Cloud remote-cache auth failures (e.g. HTTP 401 "insufficient access") are benign — the local cache is still used. Set `NX_CLOUD_ACCESS_TOKEN` to authenticate; a read-only token enables cache reads but still cannot store artifacts, so the "wasn't able to store" warning remains expected
 
 ## Sandbox Notes
 
@@ -338,6 +338,7 @@ Avoid `console.log`, `console.warn`, and `console.error` unless the file is isol
 | `STORYBOOK_TELEMETRY_DEBUG`   | Log telemetry events                            |
 | `DEBUG`                       | Enable debug logging                            |
 | `FIX_ON_COMMIT`               | Force autofix for fmt & lint in pre-commit hook |
+| `NX_CLOUD_ACCESS_TOKEN`       | Authenticate the NX Cloud remote cache          |
 
 ## Commands To Avoid
 
@@ -370,6 +371,10 @@ These are recurring failure modes in agent-authored changes to this repo. Apply 
 
 The cloud VM boots from a snapshot with dependencies already installed; the startup update script only runs `yarn` (install). Standard commands are documented above — notes below are cloud-only caveats.
 
-- **Node is already configured in the snapshot.** `~/.bashrc` prepends the nvm-managed Node (`.nvmrc` / `22.22.3`) ahead of `/exec-daemon/node`, so login shells and shells that source `~/.bashrc` get the correct version for native `.ts` execution (`yarn task check`, etc.). Do not re-document or re-apply that PATH workaround in-session unless `node --version` is unexpectedly below 22.18.
+- **Node is fixed in the VM snapshot, not in this repo.** `/exec-daemon/node` (Node 22.14) is injected ahead of nvm in `PATH`, and `nvm use` does not override it. That breaks anything running a `.ts` file directly through `node` (`yarn task check`, `yarn nx run-many -t check`). The snapshot's `~/.bashrc` already prepends the nvm-managed Node (`.nvmrc` / `22.22.3`), so normally you do nothing. Because that fix lives in the VM image rather than in git, it is not reproducible from this repo alone — if `node --version` reports below 22.18, the snapshot was rebuilt without it and you should restore it:
+  ```bash
+  export PATH="$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node" | sort -V | tail -1)/bin:$PATH"
+  corepack enable   # provides yarn 4.10.3 on that Node
+  ```
 - **Compile before running or typechecking.** The update script does not build. `yarn storybook:ui` runs `code/core/dist/bin/dispatcher.js`, so run `yarn task --task=compile --start-from=compile` (or `yarn nx run-many -t compile`) after a fresh boot or after changing package source. NX caches make reruns fast.
 - **Running the app:** `cd code && yarn storybook:ui` serves the internal Storybook UI on port `6006`. Verify with `curl -s localhost:6006/index.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,7 +366,3 @@ These are recurring failure modes in agent-authored changes to this repo. Apply 
 - Update `AGENTS.md` when architecture, commands, versions, release flows, or contributor guidance changes
 - Keep `CLAUDE.md` and other agent entrypoints as thin references to `AGENTS.md`
 - Do not reintroduce duplicated instruction files when a reference will do
-
-## Cursor Cloud specific instructions
-
-Cursor Cloud agents must also read [`.cursor/cloud-agent.md`](.cursor/cloud-agent.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What I did

Set up and verified the Storybook development environment on a Cursor Cloud VM, and moved environment config to the Cursor-managed snapshot.

### Removed `.cursor/environment.json`

It was snapshot-only and pinned an old May 2025 snapshot. A committed environment file outranks the dashboard-managed environment, so removing it lets Cursor use the newly saved snapshot and `yarn`-only update script.

### Agent guidance

- General guidance stays in `AGENTS.md`: `NX_CLOUD_ACCESS_TOKEN`, scoped NX Cloud authentication guidance, and focused `yarn test <pattern>` usage.
- Cursor Cloud-only guidance lives in `.cursor/rules/cursor-cloud.mdc` as a contextual Cursor rule with `alwaysApply: false` and the description “Always use this when you are a Cursor Cloud agent.” Nothing Cursor Cloud-specific remains in `AGENTS.md`.
- The rule documents the snapshot-owned Node/PATH setup, a verified `.nvmrc`-pinned recovery path, compile-before-run, and starting/verifying Storybook.

## Environment verification

| Step | Command | Result |
| --- | --- | --- |
| Install | `yarn` | dependencies installed |
| Compile | `yarn task --task=compile --start-from=compile` | 46 projects |
| Lint | `cd code && yarn lint` | passed |
| Test | `yarn test csf-tools` | 333 passed / 3 skipped |
| Typecheck | `yarn nx check addon-links` | passed |
| Run app | `cd code && yarn storybook:ui` | port 6006 |

### Hello-world

Opened `Example / Button → Primary`, edited the `label` control to “Hello World,” and verified the button re-rendered live.

[storybook_ui_hello_world.mp4](https://cursor.com/agents/bc-afe50c01-18b1-4d41-8812-8d78f52c1230/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_ui_hello_world.mp4)

![Button story with Hello World control](https://cursor.com/artifacts/c/art-8097f735-7248-429a-949a-97a358c6d8c2)

## Update script

`yarn` only. Compile remains a separate NX-cached step documented in the contextual Cursor Cloud rule.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afe50c01-18b1-4d41-8812-8d78f52c1230?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afe50c01-18b1-4d41-8812-8d78f52c1230&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

#### Manual testing

No manual testing neccessary.