### PR TITLE
Build: Add 7d minimum release age gate to the repository's Yarn config

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,6 +14,8 @@ logFilters:
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: 10080
+
 npmPublishAccess: public
 
 tsEnableAutoTypes: true


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Yarn can refuse to install package versions that were published very recently.
Recent npm supply-chain attacks have followed the same shape: an attacker publishes a malicious patch release over a widely used package, and it is caught and pulled within hours.
Anything that installs during that short window gets the payload; anything that waits does not.

Our own repository had no such rule configured, so an attack landing in that window could reach a contributor or CI machine through any dependency update.

This sets that window to 7 days for the repository.

The rule only applies when a dependency is added or updated.
Installing from the committed lockfile is unaffected, so day-to-day work and CI behave exactly as before.
The practical effect is that adding or bumping a dependency will not pick up a release younger than a week.

This matches the rule applied to generated sandboxes in #34852.

> Recreated from #35756 as a standalone PR (not part of the stacked PR chain), because GitHub's stacked-PR merge path could not land the bottom PR while CircleCI triggering is disabled for containment.

#### Manual testing

1. Install from the committed lockfile. It should succeed unchanged, with no lockfile modifications.
2. Try adding a dependency whose only matching release is a few days old. It should be refused rather than installed.
3. Add or bump a dependency whose releases are older than a week. It should succeed normally.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Install from the committed lockfile. It should succeed unchanged, with no lockfile modifications.
2. Try adding a dependency whose only matching release is a few days old. It should be refused rather than installed.
3. Add or bump a dependency whose releases are older than a week. It should succeed normally.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)