### PR TITLE
Build: Give AGENTS.md a real comments and JSDoc rule

### DIFF
--- a/.agents/guidelines/comments-and-jsdoc.md
+++ b/.agents/guidelines/comments-and-jsdoc.md
@@ -6,18 +6,36 @@ Default to zero comments.
 Code that needs a comment to be understood usually needs to be rewritten instead: better names, a smaller function, an earlier return, a type that makes the invalid state unrepresentable.
 Reach for a comment only after that rewrite is impossible or clearly worse.
 
-## The only two reasons to write a comment
+The rules below are deliberately mechanical. "Does this comment add value?" is a judgement every author answers "yes" to about their own writing, so it constrains nothing. These can be applied without deciding whether you like the sentence.
 
-1. **The code cannot explain itself.** A non-obvious *why*: a workaround for an upstream bug (link it), an ordering constraint, a performance trade-off that looks wrong, a spec or protocol requirement, a deliberate deviation from the obvious approach.
-2. **It is a public API.** Exported functions, types, options, and config surfaces that another package or an external consumer will use. A JSDoc block earns its place there because the reader may never see the implementation.
+## The deletion test
 
-If a comment does not fall into one of those two buckets, delete it.
+This is the only justification for a comment that is not public API.
+
+Delete the comment, reread the code, and write down the question you can no longer answer.
+
+- Cannot state the question in one sentence? It stays deleted.
+- Can state it? **That sentence is the comment.** Not the paragraph you were about to write.
+
+## The four mechanical rules
+
+**1. `/** */` is reserved for the package's public API.**
+Public API means what a consumer can import from the package entry point, not what a file happens to `export`. Everything else is a `//` comment. The syntax tells a reviewer who the audience is without reading a word of it.
+
+**2. A comment may never be longer than the code it describes.**
+If the block is longer than the body, delete the block or shrink the code. No exception, and no arbitrary line limit needed: the rule scales itself.
+
+**3. `private` and `protected` members get no comment at all.**
+Not "unless it explains why". None. Nothing outside the class can reach them, so if one needs explaining you are free to rename it or split it, and one of those is the actual fix.
+
+**4. In test files: no JSDoc, ever.**
+A `//` comment is allowed only for a fixture or environment fact the test cannot state itself, such as why a timestamp is pinned or why a module must be mocked before import. Never for what the test does or asserts. That is the `it()` name's job, and a test that needs a comment to explain its assertions has the wrong name.
 
 ## Public API JSDoc
 
-Write it for someone who only sees the signature and the docblock. Keep it tight.
+Write it for someone who only sees the signature and the docblock.
 
-- One-line summary of what it does, in the imperative. Add a second short paragraph only for a caveat the signature cannot express.
+- One-line summary of what it does, in the imperative. A second short paragraph only for a caveat the signature cannot express.
 - `@throws` when callers are expected to handle it.
 - `@example` only when usage is genuinely non-obvious, and then one short real snippet, not a tour.
 - `@deprecated` with the replacement, always.
@@ -26,13 +44,11 @@ Write it for someone who only sees the signature and the docblock. Keep it tight
 This is TypeScript: the signature already carries the names and the types, and the tag only repeats them in prose that drifts out of sync.
 If a parameter genuinely needs explanation, that explanation belongs in the summary or in the type itself.
 
-Internal, non-exported helpers get no JSDoc unless reason 1 applies.
-
 ## Never write these
 
 - **Justification comments.** No "we do X because the task asked for it", "this handles the case from the review comment", "added to satisfy the acceptance criteria". Nobody reading the file later cares why you were told to write it.
 - **Change narration.** No "changed from Y to X", "previously this used Z", "new in this PR", "moved here from foo", "replaced wholesale". That is what git history is for.
-- **Restatement.** No `// increment counter` above `counter++`.
+- **Restatement.** No `// increment counter` above `counter++`, and no summary that paraphrases the signature, the name, or the type.
 - **Section banners and decoration.** No `// ---- Helpers ----`, no ASCII boxes. If a file needs signposting, it needs splitting.
 - **Investigation transcripts.** No record of what you tried, what you ruled out, or what you verified. State the conclusion in one sentence or say nothing.
 - **Ticket and process codes.** No `AC-3`, `Probe B`, `R6`, and no cross-file or upstream line references like `L120 -> L131` or a permalink ending `#L83-L461`. They rot immediately.
