### PR TITLE
Build: Give node_modules a cache key that cannot fall back

### DIFF
--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -4,8 +4,9 @@ import { join } from 'path/posix';
 
 import { LINUX_ROOT_DIR, WINDOWS_ROOT_DIR, WORKING_DIR } from './utils/constants.ts';
 import {
-  CACHE_KEYS,
-  CACHE_PATHS,
+  type CachePlatform,
+  NODE_MODULES_CACHE_KEY,
+  NODE_MODULES_CACHE_PATHS,
   PACKED_NODE_MODULES_ARCHIVE,
   artifact,
   cache,
@@ -28,6 +29,19 @@ const packageDirs = glob.sync(['*/src', '*/*/src'], {
   onlyDirectories: true,
 });
 
+/**
+ * Every job that installs goes through here, so none is left on the orb's own cache: one job saving
+ * a mismatched tree there would hand it to all the others. Saving stays gated on a trusted author so
+ * a fork PR cannot put a tree where the next run will find it.
+ */
+const installWithCache = (platform: CachePlatform = 'linux') => [
+  cache.attach([NODE_MODULES_CACHE_KEY(platform)]),
+  npm.install('.'),
+  ...(isTrustedAuthor()
+    ? [cache.persist(NODE_MODULES_CACHE_PATHS, NODE_MODULES_CACHE_KEY(platform))]
+    : []),
+];
+
 export const build_linux = defineJob('Build (linux)', (workflowName) => ({
   executor: {
     name: 'sb_node_22_classic',
@@ -35,9 +49,7 @@ export const build_linux = defineJob('Build (linux)', (workflowName) => ({
   },
   steps: [
     git.checkout(),
-    cache.attach(CACHE_KEYS()),
-    npm.install('.'),
-    ...(isTrustedAuthor() ? [cache.persist(CACHE_PATHS, CACHE_KEYS()[0])] : []),
+    ...installWithCache(),
     npm.check(),
     workspace.pack(
       [
@@ -92,7 +104,7 @@ export const fmt = defineJob('Format check', () => ({
   },
   steps: [
     git.checkout(),
-    npm.install('.'),
+    ...installWithCache(),
     {
       run: {
         name: 'Format check',
@@ -111,7 +123,7 @@ export const build_windows = defineJob('Build (windows)', () => ({
   steps: [
     git.checkout({ forceHttps: true }),
     node.installOnWindows(),
-    npm.install('.'),
+    ...installWithCache('windows'),
     {
       run: {
         name: 'Compile',

--- a/scripts/ci/utils/helpers.ts
+++ b/scripts/ci/utils/helpers.ts
@@ -246,16 +246,19 @@ export const npm = {
       },
     };
   },
+  /**
+   * Runs `yarn install --immutable` and nothing else.
+   *
+   * The orb's own cache is off: its last restore key is the bare prefix `node-deps-{{ arch }}-<v>-`,
+   * which matches whatever `node_modules` any job on any branch saved last, whatever lockfile built
+   * it. Callers restore {@link NODE_MODULES_CACHE_KEY} instead, which cannot degrade that way.
+   */
   install: (appDir: string, pkgManager: string = 'yarn') => {
     return {
       'node/install-packages': {
         'app-dir': appDir,
         'pkg-manager': pkgManager,
-        'cache-only-lockfile': true,
-        // v3: the orb's v2 node_modules cache carries the same poisoned tree
-        // as the v7 CACHE_KEYS entries (see above); its restore overlays
-        // node_modules on top of the primary cache without overwriting.
-        'cache-version': 'v3',
+        'with-cache': false,
       },
     };
   },
@@ -382,20 +385,28 @@ export const workflow = {
   },
 };
 
-export const CACHE_KEYS = (platform = 'linux') =>
+/** Namespaces the cache per executor, so a Linux tree can never be restored on Windows. */
+export type CachePlatform = 'linux' | 'windows';
+
+/**
+ * The one key `node_modules` may be restored from.
+ *
+ * A `node_modules` tree is a layout, not a set of downloads: which copy of a duplicated package
+ * gets hoisted to the root falls out of the whole graph. `yarn install` prunes what its state file
+ * lists, and a path the current graph never assigns is not in it, so restoring a tree built from
+ * another lockfile leaves a stale copy shadowing the right one. Hence no fallback keys: either the
+ * tree came from this exact lockfile or it is linked again.
+ */
+export const NODE_MODULES_CACHE_KEY = (platform: CachePlatform = 'linux') =>
   [
-    `v9-${platform}-node_modules`,
+    `v1-${platform}-node-modules`,
     '{{ checksum ".nvmrc" }}',
     '{{ checksum ".yarnrc.yml" }}',
     '{{ checksum "yarn.lock" }}',
-  ].map((_, index, list) => {
-    return list.slice(0, list.length - index).join('/');
-  });
+  ].join('/');
 
-export const CACHE_PATHS = [
-  '.yarn/cache',
-  '.yarn/unplugged',
-  '.yarn/build-state.yml',
+export const NODE_MODULES_CACHE_PATHS = [
+  // Yarn's record of what it linked, so only meaningful beside the tree it describes.
   '.yarn/root-install-state.gz',
   'node_modules',
   'code/node_modules',


### PR DESCRIPTION
Closes #

## What I did

CI restores `node_modules` from a partial cache key when the exact one misses, which hands a job a tree built from a different `yarn.lock`.
`yarn install` does not repair that tree, so a stale package can sit at the root shadowing the version the lockfile pins.
This gives `node_modules` a single key with no fallback, turns off the second `node_modules` cache the CircleCI node orb keeps, and drops three cached paths that never exist in this repo.

### What it costs today

Last week every job that starts a dev server failed while builds, vitest and chromatic stayed green. Two error shapes, one cause.

Under vitest, loading the dev server:

```
FAIL  core  src/core-server/build-dev.onboarding.test.ts
SyntaxError: Named export 'parse' not found. The requested module '@polka/url' is a
CommonJS module, which may not support all module.exports as named exports.
 ❯ src/core-server/dev-server.ts:8:1
    7| import compression from '@polka/compression';
    8| import polka from 'polka';
     | ^
```

And in a sandbox dev server built from the same tree:

```
file:///tmp/project/code/core/dist/core-server/index.js:10317
    let info = this.parse(req), path2 = info.pathname, ...
                    ^
TypeError: this.parse is not a function
    at _Polka.handler (file:///tmp/project/code/core/dist/core-server/index.js:10317:21)
    at process.processImmediate (node:internal/timers:506:21)
```

Both mean `@polka/url` resolved to the `0.5.0` copy, which exports no named `parse`, instead of the `1.0.0-next.29` the lockfile pins. A clean install puts `0.5.0` where it belongs, nested under compodoc's own copy of polka:

```
node_modules/@polka/url                                                    -> 1.0.0-next.29
node_modules/@compodoc/compodoc/node_modules/polka/node_modules/@polka/url -> 0.5.0
```

The lockfile was fine. The installed tree was not.

### How the tree got there

```
 lockfile changes on a branch
            │
            ▼
 restore_cache: exact key misses ──► falls back to a shorter key
            │                        (a tree built for another lockfile)
            ▼
 node/install-packages restores its own node_modules over the top
            │                        (skips paths that already exist)
            ▼
 yarn install --immutable ──► prunes what its state file lists; a path this
            │                 graph never assigns is not in it, so it stays
            ▼
 save_cache under the new exact key ──► every later run on the branch
                                        restores the same bad tree
```

Both caches degrade to a bare prefix that matches whatever any job on any branch saved last. This repo's list ended at `v9-linux-node_modules`, and the orb's ends at `node-deps-{{ arch }}-v3-`:

```yaml
# circleci/node@7.2.1, install-packages
- restore_cache:
    keys:
      - node-deps-{{ arch }}-<<cache-version>>-{{ checksum "/tmp/node-project-lockfile" }}
      - node-deps-{{ arch }}-<<cache-version>>-{{ checksum "/tmp/node-project-package.json" }}
      - node-deps-{{ arch }}-<<cache-version>>-
```

Bumping the cache version clears the bad tree, which is what `v7` and `v9` were retired for and what unblocked the branch this came from. It does not stop the next one.

### The change

One key, all three checksums, nothing shorter:

```ts
export const NODE_MODULES_CACHE_KEY = (platform: CachePlatform = 'linux') =>
  [
    `v1-${platform}-node-modules`,
    '{{ checksum ".nvmrc" }}',
    '{{ checksum ".yarnrc.yml" }}',
    '{{ checksum "yarn.lock" }}',
  ].join('/');
```

The orb's own cache is off via `with-cache: false`, so no job is left on a cache that can degrade. Its install step is not gated on that parameter, only its `restore_cache` and `save_cache` are. All three installing jobs (`build_linux`, `fmt`, `build_windows`) now go through one helper so none is missed, and Windows gets a `v1-windows-*` namespace of its own.

What the generated config emits:

```yaml
- restore_cache:
    keys:
      - v1-linux-node-modules/{{ checksum ".nvmrc" }}/{{ checksum ".yarnrc.yml" }}/{{ checksum "yarn.lock" }}
- node/install-packages:
    app-dir: .
    pkg-manager: yarn
    with-cache: false
- save_cache:
    paths:
      - .yarn/root-install-state.gz
      - node_modules
      - code/node_modules
      - scripts/node_modules
    key: v1-linux-node-modules/{{ checksum ".nvmrc" }}/{{ checksum ".yarnrc.yml" }}/{{ checksum "yarn.lock" }}
```

### The dead paths, and a separate thing worth fixing

`.yarn/cache`, `.yarn/unplugged` and `.yarn/build-state.yml` were in the cached paths and are removed here, because `.yarnrc.yml` sets `enableGlobalCache: true`:

```
$ yarn config get cacheFolder
/Users/…/.yarn/berry/cache

$ ls .yarn/cache .yarn/unplugged
No such file or directory
```

So Yarn keeps downloads outside the repo and CI has been caching three paths that do not exist. That is visible in every install log, where the fetch step re-downloads the world even when `node_modules` was restored:

```
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 3313 packages were added to the project (+ 4.47 GiB).
➤ YN0000: └ Completed in 33s 647ms
```

Pointing a cache at `~/.yarn/berry/cache` would take that 34s off every install on every job. It needs per-executor path handling, so it is not in this PR.

### Cost

When the lockfile is unchanged, which is most runs, the exact key hits and nothing changes.
When it changes, `node_modules` is linked from scratch instead of being patched on top of another lockfile's tree. The fetch step is unaffected, since as shown above it already runs cold every time.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

There is no test harness for the CI config generator. The change is exercised by CI running at all: every job in this pipeline installs through the modified helper.

#### Manual testing

1. From the repo root, run `yarn dlx jiti ./scripts/ci/main.ts --workflow=normal --gh-trusted-author=true` and open the generated `.circleci/config.generated.yml`.
2. In `build--linux` and `format-check`, confirm the `restore_cache` step lists exactly one key, and that it carries all three checksums.
3. Confirm `node/install-packages` passes `with-cache: false`, and that `cache-version`, `cache-only-lockfile`, `.yarn/cache`, `.yarn/unplugged` and `build-state.yml` appear nowhere in the file.
4. Re-run with `--workflow=daily` and confirm `build--windows` has the same shape under a `v1-windows-*` key.
5. On this PR's CI, the first `build--linux` populates the key from scratch. Push an empty commit and confirm the second run restores it and installs in roughly the time it does on `next` today.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
