### PR TITLE
Build: Keep Yarn's output plain so age-gate rejections stay parseable

### DIFF
--- a/scripts/sandbox/utils/yarn.test.ts
+++ b/scripts/sandbox/utils/yarn.test.ts
@@ -183,6 +183,27 @@ describe('refreshBeforeStorybookLockfile', () => {
     );
   });
 
+  it('reads the descriptor out of colourised CI output', async () => {
+    // Captured verbatim from `yarn install` with colour forced on, as CI runs it. Yarn
+    // colourises the descriptor and wraps the error code in an OSC-8 hyperlink, so neither
+    // `YN0016:` nor `@npm:` exists as a literal until the escapes are stripped.
+    const colourised = Object.assign(new Error('yarn failed'), {
+      stdout:
+        '\u001B[91m\u27A4\u001B[39m \u001B]8;;https://yarnpkg.com/advanced/error-codes#yn0016---remote_not_found\u0007YN0016\u001B]8;;\u0007: \u2502 \u001B[91m@tailwindcss/\u001B[39m\u001B[91mturbopack\u001B[39m\u001B[36m@\u001B[39m\u001B[36mnpm:^4.3.3\u001B[39m: All versions satisfying \"^4.3.3\" are quarantined',
+    });
+    vol.writeFileSync(
+      `${SANDBOX}/package.json`,
+      JSON.stringify({ dependencies: { '@tailwindcss/turbopack': '^4.3.3' } })
+    );
+    failResolveSteps(colourised);
+
+    await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
+
+    expect(yarnCommands()).toContain(
+      `yarn up '@tailwindcss/turbopack@^4.0.0' --mode=update-lockfile`
+    );
+  });
+
   it('surfaces a failure that is not the age gate instead of upgrading blindly', async () => {
     const offline = Object.assign(new Error('yarn failed'), { stdout: 'ENOTFOUND registry' });
     failResolveSteps(offline);

--- a/scripts/sandbox/utils/yarn.test.ts
+++ b/scripts/sandbox/utils/yarn.test.ts
@@ -183,24 +183,29 @@ describe('refreshBeforeStorybookLockfile', () => {
     );
   });
 
-  it('reads the descriptor out of colourised CI output', async () => {
-    // Captured verbatim from `yarn install` with colour forced on, as CI runs it. Yarn
-    // colourises the descriptor and wraps the error code in an OSC-8 hyperlink, so neither
-    // `YN0016:` nor `@npm:` exists as a literal until the escapes are stripped.
-    const colourised = Object.assign(new Error('yarn failed'), {
-      stdout:
-        '\u001B[91m\u27A4\u001B[39m \u001B]8;;https://yarnpkg.com/advanced/error-codes#yn0016---remote_not_found\u0007YN0016\u001B]8;;\u0007: \u2502 \u001B[91m@tailwindcss/\u001B[39m\u001B[91mturbopack\u001B[39m\u001B[36m@\u001B[39m\u001B[36mnpm:^4.3.3\u001B[39m: All versions satisfying \"^4.3.3\" are quarantined',
-    });
-    vol.writeFileSync(
-      `${SANDBOX}/package.json`,
-      JSON.stringify({ dependencies: { '@tailwindcss/turbopack': '^4.3.3' } })
-    );
-    failResolveSteps(colourised);
-
+  it('keeps Yarn output plain so the descriptor stays parseable', async () => {
     await refreshBeforeStorybookLockfile({ cwd: SANDBOX });
 
-    expect(yarnCommands()).toContain(
-      `yarn up '@tailwindcss/turbopack@^4.0.0' --mode=update-lockfile`
+    // Yarn colourises and hyperlinks when CI is set, which splits `YN0016:` and
+    // `name@npm:range` across escapes and leaves nothing for the parser to match.
+    const [, options] = vi.mocked(runCommand).mock.calls[0];
+    expect(options?.env).toMatchObject({
+      YARN_ENABLE_COLORS: 'false',
+      YARN_ENABLE_HYPERLINKS: 'false',
+    });
+  });
+
+  it('says so when it cannot read a package out of a quarantine report', async () => {
+    // Yarn's colourised form, captured from a real run. If output ever looks like this
+    // again the parser must fail loudly rather than blame resolution.
+    const unparseable = Object.assign(new Error('yarn failed'), {
+      stdout:
+        '\u001B[91m\u27A4\u001B[39m \u001B]8;;https://yarnpkg.com/advanced/error-codes#yn0016---remote_not_found\u0007YN0016\u001B]8;;\u0007: \u2502 \u001B[91m@tailwindcss/\u001B[39m\u001B[91mturbopack\u001B[39m\u001B[36m@\u001B[39m\u001B[36mnpm:^4.3.3\u001B[39m: All versions satisfying "^4.3.3" are quarantined',
+    });
+    failResolveSteps(unparseable);
+
+    await expect(refreshBeforeStorybookLockfile({ cwd: SANDBOX })).rejects.toThrow(
+      /Could not read the quarantined package/
     );
   });
 

--- a/scripts/sandbox/utils/yarn.ts
+++ b/scripts/sandbox/utils/yarn.ts
@@ -136,6 +136,11 @@ export async function refreshBeforeStorybookLockfile({
     YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
     COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
     CI: 'true',
+    // Yarn colourises and hyperlinks its output whenever `CI` is set, which splits both
+    // `YN0016:` and the `name@npm:range` descriptor that `narrowQuarantinedRanges` reads
+    // back out of a failed install. Keep the output plain so it stays parseable.
+    YARN_ENABLE_COLORS: 'false',
+    YARN_ENABLE_HYPERLINKS: 'false',
   };
 
   await runCommand(`yarn config set nodeLinker node-modules`, { cwd, env }, debug);
@@ -162,16 +167,11 @@ export async function refreshBeforeStorybookLockfile({
   await narrowQuarantinedRanges({ cwd, env, debug });
 }
 
-/**
- * Yarn colourises its output and hyperlinks the error code whenever `CI` is set. Both
- * kinds of escape land inside the text we match on: the scope, the name and the `@` of
- * a descriptor each get their own colour span, and an OSC-8 link splits `YN0016` from
- * its colon. Neither `YN0016:` nor `@npm:` survives as a literal until these are gone.
- */
-const ANSI_ESCAPE = /\u001B\][^\u0007]*(?:\u0007|\u001B\\)|\u001B\[[0-9;]*m/g;
-
 /** `YN0016: @angular/build@npm:^22.1.3: All versions satisfying "^22.1.3" are quarantined` */
 const QUARANTINED_RANGE = /YN0016:.*?(\S+)@npm:.*?are quarantined/g;
+
+/** Present whenever the gate rejected something, whatever the surrounding formatting. */
+const QUARANTINE_REPORTED = /are quarantined/;
 
 function parseQuarantinedPackages(output: string): string[] {
   return [...output.matchAll(QUARANTINED_RANGE)].map(([, name]) => name);
@@ -257,7 +257,7 @@ async function narrowQuarantinedRanges({
     } catch (error) {
       const output = `${(error as { stdout?: string }).stdout ?? ''}\n${
         (error as { stderr?: string }).stderr ?? ''
-      }`.replace(ANSI_ESCAPE, '');
+      }`;
 
       if (NOT_A_DIRECT_DEPENDENCY.test(output)) {
         throw new Error(
@@ -266,7 +266,19 @@ async function narrowQuarantinedRanges({
         );
       }
 
-      const fresh = parseQuarantinedPackages(output).filter((name) => !quarantined.includes(name));
+      const reported = parseQuarantinedPackages(output);
+
+      // Yarn rejected a range but we could not read a package out of it, so the output
+      // shape has moved (it already did once, when colour escapes split the descriptor).
+      // Say that plainly instead of reporting it as an unrelated resolution failure.
+      if (!reported.length && QUARANTINE_REPORTED.test(output)) {
+        throw new Error(
+          `Could not read the quarantined package out of Yarn's output. The age-gate workaround cannot run until this parser is updated.`,
+          { cause: error }
+        );
+      }
+
+      const fresh = reported.filter((name) => !quarantined.includes(name));
 
       // Either not an age-gate failure at all, or a package still quarantined across its
       // whole major. Widening further would leave the major, so let a human decide.

--- a/scripts/sandbox/utils/yarn.ts
+++ b/scripts/sandbox/utils/yarn.ts
@@ -162,6 +162,14 @@ export async function refreshBeforeStorybookLockfile({
   await narrowQuarantinedRanges({ cwd, env, debug });
 }
 
+/**
+ * Yarn colourises its output and hyperlinks the error code whenever `CI` is set. Both
+ * kinds of escape land inside the text we match on: the scope, the name and the `@` of
+ * a descriptor each get their own colour span, and an OSC-8 link splits `YN0016` from
+ * its colon. Neither `YN0016:` nor `@npm:` survives as a literal until these are gone.
+ */
+const ANSI_ESCAPE = /\u001B\][^\u0007]*(?:\u0007|\u001B\\)|\u001B\[[0-9;]*m/g;
+
 /** `YN0016: @angular/build@npm:^22.1.3: All versions satisfying "^22.1.3" are quarantined` */
 const QUARANTINED_RANGE = /YN0016:.*?(\S+)@npm:.*?are quarantined/g;
 
@@ -249,7 +257,7 @@ async function narrowQuarantinedRanges({
     } catch (error) {
       const output = `${(error as { stdout?: string }).stdout ?? ''}\n${
         (error as { stderr?: string }).stderr ?? ''
-      }`;
+      }`.replace(ANSI_ESCAPE, '');
 
       if (NOT_A_DIRECT_DEPENDENCY.test(output)) {
         throw new Error(


### PR DESCRIPTION
## What I did

Sandbox generation narrows a dependency range when the npm age gate leaves it with nothing installable, and it works out *which* range by reading the rejection back off Yarn's output. Yarn dresses that output up whenever `CI` is set, and the escapes land inside the very text we match on, so the parser found nothing and every template fell straight through to the failure path instead.

The narrowing that shipped yesterday therefore never ran once in CI. In the nightly run, 26 lockfile refreshes failed, and every failed Storybook init that followed was downstream of one of them. Nothing failed independently.

Here is what Yarn actually hands us, captured from `yarn install` with colour on:

```
[91m➤[39m ]8;;https://yarnpkg.com/advanced/error-codes#yn0016---remote_not_foundYN0016]8;;: │ [91m@tailwindcss/[39m[91mturbopack[39m[36m@[39m[36mnpm:^4.3.3[39m: All versions satisfying "^4.3.3" are quarantined
```

Two separate things are broken there. The scope, the name and the `@` each get their own colour span, so `@npm:` is not a literal. And an OSC-8 hyperlink wraps the error code, so `YN0016:` is not a literal either. Both have to go, and they are two different settings:

| environment | `@npm:` literal | `YN0016:` literal |
| --- | --- | --- |
| what CI does today | ✗ | ✗ |
| `YARN_ENABLE_COLORS=false` | ✓ | ✗ |
| `YARN_ENABLE_COLORS=false` + `YARN_ENABLE_HYPERLINKS=false` | ✓ | ✓ |

So rather than stripping escapes after the fact, ask Yarn not to emit them. The generation env already exists in one place:

```diff
     COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
     CI: 'true',
+    YARN_ENABLE_COLORS: 'false',
+    YARN_ENABLE_HYPERLINKS: 'false',
   };
```

The escapes were only half the problem, though. The real damage was that the failure was **silent**: the parser returned nothing, the original Yarn error got rethrown, and the template looked like it had an ordinary resolution problem. So the same mistake now says what it is:

```diff
+      if (!reported.length && QUARANTINE_REPORTED.test(output)) {
+        throw new Error(`Could not read the quarantined package out of Yarn's output. …`);
+      }
```

```
yarn install --mode=update-lockfile
        │
        └── exit 1
              │
              ▼
        error.stdout ──► parse YN0016 ──► accumulate ──► yarn up <pkg>@^<major>
                              │
                              └── nothing parsed, but output says "are quarantined"
                                        └──► loud error naming the parser (was: silently rethrown)
```

Worth flagging separately: with this fixed, `nextjs/prerelease` still fails, and correctly so. `@tailwindcss/turbopack` has exactly one stable release, published inside the 7 day window, so no range can resolve it and the generator refuses rather than crossing a major. That one needs an age gate exemption, which I would rather do in its own PR.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Two tests: one pins the env that keeps the output parseable, one feeds the captured colourised line above through the real code path and expects the explicit parser error. I removed each guard in turn and confirmed the matching test fails, so neither test agrees with itself.

#### Manual testing

| command | what it does | run from |
| --- | --- | --- |
| `FORCE_COLOR=1 yarn generate-sandboxes --templates <template>` | regenerates a sandbox with colour forced on, as CI has it | `code/` |
| `yarn build-storybook --quiet` | builds a generated sandbox | `repros/<template>/after-storybook` |

1. See the problem with no Storybook code involved. In an empty directory:
   ```
   echo '{"name":"p","packageManager":"yarn@4.18.0","dependencies":{"@tailwindcss/turbopack":"^4.3.3"}}' > package.json
   touch yarn.lock
   yarn config set npmMinimalAgeGate 10080
   CI=true FORCE_COLOR=1 yarn install --mode=update-lockfile > out.txt 2>&1
   grep -c '@npm:' out.txt        # 0
   grep -c 'YN0016:' out.txt      # 0
   ```
   Re-run the install with `YARN_ENABLE_COLORS=false YARN_ENABLE_HYPERLINKS=false` and both counts become 1.
2. On this branch, regenerate a template that needs narrowing, colour on:
   `cd code && FORCE_COLOR=1 yarn generate-sandboxes --templates angular-vite/default-ts`
3. The log must contain a narrowing line. On `next` today it never appears, whatever the template:
   `⚠️ narrowed 3 range(s) with no release older than the 10080min age gate: @angular/build@^22.0.0, @angular/cli@^22.0.0, @angular/ssr@^22.0.0`
4. Check `repros/angular-vite/default-ts/before-storybook/package.json`: `typescript` stays `~6.0.2` and only the `@angular/*` entries moved.
5. Build it, which is the step that was failing: `cd repros/angular-vite/default-ts/after-storybook && yarn build-storybook --quiet`. Exit code must be 0, and Compodoc must not report `Cannot read properties of undefined`.
6. Repeat step 2 for `angular-vite/21-ts` and confirm it narrows to `^21.0.0`, so the template still tests Angular 21.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Sandbox generation tooling only, so there is nothing user facing to document.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
