### PR TITLE
Build: Exempt @tailwindcss/turbopack from the sandbox age gate

### DIFF
--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -278,7 +278,12 @@ export const baseTemplates = {
     // The point of this template is the canary line, and canaries are published
     // daily. `@next/*` covers the platform binaries, and `eslint-config-next`
     // is pinned to the same canary version by create-next-app.
-    minAgeGateExemptions: ['next', '@next/*', 'eslint-config-next'],
+    //
+    // `@tailwindcss/turbopack` is not part of that line — `--tailwind` pulls it in,
+    // and it is new enough that `^4` has only ever matched one release. Until it has
+    // a second one, every release it makes is the sole candidate and the gate blocks
+    // the whole template. Drop this entry once 4.x has some history.
+    minAgeGateExemptions: ['next', '@next/*', 'eslint-config-next', '@tailwindcss/turbopack'],
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',


### PR DESCRIPTION
## What I did

The Next.js prerelease sandbox does not generate at the moment. Sandbox generation applies a 7 day npm age gate, and `create-next-app --tailwind` pulls in `@tailwindcss/turbopack`, a package so new that `^4` has only ever matched a single release. That one release is inside the window, so the range has no installable version at all and the whole template dies:

```
❌ Failed to refresh Yarn 4 lockfile for prerelease template: Next.js Prerelease (Webpack | TypeScript)
   ➤ YN0016: @tailwindcss/turbopack@npm:^4: All versions satisfying "^4" are quarantined
```

Normally the generator works around that by narrowing the range to the newest release that clears the gate, inside the same major. Here there is nothing to narrow to, so it correctly refuses rather than dragging the template onto a different major. The only remaining lever is to let that one package past the gate:

```diff
-    minAgeGateExemptions: ['next', '@next/*', 'eslint-config-next'],
+    minAgeGateExemptions: ['next', '@next/*', 'eslint-config-next', '@tailwindcss/turbopack'],
```

The gate still applies to everything else in the template, and the canary line is unaffected. Generating it now succeeds with no ranges rewritten at all:

```
✅ Generated Next.js Prerelease (Webpack | TypeScript) (nextjs/prerelease) in 22 s
```

| dependency | range after generation | resolved |
| --- | --- | --- |
| `next` | `16.3.1-canary.4` | 16.3.1-canary.4 |
| `eslint-config-next` | `16.3.1-canary.4` | — |
| `@tailwindcss/turbopack` | `^4` (untouched) | 4.3.3 |
| `typescript` | `^5` | — |

One caveat worth stating plainly: this is a permanent entry for what is really a temporary condition. `@tailwindcss/turbopack@4.3.3` was published on 2026-07-31, so it clears the 7 day window on its own on 2026-08-07, and once 4.x has a second release the range will always have an older candidate to fall back on. I would rather unblock generation now than wait a day for it, but the entry should come out again once that package has some history, and I noted that where it is declared.

Only one exemption was needed, by the way. I checked whether the rest of the family gets pulled in transitively, and it does not, so there is no reason to reach for a `@tailwindcss/*` glob here.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

This is one entry in a template's config. There is no logic to unit test, and asserting the array contents back would just restate the change. The nightly sandbox generation is what actually exercises it.

#### Manual testing

| command | what it does | run from |
| --- | --- | --- |
| `yarn generate-sandboxes --templates nextjs/prerelease` | regenerates the affected sandbox | `code/` |
| `yarn build-storybook --quiet` | builds it | `repros/nextjs/prerelease/after-storybook` |

1. Reproduce the failure on `next` first, so the change has something to prove:
   `cd code && yarn generate-sandboxes --templates nextjs/prerelease`
   It fails with `All versions satisfying "^4" are quarantined` for `@tailwindcss/turbopack`.
2. Switch to this branch and run the same command. It must print `✅ Generated Next.js Prerelease`.
3. Check `repros/nextjs/prerelease/before-storybook/package.json` still tracks the canary: `next` and `eslint-config-next` on a `-canary.N` version, and `@tailwindcss/turbopack` still `^4` rather than a rewritten range.
4. Confirm the gate is still on for the rest of the template: `repros/nextjs/prerelease/before-storybook/.yarnrc.yml` must still contain `npmMinimalAgeGate: 10080`, with the four names under `npmPreapprovedPackages`.
5. Build it: `cd repros/nextjs/prerelease/after-storybook && yarn build-storybook --quiet`. Exit code must be 0.

> [!NOTE]
> After 2026-08-07 step 1 will no longer reproduce, because the blocking release ages out of the window. That is expected, and is the same reason this entry should eventually be removed.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Sandbox template config only, so there is nothing user facing to document.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
