### PR TITLE
Build: Stop nissuer from treating every repro URL as blocklisted

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -26,6 +26,10 @@ jobs:
             }
           reproduction-comment: '.github/comments/invalid-link.md'
           reproduction-hosts: 'github.com,codesandbox.io,stackblitz.com'
+          # nissuer v1.10.0 turns an unset/empty blocklist into [new RegExp("")], which matches
+          # every URL and auto-closes valid bug reports (see balazsorban44/nissuer#41, #35810).
+          # `$^` is a regex that matches nothing.
+          reproduction-blocklist: '$^'
           reproduction-link-section: '### Reproduction link(.*)### Reproduction steps'
           reproduction-invalid-label: 'needs reproduction'
           reproduction-issue-labels: 'bug,needs triage'


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixes the triage bot auto-closing valid bug reports (as happened on #35810).

Storybook pins `balazsorban44/nissuer@v1.10.0` and does not set `reproduction-blocklist`. In that version, an empty/unset blocklist becomes:

```js
("").split(",").map((e) => new RegExp(e.trim()))
// → [ /(?:)/ ]  which matches every URL
```

So every repro link fails with “Link matched blocklist for reproduction URLs” and the issue is closed. Upstream: [balazsorban44/nissuer#41](https://github.com/balazsorban44/nissuer/issues/41). There is no newer nissuer release.

**Fix:** set `reproduction-blocklist: '$^'` (a regex that matches nothing) in `.github/workflows/triage.yml`.

Related context: Mercury / Chromatic `#storybook-weekly` report about #35810 being auto-closed despite a public repro.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. After merge, open a new issue with the bug template, labels `bug` + `needs triage`, and a valid public GitHub repro URL in the **Reproduction link** section (e.g. any public repo under `github.com`).
2. Confirm the Nissuer triage workflow does **not** post the invalid-reproduction comment and does **not** auto-close the issue.
3. (Optional) Confirm a genuinely invalid case still fails: open a bug with no URL / a non-allowed host and expect the existing invalid-reproduction path.

No Storybook runtime / sandbox testing is required — this is workflow-only.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

Made with [Cursor](https://cursor.com)