### PR TITLE
Angular: Generate static template snippets on the server

### DIFF
--- a/code/addons/mcp/src/utils/resolve-component-stories.test.ts
+++ b/code/addons/mcp/src/utils/resolve-component-stories.test.ts
@@ -86,7 +86,10 @@ afterEach(() => {
   vi.doUnmock('storybook/internal/core-server');
 });
 
-describe('resolveComponentStories', () => {
+// `resetModules` around every test means each one re-imports the subject and, with it, the mocked
+// `storybook/internal/core-server`. That import alone can outlast the 10s default on the first test
+// of the file when the rest of the suite is saturating the machine.
+describe('resolveComponentStories', { timeout: 30_000 }, () => {
   it('strips trailing slashes so `Badge.tsx/` queries the file, not the parent-name barrel', async () => {
     // Regression for the silent-corruption bug: when a caller pastes
     // `Badge/Badge.tsx/`, the trailing slash flipped `basename === dirname`

--- a/code/frameworks/angular-vite/src/client/docs/config.test.ts
+++ b/code/frameworks/angular-vite/src/client/docs/config.test.ts
@@ -1,12 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The flag is read once at module evaluation, so each case needs a fresh module registry.
-const loadConfig = async () => {
+const loadDecorators = async () => {
   vi.resetModules();
-  return import('./config.ts');
+  return (await import('./config.ts')).decorators;
 };
-
-const loadDecorators = async () => (await loadConfig()).decorators;
 
 describe('angular docs decorators', () => {
   beforeEach(() => {
@@ -15,32 +13,15 @@ describe('angular docs decorators', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    vi.resetModules();
   });
 
   it('registers the source decorator by default', async () => {
     await expect(loadDecorators()).resolves.toHaveLength(1);
   });
 
-  // With the server-side docs path on, `story-docs` emits the snippet instead. Leaving this
-  // decorator registered would have two generators emitting for the same story.
   it('drops the source decorator when the server-side docs path is on', async () => {
     vi.stubGlobal('FEATURES', { experimentalDocgenServer: true });
 
     await expect(loadDecorators()).resolves.toEqual([]);
-  });
-
-  // `dynamic` makes the Source block render the snippet unconditionally. With no decorator
-  // guaranteeing one, that shows an empty code block for every story the server provider does not
-  // cover; `auto` is what lets the block fall back to the story's own source.
-  it.each([
-    [undefined, 'dynamic'],
-    [{ experimentalDocgenServer: true }, 'auto'],
-  ])('uses the %s source type', async (features, expected) => {
-    if (features) {
-      vi.stubGlobal('FEATURES', features);
-    }
-
-    await expect((await loadConfig()).parameters.docs.source.type).toBe(expected);
   });
 });

--- a/code/frameworks/angular-vite/src/client/docs/config.test.ts
+++ b/code/frameworks/angular-vite/src/client/docs/config.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The flag is read once at module evaluation, so each case needs a fresh module registry.
-const loadDecorators = async () => {
+const loadConfig = async () => {
   vi.resetModules();
-  return (await import('./config.ts')).decorators;
+  return import('./config.ts');
 };
+
+const loadDecorators = async () => (await loadConfig()).decorators;
 
 describe('angular docs decorators', () => {
   beforeEach(() => {
@@ -26,5 +28,19 @@ describe('angular docs decorators', () => {
     vi.stubGlobal('FEATURES', { experimentalDocgenServer: true });
 
     await expect(loadDecorators()).resolves.toEqual([]);
+  });
+
+  // `dynamic` makes the Source block render the snippet unconditionally. With no decorator
+  // guaranteeing one, that shows an empty code block for every story the server provider does not
+  // cover; `auto` is what lets the block fall back to the story's own source.
+  it.each([
+    [undefined, 'dynamic'],
+    [{ experimentalDocgenServer: true }, 'auto'],
+  ])('uses the %s source type', async (features, expected) => {
+    if (features) {
+      vi.stubGlobal('FEATURES', features);
+    }
+
+    await expect((await loadConfig()).parameters.docs.source.type).toBe(expected);
   });
 });

--- a/code/frameworks/angular-vite/src/client/docs/config.test.ts
+++ b/code/frameworks/angular-vite/src/client/docs/config.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The flag is read once at module evaluation, so each case needs a fresh module registry.
+const loadDecorators = async () => {
+  vi.resetModules();
+  return (await import('./config.ts')).decorators;
+};
+
+describe('angular docs decorators', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('registers the source decorator by default', async () => {
+    await expect(loadDecorators()).resolves.toHaveLength(1);
+  });
+
+  // With the server-side docs path on, `story-docs` emits the snippet instead. Leaving this
+  // decorator registered would have two generators emitting for the same story.
+  it('drops the source decorator when the server-side docs path is on', async () => {
+    vi.stubGlobal('FEATURES', { experimentalDocgenServer: true });
+
+    await expect(loadDecorators()).resolves.toEqual([]);
+  });
+});

--- a/code/frameworks/angular-vite/src/client/docs/config.ts
+++ b/code/frameworks/angular-vite/src/client/docs/config.ts
@@ -3,23 +3,17 @@ import type { DecoratorFunction, Parameters } from 'storybook/internal/types';
 
 import { sourceDecorator } from './sourceDecorator';
 
-// With the server-side docs path on, `story-docs` emits the snippet for every story. Leaving the
-// client decorator registered would have two generators calling `emitTransformCode` for the same
-// story with nothing coordinating them. Same gate React puts on its own legacy snippet path.
-const useStaticServiceSnippets =
-  'FEATURES' in globalThis && globalThis?.FEATURES?.experimentalDocgenServer;
-
 export const parameters: Parameters = {
   docs: {
     source: {
-      // `DYNAMIC` makes the Source block use the snippet unconditionally, which is right while the
-      // client decorator guarantees one. The server provider does not: it returns nothing for a
-      // story file it cannot resolve a component for, and `AUTO` is what lets the block fall back
-      // to the story's own source instead of rendering empty.
-      type: useStaticServiceSnippets ? SourceType.AUTO : SourceType.DYNAMIC,
+      type: SourceType.DYNAMIC,
       language: 'html',
     },
   },
 };
+
+// Two generators would otherwise call `emitTransformCode` for the same story with nothing
+// coordinating them: `story-docs` covers snippets when the server-side docs path is on.
+const useStaticServiceSnippets = globalThis.FEATURES?.experimentalDocgenServer;
 
 export const decorators: DecoratorFunction[] = useStaticServiceSnippets ? [] : [sourceDecorator];

--- a/code/frameworks/angular-vite/src/client/docs/config.ts
+++ b/code/frameworks/angular-vite/src/client/docs/config.ts
@@ -12,4 +12,10 @@ export const parameters: Parameters = {
   },
 };
 
-export const decorators: DecoratorFunction[] = [sourceDecorator];
+// With the server-side docs path on, `story-docs` emits the snippet for every story. Leaving the
+// client decorator registered would have two generators calling `emitTransformCode` for the same
+// story with nothing coordinating them. Same gate React puts on its own legacy snippet path.
+const useStaticServiceSnippets =
+  'FEATURES' in globalThis && globalThis?.FEATURES?.experimentalDocgenServer;
+
+export const decorators: DecoratorFunction[] = useStaticServiceSnippets ? [] : [sourceDecorator];

--- a/code/frameworks/angular-vite/src/client/docs/config.ts
+++ b/code/frameworks/angular-vite/src/client/docs/config.ts
@@ -3,19 +3,23 @@ import type { DecoratorFunction, Parameters } from 'storybook/internal/types';
 
 import { sourceDecorator } from './sourceDecorator';
 
-export const parameters: Parameters = {
-  docs: {
-    source: {
-      type: SourceType.DYNAMIC,
-      language: 'html',
-    },
-  },
-};
-
 // With the server-side docs path on, `story-docs` emits the snippet for every story. Leaving the
 // client decorator registered would have two generators calling `emitTransformCode` for the same
 // story with nothing coordinating them. Same gate React puts on its own legacy snippet path.
 const useStaticServiceSnippets =
   'FEATURES' in globalThis && globalThis?.FEATURES?.experimentalDocgenServer;
+
+export const parameters: Parameters = {
+  docs: {
+    source: {
+      // `DYNAMIC` makes the Source block use the snippet unconditionally, which is right while the
+      // client decorator guarantees one. The server provider does not: it returns nothing for a
+      // story file it cannot resolve a component for, and `AUTO` is what lets the block fall back
+      // to the story's own source instead of rendering empty.
+      type: useStaticServiceSnippets ? SourceType.AUTO : SourceType.DYNAMIC,
+      language: 'html',
+    },
+  },
+};
 
 export const decorators: DecoratorFunction[] = useStaticServiceSnippets ? [] : [sourceDecorator];

--- a/code/frameworks/angular-vite/src/compodoc-config.ts
+++ b/code/frameworks/angular-vite/src/compodoc-config.ts
@@ -6,11 +6,10 @@
  * each derived it separately they drifted, and a redirected output directory regenerated on every
  * cold start.
  */
-import type { Preset } from 'storybook/internal/types';
-
 import { resolve } from 'node:path';
 
 import { findTsconfigUp } from './find-tsconfig.ts';
+import { readFrameworkOptions } from './framework-options.ts';
 
 /** Compodoc invocation Storybook uses when `framework.options.compodocArgs` is unset. */
 export const DEFAULT_COMPODOC_ARGS = ['-e', 'json', '-d', '.'];
@@ -56,13 +55,7 @@ export const resolveCompodocConfig = async (
   },
   extra: { viteRoot?: string } = {}
 ) => {
-  // `framework` is either the framework's package name or `{ name, options }`; only the latter
-  // carries the Compodoc settings.
-  // `presets.apply` is untyped here, so the shape is asserted once at the boundary rather than at
-  // each use.
-  const framework = (await options?.presets?.apply('framework')) as Preset | undefined;
-  const frameworkOptions: { compodoc?: boolean; compodocArgs?: string[]; tsconfig?: string } =
-    typeof framework === 'string' ? {} : (framework?.options ?? {});
+  const frameworkOptions = await readFrameworkOptions(options);
 
   const workspaceRoot =
     options?.angularBuilderContext?.workspaceRoot ?? extra.viteRoot ?? process.cwd();

--- a/code/frameworks/angular-vite/src/docgen/__testfixtures__/documentation.json
+++ b/code/frameworks/angular-vite/src/docgen/__testfixtures__/documentation.json
@@ -1,0 +1,20 @@
+{
+  "components": [
+    {
+      "name": "ButtonComponent",
+      "type": "component",
+      "file": "button.component.ts",
+      "selector": "sb-button",
+      "propertiesClass": [],
+      "methodsClass": [],
+      "inputsClass": [
+        { "name": "label", "type": "string", "optional": false, "defaultValue": "'Badge'" },
+        { "name": "count", "type": "number", "optional": true }
+      ],
+      "outputsClass": [{ "name": "clicked", "type": "EventEmitter<string>", "optional": false }]
+    }
+  ],
+  "directives": [],
+  "classes": [],
+  "miscellaneous": {}
+}

--- a/code/frameworks/angular-vite/src/docgen/__testfixtures__/no-component.stories.ts
+++ b/code/frameworks/angular-vite/src/docgen/__testfixtures__/no-component.stories.ts
@@ -1,0 +1,4 @@
+// Fixture: a story file with no `meta.component`, which the story-docs provider passes through.
+export default { title: 'NoComponent' };
+
+export const Only = { args: { label: 'x' } };

--- a/code/frameworks/angular-vite/src/docgen/__testfixtures__/story-docs.stories.ts
+++ b/code/frameworks/angular-vite/src/docgen/__testfixtures__/story-docs.stories.ts
@@ -41,3 +41,14 @@ export const HoistedTemplate = { template: HOISTED_TEMPLATE };
 export const RenderIdentifier = { render: renderFn, args: { count: 4 } };
 
 export const ConfigSpread = { ...Basic, args: { count: 5 } };
+
+// `export { X }` registers a story without a declaration path, so it exercises the other branch of
+// the CSF parser. Its own args must still win over the meta's.
+const ReExported = { args: { label: 'reexported', count: 9 } };
+export { ReExported };
+
+const RenamedSource = { ...sharedArgs, args: { count: 10 } };
+export { RenamedSource as RenamedStory };
+
+const ReExportedTemplate = { template: '<sb-button reexported></sb-button>' };
+export { ReExportedTemplate };

--- a/code/frameworks/angular-vite/src/docgen/__testfixtures__/story-docs.stories.ts
+++ b/code/frameworks/angular-vite/src/docgen/__testfixtures__/story-docs.stories.ts
@@ -1,0 +1,35 @@
+// Fixture: the story shapes the Angular story-docs provider has to tell apart.
+// Excluded from the package tsconfig, so the loose typing here is deliberate.
+import { ButtonComponent } from './button.component';
+
+const sharedArgs = { label: 'shared' };
+const notAStoryConfig = (...parts: unknown[]) => ({ parts });
+
+export default {
+  title: 'StoryDocs',
+  component: ButtonComponent,
+  args: { label: 'meta' },
+};
+
+/** Renders the button with a label and a count. */
+export const Basic = {
+  args: { label: 'Save', count: 3, clicked: () => {}, notAnInput: 'dropped' },
+};
+
+export const InheritsMetaArgs = {};
+
+export const OwnTemplate = { template: '<sb-button emphasis>hi</sb-button>' };
+
+export const EmptyTemplate = { template: '' };
+
+export const NullTemplate = { template: null, args: { count: 2 } };
+
+export const RenderTemplate = {
+  render: () => ({ template: '<sb-button rendered></sb-button>' }),
+};
+
+export const SpreadArgs = { args: { ...sharedArgs, count: 1 } };
+
+export const Csf2Function = () => ({ template: '<sb-button csf2></sb-button>' });
+
+export const Unclassifiable = notAStoryConfig(1, 2);

--- a/code/frameworks/angular-vite/src/docgen/__testfixtures__/story-docs.stories.ts
+++ b/code/frameworks/angular-vite/src/docgen/__testfixtures__/story-docs.stories.ts
@@ -3,6 +3,8 @@
 import { ButtonComponent } from './button.component';
 
 const sharedArgs = { label: 'shared' };
+const HOISTED_TEMPLATE = '<sb-button hoisted></sb-button>';
+const renderFn = () => ({ template: '<sb-button via-fn></sb-button>' });
 const notAStoryConfig = (...parts: unknown[]) => ({ parts });
 
 export default {
@@ -33,3 +35,9 @@ export const SpreadArgs = { args: { ...sharedArgs, count: 1 } };
 export const Csf2Function = () => ({ template: '<sb-button csf2></sb-button>' });
 
 export const Unclassifiable = notAStoryConfig(1, 2);
+
+export const HoistedTemplate = { template: HOISTED_TEMPLATE };
+
+export const RenderIdentifier = { render: renderFn, args: { count: 4 } };
+
+export const ConfigSpread = { ...Basic, args: { count: 5 } };

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.ts
@@ -12,6 +12,7 @@ import { join, resolve } from 'node:path';
 
 import type {
   CompodocEntry,
+  Directive,
   CompodocJson,
   CompodocParsingLogger,
   JsDocTag,
@@ -91,11 +92,11 @@ export const findCompodocEntry = (
   json: CompodocJson,
   component: Pick<ResolvedMetaComponent, 'exportName' | 'path'>,
   workspaceRoot: string
-): CompodocEntry | undefined => {
+): Directive | undefined => {
   const { exportName, path } = component;
   const entries = [...(json.components ?? []), ...(json.directives ?? [])].filter(
     Boolean
-  ) as WithFile<CompodocEntry>[];
+  ) as WithFile<Directive>[];
 
   if (path) {
     const wanted = comparablePath(path);
@@ -128,11 +129,11 @@ export const findCompodocEntry = (
 };
 
 /** Whether every entry describes the same class, so picking the first is not a guess. */
-const namesAgree = (entries: WithFile<CompodocEntry>[]): boolean =>
+const namesAgree = (entries: WithFile<Directive>[]): boolean =>
   entries.length > 0 && entries.every((entry) => entry.name === entries[0].name);
 
 /** Whether same-named entries are all the same physical file, rather than genuine namesakes. */
-const sameComponent = (entries: WithFile<CompodocEntry>[], workspaceRoot: string): boolean => {
+const sameComponent = (entries: WithFile<Directive>[], workspaceRoot: string): boolean => {
   if (entries.length === 0) {
     return false;
   }

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
@@ -33,6 +33,7 @@ const build = (
   buildStoryDocsPayload(
     { entry: entry(importPath, title) },
     {
+      storyRoot: FIXTURES,
       workspaceRoot: FIXTURES,
       outputDir: FIXTURES,
       readDocumentationJson: documentationJson,
@@ -88,8 +89,27 @@ describe('buildStoryDocsPayload', () => {
 
   it('reports args a spread hid rather than shipping a snippet that looks complete', () => {
     expect(snippetOf(build('./story-docs.stories.ts'), 'Spread Args')).toBe(
-      `<!-- unresolved args: ...sharedArgs -->\n<sb-button [label]="'meta'" [count]="1" (clicked)="clicked($event)"></sb-button>`
+      `<!-- unresolved: ...sharedArgs -->\n<sb-button [label]="'meta'" [count]="1" (clicked)="clicked($event)"></sb-button>`
     );
+  });
+
+  it('reports a spread at the config level, not only one inside args', () => {
+    expect(snippetOf(build('./story-docs.stories.ts'), 'Config Spread')).toBe(
+      `<!-- unresolved: ...Basic -->\n<sb-button [label]="'meta'" [count]="5" (clicked)="clicked($event)"></sb-button>`
+    );
+  });
+
+  it.each([
+    // Emitting the identifier's source text would put JavaScript in the Source block where the
+    // user expects markup, so the template is reported as unresolvable instead.
+    ['Hoisted Template', 'HOISTED_TEMPLATE'],
+    // A `render` that is not an inline function returning an object literal may still produce
+    // markup; generating an element from args would silently replace it.
+    ['Render Identifier', 'render: renderFn'],
+  ])('reports the %s story rather than printing its JavaScript', (storyName, expected) => {
+    const snippet = snippetOf(build('./story-docs.stories.ts'), storyName);
+    expect(snippet).toContain(`<!-- unresolved: ${expected}`);
+    expect(snippet).toContain('<sb-button');
   });
 
   it('isolates a story it cannot read and still ships the rest of the file', () => {
@@ -130,6 +150,7 @@ describe('buildStoryDocsPayload', () => {
           entry: { id: 'x', name: 'x', title: 'x', type: 'docs', storiesImports: [] } as IndexEntry,
         },
         {
+          storyRoot: FIXTURES,
           workspaceRoot: FIXTURES,
           outputDir: FIXTURES,
           readDocumentationJson: documentationJson,

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
@@ -49,6 +49,9 @@ const snippetOf = (payload: StoryDocsPayload | undefined, storyName: string) =>
 const storyOf = (payload: StoryDocsPayload | undefined, storyName: string) =>
   Object.values(payload?.stories ?? {}).find((story) => story.name === storyName);
 
+const warningOf = (payload: StoryDocsPayload | undefined, storyName: string) =>
+  storyOf(payload, storyName)?.warning;
+
 describe('buildStoryDocsPayload', () => {
   it('builds a payload for a real Angular story file', () => {
     const payload = build('./story-docs.stories.ts');
@@ -61,6 +64,9 @@ describe('buildStoryDocsPayload', () => {
     expect(snippetOf(payload, 'Basic')).toBe(
       `<sb-button [label]="'Save'" [count]="3" (clicked)="clicked($event)"></sb-button>`
     );
+    expect(storyOf(payload, 'Basic')?.warning).toBeUndefined();
+    // The bare template carries no imports of its own.
+    expect(payload?.import).toBeUndefined();
   });
 
   it('merges meta args under story args', () => {
@@ -88,14 +94,21 @@ describe('buildStoryDocsPayload', () => {
   });
 
   it('reports args a spread hid rather than shipping a snippet that looks complete', () => {
-    expect(snippetOf(build('./story-docs.stories.ts'), 'Spread Args')).toBe(
-      `<!-- unresolved: ...sharedArgs -->\n<sb-button [label]="'meta'" [count]="1" (clicked)="clicked($event)"></sb-button>`
+    const story = storyOf(build('./story-docs.stories.ts'), 'Spread Args');
+
+    // The note is data on the story, not a comment inside the markup, so a consumer that renders
+    // the snippet is not left with a stray comment and one that reads it can act on it.
+    expect(story?.snippet).toBe(
+      `<sb-button [label]="'meta'" [count]="1" (clicked)="clicked($event)"></sb-button>`
+    );
+    expect(story?.warning).toBe(
+      'Incomplete snippet: `...sharedArgs` could not be resolved statically.'
     );
   });
 
   it('reports a spread at the config level, not only one inside args', () => {
-    expect(snippetOf(build('./story-docs.stories.ts'), 'Config Spread')).toBe(
-      `<!-- unresolved: ...Basic -->\n<sb-button [label]="'meta'" [count]="5" (clicked)="clicked($event)"></sb-button>`
+    expect(warningOf(build('./story-docs.stories.ts'), 'Config Spread')).toBe(
+      'Incomplete snippet: `...Basic` could not be resolved statically.'
     );
   });
 
@@ -107,9 +120,10 @@ describe('buildStoryDocsPayload', () => {
     // markup; generating an element from args would silently replace it.
     ['Render Identifier', 'render: renderFn'],
   ])('reports the %s story rather than printing its JavaScript', (storyName, expected) => {
-    const snippet = snippetOf(build('./story-docs.stories.ts'), storyName);
-    expect(snippet).toContain(`<!-- unresolved: ${expected}`);
-    expect(snippet).toContain('<sb-button');
+    const story = storyOf(build('./story-docs.stories.ts'), storyName);
+    expect(story?.warning).toContain(`\`${expected}\``);
+    expect(story?.snippet).toContain('<sb-button');
+    expect(story?.snippet).not.toContain(expected);
   });
 
   // `export { X }` is registered by a different branch of the CSF parser, which records no
@@ -121,7 +135,7 @@ describe('buildStoryDocsPayload', () => {
     ],
     [
       'RenamedStory',
-      `<!-- unresolved: ...sharedArgs -->\n<sb-button [label]="'meta'" [count]="10" (clicked)="clicked($event)"></sb-button>`,
+      `<sb-button [label]="'meta'" [count]="10" (clicked)="clicked($event)"></sb-button>`,
     ],
     ['ReExportedTemplate', '<sb-button reexported></sb-button>'],
   ])('reads the re-exported %s story from its own config', (storyName, expected) => {
@@ -174,5 +188,51 @@ describe('buildStoryDocsPayload', () => {
         }
       )
     ).toBeUndefined();
+  });
+});
+
+describe('buildStoryDocsPayload in component format', () => {
+  const componentPayload = () =>
+    build('./story-docs.stories.ts', { snippetFormat: 'component' as const });
+
+  it('wraps the generated bindings in a host component that declares their handlers', () => {
+    expect(snippetOf(componentPayload(), 'Basic')).toBe(
+      `@Component({
+  selector: 'app-root',
+  template: \`<sb-button [label]="'Save'" [count]="3" (clicked)="clicked($event)"></sb-button>\`,
+  imports: [ButtonComponent],
+})
+export class App {
+  clicked(event: unknown) {}
+}`
+    );
+  });
+
+  it('carries the import block once for the whole component', () => {
+    expect(componentPayload()?.import).toBe(
+      `import { Component } from '@angular/core';\nimport { ButtonComponent } from './button.component';`
+    );
+  });
+
+  it('declares no handlers for a story that supplied its own template', () => {
+    // Which outputs the user's markup binds is unknowable, so inventing methods for all of them
+    // would put members on the host that its template never references.
+    expect(snippetOf(componentPayload(), 'Own Template')).toBe(
+      `@Component({
+  selector: 'app-root',
+  template: \`<sb-button emphasis>hi</sb-button>\`,
+  imports: [ButtonComponent],
+})
+export class App {}`
+    );
+  });
+
+  it('reports an unresolved arg on the story, not inside the component it emits', () => {
+    const story = storyOf(componentPayload(), 'Spread Args');
+
+    expect(story?.warning).toBe(
+      'Incomplete snippet: `...sharedArgs` could not be resolved statically.'
+    );
+    expect(story?.snippet).not.toContain('sharedArgs');
   });
 });

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
@@ -30,8 +30,7 @@ const entry = (importPath: string, title = 'StoryDocs'): IndexEntry => ({
 const compodocResolver = (overrides: Partial<CompodocComponentResolverOptions> = {}) =>
   createCompodocComponentResolver({
     workspaceRoot: FIXTURES,
-    outputDir: FIXTURES,
-    readDocumentationJson: documentationJson,
+    readMetadata: documentationJson,
     logger: { warn: vi.fn(), debug: vi.fn() },
     ...overrides,
   });
@@ -174,16 +173,16 @@ describe('buildStoryDocsPayload', () => {
       './story-docs.stories.ts',
       {
         resolveComponent: compodocResolver({
-          readDocumentationJson: (): CompodocJson => ({ components: [] }),
+          readMetadata: (): CompodocJson => ({ components: [] }),
         }),
       },
     ],
     [
-      'an unreadable documentation.json',
+      'unreadable Compodoc metadata',
       './story-docs.stories.ts',
       {
         resolveComponent: compodocResolver({
-          readDocumentationJson: () => {
+          readMetadata: () => {
             throw new Error('ENOENT');
           },
         }),

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
@@ -9,6 +9,8 @@ import { describe, expect, it, vi } from 'vitest';
 import type { CompodocJson } from '@storybook/angular-compodoc';
 import type { BuildStoryDocsContext } from './build-story-docs.ts';
 import { buildStoryDocsPayload } from './build-story-docs.ts';
+import type { CompodocComponentResolverOptions } from './compodoc-component-resolver.ts';
+import { createCompodocComponentResolver } from './compodoc-component-resolver.ts';
 
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
 
@@ -25,6 +27,15 @@ const entry = (importPath: string, title = 'StoryDocs'): IndexEntry => ({
   importPath,
 });
 
+const compodocResolver = (overrides: Partial<CompodocComponentResolverOptions> = {}) =>
+  createCompodocComponentResolver({
+    workspaceRoot: FIXTURES,
+    outputDir: FIXTURES,
+    readDocumentationJson: documentationJson,
+    logger: { warn: vi.fn(), debug: vi.fn() },
+    ...overrides,
+  });
+
 const build = (
   importPath: string,
   overrides: Partial<BuildStoryDocsContext> = {},
@@ -34,10 +45,8 @@ const build = (
     { entry: entry(importPath, title) },
     {
       storyRoot: FIXTURES,
-      workspaceRoot: FIXTURES,
-      outputDir: FIXTURES,
-      readDocumentationJson: documentationJson,
-      logger: { warn: vi.fn(), debug: vi.fn() },
+      resolveComponent: compodocResolver(),
+      logger: { debug: vi.fn() },
       ...overrides,
     }
   );
@@ -156,17 +165,28 @@ describe('buildStoryDocsPayload', () => {
     ['a story file that does not exist', './missing.stories.ts', {}],
     ['a story file with no meta.component', './no-component.stories.ts', {}],
     [
+      'a component the docgen engine has nothing for',
+      './story-docs.stories.ts',
+      { resolveComponent: (): undefined => undefined },
+    ],
+    [
       'a component Compodoc never documented',
       './story-docs.stories.ts',
-      { readDocumentationJson: (): CompodocJson => ({ components: [] }) },
+      {
+        resolveComponent: compodocResolver({
+          readDocumentationJson: (): CompodocJson => ({ components: [] }),
+        }),
+      },
     ],
     [
       'an unreadable documentation.json',
       './story-docs.stories.ts',
       {
-        readDocumentationJson: () => {
-          throw new Error('ENOENT');
-        },
+        resolveComponent: compodocResolver({
+          readDocumentationJson: () => {
+            throw new Error('ENOENT');
+          },
+        }),
       },
     ],
   ])('falls through for %s', (_case, importPath, overrides) => {
@@ -181,13 +201,28 @@ describe('buildStoryDocsPayload', () => {
         },
         {
           storyRoot: FIXTURES,
-          workspaceRoot: FIXTURES,
-          outputDir: FIXTURES,
-          readDocumentationJson: documentationJson,
-          logger: { warn: vi.fn(), debug: vi.fn() },
+          resolveComponent: compodocResolver(),
+          logger: { debug: vi.fn() },
         }
       )
     ).toBeUndefined();
+  });
+
+  // Compodoc is one source of a component's selector and binding names; an in-process Angular
+  // component meta service is meant to be another. Snippet generation must not care which.
+  it('builds from a resolver that has never heard of Compodoc', () => {
+    const payload = build('./story-docs.stories.ts', {
+      resolveComponent: () => ({
+        name: 'ButtonComponent',
+        selector: 'my-button',
+        inputs: ['label'],
+        outputs: ['pressed'],
+      }),
+    });
+
+    expect(snippetOf(payload, 'Basic')).toBe(
+      `<my-button [label]="'Save'" (pressed)="pressed($event)"></my-button>`
+    );
   });
 });
 

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
@@ -1,0 +1,141 @@
+import type { IndexEntry, StoryDocsPayload } from 'storybook/internal/types';
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CompodocJson } from '@storybook/angular-compodoc';
+import type { BuildStoryDocsContext } from './build-story-docs.ts';
+import { buildStoryDocsPayload } from './build-story-docs.ts';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
+
+/** The same shape production reads out of the resolved output directory. */
+const documentationJson = () =>
+  JSON.parse(readFileSync(join(FIXTURES, 'documentation.json'), 'utf8')) as CompodocJson;
+
+const entry = (importPath: string, title = 'StoryDocs'): IndexEntry => ({
+  id: 'storydocs--basic',
+  name: 'Basic',
+  title,
+  type: 'story',
+  subtype: 'story',
+  importPath,
+});
+
+const build = (
+  importPath: string,
+  overrides: Partial<BuildStoryDocsContext> = {},
+  title?: string
+): StoryDocsPayload | undefined =>
+  buildStoryDocsPayload(
+    { entry: entry(importPath, title) },
+    {
+      workspaceRoot: FIXTURES,
+      outputDir: FIXTURES,
+      readDocumentationJson: documentationJson,
+      logger: { warn: vi.fn(), debug: vi.fn() },
+      ...overrides,
+    }
+  );
+
+/** Snippet for one story export, keyed the way the payload is: by story id. */
+const snippetOf = (payload: StoryDocsPayload | undefined, storyName: string) =>
+  Object.values(payload?.stories ?? {}).find((story) => story.name === storyName)?.snippet;
+
+const storyOf = (payload: StoryDocsPayload | undefined, storyName: string) =>
+  Object.values(payload?.stories ?? {}).find((story) => story.name === storyName);
+
+describe('buildStoryDocsPayload', () => {
+  it('builds a payload for a real Angular story file', () => {
+    const payload = build('./story-docs.stories.ts');
+
+    expect(payload).toMatchObject({
+      id: 'storydocs',
+      name: 'ButtonComponent',
+      path: './story-docs.stories.ts',
+    });
+    expect(snippetOf(payload, 'Basic')).toBe(
+      `<sb-button [label]="'Save'" [count]="3" (clicked)="clicked($event)"></sb-button>`
+    );
+  });
+
+  it('merges meta args under story args', () => {
+    // `label` comes from the meta, `count` from the story.
+    expect(snippetOf(build('./story-docs.stories.ts'), 'Null Template')).toBe(
+      `<sb-button [label]="'meta'" [count]="2" (clicked)="clicked($event)"></sb-button>`
+    );
+  });
+
+  it('carries the story JSDoc description through', () => {
+    expect(storyOf(build('./story-docs.stories.ts'), 'Basic')?.description).toBe(
+      'Renders the button with a label and a count.'
+    );
+  });
+
+  it.each([
+    ['Own Template', '<sb-button emphasis>hi</sb-button>'],
+    // An empty string is a user-defined template, matching the preview's own rule.
+    ['Empty Template', ''],
+    ['Render Template', '<sb-button rendered></sb-button>'],
+    // CSF2: the story is the render function, and Angular's idiom is to return `{ template }`.
+    ['Csf 2 Function', '<sb-button csf2></sb-button>'],
+  ])('leaves the %s story alone', (storyName, expected) => {
+    expect(snippetOf(build('./story-docs.stories.ts'), storyName)).toBe(expected);
+  });
+
+  it('reports args a spread hid rather than shipping a snippet that looks complete', () => {
+    expect(snippetOf(build('./story-docs.stories.ts'), 'Spread Args')).toBe(
+      `<!-- unresolved args: ...sharedArgs -->\n<sb-button [label]="'meta'" [count]="1" (clicked)="clicked($event)"></sb-button>`
+    );
+  });
+
+  it('isolates a story it cannot read and still ships the rest of the file', () => {
+    const payload = build('./story-docs.stories.ts');
+
+    expect(storyOf(payload, 'Unclassifiable')).toMatchObject({
+      error: { message: expect.stringContaining('Could not evaluate story expression') },
+    });
+    expect(storyOf(payload, 'Unclassifiable')?.snippet).toBeUndefined();
+    expect(snippetOf(payload, 'Basic')).toBeDefined();
+  });
+
+  it.each([
+    ['a story file that does not exist', './missing.stories.ts', {}],
+    ['a story file with no meta.component', './no-component.stories.ts', {}],
+    [
+      'a component Compodoc never documented',
+      './story-docs.stories.ts',
+      { readDocumentationJson: (): CompodocJson => ({ components: [] }) },
+    ],
+    [
+      'an unreadable documentation.json',
+      './story-docs.stories.ts',
+      {
+        readDocumentationJson: () => {
+          throw new Error('ENOENT');
+        },
+      },
+    ],
+  ])('falls through for %s', (_case, importPath, overrides) => {
+    expect(build(importPath, overrides as Partial<BuildStoryDocsContext>)).toBeUndefined();
+  });
+
+  it('falls through when the entry has no story import path', () => {
+    expect(
+      buildStoryDocsPayload(
+        {
+          entry: { id: 'x', name: 'x', title: 'x', type: 'docs', storiesImports: [] } as IndexEntry,
+        },
+        {
+          workspaceRoot: FIXTURES,
+          outputDir: FIXTURES,
+          readDocumentationJson: documentationJson,
+          logger: { warn: vi.fn(), debug: vi.fn() },
+        }
+      )
+    ).toBeUndefined();
+  });
+});

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.test.ts
@@ -112,6 +112,22 @@ describe('buildStoryDocsPayload', () => {
     expect(snippet).toContain('<sb-button');
   });
 
+  // `export { X }` is registered by a different branch of the CSF parser, which records no
+  // declaration path. Reading only that path silently fell back to the meta's args.
+  it.each([
+    [
+      'ReExported',
+      `<sb-button [label]="'reexported'" [count]="9" (clicked)="clicked($event)"></sb-button>`,
+    ],
+    [
+      'RenamedStory',
+      `<!-- unresolved: ...sharedArgs -->\n<sb-button [label]="'meta'" [count]="10" (clicked)="clicked($event)"></sb-button>`,
+    ],
+    ['ReExportedTemplate', '<sb-button reexported></sb-button>'],
+  ])('reads the re-exported %s story from its own config', (storyName, expected) => {
+    expect(snippetOf(build('./story-docs.stories.ts'), storyName)).toBe(expected);
+  });
+
   it('isolates a story it cannot read and still ships the rest of the file', () => {
     const payload = build('./story-docs.stories.ts');
 

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
@@ -29,7 +29,13 @@ import type { AngularComponentTemplate } from './template-snippet.ts';
 import { generateAngularSnippet } from './template-snippet.ts';
 
 export interface BuildStoryDocsContext {
-  /** Directory story `importPath`s and Compodoc's relative `file` paths resolve against. */
+  /**
+   * Directory a story index `importPath` resolves against. This is the index generator's own
+   * working directory, which is the Storybook process cwd - deliberately not Compodoc's
+   * `workspaceRoot`, which the Angular builder can report as a different directory entirely.
+   */
+  storyRoot: string;
+  /** Directory Compodoc's relative `file` paths resolve against. */
   workspaceRoot: string;
   /** Directory Compodoc writes {@link DOCUMENTATION_JSON} into. */
   outputDir: string;
@@ -49,11 +55,17 @@ const argsObjectNode = (config?: t.ObjectExpression): t.ObjectExpression | undef
   return property && t.isObjectExpression(property.value) ? property.value : undefined;
 };
 
-/** Source text of every spread in an `args` object; those values cannot be resolved statically. */
-const spreadSources = (args?: t.ObjectExpression): string[] =>
-  (args?.properties ?? [])
-    .filter((property): property is t.SpreadElement => t.isSpreadElement(property))
-    .map((property) => generate(property, { concise: true, comments: false }).code);
+const sourceOf = (node: t.Node): string => generate(node, { concise: true, comments: false }).code;
+
+/**
+ * Source text of everything in an object literal that a static pass cannot read: spreads, computed
+ * keys and methods. Applied both to an `args` object and to the config object around it, since a
+ * spread at the config level carries args just as invisibly as one inside `args`.
+ */
+const unresolvableProperties = (object?: t.ObjectExpression): string[] =>
+  (object?.properties ?? [])
+    .filter((property) => !t.isObjectProperty(property) || keyOf(property) === undefined)
+    .map(sourceOf);
 
 /** Value of a config object's own property, if it has one. */
 const propertyValue = (config: t.ObjectExpression | undefined, name: string): t.Node | undefined =>
@@ -82,11 +94,22 @@ const returnedObject = (fn: t.Node | undefined): t.ObjectExpression | undefined 
   return t.isObjectExpression(returned) ? returned : undefined;
 };
 
+/** What a `template` property turned out to be. */
+type TemplateResult =
+  /** Read as markup, so the story is passed through as written. */
+  | { kind: 'literal'; markup: string }
+  /** A `template` or `render` exists but its markup is not knowable without running the story. */
+  | { kind: 'unresolvable'; source: string };
+
 /**
  * The template markup a `template` property holds. `null` and `undefined` do not count, matching
  * the preview's rule that an empty string is still a user-defined template.
+ *
+ * Anything that is not a literal - a hoisted `const`, an interpolated template literal, a call -
+ * is reported rather than printed: emitting its JavaScript source would put an identifier in the
+ * Source block where the user expects markup.
  */
-const templateFrom = (node: t.Node | undefined): string | undefined => {
+const templateFrom = (node: t.Node | undefined): TemplateResult | undefined => {
   if (
     node === undefined ||
     t.isNullLiteral(node) ||
@@ -95,23 +118,35 @@ const templateFrom = (node: t.Node | undefined): string | undefined => {
     return undefined;
   }
   if (t.isStringLiteral(node)) {
-    return node.value;
+    return { kind: 'literal', markup: node.value };
   }
   if (t.isTemplateLiteral(node) && node.expressions.length === 0) {
-    return node.quasis[0]?.value.cooked ?? '';
+    return { kind: 'literal', markup: node.quasis[0]?.value.cooked ?? '' };
   }
-  return generate(node, { concise: true, comments: false }).code;
+  return { kind: 'unresolvable', source: sourceOf(node) };
 };
 
 /**
  * The template a story or meta supplies itself, including the `render: () => ({ template })` form
  * Angular stories use.
+ *
+ * A `render` that is not an inline function returning an object literal is itself unresolvable: it
+ * may well produce markup, and generating an element from args would silently replace it.
  */
-const userTemplate = (config: t.ObjectExpression | undefined): string | undefined =>
-  templateFrom(
-    propertyValue(config, 'template') ??
-      propertyValue(returnedObject(propertyValue(config, 'render')), 'template')
-  );
+const userTemplate = (config: t.ObjectExpression | undefined): TemplateResult | undefined => {
+  const own = templateFrom(propertyValue(config, 'template'));
+  if (own) {
+    return own;
+  }
+  const render = propertyValue(config, 'render');
+  if (!render) {
+    return undefined;
+  }
+  const returned = returnedObject(render);
+  return returned
+    ? templateFrom(propertyValue(returned, 'template'))
+    : { kind: 'unresolvable', source: `render: ${sourceOf(render)}` };
+};
 
 /** Story's own `args` object, as a path so the shared CSF helper can read it. */
 const storyArgsPath = (
@@ -200,7 +235,7 @@ export const buildStoryDocsPayload = (
     return undefined;
   }
 
-  const storyPath = resolve(context.workspaceRoot, storyImportPath);
+  const storyPath = resolve(context.storyRoot, storyImportPath);
   let csf: CsfFile;
   try {
     csf = loadCsf(readFileSync(storyPath, 'utf8'), { makeTitle: () => input.entry.title }).parse();
@@ -219,7 +254,10 @@ export const buildStoryDocsPayload = (
   const metaNode = csf._metaNode;
   const metaArgs = metaArgsRecord(metaNode);
   const metaTemplate = userTemplate(metaNode);
-  const metaSpreads = spreadSources(argsObjectNode(metaNode));
+  const metaUnresolved = [
+    ...unresolvableProperties(metaNode),
+    ...unresolvableProperties(argsObjectNode(metaNode)),
+  ];
 
   const stories: StoryDocsById = {};
   for (const [exportName, story] of Object.entries(csf._stories)) {
@@ -235,7 +273,7 @@ export const buildStoryDocsPayload = (
           component,
           metaArgs,
           metaTemplate,
-          metaSpreads,
+          metaUnresolved,
         }),
       };
     } catch (error) {
@@ -265,8 +303,8 @@ const buildSnippet = (
   file: {
     component: AngularComponentTemplate;
     metaArgs: Record<string, t.Node>;
-    metaTemplate: string | undefined;
-    metaSpreads: string[];
+    metaTemplate: TemplateResult | undefined;
+    metaUnresolved: string[];
   }
 ): string => {
   const declaration = csf._storyDeclarationPath[exportName];
@@ -281,14 +319,19 @@ const buildSnippet = (
       : undefined;
 
   const template = userTemplate(config?.node) ?? storyFnTemplate ?? file.metaTemplate;
-  if (template !== undefined) {
-    return template;
+  if (template?.kind === 'literal') {
+    return template.markup;
   }
 
   const argsPath = storyArgsPath(config);
   return generateAngularSnippet({
     component: file.component,
     args: mergeArgsRecords(file.metaArgs, argsRecordFromObjectPath(argsPath)),
-    unresolvedArgs: [...file.metaSpreads, ...spreadSources(argsPath?.node)],
+    unresolvedArgs: [
+      ...(template ? [template.source] : []),
+      ...file.metaUnresolved,
+      ...unresolvableProperties(config?.node),
+      ...unresolvableProperties(argsPath?.node),
+    ],
   });
 };

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
@@ -1,4 +1,5 @@
 import { generate, types as t } from 'storybook/internal/babel';
+import type { ResolvedMetaComponent } from 'storybook/internal/common';
 import { getComponentIdFromEntry, getStoryImportPathFromEntry } from 'storybook/internal/common';
 import { storyNameFromExport } from 'storybook/internal/csf';
 import type { CsfFile } from 'storybook/internal/csf-tools';
@@ -20,12 +21,18 @@ import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 import type { CompodocJson, CompodocParsingLogger } from '@storybook/angular-compodoc';
-import { extractArgTypesFromData, htmlToText } from '@storybook/angular-compodoc';
 import { DOCUMENTATION_JSON } from '../compodoc-config.ts';
+import { extractArgTypesFromData, htmlToText } from '@storybook/angular-compodoc';
 import { findCompodocEntry } from './build-docgen.ts';
+import type { AngularHostContext } from './component-snippet.ts';
+import { angularHostComponent, angularHostImports } from './component-snippet.ts';
 import { resolveMetaComponent } from './resolve-component.ts';
 import type { AngularComponentTemplate } from './template-snippet.ts';
 import { generateAngularSnippet } from './template-snippet.ts';
+import type { SnippetFormat } from '../types.ts';
+
+/** Preserves what the browser generator produces, so `component` stays an opt-in. */
+export const DEFAULT_SNIPPET_FORMAT: SnippetFormat = 'template';
 
 export interface BuildStoryDocsContext {
   /**
@@ -40,6 +47,8 @@ export interface BuildStoryDocsContext {
   outputDir: string;
   readDocumentationJson: (path: string) => CompodocJson;
   logger: CompodocParsingLogger;
+  /** Shape of the emitted snippet. Defaults to {@link DEFAULT_SNIPPET_FORMAT}. */
+  snippetFormat?: SnippetFormat;
 }
 
 /** `args` object of a CSF config object expression. */
@@ -146,7 +155,7 @@ const resolveComponentTemplate = (
   csf: CsfFile,
   storyPath: string,
   context: BuildStoryDocsContext
-): AngularComponentTemplate | undefined => {
+): { component: AngularComponentTemplate; host: AngularHostContext } | undefined => {
   const resolved = resolveMetaComponent(csf, storyPath);
   if ('reason' in resolved) {
     context.logger.debug(`No Angular component resolved from ${storyPath}: ${resolved.reason}.`);
@@ -185,13 +194,29 @@ const resolveComponentTemplate = (
       .filter(([, argType]) => argType?.table?.category === category)
       .map(([name]) => name);
 
-  return {
+  const component = {
     name: entry.name ?? resolved.component.exportName,
     selector: entry.selector,
     inputs: named('inputs'),
     outputs: named('outputs'),
   };
+
+  return { component, host: hostContext(resolved.component, component) };
 };
+
+/**
+ * How the host wrapper names and imports the component. A default import has no export name worth
+ * printing, so the story file's own local name is the only one available.
+ */
+const hostContext = (
+  ref: ResolvedMetaComponent,
+  component: AngularComponentTemplate
+): AngularHostContext => ({
+  componentName: ref.exportName === 'default' ? ref.localName : ref.exportName,
+  importId: ref.importId,
+  defaultImport: ref.exportName === 'default',
+  outlet: !component.selector,
+});
 
 /**
  * Static Angular template snippets for one CSF story file.
@@ -220,10 +245,12 @@ export const buildStoryDocsPayload = (
     return undefined;
   }
 
-  const component = resolveComponentTemplate(csf, storyPath, context);
-  if (!component) {
+  const resolved = resolveComponentTemplate(csf, storyPath, context);
+  if (!resolved) {
     return undefined;
   }
+  const { component, host } = resolved;
+  const format = context.snippetFormat ?? DEFAULT_SNIPPET_FORMAT;
 
   const metaNode = csf._metaNode;
   const metaArgs = metaArgsRecord(metaNode);
@@ -235,17 +262,19 @@ export const buildStoryDocsPayload = (
     const name = story.name ?? storyNameFromExport(exportName);
     try {
       const { description, summary } = extractStoryJSDocInfo(csf._storyStatements[exportName]);
+      const { snippet, warning, handlers } = buildSnippet(csf, exportName, {
+        component,
+        metaArgs,
+        metaTemplate,
+        metaUnresolved,
+      });
       stories[story.id] = {
         id: story.id,
         name,
         description,
         summary,
-        snippet: buildSnippet(csf, exportName, {
-          component,
-          metaArgs,
-          metaTemplate,
-          metaUnresolved,
-        }),
+        snippet: format === 'component' ? angularHostComponent(snippet, handlers, host) : snippet,
+        warning,
       };
     } catch (error) {
       stories[story.id] = {
@@ -263,9 +292,19 @@ export const buildStoryDocsPayload = (
     id: getComponentIdFromEntry(input.entry),
     name: component.name,
     path: storyImportPath,
+    ...(format === 'component' ? { import: angularHostImports(host) } : {}),
     stories,
   };
 };
+
+/** What a story's snippet turned out to be, plus what the host component needs to render it. */
+interface SnippetResult {
+  snippet: string;
+  /** Set when the snippet is an incomplete example. */
+  warning?: string;
+  /** Output names the snippet binds, which the host class has to declare methods for. */
+  handlers: readonly string[];
+}
 
 /** Snippet for one story: the template it supplies itself, or one built from its declared args. */
 const buildSnippet = (
@@ -277,25 +316,36 @@ const buildSnippet = (
     metaTemplate: TemplateResult | undefined;
     metaUnresolved: string[];
   }
-): string => {
+): SnippetResult => {
   const config = storyConfig(csf, exportName);
 
   const template = userTemplate(config.object) ?? config.fnTemplate ?? file.metaTemplate;
   if (template?.kind === 'literal') {
-    return template.markup;
+    // Which outputs the story's own markup binds is not knowable, so the host declares none.
+    return { snippet: template.markup, handlers: [] };
   }
 
-  return generateAngularSnippet({
-    component: file.component,
-    // Not meta-specific: the helper reads the `args` property of any CSF config object.
-    args: mergeArgsRecords(file.metaArgs, metaArgsRecord(config.object)),
-    unresolvedArgs: [
-      ...(template ? [template.source] : []),
-      ...file.metaUnresolved,
-      ...unresolvableProperties(config.object),
-    ],
-  });
+  const unresolved = [
+    ...(template ? [template.source] : []),
+    ...file.metaUnresolved,
+    ...unresolvableProperties(config.object),
+  ];
+
+  return {
+    snippet: generateAngularSnippet({
+      component: file.component,
+      // Not meta-specific: the helper reads the `args` property of any CSF config object.
+      args: mergeArgsRecords(file.metaArgs, metaArgsRecord(config.object)),
+    }),
+    warning: unresolved.length > 0 ? unresolvedWarning(unresolved) : undefined,
+    // A component with no selector renders through `*ngComponentOutlet`, which binds nothing.
+    handlers: file.component.selector ? file.component.outputs : [],
+  };
 };
+
+/** Says which source text a static pass could not read, so a reader can see what is missing. */
+const unresolvedWarning = (unresolved: readonly string[]): string =>
+  `Incomplete snippet: ${unresolved.map((source) => `\`${source}\``).join(', ')} could not be resolved statically.`;
 
 /**
  * A story's own config object, plus the template a CSF2 story returns from its function body.

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
@@ -43,29 +43,25 @@ export interface BuildStoryDocsContext {
   logger: CompodocParsingLogger;
 }
 
-/** Compodoc records a component's selector, but its published types omit the field. */
-type WithSelector<T> = T & { selector?: string };
-
 /** `args` object of a CSF config object expression. */
 const argsObjectNode = (config?: t.ObjectExpression): t.ObjectExpression | undefined => {
-  const property = config?.properties.find(
-    (candidate): candidate is t.ObjectProperty =>
-      t.isObjectProperty(candidate) && keyOf(candidate) === 'args'
-  );
-  return property && t.isObjectExpression(property.value) ? property.value : undefined;
+  const value = propertyValue(config, 'args');
+  return t.isObjectExpression(value) ? value : undefined;
 };
 
 const sourceOf = (node: t.Node): string => generate(node, { concise: true, comments: false }).code;
 
 /**
- * Source text of everything in an object literal that a static pass cannot read: spreads, computed
- * keys and methods. Applied both to an `args` object and to the config object around it, since a
- * spread at the config level carries args just as invisibly as one inside `args`.
+ * Source text of everything a static pass cannot read - spreads, computed keys, methods - in a
+ * story or meta config and in its `args`. A spread at the config level carries args just as
+ * invisibly as one inside `args`.
  */
-const unresolvableProperties = (object?: t.ObjectExpression): string[] =>
-  (object?.properties ?? [])
-    .filter((property) => !t.isObjectProperty(property) || keyOf(property) === undefined)
-    .map(sourceOf);
+const unresolvableProperties = (config?: t.ObjectExpression): string[] =>
+  [config, argsObjectNode(config)].flatMap((object) =>
+    (object?.properties ?? [])
+      .filter((property) => !t.isObjectProperty(property) || keyOf(property) === null)
+      .map(sourceOf)
+  );
 
 /** Value of a config object's own property, if it has one. */
 const propertyValue = (config: t.ObjectExpression | undefined, name: string): t.Node | undefined =>
@@ -102,12 +98,9 @@ type TemplateResult =
   | { kind: 'unresolvable'; source: string };
 
 /**
- * The template markup a `template` property holds. `null` and `undefined` do not count, matching
- * the preview's rule that an empty string is still a user-defined template.
- *
- * Anything that is not a literal - a hoisted `const`, an interpolated template literal, a call -
- * is reported rather than printed: emitting its JavaScript source would put an identifier in the
- * Source block where the user expects markup.
+ * Markup a `template` property holds. `null` and `undefined` are not templates, but an empty string
+ * is, matching the preview's own rule. A non-literal is reported rather than printed, so JavaScript
+ * source never lands in the Source block where markup is expected.
  */
 const templateFrom = (node: t.Node | undefined): TemplateResult | undefined => {
   if (
@@ -128,10 +121,8 @@ const templateFrom = (node: t.Node | undefined): TemplateResult | undefined => {
 
 /**
  * The template a story or meta supplies itself, including the `render: () => ({ template })` form
- * Angular stories use.
- *
- * A `render` that is not an inline function returning an object literal is itself unresolvable: it
- * may well produce markup, and generating an element from args would silently replace it.
+ * Angular stories use. A `render` this cannot read into an object literal may still produce markup,
+ * so it counts as unresolvable rather than being replaced by generated bindings.
  */
 const userTemplate = (config: t.ObjectExpression | undefined): TemplateResult | undefined => {
   const own = templateFrom(propertyValue(config, 'template'));
@@ -160,11 +151,8 @@ const storyArgsPath = (
     .find((value) => value.isObjectExpression());
 
 /**
- * The component's selector and binding names, from its Compodoc entry.
- *
- * `extractArgTypesFromData` is what already knows how to read Compodoc's members - including that a
- * name appearing in both `inputsClass` and `outputsClass` is an Angular `model()` whose output is
- * `${name}Change` - so the discrimination is shared rather than reimplemented here.
+ * The component's selector and binding names, from its Compodoc entry. `extractArgTypesFromData`
+ * already resolves a `model()` into an input plus a `${name}Change` output.
  */
 const resolveComponentTemplate = (
   csf: CsfFile,
@@ -198,8 +186,7 @@ const resolveComponentTemplate = (
 
   const argTypes = extractArgTypesFromData(entry, {
     compodocJson,
-    // Snippets bind inputs and outputs, which this flag never removes; it only hides the
-    // properties and methods a snippet has no use for.
+    // Snippets bind inputs and outputs, which this flag never filters.
     filterNonInputControls: false,
     logger: context.logger,
     unwrapHtml: htmlToText,
@@ -212,19 +199,18 @@ const resolveComponentTemplate = (
 
   return {
     name: entry.name ?? resolved.component.exportName,
-    selector: (entry as WithSelector<typeof entry>).selector,
+    selector: entry.selector,
     inputs: named('inputs'),
     outputs: named('outputs'),
   };
 };
 
 /**
- * Builds a {@link StoryDocsPayload} of static Angular template snippets for one CSF story file.
+ * Static Angular template snippets for one CSF story file.
  *
- * Returns `undefined` when the file is unusable - not a story file, unparseable, no
- * `meta.component`, or no Compodoc entry for that component - which is the contract's "not mine,
- * fall through". A story whose snippet cannot be generated instead carries an `error` while the
- * rest of the file still ships; the two levels are different and must not be collapsed.
+ * `undefined` means the file is not ours to handle - unparseable, no `meta.component`, or no
+ * Compodoc entry. A story whose snippet fails instead carries an `error` while the rest of the file
+ * still ships; the two levels are deliberately distinct.
  */
 export const buildStoryDocsPayload = (
   input: StoryDocsProviderInput,
@@ -254,10 +240,7 @@ export const buildStoryDocsPayload = (
   const metaNode = csf._metaNode;
   const metaArgs = metaArgsRecord(metaNode);
   const metaTemplate = userTemplate(metaNode);
-  const metaUnresolved = [
-    ...unresolvableProperties(metaNode),
-    ...unresolvableProperties(argsObjectNode(metaNode)),
-  ];
+  const metaUnresolved = unresolvableProperties(metaNode);
 
   const stories: StoryDocsById = {};
   for (const [exportName, story] of Object.entries(csf._stories)) {
@@ -331,7 +314,6 @@ const buildSnippet = (
       ...(template ? [template.source] : []),
       ...file.metaUnresolved,
       ...unresolvableProperties(config?.node),
-      ...unresolvableProperties(argsPath?.node),
     ],
   });
 };

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
@@ -1,0 +1,294 @@
+import { type NodePath, generate, types as t } from 'storybook/internal/babel';
+import { getComponentIdFromEntry, getStoryImportPathFromEntry } from 'storybook/internal/common';
+import { storyNameFromExport } from 'storybook/internal/csf';
+import type { CsfFile } from 'storybook/internal/csf-tools';
+import {
+  argsRecordFromObjectPath,
+  extractStoryJSDocInfo,
+  keyOf,
+  loadCsf,
+  mergeArgsRecords,
+  metaArgsRecord,
+  normalizeStoryDeclaration,
+} from 'storybook/internal/csf-tools';
+import type {
+  StoryDocsById,
+  StoryDocsPayload,
+  StoryDocsProviderInput,
+} from 'storybook/internal/types';
+
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import type { CompodocJson, CompodocParsingLogger } from '@storybook/angular-compodoc';
+import { extractArgTypesFromData, htmlToText } from '@storybook/angular-compodoc';
+import { DOCUMENTATION_JSON } from '../compodoc-config.ts';
+import { findCompodocEntry } from './build-docgen.ts';
+import { resolveMetaComponent } from './resolve-component.ts';
+import type { AngularComponentTemplate } from './template-snippet.ts';
+import { generateAngularSnippet } from './template-snippet.ts';
+
+export interface BuildStoryDocsContext {
+  /** Directory story `importPath`s and Compodoc's relative `file` paths resolve against. */
+  workspaceRoot: string;
+  /** Directory Compodoc writes {@link DOCUMENTATION_JSON} into. */
+  outputDir: string;
+  readDocumentationJson: (path: string) => CompodocJson;
+  logger: CompodocParsingLogger;
+}
+
+/** Compodoc records a component's selector, but its published types omit the field. */
+type WithSelector<T> = T & { selector?: string };
+
+/** `args` object of a CSF config object expression. */
+const argsObjectNode = (config?: t.ObjectExpression): t.ObjectExpression | undefined => {
+  const property = config?.properties.find(
+    (candidate): candidate is t.ObjectProperty =>
+      t.isObjectProperty(candidate) && keyOf(candidate) === 'args'
+  );
+  return property && t.isObjectExpression(property.value) ? property.value : undefined;
+};
+
+/** Source text of every spread in an `args` object; those values cannot be resolved statically. */
+const spreadSources = (args?: t.ObjectExpression): string[] =>
+  (args?.properties ?? [])
+    .filter((property): property is t.SpreadElement => t.isSpreadElement(property))
+    .map((property) => generate(property, { concise: true, comments: false }).code);
+
+/** Value of a config object's own property, if it has one. */
+const propertyValue = (config: t.ObjectExpression | undefined, name: string): t.Node | undefined =>
+  config?.properties.find(
+    (candidate): candidate is t.ObjectProperty =>
+      t.isObjectProperty(candidate) && keyOf(candidate) === name
+  )?.value;
+
+/** Object literal a story or `render` function returns, when it returns one directly. */
+const returnedObject = (fn: t.Node | undefined): t.ObjectExpression | undefined => {
+  if (
+    !t.isArrowFunctionExpression(fn) &&
+    !t.isFunctionExpression(fn) &&
+    !t.isFunctionDeclaration(fn)
+  ) {
+    return undefined;
+  }
+  if (t.isObjectExpression(fn.body)) {
+    return fn.body;
+  }
+  const returned = t.isBlockStatement(fn.body)
+    ? fn.body.body.find((statement): statement is t.ReturnStatement =>
+        t.isReturnStatement(statement)
+      )?.argument
+    : undefined;
+  return t.isObjectExpression(returned) ? returned : undefined;
+};
+
+/**
+ * The template markup a `template` property holds. `null` and `undefined` do not count, matching
+ * the preview's rule that an empty string is still a user-defined template.
+ */
+const templateFrom = (node: t.Node | undefined): string | undefined => {
+  if (
+    node === undefined ||
+    t.isNullLiteral(node) ||
+    (t.isIdentifier(node) && node.name === 'undefined')
+  ) {
+    return undefined;
+  }
+  if (t.isStringLiteral(node)) {
+    return node.value;
+  }
+  if (t.isTemplateLiteral(node) && node.expressions.length === 0) {
+    return node.quasis[0]?.value.cooked ?? '';
+  }
+  return generate(node, { concise: true, comments: false }).code;
+};
+
+/**
+ * The template a story or meta supplies itself, including the `render: () => ({ template })` form
+ * Angular stories use.
+ */
+const userTemplate = (config: t.ObjectExpression | undefined): string | undefined =>
+  templateFrom(
+    propertyValue(config, 'template') ??
+      propertyValue(returnedObject(propertyValue(config, 'render')), 'template')
+  );
+
+/** Story's own `args` object, as a path so the shared CSF helper can read it. */
+const storyArgsPath = (
+  config: NodePath<t.ObjectExpression> | undefined
+): NodePath<t.ObjectExpression> | undefined =>
+  config
+    ?.get('properties')
+    .filter((property) => property.isObjectProperty())
+    .filter((property) => keyOf(property.node) === 'args')
+    .map((property) => property.get('value'))
+    .find((value) => value.isObjectExpression());
+
+/**
+ * The component's selector and binding names, from its Compodoc entry.
+ *
+ * `extractArgTypesFromData` is what already knows how to read Compodoc's members - including that a
+ * name appearing in both `inputsClass` and `outputsClass` is an Angular `model()` whose output is
+ * `${name}Change` - so the discrimination is shared rather than reimplemented here.
+ */
+const resolveComponentTemplate = (
+  csf: CsfFile,
+  storyPath: string,
+  context: BuildStoryDocsContext
+): AngularComponentTemplate | undefined => {
+  const resolved = resolveMetaComponent(csf, storyPath);
+  if ('reason' in resolved) {
+    context.logger.debug(`No Angular component resolved from ${storyPath}: ${resolved.reason}.`);
+    return undefined;
+  }
+
+  const documentationJson = join(context.outputDir, DOCUMENTATION_JSON);
+  let compodocJson: CompodocJson;
+  try {
+    compodocJson = context.readDocumentationJson(documentationJson);
+  } catch (error) {
+    context.logger.debug(
+      `Could not read ${documentationJson}: ${error instanceof Error ? error.message : String(error)}.`
+    );
+    return undefined;
+  }
+
+  const entry = findCompodocEntry(compodocJson, resolved.component, context.workspaceRoot);
+  if (!entry) {
+    context.logger.debug(
+      `Compodoc has no entry for "${resolved.component.exportName}" (${storyPath}).`
+    );
+    return undefined;
+  }
+
+  const argTypes = extractArgTypesFromData(entry, {
+    compodocJson,
+    // Snippets bind inputs and outputs, which this flag never removes; it only hides the
+    // properties and methods a snippet has no use for.
+    filterNonInputControls: false,
+    logger: context.logger,
+    unwrapHtml: htmlToText,
+  });
+
+  const named = (category: string) =>
+    Object.entries(argTypes ?? {})
+      .filter(([, argType]) => argType?.table?.category === category)
+      .map(([name]) => name);
+
+  return {
+    name: entry.name ?? resolved.component.exportName,
+    selector: (entry as WithSelector<typeof entry>).selector,
+    inputs: named('inputs'),
+    outputs: named('outputs'),
+  };
+};
+
+/**
+ * Builds a {@link StoryDocsPayload} of static Angular template snippets for one CSF story file.
+ *
+ * Returns `undefined` when the file is unusable - not a story file, unparseable, no
+ * `meta.component`, or no Compodoc entry for that component - which is the contract's "not mine,
+ * fall through". A story whose snippet cannot be generated instead carries an `error` while the
+ * rest of the file still ships; the two levels are different and must not be collapsed.
+ */
+export const buildStoryDocsPayload = (
+  input: StoryDocsProviderInput,
+  context: BuildStoryDocsContext
+): StoryDocsPayload | undefined => {
+  const storyImportPath = getStoryImportPathFromEntry(input.entry);
+  if (!storyImportPath) {
+    return undefined;
+  }
+
+  const storyPath = resolve(context.workspaceRoot, storyImportPath);
+  let csf: CsfFile;
+  try {
+    csf = loadCsf(readFileSync(storyPath, 'utf8'), { makeTitle: () => input.entry.title }).parse();
+  } catch (error) {
+    context.logger.debug(
+      `Could not parse ${storyPath}: ${error instanceof Error ? error.message : String(error)}.`
+    );
+    return undefined;
+  }
+
+  const component = resolveComponentTemplate(csf, storyPath, context);
+  if (!component) {
+    return undefined;
+  }
+
+  const metaNode = csf._metaNode;
+  const metaArgs = metaArgsRecord(metaNode);
+  const metaTemplate = userTemplate(metaNode);
+  const metaSpreads = spreadSources(argsObjectNode(metaNode));
+
+  const stories: StoryDocsById = {};
+  for (const [exportName, story] of Object.entries(csf._stories)) {
+    const name = story.name ?? storyNameFromExport(exportName);
+    try {
+      const { description, summary } = extractStoryJSDocInfo(csf._storyStatements[exportName]);
+      stories[story.id] = {
+        id: story.id,
+        name,
+        description,
+        summary,
+        snippet: buildSnippet(csf, exportName, {
+          component,
+          metaArgs,
+          metaTemplate,
+          metaSpreads,
+        }),
+      };
+    } catch (error) {
+      stories[story.id] = {
+        id: story.id,
+        name,
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message }
+            : { name: 'Error', message: String(error) },
+      };
+    }
+  }
+
+  return {
+    id: getComponentIdFromEntry(input.entry),
+    name: component.name,
+    path: storyImportPath,
+    stories,
+  };
+};
+
+/** Snippet for one story: the template it supplies itself, or one built from its declared args. */
+const buildSnippet = (
+  csf: CsfFile,
+  exportName: string,
+  file: {
+    component: AngularComponentTemplate;
+    metaArgs: Record<string, t.Node>;
+    metaTemplate: string | undefined;
+    metaSpreads: string[];
+  }
+): string => {
+  const declaration = csf._storyDeclarationPath[exportName];
+  const normalized = declaration ? normalizeStoryDeclaration(declaration) : undefined;
+  const config = normalized?.type === 'config' ? normalized.path : undefined;
+
+  // A CSF2 story is the render function itself, and Angular's idiom is to return `{ template }`
+  // from it. Ignoring that would replace the user's markup with a fabricated element.
+  const storyFnTemplate =
+    normalized?.type === 'fn'
+      ? templateFrom(propertyValue(returnedObject(normalized.path.node), 'template'))
+      : undefined;
+
+  const template = userTemplate(config?.node) ?? storyFnTemplate ?? file.metaTemplate;
+  if (template !== undefined) {
+    return template;
+  }
+
+  const argsPath = storyArgsPath(config);
+  return generateAngularSnippet({
+    component: file.component,
+    args: mergeArgsRecords(file.metaArgs, argsRecordFromObjectPath(argsPath)),
+    unresolvedArgs: [...file.metaSpreads, ...spreadSources(argsPath?.node)],
+  });
+};

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
@@ -1,9 +1,8 @@
-import { type NodePath, generate, types as t } from 'storybook/internal/babel';
+import { generate, types as t } from 'storybook/internal/babel';
 import { getComponentIdFromEntry, getStoryImportPathFromEntry } from 'storybook/internal/common';
 import { storyNameFromExport } from 'storybook/internal/csf';
 import type { CsfFile } from 'storybook/internal/csf-tools';
 import {
-  argsRecordFromObjectPath,
   extractStoryJSDocInfo,
   keyOf,
   loadCsf,
@@ -138,17 +137,6 @@ const userTemplate = (config: t.ObjectExpression | undefined): TemplateResult | 
     ? templateFrom(propertyValue(returned, 'template'))
     : { kind: 'unresolvable', source: `render: ${sourceOf(render)}` };
 };
-
-/** Story's own `args` object, as a path so the shared CSF helper can read it. */
-const storyArgsPath = (
-  config: NodePath<t.ObjectExpression> | undefined
-): NodePath<t.ObjectExpression> | undefined =>
-  config
-    ?.get('properties')
-    .filter((property) => property.isObjectProperty())
-    .filter((property) => keyOf(property.node) === 'args')
-    .map((property) => property.get('value'))
-    .find((value) => value.isObjectExpression());
 
 /**
  * The component's selector and binding names, from its Compodoc entry. `extractArgTypesFromData`
@@ -290,30 +278,50 @@ const buildSnippet = (
     metaUnresolved: string[];
   }
 ): string => {
-  const declaration = csf._storyDeclarationPath[exportName];
-  const normalized = declaration ? normalizeStoryDeclaration(declaration) : undefined;
-  const config = normalized?.type === 'config' ? normalized.path : undefined;
+  const config = storyConfig(csf, exportName);
 
-  // A CSF2 story is the render function itself, and Angular's idiom is to return `{ template }`
-  // from it. Ignoring that would replace the user's markup with a fabricated element.
-  const storyFnTemplate =
-    normalized?.type === 'fn'
-      ? templateFrom(propertyValue(returnedObject(normalized.path.node), 'template'))
-      : undefined;
-
-  const template = userTemplate(config?.node) ?? storyFnTemplate ?? file.metaTemplate;
+  const template = userTemplate(config.object) ?? config.fnTemplate ?? file.metaTemplate;
   if (template?.kind === 'literal') {
     return template.markup;
   }
 
-  const argsPath = storyArgsPath(config);
   return generateAngularSnippet({
     component: file.component,
-    args: mergeArgsRecords(file.metaArgs, argsRecordFromObjectPath(argsPath)),
+    // Not meta-specific: the helper reads the `args` property of any CSF config object.
+    args: mergeArgsRecords(file.metaArgs, metaArgsRecord(config.object)),
     unresolvedArgs: [
       ...(template ? [template.source] : []),
       ...file.metaUnresolved,
-      ...unresolvableProperties(config?.node),
+      ...unresolvableProperties(config.object),
     ],
   });
+};
+
+/**
+ * A story's own config object, plus the template a CSF2 story returns from its function body.
+ *
+ * `export { A }` registers a story without a declaration path, because the parser resolves the
+ * re-exported binding instead. Its initializer is still recorded, so the config object is reachable
+ * either way and a re-exported story keeps its own args rather than silently inheriting the meta's.
+ */
+const storyConfig = (
+  csf: CsfFile,
+  exportName: string
+): { object?: t.ObjectExpression; fnTemplate?: TemplateResult } => {
+  const declaration = csf._storyDeclarationPath[exportName];
+  const normalized = declaration ? normalizeStoryDeclaration(declaration) : undefined;
+
+  if (normalized?.type === 'config') {
+    return { object: normalized.path.node };
+  }
+  if (normalized?.type === 'fn') {
+    // Angular's CSF2 idiom is to return `{ template }`; ignoring it would replace the user's
+    // markup with a fabricated element.
+    return {
+      fnTemplate: templateFrom(propertyValue(returnedObject(normalized.path.node), 'template')),
+    };
+  }
+
+  const reExported = csf._storyStatements[exportName];
+  return { object: t.isObjectExpression(reExported) ? reExported : undefined };
 };

--- a/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-story-docs.ts
@@ -18,12 +18,8 @@ import type {
 } from 'storybook/internal/types';
 
 import { readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
-import type { CompodocJson, CompodocParsingLogger } from '@storybook/angular-compodoc';
-import { DOCUMENTATION_JSON } from '../compodoc-config.ts';
-import { extractArgTypesFromData, htmlToText } from '@storybook/angular-compodoc';
-import { findCompodocEntry } from './build-docgen.ts';
 import type { AngularHostContext } from './component-snippet.ts';
 import { angularHostComponent, angularHostImports } from './component-snippet.ts';
 import { resolveMetaComponent } from './resolve-component.ts';
@@ -34,19 +30,30 @@ import type { SnippetFormat } from '../types.ts';
 /** Preserves what the browser generator produces, so `component` stays an opt-in. */
 export const DEFAULT_SNIPPET_FORMAT: SnippetFormat = 'template';
 
+/**
+ * The selector and binding names a snippet is built from, for one component.
+ *
+ * Which engine produced them is deliberately not expressed here. Compodoc is one source; an
+ * in-process Angular component meta service is another, and swapping between them must not reach
+ * into snippet generation.
+ */
+export type AngularComponentResolver = (
+  component: ResolvedMetaComponent
+) => AngularComponentTemplate | undefined;
+
+/** The slice of the logger this module uses. */
+export interface StoryDocsLogger {
+  debug: (message: string) => void;
+}
+
 export interface BuildStoryDocsContext {
   /**
    * Directory a story index `importPath` resolves against. This is the index generator's own
-   * working directory, which is the Storybook process cwd - deliberately not Compodoc's
-   * `workspaceRoot`, which the Angular builder can report as a different directory entirely.
+   * working directory, which is the Storybook process cwd.
    */
   storyRoot: string;
-  /** Directory Compodoc's relative `file` paths resolve against. */
-  workspaceRoot: string;
-  /** Directory Compodoc writes {@link DOCUMENTATION_JSON} into. */
-  outputDir: string;
-  readDocumentationJson: (path: string) => CompodocJson;
-  logger: CompodocParsingLogger;
+  resolveComponent: AngularComponentResolver;
+  logger: StoryDocsLogger;
   /** Shape of the emitted snippet. Defaults to {@link DEFAULT_SNIPPET_FORMAT}. */
   snippetFormat?: SnippetFormat;
 }
@@ -148,63 +155,6 @@ const userTemplate = (config: t.ObjectExpression | undefined): TemplateResult | 
 };
 
 /**
- * The component's selector and binding names, from its Compodoc entry. `extractArgTypesFromData`
- * already resolves a `model()` into an input plus a `${name}Change` output.
- */
-const resolveComponentTemplate = (
-  csf: CsfFile,
-  storyPath: string,
-  context: BuildStoryDocsContext
-): { component: AngularComponentTemplate; host: AngularHostContext } | undefined => {
-  const resolved = resolveMetaComponent(csf, storyPath);
-  if ('reason' in resolved) {
-    context.logger.debug(`No Angular component resolved from ${storyPath}: ${resolved.reason}.`);
-    return undefined;
-  }
-
-  const documentationJson = join(context.outputDir, DOCUMENTATION_JSON);
-  let compodocJson: CompodocJson;
-  try {
-    compodocJson = context.readDocumentationJson(documentationJson);
-  } catch (error) {
-    context.logger.debug(
-      `Could not read ${documentationJson}: ${error instanceof Error ? error.message : String(error)}.`
-    );
-    return undefined;
-  }
-
-  const entry = findCompodocEntry(compodocJson, resolved.component, context.workspaceRoot);
-  if (!entry) {
-    context.logger.debug(
-      `Compodoc has no entry for "${resolved.component.exportName}" (${storyPath}).`
-    );
-    return undefined;
-  }
-
-  const argTypes = extractArgTypesFromData(entry, {
-    compodocJson,
-    // Snippets bind inputs and outputs, which this flag never filters.
-    filterNonInputControls: false,
-    logger: context.logger,
-    unwrapHtml: htmlToText,
-  });
-
-  const named = (category: string) =>
-    Object.entries(argTypes ?? {})
-      .filter(([, argType]) => argType?.table?.category === category)
-      .map(([name]) => name);
-
-  const component = {
-    name: entry.name ?? resolved.component.exportName,
-    selector: entry.selector,
-    inputs: named('inputs'),
-    outputs: named('outputs'),
-  };
-
-  return { component, host: hostContext(resolved.component, component) };
-};
-
-/**
  * How the host wrapper names and imports the component. A default import has no export name worth
  * printing, so the story file's own local name is the only one available.
  */
@@ -221,9 +171,9 @@ const hostContext = (
 /**
  * Static Angular template snippets for one CSF story file.
  *
- * `undefined` means the file is not ours to handle - unparseable, no `meta.component`, or no
- * Compodoc entry. A story whose snippet fails instead carries an `error` while the rest of the file
- * still ships; the two levels are deliberately distinct.
+ * `undefined` means the file is not ours to handle - unparseable, no `meta.component`, or a
+ * component the docgen engine has nothing for. A story whose snippet fails instead carries an
+ * `error` while the rest of the file still ships; the two levels are deliberately distinct.
  */
 export const buildStoryDocsPayload = (
   input: StoryDocsProviderInput,
@@ -245,11 +195,17 @@ export const buildStoryDocsPayload = (
     return undefined;
   }
 
-  const resolved = resolveComponentTemplate(csf, storyPath, context);
-  if (!resolved) {
+  const ref = resolveMetaComponent(csf, storyPath);
+  if ('reason' in ref) {
+    context.logger.debug(`No Angular component resolved from ${storyPath}: ${ref.reason}.`);
     return undefined;
   }
-  const { component, host } = resolved;
+
+  const component = context.resolveComponent(ref.component);
+  if (!component) {
+    return undefined;
+  }
+  const host = hostContext(ref.component, component);
   const format = context.snippetFormat ?? DEFAULT_SNIPPET_FORMAT;
 
   const metaNode = csf._metaNode;

--- a/code/frameworks/angular-vite/src/docgen/compodoc-component-resolver.ts
+++ b/code/frameworks/angular-vite/src/docgen/compodoc-component-resolver.ts
@@ -1,27 +1,26 @@
 /**
  * Compodoc's answer to "what does this component declare".
  *
- * This is the only place in the snippet path that knows `documentation.json` exists. Snippet
- * generation consumes {@link AngularComponentResolver}, so a different metadata source - an
- * in-process Angular component meta service, say - is a second implementation of this file rather
- * than a change to any of the generators.
+ * Snippet generation consumes {@link AngularComponentResolver} and never reaches for a metadata
+ * source itself, so a different one - an in-process Angular component meta service, say - is a
+ * sibling of this file rather than a change to any of the generators. Where Compodoc's metadata is
+ * read from stays with the caller that wires this up.
  */
 import type { ResolvedMetaComponent } from 'storybook/internal/common';
 
-import { join } from 'node:path';
-
 import type { CompodocJson, CompodocParsingLogger } from '@storybook/angular-compodoc';
 import { extractArgTypesFromData, htmlToText } from '@storybook/angular-compodoc';
-import { DOCUMENTATION_JSON } from '../compodoc-config.ts';
 import { findCompodocEntry } from './build-docgen.ts';
 import type { AngularComponentResolver } from './build-story-docs.ts';
 
 export interface CompodocComponentResolverOptions {
   /** Directory Compodoc's relative `file` paths resolve against. */
   workspaceRoot: string;
-  /** Directory Compodoc writes {@link DOCUMENTATION_JSON} into. */
-  outputDir: string;
-  readDocumentationJson: (path: string) => CompodocJson;
+  /**
+   * Compodoc's metadata. Called per resolve rather than captured once, so a Compodoc run that
+   * finishes mid-session is picked up; where it comes from is the caller's business.
+   */
+  readMetadata: () => CompodocJson;
   logger: CompodocParsingLogger;
 }
 
@@ -32,13 +31,12 @@ export interface CompodocComponentResolverOptions {
 export const createCompodocComponentResolver =
   (options: CompodocComponentResolverOptions): AngularComponentResolver =>
   (component: ResolvedMetaComponent) => {
-    const documentationJson = join(options.outputDir, DOCUMENTATION_JSON);
     let compodocJson: CompodocJson;
     try {
-      compodocJson = options.readDocumentationJson(documentationJson);
+      compodocJson = options.readMetadata();
     } catch (error) {
       options.logger.debug(
-        `Could not read ${documentationJson}: ${error instanceof Error ? error.message : String(error)}.`
+        `Could not read Compodoc metadata: ${error instanceof Error ? error.message : String(error)}.`
       );
       return undefined;
     }

--- a/code/frameworks/angular-vite/src/docgen/compodoc-component-resolver.ts
+++ b/code/frameworks/angular-vite/src/docgen/compodoc-component-resolver.ts
@@ -1,0 +1,73 @@
+/**
+ * Compodoc's answer to "what does this component declare".
+ *
+ * This is the only place in the snippet path that knows `documentation.json` exists. Snippet
+ * generation consumes {@link AngularComponentResolver}, so a different metadata source - an
+ * in-process Angular component meta service, say - is a second implementation of this file rather
+ * than a change to any of the generators.
+ */
+import type { ResolvedMetaComponent } from 'storybook/internal/common';
+
+import { join } from 'node:path';
+
+import type { CompodocJson, CompodocParsingLogger } from '@storybook/angular-compodoc';
+import { extractArgTypesFromData, htmlToText } from '@storybook/angular-compodoc';
+import { DOCUMENTATION_JSON } from '../compodoc-config.ts';
+import { findCompodocEntry } from './build-docgen.ts';
+import type { AngularComponentResolver } from './build-story-docs.ts';
+
+export interface CompodocComponentResolverOptions {
+  /** Directory Compodoc's relative `file` paths resolve against. */
+  workspaceRoot: string;
+  /** Directory Compodoc writes {@link DOCUMENTATION_JSON} into. */
+  outputDir: string;
+  readDocumentationJson: (path: string) => CompodocJson;
+  logger: CompodocParsingLogger;
+}
+
+/**
+ * `extractArgTypesFromData` already resolves a `model()` into an input plus a `${name}Change`
+ * output, so the binding names it reports are the ones a template may bind.
+ */
+export const createCompodocComponentResolver =
+  (options: CompodocComponentResolverOptions): AngularComponentResolver =>
+  (component: ResolvedMetaComponent) => {
+    const documentationJson = join(options.outputDir, DOCUMENTATION_JSON);
+    let compodocJson: CompodocJson;
+    try {
+      compodocJson = options.readDocumentationJson(documentationJson);
+    } catch (error) {
+      options.logger.debug(
+        `Could not read ${documentationJson}: ${error instanceof Error ? error.message : String(error)}.`
+      );
+      return undefined;
+    }
+
+    const entry = findCompodocEntry(compodocJson, component, options.workspaceRoot);
+    if (!entry) {
+      options.logger.debug(
+        `Compodoc has no entry for "${component.exportName}" (${component.path ?? 'unresolved'}).`
+      );
+      return undefined;
+    }
+
+    const argTypes = extractArgTypesFromData(entry, {
+      compodocJson,
+      // Snippets bind inputs and outputs, which this flag never filters.
+      filterNonInputControls: false,
+      logger: options.logger,
+      unwrapHtml: htmlToText,
+    });
+
+    const named = (category: string) =>
+      Object.entries(argTypes ?? {})
+        .filter(([, argType]) => argType?.table?.category === category)
+        .map(([name]) => name);
+
+    return {
+      name: entry.name ?? component.exportName,
+      selector: entry.selector,
+      inputs: named('inputs'),
+      outputs: named('outputs'),
+    };
+  };

--- a/code/frameworks/angular-vite/src/docgen/component-snippet.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/component-snippet.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AngularHostContext } from './component-snippet.ts';
+import { angularHostComponent, angularHostImports } from './component-snippet.ts';
+
+const context = (overrides: Partial<AngularHostContext> = {}): AngularHostContext => ({
+  componentName: 'ButtonComponent',
+  importId: './button.component',
+  ...overrides,
+});
+
+describe('angularHostImports', () => {
+  it('imports a named export the way the story file did', () => {
+    expect(angularHostImports(context())).toBe(
+      `import { Component } from '@angular/core';\nimport { ButtonComponent } from './button.component';`
+    );
+  });
+
+  it('imports a default export without braces', () => {
+    expect(angularHostImports(context({ defaultImport: true }))).toBe(
+      `import { Component } from '@angular/core';\nimport ButtonComponent from './button.component';`
+    );
+  });
+
+  it('emits no component import when the story file declares the component itself', () => {
+    expect(angularHostImports(context({ importId: undefined }))).toBe(
+      `import { Component } from '@angular/core';`
+    );
+  });
+
+  it('pulls in NgComponentOutlet for a component with no selector', () => {
+    expect(angularHostImports(context({ outlet: true }))).toContain(
+      `import { NgComponentOutlet } from '@angular/common';`
+    );
+  });
+});
+
+describe('angularHostComponent', () => {
+  it('declares a no-op method per bound output so the template type-checks', () => {
+    expect(angularHostComponent('<sb-button />', ['clicked', 'closed'], context())).toBe(
+      `@Component({
+  selector: 'app-root',
+  template: \`<sb-button />\`,
+  imports: [ButtonComponent],
+})
+export class App {
+  clicked(event: unknown) {}
+  closed(event: unknown) {}
+}`
+    );
+  });
+
+  it('leaves the class empty when the template binds nothing', () => {
+    expect(angularHostComponent('<sb-button />', [], context())).toContain('export class App {}');
+  });
+
+  it('quotes an output name that is not a valid identifier', () => {
+    expect(angularHostComponent('<sb-button />', ['data-changed'], context())).toContain(
+      `['data-changed'](event: unknown) {}`
+    );
+  });
+
+  it('exposes the class the outlet template reads as a value', () => {
+    const snippet = angularHostComponent(
+      '<ng-container *ngComponentOutlet="ButtonComponent"></ng-container>',
+      [],
+      context({ outlet: true })
+    );
+
+    expect(snippet).toContain('imports: [NgComponentOutlet],');
+    expect(snippet).toContain('readonly ButtonComponent = ButtonComponent;');
+  });
+
+  it.each([
+    ['a backtick', '<sb-button [label]="`hi`" />', '<sb-button [label]="\\`hi\\`" />'],
+    ['an interpolation', '<sb-button>${x}</sb-button>', '<sb-button>\\${x}</sb-button>'],
+    ['a backslash', '<sb-button [re]="/a\\d/" />', '<sb-button [re]="/a\\\\d/" />'],
+  ])('escapes %s so it cannot break out of the host template literal', (_case, markup, escaped) => {
+    expect(angularHostComponent(markup, [], context())).toContain(`template: \`${escaped}\`,`);
+  });
+});

--- a/code/frameworks/angular-vite/src/docgen/component-snippet.ts
+++ b/code/frameworks/angular-vite/src/docgen/component-snippet.ts
@@ -1,0 +1,77 @@
+/**
+ * The standalone host component a story's markup is wrapped in, for the `component` snippet format.
+ *
+ * The `template` format emits the markup on its own. That reads well beside a rendered story but
+ * cannot be pasted anywhere, because an Angular template only exists inside a component. This
+ * format adds the host, the standalone imports it needs and the members its template references, so
+ * the snippet stands on its own.
+ */
+import { IDENTIFIER } from './template-snippet.ts';
+
+/** Selector of the generated host, matching what the Angular CLI scaffolds for a root component. */
+const HOST_SELECTOR = 'app-root';
+const HOST_CLASS = 'App';
+const INDENT = '  ';
+
+/** What the host wrapper needs, all of it the same for every story under one component. */
+export interface AngularHostContext {
+  /** Class name the template renders and the host's `imports` lists. */
+  componentName: string;
+  /** Specifier the component is imported from; absent when the story file declares it inline. */
+  importId?: string;
+  /** The story file imports the component as a default export. */
+  defaultImport?: boolean;
+  /** The template renders through `*ngComponentOutlet`, because the component has no selector. */
+  outlet?: boolean;
+}
+
+/** Import block for a component's snippets, carried once per payload rather than per story. */
+export const angularHostImports = (context: AngularHostContext): string =>
+  [
+    `import { Component } from '@angular/core';`,
+    ...(context.outlet ? [`import { NgComponentOutlet } from '@angular/common';`] : []),
+    ...(context.importId
+      ? [
+          context.defaultImport
+            ? `import ${context.componentName} from '${context.importId}';`
+            : `import { ${context.componentName} } from '${context.importId}';`,
+        ]
+      : []),
+  ].join('\n');
+
+/**
+ * Wraps one story's markup in its host component.
+ *
+ * `handlers` are the output names the markup binds. Angular's template type checking resolves them
+ * against the host class, so a snippet that binds an output without declaring the method would not
+ * compile - which is the whole point of this format.
+ */
+export const angularHostComponent = (
+  template: string,
+  handlers: readonly string[],
+  context: AngularHostContext
+): string => {
+  const members = [
+    // `*ngComponentOutlet` reads the class as a template expression, so the host has to expose it.
+    ...(context.outlet ? [`readonly ${context.componentName} = ${context.componentName};`] : []),
+    ...handlers.map((name) => `${memberName(name)}(event: unknown) {}`),
+  ];
+
+  return [
+    '@Component({',
+    `${INDENT}selector: '${HOST_SELECTOR}',`,
+    `${INDENT}template: \`${escapeTemplateLiteral(template)}\`,`,
+    `${INDENT}imports: [${context.outlet ? 'NgComponentOutlet' : context.componentName}],`,
+    '})',
+    members.length === 0
+      ? `export class ${HOST_CLASS} {}`
+      : `export class ${HOST_CLASS} {\n${members.map((member) => INDENT + member).join('\n')}\n}`,
+  ].join('\n');
+};
+
+/** Class member name: written plainly when it is an identifier, quoted otherwise. */
+const memberName = (name: string): string => (IDENTIFIER.test(name) ? name : `['${name}']`);
+
+/** Escapes what would otherwise close or interpolate the host's template literal. */
+const escapeTemplateLiteral = (markup: string): string =>
+  markup.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');

--- a/code/frameworks/angular-vite/src/docgen/docgen-worker.ts
+++ b/code/frameworks/angular-vite/src/docgen/docgen-worker.ts
@@ -6,19 +6,12 @@
  * only reads Compodoc's `documentation.json` from disk; generating it is not this module's job.
  */
 import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
-import { logger } from 'storybook/internal/node-logger';
 import type { DocgenMiddleware, DocgenProvider } from 'storybook/internal/types';
 
-import type { CompodocParsingLogger } from '@storybook/angular-compodoc';
 import type { AngularDocgenOptions } from './build-docgen.ts';
 import { buildDocgenPayload } from './build-docgen.ts';
 import { createDocumentationJsonReader } from './documentation-json.ts';
-
-/** Worker-side logger, prefixed so a line from a worker thread is attributable. */
-const workerLogger: CompodocParsingLogger = {
-  warn: (message) => logger.warn(`[storybook-angular-vite] ${message}`),
-  debug: (message) => logger.debug(`[storybook-angular-vite] ${message}`),
-};
+import { compodocLogger } from './logger.ts';
 
 /** Builds the Angular docgen middleware. */
 export const createDocgenProvider = (options: AngularDocgenOptions): DocgenMiddleware => {
@@ -34,7 +27,7 @@ export const createDocgenProvider = (options: AngularDocgenOptions): DocgenMiddl
       const ours = buildDocgenPayload(input, {
         options,
         readDocumentationJson,
-        logger: workerLogger,
+        logger: compodocLogger,
       });
 
       if (!ours) {

--- a/code/frameworks/angular-vite/src/docgen/docgen-worker.ts
+++ b/code/frameworks/angular-vite/src/docgen/docgen-worker.ts
@@ -9,34 +9,15 @@ import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/i
 import { logger } from 'storybook/internal/node-logger';
 import type { DocgenMiddleware, DocgenProvider } from 'storybook/internal/types';
 
-import { readFileSync, statSync } from 'node:fs';
-
-import type { CompodocJson, CompodocParsingLogger } from '@storybook/angular-compodoc';
+import type { CompodocParsingLogger } from '@storybook/angular-compodoc';
 import type { AngularDocgenOptions } from './build-docgen.ts';
 import { buildDocgenPayload } from './build-docgen.ts';
+import { createDocumentationJsonReader } from './documentation-json.ts';
 
 /** Worker-side logger, prefixed so a line from a worker thread is attributable. */
 const workerLogger: CompodocParsingLogger = {
   warn: (message) => logger.warn(`[storybook-angular-vite] ${message}`),
   debug: (message) => logger.debug(`[storybook-angular-vite] ${message}`),
-};
-
-/**
- * Reads `documentation.json`, memoized on the file's mtime and size: the burst of one request per
- * component would otherwise reparse a real app's multi-megabyte file, while keying on the file's
- * identity still picks up a Compodoc run the user starts mid-session.
- */
-const createDocumentationJsonReader = () => {
-  let cached: { key: string; json: CompodocJson } | undefined;
-
-  return (path: string): CompodocJson => {
-    const stats = statSync(path);
-    const key = `${path}:${stats.mtimeMs}:${stats.size}`;
-    if (cached?.key !== key) {
-      cached = { key, json: JSON.parse(readFileSync(path, 'utf8')) as CompodocJson };
-    }
-    return cached.json;
-  };
 };
 
 /** Builds the Angular docgen middleware. */

--- a/code/frameworks/angular-vite/src/docgen/documentation-json.ts
+++ b/code/frameworks/angular-vite/src/docgen/documentation-json.ts
@@ -3,12 +3,9 @@ import { readFileSync, statSync } from 'node:fs';
 import type { CompodocJson } from '@storybook/angular-compodoc';
 
 /**
- * Reads `documentation.json`, memoized on the file's mtime and size: the burst of one request per
- * component would otherwise reparse a real app's multi-megabyte file, while keying on the file's
- * identity still picks up a Compodoc run the user starts mid-session.
- *
- * Throws when the file is absent or unreadable, so callers decide what an unusable scan means for
- * them rather than inheriting a shared answer.
+ * Reads `documentation.json`, memoized on mtime and size: a burst of one request per component
+ * would otherwise reparse a multi-megabyte file, while keying on the file's identity still picks up
+ * a Compodoc run started mid-session.
  */
 export const createDocumentationJsonReader = () => {
   let cached: { key: string; json: CompodocJson } | undefined;

--- a/code/frameworks/angular-vite/src/docgen/documentation-json.ts
+++ b/code/frameworks/angular-vite/src/docgen/documentation-json.ts
@@ -1,0 +1,24 @@
+import { readFileSync, statSync } from 'node:fs';
+
+import type { CompodocJson } from '@storybook/angular-compodoc';
+
+/**
+ * Reads `documentation.json`, memoized on the file's mtime and size: the burst of one request per
+ * component would otherwise reparse a real app's multi-megabyte file, while keying on the file's
+ * identity still picks up a Compodoc run the user starts mid-session.
+ *
+ * Throws when the file is absent or unreadable, so callers decide what an unusable scan means for
+ * them rather than inheriting a shared answer.
+ */
+export const createDocumentationJsonReader = () => {
+  let cached: { key: string; json: CompodocJson } | undefined;
+
+  return (path: string): CompodocJson => {
+    const stats = statSync(path);
+    const key = `${path}:${stats.mtimeMs}:${stats.size}`;
+    if (cached?.key !== key) {
+      cached = { key, json: JSON.parse(readFileSync(path, 'utf8')) as CompodocJson };
+    }
+    return cached.json;
+  };
+};

--- a/code/frameworks/angular-vite/src/docgen/logger.ts
+++ b/code/frameworks/angular-vite/src/docgen/logger.ts
@@ -1,0 +1,9 @@
+import { logger } from 'storybook/internal/node-logger';
+
+import type { CompodocParsingLogger } from '@storybook/angular-compodoc';
+
+/** Prefixed so a line is attributable to this framework, wherever it was emitted from. */
+export const compodocLogger: CompodocParsingLogger = {
+  warn: (message) => logger.warn(`[storybook-angular-vite] ${message}`),
+  debug: (message) => logger.debug(`[storybook-angular-vite] ${message}`),
+};

--- a/code/frameworks/angular-vite/src/docgen/resolve-component.ts
+++ b/code/frameworks/angular-vite/src/docgen/resolve-component.ts
@@ -5,8 +5,9 @@ import { loadCsf } from 'storybook/internal/csf-tools';
 import { readFileSync } from 'node:fs';
 
 // Angular has no single-file-component format, so the JS/TS extensions the resolver already tries
-// are enough.
-const resolveMetaComponent = createMetaComponentResolver();
+// are enough. Exported so a caller that already parsed the story file resolves against that parse
+// instead of reading and parsing it a second time.
+export const resolveMetaComponent = createMetaComponentResolver();
 
 /**
  * Story file → the component it documents.

--- a/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
@@ -3,6 +3,50 @@
 Source material for the user-facing setup and known-limitations page.
 Behaviour described here applies to `@storybook/angular-vite` with the `experimentalDocgenServer` feature flag on, where the Source block and the Code panel show a snippet generated on the server from Compodoc metadata instead of one generated in the browser from the loaded component class.
 
+## Two snippet formats
+
+`framework.options.snippetFormat` picks the shape of the emitted snippet.
+
+`'template'` is the default and emits the bare markup, which is what the browser generator has always produced:
+
+```html
+<sb-button [label]="'Save'" [count]="3" (clicked)="clicked($event)"></sb-button>
+```
+
+`'component'` wraps that markup in the standalone host component it needs in order to compile, and the payload carries the matching import block:
+
+```ts
+import { Component } from '@angular/core';
+import { ButtonComponent } from './button.component';
+
+@Component({
+  selector: 'app-root',
+  template: `<sb-button [label]="'Save'" [count]="3" (clicked)="clicked($event)"></sb-button>`,
+  imports: [ButtonComponent],
+})
+export class App {
+  clicked(event: unknown) {}
+}
+```
+
+The host declares a no-op method per bound output because Angular's template type checking resolves `(clicked)="clicked($event)"` against the host class, so a snippet without it would not compile.
+The host `selector` and class name are fixed, and the component is imported through the specifier the story file itself used.
+
+## An incomplete snippet says so in `warning`, not in the markup
+
+When a static pass cannot read part of a story, the affected story carries a `warning` alongside its `snippet` rather than a comment inside the snippet:
+
+```json
+{
+  "id": "storydocs--spread-args",
+  "name": "Spread Args",
+  "snippet": "<sb-button [label]=\"'meta'\" [count]=\"1\" (clicked)=\"clicked($event)\"></sb-button>",
+  "warning": "Incomplete snippet: `...sharedArgs` could not be resolved statically."
+}
+```
+
+A `warning` still comes with a snippet; an `error` means there is no snippet at all.
+
 ## Snippets no longer update as you change Controls
 
 This is the one accepted regression of the server-side docs path.
@@ -35,7 +79,7 @@ For example `args: { kind: ButtonKind.Secondary }` is shown as `[kind]="ButtonKi
 
 Two related consequences:
 
-- Args merged in with a spread (`args: { ...shared, count: 1 }`) cannot be resolved. The snippet keeps what it can and prefixes an `<!-- unresolved: ... -->` comment rather than silently shipping an incomplete example.
+- Args merged in with a spread (`args: { ...shared, count: 1 }`) cannot be resolved. The snippet keeps what it can and the story carries a `warning` rather than silently shipping an incomplete example.
 - Args assigned in the older CSF2 style (`MyStory.args = { ... }`) are not read. Declare them on the story object or on the meta instead.
 
 ## Stories that supply their own template are untouched
@@ -45,7 +89,7 @@ That matches what the browser generator does today.
 
 The markup has to be readable from the source, though.
 A template held in a variable, one built by interpolation, or a `render` that is a reference to a function declared elsewhere cannot be read without running the story.
-In those cases the snippet falls back to the generated bindings and says what it could not resolve, rather than printing the variable name as if it were markup.
+In those cases the snippet falls back to the generated bindings and the story carries a `warning` naming what it could not resolve, rather than printing the variable name as if it were markup.
 
 ## Compodoc has to have run
 

--- a/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
@@ -91,7 +91,10 @@ The markup has to be readable from the source, though.
 A template held in a variable, one built by interpolation, or a `render` that is a reference to a function declared elsewhere cannot be read without running the story.
 In those cases the snippet falls back to the generated bindings and the story carries a `warning` naming what it could not resolve, rather than printing the variable name as if it were markup.
 
-## Compodoc has to have run
+## The component's metadata has to be available
 
-The snippet needs the component's selector and its input and output names, which come from Compodoc's `documentation.json`.
-When Compodoc is disabled or has not run, no snippet is generated and Storybook falls back to showing the story's own source.
+The snippet needs the component's selector and its input and output names.
+Today those come from Compodoc's `documentation.json`, so when Compodoc is disabled or has not run, no snippet is generated and Storybook falls back to showing the story's own source.
+
+Which engine supplies that metadata is not something snippet generation knows about; it consumes a resolver.
+Replacing Compodoc with another source changes the resolver, not the snippets.

--- a/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
@@ -40,8 +40,12 @@ Two related consequences:
 
 ## Stories that supply their own template are untouched
 
-A story with a `template` (directly, or returned from `render`) is shown as written, including an empty one.
+A story with a `template` (directly, or returned from an inline `render`) is shown as written, including an empty one.
 That matches what the browser generator does today.
+
+The markup has to be readable from the source, though.
+A template held in a variable, one built by interpolation, or a `render` that is a reference to a function declared elsewhere cannot be read without running the story.
+In those cases the snippet falls back to the generated bindings and says what it could not resolve, rather than printing the variable name as if it were markup.
 
 ## Compodoc has to have run
 

--- a/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
@@ -1,0 +1,49 @@
+# Angular story-docs snippets: v1 known limitations
+
+Source material for the user-facing setup and known-limitations page.
+Behaviour described here applies to `@storybook/angular-vite` with the `experimentalDocgenServer` feature flag on, where the Source block and the Code panel show a snippet generated on the server from Compodoc metadata instead of one generated in the browser from the loaded component class.
+
+## Snippets no longer update as you change Controls
+
+This is the one accepted regression of the server-side docs path.
+The snippet is generated once, from the args written in the story file, so changing a Control updates the story but not the code shown next to it.
+
+## Property and event bindings only
+
+The generator emits `[input]="value"` and `(output)="handler($event)"` and nothing else.
+Out of scope for this version:
+
+- structural directives (`*ngIf`, `*ngFor`, `*ngSwitch`)
+- two-way banana-in-a-box syntax: an Angular `model()` is shown as a separate `[value]` input and `(valueChange)` output, which is what `[(value)]` desugars to
+- content projection, so a component with `<ng-content>` is shown as an empty element
+
+## Args the component does not accept are not shown
+
+Which args become bindings is decided by the component's Compodoc metadata: an arg is an event binding only when it matches a declared output, and a property binding only when it matches a declared input.
+Args that match neither are omitted, exactly as the browser generator omits them today.
+A consequence worth knowing: a function passed to an `@Input()` stays a property binding rather than being reclassified as an event.
+
+## Functions and `undefined` are printed literally
+
+An arg whose value is a function is printed as its source text, and an explicit `undefined` is printed as `undefined`.
+Angular template expressions cannot contain function literals, so such a snippet reads correctly but would not compile as written.
+
+## Values are read from the source, not evaluated
+
+The snippet is built by reading the story file rather than by running it, so an arg whose value is a constant, an enum member, or a call expression is shown as that expression rather than as the value it evaluates to.
+For example `args: { kind: ButtonKind.Secondary }` is shown as `[kind]="ButtonKind.Secondary"`, where the browser generator showed `[kind]="'secondary'"`.
+
+Two related consequences:
+
+- Args merged in with a spread (`args: { ...shared, count: 1 }`) cannot be resolved. The snippet keeps what it can and prefixes an `<!-- unresolved args: ... -->` comment rather than silently shipping an incomplete example.
+- Args assigned in the older CSF2 style (`MyStory.args = { ... }`) are not read. Declare them on the story object or on the meta instead.
+
+## Stories that supply their own template are untouched
+
+A story with a `template` (directly, or returned from `render`) is shown as written, including an empty one.
+That matches what the browser generator does today.
+
+## Compodoc has to have run
+
+The snippet needs the component's selector and its input and output names, which come from Compodoc's `documentation.json`.
+When Compodoc is disabled or has not run, no snippet is generated and Storybook falls back to showing the story's own source.

--- a/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
@@ -35,7 +35,7 @@ For example `args: { kind: ButtonKind.Secondary }` is shown as `[kind]="ButtonKi
 
 Two related consequences:
 
-- Args merged in with a spread (`args: { ...shared, count: 1 }`) cannot be resolved. The snippet keeps what it can and prefixes an `<!-- unresolved args: ... -->` comment rather than silently shipping an incomplete example.
+- Args merged in with a spread (`args: { ...shared, count: 1 }`) cannot be resolved. The snippet keeps what it can and prefixes an `<!-- unresolved: ... -->` comment rather than silently shipping an incomplete example.
 - Args assigned in the older CSF2 style (`MyStory.args = { ... }`) are not read. Declare them on the story object or on the meta instead.
 
 ## Stories that supply their own template are untouched

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.test.ts
@@ -14,9 +14,7 @@ import { experimental_storyDocsProvider } from './story-docs-preset.ts';
 
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
 
-// A story index `importPath` is written relative to the Storybook process cwd, so that - and not
-// Compodoc's `workspaceRoot`, which the Angular builder reports separately - is what the provider
-// resolves story files against. The two differ here on purpose.
+// `storyRoot` and `workspaceRoot` differ here on purpose.
 beforeEach(() => {
   vi.spyOn(process, 'cwd').mockReturnValue(FIXTURES);
 });

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.test.ts
@@ -1,0 +1,92 @@
+import type {
+  IndexEntry,
+  Options,
+  StoryDocsPayload,
+  StoryDocsProvider,
+} from 'storybook/internal/types';
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { experimental_storyDocsProvider } from './story-docs-preset.ts';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
+
+/** Minimal `Options` stand-in: no dev server, no Vite, no builder context beyond the root. */
+const options = (frameworkOptions: Record<string, unknown> = {}): Options =>
+  ({
+    presets: {
+      apply: async (key: string, fallback?: unknown): Promise<unknown> =>
+        key === 'framework'
+          ? { name: '@storybook/angular-vite', options: frameworkOptions }
+          : fallback,
+    },
+    angularBuilderContext: { workspaceRoot: FIXTURES },
+  }) as unknown as Options;
+
+const storyEntry: IndexEntry = {
+  id: 'storydocs--basic',
+  name: 'Basic',
+  title: 'StoryDocs',
+  type: 'story',
+  subtype: 'story',
+  importPath: './story-docs.stories.ts',
+};
+
+const noDownstream: StoryDocsProvider = async () => undefined;
+
+describe('experimental_storyDocsProvider', () => {
+  // NFR3: cold-callable as a plain Node function. Everything it needs comes from the preset
+  // options and the filesystem, and the assertion is the real snippet rather than "it returned".
+  it('generates snippets from a bare preset call, with no dev server running', async () => {
+    const provider = await experimental_storyDocsProvider(noDownstream, options());
+
+    const payload = await provider({ entry: storyEntry });
+
+    expect(Object.values(payload!.stories).map((story) => story.snippet)).toContain(
+      `<sb-button [label]="'Save'" [count]="3" (clicked)="clicked($event)"></sb-button>`
+    );
+  });
+
+  it('falls through to the next provider for an entry that is not a story file', async () => {
+    const downstream: StoryDocsPayload = {
+      id: 'other',
+      name: 'Other',
+      path: './other.ts',
+      stories: {},
+    };
+    const provider = await experimental_storyDocsProvider(async () => downstream, options());
+
+    expect(await provider({ entry: { ...storyEntry, importPath: './readme.mdx' } })).toBe(
+      downstream
+    );
+  });
+
+  it('keeps downstream keys our payload does not set', async () => {
+    const provider = await experimental_storyDocsProvider(
+      async () => ({
+        id: 'downstream',
+        name: 'Downstream',
+        path: './x',
+        stories: {},
+        import: 'IMPORT',
+      }),
+      options()
+    );
+
+    const payload = await provider({ entry: storyEntry });
+
+    expect(payload).toMatchObject({ id: 'storydocs', name: 'ButtonComponent', import: 'IMPORT' });
+  });
+
+  it('does not register at all when the user opted out of Compodoc', async () => {
+    const provider = await experimental_storyDocsProvider(
+      noDownstream,
+      options({ compodoc: false })
+    );
+
+    expect(provider).toBe(noDownstream);
+  });
+});

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.test.ts
@@ -8,11 +8,22 @@ import type {
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { experimental_storyDocsProvider } from './story-docs-preset.ts';
 
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
+
+// A story index `importPath` is written relative to the Storybook process cwd, so that - and not
+// Compodoc's `workspaceRoot`, which the Angular builder reports separately - is what the provider
+// resolves story files against. The two differ here on purpose.
+beforeEach(() => {
+  vi.spyOn(process, 'cwd').mockReturnValue(FIXTURES);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 /** Minimal `Options` stand-in: no dev server, no Vite, no builder context beyond the root. */
 const options = (frameworkOptions: Record<string, unknown> = {}): Options =>
@@ -79,6 +90,13 @@ describe('experimental_storyDocsProvider', () => {
     const payload = await provider({ entry: storyEntry });
 
     expect(payload).toMatchObject({ id: 'storydocs', name: 'ButtonComponent', import: 'IMPORT' });
+  });
+
+  it('falls through when the story path resolves against cwd but Compodoc lives elsewhere', async () => {
+    vi.mocked(process.cwd).mockReturnValue(join(FIXTURES, 'aliased'));
+    const provider = await experimental_storyDocsProvider(noDownstream, options());
+
+    expect(await provider({ entry: storyEntry })).toBeUndefined();
   });
 
   it('does not register at all when the user opted out of Compodoc', async () => {

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
@@ -2,6 +2,7 @@ import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/i
 import type { StoryDocsProviderPreset } from 'storybook/internal/types';
 
 import { resolveCompodocConfig } from '../compodoc-config.ts';
+import { readFrameworkOptions } from '../framework-options.ts';
 import { buildStoryDocsPayload } from './build-story-docs.ts';
 import { createDocumentationJsonReader } from './documentation-json.ts';
 import { compodocLogger } from './logger.ts';
@@ -29,6 +30,7 @@ export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (
     outputDir: compodoc.outputDir,
     readDocumentationJson: createDocumentationJsonReader(),
     logger: compodocLogger,
+    snippetFormat: (await readFrameworkOptions(options)).snippetFormat,
   };
 
   return async (input) => {

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
@@ -1,7 +1,9 @@
 import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
 import type { StoryDocsProviderPreset } from 'storybook/internal/types';
 
-import { resolveCompodocConfig } from '../compodoc-config.ts';
+import { join } from 'node:path';
+
+import { DOCUMENTATION_JSON, resolveCompodocConfig } from '../compodoc-config.ts';
 import { readFrameworkOptions } from '../framework-options.ts';
 import { buildStoryDocsPayload } from './build-story-docs.ts';
 import { createCompodocComponentResolver } from './compodoc-component-resolver.ts';
@@ -25,12 +27,14 @@ export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (
     return nextStoryDocs;
   }
 
+  const readDocumentationJson = createDocumentationJsonReader();
+  const documentationJson = join(compodoc.outputDir, DOCUMENTATION_JSON);
+
   const context = {
     storyRoot: process.cwd(),
     resolveComponent: createCompodocComponentResolver({
       workspaceRoot: compodoc.workspaceRoot,
-      outputDir: compodoc.outputDir,
-      readDocumentationJson: createDocumentationJsonReader(),
+      readMetadata: () => readDocumentationJson(documentationJson),
       logger: compodocLogger,
     }),
     logger: compodocLogger,

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
@@ -4,6 +4,7 @@ import type { StoryDocsProviderPreset } from 'storybook/internal/types';
 import { resolveCompodocConfig } from '../compodoc-config.ts';
 import { readFrameworkOptions } from '../framework-options.ts';
 import { buildStoryDocsPayload } from './build-story-docs.ts';
+import { createCompodocComponentResolver } from './compodoc-component-resolver.ts';
 import { createDocumentationJsonReader } from './documentation-json.ts';
 import { compodocLogger } from './logger.ts';
 
@@ -26,9 +27,12 @@ export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (
 
   const context = {
     storyRoot: process.cwd(),
-    workspaceRoot: compodoc.workspaceRoot,
-    outputDir: compodoc.outputDir,
-    readDocumentationJson: createDocumentationJsonReader(),
+    resolveComponent: createCompodocComponentResolver({
+      workspaceRoot: compodoc.workspaceRoot,
+      outputDir: compodoc.outputDir,
+      readDocumentationJson: createDocumentationJsonReader(),
+      logger: compodocLogger,
+    }),
     logger: compodocLogger,
     snippetFormat: (await readFrameworkOptions(options)).snippetFormat,
   };

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
@@ -34,6 +34,9 @@ export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (
   }
 
   const context = {
+    // Story `importPath`s come from the index, which is generated against the Storybook process
+    // cwd. Compodoc's `workspaceRoot` is a different directory under the Angular builder.
+    storyRoot: process.cwd(),
     workspaceRoot: compodoc.workspaceRoot,
     outputDir: compodoc.outputDir,
     readDocumentationJson: createDocumentationJsonReader(),

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
@@ -1,0 +1,56 @@
+import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
+import { logger } from 'storybook/internal/node-logger';
+import type { StoryDocsProviderPreset } from 'storybook/internal/types';
+
+import type { CompodocParsingLogger } from '@storybook/angular-compodoc';
+import { resolveCompodocConfig } from '../compodoc-config.ts';
+import { buildStoryDocsPayload } from './build-story-docs.ts';
+import { createDocumentationJsonReader } from './documentation-json.ts';
+
+const presetLogger: CompodocParsingLogger = {
+  warn: (message) => logger.warn(`[storybook-angular-vite] ${message}`),
+  debug: (message) => logger.debug(`[storybook-angular-vite] ${message}`),
+};
+
+/**
+ * Angular story-docs provider: static template snippets for the Source block and the Code panel.
+ *
+ * Unlike {@link experimental_docgenProvider} this runs in-process on the dev-server main thread,
+ * so there is no worker entry and no structured-clone boundary. Bails to `nextStoryDocs` when the
+ * entry is not a CSF story file or the file yields nothing; otherwise the payload is merged with
+ * downstream via the documented `{ ...downstream, ...ours }` spread, so `stories` is replaced
+ * wholesale rather than merged per story.
+ */
+export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (
+  nextStoryDocs,
+  options
+) => {
+  const compodoc = await resolveCompodocConfig(options);
+
+  // Opting out of Compodoc removes the only source of a component's selector and binding names, so
+  // there is nothing left for this provider to generate from.
+  if (!compodoc.enabled) {
+    return nextStoryDocs;
+  }
+
+  const context = {
+    workspaceRoot: compodoc.workspaceRoot,
+    outputDir: compodoc.outputDir,
+    readDocumentationJson: createDocumentationJsonReader(),
+    logger: presetLogger,
+  };
+
+  return async (input) => {
+    const storyImportPath = getStoryImportPathFromEntry(input.entry);
+    if (!storyImportPath || !STORY_FILE_TEST_REGEXP.test(storyImportPath)) {
+      return nextStoryDocs(input);
+    }
+
+    const ours = buildStoryDocsPayload(input, context);
+    if (!ours) {
+      return nextStoryDocs(input);
+    }
+
+    return { ...(await nextStoryDocs(input)), ...ours };
+  };
+};

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
@@ -1,25 +1,15 @@
 import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
-import { logger } from 'storybook/internal/node-logger';
 import type { StoryDocsProviderPreset } from 'storybook/internal/types';
 
-import type { CompodocParsingLogger } from '@storybook/angular-compodoc';
 import { resolveCompodocConfig } from '../compodoc-config.ts';
 import { buildStoryDocsPayload } from './build-story-docs.ts';
 import { createDocumentationJsonReader } from './documentation-json.ts';
-
-const presetLogger: CompodocParsingLogger = {
-  warn: (message) => logger.warn(`[storybook-angular-vite] ${message}`),
-  debug: (message) => logger.debug(`[storybook-angular-vite] ${message}`),
-};
+import { compodocLogger } from './logger.ts';
 
 /**
  * Angular story-docs provider: static template snippets for the Source block and the Code panel.
- *
- * Unlike {@link experimental_docgenProvider} this runs in-process on the dev-server main thread,
- * so there is no worker entry and no structured-clone boundary. Bails to `nextStoryDocs` when the
- * entry is not a CSF story file or the file yields nothing; otherwise the payload is merged with
- * downstream via the documented `{ ...downstream, ...ours }` spread, so `stories` is replaced
- * wholesale rather than merged per story.
+ * Runs in-process on the dev-server main thread, so unlike the docgen provider there is no worker
+ * entry and no structured-clone boundary.
  */
 export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (
   nextStoryDocs,
@@ -34,13 +24,11 @@ export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (
   }
 
   const context = {
-    // Story `importPath`s come from the index, which is generated against the Storybook process
-    // cwd. Compodoc's `workspaceRoot` is a different directory under the Angular builder.
     storyRoot: process.cwd(),
     workspaceRoot: compodoc.workspaceRoot,
     outputDir: compodoc.outputDir,
     readDocumentationJson: createDocumentationJsonReader(),
-    logger: presetLogger,
+    logger: compodocLogger,
   };
 
   return async (input) => {

--- a/code/frameworks/angular-vite/src/docgen/template-snippet.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/template-snippet.test.ts
@@ -23,15 +23,10 @@ const component = (
   ...overrides,
 });
 
-const snippet = (
-  args: Record<string, string>,
-  overrides?: Partial<AngularComponentTemplate>,
-  unresolvedArgs?: string[]
-) =>
+const snippet = (args: Record<string, string>, overrides?: Partial<AngularComponentTemplate>) =>
   generateAngularSnippet({
     component: component(overrides),
     args: Object.fromEntries(Object.entries(args).map(([key, src]) => [key, expression(src)])),
-    unresolvedArgs,
   });
 
 describe('selector to host element', () => {
@@ -140,18 +135,6 @@ describe('generateAngularSnippet', () => {
   it('references an output whose name is not an identifier through bracket notation', () => {
     expect(snippet({}, { inputs: [], outputs: ['data-changed'] })).toBe(
       `<sb-button (data-changed)="this['data-changed']($event)"></sb-button>`
-    );
-  });
-
-  it('reports args it could not resolve instead of dropping them silently', () => {
-    expect(snippet({ label: `'Save'` }, undefined, ['...sharedArgs'])).toBe(
-      `<!-- unresolved: ...sharedArgs -->\n<sb-button [label]="'Save'" (clicked)="clicked($event)"></sb-button>`
-    );
-  });
-
-  it('still reports unresolved args on the no-selector fallback', () => {
-    expect(snippet({}, { selector: undefined }, ['...sharedArgs'])).toBe(
-      `<!-- unresolved: ...sharedArgs -->\n<ng-container *ngComponentOutlet="ButtonComponent"></ng-container>`
     );
   });
 

--- a/code/frameworks/angular-vite/src/docgen/template-snippet.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/template-snippet.test.ts
@@ -1,0 +1,148 @@
+import type { types as t } from 'storybook/internal/babel';
+import { babelParse } from 'storybook/internal/babel';
+
+import { describe, expect, it } from 'vitest';
+
+import type { AngularComponentTemplate } from './template-snippet.ts';
+import { generateAngularSnippet, parseSelector, templateExpression } from './template-snippet.ts';
+
+/** Parses one expression the way an arg value arrives from a story file. */
+const expression = (source: string): t.Node => {
+  const program = babelParse(`const value = ${source};`);
+  const declaration = program.program.body[0] as t.VariableDeclaration;
+  return declaration.declarations[0].init as t.Node;
+};
+
+const component = (
+  overrides: Partial<AngularComponentTemplate> = {}
+): AngularComponentTemplate => ({
+  name: 'ButtonComponent',
+  selector: 'sb-button',
+  inputs: ['label', 'count'],
+  outputs: ['clicked'],
+  ...overrides,
+});
+
+const snippet = (
+  args: Record<string, string>,
+  overrides?: Partial<AngularComponentTemplate>,
+  unresolvedArgs?: string[]
+) =>
+  generateAngularSnippet({
+    component: component(overrides),
+    args: Object.fromEntries(Object.entries(args).map(([key, src]) => [key, expression(src)])),
+    unresolvedArgs,
+  });
+
+describe('parseSelector', () => {
+  it.each([
+    ['sb-button', '<sb-button></sb-button>'],
+    // Compound selector: the directive belongs on its host element, not on an invented one.
+    ['button[sb-harness-action], a[sb-harness-action]', '<button sb-harness-action></button>'],
+    ['[myDirective]', '<div myDirective></div>'],
+    ['.my-class', '<div class="my-class"></div>'],
+    ['sb-button.a.b', '<sb-button class="a b"></sb-button>'],
+    ['sb-button#main', '<sb-button id="main"></sb-button>'],
+    // Void elements cannot carry a closing tag.
+    ['input[myDir]', '<input myDir />'],
+    // A comma inside an attribute value does not start a second selector.
+    ['sb-button[data-tags="a,b"]', '<sb-button data-tags="a,b"></sb-button>'],
+    // A pseudo-selector narrows when a directive applies; it is not part of the host element.
+    ['sb-button:not([disabled])', '<sb-button></sb-button>'],
+    ['[myDir]:not(.excluded)', '<div myDir></div>'],
+    ['sb-button[type=submit]', '<sb-button type="submit"></sb-button>'],
+  ])('%s renders as %s', (selector, expected) => {
+    expect(snippet({}, { selector, inputs: [], outputs: [] })).toBe(expected);
+  });
+
+  it('reports the host element parts separately', () => {
+    expect(parseSelector('a.link.external#home[href="/a,b"]')).toEqual({
+      tag: 'a',
+      id: 'home',
+      classes: ['link', 'external'],
+      attributes: ['href="/a,b"'],
+    });
+  });
+});
+
+describe('templateExpression', () => {
+  it.each([
+    [`'Save'`, `'Save'`],
+    ['3', '3'],
+    ['true', 'true'],
+    ['null', 'null'],
+    ['undefined', 'undefined'],
+    [`['a', 'b']`, `['a', 'b']`],
+    [
+      `{ id: 7, tags: ['a', 'b'], nested: { deep: true } }`,
+      `{ id: 7, tags: ['a', 'b'], nested: { deep: true } }`,
+    ],
+    // Functions print literally: Angular template expressions cannot hold one, and the browser
+    // generator does the same, so the baselines encode it.
+    ['() => {}', '() => {}'],
+    ['(value) => value.toFixed(2)', 'value => value.toFixed(2)'],
+    // Comments and line breaks would leave the attribute value spanning lines.
+    ['{\n  id: 1, // note\n  other: 2\n}', '{ id: 1, other: 2 }'],
+    // The value lives inside a double-quoted HTML attribute, so quotes and ampersands must survive
+    // as entities or the snippet stops being well-formed markup.
+    [`"it's fine"`, `&quot;it's fine&quot;`],
+    [`'say "hi"'`, `'say &quot;hi&quot;'`],
+    [`'a & b'`, `'a &amp; b'`],
+    [`'&quot;'`, `'&amp;quot;'`],
+  ])('%s serializes to %s', (source, expected) => {
+    expect(templateExpression(expression(source))).toBe(expected);
+  });
+});
+
+describe('generateAngularSnippet', () => {
+  it('emits a property binding per declared arg the component accepts', () => {
+    expect(snippet({ label: `'Save'`, count: '3' })).toBe(
+      `<sb-button [label]="'Save'" [count]="3" (clicked)="clicked($event)"></sb-button>`
+    );
+  });
+
+  it('drops args the component declares as neither an input nor an output', () => {
+    expect(snippet({ label: `'Save'`, notAnInput: `'x'` })).toBe(
+      `<sb-button [label]="'Save'" (clicked)="clicked($event)"></sb-button>`
+    );
+  });
+
+  it('emits an event binding for every output, declared as an arg or not', () => {
+    expect(snippet({})).toBe(`<sb-button (clicked)="clicked($event)"></sb-button>`);
+  });
+
+  it('keeps a function passed to an input as a property binding', () => {
+    expect(snippet({ label: '() => {}' }, { inputs: ['label'], outputs: [] })).toBe(
+      `<sb-button [label]="() => {}"></sb-button>`
+    );
+  });
+
+  it('emits a model() as separate input and output bindings rather than banana-in-a-box', () => {
+    expect(
+      snippet(
+        { value: `'hello'`, checked: 'true' },
+        { inputs: ['value', 'checked'], outputs: ['valueChange', 'checkedChange'] }
+      )
+    ).toBe(
+      `<sb-button [value]="'hello'" [checked]="true" (valueChange)="valueChange($event)" (checkedChange)="checkedChange($event)"></sb-button>`
+    );
+  });
+
+  it('falls back to ngComponentOutlet when the component has no selector', () => {
+    expect(snippet({ label: `'Save'` }, { selector: undefined })).toBe(
+      `<ng-container *ngComponentOutlet="ButtonComponent"></ng-container>`
+    );
+  });
+
+  it('references an output whose name is not an identifier through bracket notation', () => {
+    expect(snippet({}, { inputs: [], outputs: ['data-changed'] })).toBe(
+      `<sb-button (data-changed)="this['data-changed']($event)"></sb-button>`
+    );
+  });
+
+  it('reports args it could not resolve instead of dropping them silently', () => {
+    expect(snippet({ label: `'Save'` }, undefined, ['...sharedArgs'])).toBe(
+      `<!-- unresolved args: ...sharedArgs -->\n<sb-button [label]="'Save'" (clicked)="clicked($event)"></sb-button>`
+    );
+  });
+});

--- a/code/frameworks/angular-vite/src/docgen/template-snippet.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/template-snippet.test.ts
@@ -34,7 +34,7 @@ const snippet = (
     unresolvedArgs,
   });
 
-describe('parseSelector', () => {
+describe('selector to host element', () => {
   it.each([
     ['sb-button', '<sb-button></sb-button>'],
     // Compound selector: the directive belongs on its host element, not on an invented one.
@@ -50,6 +50,9 @@ describe('parseSelector', () => {
     // A pseudo-selector narrows when a directive applies; it is not part of the host element.
     ['sb-button:not([disabled])', '<sb-button></sb-button>'],
     ['[myDir]:not(.excluded)', '<div myDir></div>'],
+    // A comma inside a pseudo's parentheses separates its arguments, not two selectors, so
+    // everything written after it still belongs to the host element.
+    ['sb-button:not(.a, .b).cls', '<sb-button class="cls"></sb-button>'],
     ['sb-button[type=submit]', '<sb-button type="submit"></sb-button>'],
   ])('%s renders as %s', (selector, expected) => {
     expect(snippet({}, { selector, inputs: [], outputs: [] })).toBe(expected);
@@ -142,7 +145,34 @@ describe('generateAngularSnippet', () => {
 
   it('reports args it could not resolve instead of dropping them silently', () => {
     expect(snippet({ label: `'Save'` }, undefined, ['...sharedArgs'])).toBe(
-      `<!-- unresolved args: ...sharedArgs -->\n<sb-button [label]="'Save'" (clicked)="clicked($event)"></sb-button>`
+      `<!-- unresolved: ...sharedArgs -->\n<sb-button [label]="'Save'" (clicked)="clicked($event)"></sb-button>`
+    );
+  });
+
+  it('still reports unresolved args on the no-selector fallback', () => {
+    expect(snippet({}, { selector: undefined }, ['...sharedArgs'])).toBe(
+      `<!-- unresolved: ...sharedArgs -->\n<ng-container *ngComponentOutlet="ButtonComponent"></ng-container>`
+    );
+  });
+
+  it('keeps a multi-line arg value on one line', () => {
+    expect(snippet({ label: '`line1\nline2`' })).toBe(
+      '<sb-button [label]="`line1 line2`" (clicked)="clicked($event)"></sb-button>'
+    );
+  });
+
+  it('does not name a directive selector attribute twice when it is also a bound input', () => {
+    expect(
+      snippet(
+        { appHighlight: `'yellow'` },
+        { selector: '[appHighlight]', inputs: ['appHighlight'], outputs: [] }
+      )
+    ).toBe(`<div [appHighlight]="'yellow'"></div>`);
+  });
+
+  it('ignores an input named after an inherited Object member rather than throwing', () => {
+    expect(snippet({ label: `'Save'` }, { inputs: ['label', 'toString'], outputs: [] })).toBe(
+      `<sb-button [label]="'Save'"></sb-button>`
     );
   });
 });

--- a/code/frameworks/angular-vite/src/docgen/template-snippet.ts
+++ b/code/frameworks/angular-vite/src/docgen/template-snippet.ts
@@ -96,6 +96,7 @@ export const formatPropInTemplate = (propertyName: string): string =>
  */
 const firstSelector = (selector: string): string => {
   let inAttribute = false;
+  let parenDepth = 0;
   let quote: string | undefined;
 
   for (let index = 0; index < selector.length; index++) {
@@ -112,7 +113,12 @@ const firstSelector = (selector: string): string => {
       inAttribute = true;
     } else if (char === ']') {
       inAttribute = false;
-    } else if (char === ',' && !inAttribute) {
+    } else if (char === '(') {
+      parenDepth++;
+    } else if (char === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (char === ',' && !inAttribute && parenDepth === 0) {
+      // A comma inside `:not(.a, .b)` separates that pseudo's arguments, not two selectors.
       return selector.slice(0, index);
     }
   }
@@ -257,9 +263,16 @@ export const parseSelector = (selector: string): HostElement => {
 const escapeAttributeValue = (value: string): string =>
   value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
 
-/** An arg's value AST node as a single-line Angular template expression. */
+/**
+ * An arg's value AST node as a single-line Angular template expression.
+ *
+ * `concise` does not collapse newlines inside a template literal, and a real newline in an
+ * attribute value stops the snippet being single-line markup.
+ */
 export const templateExpression = (node: t.Node): string =>
-  escapeAttributeValue(generate(node, { concise: true, comments: false }).code);
+  escapeAttributeValue(
+    generate(node, { concise: true, comments: false }).code.replace(/\s*\n\s*/g, ' ')
+  );
 
 /** Builds the static Angular template snippet for one story. */
 export const generateAngularSnippet = ({
@@ -268,13 +281,18 @@ export const generateAngularSnippet = ({
   unresolvedArgs = [],
 }: AngularSnippetInput): string => {
   if (!component.selector) {
-    return `<ng-container *ngComponentOutlet="${component.name}"></ng-container>`;
+    return withUnresolvedNote(
+      `<ng-container *ngComponentOutlet="${component.name}"></ng-container>`,
+      unresolvedArgs
+    );
   }
 
   const host = parseSelector(component.selector);
 
   const inputBindings = component.inputs
-    .filter((name) => name in args)
+    // `hasOwn` rather than `in`: an input named after an `Object.prototype` member would otherwise
+    // read the inherited function and hand a non-node to the generator.
+    .filter((name) => Object.hasOwn(args, name))
     .map((name) => `[${name}]="${templateExpression(args[name])}"`);
 
   // Every output gets a handler, whether or not the story declared one: Storybook's actions
@@ -284,10 +302,13 @@ export const generateAngularSnippet = ({
     (name) => `(${name})="${formatPropInTemplate(name)}($event)"`
   );
 
+  // An attribute directive's own selector attribute is often an input too (`[appHighlight]` with
+  // an `@Input() appHighlight`). Emitting both would name it twice on the same element.
+  const boundNames = new Set(component.inputs.filter((name) => Object.hasOwn(args, name)));
   const hostAttributes = [
     ...(host.id ? [`id="${host.id}"`] : []),
     ...(host.classes.length > 0 ? [`class="${host.classes.join(' ')}"`] : []),
-    ...host.attributes,
+    ...host.attributes.filter((attribute) => !boundNames.has(attribute.split('=')[0])),
   ];
 
   const attributes = [...hostAttributes, ...inputBindings, ...outputBindings];
@@ -296,10 +317,12 @@ export const generateAngularSnippet = ({
     ? `<${host.tag}${attributeText} />`
     : `<${host.tag}${attributeText}></${host.tag}>`;
 
-  if (unresolvedArgs.length === 0) {
-    return element;
-  }
-  // A spread's contents are only known at runtime. Saying so beats emitting a snippet that looks
-  // complete while silently missing bindings.
-  return `<!-- unresolved args: ${unresolvedArgs.join(', ')} -->\n${element}`;
+  return withUnresolvedNote(element, unresolvedArgs);
 };
+
+/**
+ * Prefixes a note naming what could not be resolved statically. Saying so beats emitting a snippet
+ * that looks complete while silently missing bindings.
+ */
+const withUnresolvedNote = (element: string, unresolved: readonly string[]): string =>
+  unresolved.length === 0 ? element : `<!-- unresolved: ${unresolved.join(', ')} -->\n${element}`;

--- a/code/frameworks/angular-vite/src/docgen/template-snippet.ts
+++ b/code/frameworks/angular-vite/src/docgen/template-snippet.ts
@@ -1,6 +1,6 @@
 /**
- * Static Angular template snippets, built from a component's Compodoc metadata and a story's
- * declared args.
+ * Static Angular template snippets, built from a component's resolved selector and binding names
+ * plus a story's declared args. Which docgen engine reported those names is not its concern.
  *
  * Deliberately not shared with the browser generator
  * (`client/renderer/ComputesTemplateFromComponent.ts`): that one reads a loaded component class

--- a/code/frameworks/angular-vite/src/docgen/template-snippet.ts
+++ b/code/frameworks/angular-vite/src/docgen/template-snippet.ts
@@ -1,31 +1,11 @@
 /**
  * Static Angular template snippets, built from a component's Compodoc metadata and a story's
- * declared args without loading a single Angular class.
+ * declared args.
  *
- * The browser generator (`client/renderer/ComputesTemplateFromComponent.ts`) reads the loaded
- * component class through Angular's reflection APIs, which do not work in Node: `ɵcmp` is only
- * populated by the Angular compiler. This module reimplements its rules against Compodoc's
- * `documentation.json` instead. It is deliberately not shared with the browser copy - one runs
- * against runtime classes, the other against JSON.
- *
- * ## v1 scope and known limitations
- *
- * - **Property and event bindings only.** Structural directives (`*ngIf`, `*ngFor`), two-way
- *   banana-in-a-box syntax (`[(x)]`) and content projection (`<ng-content>`) are out of scope. An
- *   Angular `model()` is emitted as a separate `[x]` input plus an `(xChange)` output, which is
- *   what the two-way form desugars to.
- * - **Args the component does not declare as an input or an output are dropped.** The binding set
- *   is decided by Compodoc's metadata, not by the arg's runtime type, so a function passed to an
- *   `@Input` stays a property binding.
- * - **Functions and `undefined` are printed literally**, as source text. Angular template
- *   expressions cannot contain function literals, so a function-valued input produces a snippet
- *   that reads correctly but would not compile as written.
- * - **Values are read statically from the story file**, so an arg whose value is an identifier or
- *   a call expression is printed as that expression rather than as the value it evaluates to.
- * - **CSF2 `Story.args = {}` assignments are not read**; only args declared on the meta or on the
- *   story's own config object are.
- * - **The snippet no longer updates as Controls change.** That is the one accepted regression of
- *   the server-side docs path.
+ * Deliberately not shared with the browser generator
+ * (`client/renderer/ComputesTemplateFromComponent.ts`): that one reads a loaded component class
+ * through Angular's reflection APIs, which need `ɵcmp` and therefore the compiler. See
+ * `story-docs-limitations.md` for what the static path cannot do.
  */
 import type { types as t } from 'storybook/internal/babel';
 import { generate } from 'storybook/internal/babel';
@@ -45,10 +25,7 @@ export interface AngularSnippetInput {
   component: AngularComponentTemplate;
   /** Declared args (meta merged with story), as the value AST nodes they were written as. */
   args: Record<string, t.Node>;
-  /**
-   * Source text of `args` spread elements. A spread carries values no static pass can resolve, so
-   * it is reported in the snippet rather than dropped without trace.
-   */
+  /** Source text of anything a static pass could not read, reported rather than dropped silently. */
   unresolvedArgs?: readonly string[];
 }
 
@@ -90,91 +67,9 @@ const IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
 export const formatPropInTemplate = (propertyName: string): string =>
   IDENTIFIER.test(propertyName) ? propertyName : `this['${propertyName}']`;
 
-/**
- * First selector of a comma-separated list, ignoring commas inside `[...]` or a quoted attribute
- * value. Angular matches a component on any one of its selectors, so the first is as good as any.
- */
-const firstSelector = (selector: string): string => {
-  let inAttribute = false;
-  let parenDepth = 0;
-  let quote: string | undefined;
-
-  for (let index = 0; index < selector.length; index++) {
-    const char = selector[index];
-    if (quote) {
-      if (char === quote) {
-        quote = undefined;
-      }
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-    } else if (char === '[') {
-      inAttribute = true;
-    } else if (char === ']') {
-      inAttribute = false;
-    } else if (char === '(') {
-      parenDepth++;
-    } else if (char === ')') {
-      parenDepth = Math.max(0, parenDepth - 1);
-    } else if (char === ',' && !inAttribute && parenDepth === 0) {
-      // A comma inside `:not(.a, .b)` separates that pseudo's arguments, not two selectors.
-      return selector.slice(0, index);
-    }
-  }
-  return selector;
-};
-
-/** Index just past the `]` closing the attribute that starts at `start`, quotes honoured. */
-const attributeEnd = (selector: string, start: number): number => {
-  let quote: string | undefined;
-  for (let index = start + 1; index < selector.length; index++) {
-    const char = selector[index];
-    if (quote) {
-      if (char === quote) {
-        quote = undefined;
-      }
-    } else if (char === '"' || char === "'") {
-      quote = char;
-    } else if (char === ']') {
-      return index + 1;
-    }
-  }
-  return selector.length;
-};
-
-/** Index just past a `:pseudo` or `:pseudo(...)` run, nested parentheses and quotes honoured. */
-const pseudoEnd = (selector: string, start: number): number => {
-  let index = start + 1;
-  while (index < selector.length && /[\w-]/.test(selector[index])) {
-    index++;
-  }
-  if (selector[index] !== '(') {
-    return index;
-  }
-  let depth = 0;
-  let quote: string | undefined;
-  for (; index < selector.length; index++) {
-    const char = selector[index];
-    if (quote) {
-      if (char === quote) {
-        quote = undefined;
-      }
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-    } else if (char === '(') {
-      depth++;
-    } else if (char === ')') {
-      depth--;
-      if (depth === 0) {
-        return index + 1;
-      }
-    }
-  }
-  return selector.length;
-};
+/** One selector atom: an attribute, a pseudo, an element/class/id name, or any single character. */
+const SELECTOR_TOKEN =
+  /\[(?:[^\]'"]|'[^']*'|"[^"]*")*\]|:[\w-]+(?:\([^()]*\))?|[.#]?[a-zA-Z][\w-]*|[\s\S]/g;
 
 /** `attr`, `attr=value` or `attr="value"` from a selector, normalised to HTML attribute syntax. */
 const toHostAttribute = (body: string): string => {
@@ -195,82 +90,49 @@ const toHostAttribute = (body: string): string => {
 /**
  * Angular selector → the host element a story snippet renders it on.
  *
- * A real scan rather than the browser copy's regex pipeline, which mangles a comma inside an
- * attribute value and pastes pseudo-selectors into the tag name (`my-cmp:not([disabled])` becomes
- * `<my-cmp:not( disabled)>`).
- *
- * A selector with no element part - a bare `[myDirective]` or `.my-class` - describes a directive,
- * which has no host element of its own. `div` is the neutral host: it is what the browser copy
- * already renders for the `.my-class` case, and it keeps the snippet copy-pasteable.
+ * Tokenized the way Angular's own `CssSelector.parse` does, so quotes, brackets and pseudo
+ * parentheses stop being scanner state: each token consumes its own delimiters. A selector with no
+ * element part (`[myDirective]`, `.my-class`) describes a directive, which has no host element of
+ * its own, so `div` stands in as a neutral, copy-pasteable host.
  */
 export const parseSelector = (selector: string): HostElement => {
-  const single = firstSelector(selector).trim();
   const attributes: string[] = [];
   const classes: string[] = [];
   let tag: string | undefined;
   let id: string | undefined;
-  let index = 0;
 
-  while (index < single.length) {
-    const char = single[index];
-
-    if (char === '[') {
-      const end = attributeEnd(single, index);
-      const body = single.slice(index + 1, end - 1).trim();
+  for (const [token] of selector.matchAll(SELECTOR_TOKEN)) {
+    if (token === ',') {
+      // Angular matches on any one of a comma-separated list, so the first is as good as any.
+      break;
+    }
+    if (token.startsWith('[')) {
+      const body = token.slice(1, -1).trim();
       if (body) {
         attributes.push(toHostAttribute(body));
       }
-      index = end;
-      continue;
+    } else if (token.startsWith('#')) {
+      id = token.slice(1);
+    } else if (token.startsWith('.')) {
+      classes.push(token.slice(1));
+    } else if (tag === undefined && /^[a-zA-Z]/.test(token)) {
+      // A `:pseudo` token never matches here, so it stays out of the tag name.
+      tag = token;
     }
-    if (char === ':') {
-      // A pseudo-selector narrows when the directive applies; it is not part of the host element.
-      index = pseudoEnd(single, index);
-      continue;
-    }
-    if (char === '#' || char === '.') {
-      const name = /^[\w-]+/.exec(single.slice(index + 1))?.[0];
-      if (name) {
-        if (char === '#') {
-          id = name;
-        } else {
-          classes.push(name);
-        }
-        index += name.length + 1;
-        continue;
-      }
-      index++;
-      continue;
-    }
-
-    const element = /^[a-zA-Z][\w-]*/.exec(single.slice(index))?.[0];
-    if (element && tag === undefined) {
-      tag = element;
-      index += element.length;
-      continue;
-    }
-    index++;
   }
 
   return { tag: tag ?? 'div', id, classes, attributes };
 };
 
-/**
- * Angular reads a binding's expression out of an HTML attribute value, so `&` and `"` have to
- * survive as entities or the snippet stops being well-formed markup. Nothing else is rewritten:
- * the browser copy leaves both raw and produces a broken template for any string holding a quote.
- */
+// The value lands inside a double-quoted HTML attribute, so these two have to survive as entities
+// or the snippet stops being well-formed markup.
 const escapeAttributeValue = (value: string): string =>
   value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
 
-/**
- * An arg's value AST node as a single-line Angular template expression.
- *
- * `concise` does not collapse newlines inside a template literal, and a real newline in an
- * attribute value stops the snippet being single-line markup.
- */
+/** An arg's value AST node as a single-line Angular template expression. */
 export const templateExpression = (node: t.Node): string =>
   escapeAttributeValue(
+    // `concise` leaves newlines inside a template literal, which would break the attribute value.
     generate(node, { concise: true, comments: false }).code.replace(/\s*\n\s*/g, ' ')
   );
 
@@ -289,22 +151,20 @@ export const generateAngularSnippet = ({
 
   const host = parseSelector(component.selector);
 
-  const inputBindings = component.inputs
-    // `hasOwn` rather than `in`: an input named after an `Object.prototype` member would otherwise
-    // read the inherited function and hand a non-node to the generator.
-    .filter((name) => Object.hasOwn(args, name))
-    .map((name) => `[${name}]="${templateExpression(args[name])}"`);
+  // `hasOwn` rather than `in`: an input named after an `Object.prototype` member would otherwise
+  // read the inherited function and hand a non-node to the generator.
+  const boundInputs = component.inputs.filter((name) => Object.hasOwn(args, name));
+  const inputBindings = boundInputs.map((name) => `[${name}]="${templateExpression(args[name])}"`);
 
-  // Every output gets a handler, whether or not the story declared one: Storybook's actions
-  // enhancer injects an arg for each output at runtime, which is why the browser snippet shows
-  // them for stories that never mention them.
+  // Storybook's actions enhancer injects an arg for each output at runtime, so every output gets a
+  // handler whether or not the story declared one.
   const outputBindings = component.outputs.map(
     (name) => `(${name})="${formatPropInTemplate(name)}($event)"`
   );
 
   // An attribute directive's own selector attribute is often an input too (`[appHighlight]` with
   // an `@Input() appHighlight`). Emitting both would name it twice on the same element.
-  const boundNames = new Set(component.inputs.filter((name) => Object.hasOwn(args, name)));
+  const boundNames = new Set(boundInputs);
   const hostAttributes = [
     ...(host.id ? [`id="${host.id}"`] : []),
     ...(host.classes.length > 0 ? [`class="${host.classes.join(' ')}"`] : []),
@@ -320,9 +180,6 @@ export const generateAngularSnippet = ({
   return withUnresolvedNote(element, unresolvedArgs);
 };
 
-/**
- * Prefixes a note naming what could not be resolved statically. Saying so beats emitting a snippet
- * that looks complete while silently missing bindings.
- */
+/** Prefixes a note naming what could not be resolved statically. */
 const withUnresolvedNote = (element: string, unresolved: readonly string[]): string =>
   unresolved.length === 0 ? element : `<!-- unresolved: ${unresolved.join(', ')} -->\n${element}`;

--- a/code/frameworks/angular-vite/src/docgen/template-snippet.ts
+++ b/code/frameworks/angular-vite/src/docgen/template-snippet.ts
@@ -1,0 +1,305 @@
+/**
+ * Static Angular template snippets, built from a component's Compodoc metadata and a story's
+ * declared args without loading a single Angular class.
+ *
+ * The browser generator (`client/renderer/ComputesTemplateFromComponent.ts`) reads the loaded
+ * component class through Angular's reflection APIs, which do not work in Node: `ɵcmp` is only
+ * populated by the Angular compiler. This module reimplements its rules against Compodoc's
+ * `documentation.json` instead. It is deliberately not shared with the browser copy - one runs
+ * against runtime classes, the other against JSON.
+ *
+ * ## v1 scope and known limitations
+ *
+ * - **Property and event bindings only.** Structural directives (`*ngIf`, `*ngFor`), two-way
+ *   banana-in-a-box syntax (`[(x)]`) and content projection (`<ng-content>`) are out of scope. An
+ *   Angular `model()` is emitted as a separate `[x]` input plus an `(xChange)` output, which is
+ *   what the two-way form desugars to.
+ * - **Args the component does not declare as an input or an output are dropped.** The binding set
+ *   is decided by Compodoc's metadata, not by the arg's runtime type, so a function passed to an
+ *   `@Input` stays a property binding.
+ * - **Functions and `undefined` are printed literally**, as source text. Angular template
+ *   expressions cannot contain function literals, so a function-valued input produces a snippet
+ *   that reads correctly but would not compile as written.
+ * - **Values are read statically from the story file**, so an arg whose value is an identifier or
+ *   a call expression is printed as that expression rather than as the value it evaluates to.
+ * - **CSF2 `Story.args = {}` assignments are not read**; only args declared on the meta or on the
+ *   story's own config object are.
+ * - **The snippet no longer updates as Controls change.** That is the one accepted regression of
+ *   the server-side docs path.
+ */
+import type { types as t } from 'storybook/internal/babel';
+import { generate } from 'storybook/internal/babel';
+
+/** The parts of an Angular component a template snippet is built from. */
+export interface AngularComponentTemplate {
+  /** Class name. Used for the `*ngComponentOutlet` fallback when the component has no selector. */
+  name: string;
+  selector?: string;
+  /** Template names of the component's inputs, i.e. what `[binding]` may name. */
+  inputs: readonly string[];
+  /** Template names of the component's outputs, i.e. what `(binding)` may name. */
+  outputs: readonly string[];
+}
+
+export interface AngularSnippetInput {
+  component: AngularComponentTemplate;
+  /** Declared args (meta merged with story), as the value AST nodes they were written as. */
+  args: Record<string, t.Node>;
+  /**
+   * Source text of `args` spread elements. A spread carries values no static pass can resolve, so
+   * it is reported in the snippet rather than dropped without trace.
+   */
+  unresolvedArgs?: readonly string[];
+}
+
+/** Elements HTML forbids a closing tag on. */
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'command',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'keygen',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
+/** The host element an Angular selector puts a component or directive on. */
+export interface HostElement {
+  tag: string;
+  id?: string;
+  classes: string[];
+  /** Attributes the selector pins on the host, already in `name` or `name="value"` form. */
+  attributes: string[];
+}
+
+const IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+/**
+ * Property name as it can be referenced from a template: dot notation when the name is a valid
+ * identifier, bracket notation otherwise.
+ */
+export const formatPropInTemplate = (propertyName: string): string =>
+  IDENTIFIER.test(propertyName) ? propertyName : `this['${propertyName}']`;
+
+/**
+ * First selector of a comma-separated list, ignoring commas inside `[...]` or a quoted attribute
+ * value. Angular matches a component on any one of its selectors, so the first is as good as any.
+ */
+const firstSelector = (selector: string): string => {
+  let inAttribute = false;
+  let quote: string | undefined;
+
+  for (let index = 0; index < selector.length; index++) {
+    const char = selector[index];
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '[') {
+      inAttribute = true;
+    } else if (char === ']') {
+      inAttribute = false;
+    } else if (char === ',' && !inAttribute) {
+      return selector.slice(0, index);
+    }
+  }
+  return selector;
+};
+
+/** Index just past the `]` closing the attribute that starts at `start`, quotes honoured. */
+const attributeEnd = (selector: string, start: number): number => {
+  let quote: string | undefined;
+  for (let index = start + 1; index < selector.length; index++) {
+    const char = selector[index];
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ']') {
+      return index + 1;
+    }
+  }
+  return selector.length;
+};
+
+/** Index just past a `:pseudo` or `:pseudo(...)` run, nested parentheses and quotes honoured. */
+const pseudoEnd = (selector: string, start: number): number => {
+  let index = start + 1;
+  while (index < selector.length && /[\w-]/.test(selector[index])) {
+    index++;
+  }
+  if (selector[index] !== '(') {
+    return index;
+  }
+  let depth = 0;
+  let quote: string | undefined;
+  for (; index < selector.length; index++) {
+    const char = selector[index];
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+      if (depth === 0) {
+        return index + 1;
+      }
+    }
+  }
+  return selector.length;
+};
+
+/** `attr`, `attr=value` or `attr="value"` from a selector, normalised to HTML attribute syntax. */
+const toHostAttribute = (body: string): string => {
+  const equals = body.indexOf('=');
+  if (equals === -1) {
+    return body;
+  }
+  const name = body.slice(0, equals).trim();
+  const rawValue = body.slice(equals + 1).trim();
+  const value =
+    (rawValue.startsWith('"') && rawValue.endsWith('"')) ||
+    (rawValue.startsWith("'") && rawValue.endsWith("'"))
+      ? rawValue.slice(1, -1)
+      : rawValue;
+  return `${name}="${escapeAttributeValue(value)}"`;
+};
+
+/**
+ * Angular selector → the host element a story snippet renders it on.
+ *
+ * A real scan rather than the browser copy's regex pipeline, which mangles a comma inside an
+ * attribute value and pastes pseudo-selectors into the tag name (`my-cmp:not([disabled])` becomes
+ * `<my-cmp:not( disabled)>`).
+ *
+ * A selector with no element part - a bare `[myDirective]` or `.my-class` - describes a directive,
+ * which has no host element of its own. `div` is the neutral host: it is what the browser copy
+ * already renders for the `.my-class` case, and it keeps the snippet copy-pasteable.
+ */
+export const parseSelector = (selector: string): HostElement => {
+  const single = firstSelector(selector).trim();
+  const attributes: string[] = [];
+  const classes: string[] = [];
+  let tag: string | undefined;
+  let id: string | undefined;
+  let index = 0;
+
+  while (index < single.length) {
+    const char = single[index];
+
+    if (char === '[') {
+      const end = attributeEnd(single, index);
+      const body = single.slice(index + 1, end - 1).trim();
+      if (body) {
+        attributes.push(toHostAttribute(body));
+      }
+      index = end;
+      continue;
+    }
+    if (char === ':') {
+      // A pseudo-selector narrows when the directive applies; it is not part of the host element.
+      index = pseudoEnd(single, index);
+      continue;
+    }
+    if (char === '#' || char === '.') {
+      const name = /^[\w-]+/.exec(single.slice(index + 1))?.[0];
+      if (name) {
+        if (char === '#') {
+          id = name;
+        } else {
+          classes.push(name);
+        }
+        index += name.length + 1;
+        continue;
+      }
+      index++;
+      continue;
+    }
+
+    const element = /^[a-zA-Z][\w-]*/.exec(single.slice(index))?.[0];
+    if (element && tag === undefined) {
+      tag = element;
+      index += element.length;
+      continue;
+    }
+    index++;
+  }
+
+  return { tag: tag ?? 'div', id, classes, attributes };
+};
+
+/**
+ * Angular reads a binding's expression out of an HTML attribute value, so `&` and `"` have to
+ * survive as entities or the snippet stops being well-formed markup. Nothing else is rewritten:
+ * the browser copy leaves both raw and produces a broken template for any string holding a quote.
+ */
+const escapeAttributeValue = (value: string): string =>
+  value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+
+/** An arg's value AST node as a single-line Angular template expression. */
+export const templateExpression = (node: t.Node): string =>
+  escapeAttributeValue(generate(node, { concise: true, comments: false }).code);
+
+/** Builds the static Angular template snippet for one story. */
+export const generateAngularSnippet = ({
+  component,
+  args,
+  unresolvedArgs = [],
+}: AngularSnippetInput): string => {
+  if (!component.selector) {
+    return `<ng-container *ngComponentOutlet="${component.name}"></ng-container>`;
+  }
+
+  const host = parseSelector(component.selector);
+
+  const inputBindings = component.inputs
+    .filter((name) => name in args)
+    .map((name) => `[${name}]="${templateExpression(args[name])}"`);
+
+  // Every output gets a handler, whether or not the story declared one: Storybook's actions
+  // enhancer injects an arg for each output at runtime, which is why the browser snippet shows
+  // them for stories that never mention them.
+  const outputBindings = component.outputs.map(
+    (name) => `(${name})="${formatPropInTemplate(name)}($event)"`
+  );
+
+  const hostAttributes = [
+    ...(host.id ? [`id="${host.id}"`] : []),
+    ...(host.classes.length > 0 ? [`class="${host.classes.join(' ')}"`] : []),
+    ...host.attributes,
+  ];
+
+  const attributes = [...hostAttributes, ...inputBindings, ...outputBindings];
+  const attributeText = attributes.length > 0 ? ` ${attributes.join(' ')}` : '';
+  const element = VOID_ELEMENTS.has(host.tag)
+    ? `<${host.tag}${attributeText} />`
+    : `<${host.tag}${attributeText}></${host.tag}>`;
+
+  if (unresolvedArgs.length === 0) {
+    return element;
+  }
+  // A spread's contents are only known at runtime. Saying so beats emitting a snippet that looks
+  // complete while silently missing bindings.
+  return `<!-- unresolved args: ${unresolvedArgs.join(', ')} -->\n${element}`;
+};

--- a/code/frameworks/angular-vite/src/docgen/template-snippet.ts
+++ b/code/frameworks/angular-vite/src/docgen/template-snippet.ts
@@ -25,8 +25,6 @@ export interface AngularSnippetInput {
   component: AngularComponentTemplate;
   /** Declared args (meta merged with story), as the value AST nodes they were written as. */
   args: Record<string, t.Node>;
-  /** Source text of anything a static pass could not read, reported rather than dropped silently. */
-  unresolvedArgs?: readonly string[];
 }
 
 /** Elements HTML forbids a closing tag on. */
@@ -58,7 +56,8 @@ export interface HostElement {
   attributes: string[];
 }
 
-const IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+/** A name that can be written as-is rather than through bracket notation. */
+export const IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
 
 /**
  * Property name as it can be referenced from a template: dot notation when the name is a valid
@@ -137,16 +136,9 @@ export const templateExpression = (node: t.Node): string =>
   );
 
 /** Builds the static Angular template snippet for one story. */
-export const generateAngularSnippet = ({
-  component,
-  args,
-  unresolvedArgs = [],
-}: AngularSnippetInput): string => {
+export const generateAngularSnippet = ({ component, args }: AngularSnippetInput): string => {
   if (!component.selector) {
-    return withUnresolvedNote(
-      `<ng-container *ngComponentOutlet="${component.name}"></ng-container>`,
-      unresolvedArgs
-    );
+    return `<ng-container *ngComponentOutlet="${component.name}"></ng-container>`;
   }
 
   const host = parseSelector(component.selector);
@@ -173,13 +165,7 @@ export const generateAngularSnippet = ({
 
   const attributes = [...hostAttributes, ...inputBindings, ...outputBindings];
   const attributeText = attributes.length > 0 ? ` ${attributes.join(' ')}` : '';
-  const element = VOID_ELEMENTS.has(host.tag)
+  return VOID_ELEMENTS.has(host.tag)
     ? `<${host.tag}${attributeText} />`
     : `<${host.tag}${attributeText}></${host.tag}>`;
-
-  return withUnresolvedNote(element, unresolvedArgs);
 };
-
-/** Prefixes a note naming what could not be resolved statically. */
-const withUnresolvedNote = (element: string, unresolved: readonly string[]): string =>
-  unresolved.length === 0 ? element : `<!-- unresolved: ${unresolved.join(', ')} -->\n${element}`;

--- a/code/frameworks/angular-vite/src/framework-options.ts
+++ b/code/frameworks/angular-vite/src/framework-options.ts
@@ -1,0 +1,17 @@
+import type { Preset } from 'storybook/internal/types';
+
+import type { FrameworkOptions } from './types.ts';
+
+/**
+ * Reads `framework.options` from the resolved presets.
+ *
+ * `framework` is either the framework's package name or `{ name, options }`, and only the latter
+ * carries options. `presets.apply` is untyped, so the shape is asserted here rather than at each
+ * use.
+ */
+export const readFrameworkOptions = async (options?: {
+  presets?: { apply: (key: string, fallback?: unknown) => Promise<unknown> };
+}): Promise<FrameworkOptions> => {
+  const framework = (await options?.presets?.apply('framework')) as Preset | undefined;
+  return typeof framework === 'string' ? {} : (framework?.options ?? {});
+};

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -18,6 +18,7 @@ import type { StandaloneOptions } from './builders/utils/standalone-options.ts';
 import type { UserConfig, Plugin } from 'vite';
 
 export { experimental_docgenProvider, experimental_manifests } from './docgen/preset.ts';
+export { experimental_storyDocsProvider } from './docgen/story-docs-preset.ts';
 
 export const addons: PresetProperty<'addons'> = [];
 

--- a/code/frameworks/angular-vite/src/types.ts
+++ b/code/frameworks/angular-vite/src/types.ts
@@ -7,6 +7,15 @@ import type { BuilderOptions, StorybookConfigVite } from '@storybook/builder-vit
 type FrameworkName = CompatibleString<'@storybook/angular-vite'>;
 type BuilderName = CompatibleString<'@storybook/builder-vite'>;
 
+/**
+ * Shape of the server-side story snippet.
+ *
+ * `template` emits the bare markup, which is what the browser generator has always produced.
+ * `component` wraps it in the standalone host component it needs to compile, so the snippet can be
+ * pasted into a project or handed to an agent as-is.
+ */
+export type SnippetFormat = 'template' | 'component';
+
 export type FrameworkOptions = {
   builder?: BuilderOptions;
   jit?: boolean;
@@ -15,6 +24,8 @@ export type FrameworkOptions = {
   tsconfig?: string;
   compodoc?: boolean;
   compodocArgs?: string[];
+  /** Only read when `features.experimentalDocgenServer` is on. Defaults to `'template'`. */
+  snippetFormat?: SnippetFormat;
 };
 
 type StorybookConfigFramework = {

--- a/code/lib/angular-compodoc/src/compodoc-types.ts
+++ b/code/lib/angular-compodoc/src/compodoc-types.ts
@@ -81,6 +81,8 @@ export interface Directive {
   methodsClass: Method[];
   description?: Html;
   rawdescription?: string;
+  /** CSS selector the directive or component matches on. */
+  selector?: string;
 }
 
 export type Component = Directive;

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<button sb-harness-action [emphasis]="true"></button>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-cross-file-inheritance [heading]="'Storage almost full'" [dismissible]="true" (dismissed)="dismissed($event)"></sb-cross-file-inheritance>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-generic [items]="['alpha', 'beta']" [selected]="'alpha'"></sb-decorator-generic>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-getter-setter [volume]="7"></sb-decorator-getter-setter>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/osa-snippet-EventHandlerArg.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/osa-snippet-EventHandlerArg.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-io-basics [label]="'Save'" (clicked)="clicked($event)"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/osa-snippet-ExplicitUndefinedArg.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/osa-snippet-ExplicitUndefinedArg.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-io-basics [count]="1" [label]="undefined" (clicked)="clicked($event)"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/osa-snippet-ObjectAndArrayArgs.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/osa-snippet-ObjectAndArrayArgs.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-io-basics [data]="{ id: 7, tags: ['a', 'b'], nested: { deep: true } }" [label]="'Save'" (clicked)="clicked($event)"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-io-basics [count]="3" [label]="'Save'" (clicked)="clicked($event)"></sb-decorator-io-basics>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-decorator-union-enum [kind]="ButtonKind.Secondary" [size]="'large'" [tone]="'warn'"></sb-decorator-union-enum>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-expression-defaults [rows]="8" [timeoutMs]="1000" (saved)="saved($event)"></sb-expression-defaults>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-jsdoc-tags [accent]="'seagreen'" [text]="'Deployed'"></sb-jsdoc-tags>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-properties-methods-noise [title]="'Paged results'"></sb-properties-methods-noise>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/osa-snippet-EventHandlerArg.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/osa-snippet-EventHandlerArg.snapshot
@@ -1,0 +1,1 @@
+<sb-signal-io [count]="2" [label]="'Quantity'" (toggled)="toggled($event)"></sb-signal-io>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/osa-snippet-PropsAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/osa-snippet-PropsAsWritten.snapshot
@@ -1,0 +1,1 @@
+<sb-signal-io [count]="2" [disabled]="true" [label]="'Quantity'" [increment]="5" (toggled)="toggled($event)"></sb-signal-io>

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/osa-snippet-TwoWayBinding.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/osa-snippet-TwoWayBinding.snapshot
@@ -1,0 +1,1 @@
+<sb-signal-model [checked]="true" [value]="'hello'" (checkedChange)="checkedChange($event)" (valueChange)="valueChange($event)"></sb-signal-model>

--- a/code/lib/docgen-harness/src/angular/angular-osa-snippets.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-osa-snippets.test.ts
@@ -55,8 +55,7 @@ describe('angular OSA snippet baselines', () => {
         storyRoot: testDir,
         resolveComponent: createCompodocComponentResolver({
           workspaceRoot: testDir,
-          outputDir: testDir,
-          readDocumentationJson: () => compodocJson,
+          readMetadata: () => compodocJson,
           logger: silentLogger,
         }),
         logger: silentLogger,

--- a/code/lib/docgen-harness/src/angular/angular-osa-snippets.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-osa-snippets.test.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import { buildStoryDocsPayload } from '../../../../frameworks/angular-vite/src/docgen/build-story-docs.ts';
+import { createCompodocComponentResolver } from '../../../../frameworks/angular-vite/src/docgen/compodoc-component-resolver.ts';
 import { expectCurrentOrBetter } from '../compare/expect-current-or-better.ts';
 import { BASELINE_PATH } from './baseline-path.ts';
 
@@ -52,9 +53,12 @@ describe('angular OSA snippet baselines', () => {
       },
       {
         storyRoot: testDir,
-        workspaceRoot: testDir,
-        outputDir: testDir,
-        readDocumentationJson: () => compodocJson,
+        resolveComponent: createCompodocComponentResolver({
+          workspaceRoot: testDir,
+          outputDir: testDir,
+          readDocumentationJson: () => compodocJson,
+          logger: silentLogger,
+        }),
         logger: silentLogger,
       }
     );

--- a/code/lib/docgen-harness/src/angular/angular-osa-snippets.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-osa-snippets.test.ts
@@ -51,6 +51,7 @@ describe('angular OSA snippet baselines', () => {
         } as IndexEntry,
       },
       {
+        storyRoot: testDir,
         workspaceRoot: testDir,
         outputDir: testDir,
         readDocumentationJson: () => compodocJson,

--- a/code/lib/docgen-harness/src/angular/angular-osa-snippets.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-osa-snippets.test.ts
@@ -1,0 +1,96 @@
+import type { IndexEntry } from 'storybook/internal/types';
+
+import { loadCsf } from 'storybook/internal/csf-tools';
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildStoryDocsPayload } from '../../../../frameworks/angular-vite/src/docgen/build-story-docs.ts';
+import { expectCurrentOrBetter } from '../compare/expect-current-or-better.ts';
+import { BASELINE_PATH } from './baseline-path.ts';
+
+// A second recorder alongside the legacy one, following the vue3 `cm-` precedent: the committed
+// `snippet-*.snapshot` files stay the oracle this path is measured against instead of being
+// overwritten by it, so `BASELINE_PATH` is deliberately untouched.
+if (BASELINE_PATH !== 'legacy') {
+  throw new Error(
+    'angular-osa-snippets.test.ts compares the OSA snippets against the legacy baselines; update the recorder or baseline-path.ts'
+  );
+}
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__testfixtures__');
+
+const fixtureCases = readdirSync(fixturesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+const silentLogger = { warn: () => {}, debug: () => {} };
+
+describe('angular OSA snippet baselines', () => {
+  it.each(fixtureCases)('%s', async (fixtureCase) => {
+    const testDir = join(fixturesDir, fixtureCase);
+    const title = `AngularFixtures/${fixtureCase}`;
+    const storySource = readFileSync(join(testDir, 'input.stories.ts'), 'utf8');
+    const compodocJson = JSON.parse(readFileSync(join(testDir, 'compodoc-input.json'), 'utf8'));
+
+    // The fixtures ship Compodoc's capture as `compodoc-input.json`; production reads the same
+    // shape from `documentation.json` in the resolved output directory.
+    const payload = buildStoryDocsPayload(
+      {
+        entry: {
+          type: 'story',
+          subtype: 'story',
+          id: `${fixtureCase}--recorder`,
+          name: 'recorder',
+          title,
+          importPath: './input.stories.ts',
+        } as IndexEntry,
+      },
+      {
+        workspaceRoot: testDir,
+        outputDir: testDir,
+        readDocumentationJson: () => compodocJson,
+        logger: silentLogger,
+      }
+    );
+
+    expect(payload).toBeDefined();
+
+    const csf = loadCsf(storySource, { makeTitle: () => title }).parse();
+    const storyExports = Object.keys(csf._stories);
+    expect(storyExports.length).toBeGreaterThan(0);
+
+    for (const exportName of storyExports) {
+      const doc = payload!.stories[csf._stories[exportName].id];
+      expect(doc?.error).toBeUndefined();
+
+      const snippet = doc!.snippet!;
+      await expect(snippet).toMatchFileSnapshot(
+        join(testDir, `osa-snippet-${exportName}.snapshot`)
+      );
+
+      // The legacy recorder synthesizes an action arg for every output before generating, which is
+      // what the runtime actions enhancer does, so the committed baselines carry an event binding
+      // per output. Losing one here is a regression, not a formatting difference.
+      expectCurrentOrBetter({
+        kind: 'snippet',
+        framework: 'angular',
+        baseline: readFileSync(join(testDir, `snippet-${exportName}.snapshot`), 'utf8'),
+        candidate: snippet,
+      });
+    }
+
+    // toMatchFileSnapshot files sit outside vitest's obsolete-snapshot detection, so a renamed or
+    // removed story export would silently leave its old snapshot on disk.
+    const snippetFilesOnDisk = readdirSync(testDir)
+      .filter((file) => file.startsWith('osa-snippet-') && file.endsWith('.snapshot'))
+      .sort();
+    expect(snippetFilesOnDisk).toEqual(
+      storyExports.map((exportName) => `osa-snippet-${exportName}.snapshot`).sort()
+    );
+  });
+});

--- a/code/lib/docgen-harness/src/angular/angular-provider-seam.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-provider-seam.test.ts
@@ -5,6 +5,7 @@ import { isAbsolute } from 'node:path';
 
 import { expect, test } from 'vitest';
 
+import * as angularVitePreset from '../../../../frameworks/angular-vite/src/preset.ts';
 import { experimental_docgenProvider } from '../../../../frameworks/angular-vite/src/preset.ts';
 
 // Requiring a real on-disk worker module is what keeps this honest: a stub export (empty array or a
@@ -25,4 +26,12 @@ test('angular-vite registers a docgen provider pointing at a worker module that 
         isAbsolute(descriptor.moduleSpecifier) && existsSync(descriptor.moduleSpecifier)
     )
   ).toHaveLength(1);
+});
+
+// Story-docs providers are in-process middleware, so there is no module on disk to require: the
+// preset key being an exported function is the whole registration. Read through the namespace and
+// assert it is non-empty first, so a module that resolves but loses its exports cannot pass.
+test('angular-vite registers a story-docs provider', () => {
+  expect(Object.keys(angularVitePreset).length).toBeGreaterThan(0);
+  expect(typeof angularVitePreset.experimental_storyDocsProvider).toBe('function');
 });

--- a/code/lib/docgen-harness/src/angular/angular-provider-seam.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-provider-seam.test.ts
@@ -5,8 +5,10 @@ import { isAbsolute } from 'node:path';
 
 import { expect, test } from 'vitest';
 
-import * as angularVitePreset from '../../../../frameworks/angular-vite/src/preset.ts';
-import { experimental_docgenProvider } from '../../../../frameworks/angular-vite/src/preset.ts';
+import {
+  experimental_docgenProvider,
+  experimental_storyDocsProvider,
+} from '../../../../frameworks/angular-vite/src/preset.ts';
 
 // Requiring a real on-disk worker module is what keeps this honest: a stub export (empty array or a
 // dangling descriptor) must not satisfy it.
@@ -29,9 +31,7 @@ test('angular-vite registers a docgen provider pointing at a worker module that 
 });
 
 // Story-docs providers are in-process middleware, so there is no module on disk to require: the
-// preset key being an exported function is the whole registration. Read through the namespace and
-// assert it is non-empty first, so a module that resolves but loses its exports cannot pass.
+// preset key being an exported function is the whole registration.
 test('angular-vite registers a story-docs provider', () => {
-  expect(Object.keys(angularVitePreset).length).toBeGreaterThan(0);
-  expect(typeof angularVitePreset.experimental_storyDocsProvider).toBe('function');
+  expect(typeof experimental_storyDocsProvider).toBe('function');
 });


### PR DESCRIPTION
> [!NOTE]
> Stacked on #35794, which adds the `warning` field this PR is the first to populate. Review that one first; this diff assumes it. Once it lands I'll retarget to `next`.

## What I did

Today an Angular story's Source block is filled in by the browser: Storybook loads the component class, reads its inputs and outputs through Angular's reflection APIs, and builds the template string in the preview. That only works with a compiler present, so nothing outside the browser can produce a snippet - the CLI and MCP can't, and neither can anything that wants the docs without rendering the story.

This adds a server-side generator behind `experimentalDocgenServer`. It builds the same kind of snippet in Node, from the component's declared selector and bindings plus the args written in the story file, and hands it to the story-docs provider. Property and event bindings only for now. With the flag off nothing changes at all.

```
 button.stories.ts ──parse CSF──┐
                                ├──► [label]="'Save'"  ──┐
 AngularComponentResolver ──────┤    (clicked)="…"       ├──► <sb-button …></sb-button>
     selector, inputs, outputs ─┤                        │
                                │    host element ───────┘
   ▲                            │    from the selector
   └─ Compodoc today            │
```

Snippet generation never reads `documentation.json`. It asks a resolver "given the component this story file documents, what is its selector and what can it bind", and Compodoc is one implementation of that:

```ts
export type AngularComponentResolver = (
  component: ResolvedMetaComponent
) => AngularComponentTemplate | undefined;
```

That matters because the metadata source is expected to change. An in-process Angular component meta service would be a second resolver wired in the preset, with no edit to any generator. A test builds real snippets from a hand-written resolver to keep that honest:

```ts
const payload = build('./story-docs.stories.ts', {
  resolveComponent: () => ({
    name: 'ButtonComponent',
    selector: 'my-button',
    inputs: ['label'],
    outputs: ['pressed'],
  }),
});
// <my-button [label]="'Save'" (pressed)="pressed($event)"></my-button>
```

An arg becomes an event binding only when the component declares an output by that name, never because it happens to hold a function. That is what the existing baselines encode, and a function passed to an `@Input()` stays a property binding:

```ts
const inputBindings = boundInputs.map((name) => `[${name}]="${templateExpression(args[name])}"`);

// Storybook's actions enhancer injects an arg for each output at runtime, so every output gets a
// handler whether or not the story declared one.
const outputBindings = component.outputs.map(
  (name) => `(${name})="${formatPropInTemplate(name)}($event)"`
);
```

Fifteen snippets are recorded for the Angular fixtures and compared against the ones the browser path produces, so no binding may go missing. The recorded output for a two-way `model()`, which stays an input plus a `Change` output rather than banana-in-a-box:

```html
<!-- browser -->
<sb-signal-model [value]="'hello'" [checked]="true" (valueChange)="valueChange($event)" (checkedChange)="checkedChange($event)"></sb-signal-model>
<!-- server -->
<sb-signal-model [checked]="true" [value]="'hello'" (checkedChange)="checkedChange($event)" (valueChange)="valueChange($event)"></sb-signal-model>
```

Attribute order and formatting are free to differ; a lost binding is not. Dropping the outputs a story never declared looks like this:

```
Error: expectCurrentOrBetter found 1 violation(s):
- [lost-representation] clicked: represented in the baseline snippet but not in the candidate
```

## Two snippet formats

A bare template fragment is fine to read beside a rendered story, but it is not something you can paste into a project, and an agent handed one has to guess the rest. So `framework.options.snippetFormat` picks the shape:

```ts
framework: {
  name: '@storybook/angular-vite',
  options: { snippetFormat: 'component' }, // 'template' is the default
}
```

`'template'` is what the browser generator has always produced and stays the default, so this PR changes nothing until you ask for the other one. `'component'` wraps the same markup in the standalone host it needs to compile, and the payload grows the matching import block.

Both payloads below are real output for the same fixture, trimmed to two stories:

```jsonc
// snippetFormat: 'template'
{
  "id": "storydocs",
  "name": "ButtonComponent",
  "path": "./story-docs.stories.ts",
  "stories": {
    "storydocs--basic": {
      "id": "storydocs--basic",
      "name": "Basic",
      "description": "Renders the button with a label and a count.",
      "snippet": "<sb-button [label]=\"'Save'\" [count]=\"3\" (clicked)=\"clicked($event)\"></sb-button>"
    }
  }
}
```

```jsonc
// snippetFormat: 'component'
{
  "id": "storydocs",
  "name": "ButtonComponent",
  "path": "./story-docs.stories.ts",
  "import": "import { Component } from '@angular/core';\nimport { ButtonComponent } from './button.component';",
  "stories": {
    "storydocs--basic": {
      "id": "storydocs--basic",
      "name": "Basic",
      "description": "Renders the button with a label and a count.",
      "snippet": "@Component({\n  selector: 'app-root',\n  template: `<sb-button [label]=\"'Save'\" [count]=\"3\" (clicked)=\"clicked($event)\"></sb-button>`,\n  imports: [ButtonComponent],\n})\nexport class App {\n  clicked(event: unknown) {}\n}"
    }
  }
}
```

Which renders as:

```ts
import { Component } from '@angular/core';
import { ButtonComponent } from './button.component';

@Component({
  selector: 'app-root',
  template: `<sb-button [label]="'Save'" [count]="3" (clicked)="clicked($event)"></sb-button>`,
  imports: [ButtonComponent],
})
export class App {
  clicked(event: unknown) {}
}
```

The `clicked` method is not decoration. Angular's template type checking resolves `(clicked)="clicked($event)"` against the host class, so a wrapper without it would emit an example that does not compile - which would defeat the point of the format. A story that supplies its own `template` gets no methods, because which outputs its markup binds is not knowable statically.

## An incomplete snippet says so in a field, not in the markup

This is the first producer of the `warning` field added in #35794. When a static pass cannot read part of a story, the note travels as data next to the snippet instead of as a comment inside it, so a consumer that renders the snippet is not left with a stray comment and one that reads it can act on the fact:

```diff
-"snippet": "<!-- unresolved: ...sharedArgs -->\n<sb-button [label]=\"'meta'\" [count]=\"1\" …></sb-button>"
+"snippet": "<sb-button [label]=\"'meta'\" [count]=\"1\" …></sb-button>",
+"warning": "Incomplete snippet: `...sharedArgs` could not be resolved statically."
```

`warning` still comes with a snippet; `error` means there is no snippet at all. It reaches `manifests/components.json` for free, because the manifest passes the `stories` map through untouched.

| Command | What it does | Run from |
| --- | --- | --- |
| `yarn vitest run code/lib/docgen-harness/src/angular` | Records the server snippets and compares them to the browser baselines | repo root |
| `yarn vitest run code/frameworks/angular-vite/src/docgen` | Unit tests for the selector parsing, value serialization, the host wrapper, the resolver contract and the provider | repo root |
| `yarn vitest run code/lib/docgen-harness/src/angular -u` | Re-records after an intentional change; review the snapshot diff, it is the only place a value regression shows up | repo root |

### Known limitations, all documented next to the generator

Structural directives, banana-in-a-box and content projection are out of scope. Values are read from the source rather than evaluated, so `args: { kind: ButtonKind.Secondary }` prints as written. Anything that can't be read statically - a spread, a template held in a `const` - lands in `warning` rather than being dropped silently.

The one accepted regression: the snippet is static, so it no longer follows the Controls. That was agreed for the server-side docs path and already applies to Vue.

### Also in here

One unrelated fix rides along in its own commit: an addon-mcp test that times out under full-suite load. It fails on the base commit too, so it isn't caused by anything here - happy to split it out if you'd rather.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `yarn task sandbox --template angular-vite/default-ts --start-from auto`
2. In the sandbox's `.storybook/main.ts`, set `features: { experimentalDocgenServer: true }`
3. `yarn storybook`
4. Open `Example/Button` → `Docs` and press **Show code**. You should see a real Angular template, not the story's source:
   ```html
   <storybook-button [label]="'Button'" [primary]="true" (onClick)="onClick($event)"></storybook-button>
   ```
5. Toggle the `primary` control to `False`. The story re-renders, the snippet does **not** change - that is the static-snippet trade-off, and it is also how you can tell the server generator is the one driving the block.
6. Now set `framework.options.snippetFormat` to `'component'` and restart. The same block should show the full host component with its imports.
7. Turn the flag back off and confirm the Source block behaves exactly as it does on `next`.

> [!WARNING]
> If step 1 gives you a sandbox where Compodoc never runs, you have hit an unrelated problem: Compodoc 2 crashes on TypeScript 7, and a freshly generated Angular sandbox now resolves TypeScript 7 because the template's `typescript@^6` pin sits in `dependencies` while the Angular CLI scaffold's `^7.0.2` sits in `devDependencies`. Pinning `typescript` back to `^6` in the sandbox works around it. This breaks the existing browser path too, so it is not caused by this PR - I've written it up separately.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

The v1 limitations are written up in the framework package as source material for the user-facing docs page, which a later story owns.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
