### PR TITLE
Harness: Measure the Angular component meta analyzer against Compodoc

### DIFF
--- a/code/lib/docgen-harness/src/perf/docgen-perf/config.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/config.test.ts
@@ -6,6 +6,7 @@ import { DEFAULT_PROFILE, QUICK_PROFILE, type SuiteProfile } from './config.ts';
 const savesPerScenario = (profile: SuiteProfile): Array<{ name: string; saves: number }> => [
   ...profile.react.map((scenario) => ({ name: `react/${scenario.shape}`, saves: scenario.saves })),
   ...profile.vue.map((scenario) => ({ name: `vue/${scenario.name}`, saves: scenario.saves })),
+  { name: 'angular/default', saves: profile.angular.saves },
 ];
 
 describe.each([

--- a/code/lib/docgen-harness/src/perf/docgen-perf/config.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/config.ts
@@ -1,41 +1,20 @@
-/**
- * Fixed measurement parameters for the per-engine docgen performance suite.
- *
- * N is pinned here for every engine and recorded with the results; numbers taken at different N are
- * not comparable. The --quick profile exists for smoke runs only and marks its results
- * non-comparable.
- */
-
-/**
- * Fresh-process spawns per cold/scan median. One value for all engines.
- *
- * Must stay even. The two sides of a control pair alternate which one runs first on odd and even
- * repetitions, so an odd N gives one side the first slot once more than the other, and the cold
- * figure - a median - then lands on a repetition from the majority slot. That turns the ordering
- * effect the alternation exists to cancel into a systematic, directional bias on the headline ratio.
- */
+// Fresh-process spawns per cold/scan median, and it must stay even: the two sides of a control pair
+// alternate which runs first on odd and even repetitions, so an odd N gives one side the first slot
+// once more than the other and turns the ordering effect into a directional bias on the ratio.
 export const PINNED_N = 6;
 
-/** Spawns for --quick smoke runs. Never comparable with PINNED_N results. */
+// Never comparable with PINNED_N results.
 export const QUICK_N = 2;
 
-/** Sampling interval for the compodoc child's externally-polled peak RSS. */
 export const RSS_POLL_INTERVAL_MS = 100;
 
-/**
- * How long one compodoc run may take before it is killed. Compodoc can hang rather than exit on
- * some inputs, and the orchestrator waits on the child's close event, so a hang without this would
- * stall the whole suite indefinitely instead of failing the one engine.
- */
+// Compodoc can hang rather than exit on some inputs, and the orchestrator waits on the child's close
+// event, so without a kill a hang stalls the whole suite instead of failing the one engine.
 export const COMPODOC_TIMEOUT_MS = 10 * 60 * 1000;
 
-/**
- * How much of the project the cold pass documents - the two shapes Storybook actually runs.
- *
- *   whole-index - one batch over every component, what the manifest generator does.
- *   first-story - the one component a request asked for, what the docgen server does; saves then
- *                 re-extract that same component.
- */
+// How much of the project the cold pass documents - the two shapes Storybook actually runs.
+// `whole-index` is one batch over every component, what the manifest generator does; `first-story` is
+// the one component a request asked for, what the docgen server does.
 export type ReactScenarioShape = 'whole-index' | 'first-story';
 
 export interface ReactScenarioConfig {
@@ -59,6 +38,8 @@ export interface VueScenarioConfig {
 export interface AngularScenarioConfig {
   components: number;
   props: number;
+  // Save-series length for the in-process engine; compodoc has no save loop and ignores it.
+  saves: number;
 }
 
 export interface SuiteProfile {
@@ -106,7 +87,7 @@ export const DEFAULT_PROFILE: SuiteProfile = {
       saves: 10,
     },
   ],
-  angular: { components: 100, props: 8 },
+  angular: { components: 100, props: 8, saves: 10 },
 };
 
 export const QUICK_PROFILE: SuiteProfile = {
@@ -145,5 +126,5 @@ export const QUICK_PROFILE: SuiteProfile = {
       saves: 3,
     },
   ],
-  angular: { components: 10, props: 4 },
+  angular: { components: 10, props: 4, saves: 3 },
 };

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/angular-component-meta.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/angular-component-meta.ts
@@ -1,0 +1,149 @@
+// Series harness for the in-process Angular analyzer, over the same generated project as the
+// compodoc engine so the angular control pair compares the two engines directly.
+//
+// Run from code/lib/docgen-harness:
+//   node --expose-gc src/perf/docgen-perf/engines/angular-component-meta.ts \
+//     --components 100 --props 8 --saves 10 --json /tmp/result.json
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import ts from 'typescript';
+import { z } from 'zod';
+
+import { countOption, parseHarnessOptions } from '../../docgen-shared/args.ts';
+import { SANDBOX_DIRECTORY } from '../../docgen-shared/paths.ts';
+import { type SeriesEngine, harnessMain, runSeriesHarness } from '../../docgen-shared/series.ts';
+import {
+  type GeneratedAngularProject,
+  angularComponentSource,
+  generateAngularProject,
+} from '../generators/angular.ts';
+import { countMembers } from './compodoc-doc.ts';
+
+type AnalyzerModule = typeof import('@storybook/angular-cm');
+type Manager = InstanceType<AnalyzerModule['AngularComponentMetaManager']>;
+
+// The analyzer resolves through built output twice over, so a missing dist makes Node name a path
+// the harness never mentioned - without this the message omits the one thing to do: compile first.
+async function loadAnalyzer(): Promise<AnalyzerModule> {
+  try {
+    return await import('@storybook/angular-cm');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/[/\\]dist[/\\]/.test(message)) {
+      throw new Error(
+        `the angular-component-meta engine needs built output that is missing. Run ` +
+          `\`yarn nx compile angular-cm\` (or \`yarn nx compile core\` when the named path ` +
+          `is storybook's dist) and try again.\n  cause: ${message}`
+      );
+    }
+    throw err;
+  }
+}
+
+const OPTIONS = {
+  components: { type: 'string' },
+  props: { type: 'string' },
+  saves: { type: 'string' },
+  out: { type: 'string' },
+  json: { type: 'string' },
+} as const;
+
+const SCHEMA = z.object({
+  components: countOption(100),
+  props: countOption(8),
+  saves: countOption(10),
+  outDir: z
+    .string()
+    .default(path.join(SANDBOX_DIRECTORY, 'docgen-perf', 'angular-component-meta', 'project')),
+  jsonOut: z.string().optional(),
+});
+
+type Options = z.infer<typeof SCHEMA>;
+
+function parseOptions(argv: string[]): Options {
+  return parseHarnessOptions<Options>(argv, OPTIONS, SCHEMA, (values) => ({
+    ...values,
+    outDir: values.out,
+    jsonOut: values.json,
+  }));
+}
+
+// Counted through the same function as compodoc's `documentation.json`, so both sides of the pair
+// count members by one rule.
+function extractOne(manager: Manager, project: GeneratedAngularProject, index: number): number {
+  const componentPath = project.componentPaths[index];
+  const result = manager.extractComponentMeta(componentPath, {
+    exportName: `Comp${index}Component`,
+  });
+  if (!result) {
+    throw new Error(`no component meta extracted from ${componentPath}`);
+  }
+  const { entry } = result;
+  // Only component/directive records carry the four member arrays; anything else counting as zero
+  // would report a broken analyzer as a fast one.
+  if (entry.type !== 'component' && entry.type !== 'directive') {
+    throw new Error(`expected a component entry for ${componentPath}, got "${entry.type}"`);
+  }
+  const { members } = countMembers([entry]);
+  if (members === 0) {
+    throw new Error(`angular-component-meta documented zero members for ${componentPath}`);
+  }
+  return members;
+}
+
+async function createEngine(options: Options): Promise<SeriesEngine> {
+  const analyzer = await loadAnalyzer();
+  const genStart = Date.now();
+  const project = generateAngularProject({
+    outDir: options.outDir,
+    components: options.components,
+    props: options.props,
+  });
+  console.log(`  generated project in ${Date.now() - genStart}ms at ${project.outDir}`);
+
+  const extraProps = new Array<number>(options.components).fill(0);
+  let manager: Manager | undefined;
+  let measured = 0;
+
+  return {
+    async cold() {
+      manager = new analyzer.AngularComponentMetaManager(ts);
+      let members = 0;
+      for (let index = 0; index < project.componentPaths.length; index++) {
+        members += extractOne(manager, project, index);
+      }
+      return members;
+    },
+    async applySave(save) {
+      // The same mutation the compodoc engine's warm run applies to component 0 - the touched
+      // component gains one extra input - walked round-robin, which is sound here because the cold
+      // pass documented every component (see PERF-METHODOLOGY.md on save targets).
+      const index = (save - 1) % project.componentPaths.length;
+      extraProps[index] += 1;
+      const filePath = project.componentPaths[index];
+      fs.writeFileSync(filePath, angularComponentSource(index, options.props + extraProps[index]));
+      manager!.onFilesChanged([{ filePath, type: 'changed' }]);
+      measured = index;
+    },
+    async reextract() {
+      return extractOne(manager!, project, measured);
+    },
+    dispose() {
+      manager?.dispose();
+    },
+  };
+}
+
+harnessMain(async () => {
+  const options = parseOptions(process.argv.slice(2));
+  await runSeriesHarness({
+    title: 'angular-component-meta harness',
+    options,
+    banner: { components: options.components, props: options.props, saves: options.saves },
+    saves: options.saves,
+    coldLabel: `${options.components} components, manager creation included`,
+    jsonOut: options.jsonOut,
+    setup: async () => createEngine(options),
+  });
+});

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/compodoc-doc.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/compodoc-doc.ts
@@ -1,19 +1,17 @@
-/**
- * Reading compodoc's `documentation.json`.
- *
- * Compodoc records how much it documented and how much of it it actually resolved, which is what
- * makes its timings readable: it never expands a named type, so a chain of aliases costs it nothing
- * and it still reports every member. Counting members alone would let it look equal to an engine
- * that did far more work.
- */
+// Compodoc never expands a named type, so a chain of aliases costs it nothing while it still reports
+// every member. Counting members alone would let it look equal to an engine that did far more work,
+// which is why the opaque-type count is read alongside them.
 import * as fs from 'node:fs';
 
 interface MemberEntry {
+  name?: string;
   type?: string;
   subProperties?: unknown[];
 }
 
-interface MemberHolder {
+// Exported so the angular-component-meta engine counts its entries through `countMembers` too: the
+// pair's like-for-like verdict rests on both sides being counted by one rule.
+export interface MemberHolder {
   inputsClass?: MemberEntry[];
   outputsClass?: MemberEntry[];
   propertiesClass?: MemberEntry[];
@@ -27,22 +25,17 @@ interface Documentation {
 
 const MEMBER_ARRAYS = ['inputsClass', 'outputsClass', 'propertiesClass', 'methodsClass'] as const;
 
-/**
- * `classes` is deliberately left out. Compodoc copies an ancestor's members into every descendant's
- * own arrays, so a base class documented under `classes` would be counted a second time. This also
- * matches what Storybook reads, which is a component's own four arrays.
- */
-function documentedMembers(doc: Documentation): MemberEntry[] {
-  return [...(doc.components ?? []), ...(doc.directives ?? [])].flatMap((holder) =>
-    MEMBER_ARRAYS.flatMap((key) => holder[key] ?? [])
-  );
+// `classes` is deliberately left out: compodoc copies an ancestor's members into every descendant's
+// own arrays, so a base class documented there would be counted a second time.
+function documentedHolders(doc: Documentation): MemberHolder[] {
+  return [...(doc.components ?? []), ...(doc.directives ?? [])];
 }
 
-/**
- * Names that describe themselves, so recording one is not a resolution an engine skipped. Keyword
- * spellings are lowercase as compodoc emits them (`function`, not `Function`); both are listed
- * because the two spellings reach the same member field.
- */
+// Names that describe themselves, so recording one is not a resolution an engine skipped. Both
+// spellings of a keyword are listed because they reach the same member field.
+//
+// A different question from the gate's `resolvesStub`, which asks whether a baseline recorded
+// anything at all: `undefined` is a resolved type name here and an extraction-failure marker there.
 const RESOLVED_TYPES = new Set([
   'string',
   'number',
@@ -63,14 +56,8 @@ const RESOLVED_TYPES = new Set([
   'Object',
 ]);
 
-/**
- * A member whose type is a bare name the engine never looked through - `Hop19Shape`, not
- * `{ x: string }`. Inline object literals, primitives and literal unions are all self-describing,
- * so only a lone identifier counts.
- *
- * This is a floor: wrapped forms such as `Partial<Shape>` are equally unresolved but do not match,
- * so the true share of unresolved types is at least what this reports.
- */
+// A member whose type is a bare name the engine never looked through. Only a lone identifier counts,
+// so wrapped forms like `Partial<Shape>` are missed and the reported share is a floor.
 function isOpaque(entry: MemberEntry): boolean {
   if (entry.subProperties?.length || !entry.type) {
     return false;
@@ -84,8 +71,12 @@ export interface DocumentationCounts {
   opaqueTypes: number;
 }
 
+export function countMembers(holders: MemberHolder[]): DocumentationCounts {
+  const members = holders.flatMap((holder) => MEMBER_ARRAYS.flatMap((key) => holder[key] ?? []));
+  return { members: members.length, opaqueTypes: members.filter(isOpaque).length };
+}
+
 export function countDocumentation(documentationJsonPath: string): DocumentationCounts {
   const doc = JSON.parse(fs.readFileSync(documentationJsonPath, 'utf8')) as Documentation;
-  const members = documentedMembers(doc);
-  return { members: members.length, opaqueTypes: members.filter(isOpaque).length };
+  return countMembers(documentedHolders(doc));
 }

--- a/code/lib/docgen-harness/src/perf/docgen-perf/engines/compodoc.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/engines/compodoc.ts
@@ -17,18 +17,16 @@ import { angularComponentSource, generateAngularProject } from '../generators/an
 import type { EngineId, EngineMetrics, MemberCounts } from '../types.ts';
 
 interface ResolvedCompodoc {
-  /** The CLI entry point, run as `node <cli>` so no shell shim or exec bit is involved. */
+  // The CLI entry point, run as `node <cli>` so no shell shim or exec bit is involved.
   cli: string;
   version: string;
 }
 
-/** The canonical install. A pin names an alias of it - see docgen-shared/pin.ts. */
+// The canonical install. A pin names an alias of it - see docgen-shared/pin.ts.
 const COMPODOC_PACKAGE = '@compodoc/compodoc';
 
-/**
- * An alias keeps the aliased package's own name, so the name check is what stops a pin naming some
- * other package from being measured as compodoc.
- */
+// An alias keeps the aliased package's own name, so the name check is what stops a pin naming some
+// other package from being measured as compodoc.
 function resolveCompodoc(specifier: string): ResolvedCompodoc | undefined {
   const found = resolvePin(specifier);
   if (found?.name !== COMPODOC_PACKAGE || !found.bin?.compodoc) {
@@ -39,11 +37,8 @@ function resolveCompodoc(specifier: string): ResolvedCompodoc | undefined {
 
 interface CompodocRun extends DocumentationCounts {
   durMs: number;
-  /**
-   * Undefined when no poll ever read the child's RSS - `ps` is POSIX-only, and a run shorter than
-   * one interval is never sampled. Reporting the initial 0 instead would put a fabricated peak in
-   * the results, which is the one thing a floor may not become.
-   */
+  // Undefined when no poll ever read the child's RSS: `ps` is POSIX-only, and a run shorter than one
+  // interval is never sampled. Reporting the initial 0 would put a fabricated peak in the results.
   peakRssMb: number | undefined;
 }
 
@@ -130,13 +125,10 @@ function runCompodocOnce(
   });
 }
 
-/**
- * One repetition: fresh project, cold full run, touch one component, warm full run. Both runs are
- * fresh compodoc processes, matching the one-sample-per-fresh-process topology.
- */
+// Both runs are fresh compodoc processes, matching the one-sample-per-fresh-process topology.
 export async function runCompodocRepetition(
   cli: string,
-  scenario: AngularScenarioConfig,
+  scenario: Pick<AngularScenarioConfig, 'components' | 'props'>,
   workDir: string,
   pollIntervalMs: number
 ): Promise<OneShotRepetition> {
@@ -169,10 +161,7 @@ export async function runCompodocRepetition(
   };
 }
 
-/**
- * Compodoc is a spawned CLI rather than an imported module, so its pin selects which CLI to run.
- * A version pair is two entries differing only in `pin`, as it is for the series engines.
- */
+// Compodoc is a spawned CLI rather than an imported module, so its pin selects which CLI to run.
 export interface CompodocConfig {
   id: EngineId;
   pin: string;
@@ -196,9 +185,11 @@ export class CompodocEngine extends BenchEngine<OneShotRepetition> {
   scenarios(profile: SuiteProfile): ScenarioSpec[] {
     // The poll interval rides in params because it qualifies the peak this engine reports: the
     // sample misses spikes shorter than the gap between polls, so the recorded peak is a floor and
-    // reading it later means knowing how wide that gap was.
+    // reading it later means knowing how wide that gap was. The profile's `saves` stays out: this
+    // engine has no save loop, and recording one would misdescribe the run.
+    const { components, props } = profile.angular;
     return [
-      { name: 'default', params: { ...profile.angular, rssPollIntervalMs: RSS_POLL_INTERVAL_MS } },
+      { name: 'default', params: { components, props, rssPollIntervalMs: RSS_POLL_INTERVAL_MS } },
     ];
   }
 

--- a/code/lib/docgen-harness/src/perf/docgen-perf/ratios.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/ratios.ts
@@ -1,8 +1,5 @@
-/**
- * The calibration references: each framework's legacy-engine median divided by its new-engine
- * median, both measured in the same invocation. Ratios stand in for absolute milliseconds because
- * wall-clock on shared CI executors is too noisy to gate (PERF-METHODOLOGY.md, "Budget shape").
- */
+// Ratios stand in for absolute milliseconds because wall-clock on shared CI executors is too noisy
+// to gate. See PERF-METHODOLOGY.md, "Budget shape".
 import type {
   Comparability,
   EngineId,
@@ -14,10 +11,13 @@ import type {
 } from './types.ts';
 
 interface ControlPair {
-  /** Key under which this pair's ratios appear in the results. */
+  // Key under which this pair's ratios appear in the results.
   name: string;
   legacy: EngineId;
   next: EngineId;
+  // The two sides count different things on a save, so their warm member counts say nothing about
+  // whether the ratio is like-for-like and are left out rather than compared.
+  warmScopeDiffers?: true;
 }
 
 // A pair whose engines are not both registered yields no ratio, so a pair may be listed before the
@@ -25,6 +25,14 @@ interface ControlPair {
 export const CONTROL_PAIRS: ControlPair[] = [
   { name: 'react', legacy: 'react-legacy', next: 'react-osa' },
   { name: 'vue', legacy: 'vue-docgen-api', next: 'vue-component-meta' },
+  // compodoc's warm pass re-documents the whole project; the analyzer re-extracts the one component
+  // that changed.
+  {
+    name: 'angular',
+    legacy: 'compodoc',
+    next: 'angular-component-meta',
+    warmScopeDiffers: true,
+  },
   {
     name: 'vue-component-meta-version',
     legacy: 'vue-component-meta',
@@ -32,25 +40,15 @@ export const CONTROL_PAIRS: ControlPair[] = [
   },
 ];
 
-/**
- * Even repetitions run the engines back to front, so cache warming and thermal drift do not
- * consistently favour whichever side of a pair is listed first.
- *
- * Reversing the whole list rather than swapping each pair in place is what makes that hold for
- * *every* pair at once. Pairs can share an engine - `vue-component-meta` is the new side of the vue
- * pair and the legacy side of the version pair - and swapping such a chain pairwise moves the shared
- * engine twice, which puts the first pair back in its original relative order.
- */
+// Even repetitions run the engines back to front, so cache warming and thermal drift do not
+// consistently favour whichever side of a pair is listed first. Reversing the whole list rather than
+// swapping each pair in place is what makes that hold for pairs that share an engine.
 export function engineOrderForRep(engines: EngineId[], rep: number): EngineId[] {
   return rep % 2 === 0 ? [...engines].reverse() : [...engines];
 }
 
-/**
- * Undefined unless both sides measured: dividing by a skipped or failed side is not a comparison.
- *
- * A zero denominator is treated the same way. It means the new engine's median landed below the
- * clock's resolution, and Infinity would then be rendered and stored as if it were a ratio.
- */
+// Undefined unless both sides measured, and for a zero denominator too: an Infinity would be
+// rendered and stored as if it were a ratio.
 function medianRatio(legacy: Metric, next: Metric) {
   if (legacy.status !== 'measured' || next.status !== 'measured') {
     return undefined;
@@ -59,14 +57,8 @@ function medianRatio(legacy: Metric, next: Metric) {
   return Number.isFinite(ratio) ? ratio : undefined;
 }
 
-/**
- * Member counts decide first, and any difference there settles it. Only once they agree does the
- * count of types an engine never looked through get a say, which is the case a member count on its
- * own cannot see.
- *
- * A missing count on either side yields `unknown` rather than a verdict. Treating it as agreement
- * would mark a pair like-for-like on the strength of a number nobody measured.
- */
+// Member counts settle it whenever they differ; the opaque-type counts only break a tie, because
+// documenting a type's name without looking through it is the case a member count cannot see.
 function comparability(
   legacyMembers: number | undefined,
   nextMembers: number | undefined,
@@ -91,6 +83,11 @@ function ratioFor(
   next: ScenarioResult,
   versions: PairVersions
 ): RatioEntry {
+  const warmMembers: Pick<RatioEntry, 'legacyWarmMembers' | 'nextWarmMembers'> =
+    pair.warmScopeDiffers
+      ? {}
+      : { legacyWarmMembers: legacy.warmMembers, nextWarmMembers: next.warmMembers };
+
   return {
     legacyEngine: pair.legacy,
     nextEngine: pair.next,
@@ -98,8 +95,7 @@ function ratioFor(
     warm: medianRatio(legacy.metrics.warmExtractionMs, next.metrics.warmExtractionMs),
     legacyColdMembers: legacy.coldMembers,
     nextColdMembers: next.coldMembers,
-    legacyWarmMembers: legacy.warmMembers,
-    nextWarmMembers: next.warmMembers,
+    ...warmMembers,
     coldComparability: comparability(
       legacy.coldMembers,
       next.coldMembers,
@@ -107,7 +103,8 @@ function ratioFor(
       next.coldOpaqueTypes
     ),
     // No engine reports opaque types for the re-extracted member, so warm is judged on counts alone.
-    warmComparability: comparability(legacy.warmMembers, next.warmMembers),
+    // Omitted counts yield `unknown`, which is what a differing warm scope must report.
+    warmComparability: comparability(warmMembers.legacyWarmMembers, warmMembers.nextWarmMembers),
     ...versions,
   };
 }
@@ -117,14 +114,8 @@ interface PairVersions {
   nextVersion?: string;
 }
 
-/**
- * Ratios for every control pair whose two engines both measured in this invocation. A pair with one
- * failed or skipped side yields nothing: dividing a fresh median by a stale one is not a comparison.
- *
- * Resolved versions ride along because a pair can have both sides land on the same version - a
- * range on one side is enough - and a ratio of one taken against itself must not read as a clean
- * result.
- */
+// Resolved versions ride along because a range on one side can land both sides on the same version,
+// and a ratio taken against itself must not read as a clean result.
 export function computeRatios(
   results: Partial<Record<EngineId, EngineResult>>,
   engineVersions: Partial<Record<EngineId, string>> = {}

--- a/code/lib/docgen-harness/src/perf/docgen-perf/registry.test.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/registry.test.ts
@@ -9,7 +9,7 @@ import { CONTROL_PAIRS } from './ratios.ts';
 import { ALL_ENGINE_IDS, DEFAULT_ENGINE_IDS, ENGINES, engineById } from './registry.ts';
 import type { EngineId } from './types.ts';
 
-/** Captures what an engine would have spawned, without spawning it. */
+// Captures what an engine would have spawned, without spawning it.
 function captureSpawn() {
   const calls: Array<{ spec: Parameters<MeasureContext['runSeriesChild']>[0]; jsonPath: string }> =
     [];
@@ -29,7 +29,8 @@ async function specFor(id: EngineId, scenario: ScenarioSpec, rep = 1) {
   return calls[0];
 }
 
-/** Everything that describes the generated project, which is what a flag comparison is about. */
+// The pin selects a version rather than describing the generated project, so a flag comparison
+// drops it.
 function withoutPin(args: string[]): string[] {
   const pin = args.indexOf('--pin');
   return pin === -1 ? args : [...args.slice(0, pin), ...args.slice(pin + 2)];
@@ -39,6 +40,7 @@ const reactScenario = engineById('react-legacy').scenarios(QUICK_PROFILE)[0];
 const vueFlatScenario = engineById('vue-component-meta')
   .scenarios(QUICK_PROFILE)
   .find((s) => s.name === 'flat')!;
+const angularScenario = engineById('angular-component-meta').scenarios(QUICK_PROFILE)[0];
 
 describe('the engine table', () => {
   it('registers each id exactly once', () => {
@@ -48,6 +50,11 @@ describe('the engine table', () => {
   it('keeps the unbudgeted react-docgen-typescript engine out of the default run', () => {
     expect(DEFAULT_ENGINE_IDS).not.toContain('react-legacy-rdt');
     expect(ALL_ENGINE_IDS).toContain('react-legacy-rdt');
+  });
+
+  it('keeps the unbudgeted angular-component-meta engine out of the default run', () => {
+    expect(DEFAULT_ENGINE_IDS).not.toContain('angular-component-meta');
+    expect(ALL_ENGINE_IDS).toContain('angular-component-meta');
   });
 
   it('names an engine that is not registered', () => {
@@ -102,6 +109,7 @@ describe('what the series engines spawn', () => {
     expect((await specFor('react-osa', reactScenario)).spec.jiti).toBe(true);
     expect((await specFor('react-legacy', reactScenario)).spec.jiti).toBeFalsy();
     expect((await specFor('react-legacy-rdt', reactScenario)).spec.jiti).toBeFalsy();
+    expect((await specFor('angular-component-meta', angularScenario)).spec.jiti).toBeFalsy();
   });
 
   it('sends the two React legacy engines to one child with different parsers', async () => {
@@ -162,6 +170,25 @@ describe('what the series engines spawn', () => {
       expect(withoutPin(meta.spec.args), scenario.name).toEqual(withoutPin(legacy.spec.args));
       expect(meta.spec.childPath).not.toBe(legacy.spec.childPath);
     }
+  });
+
+  it('measures both Angular engines on the same scenario name, so the pair produces a ratio', () => {
+    const compodocNames = engineById('compodoc')
+      .scenarios(QUICK_PROFILE)
+      .map((s) => s.name);
+    const metaNames = engineById('angular-component-meta')
+      .scenarios(QUICK_PROFILE)
+      .map((s) => s.name);
+    expect(metaNames).toEqual(compodocNames);
+  });
+
+  it('generates the same Angular project for both engines, so the ratio compares engines not corpora', async () => {
+    const compodoc = engineById('compodoc').scenarios(QUICK_PROFILE)[0];
+    const { spec } = await specFor('angular-component-meta', angularScenario);
+    const flag = (name: string) => spec.args[spec.args.indexOf(name) + 1];
+    expect(flag('--components')).toBe(String(compodoc.params.components));
+    expect(flag('--props')).toBe(String(compodoc.params.props));
+    expect(flag('--saves')).toBe(String(QUICK_PROFILE.angular.saves));
   });
 
   it('writes each repetition to its own result file', async () => {

--- a/code/lib/docgen-harness/src/perf/docgen-perf/registry.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-perf/registry.ts
@@ -1,8 +1,5 @@
-/**
- * The engine table. Adding an engine means adding one entry here; the orchestrator has no
- * per-engine branches. Everything below is data: which child to spawn, with which flags, over
- * which scenarios.
- */
+// The engine table: adding an engine means adding one entry here, and the orchestrator has no
+// per-engine branches.
 import type { SuiteProfile } from './config.ts';
 import { type BenchEngine, type ScenarioSpec, SeriesChildEngine } from './engine.ts';
 import { CompodocEngine } from './engines/compodoc.ts';
@@ -21,6 +18,21 @@ const reactArgs = ({ params }: ScenarioSpec): string[] => [
   String(params.components),
   '--variants',
   String(params.variants),
+  '--props',
+  String(params.props),
+  '--saves',
+  String(params.saves),
+];
+
+const angularScenarios = (profile: SuiteProfile): ScenarioSpec[] => [
+  // Named like compodoc's one scenario, because a control pair only produces a ratio for scenario
+  // names both sides measured.
+  { name: 'default', params: { ...profile.angular } },
+];
+
+const angularArgs = ({ params }: ScenarioSpec): string[] => [
+  '--components',
+  String(params.components),
   '--props',
   String(params.props),
   '--saves',
@@ -98,6 +110,16 @@ export const ENGINES: BenchEngine[] = [
     pin: 'vue-component-meta-next',
   }),
   new CompodocEngine(),
+  // The in-process Angular analyzer, over the same generated project as the compodoc engine above,
+  // so the angular control pair compares the two engines directly. It carries no budget row yet,
+  // so it stays out of the default run.
+  new SeriesChildEngine({
+    id: 'angular-component-meta',
+    child: 'engines/angular-component-meta.ts',
+    scenarios: angularScenarios,
+    inDefaultRun: false,
+    args: angularArgs,
+  }),
   // Always fails. The gate names it explicitly to prove the gate reports a failing engine as a
   // failure; nothing else ever runs it.
   new SeriesChildEngine({

--- a/code/lib/docgen-harness/src/perf/docgen-shared/engine-ids.ts
+++ b/code/lib/docgen-harness/src/perf/docgen-shared/engine-ids.ts
@@ -1,6 +1,3 @@
-/**
- * The docgen engines under measurement.
- */
 export type EngineId =
   | 'react-legacy'
   | 'react-legacy-rdt'
@@ -9,5 +6,6 @@ export type EngineId =
   | 'vue-component-meta'
   | 'vue-component-meta-next'
   | 'compodoc'
+  | 'angular-component-meta'
   // Not an engine: a deliberately failing entry the perf gate uses as its negative control.
   | 'crash-control';


### PR DESCRIPTION
## What I did

The docgen perf suite could time Compodoc but had nothing to time it against, so "is the Angular analyzer actually faster" was a question the suite could not answer. This registers `angular-component-meta` as an engine over the same generated project the compodoc engine already uses, which turns the Angular entry in the control-pair table into a real engine-vs-engine comparison.

Split out of #35808, which is about the baseline recorders. Nothing here was reachable from those: the perf tree never referenced the compare or sandbox-baselines layers.

### The pair

```
  generators/angular.ts  ->  one generated project, N components, M props
              │
      ┌───────┴────────┐
      │                │
  compodoc CLI     AngularComponentMetaManager
  (spawned)        (in-process, @storybook/angular-cm)
      │                │
      ▼                ▼
 documentation.json   per-component entry
      │                │
      └──── countMembers() ────┘   one counting rule for both sides
                   │
                   ▼
            ratios.ts -> cold ratio + comparability verdict
```

Both sides count members through the same `countMembers`, so the like-for-like verdict rests on one rule rather than two. The manager is constructed inside the cold pass because program build is part of first-extraction cost, matching how `vue-component-meta` treats checker creation.

### Warm is not comparable for this pair, and said so wrongly

`compodoc`'s warm pass is a second whole-project run. The analyzer's warm pass re-extracts the one component that changed. Those member counts describe different scopes, so feeding them to the same comparability rule produced a verdict that read as a regression:

```
ratio warm (compodoc over angular-component-meta, default): 148.71  [documented members 91 vs 10 - NOT like-for-like - new engine documented less, so it is fast for the wrong reason]
```

91 is the whole project; 10 is the single re-extracted component. The analyzer did not document less, it measured a different scope. A pair can now declare that:

```ts
{
  name: 'angular',
  legacy: 'compodoc',
  next: 'angular-component-meta',
  warmScopeDiffers: true,
}
```

which omits the warm member counts and leaves the verdict `unknown`, so the line carries the ratio without a claim it cannot support:

```
ratio warm (compodoc over angular-component-meta, default): 143.56
```

### Commands

Run from the repository root.

| command | what it does |
|---|---|
| `yarn workspace @storybook/docgen-harness bench:docgen-perf --quick --engine angular-component-meta` | smoke-runs the new engine alone |
| `yarn workspace @storybook/docgen-harness bench:docgen-perf --quick --engine angular-component-meta --engine compodoc` | runs both sides so the pair produces a ratio |
| `yarn test --project "@storybook/docgen-harness"` | the harness suite, including the engine-table checks |

The engine is `inDefaultRun: false` — it carries no budget row yet, so a plain `bench:docgen-perf` does not run it.

### What a run looks like

```
results
  engine/scenario                 cold   warm   scan   peak     ret-growth  ret-slope
  angular-component-meta/default  119ms  2ms    n/a    1.7MB    0.3MB       0.05MB/save
  compodoc/default                397ms  344ms  397ms  203.9MB  n/a         n/a
  each ratio divides the first engine's median by the second's, so above 1.00 means the second is faster
  ratio cold (compodoc over angular-component-meta, default): 3.34  [documented members 90 vs 90]
  ratio warm (compodoc over angular-component-meta, default): 143.56
```

`--quick` numbers are smoke values and the suite marks them non-comparable; the shape of the output is the point here, not the figures.

### What a bad run looks like

The engine resolves through built output twice over - the specifier lands on this package's dist, whose imports land on storybook's - so a missing build makes Node name a path the harness never mentioned. Running the child directly redirects that:

```
Error: the angular-component-meta engine needs built output that is missing. Run `yarn nx compile angular-cm` (or `yarn nx compile core` when the named path is storybook's dist) and try again.
  cause: Cannot find module '<repo>/node_modules/@storybook/angular-cm/dist/index.js' imported from <repo>/code/lib/docgen-harness/src/perf/docgen-perf/engines/angular-component-meta.ts
```

Known rough edge, pre-existing and not introduced here: through the suite rather than the child, the parent reports only the tail of the child's output, so that headline is trimmed off and a maintainer sees four stack frames instead:

```
docgen-perf suite FAILED:
  - angular-component-meta: child exited with status 1:
        at loadAnalyzer (.../engines/angular-component-meta.ts:34:13)
        at async createEngine (.../engines/angular-component-meta.ts:96:20)
        at async runSeriesHarness (.../docgen-shared/series.ts:135:18)
```

The redirect is worth keeping for direct child runs; widening the tail so a child's error headline survives belongs with `docgen-shared/child-output.ts` rather than with this engine.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

The engine-table tests assert that every control pair names two registered engines, that both sides of a default-run pair are on by default, and that each spawning engine points at a child script that exists — the last one is what stops a wrong `child` path surfacing only at runtime after full project generation has been paid for.

#### Manual testing

1. Check out this branch and run `yarn`, then `yarn nx compile angular-cm`.
2. Run `yarn workspace @storybook/docgen-harness bench:docgen-perf --quick --engine angular-component-meta --engine compodoc`.
3. Expect a `results` table with both engines and two ratio lines. The `ratio cold` line should carry `[documented members N vs N]` with both numbers equal; the `ratio warm` line should carry no member-count bracket at all.
4. To see the gate the flag replaces, delete `warmScopeDiffers: true` from the angular entry in `src/perf/docgen-perf/ratios.ts` and re-run step 2. The warm line should gain `NOT like-for-like - new engine documented less`. Revert it.
5. Run `yarn test --project "@storybook/docgen-harness"` and expect it green.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user-facing documentation: nothing here ships. `PERF-METHODOLOGY.md` already describes the control-pair and ratio methodology this follows.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
