### PR TITLE
Core: Apply panel disabled filter for non-story entries

### DIFF
--- a/code/core/src/manager/container/Panel.tsx
+++ b/code/core/src/manager/container/Panel.tsx
@@ -47,7 +47,7 @@ const Panel: FC<any> = (props) => {
   const panels = useMemo(() => {
     const allPanels = api.getElements(Addon_TypesEnum.PANEL);
 
-    if (!allPanels || type !== 'story') {
+    if (!allPanels) {
       return allPanels;
     }
 


### PR DESCRIPTION
Closes #35774

## What I did

Removed the `type !== 'story'` early return in the addon panel container so that panel `disabled` predicates are always evaluated. Previously, when the current entry was not a resolved story (cold deep link, composed refs), all panels were returned unfiltered, causing the Code panel to appear even when `docs.codePanel` is unset or explicitly false.

The existing filtering logic already handles undefined parameters correctly: `paramKey` checks guard with `parameters &&`, and `disabled` functions like the Code panel's already use optional chaining (`parameters?.docs?.codePanel`).

## Checklist for Contributors

### Testing
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing
1. Open Storybook in a new tab with `?path=/story/example-button--primary`
2. Hard-refresh and verify the Code panel tab does not appear in the addon strip

### Documentation
- [x] This is a bugfix and does not require documentation updates.
