### PR TITLE
Build: Add 7d minimum release age gate to the repository's Yarn config

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,6 +14,12 @@ logFilters:
 
 nodeLinker: node-modules
 
+# Refuse to resolve versions published less than 7 days ago, so a compromised
+# release has time to be detected and unpublished before it can enter the tree.
+# Only affects new or updated resolutions; installs from the committed lockfile
+# are unaffected. Matches the gate used for generated sandboxes.
+npmMinimalAgeGate: 10080
+
 npmPublishAccess: public
 
 tsEnableAutoTypes: true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,10 +14,6 @@ logFilters:
 
 nodeLinker: node-modules
 
-# Refuse to resolve versions published less than 7 days ago, so a compromised
-# release has time to be detected and unpublished before it can enter the tree.
-# Only affects new or updated resolutions; installs from the committed lockfile
-# are unaffected. Matches the gate used for generated sandboxes.
 npmMinimalAgeGate: 10080
 
 npmPublishAccess: public


### PR DESCRIPTION
## What I did

Yarn can refuse to install package versions that were published very recently.
Recent npm supply-chain attacks have followed the same shape: an attacker publishes a malicious patch release over a widely used package, and it is caught and pulled within hours.
Anything that installs during that short window gets the payload; anything that waits does not.

Our own repository had no such rule configured, so an attack landing in that window could reach a contributor or CI machine through any dependency update.

This sets that window to 7 days for the repository.

The rule only applies when a dependency is added or updated.
Installing from the committed lockfile is unaffected, so day-to-day work and CI behave exactly as before.
The practical effect is that adding or bumping a dependency will not pick up a release younger than a week.

This matches the rule applied to generated sandboxes in #34852.

#### Manual testing

1. Install from the committed lockfile. It should succeed unchanged, with no lockfile modifications.
2. Try adding a dependency whose only matching release is a few days old. It should be refused rather than installed.
3. Add or bump a dependency whose releases are older than a week. It should succeed normally.
