### PR TITLE
Core: Split module-graph into hot revisions and cold index services

### DIFF
--- a/code/core/src/shared/open-service/core-service-types.ts
+++ b/code/core/src/shared/open-service/core-service-types.ts
@@ -1,5 +1,6 @@
 import { docgenServiceDef } from './services/docgen/definition.ts';
 import { moduleGraphServiceDef } from './services/module-graph/definition.ts';
+import { moduleGraphIndexServiceDef } from './services/module-graph-index/definition.ts';
 import { reviewServiceDef } from './services/review/definition.ts';
 import { storyDocsServiceDef } from './services/story-docs/definition.ts';
 import type {
@@ -31,6 +32,7 @@ export const previewCoreServiceDefs = [docgenServiceDef, storyDocsServiceDef];
 export const serverCoreServiceDefs = [
   docgenServiceDef,
   storyDocsServiceDef,
+  moduleGraphIndexServiceDef,
   moduleGraphServiceDef,
   reviewServiceDef,
 ];

--- a/code/core/src/shared/open-service/services/module-graph-index/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph-index/definition.ts
@@ -2,13 +2,9 @@ import * as v from 'valibot';
 
 import { defineService } from '../../service-definition.ts';
 import type { ServiceInstanceOf } from '../../types.ts';
-import type { ModuleGraphIndexServiceState, StoriesByFileRecord } from './types.ts';
-import { toStoryIndexPath } from './types.ts';
+import type { ModuleGraphIndexServiceState, StoriesByFileRecord } from '../module-graph/types.ts';
+import { toStoryIndexPath } from '../module-graph/types.ts';
 
-/**
- * Reverse index shape `sourceFile -> storyFile -> breadth-first-search depth`. The depth is the
- * shortest number of import edges between the source file and the affected story file.
- */
 const storyIndexPathSchema = v.pipe(
   v.string(),
   v.description('A story-index-style relative path such as `./src/Button.stories.tsx`.')
@@ -24,24 +20,22 @@ const storiesByFileSchema = v.record(
   v.record(storyIndexPathSchema, storyDependencyDepthSchema)
 );
 
-/**
- * Cold half of the module graph: the fat reverse index. Updated only when the index structure
- * moves (initial build or an import-set change). Bump-only saves never touch this service, so its
- * snapshot is not re-broadcast on every keystroke.
- */
+export type { ModuleGraphIndexServiceState } from '../module-graph/types.ts';
+
 export const moduleGraphIndexServiceDef = defineService({
   id: 'core/module-graph-index',
   internal: true,
   description:
-    'Reverse index from source files to story files. Paired with `core/module-graph` (revisions/status); not updated on bump-only patches.',
+    'Reverse index from source files to story files. Paired with `core/module-graph` (revisions/status); updated only when the index structure moves, not on bump-only patches.',
   initialState: {
     workingDir: process.cwd(),
     storiesByFile: {},
   } as ModuleGraphIndexServiceState,
   queries: {
     storiesForFiles: {
+      internal: true,
       description:
-        'Returns, for each input file (same order), story-index-relative story files that depend on it and their breadth-first-search depth: the shortest number of import edges between the input file and the story file.',
+        'Internal lookup used by `core/module-graph.storiesForFiles`. Prefer the hot service query from consumers.',
       input: v.object({
         files: v.pipe(
           v.array(

--- a/code/core/src/shared/open-service/services/module-graph-index/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph-index/definition.ts
@@ -32,7 +32,7 @@ export const moduleGraphIndexServiceDef = defineService({
     storiesByFile: {},
   } as ModuleGraphIndexServiceState,
   queries: {
-    storiesForFiles: {
+    _storiesForFiles: {
       internal: true,
       description:
         'Internal lookup used by `core/module-graph.storiesForFiles`. Prefer the hot service query from consumers.',

--- a/code/core/src/shared/open-service/services/module-graph-index/server.ts
+++ b/code/core/src/shared/open-service/services/module-graph-index/server.ts
@@ -1,0 +1,13 @@
+import { registerService } from '../../server.ts';
+import { moduleGraphIndexServiceDef } from './definition.ts';
+
+/** Registers the cold reverse-index half of the module graph. Call before the hot service. */
+export function registerModuleGraphIndexService(workingDir = process.cwd()) {
+  return registerService({
+    ...moduleGraphIndexServiceDef,
+    initialState: {
+      ...moduleGraphIndexServiceDef.initialState,
+      workingDir,
+    },
+  });
+}

--- a/code/core/src/shared/open-service/services/module-graph/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph/definition.ts
@@ -2,7 +2,7 @@ import * as v from 'valibot';
 
 import { defineService } from '../../service-definition.ts';
 import type { ServiceInstanceOf } from '../../types.ts';
-import type { ModuleGraphIndexService } from './index-definition.ts';
+import type { ModuleGraphIndexService } from '../module-graph-index/definition.ts';
 import type { ModuleGraphServiceState } from './types.ts';
 import { toStoryIndexPath } from './types.ts';
 

--- a/code/core/src/shared/open-service/services/module-graph/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph/definition.ts
@@ -6,12 +6,6 @@ import type { ModuleGraphIndexService } from '../module-graph-index/definition.t
 import type { ModuleGraphServiceState } from './types.ts';
 import { toStoryIndexPath } from './types.ts';
 
-const MODULE_GRAPH_INDEX_ID = 'core/module-graph-index' as const;
-
-function getModuleGraphIndex(getService: (id: string, options: { internal: true }) => unknown) {
-  return getService(MODULE_GRAPH_INDEX_ID, { internal: true }) as ModuleGraphIndexService;
-}
-
 const errorLikeSchema: v.GenericSchema = v.object({
   message: v.pipe(v.string(), v.description('Human-readable error message.')),
   name: v.optional(v.pipe(v.string(), v.description('Error class/name, when available.'))),
@@ -117,7 +111,9 @@ export const moduleGraphServiceDef = defineService({
         )
       ),
       handler: (input, ctx) =>
-        getModuleGraphIndex(ctx.getService).queries.storiesForFiles.get(input),
+        ctx
+          .getService<ModuleGraphIndexService>('core/module-graph-index', { internal: true })
+          .queries.storiesForFiles.get(input),
     },
     status: {
       description:
@@ -233,9 +229,11 @@ export const moduleGraphServiceDef = defineService({
       }),
       output: v.void(),
       handler: async (input, ctx) => {
-        await getModuleGraphIndex(ctx.getService).commands._applyIndex({
-          storiesByFile: input.storiesByFile,
-        });
+        await ctx
+          .getService<ModuleGraphIndexService>('core/module-graph-index', { internal: true })
+          .commands._applyIndex({
+            storiesByFile: input.storiesByFile,
+          });
         ctx.self.setState((state) => {
           state.status = { value: 'ready' };
           // The snapshot is the baseline, not a change, so it does not advance the revision. Seed
@@ -274,9 +272,11 @@ export const moduleGraphServiceDef = defineService({
       output: v.void(),
       handler: async (input, ctx) => {
         if (input.storiesByFile !== undefined) {
-          await getModuleGraphIndex(ctx.getService).commands._applyIndex({
-            storiesByFile: input.storiesByFile,
-          });
+          await ctx
+            .getService<ModuleGraphIndexService>('core/module-graph-index', { internal: true })
+            .commands._applyIndex({
+              storiesByFile: input.storiesByFile,
+            });
         }
         // A change that bumps no stories must not advance the revision, so watch-all and scoped
         // subscribers stay put.

--- a/code/core/src/shared/open-service/services/module-graph/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph/definition.ts
@@ -2,8 +2,15 @@ import * as v from 'valibot';
 
 import { defineService } from '../../service-definition.ts';
 import type { ServiceInstanceOf } from '../../types.ts';
+import type { ModuleGraphIndexService } from './index-definition.ts';
 import type { ModuleGraphServiceState } from './types.ts';
 import { toStoryIndexPath } from './types.ts';
+
+const MODULE_GRAPH_INDEX_ID = 'core/module-graph-index' as const;
+
+function getModuleGraphIndex(getService: (id: string, options: { internal: true }) => unknown) {
+  return getService(MODULE_GRAPH_INDEX_ID, { internal: true }) as ModuleGraphIndexService;
+}
 
 const errorLikeSchema: v.GenericSchema = v.object({
   message: v.pipe(v.string(), v.description('Human-readable error message.')),
@@ -71,12 +78,11 @@ export const moduleGraphServiceDef = defineService({
   id: 'core/module-graph',
   internal: true,
   description:
-    'Story module dependency graph: reverse index from source files to story files, with reactive updates.',
+    'Story module dependency graph: status and revision counters for reactive updates. The reverse index lives in `core/module-graph-index`.',
   initialState: {
     workingDir: process.cwd(),
     status: { value: 'booting' },
     graphRevision: 0,
-    storiesByFile: {},
     storyChangeRevisions: {},
     latestChangedStoryFiles: [],
   } as ModuleGraphServiceState,
@@ -110,19 +116,8 @@ export const moduleGraphServiceDef = defineService({
           })
         )
       ),
-      handler: (input, ctx) => {
-        const { workingDir } = ctx.self.state;
-        return input.files.map((file) => {
-          const entries = ctx.self.state.storiesByFile[toStoryIndexPath(file, workingDir)];
-          if (!entries) {
-            return [];
-          }
-          return Object.entries(entries).map(([storyFile, depth]) => ({
-            storyFile,
-            depth,
-          }));
-        });
-      },
+      handler: (input, ctx) =>
+        getModuleGraphIndex(ctx.getService).queries.storiesForFiles.get(input),
     },
     status: {
       description:
@@ -238,9 +233,11 @@ export const moduleGraphServiceDef = defineService({
       }),
       output: v.void(),
       handler: async (input, ctx) => {
+        await getModuleGraphIndex(ctx.getService).commands._applyIndex({
+          storiesByFile: input.storiesByFile,
+        });
         ctx.self.setState((state) => {
           state.status = { value: 'ready' };
-          state.storiesByFile = input.storiesByFile;
           // The snapshot is the baseline, not a change, so it does not advance the revision. Seed
           // every known story to revision 0 so scoped `graphRevision` reads track existing keys
           // and observe later per-story bumps.
@@ -257,7 +254,7 @@ export const moduleGraphServiceDef = defineService({
     _applyGraphUpdate: {
       internal: true,
       description:
-        'Replaces the reverse index after an incremental patch and bumps versions for affected story files. Called by the graph engine, not by external consumers.',
+        'Optionally replaces the reverse index after an incremental patch and bumps versions for affected story files. Called by the graph engine, not by external consumers.',
       input: v.object({
         storiesByFile: v.optional(
           v.pipe(
@@ -276,15 +273,17 @@ export const moduleGraphServiceDef = defineService({
       }),
       output: v.void(),
       handler: async (input, ctx) => {
+        if (input.storiesByFile !== undefined) {
+          await getModuleGraphIndex(ctx.getService).commands._applyIndex({
+            storiesByFile: input.storiesByFile,
+          });
+        }
+        // A change that bumps no stories must not advance the revision, so watch-all and scoped
+        // subscribers stay put.
+        if (input.bumpedStoryFiles.length === 0) {
+          return;
+        }
         ctx.self.setState((state) => {
-          if (input.storiesByFile !== undefined) {
-            state.storiesByFile = input.storiesByFile;
-          }
-          // A change that bumps no stories must not advance the revision, so watch-all and scoped
-          // subscribers stay put.
-          if (input.bumpedStoryFiles.length === 0) {
-            return;
-          }
           state.graphRevision += 1;
           state.latestChangedStoryFiles = input.bumpedStoryFiles;
           for (const storyFile of input.bumpedStoryFiles) {

--- a/code/core/src/shared/open-service/services/module-graph/definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph/definition.ts
@@ -113,7 +113,7 @@ export const moduleGraphServiceDef = defineService({
       handler: (input, ctx) =>
         ctx
           .getService<ModuleGraphIndexService>('core/module-graph-index', { internal: true })
-          .queries.storiesForFiles.get(input),
+          .queries._storiesForFiles.get(input),
     },
     status: {
       description:

--- a/code/core/src/shared/open-service/services/module-graph/index-definition.ts
+++ b/code/core/src/shared/open-service/services/module-graph/index-definition.ts
@@ -1,0 +1,109 @@
+import * as v from 'valibot';
+
+import { defineService } from '../../service-definition.ts';
+import type { ServiceInstanceOf } from '../../types.ts';
+import type { ModuleGraphIndexServiceState, StoriesByFileRecord } from './types.ts';
+import { toStoryIndexPath } from './types.ts';
+
+/**
+ * Reverse index shape `sourceFile -> storyFile -> breadth-first-search depth`. The depth is the
+ * shortest number of import edges between the source file and the affected story file.
+ */
+const storyIndexPathSchema = v.pipe(
+  v.string(),
+  v.description('A story-index-style relative path such as `./src/Button.stories.tsx`.')
+);
+const storyDependencyDepthSchema = v.pipe(
+  v.number(),
+  v.description(
+    'Breadth-first-search depth: the shortest number of import edges between the source file and this story file.'
+  )
+);
+const storiesByFileSchema = v.record(
+  storyIndexPathSchema,
+  v.record(storyIndexPathSchema, storyDependencyDepthSchema)
+);
+
+/**
+ * Cold half of the module graph: the fat reverse index. Updated only when the index structure
+ * moves (initial build or an import-set change). Bump-only saves never touch this service, so its
+ * snapshot is not re-broadcast on every keystroke.
+ */
+export const moduleGraphIndexServiceDef = defineService({
+  id: 'core/module-graph-index',
+  internal: true,
+  description:
+    'Reverse index from source files to story files. Paired with `core/module-graph` (revisions/status); not updated on bump-only patches.',
+  initialState: {
+    workingDir: process.cwd(),
+    storiesByFile: {},
+  } as ModuleGraphIndexServiceState,
+  queries: {
+    storiesForFiles: {
+      description:
+        'Returns, for each input file (same order), story-index-relative story files that depend on it and their breadth-first-search depth: the shortest number of import edges between the input file and the story file.',
+      input: v.object({
+        files: v.pipe(
+          v.array(
+            v.pipe(
+              v.string(),
+              v.description(
+                'Input source file path. Accepts absolute paths, story-index-style relative paths with `./`, or relative paths without `./`.'
+              )
+            )
+          ),
+          v.description('Source files to look up. Output arrays match this input order.')
+        ),
+      }),
+      output: v.array(
+        v.array(
+          v.object({
+            storyFile: v.pipe(
+              storyIndexPathSchema,
+              v.description(
+                'Affected story file, returned in the same `./`-prefixed relative import-path format used by the story index.'
+              )
+            ),
+            depth: storyDependencyDepthSchema,
+          })
+        )
+      ),
+      handler: (input, ctx) => {
+        const { workingDir } = ctx.self.state;
+        return input.files.map((file) => {
+          const entries = ctx.self.state.storiesByFile[toStoryIndexPath(file, workingDir)];
+          if (!entries) {
+            return [];
+          }
+          return Object.entries(entries).map(([storyFile, depth]) => ({
+            storyFile,
+            depth,
+          }));
+        });
+      },
+    },
+  },
+  commands: {
+    _applyIndex: {
+      internal: true,
+      description:
+        'Replaces the reverse index. Called by `core/module-graph` snapshot/update commands when the index moved.',
+      input: v.object({
+        storiesByFile: v.pipe(
+          storiesByFileSchema,
+          v.description(
+            'Complete relative reverse index keyed by story-index-style source file paths. Values map affected story-index-style story file paths to breadth-first-search depths.'
+          )
+        ),
+      }),
+      output: v.void(),
+      handler: async (input, ctx) => {
+        ctx.self.setState((state) => {
+          state.storiesByFile = input.storiesByFile as StoriesByFileRecord;
+        });
+      },
+    },
+  },
+});
+
+export type ModuleGraphIndexService = ServiceInstanceOf<typeof moduleGraphIndexServiceDef>;

--- a/code/core/src/shared/open-service/services/module-graph/module-graph.test-helpers.ts
+++ b/code/core/src/shared/open-service/services/module-graph/module-graph.test-helpers.ts
@@ -3,13 +3,13 @@ import { vi } from 'vitest';
 import type { StoryIndex } from 'storybook/internal/types';
 
 import { registerService } from '../../server.ts';
+import { registerModuleGraphIndexService } from '../module-graph-index/server.ts';
 import { moduleGraphServiceDef } from './definition.ts';
 import type { ChangeDetectionAdapter, FileChangeEvent } from './engine/adapters/types.ts';
 import { DependencyGraphBuilder } from './engine/dependency-graph/dependency-graph-builder.ts';
 import { IncrementalPatcher } from './engine/dependency-graph/incremental-patcher.ts';
 import { ChangeDetectionResolverFactory } from './engine/dependency-graph/resolver-factory.ts';
 import { ReverseIndexImpl } from './engine/dependency-graph/reverse-index.ts';
-import { moduleGraphIndexServiceDef } from './index-definition.ts';
 
 export function createDeferred<T>() {
   let resolve!: (value: T) => void;
@@ -122,15 +122,9 @@ export function installDependencyGraphMocks(reverseIndex: ReverseIndexImpl): {
   return { patchSpy, buildSpy };
 }
 
-/** Registers cold index + hot module-graph for unit tests without a live engine. */
+// Registers cold index + hot module-graph for unit tests without a live engine.
 export function registerTestModuleGraphService(workingDir = process.cwd()) {
-  registerService({
-    ...moduleGraphIndexServiceDef,
-    initialState: {
-      ...moduleGraphIndexServiceDef.initialState,
-      workingDir,
-    },
-  });
+  registerModuleGraphIndexService(workingDir);
 
   return registerService(
     {

--- a/code/core/src/shared/open-service/services/module-graph/module-graph.test-helpers.ts
+++ b/code/core/src/shared/open-service/services/module-graph/module-graph.test-helpers.ts
@@ -9,6 +9,7 @@ import { DependencyGraphBuilder } from './engine/dependency-graph/dependency-gra
 import { IncrementalPatcher } from './engine/dependency-graph/incremental-patcher.ts';
 import { ChangeDetectionResolverFactory } from './engine/dependency-graph/resolver-factory.ts';
 import { ReverseIndexImpl } from './engine/dependency-graph/reverse-index.ts';
+import { moduleGraphIndexServiceDef } from './index-definition.ts';
 
 export function createDeferred<T>() {
   let resolve!: (value: T) => void;
@@ -121,8 +122,16 @@ export function installDependencyGraphMocks(reverseIndex: ReverseIndexImpl): {
   return { patchSpy, buildSpy };
 }
 
-/** Registers module-graph for unit tests without a live engine (no-op settlement command). */
+/** Registers cold index + hot module-graph for unit tests without a live engine. */
 export function registerTestModuleGraphService(workingDir = process.cwd()) {
+  registerService({
+    ...moduleGraphIndexServiceDef,
+    initialState: {
+      ...moduleGraphIndexServiceDef.initialState,
+      workingDir,
+    },
+  });
+
   return registerService(
     {
       ...moduleGraphServiceDef,

--- a/code/core/src/shared/open-service/services/module-graph/server.test.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { STORY_INDEX_INVALIDATED } from 'storybook/internal/core-events';
 
+import { createTestChannel, installTestChannel } from '../../../../channels/test-channel.ts';
+import { SERVICE_PATCHES } from '../../service-channel.ts';
 import { clearRegistry } from '../../server.ts';
 import {
   buildReverseIndex,
@@ -586,6 +588,47 @@ describe('module-graph open service', () => {
           storyFiles: ['./src/Card.stories.tsx'],
         });
       });
+    });
+  });
+
+  describe('hot/cold split sync (spike)', () => {
+    afterEach(() => {
+      installTestChannel(null);
+    });
+
+    it('broadcasts only the slim hot snapshot on a bump-only update', async () => {
+      const channel = createTestChannel();
+      installTestChannel(channel);
+
+      // Many edges, few stories: cold index is large; hot revisions stay small.
+      const storyFiles = Array.from({ length: 20 }, (_, j) => `./src/story-${j}.stories.ts`);
+      const fatIndex = Object.fromEntries(
+        Array.from({ length: 400 }, (_, i) => [
+          `./src/file-${i}.ts`,
+          Object.fromEntries(storyFiles.map((storyFile) => [storyFile, 1])),
+        ])
+      );
+      const fatIndexBytes = JSON.stringify(fatIndex).length;
+
+      const runtime = registerBareModuleGraph();
+      await runtime.commands._applyGraphSnapshot({ storiesByFile: fatIndex });
+      channel.emit.mockClear();
+
+      await runtime.commands._applyGraphUpdate({
+        bumpedStoryFiles: ['./src/story-0.stories.ts'],
+      });
+
+      const patches = channel.emit.mock.calls
+        .filter(([event]) => event === SERVICE_PATCHES)
+        .map(([, payload]) => payload as { serviceId: string; state: Record<string, unknown> });
+
+      expect(patches.map((p) => p.serviceId)).toEqual(['core/module-graph']);
+      expect(patches[0].state).not.toHaveProperty('storiesByFile');
+      expect(JSON.stringify(patches[0].state).length).toBeLessThan(fatIndexBytes / 20);
+      expect(runtime.queries.graphRevision.get(undefined)).toBe(1);
+      expect(runtime.queries.storiesForFiles.get({ files: ['./src/file-0.ts'] })).toEqual([
+        storyFiles.map((storyFile) => ({ storyFile, depth: 1 })),
+      ]);
     });
   });
 });

--- a/code/core/src/shared/open-service/services/module-graph/server.test.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.test.ts
@@ -591,16 +591,13 @@ describe('module-graph open service', () => {
     });
   });
 
-  describe('hot/cold split sync (spike)', () => {
+  describe('hot/cold split sync', () => {
     afterEach(() => {
       installTestChannel(null);
     });
 
-    it('broadcasts only the slim hot snapshot on a bump-only update', async () => {
-      const channel = createTestChannel();
-      installTestChannel(channel);
-
-      // Many edges, few stories: cold index is large; hot revisions stay small.
+    // Many edges, few stories: cold index is large; hot revisions stay small.
+    function fatIndexFixture() {
       const storyFiles = Array.from({ length: 20 }, (_, j) => `./src/story-${j}.stories.ts`);
       const fatIndex = Object.fromEntries(
         Array.from({ length: 400 }, (_, i) => [
@@ -608,7 +605,19 @@ describe('module-graph open service', () => {
           Object.fromEntries(storyFiles.map((storyFile) => [storyFile, 1])),
         ])
       );
-      const fatIndexBytes = JSON.stringify(fatIndex).length;
+      return { storyFiles, fatIndex, fatIndexBytes: JSON.stringify(fatIndex).length };
+    }
+
+    function servicePatches(channel: ReturnType<typeof createTestChannel>) {
+      return channel.emit.mock.calls
+        .filter(([event]) => event === SERVICE_PATCHES)
+        .map(([, payload]) => payload as { serviceId: string; state: Record<string, unknown> });
+    }
+
+    it('broadcasts only the slim hot snapshot on a bump-only update', async () => {
+      const channel = createTestChannel();
+      installTestChannel(channel);
+      const { storyFiles, fatIndex, fatIndexBytes } = fatIndexFixture();
 
       const runtime = registerBareModuleGraph();
       await runtime.commands._applyGraphSnapshot({ storiesByFile: fatIndex });
@@ -618,16 +627,44 @@ describe('module-graph open service', () => {
         bumpedStoryFiles: ['./src/story-0.stories.ts'],
       });
 
-      const patches = channel.emit.mock.calls
-        .filter(([event]) => event === SERVICE_PATCHES)
-        .map(([, payload]) => payload as { serviceId: string; state: Record<string, unknown> });
-
+      const patches = servicePatches(channel);
       expect(patches.map((p) => p.serviceId)).toEqual(['core/module-graph']);
       expect(patches[0].state).not.toHaveProperty('storiesByFile');
       expect(JSON.stringify(patches[0].state).length).toBeLessThan(fatIndexBytes / 20);
       expect(runtime.queries.graphRevision.get(undefined)).toBe(1);
       expect(runtime.queries.storiesForFiles.get({ files: ['./src/file-0.ts'] })).toEqual([
         storyFiles.map((storyFile) => ({ storyFile, depth: 1 })),
+      ]);
+    });
+
+    it('broadcasts the cold index when an update includes storiesByFile', async () => {
+      const channel = createTestChannel();
+      installTestChannel(channel);
+      const { fatIndex } = fatIndexFixture();
+
+      const runtime = registerBareModuleGraph();
+      await runtime.commands._applyGraphSnapshot({ storiesByFile: fatIndex });
+      channel.emit.mockClear();
+
+      const nextIndex = {
+        ...fatIndex,
+        './src/file-new.ts': { './src/story-0.stories.ts': 2 },
+      };
+      await runtime.commands._applyGraphUpdate({
+        storiesByFile: nextIndex,
+        bumpedStoryFiles: ['./src/story-0.stories.ts'],
+      });
+
+      const patches = servicePatches(channel);
+      expect(patches.map((p) => p.serviceId)).toEqual([
+        'core/module-graph-index',
+        'core/module-graph',
+      ]);
+      expect(patches[0].state).toHaveProperty('storiesByFile');
+      expect(patches[0].state.storiesByFile).toEqual(nextIndex);
+      expect(patches[1].state).not.toHaveProperty('storiesByFile');
+      expect(runtime.queries.storiesForFiles.get({ files: ['./src/file-new.ts'] })).toEqual([
+        [{ storyFile: './src/story-0.stories.ts', depth: 2 }],
       ]);
     });
   });

--- a/code/core/src/shared/open-service/services/module-graph/server.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.ts
@@ -6,6 +6,7 @@ import { registerService } from '../../server.ts';
 import { moduleGraphServiceDef } from './definition.ts';
 import type { ChangeDetectionAdapter } from './engine/adapters/types.ts';
 import { ModuleGraphEngine, type ModuleGraphEngineOptions } from './engine/module-graph-engine.ts';
+import { moduleGraphIndexServiceDef } from './index-definition.ts';
 import { errorToErrorLike } from './types.ts';
 
 export type RegisterModuleGraphServiceOptions = {
@@ -38,9 +39,10 @@ export function resolveChangeDetectionAdapter(
 }
 
 /**
- * Registers the `core/module-graph` open service, constructs the graph engine, wires state mirroring
- * into the service commands, and listens for story-index invalidation on the server channel. The
- * engine starts once {@link resolveChangeDetectionAdapter} provides the builder adapter.
+ * Registers `core/module-graph-index` (cold reverse index) and `core/module-graph` (hot revisions),
+ * constructs the graph engine, wires state mirroring into the service commands, and listens for
+ * story-index invalidation on the server channel. The engine starts once
+ * {@link resolveChangeDetectionAdapter} provides the builder adapter.
  *
  * The engine lives for the entire dev-server process, so there is no teardown path: the OS reclaims
  * everything when the process exits.
@@ -48,6 +50,14 @@ export function resolveChangeDetectionAdapter(
 export function registerModuleGraphService(options: RegisterModuleGraphServiceOptions) {
   const workingDir = options.workingDir ?? process.cwd();
   let engine: ModuleGraphEngine | undefined = undefined;
+
+  registerService({
+    ...moduleGraphIndexServiceDef,
+    initialState: {
+      ...moduleGraphIndexServiceDef.initialState,
+      workingDir,
+    },
+  });
 
   const runtime = registerService(
     {

--- a/code/core/src/shared/open-service/services/module-graph/server.ts
+++ b/code/core/src/shared/open-service/services/module-graph/server.ts
@@ -3,10 +3,10 @@ import { STORY_INDEX_INVALIDATED } from 'storybook/internal/core-events';
 import type { Presets } from 'storybook/internal/types';
 
 import { registerService } from '../../server.ts';
+import { registerModuleGraphIndexService } from '../module-graph-index/server.ts';
 import { moduleGraphServiceDef } from './definition.ts';
 import type { ChangeDetectionAdapter } from './engine/adapters/types.ts';
 import { ModuleGraphEngine, type ModuleGraphEngineOptions } from './engine/module-graph-engine.ts';
-import { moduleGraphIndexServiceDef } from './index-definition.ts';
 import { errorToErrorLike } from './types.ts';
 
 export type RegisterModuleGraphServiceOptions = {
@@ -39,10 +39,9 @@ export function resolveChangeDetectionAdapter(
 }
 
 /**
- * Registers `core/module-graph-index` (cold reverse index) and `core/module-graph` (hot revisions),
- * constructs the graph engine, wires state mirroring into the service commands, and listens for
- * story-index invalidation on the server channel. The engine starts once
- * {@link resolveChangeDetectionAdapter} provides the builder adapter.
+ * Registers `core/module-graph-index` then `core/module-graph`, constructs the graph engine, wires
+ * state mirroring into the service commands, and listens for story-index invalidation on the server
+ * channel. The engine starts once {@link resolveChangeDetectionAdapter} provides the builder adapter.
  *
  * The engine lives for the entire dev-server process, so there is no teardown path: the OS reclaims
  * everything when the process exits.
@@ -51,13 +50,7 @@ export function registerModuleGraphService(options: RegisterModuleGraphServiceOp
   const workingDir = options.workingDir ?? process.cwd();
   let engine: ModuleGraphEngine | undefined = undefined;
 
-  registerService({
-    ...moduleGraphIndexServiceDef,
-    initialState: {
-      ...moduleGraphIndexServiceDef.initialState,
-      workingDir,
-    },
-  });
+  registerModuleGraphIndexService(workingDir);
 
   const runtime = registerService(
     {

--- a/code/core/src/shared/open-service/services/module-graph/types.ts
+++ b/code/core/src/shared/open-service/services/module-graph/types.ts
@@ -20,7 +20,6 @@ export type ModuleGraphStatus =
   | { value: 'error'; error: ErrorLike }
   | { value: 'unavailable'; reason: string; error?: ErrorLike };
 
-/** Hot half: status + revision counters. Synced on every in-graph bump. */
 export type ModuleGraphServiceState = {
   /** Project root used to normalize absolute file paths in query inputs. */
   workingDir: string;
@@ -35,7 +34,6 @@ export type ModuleGraphServiceState = {
   latestChangedStoryFiles: string[];
 };
 
-/** Cold half: fat reverse index. Synced only when the index structure moves. */
 export type ModuleGraphIndexServiceState = {
   workingDir: string;
   storiesByFile: StoriesByFileRecord;

--- a/code/core/src/shared/open-service/services/module-graph/types.ts
+++ b/code/core/src/shared/open-service/services/module-graph/types.ts
@@ -20,12 +20,12 @@ export type ModuleGraphStatus =
   | { value: 'error'; error: ErrorLike }
   | { value: 'unavailable'; reason: string; error?: ErrorLike };
 
+/** Hot half: status + revision counters. Synced on every in-graph bump. */
 export type ModuleGraphServiceState = {
   /** Project root used to normalize absolute file paths in query inputs. */
   workingDir: string;
   status: ModuleGraphStatus;
   graphRevision: number;
-  storiesByFile: StoriesByFileRecord;
   /**
    * Per-story revision stamps keyed by story-index-style relative path. Each entry holds the
    * {@link graphRevision} at which that story's subgraph last changed. Seeded to `0` for every
@@ -33,6 +33,12 @@ export type ModuleGraphServiceState = {
    */
   storyChangeRevisions: Record<string, number>;
   latestChangedStoryFiles: string[];
+};
+
+/** Cold half: fat reverse index. Synced only when the index structure moves. */
+export type ModuleGraphIndexServiceState = {
+  workingDir: string;
+  storiesByFile: StoriesByFileRecord;
 };
 
 export function errorToErrorLike(error: unknown): ErrorLike {


### PR DESCRIPTION
Closes #

<!-- Related: #35810 (remaining wire cost after #35825). Does not close #35810 alone — stack with #35825. -->

## What I did

**Proposal:** stop shipping ~18 MB of unchanged `storiesByFile` on every bump-only save **without** `localStateKeys`, by splitting the module graph into two internal OSA services.

Stacked on [#35825](https://github.com/storybookjs/storybook/pull/35825) (engine skip / optional index in the update payload). Together they address the HMR regression in [#35810](https://github.com/storybookjs/storybook/issues/35810): #35825 removes rebuild work on no-ops; this PR removes the fat full-state sync on everyday saves.

### Design

| Service | State | Synced when |
|---|---|---|
| `core/module-graph` (hot) | `status`, `graphRevision`, `storyChangeRevisions`, `latestChangedStoryFiles` | Every in-graph bump |
| `core/module-graph-index` (cold) | `storiesByFile` | Initial snapshot / when the index structure moves |

- Consumers keep using `getService('core/module-graph')` — `storiesForFiles` stays on the hot service and delegates to an **internal** cold query.
- Cold lives in `services/module-graph-index/` and is listed in `serverCoreServiceDefs`; hot registration calls the cold registrar first.
- No OSA protocol escape hatch (`localStateKeys` rejected in #35814 review).

### Why this over alternatives

1. **`localStateKeys`** — works for wire size, but breaks the “OSA state syncs everywhere” promise.
2. **Engine-owned index (not in OSA state)** — also viable; this PR prefers keeping the index as OSA state so server peers / static snapshot paths stay uniform, while partitioning sync by service.
3. **Patch-based sync** — longer-term OSA roadmap; this unblocks #35810’s common path now.

### Measured (same microbench as #35825; 480,400 pairs; rebuild + clone + stringify)

| Workload | Before | #35825 only | **This PR** | #35814 (+ localStateKeys) |
|---|---|---|---|---|
| `.log` / unknown file | 174.5 ms / 18.26 MB | 0 | **0** | 0 |
| Comment/impl, imports stable | 174.5 ms / 18.26 MB | 36.7 ms / **18.26 MB** | **~0 ms / 15.7 KB** | ~0 ms / 15.7 KB |
| Imports changing | 174.5 ms / 18.26 MB | 173.9 ms / 18.26 MB | 172.4 ms / 18.26 MB | 135.9 ms / 15.7 KB |

Everyday auto-save matches Valentin’s wire win. Real import churn still ships the cold index (expected until patch sync or engine-owned index).

### Trade-offs / follow-ups

- Index moves still emit two broadcasts (cold + hot).
- Hot `storyChangeRevisions` scales with story count (~16 KB at 400 stories), not edge count.
- Browser runtimes that need `storiesForFiles` must resolve the hot facade after cold is registered on the server (server-authored today).
- Import-churn wire cost remains; longer-term still wants patch-based sync or keeping the index off the channel entirely.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No sandbox QA required for review of this design. Unit coverage includes channel assertions that:

1. bump-only updates broadcast only `core/module-graph` (no `storiesByFile`)
2. updates that include `storiesByFile` broadcast `core/module-graph-index` then `core/module-graph`

To re-check locally:

```bash
cd code && yarn vitest run --config core/vitest.config.ts shared/open-service/services/module-graph shared/open-service/core-service-types
```

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->