### PR TITLE
Build: Fix Windows failure in the Angular docgen worker test

### DIFF
--- a/code/frameworks/angular-vite/src/docgen/docgen-worker.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/docgen-worker.test.ts
@@ -31,8 +31,6 @@ afterEach(() => {
 });
 
 const OUTPUT_DIR = '/workspace/docs';
-// Joined rather than interpolated: the provider spells this path with `path.join`, and the
-// read-count assertions below compare the argument it passed by string equality.
 const DOCUMENTATION_JSON = join(OUTPUT_DIR, 'documentation.json');
 const STORY_PATH = resolve(process.cwd(), 'button.stories.ts');
 

--- a/code/frameworks/angular-vite/src/docgen/docgen-worker.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/docgen-worker.test.ts
@@ -2,7 +2,7 @@ import { getComponentIdFromEntry } from 'storybook/internal/common';
 import type { DocgenPayload, DocgenProvider, IndexEntry } from 'storybook/internal/types';
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -31,7 +31,9 @@ afterEach(() => {
 });
 
 const OUTPUT_DIR = '/workspace/docs';
-const DOCUMENTATION_JSON = `${OUTPUT_DIR}/documentation.json`;
+// Joined rather than interpolated: the provider spells this path with `path.join`, and the
+// read-count assertions below compare the argument it passed by string equality.
+const DOCUMENTATION_JSON = join(OUTPUT_DIR, 'documentation.json');
 const STORY_PATH = resolve(process.cwd(), 'button.stories.ts');
 
 const entry: IndexEntry = {


### PR DESCRIPTION
Closes #

## What I did

The Angular docgen worker test asserts that `documentation.json` is read once and then served from a memo.
It checked that by filtering the `readFileSync` spy's calls for the exact path string, but built the expected string by interpolating a posix separator while the code under test builds it with `path.join`.
On Windows the two spellings differ, so the filter matched nothing and the daily Windows unit-test job failed.

```
provider passes  ->  path.join('/workspace/docs', 'documentation.json')
                       posix: "/workspace/docs/documentation.json"
                       win32: "\workspace\docs\documentation.json"
test expected    ->  `${OUTPUT_DIR}/documentation.json`
                       both:  "/workspace/docs/documentation.json"   <- never equal on win32
```

The expected path is now built the same way the code builds it. Both spellings resolve to the same memfs node (memfs normalizes separators and strips the drive letter), so the fixture keeps writing and reading the same file:

```
mkdir target (fixture)                   "/workspace/docs"                       -> /workspace/docs
posix spelling                           "/workspace/docs/documentation.json"    -> /workspace/docs/documentation.json
win32 join (what the provider passes)    "\workspace\docs\documentation.json"    -> /workspace/docs/documentation.json
```

```diff
-const DOCUMENTATION_JSON = `${OUTPUT_DIR}/documentation.json`;
+// Joined rather than interpolated: the provider spells this path with `path.join`, and the
+// read-count assertions below compare the argument it passed by string equality.
+const DOCUMENTATION_JSON = join(OUTPUT_DIR, 'documentation.json');
```

This is a test-only fix. The provider itself was already correct on Windows: the read succeeded there, which is why the failure only showed up in the call-count assertion.

### What the failure looked like

From [`tests-unit--windows` on the daily pipeline](https://app.circleci.com/pipelines/github/storybookjs/storybook/129323/workflows/07681bce-e538-4198-b118-0ef00cf10a12/jobs/1855424):

```
 FAIL   @storybook/angular-vite  src/docgen/docgen-worker.test.ts > createDocgenProvider > re-reads documentation.json when Compodoc is re-run mid-session
AssertionError: expected [] to have a length of 1 but got +0

- Expected
+ Received

- 1
+ 0

 ❯ src/docgen/docgen-worker.test.ts:156:7
    154|     expect(
    155|       vi.mocked(readFileSync).mock.calls.filter(([p]) => p === DOCUMEN…
    156|     ).toHaveLength(1);
       |       ^

 Test Files  1 failed | 664 passed | 7 skipped (672)
      Tests  1 failed | 8340 passed | 25 expected fail | 76 skipped | 2 todo (8444)
```

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. From the repository root, run `yarn test code/frameworks/angular-vite`
2. All 20 test files pass on macOS/Linux, unchanged from before
3. The Windows unit-test job is the one that proves the fix; it runs on the daily pipeline and on this PR's CI

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
