### PR TITLE
Build: Narrow only quarantined ranges when generating sandboxes

### DIFF
--- a/scripts/sandbox/generate.ts
+++ b/scripts/sandbox/generate.ts
@@ -341,10 +341,10 @@ const runGenerators = async (
           // template's original lockfile is already gone, but the consumer can
           // still install from package.json.
           //
-          // Prerelease templates (allowlist set): refreshBeforeStorybookLockfile
-          // refuses to widen ranges, because that would silently resolve stable.
-          // That failure must stay fatal here; soft-failing would ship a
-          // "prerelease" sandbox that no longer tracks a prerelease.
+          // Prerelease templates (allowlist set): a failure here means a package
+          // published in lockstep with the prerelease is still quarantined and
+          // needs adding to the allowlist. That must stay fatal; soft-failing
+          // would ship a "prerelease" sandbox that no longer tracks a prerelease.
           try {
             await refreshBeforeStorybookLockfile({
               cwd: createBeforeDir,

--- a/scripts/sandbox/utils/yarn.test.ts
+++ b/scripts/sandbox/utils/yarn.test.ts
@@ -161,8 +161,8 @@ describe('refreshBeforeStorybookLockfile', () => {
 
     await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
 
-    // A bare `yarn up @angular/build` resolves the `latest` dist-tag, which would
-    // move the Angular 21 template onto Angular 22 and stop it testing Angular 21.
+    // A bare `yarn up @angular/build` takes the newest gate-clearing release of any
+    // major, which would move this template onto Angular 22 and stop it testing 21.
     expect(yarnCommands()).toContain(`yarn up '@angular/build@^21.0.0' --mode=update-lockfile`);
   });
 

--- a/scripts/sandbox/utils/yarn.test.ts
+++ b/scripts/sandbox/utils/yarn.test.ts
@@ -6,9 +6,16 @@ import * as memfs from 'memfs';
 import { vol } from 'memfs';
 import yml from 'yaml';
 
-import { LOCALLY_PUBLISHED_PACKAGE_PATTERNS, preapproveLocallyPublishedPackages } from './yarn.ts';
+import { ROOT_DIRECTORY } from '../../utils/constants.ts';
+import { runCommand } from '../generate.ts';
+import {
+  LOCALLY_PUBLISHED_PACKAGE_PATTERNS,
+  preapproveLocallyPublishedPackages,
+  refreshBeforeStorybookLockfile,
+} from './yarn.ts';
 
 vi.mock('node:fs/promises', { spy: true });
+vi.mock('../generate.ts', () => ({ runCommand: vi.fn() }));
 
 const SANDBOX = resolve('sandbox');
 const CONFIG = `${SANDBOX}/.yarnrc.yml`;
@@ -20,6 +27,7 @@ beforeEach(async () => {
   const fsp = await import('node:fs/promises');
   vi.mocked(fsp.readFile).mockImplementation(memfs.fs.promises.readFile as never);
   vi.mocked(fsp.writeFile).mockImplementation(memfs.fs.promises.writeFile as never);
+  vi.mocked(fsp.rm).mockImplementation(memfs.fs.promises.rm as never);
   vol.mkdirSync(SANDBOX, { recursive: true });
 });
 
@@ -75,5 +83,129 @@ describe('preapproveLocallyPublishedPackages', () => {
     expect(LOCALLY_PUBLISHED_PACKAGE_PATTERNS).toEqual(
       expect.arrayContaining(['storybook', '@storybook/*', 'create-storybook'])
     );
+  });
+});
+
+describe('refreshBeforeStorybookLockfile', () => {
+  const MANIFEST = {
+    name: 'angular-latest',
+    dependencies: { '@angular/build': '^22.1.3', rxjs: '~7.8.0' },
+    devDependencies: { typescript: '~6.0.2' },
+  };
+
+  /** Yarn's age-gate rejection, verbatim, as it reaches us on the failed command's stdout. */
+  const quarantined = (descriptor: string) =>
+    Object.assign(new Error('yarn failed'), {
+      stdout: `➤ YN0016: │ ${descriptor}: All versions satisfying "x" are quarantined`,
+    });
+
+  const isResolveStep = (script: string) => /^yarn (install|up)\b/.test(script);
+
+  /** The `yarn install` / `yarn up` calls, in order, ignoring the `yarn config set` preamble. */
+  const yarnCommands = () =>
+    vi
+      .mocked(runCommand)
+      .mock.calls.map(([script]) => script)
+      .filter(isResolveStep);
+
+  /**
+   * Fail the first N resolve steps with the given errors and let everything else
+   * through, so a test can describe what Yarn reports without counting the
+   * `yarn config set` calls that precede it.
+   */
+  const failResolveSteps = (...errors: Error[]) => {
+    const queue = [...errors];
+    vi.mocked(runCommand).mockImplementation((async (script: string) => {
+      if (isResolveStep(script) && queue.length) {
+        throw queue.shift();
+      }
+      return { stdout: '' };
+    }) as never);
+  };
+
+  beforeEach(() => {
+    vol.writeFileSync(`${SANDBOX}/package.json`, JSON.stringify(MANIFEST));
+    // pinYarnPackageManager reads the monorepo root manifest.
+    vol.mkdirSync(ROOT_DIRECTORY, { recursive: true });
+    vol.writeFileSync(
+      `${ROOT_DIRECTORY}/package.json`,
+      JSON.stringify({ packageManager: 'yarn@4.18.0' })
+    );
+    failResolveSteps();
+  });
+
+  it('installs the template ranges as-is when nothing is quarantined', async () => {
+    await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
+
+    // No `yarn up` at all: every declared range still has an installable version.
+    expect(yarnCommands()).toEqual(['yarn install --mode=update-lockfile']);
+  });
+
+  it('upgrades only the quarantined package, leaving every other range alone', async () => {
+    failResolveSteps(quarantined('@angular/build@npm:^22.1.3'));
+
+    await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
+
+    // The regression this guards: `yarn up '*'` swept up `typescript: ~6.0.2` and
+    // rewrote it to `^7.0.2`, which Compodoc cannot parse.
+    expect(yarnCommands()).not.toContain(expect.stringContaining("'*'"));
+    expect(yarnCommands()).toContain(`yarn up '@angular/build@^22.0.0' --mode=update-lockfile`);
+  });
+
+  it('keeps a quarantined package inside the major the template pinned', async () => {
+    vol.writeFileSync(
+      `${SANDBOX}/package.json`,
+      JSON.stringify({ dependencies: { '@angular/build': '^21.2.19' } })
+    );
+    failResolveSteps(quarantined('@angular/build@npm:^21.2.19'));
+
+    await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
+
+    // A bare `yarn up @angular/build` resolves the `latest` dist-tag, which would
+    // move the Angular 21 template onto Angular 22 and stop it testing Angular 21.
+    expect(yarnCommands()).toContain(`yarn up '@angular/build@^21.0.0' --mode=update-lockfile`);
+  });
+
+  it('accumulates packages across rounds, because Yarn only reports the first', async () => {
+    failResolveSteps(quarantined('@angular/build@npm:^22.1.3'), quarantined('rxjs@npm:~7.8.0'));
+
+    await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
+
+    // Yarn re-resolves the whole project, so the second package has to be added to
+    // the first `yarn up` rather than upgraded on its own.
+    expect(yarnCommands()).toContain(
+      `yarn up '@angular/build@^22.0.0' 'rxjs@^7.0.0' --mode=update-lockfile`
+    );
+  });
+
+  it('refuses to narrow a prerelease pin down to a stable release', async () => {
+    vol.writeFileSync(
+      `${SANDBOX}/package.json`,
+      JSON.stringify({ dependencies: { next: '16.3.1-canary.3' } })
+    );
+    failResolveSteps(quarantined('next@npm:16.3.1-canary.3'));
+
+    // Every stable 16.x sorts above a 16.3.1 canary, so narrowing would drop a
+    // prerelease template onto stable. Exempting the package is the only fix.
+    await expect(refreshBeforeStorybookLockfile({ cwd: SANDBOX })).rejects.toThrow(
+      /minAgeGateExemptions/
+    );
+  });
+
+  it('surfaces a failure that is not the age gate instead of upgrading blindly', async () => {
+    const offline = Object.assign(new Error('yarn failed'), { stdout: 'ENOTFOUND registry' });
+    failResolveSteps(offline);
+
+    await expect(refreshBeforeStorybookLockfile({ cwd: SANDBOX })).rejects.toThrow(offline);
+    expect(yarnCommands()).not.toContain(expect.stringContaining('yarn up'));
+  });
+
+  it('gives up rather than leave the major when a whole major is quarantined', async () => {
+    // Yarn keeps naming the same package: nothing in `^22` is old enough either.
+    failResolveSteps(
+      ...Array.from({ length: 50 }, () => quarantined('@angular/build@npm:^22.1.3'))
+    );
+
+    await expect(refreshBeforeStorybookLockfile({ cwd: SANDBOX })).rejects.toThrow();
   });
 });

--- a/scripts/sandbox/utils/yarn.test.ts
+++ b/scripts/sandbox/utils/yarn.test.ts
@@ -101,18 +101,14 @@ describe('refreshBeforeStorybookLockfile', () => {
 
   const isResolveStep = (script: string) => /^yarn (install|up)\b/.test(script);
 
-  /** The `yarn install` / `yarn up` calls, in order, ignoring the `yarn config set` preamble. */
+  /** The resolve steps, ignoring the `yarn config set` preamble. */
   const yarnCommands = () =>
     vi
       .mocked(runCommand)
       .mock.calls.map(([script]) => script)
       .filter(isResolveStep);
 
-  /**
-   * Fail the first N resolve steps with the given errors and let everything else
-   * through, so a test can describe what Yarn reports without counting the
-   * `yarn config set` calls that precede it.
-   */
+  /** Fail the first N resolve steps, letting the `yarn config set` preamble through. */
   const failResolveSteps = (...errors: Error[]) => {
     const queue = [...errors];
     vi.mocked(runCommand).mockImplementation((async (script: string) => {
@@ -137,7 +133,6 @@ describe('refreshBeforeStorybookLockfile', () => {
   it('installs the template ranges as-is when nothing is quarantined', async () => {
     await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
 
-    // No `yarn up` at all: every declared range still has an installable version.
     expect(yarnCommands()).toEqual(['yarn install --mode=update-lockfile']);
   });
 
@@ -146,8 +141,7 @@ describe('refreshBeforeStorybookLockfile', () => {
 
     await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
 
-    // The regression this guards: `yarn up '*'` swept up `typescript: ~6.0.2` and
-    // rewrote it to `^7.0.2`, which Compodoc cannot parse.
+    // The regression: `yarn up '*'` swept up `typescript: ~6.0.2` into `^7.0.2`.
     expect(yarnCommands()).not.toContain(expect.stringContaining("'*'"));
     expect(yarnCommands()).toContain(`yarn up '@angular/build@^22.0.0' --mode=update-lockfile`);
   });
@@ -161,8 +155,7 @@ describe('refreshBeforeStorybookLockfile', () => {
 
     await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
 
-    // A bare `yarn up @angular/build` takes the newest gate-clearing release of any
-    // major, which would move this template onto Angular 22 and stop it testing 21.
+    // A bare `yarn up` would move this template to Angular 22 and stop it testing 21.
     expect(yarnCommands()).toContain(`yarn up '@angular/build@^21.0.0' --mode=update-lockfile`);
   });
 
@@ -171,8 +164,7 @@ describe('refreshBeforeStorybookLockfile', () => {
 
     await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
 
-    // Yarn re-resolves the whole project, so the second package has to be added to
-    // the first `yarn up` rather than upgraded on its own.
+    // Yarn re-resolves everything, so the second package joins the first `yarn up`.
     expect(yarnCommands()).toContain(
       `yarn up '@angular/build@^22.0.0' 'rxjs@^7.0.0' --mode=update-lockfile`
     );
@@ -185,8 +177,7 @@ describe('refreshBeforeStorybookLockfile', () => {
     );
     failResolveSteps(quarantined('next@npm:16.3.1-canary.3'));
 
-    // Every stable 16.x sorts above a 16.3.1 canary, so narrowing would drop a
-    // prerelease template onto stable. Exempting the package is the only fix.
+    // Every stable 16.x sorts above the canary, so narrowing would land on stable.
     await expect(refreshBeforeStorybookLockfile({ cwd: SANDBOX })).rejects.toThrow(
       /minAgeGateExemptions/
     );

--- a/scripts/sandbox/utils/yarn.ts
+++ b/scripts/sandbox/utils/yarn.ts
@@ -182,10 +182,11 @@ const NOT_A_DIRECT_DEPENDENCY = /doesn't match any packages referenced by any wo
  * The `yarn up` descriptor to move a quarantined package onto its newest installable
  * release without leaving the major the template asked for.
  *
- * A bare `yarn up typescript` resolves to the `latest` dist-tag, so a template pinned
- * to an older line would be silently upgraded off it. Re-anchoring the range at the
- * bottom of its own major keeps the pin: `~5.9.2` stays on 5.x, `^22.1.3` on 22.x.
- * Caret ranges treat a `0.x` major as breaking, so those keep their minor too.
+ * A bare `yarn up typescript` takes the newest release that clears the gate, from the
+ * whole version list rather than the declared range, so a template pinned to an older
+ * line would be silently upgraded off it. Re-anchoring the range at the bottom of its
+ * own major keeps the pin: `~5.9.2` stays on 5.x, `^22.1.3` on 22.x. Caret ranges treat
+ * a `0.x` major as breaking, so those keep their minor too.
  *
  * Ranges semver cannot read (`latest`, `workspace:*`, git URLs) fall back to the bare
  * name — they carry no major to preserve.
@@ -227,10 +228,10 @@ const MAX_NARROWING_ROUNDS = 25;
  * A range like `@angular/build@^22.1.3` has no installable version when its only
  * matching release is younger than the gate, and `yarn install` then fails outright.
  * `yarn up` is the escape hatch, but it is documented as the counterpart to
- * `yarn upgrade --latest`: it *ignores* the declared range and jumps every package
- * it is given to the newest allowed release. Passing it `'*'` therefore rewrites the
- * whole manifest — that is what turned the Angular sandbox's `typescript: ~6.0.2`
- * into `^7.0.2`, which Compodoc (bundling TypeScript 6) cannot parse.
+ * `yarn upgrade --latest`: it *ignores* the declared range and jumps every package it
+ * is given to that package's newest gate-clearing release. Passing it `'*'` therefore
+ * rewrites the whole manifest — that is what turned the Angular sandbox's
+ * `typescript: ~6.0.2` into `^7.0.2`, which Compodoc (bundling TypeScript 6) cannot parse.
  *
  * So hand `yarn up` only the packages Yarn itself reported as quarantined. Everything
  * the template pinned deliberately keeps its range, and prerelease templates keep

--- a/scripts/sandbox/utils/yarn.ts
+++ b/scripts/sandbox/utils/yarn.ts
@@ -162,34 +162,24 @@ export async function refreshBeforeStorybookLockfile({
   await narrowQuarantinedRanges({ cwd, env, debug });
 }
 
-/**
- * Yarn's age-gate rejection, e.g.
- * `➤ YN0016: │ @angular/build@npm:^22.1.3: All versions satisfying "^22.1.3" are quarantined`.
- *
- * Yarn aborts resolution at the first such range, so one run reports one package.
- */
+/** `YN0016: @angular/build@npm:^22.1.3: All versions satisfying "^22.1.3" are quarantined` */
 const QUARANTINED_RANGE = /YN0016:.*?(\S+)@npm:.*?are quarantined/g;
 
-/** Package names Yarn reported as having no installable version under the age gate. */
 function parseQuarantinedPackages(output: string): string[] {
   return [...output.matchAll(QUARANTINED_RANGE)].map(([, name]) => name);
 }
 
-/** Yarn's own wording when `yarn up` is handed a package the manifest does not declare. */
+/** Yarn's wording when `yarn up` is handed a package the manifest does not declare. */
 const NOT_A_DIRECT_DEPENDENCY = /doesn't match any packages referenced by any workspace/;
 
 /**
- * The `yarn up` descriptor to move a quarantined package onto its newest installable
+ * The `yarn up` descriptor that moves a quarantined package onto its newest installable
  * release without leaving the major the template asked for.
  *
- * A bare `yarn up typescript` takes the newest release that clears the gate, from the
- * whole version list rather than the declared range, so a template pinned to an older
- * line would be silently upgraded off it. Re-anchoring the range at the bottom of its
- * own major keeps the pin: `~5.9.2` stays on 5.x, `^22.1.3` on 22.x. Caret ranges treat
- * a `0.x` major as breaking, so those keep their minor too.
- *
- * Ranges semver cannot read (`latest`, `workspace:*`, git URLs) fall back to the bare
- * name — they carry no major to preserve.
+ * A bare `yarn up typescript` ignores the declared range and takes the newest release of
+ * any major. Passing an explicit range bounds it instead, and the gate then picks the
+ * newest allowed version inside that range. Unparseable ranges (`latest`, `workspace:*`)
+ * carry no major to preserve, so they fall back to the bare name.
  */
 function narrowingDescriptor(name: string, range: string | undefined): string {
   const floor = range && semver.validRange(range) ? semver.minVersion(range) : null;
@@ -197,46 +187,38 @@ function narrowingDescriptor(name: string, range: string | undefined): string {
     return name;
   }
 
-  // A prerelease pin is the one range narrowing cannot repair: every stable release
-  // in the major sorts above it, so `^16.0.0` would quietly resolve a `canary`
-  // template onto stable. Exempting the package is the only correct answer.
+  // Every stable release in the major sorts above a prerelease, so no range can admit
+  // newer canaries without also admitting stable.
   if (semver.prerelease(floor)) {
     throw new Error(
       `${name}@${range} is quarantined by the ${BEFORE_SANDBOX_MIN_AGE_MINUTES}min age gate, and narrowing a prerelease range would resolve it to a stable release. Add ${name} to the template's minAgeGateExemptions.`
     );
   }
 
+  // Caret treats a 0.x major as breaking, so those keep their minor.
   return floor.major === 0 ? `${name}@^0.${floor.minor}.0` : `${name}@^${floor.major}.0.0`;
 }
 
-/** The range a manifest declares for a package, across the fields `yarn up` rewrites. */
 async function declaredRange(cwd: string, name: string): Promise<string | undefined> {
   const manifest = JSON.parse(await readFile(join(cwd, 'package.json'), 'utf-8'));
   return manifest.dependencies?.[name] ?? manifest.devDependencies?.[name];
 }
 
-/**
- * Yarn re-resolves the whole project on every attempt and stops at the first
- * offender, so each round can only reveal one more. Angular scaffolds eleven
- * lockstep-published packages, which is the widest case in the template set.
- */
+/** Angular, the widest template, needs 12. The rest is headroom. */
 const MAX_NARROWING_ROUNDS = 25;
 
 /**
  * Resolve a lockfile under the age gate, rewriting as few manifest ranges as possible.
  *
- * A range like `@angular/build@^22.1.3` has no installable version when its only
- * matching release is younger than the gate, and `yarn install` then fails outright.
- * `yarn up` is the escape hatch, but it is documented as the counterpart to
- * `yarn upgrade --latest`: it *ignores* the declared range and jumps every package it
- * is given to that package's newest gate-clearing release. Passing it `'*'` therefore
- * rewrites the whole manifest — that is what turned the Angular sandbox's
- * `typescript: ~6.0.2` into `^7.0.2`, which Compodoc (bundling TypeScript 6) cannot parse.
+ * A range whose every matching release is younger than the gate has nothing installable,
+ * and `yarn install` fails outright. `yarn up` is the escape hatch, but it rewrites the
+ * ranges of whatever it is given, so `yarn up '*'` rewrites the whole manifest — that is
+ * what turned the Angular sandbox's `typescript: ~6.0.2` into `^7.0.2`, which Compodoc
+ * (bundling TypeScript 6) cannot parse.
  *
- * So hand `yarn up` only the packages Yarn itself reported as quarantined. Everything
- * the template pinned deliberately keeps its range, and prerelease templates keep
- * tracking their prerelease: an exempted package is never quarantined, so it is never
- * passed to `yarn up` and never resolved to its stable `latest`.
+ * Yarn reports one offending range per run and re-resolves the whole project on each
+ * attempt, so the only way to fix them is to accumulate the names it reports and pass the
+ * growing set to a single `yarn up`.
  */
 async function narrowQuarantinedRanges({
   cwd,
@@ -257,8 +239,8 @@ async function narrowQuarantinedRanges({
       : `yarn install --mode=update-lockfile`;
 
     try {
-      // Capture rather than stream even under `debug`: the age-gate rejection is
-      // only readable off the failed command's stdout.
+      // Capture rather than stream even under `debug`: the rejection is only readable
+      // off the failed command's stdout.
       const { stdout } = await runCommand(command, { cwd, env, stdout: 'pipe' }, debug);
       if (debug) {
         console.log(stdout);
@@ -278,10 +260,8 @@ async function narrowQuarantinedRanges({
 
       const fresh = parseQuarantinedPackages(output).filter((name) => !quarantined.includes(name));
 
-      // Either the failure has nothing to do with the age gate, or the package is
-      // still quarantined across its whole major. Both need a human: the remaining
-      // escape is to exempt it, and picking that for them would either hide a real
-      // resolution error or upgrade the template off the version it exists to test.
+      // Either not an age-gate failure at all, or a package still quarantined across its
+      // whole major. Widening further would leave the major, so let a human decide.
       if (!fresh.length) {
         throw error;
       }
@@ -309,8 +289,7 @@ async function narrowQuarantinedRanges({
     `⚠️ narrowed ${descriptors.length} range(s) with no release older than the ${BEFORE_SANDBOX_MIN_AGE_MINUTES}min age gate: ${descriptors.join(', ')}`
   );
 
-  // `yarn up` leaves the lockfile resolved, but run the install once more so the
-  // committed lockfile is always the product of a plain `yarn install`.
+  // So the committed lockfile is always the product of a plain `yarn install`.
   await runCommand(`yarn install --mode=update-lockfile`, { cwd, env }, debug);
 }
 

--- a/scripts/sandbox/utils/yarn.ts
+++ b/scripts/sandbox/utils/yarn.ts
@@ -2,6 +2,7 @@ import { readFile, rename, rm, writeFile } from 'node:fs/promises';
 
 import { join } from 'path';
 
+import semver from 'semver';
 import yml from 'yaml';
 
 import { STORYBOOK_PACKAGE_PATTERNS } from '../../../code/core/src/common/js-package-manager/util.ts';
@@ -91,9 +92,8 @@ interface RefreshLockfileOptions {
  *    resolves it deterministically (no network `yarn set version`).
  * 3. Set `npmMinimalAgeGate` to 7 days so resolution skips quarantined versions,
  *    plus any per-template `npmPreapprovedPackages` allowlist.
- * 4. Run `yarn install --mode=update-lockfile`, falling back to `yarn up '*'`
- *    plus a retry only when the template's own ranges cannot resolve under the
- *    gate. Installing first keeps deliberately pinned majors intact.
+ * 4. Run `yarn install --mode=update-lockfile`, narrowing only the ranges that
+ *    the gate leaves with no installable version (see `narrowQuarantinedRanges`).
  *
  * `YARN_ENABLE_IMMUTABLE_INSTALLS=false` is set via env (not `.yarnrc.yml`) so
  * the consumer-facing config stays clean.
@@ -159,52 +159,157 @@ export async function refreshBeforeStorybookLockfile({
     );
   }
 
-  // Resolve the template's own ranges first. This is the path almost every
-  // template takes, and it is the only one that preserves deliberately pinned
-  // majors: `nextjs/14-ts`, `react-webpack/17-ts`, `ember/3-js` and friends
-  // exist to exercise an old framework version, and `yarn up '*'` would rewrite
-  // those ranges to latest and silently turn them into duplicates of the
-  // `default` templates.
-  try {
-    await runCommand(`yarn install --mode=update-lockfile`, { cwd, env }, debug);
-    return;
-  } catch (error) {
-    if (debug) {
-      console.warn(error);
-    }
+  await narrowQuarantinedRanges({ cwd, env, debug });
+}
 
-    // Widening would move a prerelease template onto the stable release, which
-    // is the one outcome it must never produce. Warn if the minageGateExemptions list is incomplete
-    if (minAgeGateExemptions?.length) {
-      console.warn(
-        `Install failed under the age gate and the allowlist (${minAgeGateExemptions.join(
-          ', '
-        )}) does not cover every quarantined package. Add the missing ones rather than widening, which would drop this template to the stable release.`,
-        { cause: error }
+/**
+ * Yarn's age-gate rejection, e.g.
+ * `➤ YN0016: │ @angular/build@npm:^22.1.3: All versions satisfying "^22.1.3" are quarantined`.
+ *
+ * Yarn aborts resolution at the first such range, so one run reports one package.
+ */
+const QUARANTINED_RANGE = /YN0016:.*?(\S+)@npm:.*?are quarantined/g;
+
+/** Package names Yarn reported as having no installable version under the age gate. */
+function parseQuarantinedPackages(output: string): string[] {
+  return [...output.matchAll(QUARANTINED_RANGE)].map(([, name]) => name);
+}
+
+/** Yarn's own wording when `yarn up` is handed a package the manifest does not declare. */
+const NOT_A_DIRECT_DEPENDENCY = /doesn't match any packages referenced by any workspace/;
+
+/**
+ * The `yarn up` descriptor to move a quarantined package onto its newest installable
+ * release without leaving the major the template asked for.
+ *
+ * A bare `yarn up typescript` resolves to the `latest` dist-tag, so a template pinned
+ * to an older line would be silently upgraded off it. Re-anchoring the range at the
+ * bottom of its own major keeps the pin: `~5.9.2` stays on 5.x, `^22.1.3` on 22.x.
+ * Caret ranges treat a `0.x` major as breaking, so those keep their minor too.
+ *
+ * Ranges semver cannot read (`latest`, `workspace:*`, git URLs) fall back to the bare
+ * name — they carry no major to preserve.
+ */
+function narrowingDescriptor(name: string, range: string | undefined): string {
+  const floor = range && semver.validRange(range) ? semver.minVersion(range) : null;
+  if (!floor) {
+    return name;
+  }
+
+  // A prerelease pin is the one range narrowing cannot repair: every stable release
+  // in the major sorts above it, so `^16.0.0` would quietly resolve a `canary`
+  // template onto stable. Exempting the package is the only correct answer.
+  if (semver.prerelease(floor)) {
+    throw new Error(
+      `${name}@${range} is quarantined by the ${BEFORE_SANDBOX_MIN_AGE_MINUTES}min age gate, and narrowing a prerelease range would resolve it to a stable release. Add ${name} to the template's minAgeGateExemptions.`
+    );
+  }
+
+  return floor.major === 0 ? `${name}@^0.${floor.minor}.0` : `${name}@^${floor.major}.0.0`;
+}
+
+/** The range a manifest declares for a package, across the fields `yarn up` rewrites. */
+async function declaredRange(cwd: string, name: string): Promise<string | undefined> {
+  const manifest = JSON.parse(await readFile(join(cwd, 'package.json'), 'utf-8'));
+  return manifest.dependencies?.[name] ?? manifest.devDependencies?.[name];
+}
+
+/**
+ * Yarn re-resolves the whole project on every attempt and stops at the first
+ * offender, so each round can only reveal one more. Angular scaffolds eleven
+ * lockstep-published packages, which is the widest case in the template set.
+ */
+const MAX_NARROWING_ROUNDS = 25;
+
+/**
+ * Resolve a lockfile under the age gate, rewriting as few manifest ranges as possible.
+ *
+ * A range like `@angular/build@^22.1.3` has no installable version when its only
+ * matching release is younger than the gate, and `yarn install` then fails outright.
+ * `yarn up` is the escape hatch, but it is documented as the counterpart to
+ * `yarn upgrade --latest`: it *ignores* the declared range and jumps every package
+ * it is given to the newest allowed release. Passing it `'*'` therefore rewrites the
+ * whole manifest — that is what turned the Angular sandbox's `typescript: ~6.0.2`
+ * into `^7.0.2`, which Compodoc (bundling TypeScript 6) cannot parse.
+ *
+ * So hand `yarn up` only the packages Yarn itself reported as quarantined. Everything
+ * the template pinned deliberately keeps its range, and prerelease templates keep
+ * tracking their prerelease: an exempted package is never quarantined, so it is never
+ * passed to `yarn up` and never resolved to its stable `latest`.
+ */
+async function narrowQuarantinedRanges({
+  cwd,
+  env,
+  debug,
+}: {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  debug?: boolean;
+}) {
+  const quarantined: string[] = [];
+  const descriptors: string[] = [];
+  let resolved = false;
+
+  for (let round = 0; round <= MAX_NARROWING_ROUNDS && !resolved; round++) {
+    const command = descriptors.length
+      ? `yarn up ${descriptors.map((descriptor) => `'${descriptor}'`).join(' ')} --mode=update-lockfile`
+      : `yarn install --mode=update-lockfile`;
+
+    try {
+      // Capture rather than stream even under `debug`: the age-gate rejection is
+      // only readable off the failed command's stdout.
+      const { stdout } = await runCommand(command, { cwd, env, stdout: 'pipe' }, debug);
+      if (debug) {
+        console.log(stdout);
+      }
+      resolved = true;
+    } catch (error) {
+      const output = `${(error as { stdout?: string }).stdout ?? ''}\n${
+        (error as { stderr?: string }).stderr ?? ''
+      }`;
+
+      if (NOT_A_DIRECT_DEPENDENCY.test(output)) {
+        throw new Error(
+          `A transitively required package is quarantined by the ${BEFORE_SANDBOX_MIN_AGE_MINUTES}min age gate, and only its parent can move off it. Add it to the template's minAgeGateExemptions if it is trusted.`,
+          { cause: error }
+        );
+      }
+
+      const fresh = parseQuarantinedPackages(output).filter((name) => !quarantined.includes(name));
+
+      // Either the failure has nothing to do with the age gate, or the package is
+      // still quarantined across its whole major. Both need a human: the remaining
+      // escape is to exempt it, and picking that for them would either hide a real
+      // resolution error or upgrade the template off the version it exists to test.
+      if (!fresh.length) {
+        throw error;
+      }
+
+      quarantined.push(...fresh);
+      descriptors.push(
+        ...(await Promise.all(
+          fresh.map(async (name) => narrowingDescriptor(name, await declaredRange(cwd, name)))
+        ))
       );
     }
   }
 
-  // The install only fails here when the template's CLI pinned a version that
-  // is itself inside the age-gate window (`ng new` → `@angular/build@^21.x`),
-  // leaving the range with no resolvable candidates. Widening is the last
-  // resort, and it is safe for these templates precisely because they track
-  // latest anyway.
-  console.warn(
-    `⚠️ install failed under the ${BEFORE_SANDBOX_MIN_AGE_MINUTES}min age gate; widening ranges via yarn up`
-  );
-
-  // `yarn up '*'` errors when the project has no direct dependencies
-  // (`internal/server-webpack5` is just `yarn init -y`) — non-fatal.
-  try {
-    await runCommand(`yarn up '*' --mode=update-lockfile`, { cwd, env }, debug);
-  } catch (error) {
-    console.warn(`⚠️ yarn up '*' skipped (likely no upgradeable dependencies).`);
-    if (debug) {
-      console.warn(error);
-    }
+  if (!resolved) {
+    throw new Error(
+      `Still hitting the ${BEFORE_SANDBOX_MIN_AGE_MINUTES}min age gate after ${MAX_NARROWING_ROUNDS} rounds of narrowing (${quarantined.join(', ')}).`
+    );
   }
 
+  if (!descriptors.length) {
+    return;
+  }
+
+  console.warn(
+    `⚠️ narrowed ${descriptors.length} range(s) with no release older than the ${BEFORE_SANDBOX_MIN_AGE_MINUTES}min age gate: ${descriptors.join(', ')}`
+  );
+
+  // `yarn up` leaves the lockfile resolved, but run the install once more so the
+  // committed lockfile is always the product of a plain `yarn install`.
   await runCommand(`yarn install --mode=update-lockfile`, { cwd, env }, debug);
 }
 


### PR DESCRIPTION
## What I did

We generate sandboxes with a 7 day npm minimum age gate now, so a package published within the last week never ends up in a sandbox. When a declared range has no release old enough to clear that gate, the install cannot resolve at all, and our recovery path upgraded *every* dependency of the template to its newest allowed version.

That recovery is pretty much the broadest thing we could have done. `yarn up` ignores the ranges in your manifest per default, it is basically the counterpart to `yarn upgrade --latest`. So one single blocked package rewrote the whole manifest, 154 files in the last publish:

- The Angular sandboxes moved from TypeScript 6 to TypeScript 7. Compodoc bundles TypeScript 6 and crashes when it parses a TS 7 project, which is exactly why the Angular sandbox builds are red right now.
- The Angular 21 template got upgraded to Angular 22, so its dependencies are identical to the Angular 22 template. It has not been testing Angular 21 since that run.
- In a bunch of other templates exact pins were loosened to ranges and tilde ranges became carets.

**Solution:** only narrow the ranges that Yarn actually reports as quarantined, and hand `yarn up` an explicit range anchored at the major the template already declared. Yarn respects a range you give it, so it then picks the newest allowed version *inside* that range, and every other dependency keeps whatever its own scaffolder generated. Regenerating the Angular sandbox now keeps TypeScript on 6 and only moves the Angular packages, which is the minimum needed to get a resolvable lockfile.

Two cases fail loudly now instead of quietly publishing a wrong sandbox: a package pinned to a prerelease (every stable release sorts above it, so any narrowing would land on stable) and a package that only its parent can move off. Both are solved by adding the package to that template's age gate exemption list.

Worth knowing: the currently published sandboxes are already mangled, so they need a regeneration once this lands. The failing tanstack jobs are unrelated to this PR, though, that one is an upstream `@tanstack/react-router` release and I am handling it separately.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Check what we publish today, it has `"typescript": "^7.0.2"`:
   `curl -s https://raw.githubusercontent.com/storybookjs/sandboxes/next/angular-vite/default-ts/before-storybook/package.json`
2. Regenerate the same template with this branch checked out:
   `cd code && yarn generate-sandboxes --templates angular-vite/default-ts --debug`
3. Open `repros/angular-vite-default-ts/before-storybook/package.json` and compare:
   - `typescript` stays on `~6.x`, it must not be `^7`
   - `@types/node` stays on `^20.x`
   - `express`, `rxjs`, `tslib` and `prettier` keep the ranges from step 1's pre-gate state
   - only the `@angular/*` entries moved, and they stay inside `^22`
4. The log prints which ranges were touched, so you can check the blast radius directly:
   `⚠️ narrowed 11 range(s) with no release older than the 10080min age gate: @angular/build@^22.0.0, ...`
5. To confirm the deliberate old pins survive, regenerate `angular-vite/21-ts` as well and verify it is still on Angular 21.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

This only touches our own sandbox generation tooling, so there is no user facing surface to document.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
