### PR TITLE
Build: Give the addon-mcp component-stories test room to import

### DIFF
--- a/code/addons/mcp/src/utils/resolve-component-stories.test.ts
+++ b/code/addons/mcp/src/utils/resolve-component-stories.test.ts
@@ -86,7 +86,10 @@ afterEach(() => {
   vi.doUnmock('storybook/internal/core-server');
 });
 
-describe('resolveComponentStories', () => {
+// `resetModules` around every test means each one re-imports the subject and, with it, the mocked
+// `storybook/internal/core-server`. That import alone can outlast the 10s default on the first test
+// of the file when the rest of the suite is saturating the machine.
+describe('resolveComponentStories', { timeout: 30_000 }, () => {
   it('strips trailing slashes so `Badge.tsx/` queries the file, not the parent-name barrel', async () => {
     // Regression for the silent-corruption bug: when a caller pastes
     // `Badge/Badge.tsx/`, the trailing slash flipped `basename === dirname`


### PR DESCRIPTION
## What I did

`resolve-component-stories.test.ts` resets the module registry around every test, so each one re-imports the subject and the mocked `core-server` with it. Under a saturated machine the first test of the file can outlast the 10s default and fail the suite:

```
Error: Test timed out in 10000ms.
 ❯ src/utils/resolve-component-stories.test.ts
```

This gives the file a 30s timeout. It is a pre-existing flake, reproducible on `next` with no changes applied, and it was riding along in an unrelated Angular branch until now.

```ts
describe('resolveComponentStories', { timeout: 30_000 }, () => {
```

| Command | What it does | Run from |
| --- | --- | --- |
| `yarn vitest run code/addons/mcp/src/utils/resolve-component-stories.test.ts` | Runs the file on its own | repo root |

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

None needed; the change is a test timeout.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>