### PR TITLE
Core: Remove the unread invalidated Set in StoryIndexGenerator

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -823,13 +823,10 @@ export class StoryIndexGenerator {
     if (cacheEntry && cacheEntry.type === 'stories') {
       const { dependents } = cacheEntry;
 
-      const invalidated = new Set();
       // the dependent can be in ANY cache, so we loop over all of them
       this.specifierToCache.forEach((otherCache) => {
         dependents.forEach((dep) => {
           if (otherCache[dep]) {
-            invalidated.add(dep);
-
             otherCache[dep] = false;
           }
         });


### PR DESCRIPTION
## What I did

`StoryIndexGenerator.invalidate()` builds a `Set` called `invalidated`, adds every dependent it touches to it, and then never reads it.

```ts
const invalidated = new Set();
// the dependent can be in ANY cache, so we loop over all of them
this.specifierToCache.forEach((otherCache) => {
  dependents.forEach((dep) => {
    if (otherCache[dep]) {
      invalidated.add(dep);

      otherCache[dep] = false;
    }
  });
});
```

`invalidated` appears exactly twice in the repository — the declaration and the `.add()` above.

It did have a consumer once. It was added in 6fc9f4fee (Apr 2022) together with:

```ts
const notFound = dependents.filter((dep) => !invalidated.has(dep));
if (notFound.length > 0) {
  throw new Error(`Could not invalidate ${notFound.length} deps: ${notFound.join(', ')}`);
}
```

That check was commented out, and then 78a7fd5f4c ("Remove unused code and test", Nov 2022) deleted the commented block along with its test — with the comment explaining why the throw was wrong (docs cache entries can be invalidated before story ones, so a missing dep is not an error). The `Set` that only fed that check was left behind.

So this is not a "should we revive this?" question — the decision was already made in that commit. This just removes the leftover.

## What this changes

Nothing observable. `invalidate()` still walks every cache and still sets `otherCache[dep] = false` for each dependent it finds. The only difference is that it no longer allocates a `Set` and populates it on every file change during dev.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

The existing `StoryIndexGenerator` invalidation tests cover this method and pass unchanged. No new test is added because the removed value had no consumer, so there is no new behaviour to assert.

#### Manual testing

1. Start a sandbox, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. With Storybook running, edit a story file that another story or docs file imports from (a component or a shared `meta`)
3. Confirm the index still updates in the sidebar for both the edited file and its dependents, and that no error appears in the terminal

That is the path through `invalidate()` — dependents living in a different specifier cache are the case the removed `Set` was tracking.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [x] Not applicable
