### PR TITLE
Angular Vite: Resolve global styles against the workspace root

### DIFF
--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { findConfigFile } from 'storybook/internal/common';
+
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -12,10 +14,7 @@ import type { StandaloneOptions } from './builders/utils/standalone-options.ts';
 
 // The plugin's `config` hook looks up the preview file on disk before reading
 // style options; stub just that lookup so the test stays hermetic.
-vi.mock(import('storybook/internal/common'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  findConfigFile: () => undefined,
-}));
+vi.mock('storybook/internal/common', { spy: true });
 vi.mock('node:fs', { spy: true });
 vi.mock('./builders/utils/run-compodoc.ts', { spy: true });
 vi.mock('vite', { spy: true });
@@ -26,6 +25,7 @@ vi.mock('@analogjs/vite-plugin-angular', () => ({ default: (): unknown[] => [] }
 beforeEach(async () => {
   vol.reset();
   const memfs = await vi.importActual<typeof import('memfs')>('memfs');
+  vi.mocked(findConfigFile).mockReturnValue(null);
   vi.mocked(existsSync).mockImplementation(memfs.fs.existsSync as typeof existsSync);
   vi.mocked(runCompodoc).mockResolvedValue(undefined);
   vi.mocked(mergeConfig).mockImplementation(
@@ -40,6 +40,8 @@ afterEach(() => {
 });
 
 const WORKSPACE_ROOT = resolve('/workspace');
+const VITE_ROOT = resolve('/workspace/projects/lib');
+const PREVIEW_PATH = resolve('/workspace/.storybook/preview.ts');
 
 function runConfig(stylePreprocessorOptions: Record<string, unknown> | undefined) {
   const options = {
@@ -144,5 +146,96 @@ describe('viteFinal Compodoc generation', () => {
     await viteFinal({ root: WORKSPACE_ROOT }, optionsWith({ compodoc: false }));
 
     expect(runCompodoc).not.toHaveBeenCalled();
+  });
+});
+
+async function runTransform(
+  styles: unknown,
+  { zoneless = true, withBuilderContext = true } = {}
+): Promise<string> {
+  vi.mocked(findConfigFile).mockReturnValue(PREVIEW_PATH);
+
+  const options = {
+    configDir: resolve(WORKSPACE_ROOT, '.storybook'),
+    angularBuilderContext: withBuilderContext ? ({ workspaceRoot: WORKSPACE_ROOT } as any) : null,
+    angularBuilderOptions: { styles },
+  } as unknown as StandaloneOptions;
+
+  const plugin = angularOptionsPlugin(options, { normalizePath, zoneless });
+  (plugin.config as (userConfig: unknown) => unknown)({ root: VITE_ROOT });
+
+  const result = await (
+    plugin.transform as (code: string, id: string) => Promise<{ code: string } | undefined>
+  )('export const parameters = {};', PREVIEW_PATH);
+
+  return result?.code ?? '';
+}
+
+const styleImport = (root: string, input: string) =>
+  `import '${normalizePath(resolve(root, input))}';`;
+
+describe('angularOptionsPlugin global styles', () => {
+  it('resolves workspace-root-relative style paths against the workspace root', async () => {
+    const code = await runTransform([
+      'projects/theme/global.scss',
+      'node_modules/@example/theme/index.css',
+    ]);
+
+    expect(code).toContain(styleImport(WORKSPACE_ROOT, 'projects/theme/global.scss'));
+    expect(code).toContain(styleImport(WORKSPACE_ROOT, 'node_modules/@example/theme/index.css'));
+  });
+
+  it('resolves `src`-prefixed and dot-relative paths against the workspace root', async () => {
+    const code = await runTransform(['src/styles.css', './.storybook/preview.css']);
+
+    expect(code).toContain(styleImport(WORKSPACE_ROOT, 'src/styles.css'));
+    expect(code).toContain(styleImport(WORKSPACE_ROOT, './.storybook/preview.css'));
+  });
+
+  it('accepts the expanded `{ input }` form from the builder schema', async () => {
+    const code = await runTransform([{ input: 'src/styles.scss', bundleName: 'theme' }]);
+
+    expect(code).toContain(styleImport(WORKSPACE_ROOT, 'src/styles.scss'));
+  });
+
+  it('skips entries marked `inject: false`, which are emitted as standalone bundles', async () => {
+    const code = await runTransform([
+      'src/injected.css',
+      { input: 'src/standalone.css', inject: false },
+    ]);
+
+    expect(code).toContain(styleImport(WORKSPACE_ROOT, 'src/injected.css'));
+    expect(code).not.toContain('standalone.css');
+  });
+
+  it('falls back to the Vite root when there is no Angular builder context', async () => {
+    const code = await runTransform(['src/styles.css'], { withBuilderContext: false });
+
+    expect(code).toContain(styleImport(VITE_ROOT, 'src/styles.css'));
+  });
+
+  it('appends zone.js as a bare import only when not zoneless', async () => {
+    await expect(runTransform(['src/styles.css'], { zoneless: false })).resolves.toContain(
+      `import 'zone.js';`
+    );
+    await expect(runTransform(['src/styles.css'])).resolves.not.toContain(`import 'zone.js';`);
+  });
+
+  it('leaves modules other than the preview untouched', async () => {
+    vi.mocked(findConfigFile).mockReturnValue(PREVIEW_PATH);
+    const options = {
+      configDir: resolve(WORKSPACE_ROOT, '.storybook'),
+      angularBuilderContext: { workspaceRoot: WORKSPACE_ROOT } as any,
+      angularBuilderOptions: { styles: ['src/styles.css'] },
+    } as unknown as StandaloneOptions;
+
+    const plugin = angularOptionsPlugin(options, { normalizePath, zoneless: true });
+    (plugin.config as (userConfig: unknown) => unknown)({ root: VITE_ROOT });
+
+    const result = await (
+      plugin.transform as (code: string, id: string) => Promise<{ code: string } | undefined>
+    )('export const x = 1;', resolve(WORKSPACE_ROOT, 'src/some-other-file.ts'));
+
+    expect(result).toBeUndefined();
   });
 });

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -232,13 +232,15 @@ export function angularOptionsPlugin(
   options: StandaloneOptions,
   { normalizePath, zoneless }: any
 ): Plugin {
-  let resolvedConfig: UserConfig;
+  let workspaceRoot: string;
   let resolvedPreviewPath: string | undefined;
   return {
     name: 'storybook-angular-vite-options-plugin',
     config(userConfig: UserConfig) {
-      resolvedConfig = userConfig;
       resolvedPreviewPath = findConfigFile('preview', options.configDir) ?? undefined;
+      // No builder context when running via Vitest instead of the Angular builders.
+      workspaceRoot =
+        options.angularBuilderContext?.workspaceRoot ?? userConfig?.root ?? process.cwd();
       const stylePreprocessorOptions =
         options?.angularBuilderOptions?.stylePreprocessorOptions ?? {};
       // Angular's builder schema (and this framework's builder schema) names the
@@ -250,8 +252,6 @@ export function angularOptionsPlugin(
       const sassOptions = stylePreprocessorOptions.sass;
 
       if (Array.isArray(loadPaths)) {
-        const workspaceRoot =
-          options.angularBuilderContext?.workspaceRoot ?? userConfig?.root ?? process.cwd();
         return {
           css: {
             preprocessorOptions: {
@@ -268,37 +268,21 @@ export function angularOptionsPlugin(
     },
     async transform(code, id) {
       if (resolvedPreviewPath && normalizePath(id).endsWith(normalizePath(resolvedPreviewPath))) {
-        const imports = [];
         const styles = options?.angularBuilderOptions?.styles;
-
-        if (Array.isArray(styles)) {
-          styles.forEach((style) => {
-            imports.push(style);
-          });
-        }
+        const imports = (Array.isArray(styles) ? styles : [])
+          .map((style) => (typeof style === 'string' ? { input: style } : style))
+          // `inject: false` entries are emitted as standalone bundles, not preview styles.
+          .filter((style) => typeof style?.input === 'string' && style.inject !== false)
+          // Normalize to forward slashes so the specifier is valid on Windows.
+          .map(({ input }) => `import '${normalizePath(resolve(workspaceRoot, input))}';`);
 
         if (!zoneless) {
-          imports.push('zone.js');
+          imports.push(`import 'zone.js';`);
         }
-
-        // Use vite config root when angularBuilderContext is not available
-        // (e.g., when running via Vitest instead of Angular builders)
-        const projectRoot = resolvedConfig?.root ?? process.cwd();
 
         return {
           code: `
-            ${imports
-              .map((extraImport) => {
-                if (extraImport.startsWith('.') || extraImport.startsWith('src')) {
-                  // relative to root — normalize to forward slashes so the
-                  // generated import specifier is valid on Windows.
-                  return `import '${normalizePath(resolve(projectRoot, extraImport))}';`;
-                }
-
-                // absolute import
-                return `import '${extraImport}';`;
-              })
-              .join('\n')}
+            ${imports.join('\n')}
             ${code}
           `,
         };


### PR DESCRIPTION
Closes #

## What I did

`angularOptionsPlugin` resolves two path options, and it was using a different root for each one.

`stylePreprocessorOptions.includePaths` uses
`angularBuilderContext?.workspaceRoot ?? userConfig?.root ?? process.cwd()`, which is right. The
`styles` transform a few lines further down used `resolvedConfig?.root ?? process.cwd()`. That is
the same Vite config object, but it skips the builder context. So when a builder context is
present, SCSS include paths resolved against the workspace root while global styles resolved
against the project directory.

In any workspace where those two are not the same directory, the configured stylesheet never
loads. Nothing fails, the styles are just missing.

There were three problems in that transform:

1. The root was wrong. `styles` entries are workspace-relative, same as in `angular.json`.
2. The expanded form threw. The schema allows `{ input, bundleName, inject }`, but entries were
   pushed through as-is and then called with `.startsWith(...)`, so an object entry gave
   `TypeError: extraImport.startsWith is not a function`.
3. The test for "is this a path or a package name" was `startsWith('.') || startsWith('src')`.
   That gets both directions wrong. `theme/global.css` came out as a bare import and never
   resolved, and `srcery/index.css` was treated as a path.

The transform now turns every entry into its object form, resolves all of them against
`workspaceRoot`, and drops the guessing. The schema already tells us what each entry is, so there
is nothing to infer. Entries with `inject: false` are skipped, because Angular emits those as
standalone bundles instead of injecting them into the page. `zone.js` is appended as its own
import rather than going into the same list and relying on the old check to leave it alone.

`workspaceRoot` is now worked out once in `config()` and shared, which is what stops the two
options from disagreeing again.

### Behaviour change

If you are in a multi-project workspace and worked around the old behaviour by writing
project-relative `styles` paths, those need to become workspace-relative, matching the schema,
`angular.json`, and `stylePreprocessorOptions.includePaths`. Single-project workspaces are not
affected, because there the two roots are the same directory.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Seven cases added to `preset.test.ts`: workspace-relative paths, `src`-prefixed and dot-relative
paths, the expanded `{ input }` form, `inject: false`, the fallback to the Vite root when there is
no builder context, `zone.js` only showing up when not zoneless, and modules other than the preview
being left alone. They fail on the old code.

#### Manual testing

1. `yarn task --task sandbox --start-from auto --template angular-vite/default-ts`
2. In the sandbox, make the project root different from the workspace root: set
   `"root": "projects/app"` in `angular.json`, move `src/` to `projects/app/src/`, and update
   `sourceRoot`.
3. Add `theme/global.css` at the **workspace** root with `body { background: deeppink }`.
4. Add `"styles": ["theme/global.css"]` to the `storybook` target.
5. `ng run app:storybook`

On the old code the background does not change. The entry starts with neither `.` nor `src`, so it
comes out as `import 'theme/global.css'` and never resolves. With this change the background is
pink.

Then change the entry to `[{ "input": "theme/global.css" }]` and run it again. On the old code that
throws `TypeError: extraImport.startsWith is not a function`. With this change it does the same
thing as the string form.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)