### PR TITLE
Build: Also exempt `@vue/language-core` from Vue sandbox age gate

### DIFF
--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -603,11 +603,7 @@ export const baseTemplates = {
   'vue3-vite/default-js': {
     name: 'Vue v3 (Vite | JavaScript)',
     script: 'npm create vite --yes {{beforeDir}} -- --template vue',
-    // @storybook/vue3-vite depends on vue-component-meta@^3.3.9; that release is
-    // still inside the 7-day age gate and contains a fix we need.
-    // vue-component-meta pins @vue/language-core to the same version, so both
-    // must be allowlisted (Yarn's gate is per-package). Written onto
-    // before-storybook and inherited by the after-storybook install.
+    // vue-component-meta@^3.3.9 pins @vue/language-core; both are inside the age gate.
     minAgeGateExemptions: ['vue-component-meta', '@vue/language-core'],
     expected: {
       framework: '@storybook/vue3-vite',
@@ -622,7 +618,6 @@ export const baseTemplates = {
   'vue3-vite/default-ts': {
     name: 'Vue v3 (Vite | TypeScript)',
     script: 'npm create vite --yes {{beforeDir}} -- --template vue-ts',
-    // See vue3-vite/default-js — same @storybook/vue3-vite dependency constraint.
     minAgeGateExemptions: ['vue-component-meta', '@vue/language-core'],
     expected: {
       framework: '@storybook/vue3-vite',

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -604,9 +604,11 @@ export const baseTemplates = {
     name: 'Vue v3 (Vite | JavaScript)',
     script: 'npm create vite --yes {{beforeDir}} -- --template vue',
     // @storybook/vue3-vite depends on vue-component-meta@^3.3.9; that release is
-    // still inside the 7-day age gate and contains a fix we need. Written onto
+    // still inside the 7-day age gate and contains a fix we need.
+    // vue-component-meta pins @vue/language-core to the same version, so both
+    // must be allowlisted (Yarn's gate is per-package). Written onto
     // before-storybook and inherited by the after-storybook install.
-    minAgeGateExemptions: ['vue-component-meta'],
+    minAgeGateExemptions: ['vue-component-meta', '@vue/language-core'],
     expected: {
       framework: '@storybook/vue3-vite',
       renderer: '@storybook/vue3',
@@ -621,7 +623,7 @@ export const baseTemplates = {
     name: 'Vue v3 (Vite | TypeScript)',
     script: 'npm create vite --yes {{beforeDir}} -- --template vue-ts',
     // See vue3-vite/default-js — same @storybook/vue3-vite dependency constraint.
-    minAgeGateExemptions: ['vue-component-meta'],
+    minAgeGateExemptions: ['vue-component-meta', '@vue/language-core'],
     expected: {
       framework: '@storybook/vue3-vite',
       renderer: '@storybook/vue3',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Follow-up to #35770. Sandbox generation for `vue3-vite/default-js` and `vue3-vite/default-ts` still failed after that PR because Storybook init blocked `@vue/language-core@3.3.9` under the 7-day age gate.

`vue-component-meta@3.3.9` pins `@vue/language-core` to the same version, so Yarn's per-package gate needs both names on `minAgeGateExemptions`.

Seen in https://github.com/storybookjs/storybook/actions/runs/31008247758:

```
Failed package: @vue/language-core@3.3.9
```

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Merge this PR to `next`.
2. Re-run **Generate and publish sandboxes** from `next`.
3. Confirm `vue3-vite/default-js` and `vue3-vite/default-ts` get past Storybook init without `@vue/language-core` / `npmMinimalAgeGate` errors.
4. Confirm other templates are unchanged.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)