### PR TITLE
Angular Vite: Resolve tsConfig against the workspace root

### DIFF
--- a/code/frameworks/angular-vite/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular-vite/src/builders/build-storybook/index.ts
@@ -29,7 +29,7 @@ import * as pkg from 'empathic/package';
 import { errorSummary, printErrorDetails } from '../utils/error-handler.ts';
 import type { StandaloneOptions } from '../utils/standalone-options.ts';
 import { Channel } from 'storybook/internal/channels';
-import { findTsconfigUp } from '../../find-tsconfig.ts';
+import { resolveTsconfig } from '../../find-tsconfig.ts';
 
 addToGlobalContext('cliVersion', versions.storybook);
 
@@ -172,7 +172,12 @@ async function setup(options: StorybookBuilderOptions, context: BuilderContext) 
   }
 
   return {
-    tsConfig: options.tsConfig ?? findTsconfigUp(options.configDir) ?? browserOptions.tsConfig,
+    tsConfig: resolveTsconfig({
+      workspaceRoot: context.workspaceRoot,
+      configDir: options.configDir,
+      tsConfig: options.tsConfig,
+      browserTsConfig: browserOptions?.tsConfig,
+    }),
   };
 }
 

--- a/code/frameworks/angular-vite/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular-vite/src/builders/start-storybook/index.ts
@@ -30,7 +30,7 @@ import * as pkg from 'empathic/package';
 import { errorSummary, printErrorDetails } from '../utils/error-handler.ts';
 import type { StandaloneOptions } from '../utils/standalone-options.ts';
 import { Channel } from 'storybook/internal/channels';
-import { findTsconfigUp } from '../../find-tsconfig.ts';
+import { resolveTsconfig } from '../../find-tsconfig.ts';
 
 addToGlobalContext('cliVersion', versions.storybook);
 
