### PR TITLE
CLI: Allow esbuild builds for Storybook-owned pnpm dlx

### DIFF
--- a/code/core/src/common/js-package-manager/PNPMProxy.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.test.ts
@@ -74,7 +74,7 @@ describe('PNPM Proxy', () => {
   });
 
   describe('installDependencies', () => {
-    it('should run plain `pnpm install` without --allow-build', async () => {
+    it('should run `pnpm install`', async () => {
       // sort of un-mock part of the function so executeCommand (also mocked) is called
       vi.mocked(prompt.executeTaskWithSpinner).mockImplementationOnce(async (fn: any) => {
         await Promise.resolve(fn());
@@ -84,10 +84,7 @@ describe('PNPM Proxy', () => {
       await pnpmProxy.installDependencies();
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'pnpm',
-          args: ['install'],
-        })
+        expect.objectContaining({ command: 'pnpm', args: ['install'] })
       );
     });
 
@@ -126,45 +123,57 @@ describe('PNPM Proxy', () => {
       );
     });
 
-    it('should pass --allow-build=esbuild before dlx on pnpm >= 10.2', () => {
-      mockPnpmVersion('10.2.0');
-      pnpmProxy = new PNPMProxy();
-      const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '' } as any);
+    describe('useRemotePkg (dlx)', () => {
+      describe('on pnpm >= 10.2', () => {
+        beforeEach(() => {
+          mockPnpmVersion('10.2.0');
+          pnpmProxy = new PNPMProxy();
+        });
 
-      pnpmProxy.runPackageCommand({
-        args: ['create-storybook@10.5.5', '-y'],
-        useRemotePkg: true,
+        it('should pass --allow-build=esbuild before dlx', () => {
+          const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '' } as any);
+
+          pnpmProxy.runPackageCommand({
+            args: ['create-storybook@10.5.5', '-y'],
+            useRemotePkg: true,
+          });
+
+          expect(executeCommandSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              command: 'pnpm',
+              args: ['--allow-build=esbuild', 'dlx', 'create-storybook@10.5.5', '-y'],
+            })
+          );
+        });
       });
 
-      expect(executeCommandSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'pnpm',
-          args: ['--allow-build=esbuild', 'dlx', 'create-storybook@10.5.5', '-y'],
-        })
-      );
-    });
+      describe('on pnpm < 10.2', () => {
+        beforeEach(() => {
+          mockPnpmVersion('9.15.9');
+          pnpmProxy = new PNPMProxy();
+        });
 
-    it('should not pass --allow-build on dlx for pnpm < 10.2', () => {
-      mockPnpmVersion('9.15.9');
-      pnpmProxy = new PNPMProxy();
-      const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '' } as any);
+        it('should not pass --allow-build on dlx', () => {
+          const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '' } as any);
 
-      pnpmProxy.runPackageCommand({
-        args: ['create-storybook@10.5.5', '-y'],
-        useRemotePkg: true,
+          pnpmProxy.runPackageCommand({
+            args: ['create-storybook@10.5.5', '-y'],
+            useRemotePkg: true,
+          });
+
+          expect(executeCommandSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              command: 'pnpm',
+              args: ['dlx', 'create-storybook@10.5.5', '-y'],
+            })
+          );
+        });
       });
