### PR TITLE
Core: Stop recomputing and broadcasting the whole module graph on every file change

### DIFF
--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -590,6 +590,23 @@ Incoming state (from sync-start-reply or patches) is applied via `serviceRuntime
 
 Rather than replacing the entire state object on each patch (which would invalidate all signal subscriptions), `applyStatePatch` (in [service-sync.ts](./service-sync.ts)) recursively merges plain-object values in place: arrays and primitives are replaced directly, `__proto__`/`constructor`/`prototype` are skipped to block prototype pollution, and `preserveMissingKeys` controls whether missing keys are deleted. Cross-peer sync passes `false` so deletions propagate from full snapshots; static JSON loading passes `true` because each static file is a partial snapshot. This keeps fine-grained subscriptions on unaffected nested fields from firing spuriously.
 
+### `localStateKeys`
+
+A definition can name top-level state keys that never leave the runtime owning them:
+
+```ts
+defineService({
+  id: 'core/module-graph',
+  initialState: { graphRevision: 0, storiesByFile: {} },
+  localStateKeys: ['storiesByFile'],
+  // ...
+});
+```
+
+Listed keys are dropped from every snapshot before it is cloned for the channel, and `applyStatePatch` neither deletes nor overwrites them when a peer snapshot arrives, so each runtime keeps its own copy. Everything else syncs normally.
+
+Reach for this when a service holds large derived data that only the owning runtime queries. `core/module-graph` is the motivating case: it is registered on the server alone, and its reverse index runs to millions of `(file, story)` pairs on a large project — syncing it meant a full clone plus a telejson serialization on every command, for a payload no peer ever read. Anything a peer does need must stay off the list.
+
 ### State sync sequence
 
 ```text

--- a/code/core/src/shared/open-service/service-definition.ts
+++ b/code/core/src/shared/open-service/service-definition.ts
@@ -108,6 +108,7 @@ export const defineService = <
   description?: string;
   internal?: boolean;
   initialState: ServiceState<TState>;
+  localStateKeys?: readonly (keyof TState & string)[];
   queries: DefinedQueries<
     TState,
     TQueryInputSchemas,

--- a/code/core/src/shared/open-service/service-registry.ts
+++ b/code/core/src/shared/open-service/service-registry.ts
@@ -258,14 +258,19 @@ export function registerService<
   // Owns the per-service last-write-wins stamp and the adopt/advance logic. Adopting a peer snapshot
   // goes through `commandSelf.setState` — not the wrapped commands below — which is how the broadcast
   // loop is prevented.
+  // State this runtime owns exclusively: kept out of every snapshot that goes on the channel, and
+  // never clobbered by one arriving from a peer.
+  const { localStateKeys } = resolvedDefinition;
+
   const reconciler = createSnapshotReconciler({
     setState: (mutate) =>
       runtime.commandSelf.setState((state) => mutate(state as Record<string, unknown>)),
     initialStamp: { version: 0, clientId: ownClientId },
+    localStateKeys,
   });
 
   const getSnapshot = (): Record<string, unknown> =>
-    runtime.getStateSnapshot() as Record<string, unknown>;
+    runtime.getStateSnapshot(localStateKeys) as Record<string, unknown>;
 
   const descriptor = describeDefinition(resolvedDefinition as AnyServiceDefinition);
 

