### PR TITLE
Build: Run yarn dedupe after sandbox install

### DIFF
--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -7,6 +7,7 @@ import dirSize from 'fast-folder-size';
 import { now, saveBench } from '../bench/utils.ts';
 import type { Task, TaskKey } from '../task.ts';
 import { ROOT_DIRECTORY, SANDBOX_DIRECTORY } from '../utils/constants.ts';
+import { exec } from '../utils/exec.ts';
 import { isNxTaskExecution } from '../utils/nx.ts';
 
 const logger = console;
@@ -184,6 +185,20 @@ export const sandbox: Task = {
 
     await rm(path.join(details.sandboxDir, 'node_modules'), { force: true, recursive: true });
     await packageManager.installDependencies();
+
+    // After sb init the kept before-storybook lockfile can leave nested copies
+    // of shared packages (notably react under @storybook/addon-docs). Collapse
+    // those before we cache/run the sandbox.
+    await exec(
+      'yarn dedupe',
+      { cwd: details.sandboxDir },
+      {
+        dryRun: options.dryRun,
+        debug: options.debug,
+        startMessage: '🧶 Deduplicating dependencies',
+        errorMessage: '🚨 yarn dedupe failed',
+      }
+    );
 
     await runMigrations(details, options);
 


### PR DESCRIPTION
Closes #

## What I did

`react-latest--vite---typescript---vitest` went red on `next` after #35790 kept the published `before-storybook` lockfile. The failing log shows nested React under `@storybook/addon-docs` (Invalid hook call), not act-environment warnings.

This PR tries the least invasive fix: after every sandbox’s final `yarn install`, run `yarn dedupe` so Yarn can collapse nested copies before vitest/e2e/etc.

No new `resolutions` entries. Applies to **all** sandboxes, not only React.

If CI still fails, we can fall back to pinning `react` / `react-dom` resolutions (as nextjs sandboxes already do).

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Covered by sandbox vitest jobs under `ci:daily` / `ci:merged`, especially `react-latest--vite---typescript---vitest`.

#### Manual testing

1. `yarn task sandbox --template react-vite/default-ts --no-link --debug`
2. In the sandbox: `find node_modules -path '*/react/package.json' | sort`
3. Prefer a single React (no nest under `@storybook/addon-docs`)
4. `yarn task vitest-integration --template react-vite/default-ts --no-link -s vitest-integration`

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>