### PR TITLE
Manifests: Add a warning field to story entries

### DIFF
--- a/code/core/src/core-server/utils/manifests/components-ref-manifest.test.ts
+++ b/code/core/src/core-server/utils/manifests/components-ref-manifest.test.ts
@@ -159,6 +159,35 @@ describe('components-ref-manifest', () => {
     expect(Object.keys(merged.stories)).toEqual(['button--primary', 'button--secondary']);
   });
 
+  it('carries a story warning into the manifest alongside its snippet', () => {
+    const docgen: DocgenPayload = {
+      id: 'button',
+      name: 'Button',
+      path: './button.stories.tsx',
+      jsDocTags: {},
+    };
+    const storyDocs: StoryDocsPayload = {
+      id: 'button',
+      name: 'Button',
+      path: './button.stories.tsx',
+      stories: {
+        'button--primary': {
+          id: 'button--primary',
+          name: 'Primary',
+          snippet: '<Button />',
+          warning: 'Incomplete snippet: `...sharedArgs` could not be resolved statically.',
+        },
+      },
+    };
+
+    expect(mergeManifestPayloads(docgen, storyDocs).stories['button--primary']).toEqual({
+      id: 'button--primary',
+      name: 'Primary',
+      snippet: '<Button />',
+      warning: 'Incomplete snippet: `...sharedArgs` could not be resolved statically.',
+    });
+  });
+
   it('loads story-docs payloads from built snapshots on disk', async () => {
     const payload: StoryDocsPayload = {
       id: 'button',

--- a/code/core/src/shared/open-service/services/story-docs/definition.ts
+++ b/code/core/src/shared/open-service/services/story-docs/definition.ts
@@ -18,6 +18,7 @@ const storyDocSchema = v.object({
   snippet: v.optional(v.string()),
   description: v.optional(v.string()),
   summary: v.optional(v.string()),
+  warning: v.optional(v.string()),
   error: v.optional(storyDocsErrorSchema),
 });
 

--- a/code/core/src/shared/open-service/services/story-docs/types.ts
+++ b/code/core/src/shared/open-service/services/story-docs/types.ts
@@ -25,6 +25,12 @@ export interface StoryDoc {
   snippet?: string;
   description?: string;
   summary?: string;
+  /**
+   * Why the snippet is an incomplete example: what a static pass could not resolve, in the source
+   * text it was written as. A story that carries this still carries a `snippet`; an `error` means
+   * there is no snippet at all.
+   */
+  warning?: string;
   error?: StoryDocsError;
 }
 


### PR DESCRIPTION
## What I did

A generated story snippet can be valid but incomplete. Server-side snippet generation reads the story file rather than running it, so an arg merged in through a spread, or a template held in a variable, simply cannot be resolved. The snippet that comes out is still useful, it is just missing something.

There was nowhere to say that. The only option was to write it into the snippet itself:

```html
<!-- unresolved: ...sharedArgs -->
<sb-button [label]="'meta'" [count]="1"></sb-button>
```

Which pushes the problem onto every consumer. The docs Source block renders it as a stray comment, an agent reading `components.json` has to know to parse it back out, and a non-HTML renderer has no comment syntax to hide it in.

This adds a `warning` to each story entry, so the caveat travels as data next to the snippet:

```diff
 {
   "id": "button--primary",
   "name": "Primary",
-  "snippet": "<!-- unresolved: ...sharedArgs -->\n<sb-button [label]=\"'meta'\" [count]=\"1\"></sb-button>"
+  "snippet": "<sb-button [label]=\"'meta'\" [count]=\"1\"></sb-button>",
+  "warning": "Incomplete snippet: `...sharedArgs` could not be resolved statically."
 }
```

The whole change is the field on `StoryDoc` and the matching entry in the valibot schema:

```ts
export interface StoryDoc {
  id: string;
  name: string;
  snippet?: string;
  description?: string;
  summary?: string;
  /**
   * Why the snippet is an incomplete example: what a static pass could not resolve, in the source
   * text it was written as. A story that carries this still carries a `snippet`; an `error` means
   * there is no snippet at all.
   */
  warning?: string;
  error?: StoryDocsError;
}
```

The distinction from `error` is the part worth agreeing on: **a story with a `warning` still has a `snippet`, a story with an `error` does not.** One says "here is an example, mind the gap", the other says "there is no example".

Nothing populates it yet. The Angular server-side snippet generator is the first producer and is stacked on top of this. Reviewing the format on its own seemed better than reviewing it buried in a framework PR.

No change is needed for it to reach `manifests/components.json`, because the manifest passes the `stories` map straight through. There is a test for exactly that, so a future refactor of the merge cannot silently drop the field:

```ts
expect(mergeManifestPayloads(docgen, storyDocs).stories['button--primary']).toEqual({
  id: 'button--primary',
  name: 'Primary',
  snippet: '<Button />',
  warning: 'Incomplete snippet: `...sharedArgs` could not be resolved statically.',
});
```

| Command | What it does | Run from |
| --- | --- | --- |
| `yarn vitest run code/core/src/core-server/utils/manifests` | Checks the field survives into the merged manifest | repo root |

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No user-visible behaviour changes on its own: the field is additive and optional, and nothing writes it yet. The first producer is the stacked Angular PR, where it is reachable from the Docs Source block and from `components.json`.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

The docgen server RFC documents the payload shapes while they are experimental; this field should land there once a producer ships.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
