### PR TITLE
Core: Keep pnpm linker store paths intact when stripping node_modules

### DIFF
--- a/code/core/src/common/utils/strip-abs-node-modules-path.test.ts
+++ b/code/core/src/common/utils/strip-abs-node-modules-path.test.ts
@@ -1,0 +1,41 @@
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { stripAbsNodeModulesPath } from './strip-abs-node-modules-path.ts';
+
+// Paths go through resolve() so the fixtures carry the separator of the platform the
+// tests run on: CI runs these on Windows as well as Linux.
+describe('stripAbsNodeModulesPath', () => {
+  it('turns an absolute path into a bare import path', () => {
+    expect(
+      stripAbsNodeModulesPath(
+        resolve('/project/node_modules/@storybook/react/dist/entry-preview.mjs')
+      )
+    ).toBe('@storybook/react/dist/entry-preview.mjs');
+  });
+
+  it('keeps the last package when node_modules is nested', () => {
+    expect(
+      stripAbsNodeModulesPath(resolve('/project/node_modules/a/node_modules/b/dist/index.mjs'))
+    ).toBe('b/dist/index.mjs');
+  });
+
+  // Yarn's pnpm linker stores packages in node_modules/.store/<name>-virtual-<hash>/package,
+  // so stripping up to the last node_modules leaves ".store/…", which is not a specifier any
+  // bundler can resolve. The directory name is mangled, so the package name cannot be
+  // recovered from the path — leaving it absolute is what keeps it resolvable.
+  it('leaves paths under the pnpm linker store untouched', () => {
+    const abs = resolve(
+      '/project/node_modules/.store/@storybook-react-virtual-d2ec5c3452/package/dist/entry-preview.mjs'
+    );
+
+    expect(stripAbsNodeModulesPath(abs)).toBe(abs);
+  });
+
+  it('still strips packages whose name merely starts with .store', () => {
+    expect(
+      stripAbsNodeModulesPath(resolve('/project/node_modules/.storefront/dist/index.mjs'))
+    ).toBe('.storefront/dist/index.mjs');
+  });
+});

--- a/code/core/src/common/utils/strip-abs-node-modules-path.ts
+++ b/code/core/src/common/utils/strip-abs-node-modules-path.ts
@@ -10,6 +10,12 @@ function normalizePath(id: string) {
 // We need to convert from an absolute path, to a traditional node module import path,
 // so that vite can correctly pre-bundle/optimize
 export function stripAbsNodeModulesPath(absPath: string) {
+  // Yarn's pnpm linker keeps packages in node_modules/.store/<name>-virtual-<hash>/package.
+  // Stripping up to the last node_modules would yield ".store/...", which no bundler resolves,
+  // and the mangled directory name makes the package name unrecoverable from the path alone.
+  if (slash(absPath).includes('node_modules/.store/')) {
+    return absPath;
+  }
   // TODO: Evaluate if this is correct after removing pnp compatibility code in SB11
   // TODO: Evaluate if searching for node_modules in a yarn pnp environment is correct
   const splits = absPath.split(`node_modules${sep}`);


### PR DESCRIPTION
Closes #29620

## What I did

`stripAbsNodeModulesPath` splits on the last `node_modules/` and returns whatever follows. Under Yarn's pnpm linker (`nodeLinker: pnpm`) packages live in `node_modules/.store/<name>-virtual-<hash>/package/`, so it produces `.store/@storybook-react-virtual-<hash>/package/dist/entry-preview.mjs` — not a specifier anything can resolve. The store directory name is mangled, so the package name cannot be recovered from the path; leaving it absolute is what keeps it resolvable, and `presets.ts` already treats "returned unchanged" as the signal to push the absolute path instead of a `{ bare, absolute }` pair.

**On the user-visible symptom:** I could not reproduce #29620 on `next`. The reporter hit it on 8.4.4, where `builder-vite` used `path.bare`; today `processPreviewAnnotation` returns `normalize(path.absolute)` and only falls back to `bare` for the Nuxt workaround (`absolute === ''`), so the broken specifier no longer reaches Vite. `builder-webpack5` and `addon-vitest` read `.absolute` too. What remains is that the helper still emits an unresolvable `bare` value into the `previewAnnotations` preset output, which is public and consumed by third parties. So please read this as fixing the cause rather than a live breakage — and if you'd rather close #29620 as already resolved by the v9 builder change, that's a reasonable call and I'm happy to drop the `Closes`.

There were no tests for this helper; this adds four.

#29639 took the same approach earlier and matched `node_modules/.cache`. In the reproduction for this issue the resolved paths contain `node_modules/.store`, so this PR matches that directory instead.

One open question: the `TODO` above this code says *"Evaluate if this is correct after removing pnp compatibility code in SB11"*. If that removal is close, you may want a different shape here — happy to rework or drop it.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`code/core/src/common/utils/strip-abs-node-modules-path.test.ts` is new. It covers the flat layout, nested `node_modules`, the store layout, and a package merely *starting* with `.store` (`.storefront`), which must still be stripped. Fixtures go through `resolve()` so they carry the platform separator on the Windows CI leg.

#### Manual testing

The change is only observable where the pnpm linker is used, and on `next` the first-party builders already use the absolute path, so there is no visible regression to check for. What a maintainer can verify:

1. `yarn vitest run code/core/src/common/utils/strip-abs-node-modules-path.test.ts` — the store case fails without the change and passes with it.
2. In any Vite sandbox (`yarn task sandbox --template react-vite/default-ts --start-from auto`), the preview builds as before: for non-store paths the function is untouched, and first-party builders consume `absolute` either way.
3. To see the original layout, `git clone https://github.com/ethanwu10/sb-yarn-pnpm-vite-repro && yarn install` (its `.yarnrc.yml` sets `nodeLinker: pnpm`) and inspect the resolved paths — every package resolves under `node_modules/.store/…`, which is what the helper mishandled.

What I verified locally: the four unit tests, the mutations that kill each one (dropping the guard, dropping the trailing slash, matching `.cache` instead of `.store`), the full `yarn test` suite unchanged against my baseline on this machine, and `yarn nx check core` clean. On the 8.4.4 reproduction I confirmed the broken specifier reaching Vite by instrumenting the installed `@storybook/builder-vite` bundle.

### Documentation

- [ ] Add or update documentation reflecting your changes — not applicable, internal path handling with no user-facing API change.
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md) — not applicable.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

---

**AI assistance disclosure:** I used Claude as an assistant while investigating this issue and drafting this description. I reproduced the behaviour, reviewed the change, and stand behind it.
