### PR TITLE
ESLint Plugin: Fix Await Interactions Import State Latching

### DIFF
--- a/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
@@ -167,6 +167,43 @@ ruleTester.run('await-interactions', rule, {
     },
     {
       code: dedent`
+        import { expect } from '@storybook/test'
+        import Button from './Button'
+        WithModalOpen.play = async ({ args }) => {
+          const label = Button.name
+          expect(args.onClick).toHaveBeenCalledWith(label)
+        }
+      `,
+      output: dedent`
+        import { expect } from '@storybook/test'
+        import Button from './Button'
+        WithModalOpen.play = async ({ args }) => {
+          const label = Button.name
+          await expect(args.onClick).toHaveBeenCalledWith(label)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'toHaveBeenCalledWith' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { expect } from '@storybook/test'
+                import Button from './Button'
+                WithModalOpen.play = async ({ args }) => {
+                  const label = Button.name
+                  await expect(args.onClick).toHaveBeenCalledWith(label)
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
         import Button from './Button'
         import { expect } from '@storybook/test'
         WithModalOpen.play = async ({ args }) => {
@@ -312,43 +349,6 @@ ruleTester.run('await-interactions', rule, {
                 import Button from './Button'
                 Basic.play = async () => {
                   await userEvent.click(Button)
-                }
-              `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: dedent`
-        import { expect } from '@storybook/test'
-        import Button from './Button'
-        WithModalOpen.play = async ({ args }) => {
-          const label = Button.name
-          expect(args.onClick).toHaveBeenCalledWith(label)
-        }
-      `,
-      output: dedent`
-        import { expect } from '@storybook/test'
-        import Button from './Button'
-        WithModalOpen.play = async ({ args }) => {
-          const label = Button.name
-          await expect(args.onClick).toHaveBeenCalledWith(label)
-        }
-      `,
-      errors: [
-        {
-          messageId: 'interactionShouldBeAwaited',
-          data: { method: 'toHaveBeenCalledWith' },
-          suggestions: [
-            {
-              messageId: 'fixSuggestion',
-              output: dedent`
-                import { expect } from '@storybook/test'
-                import Button from './Button'
-                WithModalOpen.play = async ({ args }) => {
-                  const label = Button.name
-                  await expect(args.onClick).toHaveBeenCalledWith(label)
                 }
               `,
             },

--- a/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
@@ -108,8 +108,183 @@ ruleTester.run('await-interactions', rule, {
         }
       }
     `,
+    dedent`
+      import { expect } from 'vitest'
+
+      Basic.play = async () => {
+        expect(foo).toEqual(bar)
+      }
+    `,
+    dedent`
+      import { userEvent } from '@storybook/test'
+
+      Basic.play = async ({ userEvent }) => {
+        userEvent.click(button)
+      }
+    `,
+    dedent`
+      import { expect } from '@storybook/test'
+
+      Basic.play = async ({ expect }) => {
+        expect(foo).toEqual(bar)
+      }
+    `,
   ],
   invalid: [
+    {
+      code: dedent`
+        import Button from './Button'
+        import { userEvent } from '@storybook/test'
+        Basic.play = async () => {
+          userEvent.click(Button)
+        }
+      `,
+      output: dedent`
+        import Button from './Button'
+        import { userEvent } from '@storybook/test'
+        Basic.play = async () => {
+          await userEvent.click(Button)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'userEvent' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import Button from './Button'
+                import { userEvent } from '@storybook/test'
+                Basic.play = async () => {
+                  await userEvent.click(Button)
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import Button from './Button'
+        import { expect } from '@storybook/test'
+        WithModalOpen.play = async ({ args }) => {
+          const label = Button.name
+          expect(args.onClick).toHaveBeenCalledWith(label)
+        }
+      `,
+      output: dedent`
+        import Button from './Button'
+        import { expect } from '@storybook/test'
+        WithModalOpen.play = async ({ args }) => {
+          const label = Button.name
+          await expect(args.onClick).toHaveBeenCalledWith(label)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'toHaveBeenCalledWith' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import Button from './Button'
+                import { expect } from '@storybook/test'
+                WithModalOpen.play = async ({ args }) => {
+                  const label = Button.name
+                  await expect(args.onClick).toHaveBeenCalledWith(label)
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { expect } from './assertions'
+        import { userEvent } from '@storybook/test'
+        import Button from './Button'
+        Basic.play = async () => {
+          userEvent.click(Button)
+          expect(args.onClick).toHaveBeenCalledWith(Button.name)
+        }
+      `,
+      output: dedent`
+        import { expect } from './assertions'
+        import { userEvent } from '@storybook/test'
+        import Button from './Button'
+        Basic.play = async () => {
+          await userEvent.click(Button)
+          expect(args.onClick).toHaveBeenCalledWith(Button.name)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'userEvent' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { expect } from './assertions'
+                import { userEvent } from '@storybook/test'
+                import Button from './Button'
+                Basic.play = async () => {
+                  await userEvent.click(Button)
+                  expect(args.onClick).toHaveBeenCalledWith(Button.name)
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { userEvent } from '@storybook/test'
+        import Button from './Button'
+        Basic.play = async () => {
+          function ignored(userEvent) {
+            userEvent.click(Button)
+          }
+          userEvent.click(Button)
+        }
+      `,
+      output: dedent`
+        import { userEvent } from '@storybook/test'
+        import Button from './Button'
+        Basic.play = async () => {
+          function ignored(userEvent) {
+            userEvent.click(Button)
+          }
+          await userEvent.click(Button)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'userEvent' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { userEvent } from '@storybook/test'
+                import Button from './Button'
+                Basic.play = async () => {
+                  function ignored(userEvent) {
+                    userEvent.click(Button)
+                  }
+                  await userEvent.click(Button)
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
     {
       code: dedent`
         import { userEvent } from '@storybook/test'

--- a/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.test.ts
@@ -112,6 +112,77 @@ ruleTester.run('await-interactions', rule, {
   invalid: [
     {
       code: dedent`
+        import { userEvent } from '@storybook/test'
+        import Button from './Button'
+        Basic.play = async () => {
+          userEvent.click(Button)
+        }
+      `,
+      output: dedent`
+        import { userEvent } from '@storybook/test'
+        import Button from './Button'
+        Basic.play = async () => {
+          await userEvent.click(Button)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'userEvent' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { userEvent } from '@storybook/test'
+                import Button from './Button'
+                Basic.play = async () => {
+                  await userEvent.click(Button)
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { expect } from '@storybook/test'
+        import Button from './Button'
+        WithModalOpen.play = async ({ args }) => {
+          const label = Button.name
+          expect(args.onClick).toHaveBeenCalledWith(label)
+        }
+      `,
+      output: dedent`
+        import { expect } from '@storybook/test'
+        import Button from './Button'
+        WithModalOpen.play = async ({ args }) => {
+          const label = Button.name
+          await expect(args.onClick).toHaveBeenCalledWith(label)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'toHaveBeenCalledWith' },
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { expect } from '@storybook/test'
+                import Button from './Button'
+                WithModalOpen.play = async ({ args }) => {
+                  const label = Button.name
+                  await expect(args.onClick).toHaveBeenCalledWith(label)
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
         import { expect } from '@storybook/jest'
         WithModalOpen.play = async ({ args }) => {
           // should complain

--- a/code/lib/eslint-plugin/src/rules/await-interactions.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.ts
@@ -156,6 +156,17 @@ export default createStorybookRule({
       );
     };
 
+    const isUserEventOrExpectImported = (node: TSESTree.ImportDeclaration) => {
+      return (
+        node.specifiers.find(
+          (spec) =>
+            isImportSpecifier(spec) &&
+            'name' in spec.imported &&
+            (spec.imported.name === 'userEvent' || spec.imported.name === 'expect')
+        ) !== undefined
+      );
+    };
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
@@ -169,12 +180,16 @@ export default createStorybookRule({
 
     return {
       ImportDeclaration(node: TSESTree.ImportDeclaration) {
-        isImportedFromStorybook =
-          isUserEventFromStorybookImported(node) || isExpectFromStorybookImported(node);
+        if (isUserEventFromStorybookImported(node) || isExpectFromStorybookImported(node)) {
+          isImportedFromStorybook = true;
+        } else if (isUserEventOrExpectImported(node)) {
+          isImportedFromStorybook = false;
+        }
       },
       VariableDeclarator(node: TSESTree.VariableDeclarator) {
-        isImportedFromStorybook =
-          isImportedFromStorybook && isIdentifier(node.id) && node.id.name !== 'userEvent';
+        if (isIdentifier(node.id) && (node.id.name === 'userEvent' || node.id.name === 'expect')) {
+          isImportedFromStorybook = false;
+        }
       },
       CallExpression(node: TSESTree.CallExpression) {
         const method = getMethodThatShouldBeAwaited(node);

--- a/code/lib/eslint-plugin/src/rules/await-interactions.ts
+++ b/code/lib/eslint-plugin/src/rules/await-interactions.ts
@@ -6,6 +6,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import type { TSESLint } from '@typescript-eslint/utils';
 
 import {
+  ASTUtils,
   isArrowFunctionExpression,
   isAwaitExpression,
   isCallExpression,
@@ -63,9 +64,56 @@ export default createStorybookRule({
       'play',
     ];
 
+    const STORYBOOK_USER_EVENT_MODULES = ['@storybook/testing-library', '@storybook/test'];
+    const STORYBOOK_EXPECT_MODULES = ['@storybook/jest', '@storybook/test'];
+
+    const getScope = (node: TSESTree.Node) => {
+      const { sourceCode } = context;
+
+      // Compatibility implementation for eslint v8.x and v9.x or later
+      // see https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getscope()
+      return sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+    };
+
+    const isStorybookImport = (
+      identifier: TSESTree.Identifier,
+      importedName: 'userEvent' | 'expect',
+      moduleNames: string[],
+      scope: TSESLint.Scope.Scope
+    ) => {
+      const variable = ASTUtils.findVariable(scope, identifier.name);
+
+      if (!variable) {
+        return identifier.name === importedName;
+      }
+
+      return variable.defs.some((def) => {
+        const node = def.node;
+        const parent = node.parent;
+
+        return (
+          isImportSpecifier(node) &&
+          parent?.type === 'ImportDeclaration' &&
+          moduleNames.includes(String(parent.source.value)) &&
+          'name' in node.imported &&
+          node.imported.name === importedName
+        );
+      });
+    };
+
     const getMethodThatShouldBeAwaited = (expr: TSESTree.CallExpression) => {
+      const scope = getScope(expr);
       const shouldAwait = (name: string) => {
-        return FUNCTIONS_TO_BE_AWAITED.includes(name) || name.startsWith('findBy');
+        return (
+          (name !== 'userEvent' && FUNCTIONS_TO_BE_AWAITED.includes(name)) ||
+          name.startsWith('findBy')
+        );
+      };
+      const isUserEvent = (identifier: TSESTree.Identifier) => {
+        return isStorybookImport(identifier, 'userEvent', STORYBOOK_USER_EVENT_MODULES, scope);
+      };
+      const isExpect = (identifier: TSESTree.Identifier) => {
+        return isStorybookImport(identifier, 'expect', STORYBOOK_EXPECT_MODULES, scope);
       };
 
       // When an expression is a return value it doesn't need to be awaited
@@ -73,12 +121,15 @@ export default createStorybookRule({
         return null;
       }
 
-      if (
-        isMemberExpression(expr.callee) &&
-        isIdentifier(expr.callee.object) &&
-        shouldAwait(expr.callee.object.name)
-      ) {
-        return expr.callee.object;
+      if (isMemberExpression(expr.callee) && isIdentifier(expr.callee.object)) {
+        const shouldAwaitObject = shouldAwait(expr.callee.object.name);
+        const isStorybookUserEvent = isUserEvent(expr.callee.object);
+
+        if (shouldAwaitObject || isStorybookUserEvent) {
+          return isStorybookUserEvent && expr.callee.object.name !== 'userEvent'
+            ? ({ ...expr.callee.object, name: 'userEvent' } as TSESTree.Identifier)
+            : expr.callee.object;
+        }
       }
 
       if (
@@ -103,13 +154,18 @@ export default createStorybookRule({
         isCallExpression(expr.callee.object) &&
         isIdentifier(expr.callee.object.callee) &&
         isIdentifier(expr.callee.property) &&
-        expr.callee.object.callee.name === 'expect'
+        isExpect(expr.callee.object.callee)
       ) {
         return expr.callee.property;
       }
 
-      if (isIdentifier(expr.callee) && shouldAwait(expr.callee.name)) {
-        return expr.callee;
+      if (
+        isIdentifier(expr.callee) &&
+        (shouldAwait(expr.callee.name) || isUserEvent(expr.callee))
+      ) {
+        return isUserEvent(expr.callee) && expr.callee.name !== 'userEvent'
+          ? ({ ...expr.callee, name: 'userEvent' } as TSESTree.Identifier)
+          : expr.callee;
       }
 
       return null;
@@ -132,65 +188,17 @@ export default createStorybookRule({
       return getClosestFunctionAncestor(parent);
     };
 
-    const isUserEventFromStorybookImported = (node: TSESTree.ImportDeclaration) => {
-      return (
-        (node.source.value === '@storybook/testing-library' ||
-          node.source.value === '@storybook/test') &&
-        node.specifiers.find(
-          (spec) =>
-            isImportSpecifier(spec) &&
-            'name' in spec.imported &&
-            spec.imported.name === 'userEvent' &&
-            spec.local.name === 'userEvent'
-        ) !== undefined
-      );
-    };
-
-    const isExpectFromStorybookImported = (node: TSESTree.ImportDeclaration) => {
-      return (
-        (node.source.value === '@storybook/jest' || node.source.value === '@storybook/test') &&
-        node.specifiers.find(
-          (spec) =>
-            isImportSpecifier(spec) && 'name' in spec.imported && spec.imported.name === 'expect'
-        ) !== undefined
-      );
-    };
-
-    const isUserEventOrExpectImported = (node: TSESTree.ImportDeclaration) => {
-      return (
-        node.specifiers.find(
-          (spec) =>
-            isImportSpecifier(spec) &&
-            'name' in spec.imported &&
-            (spec.imported.name === 'userEvent' || spec.imported.name === 'expect')
-        ) !== undefined
-      );
-    };
-
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
     /** @param {import('eslint').Rule.Node} node */
 
-    let isImportedFromStorybook = true;
     const invocationsThatShouldBeAwaited = [] as Array<{
       node: TSESTree.Node;
       method: TSESTree.Identifier;
     }>;
 
     return {
-      ImportDeclaration(node: TSESTree.ImportDeclaration) {
-        if (isUserEventFromStorybookImported(node) || isExpectFromStorybookImported(node)) {
-          isImportedFromStorybook = true;
-        } else if (isUserEventOrExpectImported(node)) {
-          isImportedFromStorybook = false;
-        }
-      },
-      VariableDeclarator(node: TSESTree.VariableDeclarator) {
-        if (isIdentifier(node.id) && (node.id.name === 'userEvent' || node.id.name === 'expect')) {
-          isImportedFromStorybook = false;
-        }
-      },
       CallExpression(node: TSESTree.CallExpression) {
         const method = getMethodThatShouldBeAwaited(node);
         if (method && !isAwaitExpression(node.parent) && !isAwaitExpression(node.parent?.parent)) {
@@ -198,7 +206,7 @@ export default createStorybookRule({
         }
       },
       'Program:exit': function () {
-        if (isImportedFromStorybook && invocationsThatShouldBeAwaited.length) {
+        if (invocationsThatShouldBeAwaited.length) {
           invocationsThatShouldBeAwaited.forEach(({ node, method }) => {
             const parentFnNode = getClosestFunctionAncestor(node);
             const parentFnNeedsAsync =


### PR DESCRIPTION
Closes #35760

## What I did

Fixed `await-interactions` so Storybook interaction imports stay active when normal component imports appear later in the file.

Specifically:

- keeps the Storybook `userEvent` / `expect` import state latched instead of overwriting it on every import declaration
- only disables Storybook import handling when `userEvent` / `expect` are imported from a non-Storybook module or shadowed locally
- adds regression coverage for `@storybook/test` imports followed by a component import

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

A maintainer can verify this manually by linting a story file like:

```ts
import { userEvent, expect } from '@storybook/test';
import Button from './Button';

Basic.play = async ({ args }) => {
  userEvent.click(Button);
  expect(args.onClick).toHaveBeenCalled();
};
```

The rule should report both un-awaited interactions even though the component import appears after the Storybook import.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

### AI assistance disclosure

Codex via Jeeves assisted with implementation and local verification; Harsh reviewed and submitted the PR from his account.

## Local verification

- `yarn install`
- `yarn nx compile core`
- `yarn exec vitest run src/rules/await-interactions.test.ts --config vitest.config.ts` from `code/lib/eslint-plugin` — 24 tests passed
- `yarn exec oxfmt --check code/lib/eslint-plugin/src/rules/await-interactions.ts code/lib/eslint-plugin/src/rules/await-interactions.test.ts`
- `yarn nx compile eslint-plugin`
- `yarn --cwd code lint:js:cmd lib/eslint-plugin/src/rules/await-interactions.ts lib/eslint-plugin/src/rules/await-interactions.test.ts`

Note: Nx Cloud reported local 401 cache-access warnings, but the compile target completed successfully.
