### PR TITLE
Core: prevent unnecessary module graph rebuilds with caching

### DIFF
--- a/code/core/src/shared/open-service/services/module-graph/engine/dependency-graph/incremental-patcher.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/dependency-graph/incremental-patcher.ts
@@ -5,8 +5,8 @@ import { logger as defaultLogger } from 'storybook/internal/node-logger';
 import type { FileChangeEvent } from '../adapters/types.ts';
 import type { ParserRegistry } from '../parser-registry/parser-registry.ts';
 import { ParseResolveCache } from './parse-resolve-cache.ts';
-import type { ReverseIndexImpl } from './reverse-index.ts';
 import type { ChangeDetectionResolverFactory } from './resolver-factory.ts';
+import type { ReverseIndexImpl } from './reverse-index.ts';
 import type { DependencyGraph } from './types.ts';
 import { walkFromStory } from './walk-from-story.ts';
 
@@ -82,7 +82,11 @@ export class IncrementalPatcher {
       });
   }
 
-  async patch(event: FileChangeEvent): Promise<void> {
+  /**
+   * Applies a file change to the graph and reverse index. Returns whether the reverse index
+   * actually changed.
+   */
+  async patch(event: FileChangeEvent): Promise<boolean> {
     const path = normalize(event.path);
     // File contents may have changed (or the file is gone); drop any stale cached
     // parse/resolve data before any read.
@@ -91,9 +95,10 @@ export class IncrementalPatcher {
     if (event.kind === 'add') {
       if (this.isStoryFile(path)) {
         await this.walkStory(path);
+        return true;
       }
       // Non-story add: the documented limitation says we don't recover unresolved deps.
-      return;
+      return false;
     }
 
     if (event.kind === 'unlink') {
@@ -111,7 +116,7 @@ export class IncrementalPatcher {
         storiesToWalk.push(story);
       }
       await Promise.all(storiesToWalk.map((story) => this.walkStory(story)));
-      return;
+      return true;
     }
 
     // 'change' on an existing file: re-walk every story that depends on this file
@@ -129,7 +134,7 @@ export class IncrementalPatcher {
     if (oldDeps !== undefined) {
       const newDeps = await this.cache.resolveOnce(path);
       if (setsEqual(oldDeps, newDeps)) {
-        return;
+        return false;
       }
     }
 
@@ -142,6 +147,9 @@ export class IncrementalPatcher {
       storiesToWalk.push(story);
     }
     await Promise.all(storiesToWalk.map((story) => this.walkStory(story)));
+
+    // If nothing was re-walked, the reverse index is untouched.
+    return storiesToWalk.length > 0;
   }
 
   private walkStory(storyRoot: string): Promise<void> {

--- a/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.ts
@@ -9,6 +9,7 @@ import type { Presets } from 'storybook/internal/types';
 import type { StoryIndex } from '../../../../../types/modules/indexer.ts';
 import { ModuleGraphFailureError } from '../errors.ts';
 import { getStoryIdsByAbsolutePath } from '../story-files.ts';
+import type { StoriesByFileRecord } from '../types.ts';
 import { reverseIndexToStoriesByFile, toStoryIndexPath } from '../types.ts';
 import type { ChangeDetectionAdapter, FileChangeEvent } from './adapters/types.ts';
 import { DependencyGraphBuilder } from './dependency-graph/dependency-graph-builder.ts';
@@ -71,6 +72,12 @@ export class ModuleGraphEngine {
    */
   private patchQueue: Promise<void> = Promise.resolve();
 
+  /**
+   * Last serialized reverse index, reused by {@link mirrorUpdate} when a file change left the graph
+   * untouched.
+   */
+  private lastStoriesByFile: StoriesByFileRecord | undefined;
+
   constructor(private readonly options: ModuleGraphEngineOptions) {
     this.workingDir = options.workingDir ?? process.cwd();
   }
@@ -89,9 +96,11 @@ export class ModuleGraphEngine {
     if (!this.reverseIndex) {
       return;
     }
-    this.options.onSnapshot?.(
-      reverseIndexToStoriesByFile(this.reverseIndex.asMap(), this.workingDir)
+    this.lastStoriesByFile = reverseIndexToStoriesByFile(
+      this.reverseIndex.asMap(),
+      this.workingDir
     );
+    this.options.onSnapshot?.(this.lastStoriesByFile);
   }
 
   private collectBumpedStoryFiles(changedFile: string): Set<string> {
@@ -109,7 +118,11 @@ export class ModuleGraphEngine {
     return bumpedStoryFiles;
   }
 
-  private mirrorUpdate(changedFile: string, prePatchBumped: Set<string> = new Set()): void {
+  private mirrorUpdate(
+    changedFile: string,
+    prePatchBumped: Set<string> = new Set(),
+    indexChanged = true
+  ): void {
     if (!this.reverseIndex) {
       return;
     }
@@ -121,8 +134,14 @@ export class ModuleGraphEngine {
     if (this.storyFiles.has(normalized)) {
       bumpedStoryFiles.add(normalized);
     }
+    if (indexChanged || this.lastStoriesByFile === undefined) {
+      this.lastStoriesByFile = reverseIndexToStoriesByFile(
+        this.reverseIndex.asMap(),
+        this.workingDir
+      );
+    }
     this.options.onUpdate?.({
-      storiesByFile: reverseIndexToStoriesByFile(this.reverseIndex.asMap(), this.workingDir),
+      storiesByFile: this.lastStoriesByFile,
       bumpedStoryFiles: Array.from(bumpedStoryFiles, (storyFile) =>
         toStoryIndexPath(storyFile, this.workingDir)
       ),
@@ -382,13 +401,15 @@ export class ModuleGraphEngine {
       return;
     }
     const prePatchBumped = this.collectBumpedStoryFiles(event.path);
+    // On failure, assume the index moved to avoid staleness.
+    let indexChanged = true;
     try {
-      await this.incrementalPatcher.patch(event);
+      indexChanged = await this.incrementalPatcher.patch(event);
     } catch (error) {
       logger.warn(
         `Change detection: failed to apply ${event.kind} for ${event.path}: ${error instanceof Error ? error.message : String(error)}`
       );
     }
-    this.mirrorUpdate(event.path, prePatchBumped);
+    this.mirrorUpdate(event.path, prePatchBumped, indexChanged);
   }
 }

--- a/code/core/src/shared/open-service/services/module-graph/types.ts
+++ b/code/core/src/shared/open-service/services/module-graph/types.ts
@@ -71,12 +71,7 @@ function formatStoryIndexPath(path: string): string {
   return `./${normalized}`;
 }
 
-/**
- * Converts absolute or relative file paths into the same relative import-path format used by the
- * story index (`./src/Button.stories.tsx`). This is the storage format for module-graph service
- * state so static snapshots do not leak machine-specific filesystem roots.
- */
-export function toStoryIndexPath(path: string, workingDir: string): string {
+function computeStoryIndexPath(path: string, workingDir: string): string {
   if (isWindowsAbsolutePath(path)) {
     return formatStoryIndexPath(win32.relative(workingDir, path));
   }
@@ -87,6 +82,34 @@ export function toStoryIndexPath(path: string, workingDir: string): string {
   }
 
   return formatStoryIndexPath(slashPath);
+}
+
+/**
+ * Memoizes {@link toStoryIndexPath}, keyed by working directory then path. Nested rather than
+ * using a composite string key, since any separator character can legally occur in a path.
+ */
+const storyIndexPathCache = new Map<string, Map<string, string>>();
+
+/**
+ * Converts absolute or relative file paths into the same relative import-path format used by the
+ * story index (`./src/Button.stories.tsx`). This is the storage format for module-graph service
+ * state so static snapshots do not leak machine-specific filesystem roots.
+ */
+export function toStoryIndexPath(path: string, workingDir: string): string {
+  let cachedForWorkingDir = storyIndexPathCache.get(workingDir);
+  if (cachedForWorkingDir === undefined) {
+    cachedForWorkingDir = new Map();
+    storyIndexPathCache.set(workingDir, cachedForWorkingDir);
+  }
+
+  const cached = cachedForWorkingDir.get(path);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const result = computeStoryIndexPath(path, workingDir);
+  cachedForWorkingDir.set(path, result);
+  return result;
 }
 
 export function storyIndexPathToAbsolutePath(path: string, workingDir: string): string {


### PR DESCRIPTION
Closes #35810

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

#35810 contains a write-up of two potential problems I found with v10.5+. This PR addresses both of them by:
- making `patch()` return `false` if the module graph didn't change, so other code paths can listen on that signal
- caching `lastStoriesByFile` so it can be reused if the module graph did not change

Benchmarked impact on my machine, median across 10 runs:

|  Action | on `next` | with this PR  |
|--|--|--|
| story save  | 1.04 s | 0.41 s |
| unrelated .log write | 1.00 s | 0.29 s |

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

You could follow these steps to manually test:

1. Generate a sandbox:
```
yarn task --task sandbox --start-from auto --template react-vite/default-ts
cd ../storybook-sandboxes/react-vite-default-ts
```

2. Grow the module graph so the cost, if present, would be observable. This could be done with a Node script:
```
node -e "
const {mkdirSync,writeFileSync}=require('fs');
const S=400,M=1200;
mkdirSync('src/shared',{recursive:true}); mkdirSync('src/generated',{recursive:true});
for(let i=0;i<M;i++) writeFileSync(\`src/shared/mod\${i}.js\`,\`export const mod\${i}=\${i}\n\`);
writeFileSync('src/shared/index.js',Array.from({length:M},(_,i)=>\`export * from './mod\${i}.js'\`).join('\n'));
for(let i=0;i<S;i++) writeFileSync(\`src/generated/Comp\${i}.stories.jsx\`,
  \`import {mod0} from '../shared/index.js'\nexport default {title:'Gen/Comp\${i}',component:()=><div>{mod0}</div>}\nexport const Default={}\n\`);
"
```

3. Start Storybook and wait for startup to go quiet.
```
yarn storybook --no-open
```

4. Note the dev-server process's cumulative CPU (ps -o time= -p <pid>), then trigger each of these and re-check after each:
```
echo "" >> src/generated/Comp0.stories.jsx   # edit that does not change imports
echo "noise" >> unrelated.log                # file the graph has never seen
```

5. Repeat on `next`. Confirm that on next, each costs seconds of CPU. With this PR, each is near-zero.

6. Confirm the graph still updates when it ought to. Add a real import to `Comp0.stories.jsx`, save, and check that stories depending on the changed module are still reported as affected. Remove it again and confirm it reverts.

However! Rather than walk through all of these steps yourself, it might be easier to swap this patch into [my repro repo](https://github.com/MercuryTechnologies/storybook-modulegraph-perf-repro).

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