@@ -42,6 +58,7 @@ Internal, non-exported helpers get no JSDoc unless reason 1 applies.
 
 An elaborate comment defending a block of code is a smell, not a justification.
 The more argument a piece of code needs in prose, the more likely it should not exist in that shape.
-If you find yourself writing a paragraph, stop and either simplify the code or cut the paragraph to a single sentence of *why*.
 
-Before opening a PR, reread every comment you added and delete the ones that would not survive the question: does this tell a future maintainer something the code cannot?
+Density is the cheapest signal that something has gone wrong. Past roughly **one comment per 20 lines of code**, a file is explaining itself rather than being clear, and the fix is in the code.
+
+Before opening a PR, apply the deletion test to every comment you added.

--- a/.agents/guidelines/comments-and-jsdoc.md
+++ b/.agents/guidelines/comments-and-jsdoc.md
@@ -17,7 +17,7 @@ Delete the comment, reread the code, and write down the question you can no long
 - Cannot state the question in one sentence? It stays deleted.
 - Can state it? **That sentence is the comment.** Not the paragraph you were about to write.
 
-## The four mechanical rules
+## The mechanical rules
 
 **1. `/** */` is reserved for the package's public API.**
 Public API means what a consumer can import from the package entry point, not what a file happens to `export`. Everything else is a `//` comment. The syntax tells a reviewer who the audience is without reading a word of it.
@@ -25,8 +25,8 @@ Public API means what a consumer can import from the package entry point, not wh
 **2. A comment may never be longer than the code it describes.**
 If the block is longer than the body, delete the block or shrink the code. No exception, and no arbitrary line limit needed: the rule scales itself.
 
-**3. `private` and `protected` members get no comment at all.**
-Not "unless it explains why". None. Nothing outside the class can reach them, so if one needs explaining you are free to rename it or split it, and one of those is the actual fix.
+**3. On a `private` or `protected` member, a docblock has to earn its place.**
+It is allowed, and a subtle algorithm or a non-obvious invariant is a good reason for one. But nothing outside the class can reach the member, so renaming or splitting it is always available to you, and one of those is often the better fix. Apply the deletion test before writing one.
 
 **4. In test files: no JSDoc, ever.**
 A `//` comment is allowed only for a fixture or environment fact the test cannot state itself, such as why a timestamp is pinned or why a module must be mocked before import. Never for what the test does or asserts. That is the `it()` name's job, and a test that needs a comment to explain its assertions has the wrong name.

--- a/.agents/guidelines/comments-and-jsdoc.md
+++ b/.agents/guidelines/comments-and-jsdoc.md
@@ -21,7 +21,7 @@ Delete the comment, reread the code, and write down the question you can no long
 Public API means what a consumer can import from the package entry point, not what a file happens to `export`. Everything else is a `//` comment. The syntax tells a reviewer who the audience is without reading a word of it.
 
 **2. A comment may never be longer than the code it describes.**
-If the block is longer than the body, delete the block or shrink the code. No exception, and no arbitrary line limit needed: the rule scales itself.
+If the block is longer than the body, delete the block or shrink the code.
 
 **3. On a `private` or `protected` member, a docblock has to earn its place.**
 It is allowed, and a subtle algorithm or a non-obvious invariant is a good reason for one. But nothing outside the class can reach the member, so renaming or splitting it is always available to you, and one of those is often the better fix. Apply the deletion test before writing one.