--- a/code/core/src/shared/open-service/service-runtime.ts
+++ b/code/core/src/shared/open-service/service-runtime.ts
@@ -106,8 +106,12 @@ export type ServiceRuntime<
   TQueries extends Queries<TState>,
   TCommands extends Commands<TState>,
 > = {
-  /** Returns a plain, detached snapshot of the current state for serialization. */
-  getStateSnapshot(): TState;
+  /**
+   * Returns a plain, detached snapshot of the current state for serialization. `omitKeys` leaves
+   * the named top-level keys out without cloning them, which is how a definition's
+   * `localStateKeys` stay off the channel.
+   */
+  getStateSnapshot(omitKeys?: readonly string[]): TState;
   commandSelf: CommandSelf<TState>;
   queryCtx: QueryCtx<TState>;
   loadCtxForStatic: LoadCtx<TState>;
@@ -301,7 +305,20 @@ export function createServiceRuntime<
   // The deep reactive proxy is the single source of truth that query computations track, at
   // per-field granularity.
   const state = deepSignal(rawState as object) as TState;
-  const getStateSnapshot = (): TState => structuredClone(rawState);
+  const getStateSnapshot = (omitKeys?: readonly string[]): TState => {
+    if (!omitKeys?.length) {
+      return structuredClone(rawState);
+    }
+    // Drop the omitted keys before cloning rather than after — cloning them is the cost being
+    // avoided, and for a large derived index it dominates the whole snapshot.
+    const kept: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(rawState as Record<string, unknown>)) {
+      if (!omitKeys.includes(key)) {
+        kept[key] = value;
+      }
+    }
+    return structuredClone(kept) as TState;
+  };
   const commandSelf = createCommandSelf(state);
   const { registryApi, staticLoader } = runtimeOptions;
   const createCommandCtx = (): CommandCtx<TState> => ({

--- a/code/core/src/shared/open-service/service-sync.test.ts
+++ b/code/core/src/shared/open-service/service-sync.test.ts
@@ -62,4 +62,44 @@ describe('applyStatePatch', () => {
 
     expect(target).toEqual({ entries: { alpha: 'updated' } });
   });
+
+  it('keeps a local key that a full peer snapshot omits', () => {
+    const target = { graphRevision: 1, storiesByFile: { './a.ts': { './a.stories.ts': 1 } } };
+    // Local keys are stripped before broadcast, so a peer snapshot never carries them back.
+    const source = { graphRevision: 2 };
+
+    applyStatePatch(target as Record<string, unknown>, source as Record<string, unknown>, {
+      preserveMissingKeys: false,
+      localStateKeys: ['storiesByFile'],
+    });
+
+    expect(target).toEqual({
+      graphRevision: 2,
+      storiesByFile: { './a.ts': { './a.stories.ts': 1 } },
+    });
+  });
+
+  it('ignores a local key a peer sends anyway', () => {
+    const target = { storiesByFile: { './a.ts': { './a.stories.ts': 1 } } };
+    const source = { storiesByFile: { './b.ts': { './b.stories.ts': 1 } } };
+
+    applyStatePatch(target as Record<string, unknown>, source as Record<string, unknown>, {
+      preserveMissingKeys: false,
+      localStateKeys: ['storiesByFile'],
+    });
+
+    expect(target).toEqual({ storiesByFile: { './a.ts': { './a.stories.ts': 1 } } });
+  });
+
+  it('does not treat a nested key as local just because it shares a name', () => {
+    const target = { outer: { storiesByFile: 'nested', other: 'gone' }, storiesByFile: 'local' };
+    const source = { outer: { storiesByFile: 'replaced' } };
+
+    applyStatePatch(target as Record<string, unknown>, source as Record<string, unknown>, {
+      preserveMissingKeys: false,
+      localStateKeys: ['storiesByFile'],
+    });
+
+    expect(target).toEqual({ outer: { storiesByFile: 'replaced' }, storiesByFile: 'local' });
+  });
 });

