### PR TITLE
Refactor: Update getVersionedPackages method to handle non-Storybook packages correctly

### DIFF
--- a/code/core/src/common/js-package-manager/JsPackageManager.test.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.test.ts
@@ -46,5 +46,11 @@ describe('JsPackageManager', () => {
 
       expect(result).toEqual(['@storybook/new-addon@^next']);
     });
+
+    it('should return the package name as is if it is not a Storybook package', async () => {
+      const result = await jsPackageManager.getVersionedPackages(['some-other-package']);
+
+      expect(result).toEqual(['some-other-package']);
+    });
   });
 });

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -440,13 +440,16 @@ export abstract class JsPackageManager {
   }
 
   /**
-   * Return an array of strings matching following format: `<package_name>@<package_latest_version>`
+   * Return an array of strings matching following format: `<storybook_package_name>@<package_latest_version>`
    *
    * For packages in the storybook monorepo, when the latest version is equal to the version of the
    * current CLI the version is not added to the string.
    *
    * When a package is in the monorepo, and the version is not equal to the CLI version, the version
    * is taken from the versions.ts file and added to the string.
+   *
+   * When a package is not in the monorepo, we don't change the package version and return the package name as is.
+   * The package manager will resolve the latest version of the package upon installing it.
    *
    * @param packages
    */
@@ -457,7 +460,7 @@ export abstract class JsPackageManager {
 
         // If the packageVersion is specified and we are not dealing with a storybook package,
         // just return the requested version.
-        if (packageVersion && !(packageName in storybookPackagesVersions)) {
+        if (!(packageName in storybookPackagesVersions)) {
           return pkg;
         }
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds third-party packages during Storybook `init` with the `latest` tag to the user's package.json to make sure that an installation constrained by `npmMinimalAgeGate` is actually respected and the init passes.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