--- a/.agents/guidelines/comments-and-jsdoc.md
+++ b/.agents/guidelines/comments-and-jsdoc.md
@@ -1,0 +1,47 @@
+# Comments and JSDoc
+
+Referenced from [`AGENTS.md`](../../AGENTS.md). Read this once per session, not once per file.
+
+Default to zero comments.
+Code that needs a comment to be understood usually needs to be rewritten instead: better names, a smaller function, an earlier return, a type that makes the invalid state unrepresentable.
+Reach for a comment only after that rewrite is impossible or clearly worse.
+
+## The only two reasons to write a comment
+
+1. **The code cannot explain itself.** A non-obvious *why*: a workaround for an upstream bug (link it), an ordering constraint, a performance trade-off that looks wrong, a spec or protocol requirement, a deliberate deviation from the obvious approach.
+2. **It is a public API.** Exported functions, types, options, and config surfaces that another package or an external consumer will use. A JSDoc block earns its place there because the reader may never see the implementation.
+
+If a comment does not fall into one of those two buckets, delete it.
+
+## Public API JSDoc
+
+Write it for someone who only sees the signature and the docblock. Keep it tight.
+
+- One-line summary of what it does, in the imperative. Add a second short paragraph only for a caveat the signature cannot express.
+- `@throws` when callers are expected to handle it.
+- `@example` only when usage is genuinely non-obvious, and then one short real snippet, not a tour.
+- `@deprecated` with the replacement, always.
+
+**Never write `@param` or `@returns`.**
+This is TypeScript: the signature already carries the names and the types, and the tag only repeats them in prose that drifts out of sync.
+If a parameter genuinely needs explanation, that explanation belongs in the summary or in the type itself.
+
+Internal, non-exported helpers get no JSDoc unless reason 1 applies.
+
+## Never write these
+
+- **Justification comments.** No "we do X because the task asked for it", "this handles the case from the review comment", "added to satisfy the acceptance criteria". Nobody reading the file later cares why you were told to write it.
+- **Change narration.** No "changed from Y to X", "previously this used Z", "new in this PR", "moved here from foo", "replaced wholesale". That is what git history is for.
+- **Restatement.** No `// increment counter` above `counter++`.
+- **Section banners and decoration.** No `// ---- Helpers ----`, no ASCII boxes. If a file needs signposting, it needs splitting.
+- **Investigation transcripts.** No record of what you tried, what you ruled out, or what you verified. State the conclusion in one sentence or say nothing.
+- **Ticket and process codes.** No `AC-3`, `Probe B`, `R6`, and no cross-file or upstream line references like `L120 -> L131` or a permalink ending `#L83-L461`. They rot immediately.
+- **TODOs without an owner and a reason.** Either fix it, file an issue and link it, or leave it out.
+
+## Calibration
+
+An elaborate comment defending a block of code is a smell, not a justification.
+The more argument a piece of code needs in prose, the more likely it should not exist in that shape.
+If you find yourself writing a paragraph, stop and either simplify the code or cut the paragraph to a single sentence of *why*.
+
+Before opening a PR, reread every comment you added and delete the ones that would not survive the question: does this tell a future maintainer something the code cannot?

--- a/.agents/guidelines/comments-and-jsdoc.md
+++ b/.agents/guidelines/comments-and-jsdoc.md
@@ -1,7 +1,5 @@
 # Comments and JSDoc
 
-Referenced from [`AGENTS.md`](../../AGENTS.md). Read this once per session, not once per file.
-
 Default to zero comments.
 Code that needs a comment to be understood usually needs to be rewritten instead: better names, a smaller function, an earlier return, a type that makes the invalid state unrepresentable.
 Reach for a comment only after that rewrite is impossible or clearly worse.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ These usually start long-running development servers and are the wrong default f
 
 These are recurring failure modes in agent-authored changes to this repo. Apply them when writing or reviewing code, not just when asked.
 
