### PR TITLE
Core: Share the program-backed half of a component-meta project

### DIFF
--- a/code/core/src/component-meta/ProgramBackedProject.ts
+++ b/code/core/src/component-meta/ProgramBackedProject.ts
@@ -1,4 +1,4 @@
-import type { ProjectFileTracker} from './ProjectFileTracker.ts';
+import type { ProjectFileTracker } from './ProjectFileTracker.ts';
 import { filterSourceFilePaths, normalizePath } from './ProjectFileTracker.ts';
 import type { ComponentMetaProjectBase, FileChange, ProjectCommandLine } from './types.ts';
 

--- a/code/core/src/component-meta/ProgramBackedProject.ts
+++ b/code/core/src/component-meta/ProgramBackedProject.ts
@@ -1,0 +1,68 @@
+import type { ProjectFileTracker} from './ProjectFileTracker.ts';
+import { filterSourceFilePaths, normalizePath } from './ProjectFileTracker.ts';
+import type { ComponentMetaProjectBase, FileChange, ProjectCommandLine } from './types.ts';
+
+/**
+ * The slice of a TypeScript `Program` this base reads.
+ *
+ * Structural, like the rest of this module's contracts: naming `ts.Program` here would tie every
+ * renderer to core's copy of the compiler API (see {@link ProjectCommandLine}).
+ */
+export interface ProgramLike {
+  getSourceFile(fileName: string): unknown;
+  getSourceFiles(): readonly { fileName: string }[];
+}
+
+/** The slice of a TypeScript `LanguageService` this base drives. `ts.LanguageService` satisfies it. */
+export interface ProgramProvider {
+  getProgram(): ProgramLike | undefined;
+  dispose(): void;
+}
+
+/**
+ * The half of a component-meta project that is the same for every renderer backed by a TypeScript
+ * program: answering the manager's membership and lifecycle questions from the current program, and
+ * funnelling file events into the shared {@link ProjectFileTracker}.
+ *
+ * Renderers supply the two things that genuinely differ - how the program is built, and how
+ * metadata is extracted from it - by assigning {@link service} and {@link files}. Those are fields
+ * rather than constructor parameters because a host usually closes over the tracker, so the service
+ * cannot exist before `super()` runs.
+ *
+ * `dispose` and `onFilesChanged` are overridable: a renderer that schedules background work has to
+ * cancel and reschedule it around them.
+ */
+export abstract class ProgramBackedProject<Snapshot> implements ComponentMetaProjectBase {
+  protected abstract readonly service: ProgramProvider;
+  protected abstract readonly files: ProjectFileTracker<Snapshot>;
+
+  /** Narrowed by renderers to their own parsed command line, which core must not name. */
+  abstract getCommandLine(): ProjectCommandLine;
+
+  dispose(): void {
+    this.service.dispose();
+  }
+
+  ensureFiles(fileNames: string[]): void {
+    this.files.ensureFiles(fileNames);
+  }
+
+  hasSourceFile(fileName: string): boolean {
+    return !!this.service.getProgram()?.getSourceFile(normalizePath(fileName));
+  }
+
+  getSourceFilePaths(): string[] {
+    const program = this.service.getProgram();
+    if (!program) {
+      return [];
+    }
+    return filterSourceFilePaths(program.getSourceFiles().map((sourceFile) => sourceFile.fileName));
+  }
+
+  onFilesChanged(changes: FileChange[]): void {
+    // Membership is probed against the pre-event program, captured once so the batch cannot
+    // rebuild it mid-loop.
+    const program = this.service.getProgram();
+    this.files.onFilesChanged(changes, (fileName) => !!program?.getSourceFile(fileName));
+  }
+}

--- a/code/core/src/component-meta/ProgramBackedProject.ts
+++ b/code/core/src/component-meta/ProgramBackedProject.ts
@@ -6,16 +6,19 @@ import type { ComponentMetaProjectBase, FileChange, ProjectCommandLine } from '.
  * The slice of a TypeScript `Program` this base reads.
  *
  * Structural, like the rest of this module's contracts: naming `ts.Program` here would tie every
- * renderer to core's copy of the compiler API (see {@link ProjectCommandLine}).
+ * renderer to core's copy of the compiler API (see {@link ProjectCommandLine}). `Source` lets a
+ * renderer that is backed by a real `ts.Program` carry `ts.SourceFile` through its own subclass
+ * without this module ever naming `typescript`; core's own use of `getSourceFile` never looks past
+ * truthiness, so it stays correct at the default `unknown`.
  */
