### PR TITLE
Build: Normalize CRLF in story-shape print assertions

### DIFF
--- a/code/core/src/csf-tools/story-shape/args.test.ts
+++ b/code/core/src/csf-tools/story-shape/args.test.ts
@@ -21,7 +21,11 @@ const parse = (code: string) => {
 
 const printRecord = (record: Record<string, t.Node>) => {
   return Object.fromEntries(
-    Object.entries(record).map(([key, value]) => [key, recast.print(value).code])
+    Object.entries(record).map(([key, value]) => [
+      key,
+      // Recast may emit CRLF on Windows; keep assertions LF-stable across OSes.
+      recast.print(value).code.replace(/\r\n/g, '\n'),
+    ])
   );
 };
 

--- a/code/core/src/csf-tools/story-shape/normalize-story.test.ts
+++ b/code/core/src/csf-tools/story-shape/normalize-story.test.ts
@@ -18,7 +18,8 @@ const normalize = (code: string, exportName = 'A') => {
 const printedShape = (code: string) => {
   const normalized = normalize(code);
   return {
-    code: recast.print(normalized.path.node).code,
+    // Recast may emit CRLF on Windows; keep assertions LF-stable across OSes.
+    code: recast.print(normalized.path.node).code.replace(/\r\n/g, '\n'),
     type: normalized.type,
   };
 };

--- a/code/core/src/csf-tools/story-shape/utils.test.ts
+++ b/code/core/src/csf-tools/story-shape/utils.test.ts
@@ -11,7 +11,8 @@ const parse = (code: string) => {
   return loadCsf(code, { makeTitle: (title) => title ?? 'title' }).parse();
 };
 
-const printed = (node: t.Node) => recast.print(node).code;
+// Recast may emit CRLF on Windows; keep assertions LF-stable across OSes.
+const printed = (node: t.Node) => recast.print(node).code.replace(/\r\n/g, '\n');
 
 const storyBindIdentifier = (code: string) => {
   const storyPath = parse(code)._storyDeclarationPath['A'];


### PR DESCRIPTION
Closes #

## What I did

`tests-unit--windows` on `ci:daily` failed in `normalize-story.test.ts`:

```
resolves CSF2 Template.bind({}) to a function declaration
expected { …(2) } to deeply equal { …(2) }
```

Expected and received looked identical in the log. That usually means Recast printed CRLF on Windows while the assertion used LF.

Normalize `\r\n` → `\n` in the shared print helpers used by the story-shape tests (`printedShape`, `printed`, `printRecord`), same class of Windows-only assertion flake as the Angular docgen path fix.

No production code changes.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`ci:daily` runs `tests-unit--windows`, which is the regression surface.

#### Manual testing

No manual QA. Confirm `tests-unit--windows` is green on this PR.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

Made with [Cursor](https://cursor.com)