### PR TITLE
Angular-Vite: Add missing 'error' to loglevel schema validation

### DIFF
--- a/code/frameworks/angular-vite/src/builders/build-storybook/schema.json
+++ b/code/frameworks/angular-vite/src/builders/build-storybook/schema.json
@@ -21,7 +21,7 @@
     "loglevel": {
       "type": "string",
       "description": "Controls level of logging during build. Can be one of: [silly, verbose, info (default), warn, error, silent].",
-      "pattern": "(silly|verbose|info|warn|silent)"
+      "pattern": "(silly|verbose|info|warn|error|silent)"
     },
     "enableProdMode": {
       "type": "boolean",

--- a/code/frameworks/angular-vite/src/builders/start-storybook/schema.json
+++ b/code/frameworks/angular-vite/src/builders/start-storybook/schema.json
@@ -99,7 +99,7 @@
     "loglevel": {
       "type": "string",
       "description": "Controls level of logging during build. Can be one of: [silly, verbose, info (default), warn, error, silent].",
-      "pattern": "(silly|verbose|info|warn|silent)"
+      "pattern": "(silly|verbose|info|warn|error|silent)"
     },
     "zoneless": {
       "type": "boolean",


### PR DESCRIPTION
Fixes #31559

## What does this PR do?

Adds `error` to the allowed `loglevel` values in the Angular-Vite `build-storybook` and `start-storybook` schemas. The description already documented `error` as an option, but the JSON schema regex rejected it.

## Changes

- `code/frameworks/angular-vite/src/builders/build-storybook/schema.json`
- `code/frameworks/angular-vite/src/builders/start-storybook/schema.json`

Both files update the `loglevel.pattern` from `(silly|verbose|info|warn|silent)` to `(silly|verbose|info|warn|error|silent)`.

#### Manual testing

I ran the actual `start-storybook` schema through `ajv` with the patched pattern.

```
PS E:\coding\prs-rescue\storybook-verification>

==================================================
PR #35738 - Angular-Vite: Add missing 'error' to loglevel schema
==================================================
loglevel="error" => ACCEPTED
loglevel="warn" => ACCEPTED
loglevel="silent" => ACCEPTED
loglevel="invalid" => REJECTED: data/loglevel must match pattern "(silly|verbose|info|warn|error|silent)"
loglevel="debug" => REJECTED: data/loglevel must match pattern "(silly|verbose|info|warn|error|silent)"
```

Terminal screenshot of the same run:

![PR #35738 verification](https://raw.githubusercontent.com/aalhadxx/storybook/5c114dc8394c4318cfe7602fae7017a1499b2fcb/verify-35738.png)

This confirms `error` is now accepted while invalid values remain rejected.