-
-      expect(executeCommandSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'pnpm',
-          args: ['dlx', 'create-storybook@10.5.5', '-y'],
-        })
-      );
     });
   });
 
   describe('addDependencies', () => {
-    it('with devDep it should run `pnpm add -D storybook` without --allow-build', async () => {
+    it('with devDep it should run `pnpm add -D storybook`', async () => {
       const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '6.0.0' } as any);
 
       await pnpmProxy.addDependencies({ type: 'devDependencies' }, ['storybook']);

--- a/code/core/src/common/js-package-manager/PNPMProxy.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { logger, prompt } from 'storybook/internal/node-logger';
 import { MinimumReleaseAgeHandledError } from 'storybook/internal/server-errors';
 
-import { executeCommand } from '../utils/command.ts';
+import { executeCommand, executeCommandSync } from '../utils/command.ts';
 import { JsPackageManager } from './JsPackageManager.ts';
 import { PNPMProxy } from './PNPMProxy.ts';
 
@@ -23,6 +23,16 @@ vi.mock('storybook/internal/node-logger', () => ({
 
 vi.mock(import('../utils/command.ts'), { spy: true });
 const mockedExecuteCommand = vi.mocked(executeCommand);
+const mockedExecuteCommandSync = vi.mocked(executeCommandSync);
+
+const mockPnpmVersion = (version: string) => {
+  mockedExecuteCommandSync.mockImplementation((options) => {
+    if (options.command === 'pnpm' && options.args?.[0] === '--version') {
+      return version;
+    }
+    return '';
+  });
+};
 const expectedMinimumReleaseAgeExcludePackages = [
   'react',
   'webpack',
@@ -36,6 +46,7 @@ describe('PNPM Proxy', () => {
   let pnpmProxy: PNPMProxy;
 
   beforeEach(() => {
+    mockPnpmVersion('11.18.0');
     pnpmProxy = new PNPMProxy();
     JsPackageManager.clearLatestVersionCache();
     vi.spyOn(pnpmProxy, 'writePackageJson').mockImplementation(vi.fn());
@@ -63,7 +74,7 @@ describe('PNPM Proxy', () => {
   });
 
   describe('installDependencies', () => {
-    it('should run `pnpm install`', async () => {
+    it('should run plain `pnpm install` without --allow-build', async () => {
       // sort of un-mock part of the function so executeCommand (also mocked) is called
       vi.mocked(prompt.executeTaskWithSpinner).mockImplementationOnce(async (fn: any) => {
         await Promise.resolve(fn());
@@ -73,7 +84,10 @@ describe('PNPM Proxy', () => {
       await pnpmProxy.installDependencies();
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ command: 'pnpm', args: ['install'] })
+        expect.objectContaining({
+          command: 'pnpm',
+          args: ['install'],
+        })
       );
     });
 
@@ -111,10 +125,46 @@ describe('PNPM Proxy', () => {
         })
       );
     });
+
+    it('should pass --allow-build=esbuild before dlx on pnpm >= 10.2', () => {
+      mockPnpmVersion('10.2.0');
+      pnpmProxy = new PNPMProxy();
+      const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '' } as any);
+
+      pnpmProxy.runPackageCommand({
+        args: ['create-storybook@10.5.5', '-y'],
+        useRemotePkg: true,
+      });
+
+      expect(executeCommandSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'pnpm',
+          args: ['--allow-build=esbuild', 'dlx', 'create-storybook@10.5.5', '-y'],
+        })
+      );
+    });
+
+    it('should not pass --allow-build on dlx for pnpm < 10.2', () => {
+      mockPnpmVersion('9.15.9');
+      pnpmProxy = new PNPMProxy();
+      const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '' } as any);
+
+      pnpmProxy.runPackageCommand({
+        args: ['create-storybook@10.5.5', '-y'],
+        useRemotePkg: true,
+      });
+
+      expect(executeCommandSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'pnpm',
+          args: ['dlx', 'create-storybook@10.5.5', '-y'],
+        })
+      );
+    });
   });
 
   describe('addDependencies', () => {
-    it('with devDep it should run `pnpm add -D storybook`', async () => {
+    it('with devDep it should run `pnpm add -D storybook` without --allow-build', async () => {
       const executeCommandSpy = mockedExecuteCommand.mockResolvedValue({ stdout: '6.0.0' } as any);
 
       await pnpmProxy.addDependencies({ type: 'devDependencies' }, ['storybook']);

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -55,23 +55,8 @@ export type PnpmListOutput = PnpmListItem[];
 
 const PNPM_ERROR_REGEX = /(ELIFECYCLE|ERR_PNPM_[A-Z_]+)\s+(.*)/i;
 
-/**
- * Packages Storybook needs to run install scripts under pnpm 11+.
- * Without this, Storybook-owned `pnpm dlx` can block on an interactive
- * approve-builds picker (TTY) or fail with ERR_PNPM_IGNORED_BUILDS.
- *
- * Only passed as a per-command `--allow-build` flag on Storybook-run `dlx`.
- * Do not use on `pnpm add`: that persists `allowBuilds` into the user's project
- * config (e.g. pnpm-workspace.yaml). We deliberately do not seed `allowBuilds`
- * in the user's project.
- */
-const PNPM_ALLOWED_BUILD_DEPENDENCIES = ['esbuild'] as const;
-
 /** `pnpm dlx --allow-build` support (docs: Added in v10.2.0). */
 const PNPM_ALLOW_BUILD_DLX_MIN = '10.2.0';
-
-const getPnpmAllowBuildArgs = (): string[] =>
-  PNPM_ALLOWED_BUILD_DEPENDENCIES.map((pkg) => `--allow-build=${pkg}`);
 
 export class PNPMProxy extends JsPackageManager {
   readonly type = PackageManagerName.PNPM;
@@ -129,17 +114,6 @@ export class PNPMProxy extends JsPackageManager {
     return version != null && gte(version, minimum);
   }
 
-  /**
-   * `--allow-build` is only used for Storybook-owned `pnpm dlx`. Do not pass it on
-   * `pnpm add`: recent pnpm versions persist `allowBuilds` into the project config.
-   * `pnpm install` also rejects the flag.
-   */
-  #allowBuildArgsFor(command: 'dlx'): string[] {
-    return command === 'dlx' && this.#pnpmGte(PNPM_ALLOW_BUILD_DLX_MIN)
-      ? getPnpmAllowBuildArgs()
-      : [];
-  }
-
   getInstallArgs(): string[] {
     if (!this.installArgs) {
       this.installArgs = [];
@@ -163,10 +137,15 @@ export class PNPMProxy extends JsPackageManager {
     args: string[];
     useRemotePkg?: boolean;
   }): ResultPromise {
-    // Flag before `dlx`: `pnpm --allow-build=esbuild dlx <pkg>` (required on some pnpm versions).
-    // Storybook-owned remote package runs only — never on `add`/`install`.
+    // On pnpm 11+, Storybook-owned `dlx` can hang on approve-builds for esbuild.
+    // Pass `--allow-build` only here — not on `add`, which persists `allowBuilds`
+    // into the user's project config.
     const pnpmArgs = useRemotePkg
-      ? [...this.#allowBuildArgsFor('dlx'), 'dlx', ...args]
+      ? [
+          ...(this.#pnpmGte(PNPM_ALLOW_BUILD_DLX_MIN) ? ['--allow-build=esbuild'] : []),
+          'dlx',
+          ...args,
+        ]
       : ['exec', ...args];
 
     return executeCommand({

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -11,11 +11,12 @@ import {
 import * as find from 'empathic/find';
 // eslint-disable-next-line depend/ban-dependencies
 import type { ResultPromise } from 'execa';
+import { coerce, gte } from 'semver';
 import { dedent } from 'ts-dedent';
 import { type Document, parseDocument } from 'yaml';
 
 import type { ExecuteCommandOptions } from '../utils/command.ts';
-import { executeCommand } from '../utils/command.ts';
+import { executeCommand, executeCommandSync } from '../utils/command.ts';
 import { getProjectRoot } from '../utils/paths.ts';
 import { JsPackageManager, PackageManagerName } from './JsPackageManager.ts';
 import type { PackageJson } from './PackageJson.ts';
@@ -54,10 +55,31 @@ export type PnpmListOutput = PnpmListItem[];
 
 const PNPM_ERROR_REGEX = /(ELIFECYCLE|ERR_PNPM_[A-Z_]+)\s+(.*)/i;
 
+/**
+ * Packages Storybook needs to run install scripts under pnpm 11+.
+ * Without this, Storybook-owned `pnpm dlx` can block on an interactive
+ * approve-builds picker (TTY) or fail with ERR_PNPM_IGNORED_BUILDS.
+ *
+ * Only passed as a per-command `--allow-build` flag on Storybook-run `dlx`.
+ * Do not use on `pnpm add`: that persists `allowBuilds` into the user's project
+ * config (e.g. pnpm-workspace.yaml). We deliberately do not seed `allowBuilds`
+ * in the user's project.
+ */
+const PNPM_ALLOWED_BUILD_DEPENDENCIES = ['esbuild'] as const;
+
+/** `pnpm dlx --allow-build` support (docs: Added in v10.2.0). */
+const PNPM_ALLOW_BUILD_DLX_MIN = '10.2.0';
+
+const getPnpmAllowBuildArgs = (): string[] =>
+  PNPM_ALLOWED_BUILD_DEPENDENCIES.map((pkg) => `--allow-build=${pkg}`);
+
 export class PNPMProxy extends JsPackageManager {
   readonly type = PackageManagerName.PNPM;
 
   installArgs: string[] | undefined;
+
+  /** Cached `pnpm --version` output; `undefined` until read, `null` if lookup failed. */
+  #pnpmVersion: string | null | undefined;
 
   detectWorkspaceRoot() {
     const CWD = process.cwd();
@@ -79,12 +101,43 @@ export class PNPMProxy extends JsPackageManager {
   }
 
   async getPnpmVersion(): Promise<string> {
-    const result = await executeCommand({
-      cwd: this.cwd,
-      command: 'pnpm',
-      args: ['--version'],
-    });
-    return typeof result.stdout === 'string' ? result.stdout : '';
+    return this.#readPnpmVersion() ?? '';
+  }
+
+  #readPnpmVersion(): string | null {
+    if (this.#pnpmVersion !== undefined) {
+      return this.#pnpmVersion;
+    }
+
+    try {
+      const stdout = executeCommandSync({
+        cwd: this.cwd,
+        command: 'pnpm',
+        args: ['--version'],
+        stdio: 'pipe',
+      });
+      this.#pnpmVersion = stdout.trim();
+    } catch {
+      this.#pnpmVersion = null;
+    }
+
+    return this.#pnpmVersion;
+  }
+
+  #pnpmGte(minimum: string): boolean {
+    const version = coerce(this.#readPnpmVersion());
+    return version != null && gte(version, minimum);
+  }
+
+  /**
+   * `--allow-build` is only used for Storybook-owned `pnpm dlx`. Do not pass it on
+   * `pnpm add`: recent pnpm versions persist `allowBuilds` into the project config.
+   * `pnpm install` also rejects the flag.
+   */
+  #allowBuildArgsFor(command: 'dlx'): string[] {
+    return command === 'dlx' && this.#pnpmGte(PNPM_ALLOW_BUILD_DLX_MIN)
+      ? getPnpmAllowBuildArgs()
+      : [];
   }
 
   getInstallArgs(): string[] {
@@ -110,9 +163,15 @@ export class PNPMProxy extends JsPackageManager {
     args: string[];
     useRemotePkg?: boolean;
   }): ResultPromise {
+    // Flag before `dlx`: `pnpm --allow-build=esbuild dlx <pkg>` (required on some pnpm versions).
+    // Storybook-owned remote package runs only — never on `add`/`install`.
+    const pnpmArgs = useRemotePkg
+      ? [...this.#allowBuildArgsFor('dlx'), 'dlx', ...args]
+      : ['exec', ...args];
+
     return executeCommand({
       command: 'pnpm',
-      args: [useRemotePkg ? 'dlx' : 'exec', ...args],
+      args: pnpmArgs,
       ...options,
     });
   }

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -95,6 +95,7 @@ export class PNPMProxy extends JsPackageManager {
     }
 
     try {
+      logger.debug('Executing command: pnpm --version');
       const stdout = executeCommandSync({
         cwd: this.cwd,
         command: 'pnpm',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Related to #35668. On pnpm 11+, Storybook-owned `pnpm dlx` can hang on an interactive approve-builds prompt (or fail with `ERR_PNPM_IGNORED_BUILDS`) when esbuild needs a build script.

I pass version-gated `--allow-build=esbuild` **only** for Storybook-owned `pnpm dlx` (`runPackageCommand` with `useRemotePkg: true`) when local pnpm is >= 10.2.0.

I deliberately do **not** pass `--allow-build` on `pnpm add` or `pnpm install`. Empirically on pnpm 11.18, `pnpm add --allow-build=esbuild` persists `allowBuilds.esbuild: true` into the user's `pnpm-workspace.yaml`; `pnpm --allow-build=esbuild dlx` does not. I also do not seed/write `allowBuilds` into the user's project.

This supersedes the broader approach in #35671 with a narrower scope (dlx only; no add/install flags, no project config seeding, no tasks/verdaccio changes). It does not fully fix the TanStack Start outer install hang described in #35668 (that remains upstream).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Use a clean directory with pnpm >= 10.2 (ideally 11.x) and no prior Storybook install.
2. Run a Storybook CLI path that uses `pnpm dlx` (e.g. `pnpm dlx storybook@next init` / create-storybook via the Storybook-owned remote package command), in a TTY, without pre-approving esbuild builds.
3. Confirm the command does not stop on an interactive approve-builds picker for esbuild during the Storybook-owned `dlx` step.
4. After the run, inspect the project: confirm Storybook did **not** write `allowBuilds` / `pnpm.onlyBuiltDependencies` (or similar) into `package.json` / `pnpm-workspace.yaml` solely because of this change.
5. Optionally repeat with pnpm < 10.2 and confirm CLI args omit `--allow-build` (unit tests cover this).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)