### PR TITLE
Build: Keep the published lockfile and age gate in sandbox CI

### DIFF
--- a/scripts/sandbox/utils/yarn.ts
+++ b/scripts/sandbox/utils/yarn.ts
@@ -3,11 +3,14 @@ import { readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { join } from 'path';
 
 import semver from 'semver';
-import yml from 'yaml';
 
-import { STORYBOOK_PACKAGE_PATTERNS } from '../../../code/core/src/common/js-package-manager/util.ts';
 import { ROOT_DIRECTORY } from '../../utils/constants.ts';
 import { runCommand } from '../generate.ts';
+
+export {
+  LOCALLY_PUBLISHED_PACKAGE_PATTERNS,
+  preapproveLocallyPublishedPackages,
+} from '../../utils/preapprove-local-packages.ts';
 
 interface SetupYarnOptions {
   cwd: string;
@@ -311,52 +314,6 @@ async function narrowQuarantinedRanges({
 
   // So the committed lockfile is always the product of a plain `yarn install`.
   await runCommand(`yarn install --mode=update-lockfile`, { cwd, env }, debug);
-}
-
-/**
- * Packages served by the local Verdaccio registry during sandbox generation.
- * They are published seconds before they are installed, so they can never
- * satisfy the age gate on their own.
- */
-export const LOCALLY_PUBLISHED_PACKAGE_PATTERNS = [
-  ...STORYBOOK_PACKAGE_PATTERNS,
-  'create-storybook',
-  'sb',
-];
-
-/**
- * Allow the locally published Storybook packages past the age gate for the
- * `after-storybook` install, keeping the gate itself in force.
- *
- * This install is the only step in sandbox generation that executes package
- * code (lifecycle scripts, addon postinstall hooks), and it resolves
- * third-party dependencies from the upstream registry through Verdaccio.
- * Switching the gate off here would leave the one dangerous step unprotected,
- * so name the packages that genuinely cannot satisfy it instead.
- *
- * Merges with whatever the template already allows, so a prerelease template
- * does not lose its own entries. Phase 1 strips both keys from the published
- * `after-storybook` tree, so none of this reaches consumers.
- */
-export async function preapproveLocallyPublishedPackages(cwd: string) {
-  const configPath = join(cwd, '.yarnrc.yml');
-
-  let config: Record<string, unknown> = {};
-  try {
-    config = (yml.parse(await readFile(configPath, 'utf-8')) ?? {}) as Record<string, unknown>;
-  } catch {
-    // No config yet (the lockfile refresh may have bailed); start from scratch.
-  }
-
-  const existing = Array.isArray(config.npmPreapprovedPackages)
-    ? (config.npmPreapprovedPackages as string[])
-    : [];
-
-  config.npmPreapprovedPackages = Array.from(
-    new Set([...existing, ...LOCALLY_PUBLISHED_PACKAGE_PATTERNS])
-  );
-
-  await writeFile(configPath, yml.stringify(config));
 }
 
 /**

--- a/scripts/utils/preapprove-local-packages.ts
+++ b/scripts/utils/preapprove-local-packages.ts
@@ -1,0 +1,46 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { join } from 'path';
+
+import yml from 'yaml';
+
+import { STORYBOOK_PACKAGE_PATTERNS } from '../../code/core/src/common/js-package-manager/util.ts';
+
+/**
+ * Packages served by the local Verdaccio registry. They are published seconds before
+ * they are installed, so they can never satisfy an age gate on their own.
+ */
+export const LOCALLY_PUBLISHED_PACKAGE_PATTERNS = [
+  ...STORYBOOK_PACKAGE_PATTERNS,
+  'create-storybook',
+  'sb',
+];
+
+/**
+ * Let the locally published Storybook packages past the age gate while keeping the gate
+ * itself in force, so third-party dependencies resolved through Verdaccio are still
+ * quarantined.
+ *
+ * Merges with whatever is already allowed, so a template that names its own prerelease
+ * packages does not lose them.
+ */
+export async function preapproveLocallyPublishedPackages(cwd: string) {
+  const configPath = join(cwd, '.yarnrc.yml');
+
+  let config: Record<string, unknown> = {};
+  try {
+    config = (yml.parse(await readFile(configPath, 'utf-8')) ?? {}) as Record<string, unknown>;
+  } catch {
+    // No config yet; start from scratch.
+  }
+
+  const existing = Array.isArray(config.npmPreapprovedPackages)
+    ? (config.npmPreapprovedPackages as string[])
+    : [];
+
+  config.npmPreapprovedPackages = Array.from(
+    new Set([...existing, ...LOCALLY_PUBLISHED_PACKAGE_PATTERNS])
+  );
+
+  await writeFile(configPath, yml.stringify(config));
+}

--- a/scripts/utils/yarn.test.ts
+++ b/scripts/utils/yarn.test.ts
@@ -1,0 +1,94 @@
+import { resolve } from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as memfs from 'memfs';
+import { vol } from 'memfs';
+import yml from 'yaml';
+
+import { exec } from './exec.ts';
+import { installYarn2 } from './yarn.ts';
+
+vi.mock('node:fs/promises', { spy: true });
+vi.mock('./exec.ts', () => ({ exec: vi.fn() }));
+
+const SANDBOX = resolve('sandbox');
+
+beforeEach(async () => {
+  vol.reset();
+  const fsp = await import('node:fs/promises');
+  vi.mocked(fsp.readFile).mockImplementation(memfs.fs.promises.readFile as never);
+  vi.mocked(fsp.writeFile).mockImplementation(memfs.fs.promises.writeFile as never);
+  vi.mocked(fsp.mkdir).mockImplementation(memfs.fs.promises.mkdir as never);
+  vi.mocked(fsp.access).mockImplementation(memfs.fs.promises.access as never);
+  vol.mkdirSync(SANDBOX, { recursive: true });
+});
+
+/** A sandbox as downloaded from the published repository. */
+const publishedSandbox = (config: Record<string, unknown> = {}) => {
+  vol.writeFileSync(
+    `${SANDBOX}/yarn.lock`,
+    '# published lockfile\n"chalk@npm:^4":\n  version: 4.1.2\n'
+  );
+  vol.writeFileSync(
+    `${SANDBOX}/.yarnrc.yml`,
+    yml.stringify({ nodeLinker: 'node-modules', npmMinimalAgeGate: 10080, ...config })
+  );
+};
+
+const readConfig = () => yml.parse(vol.readFileSync(`${SANDBOX}/.yarnrc.yml`, 'utf-8') as string);
+const yarnCommands = () =>
+  vi
+    .mocked(exec)
+    .mock.calls.map(([command]) => String(command))
+    .join(' && ');
+
+describe('installYarn2', () => {
+  it('keeps the published lockfile instead of resolving from scratch', async () => {
+    publishedSandbox();
+
+    await installYarn2({ cwd: SANDBOX, dryRun: false, debug: false });
+
+    // Emptying this made every CI run re-resolve the whole tree against live npm.
+    expect(vol.readFileSync(`${SANDBOX}/yarn.lock`, 'utf-8')).toContain('version: 4.1.2');
+  });
+
+  it('leaves the age gate in force', async () => {
+    publishedSandbox();
+
+    await installYarn2({ cwd: SANDBOX, dryRun: false, debug: false });
+
+    expect(readConfig().npmMinimalAgeGate).toBe(10080);
+    expect(yarnCommands()).not.toContain('npmMinimalAgeGate 0');
+  });
+
+  it('preapproves the locally published Storybook packages instead', async () => {
+    publishedSandbox();
+
+    await installYarn2({ cwd: SANDBOX, dryRun: false, debug: false });
+
+    // They are published to Verdaccio seconds before this install, so they can never
+    // satisfy the gate on their own.
+    expect(readConfig().npmPreapprovedPackages).toEqual(
+      expect.arrayContaining(['storybook', '@storybook/*', 'create-storybook', 'sb'])
+    );
+  });
+
+  it('keeps a template allowlist rather than replacing it', async () => {
+    publishedSandbox({ npmPreapprovedPackages: ['next', '@next/*'] });
+
+    await installYarn2({ cwd: SANDBOX, dryRun: false, debug: false });
+
+    const approved: string[] = readConfig().npmPreapprovedPackages;
+    expect(approved).toEqual(expect.arrayContaining(['next', '@next/*', 'storybook']));
+  });
+
+  it('does not write a yarnPath next to the pinned packageManager', async () => {
+    publishedSandbox();
+
+    await installYarn2({ cwd: SANDBOX, dryRun: false, debug: false });
+
+    // corepack aborts when `yarnPath` and `packageManager` disagree.
+    expect(yarnCommands()).not.toContain('yarn set version');
+  });
+});

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 // TODO -- should we generate this file a second time outside of CLI?
@@ -6,6 +6,7 @@ import storybookVersions from '../../code/core/src/common/versions.ts';
 import { allTemplates } from '../../code/lib/cli-storybook/src/sandbox-templates.ts';
 import type { AllTemplatesKey } from '../../code/lib/cli-storybook/src/sandbox-templates.ts';
 import { exec } from './exec.ts';
+import { preapproveLocallyPublishedPackages } from './preapprove-local-packages.ts';
 
 export type YarnOptions = {
   cwd: string;
@@ -46,27 +47,25 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
 };
 
 export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
-  await rm(join(cwd, '.yarnrc.yml'), { force: true }).catch(() => {});
-
   // TODO: Remove in SB11
   const pnpApiExists = await pathExists(join(cwd, '.pnp.cjs'));
 
-  await mkdir(cwd, { recursive: true }).then(() =>
-    Promise.all([
-      //
-      writeFile(join(cwd, 'yarn.lock'), ''),
-      writeFile(join(cwd, '.yarnrc.yml'), ''),
-    ])
-  );
+  await mkdir(cwd, { recursive: true });
+
+  // The published sandbox ships a lockfile and a `.yarnrc.yml` carrying the age gate.
+  // Both are deliberately kept: wiping them made every CI run resolve the whole tree
+  // from live npm, which is how a package hours old could reach a runner.
+  //
+  // Our own Storybook packages are published to Verdaccio seconds before this install,
+  // so they can never satisfy the gate. Name them instead of switching it off, exactly
+  // as sandbox generation does for the `after-storybook` install.
+  await preapproveLocallyPublishedPackages(cwd);
 
   const command = [
-    `yarn set version berry`,
+    // No `yarn set version` here: the sandbox pins Yarn through the `packageManager`
+    // field, and writing a `yarnPath` alongside it makes corepack abort on the mismatch.
     `yarn config set enableGlobalCache true`, // Use the global cache so we aren't re-caching dependencies each time we run sandbox
     `yarn config set checksumBehavior ignore`,
-    // Yarn 4.15.0 defaults `npmMinimalAgeGate` to 1d, which quarantines freshly
-    // published Storybook packages from the local Verdaccio registry. Disable
-    // the gate inside sandboxes so installs aren't blocked.
-    `yarn config set npmMinimalAgeGate 0`,
   ];
 
   if (!pnpApiExists) {


### PR DESCRIPTION
## What I did

We publish every sandbox with a lockfile and a 7 day npm age gate, so that a package released in the last week never gets installed. Our own CI then threw both away before installing. It emptied `yarn.lock` and `.yarnrc.yml` and set the gate to `0`, which means every sandbox job re-resolved the whole dependency tree from live npm, and `sb init` afterwards executed whatever came back.

That is not theoretical. From a real run on 2026-08-05:

```
> yarn config set npmMinimalAgeGate 0
➤ YN0000: ┌ Resolution step
➤ YN0085: │ + @angular/build@npm:22.1.3 …, and 478 more.
```

479 packages added means the lockfile was empty and everything resolved from scratch. `@angular/build@22.1.3` had been published at 08:23 UTC that morning and the job started at 16:36, so CI installed a package about eight hours old and then ran its lifecycle scripts.

The reason it was ever switched off is that our own Storybook packages are published to a local Verdaccio registry seconds before the sandbox installs them, so they can never satisfy an age gate. Sandbox generation already solved that properly by naming those packages instead of disabling the gate. This does the same on the CI side.

```diff
-  await rm(join(cwd, '.yarnrc.yml'), { force: true }).catch(() => {});
-  await Promise.all([
-    writeFile(join(cwd, 'yarn.lock'), ''),
-    writeFile(join(cwd, '.yarnrc.yml'), ''),
-  ]);
+  await preapproveLocallyPublishedPackages(cwd);
 
   const command = [
-    `yarn set version berry`,
     `yarn config set enableGlobalCache true`,
     `yarn config set checksumBehavior ignore`,
-    `yarn config set npmMinimalAgeGate 0`,
   ];
```

`yarn set version berry` goes with them, and that part is not optional: it only worked because the config was wiped first. Keeping the published `.yarnrc.yml` means a `yarnPath` would now sit next to the pinned `packageManager` field, which is the corepack conflict we already had to fix once on the generation side. Sandboxes pin Yarn through `packageManager`, and CI has a Setup Corepack step.

The preapproval helper moved into its own module so both paths share one implementation. Importing it from the sandbox side would have pulled the whole generation stack into the CI install path.

After this change, a sandbox that CI has installed looks like this:

```yaml
npmMinimalAgeGate: 10080
npmPreapprovedPackages:
  - storybook
  - "@storybook/*"
  - eslint-plugin-storybook
  - "@chromatic-com/storybook"
  - create-storybook
  - sb
npmRegistryServer: "http://localhost:6001/"
```

The gate is in force for everything except the packages we published ourselves moments earlier.

One thing I checked first, because the whole change depends on it: the gate has to work through Verdaccio, which proxies npm. It does. Verdaccio preserves npm's `time` metadata, and resolution honours it:

| gate | `chalk: "*"` resolves to |
| --- | --- |
| `0` | 6.0.0, the newest |
| `28800` (20 days) | 5.6.2, because 6.0.0 is 11 days old |

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Five tests pin the properties that matter: the published lockfile survives, the gate stays at its configured value, our own packages get preapproved instead, a template's own allowlist is merged rather than replaced, and no `yarnPath` is written. I restored the old wiping behaviour and confirmed all five fail, so none of them agrees with itself.

#### Manual testing

| command | what it does | run from |
| --- | --- | --- |
| `yarn local-registry --publish` then `yarn local-registry --open` | serves our packages on `:6001` | `code/` |
| `yarn task sandbox -s task --debug --no-link --template=react-vite/default-ts` | the exact command CI runs | `code/` |

1. Compile and publish to the local registry, then leave it running.
2. Run the sandbox task above. It must exit 0, on `next` and on this branch.
3. Open `.yarnrc.yml` in the generated sandbox. On `next` it has `npmMinimalAgeGate: 0`. On this branch it must show `npmMinimalAgeGate: 10080` plus the six preapproved patterns above.
4. Check the lockfile is not empty. On `next` it is truncated to 0 bytes before installing; here it should be a few hundred KB.
5. Confirm `sb init` still worked: `.storybook/main.ts` exists and `package.json` has a `storybook` dependency resolved from the local registry.

> [!CAUTION]
> This touches every sandbox CI job, so please run a full sandbox set rather than trusting one template. I verified `react-vite/default-ts` end to end locally, which is one template out of 48, and prerelease templates in particular exercise a path I did not run: their own `minAgeGateExemptions` now have to merge with the locally published patterns rather than be replaced.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Sandbox CI tooling only, so there is nothing user facing to document.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
