### PR TITLE
Core: Use slimsemver instead of semver

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -263,7 +263,7 @@
     "oxc-parser": "^0.127.0",
     "oxc-resolver": "^11.19.1",
     "recast": "^0.23.5",
-    "semver": "^7.7.3",
+    "slimsemver": "^1.0.1",
     "use-sync-external-store": "^1.5.0",
     "ws": "^8.21.1"
   },
@@ -314,7 +314,6 @@
     "@types/pretty-hrtime": "^1.0.0",
     "@types/prompts": "^2.0.9",
     "@types/react-syntax-highlighter": "11.0.5",
-    "@types/semver": "^7.7.1",
     "@types/ws": "^8",
     "@vitest/mocker": "3.2.4",
     "@vitest/utils": "^3.2.4",

--- a/code/core/src/cli/AddonVitestService.ts
+++ b/code/core/src/cli/AddonVitestService.ts
@@ -9,7 +9,7 @@ import { logger, prompt } from 'storybook/internal/node-logger';
 import { ErrorCollector } from 'storybook/internal/telemetry';
 
 import * as find from 'empathic/find';
-import { coerce, minVersion, satisfies, validRange } from 'semver';
+import { coerce, minVersion, satisfies, validRange } from 'slimsemver';
 import { dedent } from 'ts-dedent';
 
 import { SupportedBuilder, type SupportedFramework } from '../types/index.ts';

--- a/code/core/src/cli/detectLanguage.ts
+++ b/code/core/src/cli/detectLanguage.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { JsPackageManager } from 'storybook/internal/common';
 import { SupportedLanguage } from 'storybook/internal/types';
 
