### PR TITLE
Core: Move the component-meta invalidation state machine into core

### DIFF
--- a/code/addons/mcp/src/utils/detect-unreachable-changes.ts
+++ b/code/addons/mcp/src/utils/detect-unreachable-changes.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
+import { slash } from 'storybook/internal/common';
 import path from 'node:path';
 import { getModuleGraphService } from './module-graph.ts';
-import { slash } from './slash.ts';
 
 const SOURCE_EXT_RE = /\.(?:tsx?|jsx?|mjs|cjs)$/i;
 

--- a/code/addons/mcp/src/utils/find-story-ids.ts
+++ b/code/addons/mcp/src/utils/find-story-ids.ts
@@ -1,10 +1,9 @@
 import path from 'node:path';
-import { normalizeStoryPath } from 'storybook/internal/common';
+import { normalizeStoryPath, slash } from 'storybook/internal/common';
 import { storyNameFromExport } from 'storybook/internal/csf';
 import { logger } from 'storybook/internal/node-logger';
 import type { StoryIndex } from 'storybook/internal/types';
 import type { StoryInput } from '../types.ts';
-import { slash } from './slash.ts';
 
 export interface FoundStory {
   id: string;

--- a/code/addons/mcp/src/utils/resolve-component-stories.ts
+++ b/code/addons/mcp/src/utils/resolve-component-stories.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { slash } from 'storybook/internal/common';
 import path from 'node:path';
 import type { StoryIndex } from 'storybook/internal/types';
 import {
@@ -6,7 +7,6 @@ import {
   type ModuleGraphStatus,
   type ModuleGraphStoryHit,
 } from './module-graph.ts';
-import { slash } from './slash.ts';
 
 const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'] as const;
 const INDEX_BASENAMES = SOURCE_EXTENSIONS.map((ext) => `index${ext}`);

--- a/code/addons/mcp/src/utils/slash.ts
+++ b/code/addons/mcp/src/utils/slash.ts
@@ -1,7 +1,0 @@
-/**
- * Normalize paths to forward slashes for cross-platform compatibility
- * Storybook import paths always use forward slashes
- */
-export function slash(path: string) {
-  return path.replace(/\\/g, '/');
-}

--- a/code/core/src/common/index.ts
+++ b/code/core/src/common/index.ts
@@ -53,6 +53,7 @@ export * from './js-package-manager/index.ts';
 export * from './utils/scan-and-transform-files.ts';
 export * from './utils/transform-imports.ts';
 export * from '../shared/utils/module.ts';
+export * from '../shared/utils/paths.ts';
 export * from './utils/get-addon-names.ts';
 export * from './utils/utils.ts';
 export * from './utils/command.ts';

--- a/code/core/src/component-meta/ComponentMetaManager.ts
+++ b/code/core/src/component-meta/ComponentMetaManager.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import { dedent } from 'ts-dedent';
 import * as v8 from 'v8';
 
+import { slash } from '../shared/utils/paths.ts';
 import type {
   ComponentMetaFileSystem,
   ComponentMetaProjectBase,
@@ -132,7 +133,7 @@ export class ComponentMetaManager<
   // ---------------------------------------------------------------------------
 
   private findMatchTSConfig(filePath: string): string | null {
-    const fileName = filePath.replace(/\\/g, '/');
+    const fileName = slash(filePath);
 
     // Adapted from:
     // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L104-L118
@@ -143,7 +144,7 @@ export class ComponentMetaManager<
       }
       this.searchedDirs.add(dir);
       for (const tsConfigName of rootTsConfigNames) {
-        const tsconfigPath = path.join(dir, tsConfigName).replace(/\\/g, '/');
+        const tsconfigPath = slash(path.join(dir, tsConfigName));
         if (this.typescript.sys.fileExists(tsconfigPath)) {
           this.rootTsConfigs.add(tsconfigPath);
         }
@@ -241,7 +242,7 @@ export class ComponentMetaManager<
         const newChains: string[][] = [];
 
         for (const projectReference of commandLine.projectReferences) {
-          let tsConfigPath = projectReference.path.replace(/\\/g, '/');
+          let tsConfigPath = slash(projectReference.path);
 
           // fix https://github.com/johnsoncodehk/volar/issues/712
           if (this.typescript.sys.directoryExists(tsConfigPath)) {
@@ -294,7 +295,7 @@ export class ComponentMetaManager<
   // ---------------------------------------------------------------------------
 
   private getOrCreateConfiguredProject(tsconfig: string): P | null {
-    tsconfig = tsconfig.replace(/\\/g, '/');
+    tsconfig = slash(tsconfig);
     let project = this.configProjects.get(tsconfig);
     if (!project) {
       try {
@@ -353,7 +354,7 @@ export class ComponentMetaManager<
    * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProject.ts#L43-L68
    */
   onConfigChanged(configPath: string, type: 'created' | 'changed' | 'deleted') {
-    configPath = configPath.replace(/\\/g, '/');
+    configPath = slash(configPath);
     if (type === 'created') {
       this.rootTsConfigs.add(configPath);
     } else if ((type === 'changed' || type === 'deleted') && this.configProjects.has(configPath)) {
@@ -424,7 +425,7 @@ export class ComponentMetaManager<
       let candidate = dir;
       while (candidate !== path.dirname(candidate)) {
         // If already covered by an existing watcher, skip
-        const normalized = candidate.replace(/\\/g, '/');
+        const normalized = slash(candidate);
         let alreadyWatched = false;
         for (const watched of this.watchersByDir.keys()) {
           if (normalized === watched || normalized.startsWith(watched + '/')) {
@@ -458,7 +459,7 @@ export class ComponentMetaManager<
       return;
     }
 
-    const normalized = dir.replace(/\\/g, '/');
+    const normalized = slash(dir);
 
     for (const watched of this.watchersByDir.keys()) {
       // Already covered by an existing broader watcher
@@ -482,7 +483,7 @@ export class ComponentMetaManager<
         if (!filename) {
           return;
         }
-        const filePath = path.resolve(dir, filename).replace(/\\/g, '/');
+        const filePath = slash(path.resolve(dir, filename));
 
         if (filePath.includes('/node_modules/') || filePath.includes('/.git/')) {
           return;

--- a/code/core/src/component-meta/ProjectFileTracker.test.ts
+++ b/code/core/src/component-meta/ProjectFileTracker.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type FileSnapshotCache,
+  ProjectFileTracker,
+  filterSourceFilePaths,
+} from './ProjectFileTracker.ts';
+
+describe('filterSourceFilePaths', () => {
+  it('drops files under a node_modules directory', () => {
+    expect(
+      filterSourceFilePaths([
+        '/repo/src/Button.tsx',
+        '/repo/node_modules/react/index.d.ts',
+        'node_modules/csstype/index.d.ts',
+      ])
+    ).toEqual(['/repo/src/Button.tsx']);
+  });
+
+  it('keeps a source directory that merely starts with `node_modules`', () => {
+    // A substring test would drop these, leaving their components without metadata and without a
+    // watcher, so an edit would never invalidate.
+    expect(
+      filterSourceFilePaths(['/repo/src/node_modules-tools/Tag.tsx', '/repo/my_node_modules/a.ts'])
+    ).toEqual(['/repo/src/node_modules-tools/Tag.tsx', '/repo/my_node_modules/a.ts']);
+  });
+
+  it('normalizes Windows separators', () => {
+    expect(filterSourceFilePaths(['C:\\repo\\src\\Button.tsx'])).toEqual([
+      'C:/repo/src/Button.tsx',
+    ]);
+    expect(filterSourceFilePaths(['C:\\repo\\node_modules\\react\\index.d.ts'])).toEqual([]);
+  });
+});
+
+describe('ProjectFileTracker path keys', () => {
+  const createTracker = () => {
+    const snapshots: FileSnapshotCache<string> = new Map();
+    const tracker = new ProjectFileTracker<string>(
+      {
+        sys: {
+          fileExists: () => true,
+          readFile: () => 'export const Tag = () => null;',
+          getModifiedTime: () => new Date(1000),
+        },
+      },
+      { fileNames: ['C:/repo/Tag.tsx'] },
+      snapshots,
+      (text) => text
+    );
+    return { tracker, snapshots };
+  };
+
+  it('reads a backslash path out of the cache a forward-slash path filled', () => {
+    // TypeScript asks with forward slashes; watcher events and Storybook story paths can arrive with
+    // backslashes. Both have to land on one entry or a rewrite is served from a stale snapshot.
+    const { tracker, snapshots } = createTracker();
+
+    tracker.getSnapshot('C:/repo/Tag.tsx');
+    expect([...snapshots.keys()]).toEqual(['C:/repo/Tag.tsx']);
+
+    tracker.getSnapshot('C:\\repo\\Tag.tsx');
+    expect([...snapshots.keys()]).toEqual(['C:/repo/Tag.tsx']);
+  });
+
+  it('invalidates a forward-slash snapshot from a backslash change event', () => {
+    const { tracker, snapshots } = createTracker();
+
+    tracker.getSnapshot('C:/repo/Tag.tsx');
+    const before = tracker.getScriptVersion('C:/repo/Tag.tsx');
+
+    tracker.onFilesChanged([{ filePath: 'C:\\repo\\Tag.tsx', type: 'changed' }], () => true);
+
+    expect(snapshots.has('C:/repo/Tag.tsx')).toBe(false);
+    // The edit counter is what moves here: the mtime is pinned, so a version derived from mtime
+    // alone would be unchanged and the DocumentRegistry would keep serving the old AST.
+    expect(tracker.getScriptVersion('C:\\repo\\Tag.tsx')).not.toBe(before);
+  });
+});

--- a/code/core/src/component-meta/ProjectFileTracker.ts
+++ b/code/core/src/component-meta/ProjectFileTracker.ts
@@ -146,8 +146,7 @@ export class ProjectFileTracker<Snapshot> {
   }
 }
 
-// Adapted from:
-// https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L450-L461
+// Adapted from the root-file-set comparison in @volar/kit's createChecker.
 function arrayItemsEqual(a: string[], b: string[]) {
   if (a.length !== b.length) {
     return false;

--- a/code/core/src/component-meta/ProjectFileTracker.ts
+++ b/code/core/src/component-meta/ProjectFileTracker.ts
@@ -138,9 +138,9 @@ export class ProjectFileTracker<Snapshot> {
     if (!this.getCommandLineFn) {
       return;
     }
-    const newCommandLine = this.getCommandLineFn();
-    if (!arrayItemsEqual(newCommandLine.fileNames, this.commandLine.fileNames)) {
-      this.commandLine.fileNames = newCommandLine.fileNames;
+    const newFileNames = this.getCommandLineFn().fileNames.map(normalize);
+    if (!arrayItemsEqual(newFileNames, this.commandLine.fileNames)) {
+      this.commandLine.fileNames = newFileNames;
       this.projectVersion++;
     }
   }

--- a/code/core/src/component-meta/ProjectFileTracker.ts
+++ b/code/core/src/component-meta/ProjectFileTracker.ts
@@ -1,0 +1,202 @@
+/**
+ * The invalidation state machine shared by renderer component-meta projects. A project (one
+ * language service per tsconfig; React hosts it via Volar, Angular hand-writes the host) delegates
+ * every freshness decision here: the mtime-keyed snapshot cache, per-file edit counters, the
+ * projectVersion gate, lazy root-set re-checks, and the targeted ensureFresh guard. The language
+ * service itself stays in the renderer - core never names types from the `typescript` package (see
+ * ./types.ts), so snapshots are an opaque generic and the fs surface is structural.
+ */
+import type { FileChange, ProjectFileSystem } from './types.ts';
+
+/**
+ * Mtime-keyed snapshot cache shared across every project of one manager (Volar Kit checker
+ * pattern); owned by the manager's factory so it dies with the manager.
+ */
+export type FileSnapshotCache<Snapshot> = Map<string, [number | undefined, Snapshot | undefined]>;
+
+const normalize = (fileName: string) => fileName.replace(/\\/g, '/');
+
+/** Normalize program file paths and drop node_modules, for the manager's directory watching. */
+export function filterSourceFilePaths(fileNames: readonly string[]): string[] {
+  return fileNames.map(normalize).filter((fileName) => !fileName.includes('node_modules'));
+}
+
+export class ProjectFileTracker<Snapshot> {
+  private projectVersion = 0;
+  private shouldCheckRootFiles = false;
+  /**
+   * Per-file edit counters folded into getScriptVersion. Mtime alone violates the LS host version
+   * contract: a rewrite landing within the same mtime tick keeps the version string unchanged, so
+   * the DocumentRegistry would pin the old AST forever. Every reported change and every ensureFresh
+   * eviction bumps here.
+   */
+  private readonly fileVersions = new Map<string, number>();
+
+  constructor(
+    private readonly fs: ProjectFileSystem,
+    /**
+     * The project's parsed command line, held by reference: root-set updates assign
+     * `commandLine.fileNames` in place so the owning project observes them without copies.
+     */
+    private readonly commandLine: { fileNames: string[] },
+    private readonly snapshots: FileSnapshotCache<Snapshot>,
+    private readonly createSnapshot: (text: string) => Snapshot,
+    private readonly getCommandLineFn?: () => { fileNames: string[] }
+  ) {}
+
+  /**
+   * The language service's host re-sync gate: script names, versions, and snapshots are only
+   * re-read when this string moves, so every invalidation below funnels into a projectVersion
+   * bump.
+   */
+  getProjectVersion(): string {
+    this.checkRootFilesUpdate();
+    return this.projectVersion.toString();
+  }
+
+  getScriptFileNames(): string[] {
+    this.checkRootFilesUpdate();
+    return this.commandLine.fileNames;
+  }
+
+  getScriptVersion(fileName: string): string {
+    const edits = this.fileVersions.get(fileName) ?? 0;
+    const cached = this.snapshots.get(fileName);
+    if (cached) {
+      // Mtime of the cached snapshot; deliberately no stat here. Freshness is driven by the watch
+      // layer and ensureFresh deleting entries, keeping program syncs free of per-file fs churn.
+      return `${edits}:${cached[0] ?? 0}`;
+    }
+    return `${edits}:${this.fs.sys.getModifiedTime?.(fileName)?.valueOf() ?? 0}`;
+  }
+
+  /** Mtime-checked read-through: re-reads the file only when its mtime moved or was evicted. */
+  getSnapshot(fileName: string): Snapshot | undefined {
+    const modifiedTime = this.fs.sys.getModifiedTime?.(fileName)?.valueOf();
+    const cache = this.snapshots.get(fileName);
+    if (!cache || cache[0] !== modifiedTime) {
+      const text = this.fs.sys.fileExists(fileName) ? this.fs.sys.readFile(fileName) : undefined;
+      this.snapshots.set(fileName, [
+        modifiedTime,
+        text !== undefined ? this.createSnapshot(text) : undefined,
+      ]);
+    }
+    return this.snapshots.get(fileName)?.[1];
+  }
+
+  /**
+   * Batch-add files to the project's root set (inferred projects and on-demand inclusion). Bumps
+   * projectVersion once for the whole batch to avoid repeated program rebuilds.
+   */
+  ensureFiles(fileNames: string[]): void {
+    let added = false;
+    for (const fileName of fileNames) {
+      const normalized = normalize(fileName);
+      if (!this.commandLine.fileNames.includes(normalized)) {
+        this.commandLine.fileNames.push(normalized);
+        added = true;
+      }
+    }
+    if (added) {
+      this.projectVersion++;
+    }
+  }
+
+  /**
+   * Broadcast handler for watcher events. Snapshots for every reported path are evicted (and their
+   * edit counters bumped) before any version decision, so a batch stays coherent. `changed` bumps
+   * projectVersion only when the program holds the file (per `isTracked`, which callers capture
+   * against the pre-event program); created/deleted always bump - a new or removed file can change
+   * module resolution even when the root set is unchanged - and additionally schedule a lazy
+   * root-set re-check.
+   *
+   * Returns whether projectVersion moved, so callers can chain renderer-specific reactions (e.g.
+   * React's background warmup re-extraction).
+   */
+  onFilesChanged(changes: FileChange[], isTracked: (fileName: string) => boolean): boolean {
+    for (const { filePath } of changes) {
+      const fileName = normalize(filePath);
+      this.snapshots.delete(fileName);
+      this.bumpFileVersion(fileName);
+    }
+
+    const oldVersion = this.projectVersion;
+    for (const { filePath, type } of changes) {
+      const fileName = normalize(filePath);
+      if (type === 'changed') {
+        if (isTracked(fileName)) {
+          this.projectVersion++;
+        }
+      } else {
+        this.projectVersion++;
+        this.shouldCheckRootFiles = true;
+      }
+    }
+    return this.projectVersion !== oldVersion;
+  }
+
+  /**
+   * Targeted mtime check right before extraction. The projectVersion gate only re-reads files when
+   * the version moves, so this covers the race where an extraction lands before the debounced
+   * fs.watch event (or the event was missed entirely).
+   *
+   * Costs one stat per name, so callers pass the files their work actually reads rather than
+   * everything cached. Returns whether projectVersion moved, so a caller holding a program built
+   * before the sweep knows to re-read it.
+   */
+  ensureFresh(fileNames: string[]): boolean {
+    let stale = false;
+    for (const fileName of fileNames) {
+      const normalized = normalize(fileName);
+      const cache = this.snapshots.get(normalized);
+      if (!cache) {
+        continue;
+      }
+      const currentMtime = this.fs.sys.getModifiedTime?.(normalized)?.valueOf();
+      if (cache[0] !== currentMtime) {
+        this.snapshots.delete(normalized);
+        this.bumpFileVersion(normalized);
+        stale = true;
+      }
+    }
+    if (stale) {
+      this.projectVersion++;
+    }
+    return stale;
+  }
+
+  private bumpFileVersion(fileName: string): void {
+    this.fileVersions.set(fileName, (this.fileVersions.get(fileName) ?? 0) + 1);
+  }
+
+  private checkRootFilesUpdate(): void {
+    if (!this.shouldCheckRootFiles) {
+      return;
+    }
+    this.shouldCheckRootFiles = false;
+
+    if (!this.getCommandLineFn) {
+      return;
+    }
+    const newCommandLine = this.getCommandLineFn();
+    if (!arrayItemsEqual(newCommandLine.fileNames, this.commandLine.fileNames)) {
+      this.commandLine.fileNames = newCommandLine.fileNames;
+      this.projectVersion++;
+    }
+  }
+}
+
+// Adapted from:
+// https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L450-L461
+function arrayItemsEqual(a: string[], b: string[]) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const set = new Set(a);
+  for (const file of b) {
+    if (!set.has(file)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/code/core/src/component-meta/ProjectFileTracker.ts
+++ b/code/core/src/component-meta/ProjectFileTracker.ts
@@ -1,17 +1,5 @@
-/**
- * The invalidation state machine shared by renderer component-meta projects. A project (one
- * language service per tsconfig; React hosts it via Volar, Angular hand-writes the host) delegates
- * every freshness decision here: the mtime-keyed snapshot cache, per-file edit counters, the
- * projectVersion gate, lazy root-set re-checks, and the targeted ensureFresh guard. The language
- * service itself stays in the renderer - core never names types from the `typescript` package (see
- * ./types.ts), so snapshots are an opaque generic and the fs surface is structural.
- */
 import type { FileChange, ProjectFileSystem } from './types.ts';
 
-/**
- * Mtime-keyed snapshot cache shared across every project of one manager (Volar Kit checker
- * pattern); owned by the manager's factory so it dies with the manager.
- */
 export type FileSnapshotCache<Snapshot> = Map<string, [number | undefined, Snapshot | undefined]>;
 
 const normalize = (fileName: string) => fileName.replace(/\\/g, '/');
@@ -24,41 +12,19 @@ export function filterSourceFilePaths(fileNames: readonly string[]): string[] {
   return fileNames.map(normalize).filter((fileName) => !NODE_MODULES_SEGMENT.test(fileName));
 }
 
-/**
- * Every public entry point normalizes its path argument to forward slashes, so `snapshots`,
- * `fileVersions` and the fs probes are all keyed the same way. Watcher events and the story and
- * component paths Storybook hands down can carry Windows backslashes, while TypeScript always uses
- * forward slashes, and the two meet in this cache.
- */
 export class ProjectFileTracker<Snapshot> {
   private projectVersion = 0;
   private shouldCheckRootFiles = false;
-  /**
-   * Per-file edit counters folded into getScriptVersion. Mtime alone violates the LS host version
-   * contract: a rewrite landing within the same mtime tick keeps the version string unchanged, so
-   * the DocumentRegistry would pin the old AST forever. Every reported change and every ensureFresh
-   * eviction bumps here.
-   */
   private readonly fileVersions = new Map<string, number>();
 
   constructor(
     private readonly fs: ProjectFileSystem,
-    /**
-     * The project's parsed command line, held by reference: root-set updates assign
-     * `commandLine.fileNames` in place so the owning project observes them without copies. Its names
-     * arrive already normalized, from `parseTsconfigCommandLine`.
-     */
     private readonly commandLine: { fileNames: string[] },
     private readonly snapshots: FileSnapshotCache<Snapshot>,
     private readonly createSnapshot: (text: string) => Snapshot,
     private readonly getCommandLineFn?: () => { fileNames: string[] }
   ) {}
 
-  /**
-   * The language service's host re-sync gate: script names, versions, and snapshots are only
-   * re-read when this string moves, so every invalidation below funnels into a projectVersion
-   * bump.
-   */
   getProjectVersion(): string {
     this.checkRootFilesUpdate();
     return this.projectVersion.toString();
@@ -116,17 +82,6 @@ export class ProjectFileTracker<Snapshot> {
     }
   }
 
-  /**
-   * Broadcast handler for watcher events. Snapshots for every reported path are evicted (and their
-   * edit counters bumped) before any version decision, so a batch stays coherent. `changed` bumps
-   * projectVersion only when the program holds the file (per `isTracked`, which callers capture
-   * against the pre-event program); created/deleted always bump - a new or removed file can change
-   * module resolution even when the root set is unchanged - and additionally schedule a lazy
-   * root-set re-check.
-   *
-   * Returns whether projectVersion moved, so callers can chain renderer-specific reactions (e.g.
-   * React's background warmup re-extraction).
-   */
   onFilesChanged(changes: FileChange[], isTracked: (fileName: string) => boolean): boolean {
     for (const { filePath } of changes) {
       const fileName = normalize(filePath);
@@ -149,15 +104,6 @@ export class ProjectFileTracker<Snapshot> {
     return this.projectVersion !== oldVersion;
   }
 
-  /**
-   * Targeted mtime check right before extraction. The projectVersion gate only re-reads files when
-   * the version moves, so this covers the race where an extraction lands before the debounced
-   * fs.watch event (or the event was missed entirely).
-   *
-   * Costs one stat per name, so callers pass the files their work actually reads rather than
-   * everything cached. Returns whether projectVersion moved, so a caller holding a program built
-   * before the sweep knows to re-read it.
-   */
   ensureFresh(fileNames: string[]): boolean {
     let stale = false;
     for (const fileName of fileNames) {

--- a/code/core/src/component-meta/ProjectFileTracker.ts
+++ b/code/core/src/component-meta/ProjectFileTracker.ts
@@ -16,11 +16,20 @@ export type FileSnapshotCache<Snapshot> = Map<string, [number | undefined, Snaps
 
 const normalize = (fileName: string) => fileName.replace(/\\/g, '/');
 
+/** Matches a whole `node_modules` path segment, so `src/node_modules-tools/Tag.tsx` is kept. */
+const NODE_MODULES_SEGMENT = /(?:^|\/)node_modules(?:\/|$)/;
+
 /** Normalize program file paths and drop node_modules, for the manager's directory watching. */
 export function filterSourceFilePaths(fileNames: readonly string[]): string[] {
-  return fileNames.map(normalize).filter((fileName) => !fileName.includes('node_modules'));
+  return fileNames.map(normalize).filter((fileName) => !NODE_MODULES_SEGMENT.test(fileName));
 }
 
+/**
+ * Every public entry point normalizes its path argument to forward slashes, so `snapshots`,
+ * `fileVersions` and the fs probes are all keyed the same way. Watcher events and the story and
+ * component paths Storybook hands down can carry Windows backslashes, while TypeScript always uses
+ * forward slashes, and the two meet in this cache.
+ */
 export class ProjectFileTracker<Snapshot> {
   private projectVersion = 0;
   private shouldCheckRootFiles = false;
@@ -36,7 +45,8 @@ export class ProjectFileTracker<Snapshot> {
     private readonly fs: ProjectFileSystem,
     /**
      * The project's parsed command line, held by reference: root-set updates assign
-     * `commandLine.fileNames` in place so the owning project observes them without copies.
+     * `commandLine.fileNames` in place so the owning project observes them without copies. Its names
+     * arrive already normalized, from `parseTsconfigCommandLine`.
      */
     private readonly commandLine: { fileNames: string[] },
     private readonly snapshots: FileSnapshotCache<Snapshot>,
@@ -60,28 +70,32 @@ export class ProjectFileTracker<Snapshot> {
   }
 
   getScriptVersion(fileName: string): string {
-    const edits = this.fileVersions.get(fileName) ?? 0;
-    const cached = this.snapshots.get(fileName);
+    const normalized = normalize(fileName);
+    const edits = this.fileVersions.get(normalized) ?? 0;
+    const cached = this.snapshots.get(normalized);
     if (cached) {
       // Mtime of the cached snapshot; deliberately no stat here. Freshness is driven by the watch
       // layer and ensureFresh deleting entries, keeping program syncs free of per-file fs churn.
       return `${edits}:${cached[0] ?? 0}`;
     }
-    return `${edits}:${this.fs.sys.getModifiedTime?.(fileName)?.valueOf() ?? 0}`;
+    return `${edits}:${this.fs.sys.getModifiedTime?.(normalized)?.valueOf() ?? 0}`;
   }
 
   /** Mtime-checked read-through: re-reads the file only when its mtime moved or was evicted. */
   getSnapshot(fileName: string): Snapshot | undefined {
-    const modifiedTime = this.fs.sys.getModifiedTime?.(fileName)?.valueOf();
-    const cache = this.snapshots.get(fileName);
+    const normalized = normalize(fileName);
+    const modifiedTime = this.fs.sys.getModifiedTime?.(normalized)?.valueOf();
+    const cache = this.snapshots.get(normalized);
     if (!cache || cache[0] !== modifiedTime) {
-      const text = this.fs.sys.fileExists(fileName) ? this.fs.sys.readFile(fileName) : undefined;
-      this.snapshots.set(fileName, [
+      const text = this.fs.sys.fileExists(normalized)
+        ? this.fs.sys.readFile(normalized)
+        : undefined;
+      this.snapshots.set(normalized, [
         modifiedTime,
         text !== undefined ? this.createSnapshot(text) : undefined,
       ]);
     }
-    return this.snapshots.get(fileName)?.[1];
+    return this.snapshots.get(normalized)?.[1];
   }
 
   /**

--- a/code/core/src/component-meta/ProjectFileTracker.ts
+++ b/code/core/src/component-meta/ProjectFileTracker.ts
@@ -1,15 +1,11 @@
+import { isInNodeModules, slash } from '../shared/utils/paths.ts';
 import type { FileChange, ProjectFileSystem } from './types.ts';
 
 export type FileSnapshotCache<Snapshot> = Map<string, [number | undefined, Snapshot | undefined]>;
 
-const normalize = (fileName: string) => fileName.replace(/\\/g, '/');
-
-/** Matches a whole `node_modules` path segment, so `src/node_modules-tools/Tag.tsx` is kept. */
-const NODE_MODULES_SEGMENT = /(?:^|\/)node_modules(?:\/|$)/;
-
 /** Normalize program file paths and drop node_modules, for the manager's directory watching. */
 export function filterSourceFilePaths(fileNames: readonly string[]): string[] {
-  return fileNames.map(normalize).filter((fileName) => !NODE_MODULES_SEGMENT.test(fileName));
+  return fileNames.map(slash).filter((fileName) => !isInNodeModules(fileName));
 }
 
 export class ProjectFileTracker<Snapshot> {
@@ -36,7 +32,7 @@ export class ProjectFileTracker<Snapshot> {
   }
 
   getScriptVersion(fileName: string): string {
-    const normalized = normalize(fileName);
+    const normalized = slash(fileName);
     const edits = this.fileVersions.get(normalized) ?? 0;
     const cached = this.snapshots.get(normalized);
     if (cached) {
@@ -49,7 +45,7 @@ export class ProjectFileTracker<Snapshot> {
 
   /** Mtime-checked read-through: re-reads the file only when its mtime moved or was evicted. */
   getSnapshot(fileName: string): Snapshot | undefined {
-    const normalized = normalize(fileName);
+    const normalized = slash(fileName);
     const modifiedTime = this.fs.sys.getModifiedTime?.(normalized)?.valueOf();
     const cache = this.snapshots.get(normalized);
     if (!cache || cache[0] !== modifiedTime) {
@@ -71,7 +67,7 @@ export class ProjectFileTracker<Snapshot> {
   ensureFiles(fileNames: string[]): void {
     let added = false;
     for (const fileName of fileNames) {
-      const normalized = normalize(fileName);
+      const normalized = slash(fileName);
       if (!this.commandLine.fileNames.includes(normalized)) {
         this.commandLine.fileNames.push(normalized);
         added = true;
@@ -84,14 +80,14 @@ export class ProjectFileTracker<Snapshot> {
 
   onFilesChanged(changes: FileChange[], isTracked: (fileName: string) => boolean): boolean {
     for (const { filePath } of changes) {
-      const fileName = normalize(filePath);
+      const fileName = slash(filePath);
       this.snapshots.delete(fileName);
       this.bumpFileVersion(fileName);
     }
 
     const oldVersion = this.projectVersion;
     for (const { filePath, type } of changes) {
-      const fileName = normalize(filePath);
+      const fileName = slash(filePath);
       if (type === 'changed') {
         if (isTracked(fileName)) {
           this.projectVersion++;
@@ -107,7 +103,7 @@ export class ProjectFileTracker<Snapshot> {
   ensureFresh(fileNames: string[]): boolean {
     let stale = false;
     for (const fileName of fileNames) {
-      const normalized = normalize(fileName);
+      const normalized = slash(fileName);
       const cache = this.snapshots.get(normalized);
       if (!cache) {
         continue;
@@ -138,7 +134,7 @@ export class ProjectFileTracker<Snapshot> {
     if (!this.getCommandLineFn) {
       return;
     }
-    const newFileNames = this.getCommandLineFn().fileNames.map(normalize);
+    const newFileNames = this.getCommandLineFn().fileNames.map(slash);
     if (!arrayItemsEqual(newFileNames, this.commandLine.fileNames)) {
       this.commandLine.fileNames = newFileNames;
       this.projectVersion++;

--- a/code/core/src/component-meta/index.ts
+++ b/code/core/src/component-meta/index.ts
@@ -1,4 +1,6 @@
 export { ComponentMetaManager, isFileInDir, sortTSConfigs } from './ComponentMetaManager.ts';
 export { parseTsconfigCommandLine } from './parse-tsconfig.ts';
 export type { FileExtensionInfo, TsconfigParserModule } from './parse-tsconfig.ts';
+export { ProjectFileTracker, filterSourceFilePaths } from './ProjectFileTracker.ts';
+export type { FileSnapshotCache } from './ProjectFileTracker.ts';
 export type { ComponentMetaProjectBase, ComponentMetaProjectFactory, FileChange } from './types.ts';

--- a/code/core/src/component-meta/parse-tsconfig.ts
+++ b/code/core/src/component-meta/parse-tsconfig.ts
@@ -1,5 +1,6 @@
 import { dirname } from 'node:path';
 
+import { slash } from '../shared/utils/paths.ts';
 import type { ProjectCommandLine } from './types.ts';
 
 /**
@@ -63,7 +64,7 @@ export function parseTsconfigCommandLine<CL extends ProjectCommandLine = Project
   // fix https://github.com/johnsoncodehk/volar/issues/1786
   // https://github.com/microsoft/TypeScript/issues/30457
   content.options.outDir = undefined;
-  content.fileNames = content.fileNames.map((fileName) => fileName.replace(/\\/g, '/'));
+  content.fileNames = content.fileNames.map(slash);
   // The runtime value is whatever the caller's own module produced; core only typed the subset.
   return content as unknown as CL;
 }

--- a/code/core/src/component-meta/types.ts
+++ b/code/core/src/component-meta/types.ts
@@ -35,6 +35,19 @@ export interface ComponentMetaFileSystem {
 }
 
 /**
+ * The fs probes {@link ../ProjectFileTracker} needs for snapshot reads and freshness checks.
+ * `typeof ts` satisfies this via `ts.sys`, so callers pass their own `typescript` module (see
+ * {@link ComponentMetaFileSystem} for why the contract is structural).
+ */
+export interface ProjectFileSystem {
+  sys: {
+    fileExists(path: string): boolean;
+    readFile(path: string): string | undefined;
+    getModifiedTime?(path: string): Date | undefined;
+  };
+}
+
+/**
  * Contract a per-tsconfig project must satisfy for {@link ../ComponentMetaManager} to manage it.
  *
  * The manager only needs enough surface to match files to tsconfigs (parsed command lines,

--- a/code/core/src/component-meta/types.ts
+++ b/code/core/src/component-meta/types.ts
@@ -34,11 +34,6 @@ export interface ComponentMetaFileSystem {
   };
 }
 
-/**
- * The fs probes {@link ../ProjectFileTracker} needs for snapshot reads and freshness checks.
- * `typeof ts` satisfies this via `ts.sys`, so callers pass their own `typescript` module (see
- * {@link ComponentMetaFileSystem} for why the contract is structural).
- */
 export interface ProjectFileSystem {
   sys: {
     fileExists(path: string): boolean;

--- a/code/core/src/shared/open-service/services/docgen/worker/docgen-worker-client.test.ts
+++ b/code/core/src/shared/open-service/services/docgen/worker/docgen-worker-client.test.ts
@@ -106,7 +106,7 @@ describe('createDocgenWorkerClient', () => {
     // listeners are on leaves the worker holding the event loop open and `build-storybook` never
     // exits. Asserting the order here because a unit test cannot observe the process failing to
     // exit; the ordering is what makes the difference.
-    expect(worker.messageListenersAtUnref).toBeGreaterThan(0);
+    expect(worker.messageListenersAtUnref).toBe(2);
 
     // Drive the extract to completion so dispose isn't racing a not-yet-queued request.
     ackInit(worker);

--- a/code/core/src/shared/open-service/services/module-graph/types.ts
+++ b/code/core/src/shared/open-service/services/module-graph/types.ts
@@ -2,6 +2,8 @@ import { posix, win32 } from 'node:path';
 
 import { normalize } from 'pathe';
 
+import { slash } from '../../../utils/paths.ts';
+
 import type { ReverseIndex } from './engine/dependency-graph/types.ts';
 
 /** JSON-serializable reverse index shape stored in open-service state. */
@@ -56,13 +58,9 @@ function isPosixAbsolutePath(path: string): boolean {
   return posix.isAbsolute(path);
 }
 
-function normalizePathSeparators(path: string): string {
-  return path.replace(/\\/g, '/');
-}
-
 function formatStoryIndexPath(path: string): string {
   const withoutDotSlash = path.startsWith('./') ? path.slice(2) : path;
-  const normalized = normalizePathSeparators(normalize(withoutDotSlash));
+  const normalized = slash(normalize(withoutDotSlash));
 
   if (normalized === '.' || normalized.startsWith('../')) {
     return normalized;
@@ -81,20 +79,20 @@ export function toStoryIndexPath(path: string, workingDir: string): string {
     return formatStoryIndexPath(win32.relative(workingDir, path));
   }
 
-  const slashPath = normalizePathSeparators(path);
+  const slashPath = slash(path);
   if (isPosixAbsolutePath(slashPath)) {
-    return formatStoryIndexPath(posix.relative(normalizePathSeparators(workingDir), slashPath));
+    return formatStoryIndexPath(posix.relative(slash(workingDir), slashPath));
   }
 
   return formatStoryIndexPath(slashPath);
 }
 
 export function storyIndexPathToAbsolutePath(path: string, workingDir: string): string {
-  if (isWindowsAbsolutePath(path) || isPosixAbsolutePath(normalizePathSeparators(path))) {
-    return normalizePathSeparators(normalize(path));
+  if (isWindowsAbsolutePath(path) || isPosixAbsolutePath(slash(path))) {
+    return slash(normalize(path));
   }
 
-  return normalizePathSeparators(normalize(posix.join(normalizePathSeparators(workingDir), path)));
+  return slash(normalize(posix.join(slash(workingDir), path)));
 }
 
 export function reverseIndexToStoriesByFile(

--- a/code/core/src/shared/utils/paths.ts
+++ b/code/core/src/shared/utils/paths.ts
@@ -1,0 +1,15 @@
+/** Matches a whole `node_modules` path segment, so `src/node_modules-tools/Tag.tsx` is kept. */
+const NODE_MODULES_SEGMENT = /(?:^|[/\\])node_modules(?:[/\\]|$)/;
+
+/**
+ * Replaces Windows path separators with forward slashes, so paths compare and key consistently
+ * across platforms.
+ */
+export function slash(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+/** Whether the path traverses a `node_modules` directory, on either path separator. */
+export function isInNodeModules(path: string): boolean {
+  return NODE_MODULES_SEGMENT.test(path);
+}

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.test.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.test.ts
@@ -240,6 +240,66 @@ describe('multi-project management', () => {
     });
   });
 
+  it(
+    're-extracts a rewrite whose mtime is unchanged after onFilesChanged',
+    { timeout: 30_000 },
+    () => {
+      tempDir = createTempDir();
+
+      const files = writeFiles(tempDir, {
+        'tsconfig.json': tsconfigJSON(),
+        'Tag.tsx': dedent`
+          import React from 'react';
+          export const Tag = (_props: { text: string }) => <span />;
+        `,
+        'Tag.stories.tsx': dedent`
+          import { Tag } from './Tag';
+          export default { component: Tag };
+        `,
+      });
+
+      manager = new ComponentMetaManager(ts);
+      const tagPath = files['Tag.tsx'];
+
+      // Pin a whole-second mtime so both writes land on the identical timestamp, reproducing a
+      // second write within one mtime tick (scripted codegen, coarse-mtime filesystems).
+      const pinned = new Date(Math.floor(Date.now() / 1000) * 1000);
+      fs.utimesSync(tagPath, pinned, pinned);
+
+      const project = manager.getProjectForFile(tagPath);
+      const before: StoryRef[] = [
+        {
+          storyPath: files['Tag.stories.tsx'],
+          component: { componentName: 'Tag', importName: 'Tag', path: tagPath, isPackage: false },
+        },
+      ];
+      project.extractPropsFromStories(before);
+      expect(before[0].component?.reactComponentMeta?.props?.text).toBeDefined();
+      expect(before[0].component?.reactComponentMeta?.props?.color).toBeUndefined();
+
+      fs.writeFileSync(
+        tagPath,
+        dedent`
+          import React from 'react';
+          export const Tag = (_props: { text: string; color?: string }) => <span />;
+        `
+      );
+      fs.utimesSync(tagPath, pinned, pinned);
+      expect(fs.statSync(tagPath).mtime.valueOf()).toBe(pinned.valueOf());
+
+      manager.onFilesChanged([{ filePath: tagPath, type: 'changed' }]);
+
+      const after: StoryRef[] = [
+        {
+          storyPath: files['Tag.stories.tsx'],
+          component: { componentName: 'Tag', importName: 'Tag', path: tagPath, isPackage: false },
+        },
+      ];
+      project.extractPropsFromStories(after);
+      expect(after[0].component?.reactComponentMeta?.props?.color).toBeDefined();
+    }
+  );
+
   it('handles config change: deleted tsconfig disposes project', () => {
     tempDir = createTempDir();
 

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
@@ -11,6 +11,7 @@
 import {
   ComponentMetaManager as BaseComponentMetaManager,
   type ComponentMetaProjectFactory,
+  type FileSnapshotCache,
   parseTsconfigCommandLine,
 } from 'storybook/internal/component-meta';
 import { logger } from 'storybook/internal/node-logger';
@@ -31,7 +32,7 @@ const DEFAULT_INFERRED_OPTIONS: ts.CompilerOptions = {
   skipLibCheck: true,
 };
 
-type FsFileSnapshots = Map<string, [number | undefined, ts.IScriptSnapshot | undefined]>;
+type FsFileSnapshots = FileSnapshotCache<ts.IScriptSnapshot>;
 
 /**
  * Builds the React project factory plus the snapshot cache it closes over. The cache is shared

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -1,21 +1,13 @@
 /**
- * ComponentMetaProject — one TS LanguageService per tsconfig.
+ * One TypeScript LanguageService per tsconfig, built on the checker and project-host patterns from
+ * `@volar/typescript`. Freshness is not decided here: the snapshot cache, projectVersion gate and
+ * root-set re-checks all live in core's `ProjectFileTracker`, which the Angular analyzer shares.
  *
- * Mirrors Volar-style checker/project-host patterns:
- *
- * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L83-L461
- * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L44-L233
- * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/typescript/lib/protocol/createProject.ts#L30-L120
- * - CreateLanguage + createLanguageServiceHost from @volar/typescript
- * - Invalidation state (snapshot cache, projectVersion, root-set re-checks, ensureFresh) delegated
- *   to core's ProjectFileTracker
-*
-* Props extraction works probe-free:
-*
-* - Path 1 (primary): Find JSX in story files → getResolvedSignature() → props type
-* - Path 2 (fallback): Direct type inspection for args-only stories (component-meta approach)
-* - SerializeComponentDoc() serializes the resolved props type into ComponentDoc format
-*/
+ * Props are read from the story rather than the component, so a component is only ever described
+ * the way a story actually uses it. The JSX in the story gives a resolved call signature; an
+ * args-only story has no JSX to resolve, so those fall back to inspecting the component type
+ * directly.
+ */
 import {
   type FileChange,
   type FileSnapshotCache,
@@ -47,7 +39,7 @@ export class ComponentMetaProject {
   /** Invalidation state machine shared with the Angular component-meta project. */
   private readonly files: ProjectFileTracker<ts.IScriptSnapshot>;
   private warmupTimer?: ReturnType<typeof setTimeout>;
-  /** Entries to extract — set by the generator, replayed during warmup for targeted type resolution. */
+  /** Entries to extract - set by the generator, replayed during warmup for targeted type resolution. */
   private entries: StoryRef[] = [];
 
   constructor(
@@ -72,8 +64,7 @@ export class ComponentMetaProject {
       getCommandLineFn
     );
 
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L110-L141
+    // Adapted from the language construction in @volar/kit's createChecker.
     const language = createLanguage<string>(
       [{ getLanguageId: (fileName: string) => resolveFileLanguageId(fileName) }],
       new FileMap(typescript.sys.useCaseSensitiveFileNames),
@@ -90,8 +81,7 @@ export class ComponentMetaProject {
       }
     );
 
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L359-L383
+    // Adapted from the project host in @volar/kit's createChecker.
     const projectHost: TypeScriptProjectHost = {
       getCurrentDirectory: () =>
         configFileName
@@ -109,13 +99,12 @@ export class ComponentMetaProject {
       getScriptFileNames: () => this.files.getScriptFileNames(),
     };
 
-    // Adapted from:
-    // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/typescript/lib/protocol/createProject.ts#L30-L120
+    // Adapted from @volar/typescript's createProject.
     const { languageServiceHost } = createLanguageServiceHost(
       typescript,
       typescript.sys,
       language,
-      (s) => s, // asScriptId — identity for React (no URI mapping needed)
+      (s) => s, // asScriptId - identity for React (no URI mapping needed)
       projectHost
     );
 
@@ -172,17 +161,16 @@ export class ComponentMetaProject {
       (fileName) => !!program?.getSourceFile(fileName)
     );
 
-    // Targeted warmup: re-extract in the background so the next request is instant.
-    // Only resolves the specific types we need (story JSX → getResolvedSignature),
-    // not the entire program. TypeScript caches resolved types on AST nodes —
-    // the real extraction then hits cached results.
+    // Targeted warmup: re-extract in the background so the next request is instant. Only the types
+    // the stories actually need get resolved, and TypeScript caches those on the AST nodes, so the
+    // real extraction that follows hits cached results.
     if (versionMoved && this.entries.length > 0) {
       clearTimeout(this.warmupTimer);
       this.warmupTimer = setTimeout(() => {
         try {
           this.extractPropsFromStories(this.entries);
         } catch {
-          // Warmup failure is non-fatal — extraction will still work on demand.
+          // Warmup failure is non-fatal - extraction will still work on demand.
         }
       }, 100);
       this.warmupTimer?.unref?.();
@@ -190,7 +178,7 @@ export class ComponentMetaProject {
   }
 
   // ---------------------------------------------------------------------------
-  // Primary extraction method — probe-free
+  // Primary extraction method - probe-free
   // ---------------------------------------------------------------------------
 
   extractPropsFromStories(entries: StoryRef[]): void {
@@ -255,7 +243,7 @@ export class ComponentMetaProject {
           );
         }
 
-        // Path 2: Fallback — resolve from meta.component in the story file.
+        // Path 2: Fallback - resolve from meta.component in the story file.
         // Only fires when the user explicitly set `component:` in the meta object.
         // Only applies to the meta component itself, not declared subcomponents.
         if (!resolvedComponent) {
@@ -319,7 +307,7 @@ export class ComponentMetaProject {
 
   /**
    * Path 2 fallback: resolve the component type from the story file's `meta.component` property.
-   * Only works when the user explicitly set `component:` in the meta — no node means no
+   * Only works when the user explicitly set `component:` in the meta - no node means no
    * extraction.
    */
   private resolveFromMetaComponent(

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -7,10 +7,8 @@
  * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/language-server/lib/project/typescriptProjectLs.ts#L44-L233
  * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/typescript/lib/protocol/createProject.ts#L30-L120
  * - CreateLanguage + createLanguageServiceHost from @volar/typescript
- * - FsFileSnapshots with mtime-based caching (shared across projects)
- * - TypeScriptProjectHost contract (projectVersion, shouldCheckRootFiles, checkRootFilesUpdate)
- * - Selective projectVersion bump on file events (Kit checker pattern)
- * - EnsureFiles for dynamic file inclusion (LS pattern)
+ * - Invalidation state (snapshot cache, projectVersion, root-set re-checks, ensureFresh) delegated
+ *   to core's ProjectFileTracker, shared with the Angular component-meta project
  *
  * Props extraction works probe-free:
  *
@@ -18,6 +16,13 @@
  * - Path 2 (fallback): Direct type inspection for args-only stories (component-meta approach)
  * - SerializeComponentDoc() serializes the resolved props type into ComponentDoc format
  */
+import {
+  type FileChange,
+  type FileSnapshotCache,
+  ProjectFileTracker,
+  filterSourceFilePaths,
+} from 'storybook/internal/component-meta';
+
 import { FileMap, createLanguage } from '@volar/language-core';
 import {
   type TypeScriptProjectHost,
@@ -39,8 +44,8 @@ import {
 
 export class ComponentMetaProject {
   private ls: ts.LanguageService;
-  private projectVersion = 0;
-  private shouldCheckRootFiles = false;
+  /** Invalidation state machine shared with the Angular component-meta project. */
+  private readonly files: ProjectFileTracker<ts.IScriptSnapshot>;
   private warmupTimer?: ReturnType<typeof setTimeout>;
   /** Entries to extract — set by the generator, replayed during warmup for targeted type resolution. */
   private entries: StoryRef[] = [];
@@ -49,17 +54,9 @@ export class ComponentMetaProject {
     private typescript: typeof ts,
     private commandLine: ts.ParsedCommandLine,
     public readonly configFileName: string | undefined,
-    /**
-     * Shared snapshot cache owned by ComponentMetaManager.
-     *
-     * Adapted from:
-     * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L83
-     */
-    private fsFileSnapshots: Map<
-      string,
-      [number | undefined, ts.IScriptSnapshot | undefined]
-    > = new Map(),
-    private getCommandLineFn?: () => ts.ParsedCommandLine,
+    /** Shared snapshot cache owned by ComponentMetaManager. */
+    fsFileSnapshots: FileSnapshotCache<ts.IScriptSnapshot> = new Map(),
+    getCommandLineFn?: () => ts.ParsedCommandLine,
     /**
      * Shared by ComponentMetaManager so projects with matching compiler options reuse parsed+bound
      * SourceFiles. The snapshot cache above dedupes the file *reads*, not the ASTs: without a shared
@@ -67,6 +64,14 @@ export class ComponentMetaProject {
      */
     private documentRegistry?: ts.DocumentRegistry
   ) {
+    this.files = new ProjectFileTracker(
+      typescript,
+      commandLine,
+      fsFileSnapshots,
+      (text) => typescript.ScriptSnapshot.fromString(text),
+      getCommandLineFn
+    );
+
     // Adapted from:
     // https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L110-L141
     const language = createLanguage<string>(
@@ -76,19 +81,7 @@ export class ComponentMetaProject {
         if (!includeFsFiles) {
           return;
         }
-        const cache = fsFileSnapshots.get(fileName);
-        const modifiedTime = typescript.sys.getModifiedTime?.(fileName)?.valueOf();
-        if (!cache || cache[0] !== modifiedTime) {
-          if (typescript.sys.fileExists(fileName)) {
-            const text = typescript.sys.readFile(fileName);
-            const snapshot =
-              text !== undefined ? typescript.ScriptSnapshot.fromString(text) : undefined;
-            fsFileSnapshots.set(fileName, [modifiedTime, snapshot]);
-          } else {
-            fsFileSnapshots.set(fileName, [modifiedTime, undefined]);
-          }
-        }
-        const snapshot = fsFileSnapshots.get(fileName)?.[1];
+        const snapshot = this.files.getSnapshot(fileName);
         if (snapshot) {
           language.scripts.set(fileName, snapshot);
         } else {
@@ -110,14 +103,10 @@ export class ComponentMetaProject {
       getProjectReferences: () => {
         return this.commandLine.projectReferences;
       },
-      getProjectVersion: () => {
-        this.checkRootFilesUpdate();
-        return this.projectVersion.toString();
-      },
-      getScriptFileNames: () => {
-        this.checkRootFilesUpdate();
-        return this.commandLine.fileNames;
-      },
+      // getProjectVersion gates the language service's host re-sync; the tracker funnels every
+      // invalidation into it.
+      getProjectVersion: () => this.files.getProjectVersion(),
+      getScriptFileNames: () => this.files.getScriptFileNames(),
     };
 
     // Adapted from:
@@ -151,36 +140,7 @@ export class ComponentMetaProject {
    * repeated program rebuilds.
    */
   ensureFiles(fileNames: string[]): void {
-    let added = false;
-    for (const fileName of fileNames) {
-      if (!this.commandLine.fileNames.includes(fileName)) {
-        this.commandLine.fileNames.push(fileName);
-        added = true;
-      }
-    }
-    if (added) {
-      this.projectVersion++;
-    }
-  }
-
-  /**
-   * Adapted from:
-   * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L436-L447
-   */
-  private checkRootFilesUpdate(): void {
-    if (!this.shouldCheckRootFiles) {
-      return;
-    }
-    this.shouldCheckRootFiles = false;
-
-    if (!this.getCommandLineFn) {
-      return;
-    }
-    const newCommandLine = this.getCommandLineFn();
-    if (!arrayItemsEqual(newCommandLine.fileNames, this.commandLine.fileNames)) {
-      this.commandLine.fileNames = newCommandLine.fileNames;
-      this.projectVersion++;
-    }
+    this.files.ensureFiles(fileNames);
   }
 
   getSourceFile(fileName: string): ts.SourceFile | undefined {
@@ -200,53 +160,23 @@ export class ComponentMetaProject {
     if (!program) {
       return [];
     }
-    return program
-      .getSourceFiles()
-      .map((sf) => sf.fileName.replace(/\\/g, '/'))
-      .filter((f) => !f.includes('node_modules'));
+    return filterSourceFilePaths(program.getSourceFiles().map((sf) => sf.fileName));
   }
 
-  /**
-   * Adapted from:
-   * https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L409-L432
-   *
-   * Created events only set shouldCheckRootFiles (version bump happens in checkRootFilesUpdate if
-   * the file list actually changed). Deleted/created break early since they trigger a full config
-   * reparse — processing remaining changes is unnecessary.
-   */
-  onFilesChanged(
-    changes: Array<{ filePath: string; type: 'changed' | 'created' | 'deleted' }>
-  ): void {
-    // Eagerly invalidate snapshot cache for ALL changes before processing.
-    // Deleting from fsFileSnapshots ensures the sync callback re-reads the file.
-    for (const { filePath } of changes) {
-      this.fsFileSnapshots.delete(filePath);
-    }
-
-    const oldVersion = this.projectVersion;
+  onFilesChanged(changes: FileChange[]): void {
+    // Membership probe against the pre-event program; captured once so the batch cannot rebuild
+    // the program mid-loop.
     const program = this.ls.getProgram();
-    for (const { filePath, type } of changes) {
-      if (type === 'changed') {
-        if (program?.getSourceFile(filePath)) {
-          this.projectVersion++;
-        }
-      } else if (type === 'deleted') {
-        if (program?.getSourceFile(filePath)) {
-          this.projectVersion++;
-        }
-        this.shouldCheckRootFiles = true;
-        break;
-      } else if (type === 'created') {
-        this.shouldCheckRootFiles = true;
-        break;
-      }
-    }
+    const versionMoved = this.files.onFilesChanged(
+      changes,
+      (fileName) => !!program?.getSourceFile(fileName)
+    );
 
     // Targeted warmup: re-extract in the background so the next request is instant.
     // Only resolves the specific types we need (story JSX → getResolvedSignature),
     // not the entire program. TypeScript caches resolved types on AST nodes —
     // the real extraction then hits cached results.
-    if (this.projectVersion !== oldVersion && this.entries.length > 0) {
+    if (versionMoved && this.entries.length > 0) {
       clearTimeout(this.warmupTimer);
       this.warmupTimer = setTimeout(() => {
         try {
@@ -269,8 +199,8 @@ export class ComponentMetaProject {
     const allFiles = entries.flatMap((entry) =>
       entry.component?.path ? [entry.storyPath, entry.component.path] : [entry.storyPath]
     );
-    this.ensureFiles(allFiles);
-    this.ensureFresh(allFiles);
+    this.files.ensureFiles(allFiles);
+    this.files.ensureFresh(allFiles);
 
     const program = this.ls.getProgram();
     if (!program) {
@@ -383,32 +313,6 @@ export class ComponentMetaProject {
     }
   }
 
-  /**
-   * Check mtime for specific files and bump projectVersion if any changed.
-   *
-   * This bypasses the sync() gate in createLanguageServiceHost — sync() only runs when
-   * projectVersion changes, so mtime-based cache alone can't detect stale files. We do a targeted
-   * mtime check for the files we're about to extract from, ensuring freshness even when the
-   * fs.watch event hasn't arrived yet (race with HMR) or was missed entirely.
-   */
-  private ensureFresh(fileNames: string[]): void {
-    let stale = false;
-    for (const fileName of fileNames) {
-      const cache = this.fsFileSnapshots.get(fileName);
-      if (!cache) {
-        continue;
-      }
-      const currentMtime = this.typescript.sys.getModifiedTime?.(fileName)?.valueOf();
-      if (cache[0] !== currentMtime) {
-        this.fsFileSnapshots.delete(fileName);
-        stale = true;
-      }
-    }
-    if (stale) {
-      this.projectVersion++;
-    }
-  }
-
   // ---------------------------------------------------------------------------
   // Internal helpers
   // ---------------------------------------------------------------------------
@@ -487,19 +391,4 @@ export class ComponentMetaProject {
       symbol: selectedSymbol,
     };
   }
-}
-
-// Adapted from:
-// https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/kit/lib/createChecker.ts#L450-L461
-function arrayItemsEqual(a: string[], b: string[]) {
-  if (a.length !== b.length) {
-    return false;
-  }
-  const set = new Set(a);
-  for (const file of b) {
-    if (!set.has(file)) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -8,14 +8,14 @@
  * - https://github.com/volarjs/volar.js/blob/882cd56d46a13d272f34e451f495d3d62251969a/packages/typescript/lib/protocol/createProject.ts#L30-L120
  * - CreateLanguage + createLanguageServiceHost from @volar/typescript
  * - Invalidation state (snapshot cache, projectVersion, root-set re-checks, ensureFresh) delegated
- *   to core's ProjectFileTracker, shared with the Angular component-meta project
- *
- * Props extraction works probe-free:
- *
- * - Path 1 (primary): Find JSX in story files → getResolvedSignature() → props type
- * - Path 2 (fallback): Direct type inspection for args-only stories (component-meta approach)
- * - SerializeComponentDoc() serializes the resolved props type into ComponentDoc format
- */
+ *   to core's ProjectFileTracker
+*
+* Props extraction works probe-free:
+*
+* - Path 1 (primary): Find JSX in story files → getResolvedSignature() → props type
+* - Path 2 (fallback): Direct type inspection for args-only stories (component-meta approach)
+* - SerializeComponentDoc() serializes the resolved props type into ComponentDoc format
+*/
 import {
   type FileChange,
   type FileSnapshotCache,

--- a/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.test-helpers.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.test-helpers.ts
@@ -50,10 +50,11 @@ export async function withProject<T>(
   vol.fromNestedJSON(
     Object.fromEntries(Object.entries(filePaths).map(([name, filePath]) => [filePath, files[name]]))
   );
-  for (const fp of Object.values(filePaths)) {
-    fsFileSnapshots.delete(fp);
-  }
-  (sharedProject as any).projectVersion++;
+  // Report every rewritten path as changed: the tracker evicts its snapshots and bumps versions,
+  // which stays correct even when consecutive writes land within one mtime tick.
+  sharedProject.onFilesChanged(
+    Object.values(filePaths).map((filePath) => ({ filePath, type: 'changed' as const }))
+  );
   return fn(sharedProject, filePaths);
 }
 

--- a/code/renderers/vue3/src/docgen/vue-project-manager.ts
+++ b/code/renderers/vue3/src/docgen/vue-project-manager.ts
@@ -18,7 +18,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-import { getProjectRoot } from 'storybook/internal/common';
+import { getProjectRoot, slash } from 'storybook/internal/common';
 import {
   ComponentMetaManager,
   type ComponentMetaProjectBase,
@@ -46,8 +46,6 @@ const INFERRED_COMPILER_OPTIONS = {
   moduleResolution: 'bundler',
   jsx: 'preserve',
 };
-
-const normalize = (fileName: string) => fileName.replace(/\\/g, '/');
 
 /** One `vue-component-meta` checker per matched tsconfig. */
 export class VueComponentMetaProject implements ComponentMetaProjectBase {
@@ -98,13 +96,13 @@ export class VueComponentMetaProject implements ComponentMetaProjectBase {
   }
 
   hasSourceFile(fileName: string): boolean {
-    return !!this.checker.getProgram()?.getSourceFile(normalize(fileName));
+    return !!this.checker.getProgram()?.getSourceFile(slash(fileName));
   }
 
   /** Push files the program does not know yet into the checker (inferred-project inclusion). */
   ensureFiles(fileNames: string[]): void {
     for (const fileName of fileNames) {
-      const normalized = normalize(fileName);
+      const normalized = slash(fileName);
       if (this.hasSourceFile(normalized)) {
         continue;
       }
@@ -122,7 +120,7 @@ export class VueComponentMetaProject implements ComponentMetaProjectBase {
    */
   ensureFresh(fileNames: string[]): void {
     for (const fileName of fileNames) {
-      const normalized = normalize(fileName);
+      const normalized = slash(fileName);
       const mtime = statMtime(normalized);
       if (mtime === undefined) {
         continue;
@@ -149,7 +147,7 @@ export class VueComponentMetaProject implements ComponentMetaProjectBase {
 
   onFilesChanged(changes: FileChange[]): void {
     for (const { filePath, type } of changes) {
-      const fileName = normalize(filePath);
+      const fileName = slash(filePath);
 
       if (type === 'deleted') {
         this.pendingCreatedFiles.delete(fileName);
@@ -187,7 +185,7 @@ export class VueComponentMetaProject implements ComponentMetaProjectBase {
     }
     return program
       .getSourceFiles()
-      .map((sourceFile) => normalize(sourceFile.fileName))
+      .map((sourceFile) => slash(sourceFile.fileName))
       .filter((fileName) => !fileName.includes('node_modules'));
   }
 
@@ -236,7 +234,7 @@ function createVueProjectFactory(
         // fix https://github.com/johnsoncodehk/volar/issues/1786
         // https://github.com/microsoft/TypeScript/issues/30457
         options: { ...commandLine.options, outDir: undefined },
-        fileNames: fileNames.map(normalize),
+        fileNames: fileNames.map(slash),
       };
     },
     createConfiguredProject: (commandLine, tsconfig, getCommandLine) =>


### PR DESCRIPTION
> [!NOTE]
> Stacked on #35750. That one records per-component docgen baselines from built sandboxes; this one lifts React's component-meta invalidation state machine into core, so the Angular analyzer in #35805 consumes it instead of writing a second copy.

## What I did

React's component-meta analyzer keeps one TypeScript `LanguageService` per matched tsconfig. The Angular analyzer arriving in the next slice needs exactly the same thing, and the same four answers from it: which files the project claims, what version each file is on, when a change event invalidates a cached snapshot, and how to stay fresh when an editor save races the debounced watcher.

All of that was inline in React. This moves it into `storybook/internal/component-meta` as `ProjectFileTracker`, so there is one implementation rather than two drifting ones.

```
                        ┌── React    ComponentMetaProject  ── loses ~150 lines
 ProjectFileTracker ────┤
   root set             └── Angular  (next slice)          ── consumes it instead of
   script versions                                            writing a second copy
   change invalidation
   mtime freshness
```

The tracker knows nothing about either renderer. It takes a structural `ProjectFileSystem` rather than importing `typescript`, so `typeof ts` satisfies it and core never names the package:

```ts
export interface ProjectFileSystem {
  fileExists(path: string): boolean;
  readFile(path: string): string | undefined;
  getModifiedTime?(path: string): Date | undefined;
}
```

## How this is measured

React's existing component-meta suite is the proof: it exercises the same invalidation paths through the extracted tracker, unchanged.

| Command | What it does | Run from |
| --- | --- | --- |
| `yarn test --project "@storybook/react"` | React's component-meta and manager suites, which is where the moved behaviour is asserted | repo root |
| `yarn nx run-many -t check` | The structural `ProjectFileSystem` boundary is a compile-time claim, so the typecheck is part of the evidence | repo root |

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

This is a behaviour-preserving move with no user-facing surface, so the meaningful check is that React docgen still invalidates correctly:

1. `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. In the sandbox's `.storybook/main.ts`, set `features: { experimentalDocgenServer: true }`
3. `yarn storybook`, open **Example/Button → Docs** and confirm the props table is populated
4. Add a new prop to `src/stories/Button.tsx` and save. The table should gain the prop without a restart - that path is the tracker's freshness handling.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Internal module with no public export, so nothing user-facing to document.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

