### PR TITLE
Angular: Stop treating input/output alias collisions as two-way bindings

### DIFF
--- a/code/frameworks/angular-vite/src/client/docs/__testfixtures__/doc-model/input.ts
+++ b/code/frameworks/angular-vite/src/client/docs/__testfixtures__/doc-model/input.ts
@@ -7,7 +7,7 @@ import { Component, model } from '@angular/core';
  * A component exercising Angular's `model()` two-way binding signal.
  *
  * compodoc emits a `model()` member as an identical entry in BOTH `inputsClass` and
- * `outputsClass` (see `.omc/plans/probe-fixtures/compodoc-model-probe-documentation.json`).
+ * `outputsClass`; the committed `compodoc-input.json` next to this file is that capture.
  */
 @Component({ selector: 'cp', template: '' })
 export class ColorPickerComponent {

--- a/code/frameworks/angular/src/client/docs/__testfixtures__/doc-model/input.ts
+++ b/code/frameworks/angular/src/client/docs/__testfixtures__/doc-model/input.ts
@@ -7,7 +7,7 @@ import { Component, model } from '@angular/core';
  * A component exercising Angular's `model()` two-way binding signal.
  *
  * compodoc emits a `model()` member as an identical entry in BOTH `inputsClass` and
- * `outputsClass` (see `.omc/plans/probe-fixtures/compodoc-model-probe-documentation.json`).
+ * `outputsClass`; the committed `compodoc-input.json` next to this file is that capture.
  */
 @Component({ selector: 'cp', template: '' })
 export class ColorPickerComponent {

--- a/code/lib/angular-compodoc/README.md
+++ b/code/lib/angular-compodoc/README.md
@@ -7,4 +7,20 @@ Shared parsing of [Compodoc](https://compodoc.app/)'s `documentation.json` into 
 - The root entry is environment-agnostic: it reads no globals and takes the Compodoc JSON, the feature flag, the logger and the HTML unwrapper as arguments, so it runs in a Node worker as well as in the preview.
 - `./browser` is the preview-side adapter that supplies those four things from the browser globals.
 
+## Compodoc quirk: `model()` is reported twice, under the wrong name
+
+Angular's `model()` is one property that is both an input `foo` and an output `fooChange`.
+Compodoc lists it in `inputsClass` and `outputsClass`, both times under the bare name `foo`, and never emits `fooChange`.
+Left alone that renders a real two-way binding as an input plus an output the component does not have, so this package drops the bare-name output duplicate and synthesizes `fooChange` itself.
+
+There is no `model()` marker in the JSON, so detection is structural: the same name in both arrays, on the same declaration line.
+The name alone is not enough, because an `@Input('shared')` next to an `@Output('shared')` collides identically with no `model()` involved, and reading that as two-way deletes a real output and invents a `sharedChange` that does not exist.
+Being structural is also why the rule is not pinned to a Compodoc version: if Compodoc is ever fixed the two entries stop coinciding, the rule matches nothing, and this package stops synthesizing, which is correct, because a fixed Compodoc emits `fooChange` itself.
+
+Known limitations:
+
+- Two aliased members that collide on a name and also share a physical source line still read as a `model()`.
+- An alias collision keeps the real output but costs the input its row, because argTypes is keyed by binding name and the outputs section is written last. That is the better half to keep: the output is the member the component really declares.
+- A capture with no line numbers is never treated as two-way, so a genuine `model()` surfaces as Compodoc reported it, as a single bare-name entry in the outputs section with no synthesized `fooChange`.
+
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/angular-compodoc/src/compodoc-types.ts
+++ b/code/lib/angular-compodoc/src/compodoc-types.ts
@@ -38,6 +38,11 @@ export interface Property {
    */
   required?: boolean;
   defaultValue?: string;
+  /**
+   * 1-based line the member is declared on. Compodoc emits it for every member, but a hand-written
+   * or truncated capture may not.
+   */
+  line?: number;
   description?: Html;
   rawdescription?: string;
   jsdoctags?: JsDocTag[];

--- a/code/lib/angular-compodoc/src/extract-arg-types.test.ts
+++ b/code/lib/angular-compodoc/src/extract-arg-types.test.ts
@@ -73,6 +73,58 @@ describe('extractArgTypesFromData', () => {
   });
 });
 
+describe('model() two-way bindings', () => {
+  const extractFrom = (members: {
+    inputsClass: Record<string, unknown>[];
+    outputsClass: Record<string, unknown>[];
+  }) =>
+    extractArgTypesFromData(
+      {
+        name: 'PickerComponent',
+        type: 'component',
+        propertiesClass: [],
+        methodsClass: [],
+        ...members,
+      } as never,
+      {
+        compodocJson: jsonWith({} as never),
+        filterNonInputControls: false,
+        logger,
+        unwrapHtml: htmlToText,
+      }
+    );
+
+  it('records a model() once, as an input plus the synthesized change output', () => {
+    // Compodoc pushes one `model()` into both arrays from a single source object, so both entries
+    // describe the same declaration on the same line.
+    const value = { name: 'value', type: 'string', optional: false, line: 9 };
+
+    const argTypes = extractFrom({ inputsClass: [value], outputsClass: [{ ...value }] });
+
+    expect(Object.keys(argTypes)).toEqual(['value', 'valueChange']);
+    expect(argTypes.value.table?.category).toBe('inputs');
+    // Compodoc's bare-name output duplicate is suppressed, so the input is not turned into one.
+    expect(argTypes.value.action).toBeUndefined();
+    expect(argTypes.valueChange).toMatchObject({
+      action: 'valueChange',
+      table: { category: 'outputs' },
+    });
+  });
+
+  it('keeps the real output for an alias collision instead of reading it as a model()', () => {
+    // `@Input('shared')` next to `@Output('shared')` puts one name in both arrays with no `model()`
+    // anywhere. argTypes is keyed by binding name, so only one of the pair can have a row: the
+    // output the component really declares, rather than a synthesized `sharedChange` it does not.
+    const argTypes = extractFrom({
+      inputsClass: [{ name: 'shared', type: 'string', optional: false, line: 9 }],
+      outputsClass: [{ name: 'shared', type: 'EventEmitter<string>', optional: false, line: 11 }],
+    });
+
+    expect(Object.keys(argTypes)).toEqual(['shared']);
+    expect(argTypes.shared).toMatchObject({ action: 'shared', table: { category: 'outputs' } });
+  });
+});
+
 describe('required', () => {
   /** Extracts a single input declared with the given pair of Compodoc flags. */
   const requiredOf = (flags: { optional?: boolean; required?: boolean }) => {

--- a/code/lib/angular-compodoc/src/extract-arg-types.ts
+++ b/code/lib/angular-compodoc/src/extract-arg-types.ts
@@ -329,6 +329,21 @@ const readMembers = (componentData: CompodocEntry, key: string): (Method | Prope
     | (Method | Property)[]
     | undefined) || [];
 
+/**
+ * The `model()` members of a Compodoc entry: an output whose same-named input is declared on the
+ * same line. Compodoc marks a `model()` in no other way, and an `@Input('x')`/`@Output('x')` alias
+ * collision shares the name but not the line. The package README has the quirk in full.
+ */
+const getModelProperties = (componentData: CompodocEntry): Property[] => {
+  const inputsByName = new Map(
+    (readMembers(componentData, 'inputsClass') as Property[]).map((item) => [item.name, item])
+  );
+  return (readMembers(componentData, 'outputsClass') as Property[]).filter((item) => {
+    const input = inputsByName.get(item.name);
+    return input?.line !== undefined && input.line === item.line;
+  });
+};
+
 export const extractArgTypesFromData = (
   componentData: CompodocEntry,
   { compodocJson, filterNonInputControls, logger = NOOP_LOGGER, unwrapHtml }: ExtractArgTypesOptions
@@ -343,16 +358,7 @@ export const extractArgTypesFromData = (
     ? componentClasses
     : ['properties', 'methods'];
 
-  // Detect Angular `model()` signals. compodoc emits no `model()` marker: a
-  // `model()` lands under the same bare name in BOTH `inputsClass` and
-  // `outputsClass`, whereas plain inputs/outputs land in only one. A name in
-  // both arrays is the only version-tolerant discriminator.
-  const inputClassNames = new Set<string>(
-    readMembers(componentData, 'inputsClass').map((item) => item.name)
-  );
-  const modelProperties = readMembers(componentData, 'outputsClass').filter((item) =>
-    inputClassNames.has(item.name)
-  ) as Property[];
+  const modelProperties = getModelProperties(componentData);
   const modelPropertyNames = new Set<string>(modelProperties.map((item) => item.name));
 
   compodocClasses.forEach((key: CompodocMemberKey) => {

--- a/code/lib/docgen-harness/README.md
+++ b/code/lib/docgen-harness/README.md
@@ -45,7 +45,9 @@ src/
 ├── angular/
 │   ├── angular-baselines.test.ts
 │   ├── angular-legacy-gaps.test.ts
+│   ├── angular-provider-seam.test.ts
 │   ├── angular-render.test.ts
+│   ├── compodoc-parsing-parity.test.ts
 │   ├── csf-types.ts
 │   └── __testfixtures__/<case>/  # component, stories, compodoc-input.json, aot-cmp.ts (signal cases),
 │                                 # argtypes.snapshot, argtypes-filtered.snapshot, snippet-<story>.snapshot
@@ -160,7 +162,7 @@ Each has a red marker in `vue3-legacy-gaps.test.ts`.
 - Literal unions, alias unions, and TS enums all resolve to enum sbTypes at compodoc 2.0.0 - the #33779 collapse does not reproduce at this version.
 - Cross-file inheritance is fully resolved (a regression baseline, not a gap).
 - With `angularFilterNonInputControls` off, `properties`/`methods`/`view child` sections surface as argTypes, including private fields (#22007); on restricts to inputs.
-- `model()` records one input plus a synthesized `${name}Change` output.
+- `model()` records one input plus a synthesized `${name}Change` output; the compodoc quirk behind that is written up in `code/lib/angular-compodoc/README.md`.
 - Snippets use only the first comma-separated selector; attribute selectors are mangled to bare attributes.
 
 ## Issue-linked cases (angular)


### PR DESCRIPTION
Closes #

## What I did

Angular lets you alias an input and an output to the same name. Storybook was reading any such pair as a two-way binding, which deleted the component's real output and invented one that does not exist. This is the default Angular path, so nobody had to opt into anything to hit it.

A component with `@Input('shared')` next to `@Output('shared')`, extracted on `next` and then with this PR:

```
# on next
AliasCollisionComponent props table
  shared         inputs
  sharedChange   outputs

# with this PR
AliasCollisionComponent props table
  shared         outputs
```

Storybook gets Angular metadata from Compodoc, which has no marker for a two-way `model()` binding: it reports that one property under the same bare name in both its input list and its output list, and never emits the change output Angular actually creates. Storybook compensated by treating any name in both lists as two-way. An aliased pair looks identical from the outside, though, so it got the same treatment.

The fix is to require the two entries to be declared on the same source line as well:

```diff
-  const inputClassNames = new Set<string>(
-    readMembers(componentData, 'inputsClass').map((item) => item.name)
-  );
-  const modelProperties = readMembers(componentData, 'outputsClass').filter((item) =>
-    inputClassNames.has(item.name)
-  ) as Property[];
+  const inputsByName = new Map(
+    (readMembers(componentData, 'inputsClass') as Property[]).map((item) => [item.name, item])
+  );
+  return (readMembers(componentData, 'outputsClass') as Property[]).filter((item) => {
+    const input = inputsByName.get(item.name);
+    return input?.line !== undefined && input.line === item.line;
+  });
```

A `model()` is one property on one line, so both of its entries share it. An alias collision is two properties on two.

| Compodoc reports one name | read as | props table shows |
| --- | --- | --- |
| in both lists, same line | two-way `model()` | the input, plus a synthesized `Change` output |
| in both lists, different lines | two separate members | the real output |

Two things worth knowing. Two aliased members that collide on a name *and* share a source line still read as two-way. And as the capture above shows, a collision now costs the aliased input its row rather than its output, since the table is keyed by name and outputs are written last. I would rather keep the output, as that is the member the component really declares, but only one of the pair can ever be shown.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No experimental flag is needed; this is the path Angular users are on by default.

1. Generate an Angular sandbox: `yarn task --task sandbox --start-from auto --template angular-vite/default-ts`
2. Add this component next to the sandbox's generated example stories, plus a story whose meta sets `component: CollisionComponent` and `tags: ['autodocs']` so it gets a Docs page:
   ```ts
   import { Component, EventEmitter, Input, Output, model } from '@angular/core';

   @Component({ selector: 'app-collision', template: '' })
   export class CollisionComponent {
     value = model<string>('');

     @Input('shared') inputSide?: string;
     @Output('shared') outputSide = new EventEmitter<string>();
   }
   ```
3. Start Storybook from the sandbox with `yarn storybook`, which regenerates Compodoc's metadata so the new component is in it, and open that component's Docs page
4. The props table should list `shared` once, under outputs, and no `sharedChange` anywhere. On `next` you get `shared` under inputs instead, plus a `sharedChange` output the component does not have
5. Confirm the two-way binding is unaffected: `value` appears once as an input, with exactly one `valueChange` output

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