-export interface ProgramLike {
-  getSourceFile(fileName: string): unknown;
+export interface ProgramLike<Source = unknown> {
+  getSourceFile(fileName: string): Source;
   getSourceFiles(): readonly { fileName: string }[];
 }
 
 /** The slice of a TypeScript `LanguageService` this base drives. `ts.LanguageService` satisfies it. */
-export interface ProgramProvider {
-  getProgram(): ProgramLike | undefined;
+export interface ProgramProvider<Source = unknown> {
+  getProgram(): ProgramLike<Source> | undefined;
   dispose(): void;
 }
 
@@ -32,8 +35,11 @@ export interface ProgramProvider {
  * `dispose` and `onFilesChanged` are overridable: a renderer that schedules background work has to
  * cancel and reschedule it around them.
  */
-export abstract class ProgramBackedProject<Snapshot> implements ComponentMetaProjectBase {
-  protected abstract readonly service: ProgramProvider;
+export abstract class ProgramBackedProject<
+  Snapshot,
+  Source = unknown,
+> implements ComponentMetaProjectBase {
+  protected abstract readonly service: ProgramProvider<Source>;
   protected abstract readonly files: ProjectFileTracker<Snapshot>;
 
   /** Narrowed by renderers to their own parsed command line, which core must not name. */

--- a/code/core/src/component-meta/ProjectFileTracker.ts
+++ b/code/core/src/component-meta/ProjectFileTracker.ts
@@ -2,7 +2,10 @@ import type { FileChange, ProjectFileSystem } from './types.ts';
 
 export type FileSnapshotCache<Snapshot> = Map<string, [number | undefined, Snapshot | undefined]>;
 
-const normalize = (fileName: string) => fileName.replace(/\\/g, '/');
+/** Program and event paths arrive with either separator; every cache here keys on one shape. */
+export const normalizePath = (fileName: string) => fileName.replace(/\\/g, '/');
+
+const normalize = normalizePath;
 
 /** Matches a whole `node_modules` path segment, so `src/node_modules-tools/Tag.tsx` is kept. */
 const NODE_MODULES_SEGMENT = /(?:^|\/)node_modules(?:\/|$)/;

--- a/code/core/src/component-meta/index.ts
+++ b/code/core/src/component-meta/index.ts
@@ -1,6 +1,8 @@
 export { ComponentMetaManager, isFileInDir, sortTSConfigs } from './ComponentMetaManager.ts';
 export { parseTsconfigCommandLine } from './parse-tsconfig.ts';
 export type { FileExtensionInfo, TsconfigParserModule } from './parse-tsconfig.ts';
-export { ProjectFileTracker, filterSourceFilePaths } from './ProjectFileTracker.ts';
+export { ProjectFileTracker, filterSourceFilePaths, normalizePath } from './ProjectFileTracker.ts';
+export { ProgramBackedProject } from './ProgramBackedProject.ts';
+export type { ProgramLike, ProgramProvider } from './ProgramBackedProject.ts';
 export type { FileSnapshotCache } from './ProjectFileTracker.ts';
 export type { ComponentMetaProjectBase, ComponentMetaProjectFactory, FileChange } from './types.ts';

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -330,11 +330,7 @@ export class ComponentMetaProject extends ProgramBackedProject<ts.IScriptSnapsho
     }
 
     let componentType = checker.getTypeOfSymbol(componentProp);
-    let selectedSymbol =
-      componentProp.valueDeclaration &&
-      this.typescript.isPropertyAssignment(componentProp.valueDeclaration)
-        ? checker.getSymbolAtLocation(componentProp.valueDeclaration.initializer)
-        : componentType.getSymbol?.();
+    let selectedSymbol = checker.getSymbolAtLocation(metaComponentInitializer);
 
     if (memberAccess) {
       const prop = componentType.getProperty(memberAccess);

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -37,7 +37,10 @@ import {
   serializeComponentDoc,
 } from './componentMetaExtractor.ts';
 
-export class ComponentMetaProject extends ProgramBackedProject<ts.IScriptSnapshot> {
+export class ComponentMetaProject extends ProgramBackedProject<
+  ts.IScriptSnapshot,
+  ts.SourceFile | undefined
+> {
   protected readonly service: ts.LanguageService;
   /** Invalidation state machine shared with the Angular component-meta project. */
   protected readonly files: ProjectFileTracker<ts.IScriptSnapshot>;

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -3,10 +3,13 @@
  * `@volar/typescript`. Freshness is not decided here: the snapshot cache, projectVersion gate and
  * root-set re-checks all live in core's `ProjectFileTracker`, which the Angular analyzer shares.
  *
- * Props are read from the story rather than the component, so a component is only ever described
- * the way a story actually uses it. The JSX in the story gives a resolved call signature; an
- * args-only story has no JSX to resolve, so those fall back to inspecting the component type
- * directly.
+ * A generic component's props are not resolvable from its own file: the first parameter stays
+ * `Props<T>` until a call site instantiates it. The story's JSX gives a resolved call signature, so
+ * it is tried first, and a story with no JSX falls back to the component's own export. Nothing else
+ * needs the use site - forwardRef, memo, styled() and HOC wrappers all resolve the same either way.
+ *
+ * The first matching JSX element wins, so for a component rendered with different type arguments
+ * across stories, the documented type is the one the earliest story pins.
  */
 import {
   type FileChange,

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaProject.ts
@@ -11,8 +11,8 @@
 import {
   type FileChange,
   type FileSnapshotCache,
+  ProgramBackedProject,
   ProjectFileTracker,
-  filterSourceFilePaths,
 } from 'storybook/internal/component-meta';
 
 import { FileMap, createLanguage } from '@volar/language-core';
@@ -34,10 +34,10 @@ import {
   serializeComponentDoc,
 } from './componentMetaExtractor.ts';
 
-export class ComponentMetaProject {
-  private ls: ts.LanguageService;
+export class ComponentMetaProject extends ProgramBackedProject<ts.IScriptSnapshot> {
+  protected readonly service: ts.LanguageService;
   /** Invalidation state machine shared with the Angular component-meta project. */
-  private readonly files: ProjectFileTracker<ts.IScriptSnapshot>;
+  protected readonly files: ProjectFileTracker<ts.IScriptSnapshot>;
   private warmupTimer?: ReturnType<typeof setTimeout>;
   /** Entries to extract - set by the generator, replayed during warmup for targeted type resolution. */
   private entries: StoryRef[] = [];
@@ -56,6 +56,7 @@ export class ComponentMetaProject {
      */
     private documentRegistry?: ts.DocumentRegistry
   ) {
+    super();
     this.files = new ProjectFileTracker(
       typescript,
       commandLine,
@@ -108,54 +109,31 @@ export class ComponentMetaProject {
       projectHost
     );
 
-    this.ls = typescript.createLanguageService(languageServiceHost, this.documentRegistry);
+    this.service = typescript.createLanguageService(languageServiceHost, this.documentRegistry);
   }
 
   getCommandLine(): ts.ParsedCommandLine {
     return this.commandLine;
   }
 
-  dispose() {
-    clearTimeout(this.warmupTimer);
-    this.ls.dispose();
-  }
-
   // ---------------------------------------------------------------------------
   // Project management
   // ---------------------------------------------------------------------------
 
-  /**
-   * Batch-add multiple files to the project in one go. Only bumps projectVersion once, avoiding
-   * repeated program rebuilds.
-   */
-  ensureFiles(fileNames: string[]): void {
-    this.files.ensureFiles(fileNames);
+  /** Cancels the warmup the base does not know about. */
+  override dispose(): void {
+    clearTimeout(this.warmupTimer);
+    super.dispose();
   }
 
   getSourceFile(fileName: string): ts.SourceFile | undefined {
-    return this.ls.getProgram()?.getSourceFile(fileName);
+    return this.service.getProgram()?.getSourceFile(fileName);
   }
 
-  hasSourceFile(fileName: string): boolean {
-    return !!this.getSourceFile(fileName);
-  }
-
-  /**
-   * Get all non-node_modules source file paths from the TS program. Used by ComponentMetaManager to
-   * watch directories for file changes.
-   */
-  getSourceFilePaths(): string[] {
-    const program = this.ls.getProgram();
-    if (!program) {
-      return [];
-    }
-    return filterSourceFilePaths(program.getSourceFiles().map((sf) => sf.fileName));
-  }
-
-  onFilesChanged(changes: FileChange[]): void {
+  override onFilesChanged(changes: FileChange[]): void {
     // Membership probe against the pre-event program; captured once so the batch cannot rebuild
     // the program mid-loop.
-    const program = this.ls.getProgram();
+    const program = this.service.getProgram();
     const versionMoved = this.files.onFilesChanged(
       changes,
       (fileName) => !!program?.getSourceFile(fileName)
@@ -190,7 +168,7 @@ export class ComponentMetaProject {
     this.files.ensureFiles(allFiles);
     this.files.ensureFresh(allFiles);
 
-    const program = this.ls.getProgram();
+    const program = this.service.getProgram();
     if (!program) {
       return;
     }


### PR DESCRIPTION
## What I did

A renderer's component-meta project is two things bolted together. How its TypeScript program gets built, and how metadata is read out of it, differ completely between renderers. Answering the manager's membership and lifecycle questions against that program does not differ at all — but it was written out once per renderer anyway.

This moves the second half into core as `ProgramBackedProject`, and puts React's project on it.

```
                     ComponentMetaProjectBase        (the manager's contract)
                                 |
                     ProgramBackedProject<Snapshot>  <-- NEW, in core
                       dispose / ensureFiles / hasSourceFile
                       getSourceFilePaths / onFilesChanged
                                 |
              +------------------+------------------+
              |                                     |
   React ComponentMetaProject             Angular project (next PR in the stack)
     volar host + extractPropsFromStories   hand-written host + extract
     overrides dispose + onFilesChanged     inherits all five
     for its warmup timer
```

A renderer assigns two fields and gets five methods:

```ts
export abstract class ProgramBackedProject<Snapshot> implements ComponentMetaProjectBase {
  protected abstract readonly service: ProgramProvider;
  protected abstract readonly files: ProjectFileTracker<Snapshot>;

  hasSourceFile(fileName: string): boolean {
    return !!this.service.getProgram()?.getSourceFile(normalizePath(fileName));
  }
  // dispose / ensureFiles / getSourceFilePaths / onFilesChanged
}
```

Fields rather than constructor parameters, because a language service host usually closes over the file tracker — so the service cannot exist before `super()` runs.

`dispose` and `onFilesChanged` stay overridable. React schedules a background warmup re-extract and has to cancel and reschedule around both; it overrides those two and inherits the other three.

## Why the contracts are structural

`ProgramLike` and `ProgramProvider` describe only the slice of `ts.Program` / `ts.LanguageService` this base touches, rather than importing them. Naming the real types would tie every renderer to core's copy of the compiler API — the same reason `ProjectCommandLine` is not `ts.ParsedCommandLine`, documented on that type. `ts.LanguageService` satisfies `ProgramProvider` structurally.

## What it removes

| file | change |
| --- | --- |
| `ComponentMetaProject.ts` (React) | +14 / -36 |
| `project.ts` (Angular, in the child PR) | +11 / -39 |

`normalizePath` is exported alongside, so path normalization stops being a private const copied into each project.

## Not included, deliberately

`importClosure` and `findDefaultExportedClassName` in the Angular project are also generic-looking, and I was going to move them here too. They have exactly one caller each and no second renderer needs them — React resolves components from an explicit batch and Vue from its own checker. Core surface with one consumer is the speculative generality `AGENTS.md` rules out, so they stay where they are used.

Vue cannot extend this base: `vue-component-meta`'s checker owns its own snapshot cache, so it has no `ProjectFileTracker`, and exposes `clearCache()` rather than `dispose()`.

## Checklist for contributors

<!-- Please check (put an "x" inside the "[ ]") the applicable items. -->

- [ ] **Bug fix**
- [x] **Refactor**
- [ ] **Feature**
- [ ] **Documentation**
- [ ] **Maintenance**
- [ ] **Other**

## Manual testing

Run from the repository root.

1. `yarn nx run-many -t check -p core react` — expect no type errors.
2. `yarn vitest run code/core/src/component-meta code/renderers/react/src/componentManifest` — expect 279 passing.
3. To confirm the base is load-bearing rather than decorative, delete `hasSourceFile` from `ProgramBackedProject` and re-run step 1. Both React and Angular fail to compile, since neither declares it any more.

## Documentation

- [ ] Add or update documentation reflecting your changes
- [x] No documentation needed — internal contract between core and the renderers, no public API change.