-- **Comments are maintenance docs, not an investigation transcript.** Explain *why* for the next maintainer. Do not commit internal ticket / acceptance-criteria codes (`AC-X2`, `Probe B`, `R6`), the narrative of how you figured something out, "verified byte-identical" provenance prose, or cross-file line references (`L125→L131`) — they are noise and they rot. One or two sentences of rationale beats a paragraph of evidence.
+- **Write comments only for the two reasons in [Comments and JSDoc](#comments-and-jsdoc).** That section is the rule; this list does not restate it.
 - **Verify environment assumptions empirically before encoding them.** If a design rests on "the bundler strips X" or "this metadata is empty here", prove it with a throwaway probe before building on it (and before writing it into a comment as fact). A 10-line experiment is cheaper than a wrong architecture.
 - **Encode assumptions with static checks first.** If an assumption is expected to always hold, prefer making it impossible via TypeScript types and existing lint rules. When static checks are not practical, add a cheap runtime assertion close to the boundary so violations fail loudly at the source.
 - **Avoid redundant tests already covered elsewhere.** Do not add tests for code patterns already guaranteed by TypeScript or linting, and do not duplicate coverage that already exists in Storybook `play` functions or Playwright tests.
@@ -359,6 +359,50 @@ These are recurring failure modes in agent-authored changes to this repo. Apply 
 - **Bias toward broader coverage for security and migrations.** For security-sensitive code paths and legacy data migration logic, prefer handling more edge cases and documenting evidence for the chosen safeguards. Migration compatibility code should be explicitly version-scoped so it can be removed once the support window ends.
 - **Prefer deletion and simplicity over speculative generality.** No abstraction, fallback, or "flexibility" for a consumer or scenario that does not exist in this codebase today. If a change adds many lines, check whether the right change removes them.
 - **Don't commit accidental overrides to generated code.** Files like `code/core/src/manager/globals/exports.ts` are auto-generated, as stated in their JSDoc header. Only commit changes if they match changes you made on your PR, otherwise leave them untouched and flag flaky generated files in the PR description.
+
+## Comments and JSDoc
+
+Default to zero comments.
+Code that needs a comment to be understood usually needs to be rewritten instead: better names, a smaller function, an earlier return, a type that makes the invalid state unrepresentable.
+Reach for a comment only after that rewrite is impossible or clearly worse.
+
+### The only two reasons to write a comment
+
+1. **The code cannot explain itself.** A non-obvious *why*: a workaround for an upstream bug (link it), an ordering constraint, a performance trade-off that looks wrong, a spec or protocol requirement, a deliberate deviation from the obvious approach.
+2. **It is a public API.** Exported functions, types, options, and config surfaces another package or an external consumer will use. A JSDoc block earns its place there because the reader may never see the implementation.
+
+If a comment does not fall into one of those two buckets, delete it.
+
+### Public API JSDoc
+
+Write it for someone who only sees the signature and the docblock.
+
+- One-line summary of what it does, in the imperative. Add a second short paragraph only for a caveat the signature cannot express.
+- `@throws` when callers are expected to handle it.
+- `@example` only when usage is genuinely non-obvious, and then one short real snippet, not a tour.
+- `@deprecated` with the replacement, always.
+
+**Never write `@param` or `@returns`.** This is TypeScript: the signature already carries the names and the types, and the tag only repeats them in prose that drifts out of sync. If a parameter genuinely needs explanation, that explanation belongs in the summary or in the type itself.
+
+Internal, non-exported helpers get no JSDoc unless reason 1 applies.
+
+### Never write these
+
+- **Justification comments.** No "we do X because the task asked for it", "this handles the case from the review comment", "added to satisfy the acceptance criteria". Nobody reading the file later cares why you were told to write it.
+- **Change narration.** No "changed from Y to X", "previously this used Z", "new in this PR", "moved here from foo", "replaced wholesale". That is what git history is for.
+- **Restatement.** No `// increment counter` above `counter++`.
+- **Section banners and decoration.** No `// ---- Helpers ----`, no ASCII boxes. If a file needs signposting, it needs splitting.
+- **Investigation transcripts.** No record of what you tried, what you ruled out, or what you verified. State the conclusion in one sentence or say nothing.
+- **Ticket and process codes.** No `AC-3`, `Probe B`, `R6`, and no cross-file or upstream line references like `L120 -> L131` or a permalink ending `#L83-L461`. They rot immediately.
+- **TODOs without an owner and a reason.** Either fix it, file an issue and link it, or leave it out.
+
+### Calibration
+
+An elaborate comment defending a block of code is a smell, not a justification.
+The more argument a piece of code needs in prose, the more likely it should not exist in that shape.
+If you find yourself writing a paragraph, stop and either simplify the code or cut the paragraph to a single sentence of *why*.
+
+Before opening a PR, reread every comment you added and delete the ones that would not survive the question: does this tell a future maintainer something the code cannot?
 
 ## Maintenance Rules For Agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,47 +362,9 @@ These are recurring failure modes in agent-authored changes to this repo. Apply 
 
 ## Comments and JSDoc
 
-Default to zero comments.
-Code that needs a comment to be understood usually needs to be rewritten instead: better names, a smaller function, an earlier return, a type that makes the invalid state unrepresentable.
-Reach for a comment only after that rewrite is impossible or clearly worse.
+Code should be self-explanatory. A comment is only justified when the code cannot explain itself (a non-obvious *why*) or when a public API needs explanation. Never comment to record that you did x, y, z.
 
-### The only two reasons to write a comment
-
-1. **The code cannot explain itself.** A non-obvious *why*: a workaround for an upstream bug (link it), an ordering constraint, a performance trade-off that looks wrong, a spec or protocol requirement, a deliberate deviation from the obvious approach.
-2. **It is a public API.** Exported functions, types, options, and config surfaces another package or an external consumer will use. A JSDoc block earns its place there because the reader may never see the implementation.
-
-If a comment does not fall into one of those two buckets, delete it.
-
-### Public API JSDoc
-
-Write it for someone who only sees the signature and the docblock.
-
-- One-line summary of what it does, in the imperative. Add a second short paragraph only for a caveat the signature cannot express.
-- `@throws` when callers are expected to handle it.
-- `@example` only when usage is genuinely non-obvious, and then one short real snippet, not a tour.
-- `@deprecated` with the replacement, always.
-
-**Never write `@param` or `@returns`.** This is TypeScript: the signature already carries the names and the types, and the tag only repeats them in prose that drifts out of sync. If a parameter genuinely needs explanation, that explanation belongs in the summary or in the type itself.
-
-Internal, non-exported helpers get no JSDoc unless reason 1 applies.
-
-### Never write these
-
-- **Justification comments.** No "we do X because the task asked for it", "this handles the case from the review comment", "added to satisfy the acceptance criteria". Nobody reading the file later cares why you were told to write it.
-- **Change narration.** No "changed from Y to X", "previously this used Z", "new in this PR", "moved here from foo", "replaced wholesale". That is what git history is for.
-- **Restatement.** No `// increment counter` above `counter++`.
-- **Section banners and decoration.** No `// ---- Helpers ----`, no ASCII boxes. If a file needs signposting, it needs splitting.
-- **Investigation transcripts.** No record of what you tried, what you ruled out, or what you verified. State the conclusion in one sentence or say nothing.
-- **Ticket and process codes.** No `AC-3`, `Probe B`, `R6`, and no cross-file or upstream line references like `L120 -> L131` or a permalink ending `#L83-L461`. They rot immediately.
-- **TODOs without an owner and a reason.** Either fix it, file an issue and link it, or leave it out.
-
-### Calibration
-
-An elaborate comment defending a block of code is a smell, not a justification.
-The more argument a piece of code needs in prose, the more likely it should not exist in that shape.
-If you find yourself writing a paragraph, stop and either simplify the code or cut the paragraph to a single sentence of *why*.
-
-Before opening a PR, reread every comment you added and delete the ones that would not survive the question: does this tell a future maintainer something the code cannot?
+Before writing or editing any code file, read [`.agents/guidelines/comments-and-jsdoc.md`](.agents/guidelines/comments-and-jsdoc.md) and follow it. Read it once per session, not once per file.
 
 ## Maintenance Rules For Agents
 


### PR DESCRIPTION
## What I did

`AGENTS.md` had one bullet about comments: explain *why*, do not narrate an investigation. That leaves most of the decisions open. It never says when a comment is warranted at all, it says nothing about JSDoc, and the gap shows up in agent-authored diffs as `@param`/`@returns` that restate the TypeScript signature, ASCII section banners, and change narration that git history already carries.

This adds the rule as `.agents/guidelines/comments-and-jsdoc.md` and leaves a two-sentence summary plus a pointer in `AGENTS.md`.

```
AGENTS.md                                   .agents/guidelines/comments-and-jsdoc.md
+-------------------------------+           +--------------------------------------+
| ## Comments and JSDoc         |           | the two reasons to write a comment    |
| two-sentence summary          | --read--> | public API JSDoc shape                |
| "read this before editing     |  on need  | the never-write list                  |
|  any code file"               |           | calibration                           |
+-------------------------------+           +--------------------------------------+
   read in full, every session                 read once, when it applies
```

`AGENTS.md` is loaded in full at the start of every agent session, so a 40-line rule that only matters at the moment you are about to write a comment belongs one hop away. `.agents/` already holds the shared skills, so the guideline sits next to them.

The two rules that will change the most diffs:

```ts
// Never write @param or @returns. TypeScript's signature already carries
// the names and the types; the tag only repeats them in prose that drifts.

// No section banners. If a file needs signposting, it needs splitting.
// ---------------------------------------------------------------------------
// Project management
// ---------------------------------------------------------------------------
```

Both are real shapes taken from files currently on `next`.

Docs only. No code, no behaviour, no tests.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual test is applicable: this PR changes a Markdown instruction file and touches no code, config, or build output.

To read it as a maintainer:

1. Open `AGENTS.md`, jump to `## Comments and JSDoc`, and follow the link. It should resolve on GitHub.
2. Check the two-reason rule in the linked file matches how you would want a reviewer to push back on a comment.
3. Confirm the never-write list does not forbid something the repo genuinely relies on. The one worth a second look is section banners, since a few existing files use them.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

`CLAUDE.md` is a one-line pointer to `AGENTS.md` and needs no change.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