-import semver from 'semver';
+import semver from 'slimsemver';
 
 /**
  * Detect whether the project should be treated as TypeScript or JavaScript. The js/tsconfig lookup

--- a/code/core/src/cli/helpers.ts
+++ b/code/core/src/cli/helpers.ts
@@ -16,7 +16,7 @@ import {
 import { Feature } from 'storybook/internal/types';
 
 import picocolors from 'picocolors';
-import { coerce, satisfies } from 'semver';
+import { coerce, satisfies } from 'slimsemver';
 import stripJsonComments from 'strip-json-comments';
 import invariant from 'tiny-invariant';
 

--- a/code/core/src/common/js-package-manager/BUNProxy.ts
+++ b/code/core/src/common/js-package-manager/BUNProxy.ts
@@ -10,7 +10,7 @@ import {
 import * as find from 'empathic/find';
 // eslint-disable-next-line depend/ban-dependencies
 import type { ResultPromise } from 'execa';
-import sort from 'semver/functions/sort.js';
+import sort from 'slimsemver/functions/sort.js';
 import { dedent } from 'ts-dedent';
 
 import type { ExecuteCommandOptions } from '../utils/command.ts';

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -10,7 +10,7 @@ import { type ResultPromise } from 'execa';
 // eslint-disable-next-line depend/ban-dependencies
 import { globSync } from 'glob';
 import picocolors from 'picocolors';
-import { coerce, gt, satisfies, validRange } from 'semver';
+import { coerce, gt, satisfies, validRange } from 'slimsemver';
 import invariant from 'tiny-invariant';
 
 import { HandledError } from '../utils/HandledError.ts';

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -10,7 +10,7 @@ import {
 import * as find from 'empathic/find';
 // eslint-disable-next-line depend/ban-dependencies
 import type { ResultPromise } from 'execa';
-import sort from 'semver/functions/sort.js';
+import sort from 'slimsemver/functions/sort.js';
 import { dedent } from 'ts-dedent';
 
 import type { ExecuteCommandOptions } from '../utils/command.ts';

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -11,7 +11,7 @@ import {
 import * as find from 'empathic/find';
 // eslint-disable-next-line depend/ban-dependencies
 import type { ResultPromise } from 'execa';
-import { coerce, gte } from 'semver';
+import { coerce, gte } from 'slimsemver';
 import { dedent } from 'ts-dedent';
 import { type Document, parseDocument } from 'yaml';
 

--- a/code/core/src/common/js-package-manager/util.ts
+++ b/code/core/src/common/js-package-manager/util.ts
@@ -1,4 +1,4 @@
-import { gt, prerelease, valid } from 'semver';
+import { gt, prerelease, valid } from 'slimsemver';
 
 import type { JsPackageManager } from './JsPackageManager.ts';
 import { PackageManagerName } from './JsPackageManager.ts';

--- a/code/core/src/common/node-version.ts
+++ b/code/core/src/common/node-version.ts
@@ -1,4 +1,4 @@
-import { satisfies } from 'semver';
+import { satisfies } from 'slimsemver';
 
 export interface MinNodeVersion {
   major: number;

--- a/code/core/src/core-server/utils/update-check.ts
+++ b/code/core/src/core-server/utils/update-check.ts
@@ -3,7 +3,7 @@ import { colors } from 'storybook/internal/node-logger';
 import type { VersionCheck } from 'storybook/internal/types';
 
 import picocolors from 'picocolors';
-import semver from 'semver';
+import semver from 'slimsemver';
 import { dedent } from 'ts-dedent';
 
 const { STORYBOOK_VERSION_BASE = 'https://storybook.js.org', CI } = process.env;

--- a/code/core/src/manager-api/modules/versions.ts
+++ b/code/core/src/manager-api/modules/versions.ts
@@ -3,7 +3,7 @@ import type { API_UnknownEntries, API_Version, API_Versions } from 'storybook/in
 import { global } from '@storybook/global';
 
 import memoize from 'memoizerific';
-import semver from 'semver';
+import semver from 'slimsemver';
 
 import type { ModuleFn } from '../lib/types.tsx';
 import { version as currentVersion } from '../version.ts';

--- a/code/core/src/telemetry/get-known-packages.ts
+++ b/code/core/src/telemetry/get-known-packages.ts
@@ -1,6 +1,6 @@
 import type { PackageJson } from 'storybook/internal/types';
 
-import semver from 'semver';
+import semver from 'slimsemver';
 
 import {
   DATA_FETCHING_PACKAGES,


### PR DESCRIPTION
## What I did

Swapped `semver` for [`slimsemver`](https://github.com/Damin3927/slimsemver) in `code/core`, and dropped the `@types/semver` devDependency since slimsemver ships its own types.

`code/core` pulls in all of `semver`, and part of that ends up in the manager bundle, which runs in the browser — `dist/manager/globals-runtime.js` contains semver's error strings, so the whole library is in there.

Core imports `coerce`, `diff`, `gt`, `gte`, `major`, `minor`, `minVersion`, `patch`, `prerelease`, `satisfies`, `sort`, `valid` and `validRange`. `semver` is CommonJS with no `exports` field, so a bundler can't drop the rest.

slimsemver is an API-compatible reimplementation that ships ESM and tree-shakes. For the set core uses that's **5.1 KB gzip instead of 24.6 KB** — roughly 19 KB off a manager bundle that is currently ~373 KB gzip.

Only the import specifier and the dependency change; no call sites were touched.

Two things you should weigh:

- **I wrote slimsemver.** Flagging that rather than letting you find it.
- **It's new** — published this week. That's a fair reason to say no, or to revisit once it has a track record. I won't push back either way.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

The existing `code/core` unit tests cover the call sites, since nothing but the import specifier changed.

On the library itself: it runs a differential suite against `semver` on every commit — 119,796 cases comparing return values *and* thrown error types across the range grammar and all option combinations — plus a seeded fuzzer. I also ran core's exact call sites against both libraries side by side (301 checks, identical output). Happy to share that script if it's useful.

#### Manual testing

The browser-side usage is the version check in `manager-api`, so that's what's worth exercising:

1. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open the sandbox in a browser
3. Open the **About Storybook** page from the sidebar's ⚙ menu — it should show the current version and, if an update is available, the upgrade notice with a correct version comparison and a working "read the changelog" link
4. Check the browser console for errors from the manager bundle

If it's easier, temporarily setting `versions.latest` to something higher than the local version in `code/core/src/manager-api/modules/versions.ts` will force the upgrade path.

I haven't run the monorepo build locally, so CI is the real check here.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update MIGRATION.MD

No user-facing behaviour changes, so no docs needed.