### PR TITLE
Angular-Vite: Respect compodoc -d arg when checking documentation.json cache

### DIFF
--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -121,7 +121,13 @@ export const viteFinal = async (config: UserConfig, options?: StandaloneOptions)
     const path = await import('node:path');
     const workspaceRoot =
       (options as any)?.angularBuilderContext?.workspaceRoot ?? config?.root ?? process.cwd();
-    const documentationJsonPath = path.resolve(workspaceRoot, 'documentation.json');
+    const compodocArgs = framework.options?.compodocArgs ?? ['-e', 'json', '-d', '.'];
+    const outputDirIndex = compodocArgs.indexOf('-d');
+    const outputDir =
+      outputDirIndex !== -1 && compodocArgs[outputDirIndex + 1]
+        ? path.resolve(workspaceRoot, compodocArgs[outputDirIndex + 1])
+        : workspaceRoot;
+    const documentationJsonPath = path.resolve(outputDir, 'documentation.json');
     if (!existsSync(documentationJsonPath)) {
       const { runCompodoc } = await import('./builders/utils/run-compodoc.ts');
       const tsconfig =
@@ -129,7 +135,6 @@ export const viteFinal = async (config: UserConfig, options?: StandaloneOptions)
         (options as any)?.tsConfig ??
         (options as any)?.angularBuilderOptions?.tsConfig ??
         path.resolve(workspaceRoot, 'tsconfig.json');
-      const compodocArgs = framework.options?.compodocArgs ?? ['-e', 'json', '-d', '.'];
       try {
         await runCompodoc({ compodocArgs, tsconfig, workspaceRoot });
       } catch (err) {


### PR DESCRIPTION
Fixes #35674

## What does this PR do?

Respects the Compodoc `-d` output directory argument when the Angular-Vite preset checks for an existing `documentation.json` cache. Previously the preset always looked in `workspaceRoot`, ignoring a custom output directory.

## Changes

- `code/frameworks/angular-vite/src/preset.ts`

The preset now reads `compodocArgs`, locates the `-d` flag, and resolves `documentation.json` from that directory. If `-d` is missing or invalid, it falls back to the workspace root.

#### Manual testing

I ran the exact path-resolution logic used in the PR against real workspace paths.

```
PS E:\coding\prs-rescue\storybook-verification>

==================================================
PR #35740 - Angular-Vite: Respect compodoc -d arg
==================================================
With default compodocArgs: E:\project\documentation.json
With custom -d docs: E:\project\docs\documentation.json
With no -d: E:\project\documentation.json
```

Terminal screenshot of the same run:

![PR #35740 verification](https://raw.githubusercontent.com/aalhadxx/storybook/5c114dc8394c4318cfe7602fae7017a1499b2fcb/verify-35740.png)

This confirms the cache check now follows the custom output directory, while keeping the workspace-root fallback when no `-d` is provided.