--- a/code/core/src/shared/open-service/service-sync.ts
+++ b/code/core/src/shared/open-service/service-sync.ts
@@ -88,12 +88,18 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 export function applyStatePatch(
   target: Record<string, unknown>,
   source: Record<string, unknown>,
-  options: { preserveMissingKeys: boolean }
+  options: { preserveMissingKeys: boolean; localStateKeys?: readonly string[] }
 ): void {
   if (!options.preserveMissingKeys) {
     // Remove keys the source no longer carries (deletion propagation).
     for (const key of Object.keys(target)) {
       if (FORBIDDEN_KEYS.has(key)) {
+        continue;
+      }
+
+      // Local keys are stripped from every outgoing snapshot, so their absence here says nothing
+      // about the peer's intent — deleting them would discard this runtime's own data.
+      if (options.localStateKeys?.includes(key)) {
         continue;
       }
 
@@ -109,11 +115,19 @@ export function applyStatePatch(
       continue;
     }
 
+    // A peer has no authority over a local key, even if one somehow reaches us.
+    if (options.localStateKeys?.includes(key)) {
+      continue;
+    }
+
     const sourceValue = source[key];
     const tarvalue = target[key];
 
     if (isPlainObject(sourceValue) && isPlainObject(tarvalue)) {
-      applyStatePatch(tarvalue, sourceValue, options);
+      // `localStateKeys` names top-level keys only, so it must not follow the recursion down.
+      applyStatePatch(tarvalue, sourceValue, {
+        preserveMissingKeys: options.preserveMissingKeys,
+      });
     } else if (tarvalue !== sourceValue) {
       target[key] = sourceValue;
     }
@@ -157,8 +171,10 @@ export type SnapshotReconciler = {
 export function createSnapshotReconciler(options: {
   setState: (mutate: StateMutator) => void;
   initialStamp: SyncStamp;
+  /** Top-level state keys this runtime owns exclusively; never adopted from or deleted by a peer. */
+  localStateKeys?: readonly string[];
 }): SnapshotReconciler {
-  const { setState, initialStamp } = options;
+  const { setState, initialStamp, localStateKeys } = options;
   let localStamp = initialStamp;
 
   return {
@@ -177,7 +193,9 @@ export function createSnapshotReconciler(options: {
       }
 
       localStamp = { version: incoming.version, clientId: incoming.clientId };
-      setState((current) => applyStatePatch(current, state, { preserveMissingKeys: false }));
+      setState((current) =>
+        applyStatePatch(current, state, { preserveMissingKeys: false, localStateKeys })
+      );
 
       return true;
     },

--- a/code/core/src/shared/open-service/services/module-graph/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph/definition.ts
@@ -80,6 +80,11 @@ export const moduleGraphServiceDef = defineService({
     storyChangeRevisions: {},
     latestChangedStoryFiles: [],
   } as ModuleGraphServiceState,
+  // The reverse index is only ever queried in the process that builds it — this service is
+  // registered on the server alone. It is also by far the largest thing in this state: on a large
+  // project it is millions of (file, story) pairs, which syncing would clone and serialize on every
+  // command for no reader. Revisions and status still sync normally.
+  localStateKeys: ['storiesByFile'],
   queries: {
     storiesForFiles: {
       description:
@@ -259,10 +264,12 @@ export const moduleGraphServiceDef = defineService({
       description:
         'Replaces the reverse index after an incremental patch and bumps versions for affected story files. Called by the graph engine, not by external consumers.',
       input: v.object({
-        storiesByFile: v.pipe(
-          storiesByFileSchema,
-          v.description(
-            'Complete relative reverse index keyed by story-index-style source file paths. Values map affected story-index-style story file paths to breadth-first-search depths.'
+        storiesByFile: v.optional(
+          v.pipe(
+            storiesByFileSchema,
+            v.description(
+              'Complete relative reverse index keyed by story-index-style source file paths. Values map affected story-index-style story file paths to breadth-first-search depths. Omitted when the patch left the reverse index unchanged, in which case the stored index is kept as-is.'
+            )
           )
         ),
         bumpedStoryFiles: v.pipe(
@@ -275,9 +282,11 @@ export const moduleGraphServiceDef = defineService({
       output: v.void(),
       handler: async (input, ctx) => {
         ctx.self.setState((state) => {
-          state.storiesByFile = input.storiesByFile;
-          // An out-of-graph file change recomputes the (unchanged) reverse index but bumps no
-          // stories; it must not advance the revision, so watch-all and scoped subscribers stay put.
+          if (input.storiesByFile !== undefined) {
+            state.storiesByFile = input.storiesByFile;
+          }
+          // A change that bumps no stories must not advance the revision, so watch-all and scoped
+          // subscribers stay put.
           if (input.bumpedStoryFiles.length === 0) {
             return;
           }

--- a/code/core/src/shared/open-service/services/module-graph/engine/dependency-graph/incremental-patch.test.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/dependency-graph/incremental-patch.test.ts
@@ -102,9 +102,10 @@ describe('IncrementalPatcher', () => {
       world: { edges: new Map(), resolutions: new Map() },
     });
 
-    await patcher.patch({ kind: 'change', path: '/repo/src/unknown.ts' });
+    const changed = await patcher.patch({ kind: 'change', path: '/repo/src/unknown.ts' });
 
     // No dependents in reverseIndex, not a story file — nothing to re-walk.
+    expect(changed).toBe(false);
     expect(reverseIndex.asMap().size).toBe(0);
     expect(parseSpy).not.toHaveBeenCalled();
     expect(graph.has('/repo/src/unknown.ts')).toBe(false);
@@ -128,8 +129,9 @@ describe('IncrementalPatcher', () => {
       storyFiles: new Set([story]),
     });
 
-    await patcher.patch({ kind: 'change', path: story });
+    const changed = await patcher.patch({ kind: 'change', path: story });
 
+    expect(changed).toBe(true);
     expect(reverseIndex.lookup(dep).get(story)).toBe(1);
   });
 
@@ -280,9 +282,10 @@ describe('IncrementalPatcher', () => {
       storyFiles: new Set([story]),
     });
 
-    await patcher.patch({ kind: 'change', path: dep });
+    const changed = await patcher.patch({ kind: 'change', path: dep });
 
     // story must NOT be re-walked — graph and index are still accurate
+    expect(changed).toBe(false);
     const storyCalls = parseSpy.mock.calls.filter((c) => c[0].filePath === story);
     expect(storyCalls.length).toBe(0);
     // reverse-index entries are preserved unchanged
@@ -298,10 +301,22 @@ describe('IncrementalPatcher', () => {
       storyFiles: new Set(),
     });
 
-    await patcher.patch({ kind: 'add', path: file });
+    const changed = await patcher.patch({ kind: 'add', path: file });
 
+    expect(changed).toBe(false);
     expect(reverseIndex.asMap().size).toBe(0);
     expect(parseSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports an unlink of a file the graph never saw as leaving the index unchanged', async () => {
+    const { patcher, reverseIndex } = buildPatcher({
+      world: { edges: new Map(), resolutions: new Map() },
+    });
+
+    const changed = await patcher.patch({ kind: 'unlink', path: '/repo/notes.md' });
+
+    expect(changed).toBe(false);
+    expect(reverseIndex.asMap().size).toBe(0);
   });
 
   it('unlink prunes reverseIndex for a story path even when not in current storyFiles', async () => {

--- a/code/core/src/shared/open-service/services/module-graph/engine/dependency-graph/incremental-patcher.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/dependency-graph/incremental-patcher.ts
@@ -82,7 +82,15 @@ export class IncrementalPatcher {
       });
   }
 
-  async patch(event: FileChangeEvent): Promise<void> {
+  /**
+   * Applies one file-system event to the graph and reverse index, and reports whether the reverse
+   * index actually moved.
+   *
+   * Most events in a dev session leave it untouched: a comment-only edit keeps the same dependency
+   * set, and a write to a file the graph has never seen matches nothing at all. Callers use the
+   * return value to skip re-serializing and re-broadcasting an index that is still current.
+   */
+  async patch(event: FileChangeEvent): Promise<boolean> {
     const path = normalize(event.path);
     // File contents may have changed (or the file is gone); drop any stale cached
     // parse/resolve data before any read.
@@ -91,14 +99,16 @@ export class IncrementalPatcher {
     if (event.kind === 'add') {
       if (this.isStoryFile(path)) {
         await this.walkStory(path);
+        return true;
       }
       // Non-story add: the documented limitation says we don't recover unresolved deps.
-      return;
+      return false;
     }
 
     if (event.kind === 'unlink') {
       const dependentsSet = new Set(this.reverseIndex.lookup(path).keys());
-      this.graph.delete(path);
+      // Every walked node gets a graph entry, so this doubles as "was this file known at all".
+      const wasKnown = this.graph.delete(path);
       this.reverseIndex.removeStory(path); // always call — no-op for non-stories
       // Re-walk every dependent story so transitive deps reachable only through `path`
       // are pruned.
@@ -111,7 +121,7 @@ export class IncrementalPatcher {
         storiesToWalk.push(story);
       }
       await Promise.all(storiesToWalk.map((story) => this.walkStory(story)));
-      return;
+      return wasKnown || storiesToWalk.length > 0;
     }
 
     // 'change' on an existing file: re-walk every story that depends on this file
@@ -129,7 +139,7 @@ export class IncrementalPatcher {
     if (oldDeps !== undefined) {
       const newDeps = await this.cache.resolveOnce(path);
       if (setsEqual(oldDeps, newDeps)) {
-        return;
+        return false;
       }
     }
 
@@ -142,6 +152,8 @@ export class IncrementalPatcher {
       storiesToWalk.push(story);
     }
     await Promise.all(storiesToWalk.map((story) => this.walkStory(story)));
+    // A change to a file outside the graph re-walks nothing and leaves the index as it was.
+    return storiesToWalk.length > 0;
   }
 
   private walkStory(storyRoot: string): Promise<void> {

--- a/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.test.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.test.ts
@@ -174,6 +174,50 @@ describe('ModuleGraphEngine', () => {
     expect(callbacks.onUpdate).toHaveBeenCalledTimes(2);
   });
 
+  it('skips the update entirely when a patch leaves the index untouched and bumps no story', async () => {
+    const { patchSpy } = installDependencyGraphMocks(buildReverseIndex([]));
+    const { service, adapter, emitFileChange, callbacks } = setup({
+      storyIndex: createStoryIndex([
+        { storyId: 'b--default', importPath: './src/B.stories.tsx', title: 'B' },
+      ]),
+    });
+    patchSpy.mockResolvedValue(false);
+
+    service.start(adapter);
+    await vi.runAllTimersAsync();
+
+    // A file the graph has never seen: nothing to re-serialize and nothing to notify about.
+    emitFileChange({ kind: 'change', path: '/repo/unrelated.log' });
+    await vi.runAllTimersAsync();
+
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    expect(callbacks.onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('omits storiesByFile when a patch bumps stories without moving the index', async () => {
+    const story = '/repo/src/B.stories.tsx';
+    const { patchSpy } = installDependencyGraphMocks(buildReverseIndex([[story, story, 0]]));
+    const { service, adapter, emitFileChange, callbacks } = setup({
+      storyIndex: createStoryIndex([
+        { storyId: 'b--default', importPath: './src/B.stories.tsx', title: 'B' },
+      ]),
+    });
+    patchSpy.mockResolvedValue(false);
+
+    service.start(adapter);
+    await vi.runAllTimersAsync();
+
+    // A comment-only edit to a story file: its dependency set is unchanged, so the index still
+    // holds, but the story itself must still be reported as bumped.
+    emitFileChange({ kind: 'change', path: story });
+    await vi.runAllTimersAsync();
+
+    expect(callbacks.onUpdate).toHaveBeenCalledTimes(1);
+    expect(callbacks.onUpdate).toHaveBeenCalledWith({
+      bumpedStoryFiles: ['./src/B.stories.tsx'],
+    });
+  });
+
   it('buffers file events emitted during the build and applies them in order after build resolves', async () => {
     const reverseIndex = buildReverseIndex([]);
     const buildDeferred = createDeferred<void>();

--- a/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/module-graph-engine.ts
@@ -32,9 +32,13 @@ export interface ModuleGraphEngineOptions {
   onUnavailable?: (reason: string, error?: Error) => void;
   /** Mirrors the built reverse index into the `core/module-graph` open service. */
   onSnapshot?: (storiesByFile: ReturnType<typeof reverseIndexToStoriesByFile>) => void;
-  /** Mirrors state after each settled patch; includes story files whose graph may have changed. */
+  /**
+   * Mirrors state after each settled patch; includes story files whose graph may have changed.
+   * `storiesByFile` is omitted when the patch left the reverse index untouched, so a consumer keeps
+   * the index it already holds instead of receiving an identical copy of it.
+   */
   onUpdate?: (payload: {
-    storiesByFile: ReturnType<typeof reverseIndexToStoriesByFile>;
+    storiesByFile?: ReturnType<typeof reverseIndexToStoriesByFile>;
     bumpedStoryFiles: string[];
   }) => void;
 }
@@ -109,7 +113,11 @@ export class ModuleGraphEngine {
     return bumpedStoryFiles;
   }
 
-  private mirrorUpdate(changedFile: string, prePatchBumped: Set<string> = new Set()): void {
+  private mirrorUpdate(
+    changedFile: string,
+    prePatchBumped: Set<string> = new Set(),
+    indexChanged = true
+  ): void {
     if (!this.reverseIndex) {
       return;
     }
@@ -121,8 +129,19 @@ export class ModuleGraphEngine {
     if (this.storyFiles.has(normalized)) {
       bumpedStoryFiles.add(normalized);
     }
+
+    // The index is where it was and no story is affected — a write to a file outside the graph.
+    // Mirroring it would produce an identical state, so skip the whole update rather than pay to
+    // re-serialize, re-validate and re-broadcast an index nothing has changed.
+    if (!indexChanged && bumpedStoryFiles.size === 0) {
+      return;
+    }
+
     this.options.onUpdate?.({
-      storiesByFile: reverseIndexToStoriesByFile(this.reverseIndex.asMap(), this.workingDir),
+      // Serializing the index is O(files x stories reaching them); only pay it when it moved.
+      ...(indexChanged
+        ? { storiesByFile: reverseIndexToStoriesByFile(this.reverseIndex.asMap(), this.workingDir) }
+        : {}),
       bumpedStoryFiles: Array.from(bumpedStoryFiles, (storyFile) =>
         toStoryIndexPath(storyFile, this.workingDir)
       ),
@@ -382,13 +401,15 @@ export class ModuleGraphEngine {
       return;
     }
     const prePatchBumped = this.collectBumpedStoryFiles(event.path);
+    // A patch that threw may have left the index partly mutated, so assume it moved and re-mirror.
+    let indexChanged = true;
     try {
-      await this.incrementalPatcher.patch(event);
+      indexChanged = await this.incrementalPatcher.patch(event);
     } catch (error) {
       logger.warn(
         `Change detection: failed to apply ${event.kind} for ${event.path}: ${error instanceof Error ? error.message : String(error)}`
       );
     }
-    this.mirrorUpdate(event.path, prePatchBumped);
+    this.mirrorUpdate(event.path, prePatchBumped, indexChanged);
   }
 }

--- a/code/core/src/shared/open-service/services/module-graph/module-graph.test-helpers.ts
+++ b/code/core/src/shared/open-service/services/module-graph/module-graph.test-helpers.ts
@@ -103,7 +103,8 @@ export function installDependencyGraphMocks(reverseIndex: ReverseIndexImpl): {
   patchSpy: ReturnType<typeof vi.fn>;
   buildSpy: ReturnType<typeof vi.fn>;
 } {
-  const patchSpy = vi.fn(async () => undefined);
+  // Defaults to reporting the reverse index as changed, so tests opt in to the skip path explicitly.
+  const patchSpy = vi.fn(async () => true);
   const buildSpy = vi.fn(async () => ({ reverseIndex, graph: new Map() }));
 
   vi.mocked(ChangeDetectionResolverFactory).mockImplementation(function () {

--- a/code/core/src/shared/open-service/services/module-graph/server.test.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { STORY_INDEX_INVALIDATED } from 'storybook/internal/core-events';
 
+import { installNoopChannel } from '../../../../channels/channel-slot.ts';
+import { createTestChannel, installTestChannel } from '../../../../channels/test-channel.ts';
+import { SERVICE_PATCHES } from '../../service-channel.ts';
 import { clearRegistry } from '../../server.ts';
 import {
   buildReverseIndex,
@@ -283,6 +286,53 @@ describe('module-graph open service', () => {
         revision: 0,
         storyFiles: [],
       });
+    });
+
+    it('keeps the stored index when an update omits storiesByFile', async () => {
+      const runtime = registerBareModuleGraph();
+      await runtime.commands._applyGraphSnapshot({
+        storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
+      });
+
+      // A comment-only edit re-walks nothing, so the engine sends the bump without the index.
+      await runtime.commands._applyGraphUpdate({
+        bumpedStoryFiles: ['./src/Button.stories.tsx'],
+      });
+
+      expect(runtime.queries.storiesForFiles.get({ files: ['./src/Button.tsx'] })).toEqual([
+        [{ storyFile: './src/Button.stories.tsx', depth: 1 }],
+      ]);
+      expect(runtime.queries.graphRevision.get(undefined)).toBe(1);
+      expect(runtime.queries.latestStoryChanges.get(undefined)).toEqual({
+        revision: 1,
+        storyFiles: ['./src/Button.stories.tsx'],
+      });
+    });
+
+    it('keeps the reverse index off the channel while still broadcasting revisions', async () => {
+      const channel = createTestChannel();
+      installTestChannel(channel);
+      const runtime = registerBareModuleGraph();
+
+      await runtime.commands._applyGraphUpdate({
+        storiesByFile: { './src/Button.tsx': { './src/Button.stories.tsx': 1 } },
+        bumpedStoryFiles: ['./src/Button.stories.tsx'],
+      });
+
+      const [, payload] = channel.emit.mock.calls.findLast(
+        ([event]) => event === SERVICE_PATCHES
+      ) as [string, { state: Record<string, unknown> }];
+      // The index is server-only: no browser runtime registers this service, and on a large project
+      // it is the difference between a few kilobytes and a hundred megabytes per file save.
+      expect(payload.state).not.toHaveProperty('storiesByFile');
+      expect(payload.state).toMatchObject({ graphRevision: 1 });
+      // ...and it is still queryable in the process that owns it.
+      expect(runtime.queries.storiesForFiles.get({ files: ['./src/Button.tsx'] })).toEqual([
+        [{ storyFile: './src/Button.stories.tsx', depth: 1 }],
+      ]);
+
+      // Restore the in-process channel the rest of the suite registers against.
+      installNoopChannel();
     });
   });
 

--- a/code/core/src/shared/open-service/types.ts
+++ b/code/core/src/shared/open-service/types.ts
@@ -465,6 +465,19 @@ export type ServiceDefinition<
    * type stays `TState` so already-constructed definitions flow through the registry unchanged.
    */
   initialState: TState;
+  /**
+   * State keys that never leave the runtime that owns them. They are stripped from every snapshot
+   * put on the channel and are preserved when a peer snapshot is adopted, so each runtime keeps its
+   * own copy.
+   *
+   * Use this for large derived data that only the owning runtime queries. Syncing it would cost a
+   * clone plus a full serialization on every command, for a payload no peer reads. Anything a peer
+   * does need — revisions, status, small summaries — must stay out of this list.
+   *
+   * Keys are constrained to `TState` at the authoring boundary (`defineService`); the runtime type
+   * stays `string[]` so already-constructed definitions flow through the registry unchanged.
+   */
+  localStateKeys?: readonly string[];
   queries: TQueries;
   commands: TCommands;
 };


### PR DESCRIPTION
Closes #35810

## What I did

Since 10.5, every file the watcher reports causes the module graph engine to re-serialize its **entire** reverse index, run it through schema validation, deep-clone it, and telejson it onto the websocket. None of that depends on what actually changed. A comment-only edit pays it. Appending a line to a `.log` file the graph has never seen pays it too.

This PR makes the work proportional to the change: the patcher now says whether the reverse index actually moved, and the index itself no longer travels over the channel at all.

Thanks a lot to @vivshaw for the write-up in #35810 and the draft in #35809 - the analysis there was spot on and is what this PR builds on. :clap:

### The pipeline today

```text
                                                                  ┌─ 66 ms  valibot parse (whole record)
                                                                  ├─ 24 ms  structuredClone (whole state)
chokidar  ──►  patch()  ──►  mirrorUpdate  ──►  _applyGraphUpdate ─┼─ 64 ms  telejson stringify
 event         (often a      ALWAYS rebuilds    (broadcast-wrapped)└─ 17 MB  ──► websocket ──► every manager tab
               no-op)        480,800 pairs                                          + preview iframe
                             ~670 ms                                                (nobody reads it)
```

`patch()` already knows when it did nothing - it returns early for a comment-only edit and for a file outside the graph. It just threw that knowledge away, and nothing downstream could recover it.

### After

```text
chokidar  ──►  patch(): bool  ──►  mirrorUpdate
 event                              │
                                    ├─ index moved?        no,  no story affected  ──►  return, 0 work
                                    ├─ index moved?        no,  story affected     ──►  bumpedStoryFiles only
                                    └─ index moved?        yes                     ──►  full mirror
                                                                                        (index stays server-local)
```

### The two changes

| Change | File | Effect |
| --- | --- | --- |
| `patch()` returns whether the reverse index moved | `engine/dependency-graph/incremental-patcher.ts` | The signal the engine was missing |
| Engine skips the mirror, or omits `storiesByFile` | `engine/module-graph-engine.ts` | No rebuild unless the index actually changed |
| `_applyGraphUpdate.storiesByFile` becomes optional | `services/module-graph/definition.ts` | Keeps the stored index when only revisions move |
| `localStateKeys` on a service definition | `types.ts`, `service-registry.ts`, `service-runtime.ts`, `service-sync.ts` | Named state keys never go on the channel |

The decision that matters is one guard:

```ts
// module-graph-engine.ts
if (!indexChanged && bumpedStoryFiles.size === 0) {
  return;
}

this.options.onUpdate?.({
  // Serializing the index is O(files x stories reaching them); only pay it when it moved.
  ...(indexChanged
    ? { storiesByFile: reverseIndexToStoriesByFile(this.reverseIndex.asMap(), this.workingDir) }
    : {}),
  bumpedStoryFiles: /* ... */,
});
```

---

## Side findings

Three things turned up while measuring that the issue does not mention. The first is the big one.

**1. The reverse index was being broadcast to browsers that cannot use it.**

`core/module-graph` lives in `serverCoreServiceDefs` only. No manager or preview runtime registers it - I checked every `registerService` call site and every `getService('core/module-graph')` consumer, and all five are node-side. But `wrapCommandsForBroadcast` emits the full post-mutation snapshot for *every* command regardless, so the whole index crossed the wire on every save. The browsers telejson-parsed it and dropped it on a `serviceId` mismatch.

Captured on `next`, instrumenting `ServerChannelTransport.send`:

```
story save                   CPU +0.40s   rebuilds: 2
    [repro] WS SEND services:patches: 17.36 MB, stringify 86ms, 0 client(s)
    [repro] WS SEND services:patches: 17.36 MB, stringify 66ms, 0 client(s)
```

17.36 MB per send on a 400-story repro. The reporter's graph is ~3.2M pairs, roughly 6.7x - so on the order of **116 MB per file save, twice**. That is very likely the "disconnects" they described, not just slowness.

Hence `localStateKeys`. A definition can now name top-level state keys that stay in the process that owns them:

```ts
// services/module-graph/definition.ts
localStateKeys: ['storiesByFile'],
```

Listed keys are dropped from the snapshot *before* it is cloned, and `applyStatePatch` neither deletes nor overwrites them when a peer snapshot arrives. Revisions and status keep syncing normally.

**2. Two broadcasts per save, not one.** Every command is broadcast-wrapped, including `_waitForSettledEngine` - which is a *read* barrier called from the `status` query's `load`. So waiting for the engine to settle also shipped the full state. Fixed by the same change, but worth knowing: in this system a read can cost a full-state broadcast.

**3. `ServerChannelTransport.send` serializes before checking for clients.** Note the `0 client(s)` above: 66-86 ms of telejson with nothing connected. I deliberately left this alone - it is a separate concern in the channel layer, and with `localStateKeys` in place the payload is small enough that it stops mattering here. Happy to do it as a follow-up if you think it is worth it, though.

---

## Performance

Same machine, same repro, same build (`10.6.0-alpha.4`) with and without the patch, so this is not a version artifact. `rebuilds` counts full `reverseIndexToStoriesByFile` calls; CPU is the dev-server process delta from `ps -o time=`.

Before:

```
story save                   CPU +1.10s   rebuilds: 1
    [repro] REBUILT storiesByFile: 480800 pairs in 657.406375ms
unrelated .log write         CPU +0.84s   rebuilds: 1
    [repro] REBUILT storiesByFile: 480800 pairs in 662.561916ms
second story save            CPU +1.01s   rebuilds: 1
    [repro] REBUILT storiesByFile: 480800 pairs in 646.289459ms
```

After:

```
story save                   CPU +0.06s   rebuilds: 0
unrelated .log write         CPU +0.01s   rebuilds: 0
second story save            CPU +0.05s   rebuilds: 0
```

| Action | `next` | This PR | Improvement |
| --- | --- | --- | --- |
| Story save | 1.10 s CPU, 480,800-pair rebuild, 2 x 17.36 MB on the wire | 0.06 s CPU, no rebuild, no large payload | **~18x** |
| Unrelated file write | 0.84 s CPU, 480,800-pair rebuild, 2 x 17.36 MB on the wire | 0.01 s CPU, nothing happens at all | **~84x** |

This scales with graph size, so the numbers should be quite a bit more dramatic on the reporter's ~2.1K story files / ~3.2M edges.

Where the old ~1.0 s went, measured separately at repro scale:

| Stage | Cost |
| --- | --- |
| `reverseIndexToStoriesByFile` | ~670 ms |
| valibot parse of the whole record | ~66 ms |
| `structuredClone` of the whole state | ~24 ms |
| telejson stringify | ~64 ms |
| websocket write | 17.36 MB x connected clients |

---

## Correctness

The obvious worry with a change like this is that it goes fast by skipping work it should have done. I verified the graph still tracks edges by adding and removing a real import against a running dev server, with `_applyGraphUpdate` instrumented:

```
--- 1. touch the new module BEFORE anything imports it ---
(no graph update)

--- 2. add an import of it to Comp0.stories.jsx ---
[repro] GRAPH UPDATE: index resent, bumped=["./src/stories/Comp0.stories.jsx"]

--- 3. touch the new module now that the story imports it ---
[repro] GRAPH UPDATE: index unchanged, bumped=["./src/stories/Comp0.stories.jsx"]

--- 4. remove the import again ---
[repro] GRAPH UPDATE: index resent, bumped=["./src/stories/Comp0.stories.jsx"]

--- 5. touch the new module after the import is gone ---
(no graph update)
```

Step 3 is the one that matters: the new edge was recorded, so editing that module correctly reports the importing story as affected - while still not re-sending an index that did not change. Step 5 confirms the edge is pruned again.

---

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

New coverage: `patch()`'s return contract for each no-op path (`incremental-patch.test.ts`), the engine's skip and omit behaviour (`module-graph-engine.test.ts`), `_applyGraphUpdate` without `storiesByFile` plus an assertion that the index never reaches the channel (`server.test.ts`), and `localStateKeys` handling in `applyStatePatch` (`service-sync.test.ts`).

#### Manual testing

1. Generate a sandbox:
   ```sh
   yarn task sandbox --template react-vite/default-ts --start-from auto
   cd ../storybook-sandboxes/react-vite-default-ts
   ```

2. Grow the module graph so the cost is observable (400 stories x 1200 modules):
   ```sh
   node -e "
   const {mkdirSync,writeFileSync}=require('fs');
   const S=400,M=1200;
   mkdirSync('src/shared',{recursive:true}); mkdirSync('src/generated',{recursive:true});
   for(let i=0;i<M;i++) writeFileSync(\`src/shared/mod\${i}.js\`,\`export const mod\${i}=\${i}\n\`);
   writeFileSync('src/shared/index.js',Array.from({length:M},(_,i)=>\`export * from './mod\${i}.js'\`).join('\n'));
   for(let i=0;i<S;i++) writeFileSync(\`src/generated/Comp\${i}.stories.jsx\`,
     \`import {mod0} from '../shared/index.js'\nexport default {title:'Gen/Comp\${i}',component:()=><div>{mod0}</div>}\nexport const Default={}\n\`);
   "
   ```

3. Start Storybook and wait until it goes quiet:
   ```sh
   yarn storybook --no-open
   ```

4. Note the dev-server process's cumulative CPU with `ps -o time= -p <pid>`, then trigger each of these and re-check after each one:
   ```sh
   echo "" >> src/generated/Comp0.stories.jsx   # edit that does not change imports
   echo "noise" >> unrelated.log                # file the graph has never seen
   ```
   Both should be near-zero. On `next` each costs roughly a second of CPU.

5. Confirm the graph still updates when it should. Add a real import to `Comp0.stories.jsx` (e.g. a new `src/newdep.js`), save, and check that editing `src/newdep.js` afterwards still marks the story as modified in the sidebar. Remove the import and confirm editing `src/newdep.js` no longer affects it.

Alternatively - and this is a lot less setup - @vivshaw's [reproduction repo](https://github.com/MercuryTechnologies/storybook-modulegraph-perf-repro) already contains all of the above plus the instrumentation, so swapping this branch in there is the fastest path.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

`code/core/src/shared/open-service/README.md` gains a `localStateKeys` section covering when to reach for it and why `core/module-graph` is the motivating case.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