@@ -216,7 +216,12 @@ async function setup(options: StorybookBuilderOptions, context: BuilderContext) 
   }
 
   return {
-    tsConfig: options.tsConfig ?? findTsconfigUp(options.configDir) ?? browserOptions.tsConfig,
+    tsConfig: resolveTsconfig({
+      workspaceRoot: context.workspaceRoot,
+      configDir: options.configDir,
+      tsConfig: options.tsConfig,
+      browserTsConfig: browserOptions?.tsConfig,
+    }),
   };
 }
 async function runInstance(options: StandaloneOptions) {

--- a/code/frameworks/angular-vite/src/builders/utils/run-compodoc.spec.ts
+++ b/code/frameworks/angular-vite/src/builders/utils/run-compodoc.spec.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { join, resolve } from 'node:path';
+
 import { runCompodoc } from './run-compodoc.ts';
 
 const mockRunScript = vi.fn().mockResolvedValue({ stdout: '' });
@@ -74,6 +76,25 @@ describe('runCompodoc', () => {
 
     expect(mockRunScript).toHaveBeenCalledWith({
       args: ['compodoc', '-p', 'path/to/tsconfig.json', '--output', 'path/to/customFolder'],
+      cwd: 'path/to/project',
+    });
+  });
+
+  it('should make an absolute tsconfig relative to the directory compodoc runs in', async () => {
+    await runCompodoc({
+      compodocArgs: [],
+      tsconfig: resolve(workspaceRoot, 'projects/lib/.storybook/tsconfig.json'),
+      workspaceRoot,
+    });
+
+    expect(mockRunScript).toHaveBeenCalledWith({
+      args: [
+        'compodoc',
+        '-p',
+        join('projects', 'lib', '.storybook', 'tsconfig.json'),
+        '-d',
+        'path/to/project',
+      ],
       cwd: 'path/to/project',
     });
   });

--- a/code/frameworks/angular-vite/src/builders/utils/run-compodoc.ts
+++ b/code/frameworks/angular-vite/src/builders/utils/run-compodoc.ts
@@ -13,8 +13,8 @@ const hasOutputArg = (args: string[]) => readCompodocOutputDir(args) !== undefin
 
 // relative is necessary to workaround a compodoc issue with
 // absolute paths on windows machines
-const toRelativePath = (pathToTsConfig: string) => {
-  return isAbsolute(pathToTsConfig) ? relative('.', pathToTsConfig) : pathToTsConfig;
+const toRelativePath = (pathToTsConfig: string, from: string) => {
+  return isAbsolute(pathToTsConfig) ? relative(from, pathToTsConfig) : pathToTsConfig;
 };
 
 export type RunCompodocOptions = {
@@ -25,7 +25,7 @@ export type RunCompodocOptions = {
 
 export const runCompodoc = async (opts: RunCompodocOptions): Promise<void> => {
   const { compodocArgs, tsconfig, workspaceRoot } = opts;
-  const tsConfigPath = toRelativePath(tsconfig);
+  const tsConfigPath = toRelativePath(tsconfig, workspaceRoot || '.');
   const finalCompodocArgs = [
     'compodoc',
     ...(hasTsConfigArg(compodocArgs) ? [] : ['-p', tsConfigPath]),

--- a/code/frameworks/angular-vite/src/find-tsconfig.test.ts
+++ b/code/frameworks/angular-vite/src/find-tsconfig.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getProjectRoot } from 'storybook/internal/common';
+
+import { resolve } from 'node:path';
+
+import * as find from 'empathic/find';
+
+import { findTsconfigUp, resolveTsconfig } from './find-tsconfig.ts';
+
+vi.mock('storybook/internal/common', { spy: true });
+vi.mock('empathic/find', { spy: true });
+
+const WORKSPACE_ROOT = resolve('/workspace');
+const CONFIG_DIR = resolve('/workspace/projects/lib/.storybook');
+
+beforeEach(() => {
+  vi.mocked(getProjectRoot).mockReturnValue(WORKSPACE_ROOT);
+  vi.mocked(find.up).mockReturnValue(undefined);
+});
+
+describe('findTsconfigUp', () => {
+  it('walks up from the config dir, bounded by the project root', () => {
+    const found = resolve(WORKSPACE_ROOT, 'projects/lib/tsconfig.json');
+    vi.mocked(find.up).mockReturnValue(found);
+
+    expect(findTsconfigUp(CONFIG_DIR)).toBe(found);
+    expect(find.up).toHaveBeenCalledWith('tsconfig.json', {
+      cwd: CONFIG_DIR,
+      last: WORKSPACE_ROOT,
+    });
+  });
+
+  it('returns undefined when the walk finds nothing', () => {
+    expect(findTsconfigUp(CONFIG_DIR)).toBeUndefined();
+  });
+});
+
+describe('resolveTsconfig', () => {
+  it('resolves a workspace-relative `tsConfig` against the workspace root', () => {
+    const result = resolveTsconfig({
+      workspaceRoot: WORKSPACE_ROOT,
+      configDir: CONFIG_DIR,
+      tsConfig: 'projects/lib/.storybook/tsconfig.json',
+    });
+
+    expect(result).toBe(resolve(WORKSPACE_ROOT, 'projects/lib/.storybook/tsconfig.json'));
+  });
+
+  it('leaves an absolute `tsConfig` untouched', () => {
+    const absolute = resolve('/elsewhere/tsconfig.json');
+
+    const result = resolveTsconfig({
+      workspaceRoot: WORKSPACE_ROOT,
+      configDir: CONFIG_DIR,
+      tsConfig: absolute,
+    });
+
+    expect(result).toBe(absolute);
+  });
+
+  it('falls back to the nearest tsconfig above the config dir', () => {
+    const found = resolve(WORKSPACE_ROOT, 'projects/lib/.storybook/tsconfig.json');
+    vi.mocked(find.up).mockReturnValue(found);
+
+    const result = resolveTsconfig({ workspaceRoot: WORKSPACE_ROOT, configDir: CONFIG_DIR });
+
+    expect(result).toBe(found);
+  });
+
+  it('falls back to the browser target tsConfig, also workspace-relative', () => {
+    const result = resolveTsconfig({
+      workspaceRoot: WORKSPACE_ROOT,
+      configDir: CONFIG_DIR,
+      browserTsConfig: 'projects/lib/tsconfig.app.json',
+    });
+
+    expect(result).toBe(resolve(WORKSPACE_ROOT, 'projects/lib/tsconfig.app.json'));
+  });
+
+  it('prefers an explicit `tsConfig` over both fallbacks', () => {
+    vi.mocked(find.up).mockReturnValue(resolve(WORKSPACE_ROOT, 'walked/tsconfig.json'));
+
+    const result = resolveTsconfig({
+      workspaceRoot: WORKSPACE_ROOT,
+      configDir: CONFIG_DIR,
+      tsConfig: 'explicit/tsconfig.json',
+      browserTsConfig: 'browser/tsconfig.app.json',
+    });
+
+    expect(result).toBe(resolve(WORKSPACE_ROOT, 'explicit/tsconfig.json'));
+  });
+
+  it('returns undefined when no tsconfig can be found', () => {
+    const result = resolveTsconfig({ workspaceRoot: WORKSPACE_ROOT, configDir: CONFIG_DIR });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/code/frameworks/angular-vite/src/find-tsconfig.ts
+++ b/code/frameworks/angular-vite/src/find-tsconfig.ts
@@ -1,5 +1,7 @@
 import { getProjectRoot } from 'storybook/internal/common';
 
+import { resolve } from 'node:path';
+
 import * as find from 'empathic/find';
 
 /**
@@ -12,3 +14,21 @@ import * as find from 'empathic/find';
  */
 export const findTsconfigUp = (configDir: string): string | undefined =>
   find.up('tsconfig.json', { cwd: configDir, last: getProjectRoot() });
+
+export type ResolveTsconfigOptions = {
+  workspaceRoot: string;
+  configDir: string;
+  tsConfig?: string;
+  browserTsConfig?: string;
+};
+
+export const resolveTsconfig = ({
+  workspaceRoot,
+  configDir,
+  tsConfig,
+  browserTsConfig,
+}: ResolveTsconfigOptions): string | undefined => {
+  const configured = tsConfig ?? findTsconfigUp(configDir) ?? browserTsConfig;
+
+  return configured ? resolve(workspaceRoot, configured) : undefined;
+};


### PR DESCRIPTION
Closes #

## What I did

Both builder schemas say `tsConfig` is "relative to the current workspace", but `setup()` returns
the raw value. It ends up in `@analogjs/vite-plugin-angular`, which resolves it against Vite's
root. Vite's root is the project directory, not the workspace root. When the Storybook project is
not at the workspace root you get a duplicated segment:

```Unable to resolve tsconfig at /ws/projects/lib/projects/lib/.storybook/tsconfig.json```

Analog then falls back to its own default, so the build silently uses a different tsconfig than the
one that was configured.

I added `resolveTsconfig` to `find-tsconfig.ts`. It keeps the precedence that was already there
(explicit `tsConfig`, then the nearest `tsconfig.json` above `configDir` through the existing
`findTsconfigUp`, then the browser target) and resolves the result against `workspaceRoot`.
Absolute paths come back unchanged.

I put it in `find-tsconfig.ts` for the reason the docstring on `findTsconfigUp` already gives: both
builders need the same answer, and they drifted apart the last time they worked it out separately.
Both builders call it now, so the two `setup()` bodies stay identical.

I also changed `browserOptions.tsConfig` to `browserOptions?.tsConfig`. It is typed as possibly
undefined and only gets assigned when `options.browserTarget` is set.

### Why the Compodoc change is in the same PR

Once the builder hands out an absolute path, `run-compodoc.ts` takes a different branch.
`toRelativePath` only rewrites absolute paths. A relative value used to pass straight through and
work fine, because Compodoc runs with `cwd: workspaceRoot`. An absolute value goes through
`relative('.', ...)` instead, which is based on `process.cwd()`, and that only gives the right answer
when `process.cwd()` happens to be the workspace root.

So the first half of this PR on its own would break Compodoc for anyone running the builder from
another directory. `toRelativePath` now takes the base as an argument and gets `workspaceRoot`,
which is where Compodoc actually runs.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`find-tsconfig.test.ts` is new. The module had no tests before. Eight cases: two for
`findTsconfigUp`, covering that the walk is bounded by `getProjectRoot()` and that it returns
nothing when there is nothing to find, and six for `resolveTsconfig`, covering workspace-relative
input, absolute input, each of the two fallbacks, precedence when more than one is set, and the
case where nothing is found. Take the `resolve` call out and three of them fail.

`run-compodoc.spec.ts` gets one more case, for an absolute tsconfig. On the old code it produces
`path/to/project/projects/lib/.storybook/tsconfig.json` instead of
`projects/lib/.storybook/tsconfig.json`.

#### Manual testing

1. `yarn task --task sandbox --start-from auto --template angular-vite/default-ts`
2. In the sandbox, make the project root different from the workspace root: set
   `"root": "projects/app"` in `angular.json`, move `src/` to `projects/app/src/`, and update
   `sourceRoot`.
3. Move `.storybook/` to `projects/app/.storybook/` and set
   `"tsConfig": "projects/app/.storybook/tsconfig.json"` on the `storybook` target.
4. `ng run app:storybook`

On the old code the Analog plugin logs `Unable to resolve tsconfig at
<workspaceRoot>/projects/app/projects/app/.storybook/tsconfig.json` and falls back. With this
change the path resolves and the warning is gone.

For the Compodoc part, leave `framework.options.compodoc` on and run `ng run app:build-storybook`
through something that starts the builder with a working directory other than the workspace root.
On the old code Compodoc gets a `-p` path with a duplicated segment and cannot find the tsconfig.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)