### PR TITLE
CLI: Skip install type prompt for React Native

### DIFF
--- a/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AddonVitestService, ProjectType, globalSettings } from 'storybook/internal/cli';
 import { PackageManagerName, isCI } from 'storybook/internal/common';
@@ -28,7 +28,18 @@ interface CommandWithPrivates {
 
 describe('UserPreferencesCommand', () => {
   let command: UserPreferencesCommand;
-  const originalIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+  // `process.stdout.isTTY` is ambient process state and exposes no getter to spy on in this
+  // environment, so tests mutate it via Object.defineProperty through a small helper and
+  // always restore the original value after each test (mirrors withTelemetry.test.ts) to
+  // avoid leaking interactivity between tests.
+  const originalStdoutIsTTY = process.stdout.isTTY;
+
+  const setStdoutIsTTY = (value: boolean | undefined) => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value,
+      configurable: true,
+    });
+  };
 
   const defaultExecuteOptions = {
     framework: null as null,
@@ -39,15 +50,8 @@ describe('UserPreferencesCommand', () => {
     isAiSetupAvailable: false,
   };
 
-  afterAll(() => {
-    if (originalIsTTYDescriptor) {
-      Object.defineProperty(process.stdout, 'isTTY', originalIsTTYDescriptor);
-    } else {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: undefined,
-        configurable: true,
-      });
-    }
+  afterEach(() => {
+    setStdoutIsTTY(originalStdoutIsTTY);
   });
 
   beforeEach(() => {
@@ -110,12 +114,6 @@ describe('UserPreferencesCommand', () => {
     vi.mocked(logger.log).mockImplementation(() => {});
     vi.mocked(isCI).mockReturnValue(false);
 
-    // Reset isTTY to avoid leaking between tests
-    Object.defineProperty(process.stdout, 'isTTY', {
-      value: undefined,
-      configurable: true,
-    });
-
     // Reset sandbox env to avoid leaking between tests (or from the actual test environment)
     delete process.env.IN_STORYBOOK_SANDBOX;
 
@@ -142,10 +140,7 @@ describe('UserPreferencesCommand', () => {
 
     it('should prompt for new user in interactive mode', async () => {
       // Mock TTY
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
 
@@ -163,10 +158,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should track prompt cancellation for the new user prompt and exit cleanly', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true);
 
@@ -185,10 +177,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should prompt for install type when not a new user', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select)
         .mockResolvedValueOnce(false) // not new user
@@ -202,10 +191,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should remove test feature if isTestFeatureAvailable is false', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
 
@@ -245,10 +231,7 @@ describe('UserPreferencesCommand', () => {
 
   describe('AI setup prompt', () => {
     it('should include AI feature when user accepts AI setup in interactive mode', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
       vi.mocked(prompt.confirm).mockResolvedValueOnce(true); // AI setup: yes
@@ -270,10 +253,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should not include ONBOARDING feature when user accepts AI setup', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
       vi.mocked(prompt.confirm).mockResolvedValueOnce(true); // AI setup: yes
@@ -288,10 +268,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should include ONBOARDING when AI is selected inside a sandbox (IN_STORYBOOK_SANDBOX)', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
       vi.mocked(prompt.confirm).mockResolvedValueOnce(true); // AI setup: yes
 
@@ -316,10 +293,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should not include AI feature when user declines AI setup', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
       vi.mocked(prompt.confirm).mockResolvedValueOnce(false); // AI setup: no
@@ -333,10 +307,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should default AI to true when prompts are skipped (non-interactive)', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: undefined,
-        configurable: true,
-      });
+      setStdoutIsTTY(undefined);
 
       const result = await command.execute({
         ...defaultExecuteOptions,
@@ -348,10 +319,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should default AI to true when --yes flag is used', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       const commandOptions: CommandOptions = {
         packageManager: PackageManagerName.NPM,
@@ -378,10 +346,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should not prompt for AI setup when isAiSetupAvailable is false', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
 
@@ -395,10 +360,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should include test feature in minimal installs when user accepts AI setup', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select)
         .mockResolvedValueOnce(false) // not new user
@@ -417,10 +379,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should not include test feature in minimal installs when user declines AI setup', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select)
         .mockResolvedValueOnce(false) // not new user
@@ -438,10 +397,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should track ai-prompt-nudge telemetry when user accepts AI setup', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
       vi.mocked(prompt.confirm).mockResolvedValueOnce(true); // AI setup: yes
@@ -456,10 +412,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should not track ai-prompt-nudge telemetry when user declines AI setup', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
       vi.mocked(prompt.confirm).mockResolvedValueOnce(false); // AI setup: no
@@ -488,10 +441,7 @@ describe('UserPreferencesCommand', () => {
 
   describe('React Native-only projects', () => {
     it('should skip the install-type prompt and use the minimal config for existing users', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       // Not a new user - normally this would trigger the install-type prompt
       vi.mocked(prompt.select).mockResolvedValueOnce(false);
@@ -519,10 +469,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should use the minimal config for new users without prompting', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
 
@@ -547,10 +494,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should use the minimal config when --yes is set', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       const commandOptions: CommandOptions = {
         packageManager: PackageManagerName.NPM,
@@ -576,10 +520,7 @@ describe('UserPreferencesCommand', () => {
     });
 
     it('should still prompt for install type for React Native Web projects', async () => {
-      Object.defineProperty(process.stdout, 'isTTY', {
-        value: true,
-        configurable: true,
-      });
+      setStdoutIsTTY(true);
 
       vi.mocked(prompt.select)
         .mockResolvedValueOnce(false) // not a new user

--- a/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
@@ -486,6 +486,118 @@ describe('UserPreferencesCommand', () => {
     });
   });
 
+  describe('React Native-only projects', () => {
+    it('should skip the install-type prompt and use the minimal config for existing users', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+
+      // Not a new user - normally this would trigger the install-type prompt
+      vi.mocked(prompt.select).mockResolvedValueOnce(false);
+
+      const result = await command.execute({
+        ...defaultExecuteOptions,
+        projectType: ProjectType.REACT_NATIVE,
+      });
+
+      // Only the new-user prompt should have run - the install-type prompt must be skipped
+      expect(prompt.select).toHaveBeenCalledTimes(1);
+      expect(prompt.select).not.toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'What configuration should we install?' }),
+        expect.anything()
+      );
+
+      // Minimal ("light") config: none of the recommended features are installed
+      expect(result.selectedFeatures.has(Feature.DOCS)).toBe(false);
+      expect(result.selectedFeatures.has(Feature.A11Y)).toBe(false);
+      expect(result.selectedFeatures.has(Feature.TEST)).toBe(false);
+
+      // The automatic choice is still recorded for telemetry
+      const telemetryService = (command as unknown as CommandWithPrivates).telemetryService;
+      expect(telemetryService.trackInstallType).toHaveBeenCalledWith('light');
+    });
+
+    it('should use the minimal config for new users without prompting', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+
+      vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
+
+      const result = await command.execute({
+        ...defaultExecuteOptions,
+        projectType: ProjectType.REACT_NATIVE,
+      });
+
+      expect(result.newUser).toBe(true);
+      expect(result.selectedFeatures.has(Feature.DOCS)).toBe(false);
+      expect(result.selectedFeatures.has(Feature.A11Y)).toBe(false);
+    });
+
+    it('should use the minimal config in non-interactive mode', async () => {
+      const result = await command.execute({
+        ...defaultExecuteOptions,
+        projectType: ProjectType.REACT_NATIVE,
+      });
+
+      expect(prompt.select).not.toHaveBeenCalled();
+      expect(result.selectedFeatures.has(Feature.DOCS)).toBe(false);
+    });
+
+    it('should use the minimal config when --yes is set', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+
+      const commandOptions: CommandOptions = {
+        packageManager: PackageManagerName.NPM,
+        disableTelemetry: true,
+        yes: true,
+      };
+      const yesCommand = new UserPreferencesCommand(commandOptions);
+
+      (yesCommand as unknown as CommandWithPrivates).telemetryService = {
+        trackNewUserCheck: vi.fn(),
+        trackInstallType: vi.fn(),
+        trackAiSetupNudge: vi.fn(),
+        trackPromptCancel: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const result = await yesCommand.execute({
+        ...defaultExecuteOptions,
+        projectType: ProjectType.REACT_NATIVE,
+      });
+
+      expect(prompt.select).not.toHaveBeenCalled();
+      expect(result.selectedFeatures.has(Feature.DOCS)).toBe(false);
+    });
+
+    it('should still prompt for install type for React Native Web projects', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+
+      vi.mocked(prompt.select)
+        .mockResolvedValueOnce(false) // not a new user
+        .mockResolvedValueOnce('recommended'); // install type
+
+      const result = await command.execute({
+        ...defaultExecuteOptions,
+        projectType: ProjectType.REACT_NATIVE_WEB,
+      });
+
+      expect(prompt.select).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'What configuration should we install?' }),
+        expect.anything()
+      );
+      expect(result.selectedFeatures.has(Feature.DOCS)).toBe(true);
+    });
+  });
+
   describe('executeUserPreferences helper', () => {
     it('should return a valid result', async () => {
       const commandOptions: CommandOptions = {

--- a/code/lib/create-storybook/src/commands/UserPreferencesCommand.ts
+++ b/code/lib/create-storybook/src/commands/UserPreferencesCommand.ts
@@ -1,4 +1,4 @@
-import type { ProjectType } from 'storybook/internal/cli';
+import { ProjectType } from 'storybook/internal/cli';
 import { globalSettings } from 'storybook/internal/cli';
 import { isCI } from 'storybook/internal/common';
 import { logger, prompt } from 'storybook/internal/node-logger';
@@ -74,11 +74,22 @@ export class UserPreferencesCommand {
       };
     }
 
+    // React Native-only projects don't have differentiated install workflows yet
+    // (see #34873): skip the install-type prompt and always use the minimal
+    // ("light") configuration for React Native.
+    const isReactNativeOnly = options.projectType === ProjectType.REACT_NATIVE;
+
     // Get install type
-    const installType: InstallType =
-      !newUser && !this.commandOptions.features
-        ? await this.promptInstallType(skipPrompt, options.isTestFeatureAvailable)
-        : 'recommended';
+    let installType: InstallType;
+    if (isReactNativeOnly) {
+      installType = 'light';
+      await this.telemetryService.trackInstallType(installType);
+    } else {
+      installType =
+        !newUser && !this.commandOptions.features
+          ? await this.promptInstallType(skipPrompt, options.isTestFeatureAvailable)
+          : 'recommended';
+    }
 
     // Ask about AI setup (only available for compatible projects, e.g. React + Vite)
     const useAiForSetup = options.isAiSetupAvailable ? await this.promptAiSetup(skipPrompt) : false;


### PR DESCRIPTION
Closes #34873

## What I did

- Skip the Recommended/Minimal install-type prompt for React Native-only projects.
- Automatically use the existing `light` install type, which corresponds to the Minimal configuration.
- Preserve the existing prompt and behavior for React Native Web and all other supported project types.
- Add regression tests covering interactive, new-user, non-interactive, and `--yes` React Native installation flows.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No separate browser-based manual test is required because this change affects the CLI preference-selection branch and is covered directly by command-level unit tests.

### Documentation

No documentation update is required because this removes a redundant React Native installation prompt and does not introduce a new user-facing option or API.

## AI assistance disclosure

OpenAI Codex was used for investigation, implementation, and testing of this change.
