### PR TITLE
Core: Share the CSF story-shape helpers snippet generators need

### DIFF
--- a/code/core/src/csf-tools/story-shape/args.test.ts
+++ b/code/core/src/csf-tools/story-shape/args.test.ts
@@ -11,6 +11,7 @@ import {
   argsRecordFromObjectPath,
   mergeArgsRecords,
   metaArgsRecord,
+  storyAssignedArgsPath,
 } from './args.ts';
 import { normalizeStoryDeclaration } from './normalize-story.ts';
 import { keyOf, metaObjectPath } from './utils.ts';
@@ -177,5 +178,54 @@ describe('mergeArgsRecords', () => {
         "size": "'medium'",
       }
     `);
+  });
+});
+
+describe('storyAssignedArgsPath', () => {
+  const assignedArgs = (code: string) => {
+    const source = `export default { title: 'T' };\n${dedent(code)}`;
+    const csf = loadCsf(source, { makeTitle: (title) => title ?? 'title' }).parse();
+    return argsRecordFromObjectPath(storyAssignedArgsPath(csf._file.path, 'A'));
+  };
+
+  it('reads the CSF2 assignment form', () => {
+    expect(
+      Object.keys(
+        assignedArgs(`
+          export const A = () => 1;
+          A.args = { label: 'Save' };
+        `)
+      )
+    ).toEqual(['label']);
+  });
+
+  it('reads the computed spelling too', () => {
+    expect(
+      Object.keys(
+        assignedArgs(`
+          export const A = () => 1;
+          A['args'] = { label: 'Save' };
+        `)
+      )
+    ).toEqual(['label']);
+  });
+
+  it('ignores an assignment to a different story', () => {
+    expect(
+      assignedArgs(`
+        export const A = () => 1;
+        export const B = () => 1;
+        B.args = { label: 'Save' };
+      `)
+    ).toEqual({});
+  });
+
+  it('ignores a non-args property', () => {
+    expect(
+      assignedArgs(`
+        export const A = () => 1;
+        A.parameters = { docs: {} };
+      `)
+    ).toEqual({});
   });
 });

--- a/code/core/src/csf-tools/story-shape/args.ts
+++ b/code/core/src/csf-tools/story-shape/args.ts
@@ -40,6 +40,42 @@ export const metaArgsRecord = (meta?: t.ObjectExpression | null): Record<string,
     : {};
 };
 
+/**
+ * `args` assigned to a story after its declaration, the CSF2 form `MyStory.args = { … }`.
+ *
+ * Assignment happens outside the story's own initializer, so it is invisible to anything that only
+ * reads the declaration. Both `Story.args` and `Story['args']` are matched.
+ */
+export const storyAssignedArgsPath = (
+  program: NodePath<t.Program>,
+  storyName: string
+): NodePath<t.ObjectExpression> | null => {
+  let found: NodePath<t.ObjectExpression> | null = null;
+
+  program.traverse({
+    AssignmentExpression(assignment) {
+      const left = assignment.get('left');
+      const right = assignment.get('right');
+      if (!left.isMemberExpression() || !right.isObjectExpression()) {
+        return;
+      }
+
+      const object = left.get('object');
+      const property = left.get('property');
+      const isStory = object.isIdentifier() && object.node.name === storyName;
+      const isArgs =
+        (property.isIdentifier() && property.node.name === 'args' && !left.node.computed) ||
+        (t.isStringLiteral(property.node) && left.node.computed && property.node.value === 'args');
+
+      if (isStory && isArgs) {
+        found = right;
+      }
+    },
+  });
+
+  return found;
+};
+
 /** CSF arg precedence: story args override meta args per key. */
 export const mergeArgsRecords = (
   metaArgs: Record<string, t.Node>,

--- a/code/core/src/csf-tools/story-shape/index.ts
+++ b/code/core/src/csf-tools/story-shape/index.ts
@@ -1,4 +1,9 @@
-export { argsRecordFromObjectPath, mergeArgsRecords, metaArgsRecord } from './args.ts';
+export {
+  argsRecordFromObjectPath,
+  mergeArgsRecords,
+  metaArgsRecord,
+  storyAssignedArgsPath,
+} from './args.ts';
 export {
   type ImportBinding,
   collectImportBindings,
@@ -7,4 +12,11 @@ export {
 } from './imports.ts';
 export { extractStoryJSDocInfo } from './jsdoc.ts';
 export { type NormalizedStoryDeclaration, normalizeStoryDeclaration } from './normalize-story.ts';
-export { keyOf, metaObjectPath, resolveIdentifierInit } from './utils.ts';
+export { type RenderFunctionPath, type RenderResolution, resolveRenderFunction } from './render.ts';
+export {
+  keyOf,
+  metaObjectPath,
+  propertyValue,
+  resolveIdentifierInit,
+  returnedObjectExpression,
+} from './utils.ts';

--- a/code/core/src/csf-tools/story-shape/render.test.ts
+++ b/code/core/src/csf-tools/story-shape/render.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import type { types as t } from 'storybook/internal/babel';
+import { type NodePath, recast } from 'storybook/internal/babel';
+
+import { dedent } from 'ts-dedent';
+
+import { loadCsf } from '../CsfFile.ts';
+import { resolveRenderFunction } from './render.ts';
+import { normalizeStoryDeclaration } from './normalize-story.ts';
+
+/** Resolves `render` on story `A`, the way a snippet generator would. */
+const resolveStoryRender = (code: string) => {
+  const source = `export default { title: 'T' };\n${dedent(code)}`;
+  const csf = loadCsf(source, { makeTitle: (title) => title ?? 'title' }).parse();
+  const declaration = csf._storyDeclarationPath['A'];
+  const normalized = normalizeStoryDeclaration(declaration);
+  const properties: NodePath<t.ObjectProperty>[] =
+    normalized.type === 'config'
+      ? normalized.path.get('properties').filter((p) => p.isObjectProperty())
+      : [];
+
+  return resolveRenderFunction(properties, declaration);
+};
+
+const printedBody = (resolution: ReturnType<typeof resolveStoryRender>) =>
+  resolution.kind === 'resolved' ? recast.print(resolution.path.node).code : undefined;
+
+describe('resolveRenderFunction', () => {
+  it('reports a story with no render property as missing', () => {
+    expect(resolveStoryRender(`export const A = { args: {} };`)).toEqual({ kind: 'missing' });
+  });
+
+  it('resolves an inline arrow function', () => {
+    expect(printedBody(resolveStoryRender(`export const A = { render: () => 1 };`))).toBe(
+      '() => 1'
+    );
+  });
+
+  it('follows an identifier to a local arrow function', () => {
+    expect(
+      printedBody(
+        resolveStoryRender(`
+          const Template = () => 1;
+          export const A = { render: Template };
+        `)
+      )
+    ).toBe('() => 1');
+  });
+
+  it('follows an identifier to a local function declaration', () => {
+    expect(
+      printedBody(
+        resolveStoryRender(`
+          function Template() { return 1; }
+          export const A = { render: Template };
+        `)
+      )
+    ).toBe('function Template() { return 1; }');
+  });
+
+  // The distinction that matters: an unreadable render is not the same as no render, because a
+  // caller may only fall back to the meta's render in the second case.
+  it('reports an identifier it cannot follow as unresolved rather than missing', () => {
+    expect(resolveStoryRender(`export const A = { render: ImportedTemplate };`)).toEqual({
+      kind: 'unresolved',
+    });
+  });
+
+  it('reports an identifier bound to a non-function as unresolved', () => {
+    expect(
+      resolveStoryRender(`
+        const Template = 'not a function';
+        export const A = { render: Template };
+      `)
+    ).toEqual({ kind: 'unresolved' });
+  });
+
+  it('throws when render is present but is not a function at all', () => {
+    expect(() => resolveStoryRender(`export const A = { render: { nested: true } };`)).toThrow(
+      /Expected render to be an arrow function or function expression/
+    );
+  });
+});

--- a/code/core/src/csf-tools/story-shape/render.ts
+++ b/code/core/src/csf-tools/story-shape/render.ts
@@ -1,0 +1,60 @@
+import type { types as t } from 'storybook/internal/babel';
+import { type NodePath } from 'storybook/internal/babel';
+
+import { keyOf, resolveIdentifierInit } from './utils.ts';
+
+/** A function a story or meta supplies through `render`. */
+export type RenderFunctionPath = NodePath<
+  t.ArrowFunctionExpression | t.FunctionExpression | t.FunctionDeclaration
+>;
+
+/**
+ * Outcome of looking for a `render` function.
+ *
+ * `missing` and `unresolved` have to stay distinct. A story whose `render` exists but cannot be
+ * read must not fall back to the meta's `render`: the story's intent was to override it, and
+ * quietly rendering the meta's version instead produces a snippet for code the story never runs.
+ */
+export type RenderResolution =
+  | { kind: 'missing' }
+  | { kind: 'resolved'; path: RenderFunctionPath }
+  | { kind: 'unresolved' };
+
+const isRenderFunction = (path: NodePath<t.Node>): path is RenderFunctionPath =>
+  path.isArrowFunctionExpression() || path.isFunctionExpression() || path.isFunctionDeclaration();
+
+/**
+ * Resolves the `render` property of a story or meta config, following a local identifier
+ * (`render: Template`) to the function it names.
+ *
+ * `storyDeclaration` anchors the identifier lookup to the module the story lives in, so a helper
+ * declared beside the story resolves while an imported one reports `unresolved`.
+ *
+ * Throws when `render` is present but is neither a function nor an identifier, because that is a
+ * story-file mistake rather than something a static pass merely could not follow.
+ */
+export function resolveRenderFunction(
+  properties: NodePath<t.ObjectProperty>[],
+  storyDeclaration: NodePath<t.Node>
+): RenderResolution {
+  const renderPath = properties.find((property) => keyOf(property.node) === 'render')?.get('value');
+
+  if (!renderPath) {
+    return { kind: 'missing' };
+  }
+
+  if (renderPath.isIdentifier()) {
+    const resolved = resolveIdentifierInit(storyDeclaration, renderPath);
+    return resolved && isRenderFunction(resolved)
+      ? { kind: 'resolved', path: resolved }
+      : { kind: 'unresolved' };
+  }
+
+  if (!isRenderFunction(renderPath)) {
+    throw renderPath.buildCodeFrameError(
+      'Expected render to be an arrow function or function expression'
+    );
+  }
+
+  return { kind: 'resolved', path: renderPath };
+}

--- a/code/core/src/csf-tools/story-shape/utils.ts
+++ b/code/core/src/csf-tools/story-shape/utils.ts
@@ -12,6 +12,43 @@ export const keyOf = (p: t.ObjectProperty): string | null =>
         ? p.key.value
         : null;
 
+/** Value of an object expression's own property, when it has one. */
+export const propertyValue = (
+  object: t.ObjectExpression | undefined | null,
+  name: string
+): t.Node | undefined =>
+  object?.properties.find(
+    (candidate): candidate is t.ObjectProperty =>
+      t.isObjectProperty(candidate) && keyOf(candidate) === name
+  )?.value;
+
+/**
+ * Object literal a function returns, when it returns one directly.
+ *
+ * Covers the concise body (`() => ({ … })`) and a block body whose `return` carries an object
+ * literal, which is the shape template-based renderers use for `render`.
+ */
+export const returnedObjectExpression = (
+  fn: t.Node | undefined
+): t.ObjectExpression | undefined => {
+  if (
+    !t.isArrowFunctionExpression(fn) &&
+    !t.isFunctionExpression(fn) &&
+    !t.isFunctionDeclaration(fn)
+  ) {
+    return undefined;
+  }
+  if (t.isObjectExpression(fn.body)) {
+    return fn.body;
+  }
+  const returned = t.isBlockStatement(fn.body)
+    ? fn.body.body.find((statement): statement is t.ReturnStatement =>
+        t.isReturnStatement(statement)
+      )?.argument
+    : undefined;
+  return t.isObjectExpression(returned) ? returned : undefined;
+};
+
 /** Resolve a local story helper used by `Template.bind({})` or `render: Template`. */
 export function resolveIdentifierInit(
   storyPath: NodePath<t.Node>,

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
@@ -7,7 +7,8 @@ import {
   mergeArgsRecords,
   metaArgsRecord,
   normalizeStoryDeclaration,
-  resolveIdentifierInit,
+  resolveRenderFunction,
+  storyAssignedArgsPath,
 } from 'storybook/internal/csf-tools';
 
 import { invariant } from './utils.ts';
@@ -44,50 +45,8 @@ export function getCodeSnippet(
   const metaPath = metaObjectPath(csf);
   const metaProps = metaPath?.get('properties').filter((p) => p.isObjectProperty()) ?? [];
 
-  // Tri-state render resolution: distinguishes "no render property" from
-  // "render exists but couldn't be resolved" so that an unresolvable story-level
-  // render (e.g. `render: ImportedTemplate`) doesn't incorrectly fall back to meta's render.
-  type RenderResolution =
-    | { kind: 'missing' }
-    | {
-        kind: 'resolved';
-        path: NodePath<t.ArrowFunctionExpression | t.FunctionExpression | t.FunctionDeclaration>;
-      }
-    | { kind: 'unresolved' };
-
-  const getRenderPath = (object: NodePath<t.ObjectProperty>[]): RenderResolution => {
-    const renderPath = object.find((p) => keyOf(p.node) === 'render')?.get('value');
-
-    if (!renderPath) {
-      return { kind: 'missing' };
-    }
-
-    // If render is an identifier (e.g. `render: Template`), try to resolve it
-    if (renderPath.isIdentifier()) {
-      const resolved = resolveIdentifierInit(storyDeclaration, renderPath);
-      if (
-        resolved &&
-        (resolved.isArrowFunctionExpression() ||
-          resolved.isFunctionExpression() ||
-          resolved.isFunctionDeclaration())
-      ) {
-        return { kind: 'resolved', path: resolved };
-      }
-      // Render property exists but couldn't be resolved — don't fall back to meta's render
-      return { kind: 'unresolved' };
-    }
-
-    if (!(renderPath.isArrowFunctionExpression() || renderPath.isFunctionExpression())) {
-      throw renderPath.buildCodeFrameError(
-        'Expected render to be an arrow function or function expression'
-      );
-    }
-
-    return { kind: 'resolved', path: renderPath };
-  };
-
-  const metaRender = getRenderPath(metaProps);
-  const storyRender = getRenderPath(storyProps);
+  const metaRender = resolveRenderFunction(metaProps, storyDeclaration);
+  const storyRender = resolveRenderFunction(storyProps, storyDeclaration);
 
   // Story render takes precedence. Only fall back to meta render when the story
   // has no render property at all — NOT when it has one that couldn't be resolved.
@@ -107,8 +66,8 @@ export function getCodeSnippet(
     .map((p) => p.get('value'))
     .find((v) => v.isObjectExpression());
   const storyArgs = argsRecordFromObjectPath(storyArgsPath);
-  const storyAssignedArgsPath = storyArgsAssignmentPath(csf._file.path, storyName);
-  const storyAssignedArgs = argsRecordFromObjectPath(storyAssignedArgsPath);
+  const assignedArgsPath = storyAssignedArgsPath(csf._file.path, storyName);
+  const storyAssignedArgs = argsRecordFromObjectPath(assignedArgsPath);
   const merged: Record<string, t.Node> = {
     ...mergeArgsRecords(metaArgs, storyArgs),
     ...storyAssignedArgs,
@@ -217,32 +176,6 @@ function buildInvalidSpread(entries: ReadonlyArray<[string, t.Node]>): t.JSXSpre
 }
 
 const isValidJsxAttrName = (n: string) => /^[A-Za-z_][A-Za-z0-9_:-]*$/.test(n);
-
-/** Find `StoryName.args = { ... }` assignment and return the right-hand ObjectExpression if present. */
-function storyArgsAssignmentPath(
-  program: NodePath<t.Program>,
-  storyName: string
-): NodePath<t.ObjectExpression> | null {
-  let found: NodePath<t.ObjectExpression> | null = null;
-  program.traverse({
-    AssignmentExpression(p) {
-      const left = p.get('left');
-      const right = p.get('right');
-      if (left.isMemberExpression()) {
-        const obj = left.get('object');
-        const prop = left.get('property');
-        const isStoryIdent = obj.isIdentifier() && obj.node.name === storyName;
-        const isArgsProp =
-          (prop.isIdentifier() && prop.node.name === 'args' && !left.node.computed) ||
-          (t.isStringLiteral(prop.node) && left.node.computed && prop.node.value === 'args');
-        if (isStoryIdent && isArgsProp && right.isObjectExpression()) {
-          found = right as NodePath<t.ObjectExpression>;
-        }
-      }
-    },
-  });
-  return found;
-}
 
 const toAttr = (key: string, value: t.Node) => {
   if (t.isBooleanLiteral(value)) {


### PR DESCRIPTION
> [!NOTE]
> Independent of the Angular docgen stack: the move is contained to `csf-tools` and React, and none of those PRs has to land first.

## What I did

React's snippet generator accumulated several helpers for reading a story's shape. None of them are React-specific, and the Angular and Vue providers being built now need the same answers, so they were about to be reimplemented two more times.

They move into `csf-tools/story-shape`, next to `keyOf` and `normalizeStoryDeclaration` which already live there, and React imports them back. **React's 46 snapshot tests are what proves the move changed no behaviour** - that is the whole reason this is a separate PR.

| Helper | Was | Answers |
| --- | --- | --- |
| `resolveRenderFunction` | React-local `getRenderPath` | which function does `render` name, and can we read it |
| `storyAssignedArgsPath` | React-local | CSF2's `MyStory.args = { … }` |
| `propertyValue` | Angular-local | value of a config object's own property |
| `returnedObjectExpression` | Angular-local | object literal a function returns |

Net effect on React: 79 lines out, no behaviour change.

## The part worth reviewing

`resolveRenderFunction` keeps a tri-state that looks redundant until you know why it is there:

```ts
export type RenderResolution =
  | { kind: 'missing' }
  | { kind: 'resolved'; path: RenderFunctionPath }
  | { kind: 'unresolved' };
```

`missing` and `unresolved` must stay distinct. A story whose `render` exists but cannot be read must **not** fall back to the meta's `render` - the story's intent was to override it, so quietly using the meta's version produces a snippet for code the story never runs. Collapsing these two into `undefined` is the obvious simplification and it is wrong, which is exactly the kind of rule that drifts when two copies exist.

That rule now has a direct test rather than only being implied by a React snapshot:

```ts
it('reports an identifier it cannot follow as unresolved rather than missing', () => {
  expect(resolveStoryRender(`export const A = { render: ImportedTemplate };`)).toEqual({
    kind: 'unresolved',
  });
});
```

Identifier resolution itself is unchanged - it still goes through `resolveIdentifierInit`, which was already shared - so `render: Template` follows a local arrow function or function declaration, and an imported one reports `unresolved`.

A `render` that is present but is neither a function nor an identifier still throws a code-frame error, matching React's existing behaviour rather than quietly degrading.

## Why `propertyValue` and `returnedObjectExpression` are in here

They have no consumer in this PR. They are Angular-local today, the Angular story-docs slices import them from `csf-tools` as soon as they land, and Julien's Vue provider hand-rolls `propertyValue`'s lookup three times. Landing them with the rest keeps the shared module a single review.

| Command | What it does | Run from |
| --- | --- | --- |
| `yarn vitest run code/renderers/react/src/componentManifest` | React's snapshots, the behaviour-preservation proof | repo root |
| `yarn vitest run code/core/src/csf-tools` | Direct tests for the moved helpers | repo root |

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

None needed. This is a pure move plus tests; React's snapshots cover the behaviour and no user-facing output changes.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

The moved helpers are internal to `storybook/internal/csf-tools`.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
