### PR TITLE
fix(manager): blend preview overscroll gutter with Storybook chrome

### DIFF
--- a/code/core/assets/server/base-preview-head.html
+++ b/code/core/assets/server/base-preview-head.html
@@ -1,6 +1,20 @@
 <base target="_parent" />
 
 <style>
+  /* Paints the story canvas. It lives on `body` so that it still propagates to the document canvas
+     and fills the viewport for a short story — a background on `html` would break that propagation
+     and leave anything a story paints on `body` covering only its own box. `:where()` drops the
+     specificity to zero, so any story rule wins without needing `!important`.
+
+     Kept out of the manager's <iframe> element because that element is also what the browser paints
+     in the overscroll gutter, and the gutter is meant to follow the surrounding chrome instead. The
+     manager sets --sb-preview-background from the `appPreviewBg` theme variable; standing alone
+     (opening iframe.html directly) it is unset and `Canvas` keeps the browser's own
+     color-scheme-aware default. */
+  :where(body) {
+    background-color: var(--sb-preview-background, Canvas);
+  }
+
   /* While we aren't showing the main block yet, but still preparing, we want everything the user has rendered, which may or may not be in #storybook-root, to be display none */
   .sb-show-preparing-story:not(.sb-show-main) > :not(.sb-preparing-story) {
     display: none;

--- a/code/core/src/manager/components/preview/Iframe.tsx
+++ b/code/core/src/manager/components/preview/Iframe.tsx
@@ -1,12 +1,15 @@
 import type { IframeHTMLAttributes } from 'react';
-import React from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 import { Zoom } from 'storybook/internal/components';
 
-import { styled } from 'storybook/theming';
+import { styled, useTheme } from 'storybook/theming';
 
 const StyledIframe = styled.iframe(({ theme }) => ({
-  backgroundColor: theme.background.preview,
+  // The surrounding chrome colour rather than `background.preview`, so the overscroll gutter — which
+  // sits inside the iframe box but outside the preview document's scroll extent, and is therefore
+  // painted from this element — blends into Storybook instead of flashing white over a dark story.
+  backgroundColor: theme.background.app,
   display: 'block',
   boxSizing: 'content-box',
   height: '100%',
@@ -28,12 +31,33 @@ export interface IFrameProps {
 
 export function IFrame(props: IFrameProps & IframeHTMLAttributes<HTMLIFrameElement>) {
   const { active, id, title, src, allowFullScreen, scale, ...rest } = props;
-  const iFrameRef = React.useRef<HTMLIFrameElement>(null);
+  const iFrameRef = useRef<HTMLIFrameElement>(null);
+  const previewBackground = useTheme().background.preview;
+
+  // The story canvas is painted by the preview document, so `appPreviewBg` has to reach it. A
+  // cross-origin composed ref yields a null `contentDocument` rather than throwing, so the optional
+  // chain is the whole guard and that ref keeps whatever its own Storybook set.
+  const syncPreviewBackground = useCallback(() => {
+    iFrameRef.current?.contentDocument?.documentElement.style.setProperty(
+      '--sb-preview-background',
+      previewBackground
+    );
+  }, [previewBackground]);
+
+  // Assigning `src` replaces the document, so this only covers later theme changes; `onLoad` is what
+  // lands the value on a freshly loaded preview.
+  useEffect(() => {
+    syncPreviewBackground();
+  }, [syncPreviewBackground]);
+
   return (
     <Zoom.IFrame scale={scale} active={active} iFrameRef={iFrameRef}>
       <StyledIframe
         data-is-storybook={active ? 'true' : 'false'}
-        onLoad={(e) => e.currentTarget.setAttribute('data-is-loaded', 'true')}
+        onLoad={(e) => {
+          e.currentTarget.setAttribute('data-is-loaded', 'true');
+          syncPreviewBackground();
+        }}
         id={id}
         title={title}
         src={src}

--- a/code/core/src/manager/components/preview/PreviewColorScheme.stories.tsx
+++ b/code/core/src/manager/components/preview/PreviewColorScheme.stories.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import type { CSSObject } from 'storybook/theming';
+import { Global } from 'storybook/theming';
+
+const PARAGRAPHS = [
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+  'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+  'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.',
+  'Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet.',
+  'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident.',
+  'Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus.',
+];
+
+const shellStyles: CSSObject = {
+  '.cs-shell': {
+    // Padding lives here, not on `body`: `layout: 'fullscreen'` applies
+    // `.sb-show-main.sb-main-fullscreen { padding: 0 }`, which outranks an element selector.
+    maxWidth: 680,
+    margin: '0 auto',
+    padding: '64px 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  },
+  '.cs-shell p': {
+    margin: 0,
+  },
+};
+
+/**
+ * Manual harness for the preview's overscroll gutter, which only a real trackpad gesture can
+ * reveal — synthetic wheel events and CDP scroll gestures do not rubber-band. Scroll past either end
+ * with a trackpad and hold; a flick snaps back before the gutter can be seen.
+ *
+ * This half paints no background at all, so the preview document stays transparent and what shows is
+ * Storybook's own default canvas. The stories vary only `color-scheme`, which is what the browser
+ * themes its own UI from — scrollbar, native controls, and `CanvasText`. The controls are left
+ * unstyled so they double as a readout of the scheme the browser actually resolved.
+ *
+ * Snapshots are disabled because `Adaptive` resolves against the capture browser's color scheme.
+ */
+const ColorSchemePage = ({ scheme }: { scheme: 'light dark' | 'light' | 'dark' }) => (
+  <>
+    <Global
+      styles={{
+        ':root': {
+          colorScheme: scheme,
+        },
+        body: {
+          // No background: the default canvas is the thing under test, and clearing or replacing it
+          // here would hide it. Only the text color is forced, past `ThemedSetRoot` in
+          // .storybook/preview.tsx, which assigns one inline on every render.
+          color: '#2e3338 !important',
+          margin: 0,
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          lineHeight: 1.6,
+        },
+        ...shellStyles,
+        '.cs-controls': {
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: 8,
+        },
+      }}
+    />
+    <div className="cs-shell">
+      <p>
+        <code>color-scheme: {scheme}</code>
+      </p>
+
+      <h1>Overscroll follows the surrounding chrome</h1>
+      <p>
+        No background is set here, so this is Storybook&apos;s default canvas. Scroll past either
+        end with a trackpad: the gutter should be the same color, with no white flash.
+      </p>
+
+      <div className="cs-controls">
+        <input aria-label="Text input" placeholder="Text input" />
+        <button type="button">Button</button>
+      </div>
+
+      {/* Repeated so the page is tall enough to scroll, which overscrolling requires. */}
+      {Array.from({ length: 4 }, (_, round) =>
+        PARAGRAPHS.map((text, i) => <p key={`${round}-${i}`}>{text}</p>)
+      )}
+    </div>
+  </>
+);
+
+const meta = {
+  component: ColorSchemePage,
+  args: { scheme: 'light dark' },
+  // The repo's `sb_theme` decorator renders a story twice under `stacked` / `side-by-side`, which
+  // would give this harness two competing copies of a full-page background. Pin it to one render.
+  globals: { sb_theme: 'light' },
+  parameters: {
+    layout: 'fullscreen',
+    chromatic: { disableSnapshot: true },
+  },
+} satisfies Meta<typeof ColorSchemePage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Follows the OS preference — toggle dark mode at the OS level to see it flip. */
+export const Adaptive: Story = {};
+
+export const ForcedLight: Story = {
+  args: { scheme: 'light' },
+};
+
+export const ForcedDark: Story = {
+  args: { scheme: 'dark' },
+};
+
+/**
+ * The other half: a story that brings its own background instead of inheriting Storybook's default.
+ * The accents sit near white and near black so they read as plausible page colors, and separate from
+ * Storybook's cool greys by hue rather than by saturation — enough to tell the page from the gutter
+ * when they meet, without being loud. `accent` and `ink` are args, so turn them up in Controls if a
+ * given comparison needs to be starker.
+ *
+ * If the page is not the accent color while the swatch still is, something is painting over the
+ * story. Two things in this repo paint body inline and are easy to misattribute that to —
+ * `ThemedSetRoot` (background/color) and the a11y vision simulator (`filter`) — so to attribute it,
+ * clear the inline background and re-read: `document.body.style.removeProperty('background')`.
+ */
+const OwnBackgroundPage = ({
+  scheme,
+  accent,
+  ink,
+}: {
+  scheme: 'light' | 'dark';
+  accent: string;
+  ink: string;
+}) => (
+  <>
+    <Global
+      styles={{
+        ':root': {
+          colorScheme: scheme,
+        },
+        body: {
+          // Where a story would normally put its background: on `body`, which propagates to the
+          // document canvas. `!important` is needed only to outrank `ThemedSetRoot` in
+          // .storybook/preview.tsx, which assigns an opaque background and color to body inline on
+          // every render.
+          background: `${accent} !important`,
+          color: `${ink} !important`,
+          margin: 0,
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          lineHeight: 1.6,
+        },
+        ...shellStyles,
+        // Both borders derive from the inherited text color, so they follow whichever scheme the
+        // story is pinned to instead of being hardcoded for one of them.
+        '.cs-note, .cs-swatch': {
+          border: '1px solid color-mix(in srgb, currentColor 30%, transparent)',
+          padding: 12,
+        },
+        '.cs-swatch': {
+          background: accent,
+        },
+      }}
+    />
+    <div className="cs-shell">
+      <p>
+        <code>
+          background: {accent} on {ink} (color-scheme: {scheme})
+        </code>
+      </p>
+
+      <h1>Story brings its own background</h1>
+      <p className="cs-note">
+        The page should be the accent color end to end, and the swatch below should disappear into
+        it. If the swatch stands out, something is painting over the story.
+      </p>
+      <div className="cs-swatch">Accent swatch — this is the color the page should be</div>
+
+      {Array.from({ length: 4 }, (_, round) =>
+        PARAGRAPHS.map((text, i) => <p key={`${round}-${i}`}>{text}</p>)
+      )}
+    </div>
+  </>
+);
+
+const ownBackgroundMeta = {
+  render: (args: { scheme: 'light' | 'dark'; accent: string; ink: string }) => (
+    <OwnBackgroundPage {...args} />
+  ),
+  parameters: {
+    layout: 'fullscreen',
+    chromatic: { disableSnapshot: true },
+  },
+};
+
+export const OwnBackgroundLight = {
+  ...ownBackgroundMeta,
+  args: { scheme: 'light' as const, accent: '#ede6db', ink: '#3b342a' },
+};
+
+export const OwnBackgroundDark = {
+  ...ownBackgroundMeta,
+  args: { scheme: 'dark' as const, accent: '#2e2723', ink: '#d8d1c8' },
+};


### PR DESCRIPTION
Closes #

## What I did

The preview iframe element was painted with `theme.background.preview`, which is `#FFFFFF` in **both** built-in themes. That element is what the browser paints in the **overscroll gutter** — the strip inside the iframe box but outside the preview document's scroll extent — so rubber-band scrolling a dark story inside a dark Storybook flashed white.

Two changes, because the gutter and the story canvas were the same paint layer and recoloring one would have recolored the other:

**1. The gutter follows the chrome.** `Iframe.tsx` now paints the iframe element with `theme.background.app`, matching `FrameWrap`, the container the frame sits in.

```diff
 const StyledIframe = styled.iframe(({ theme }) => ({
-  backgroundColor: theme.background.preview,
+  backgroundColor: theme.background.app,
```

**2. The story canvas keeps `appPreviewBg`,** now painted from inside the preview document so it is no longer tied to the gutter. In `base-preview-head.html`:

```css
:where(body) {
  background-color: var(--sb-preview-background, Canvas);
}
```

- `:where()` drops specificity to zero, so **any** story rule overrides it without needing `!important`.
- It sits on `body`, not `html`, so it still propagates to the document canvas — a short story that paints its own background still fills the viewport. A default on `html` would break that propagation and leave a story's `body` background covering only its own box.
- The manager hands `appPreviewBg` over as `--sb-preview-background`, so the theme variable keeps working. Standalone (`iframe.html` opened directly) it is unset and `Canvas` keeps the browser's own `color-scheme`-aware default, matching today's behavior.

Net effect: unstyled stories still render on white in both themes, and the gutter now follows the surrounding chrome.

Isolation mode was never affected: a top-level document's propagated canvas background covers its own gutter, while a nested document's does not. That asymmetry is what makes this manager-only.

---

## ⚠️ The one behavior change, and the call I'd like from you

> [!IMPORTANT]
> The preview canvas is now **opaque inside the iframe's blend isolation boundary**, where the iframe element's background never reached. Story content using `mix-blend-mode` therefore blends against the canvas rather than against nothing: a `screen` layer washes out to white, `difference` inverts.

This is worth stating precisely, because the natural objection is *"wasn't the iframe already opaque?"* — it was, but an iframe is a blend isolation boundary, so its background is composited **under** the frame's output rather than participating as a backdrop **inside** it. Compositing and blending are different steps, and only the latter changed.

Verified with a white square using `mix-blend-mode: difference`, where the three possible backdrops give three distinguishable results:

| iframe element | canvas | square renders | meaning |
| --- | --- | --- | --- |
| opaque grey `#808080` | transparent (**today**) | **white** | blend is a no-op — the grey is not in the backdrop |
| opaque grey `#808080` | white (**this PR**) | **black** | `difference(255, 255) = 0` |

If the iframe element's grey were reachable, the first row would render mid-grey (`|255 − 128|`). It renders white, so it is not.

<!-- paste the blend-isolation probe screenshot here -->

Arguably the new behavior is the more correct one — it matches what the same component does over a painted page in a real app — but it is a silent visual change for anything tuned against the old transparent backdrop, so it wants a release note either way. **I'd like a maintainer's call on whether that trade is acceptable.**

For the record, the two alternatives I ruled out:

- **Recolor only the iframe element, no preview-side default.** Simpler (one line), but the gutter and the default canvas are the same layer, so unstyled stories would render on `background.app` — `#F6F9FC` in light and `#1B1C1D` in dark. The dark case is the problem: `appPreviewBg` is deliberately `color.lightest` in `themes/dark.ts` so light-designed stories stay readable in a dark Storybook.
- **Put the preview-side default on `html` instead of `body`.** Avoids nothing on the blend front, and additionally breaks canvas propagation: with the root element painted, a story's `body` background covers only its own box, so a short story shows the default below it. That is the path the backgrounds addon takes (`background !important` on `.sb-show-main`, i.e. `document.body`), so it would regress a core addon.

<!-- paste the propagation + blend 4-panel probe screenshot here -->

---

## Screenshots

macOS, dark system appearance, captured with a trackpad held past the scroll boundary. The `Forced Dark` and `Own Background Dark` pairs are the ones that carry the fix; the light pairs are included to show they are effectively unchanged.

#### 1. Before — `Forced Light` (story inherits the default canvas)

<!-- paste screenshot 1 here -->

#### 2. Before — `Forced Dark` (story inherits the default canvas)

White gutter against the dark chrome — this is the reported bug.

<!-- paste screenshot 2 here -->

#### 3. Before — `Own Background Light` (story brings its own background)

<!-- paste screenshot 3 here -->

#### 4. Before — `Own Background Dark` (story brings its own background)

White gutter against the story's own near-black page.

<!-- paste screenshot 4 here -->

#### 5. After — `Forced Light`

<!-- paste screenshot 5 here -->

#### 6. After — `Forced Dark`

Gutter is now `background.app`, continuous with the sidebar and toolbar. The canvas is still white.

<!-- paste screenshot 6 here -->

#### 7. After — `Own Background Light`

<!-- paste screenshot 7 here -->

#### 8. After — `Own Background Dark`

Gutter reads as Storybook chrome rather than as a break in the story.

<!-- paste screenshot 8 here -->

---

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

The stories are a **manual** harness, not an assertion — see below for why. They are `chromatic: { disableSnapshot: true }`, so they add no snapshot churn.

#### Manual testing

> [!NOTE]
> This behavior cannot be covered by any automated surface in this repo. Rubber-band overscroll is not produced by synthetic wheel events or by CDP `Input.synthesizeScrollGesture`, and Chromatic cannot screenshot a transient gesture. A real trackpad is required, which is why the screenshots above are hand-captured.

1. On macOS, set the system appearance to **dark** (the internal Storybook has no `manager.ts`, so its theme follows `getPreferredColorScheme()`).
2. `yarn && yarn nx compile core`, then `cd code && yarn storybook:ui`.
3. Open **manager → components → preview → Preview Color Scheme → Forced Dark**.
4. With a **trackpad**, two-finger scroll past the top or bottom edge of the preview and **hold** — a flick snaps back before the gutter is visible.
5. The gutter should be the same near-black as the sidebar and toolbar, with no white strip, while the page itself stays white. Repeat on **Own Background Dark**, where the story paints its own page color, so the gutter is clearly distinguishable from the page.
6. To confirm which layer changed, set the iframe element back to white in DevTools (console, `top` context) and overscroll again — the white strip returns:
   ```js
   document.getElementById('storybook-preview-iframe').style.background = '#fff';
   ```
7. To confirm a story can still override the canvas trivially, inject a plain rule with no `!important` — it should win over `:where(body)`:
   ```js
   const d = document.getElementById('storybook-preview-iframe').contentDocument;
   d.head.insertAdjacentHTML('beforeend', '<style>body { background-color: teal }</style>');
   ```

> [!WARNING]
> One known gap, which I'd rather flag than hide: for a **custom** `appPreviewBg`, the value only lands on `load`. Assigning `src` replaces the document, so the mount effect's write is discarded and `onLoad` is the only path that reaches a real preview document — meaning a hard reload paints the `Canvas` fallback until then. Invisible with both built-in themes, since `appPreviewBg` is `#FFFFFF` and the fallback resolves to white under a light scheme. Fixable by passing the value through the iframe URL and setting the custom property from a small inline script at the top of `base-preview-head.html`; happy to do that here or as a follow-up.

The four new stories cover both halves of the matrix: `Adaptive` / `Forced Light` / `Forced Dark` paint nothing, so they show the default canvas and vary only `color-scheme` (which is also what themes the scrollbar and the unstyled native controls); `Own Background Light` / `Own Background Dark` paint their own page and pair a foreground with it.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

`appPreviewBg` keeps its meaning, so no migration is needed for it. The `mix-blend-mode` change above likely warrants a release note; happy to add one once you've made the call.
