### PR TITLE
React: Guard docgen extraction against TypeScript builds without the compiler API

### DIFF
--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.test.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.test.ts
@@ -74,6 +74,21 @@ describe('sortTSConfigs', () => {
 });
 
 // ---------------------------------------------------------------------------
+// ComponentMetaManager: TypeScript compiler API guard
+// ---------------------------------------------------------------------------
+
+describe('TypeScript compiler API guard', () => {
+  it('throws a clear error when the resolved `typescript` has no compiler API (e.g. TS 7 preview)', () => {
+    // TypeScript 7's `typescript` package ships only version info from its main entry, so
+    // `import('typescript')` can resolve without `ts.sys`. Constructing with that shape must fail
+    // fast with an actionable message instead of crashing deep in project setup.
+    const versionOnlyTs = { version: '7.0.2', versionMajorMinor: '7.0' } as unknown as typeof ts;
+
+    expect(() => new ComponentMetaManager(versionOnlyTs)).toThrow(/compiler API/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ComponentMetaManager: multi-project scenarios
 // ---------------------------------------------------------------------------
 

--- a/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/ComponentMetaManager.ts
@@ -99,6 +99,24 @@ function createReactProjectFactory(typescript: typeof ts): {
   };
 }
 
+/**
+ * `import('typescript')` can resolve to a namespace that carries only version info: TypeScript 7's
+ * `typescript` package ships `lib/version.cjs` as its sole entry point, so `ts.sys` (and the
+ * factories the manager builds on) are `undefined`. Without this check, extraction crashes deep in
+ * project setup with a cryptic "Cannot read properties of undefined"; fail fast so callers can fall
+ * back to their no-TypeScript path.
+ */
+function assertTypeScriptCompilerApi(typescript: typeof ts): void {
+  if (typeof typescript?.sys?.fileExists !== 'function') {
+    throw new Error(
+      'The resolved `typescript` package does not expose the compiler API (`ts.sys` is undefined). ' +
+        'This happens when `typescript` resolves to a build without the full API, such as the ' +
+        'TypeScript 7 native-preview package. Component metadata extraction requires a standard ' +
+        'TypeScript installation.'
+    );
+  }
+}
+
 export class ComponentMetaManager extends BaseComponentMetaManager<
   ComponentMetaProject,
   ts.ParsedCommandLine
@@ -112,6 +130,7 @@ export class ComponentMetaManager extends BaseComponentMetaManager<
    *   to disable recycling and assert the OOM still happens without the fix.
    */
   constructor(typescript: typeof ts, recycleHeapPressureRatio?: number) {
+    assertTypeScriptCompilerApi(typescript);
     const { factory, fsFileSnapshots } = createReactProjectFactory(typescript);
     super(typescript, factory, recycleHeapPressureRatio);
     this.fsFileSnapshots = fsFileSnapshots;

--- a/code/renderers/react/src/componentManifest/componentMetaManagerSingleton.ts
+++ b/code/renderers/react/src/componentManifest/componentMetaManagerSingleton.ts
@@ -22,10 +22,8 @@ export function getSharedComponentMetaManager(): Promise<ComponentMetaManager | 
       try {
         const ts = await import('typescript');
         return new ComponentMetaManager(ts);
-      } catch {
-        logger.debug(
-          '[reactComponentMeta] TypeScript not available, skipping component meta extraction.'
-        );
+      } catch (err) {
+        logger.debug(`[reactComponentMeta] Skipping component metadata extraction: ${err}`);
         return undefined;
       }
     })();

--- a/code/renderers/react/src/componentManifest/reactDocgen/utils.ts
+++ b/code/renderers/react/src/componentManifest/reactDocgen/utils.ts
@@ -130,7 +130,6 @@ export const getTsConfig = async () => {
   try {
     const ts = await import('typescript');
     const tsconfigPath = ts.findConfigFile(process.cwd(), ts.sys.fileExists);
-    console.log({ tsconfigPath });
     if (tsconfigPath === undefined) {
       return {};
     }

--- a/code/renderers/react/src/docgen/docgen-worker.ts
+++ b/code/renderers/react/src/docgen/docgen-worker.ts
@@ -14,6 +14,7 @@
  * to the `react-docgen-typescript` engine used by the legacy manifest path — not here.
  */
 import { createLazyDocgenMiddleware } from 'storybook/internal/common';
+import { logger } from 'storybook/internal/node-logger';
 import type { DocgenMiddleware } from 'storybook/internal/types';
 
 import { ComponentMetaManager } from '../componentManifest/componentMeta/ComponentMetaManager.ts';
@@ -31,7 +32,8 @@ export const createDocgenProvider = (): DocgenMiddleware =>
       try {
         const ts = await import('typescript');
         return new ComponentMetaManager(ts);
-      } catch {
+      } catch (err) {
+        logger.debug(`[reactComponentMeta] Docgen provider disabled: ${err}`);
         return undefined;
       }
     },


### PR DESCRIPTION
`#35792` reports that `experimentalDocgenServer` + `componentsManifest` on **TypeScript 7** crashes the docgen worker with `Cannot read properties of undefined (reading 'fileExists')`. Root cause (well diagnosed by the reporter): TS 7's `typescript` package only exports `lib/version.cjs` from its main entry, so `await import('typescript')` resolves to a namespace with `version` but **no compiler API** (`ts.sys` is `undefined`).

On `next` the hard crash no longer reproduces the same way: the `BaseComponentMetaManager` refactor moved the first `ts.sys` access into construction (`createDocumentRegistry(ts.sys.useCaseSensitiveFileNames)`), so the existing `try/catch` around `new ComponentMetaManager(ts)` in both entry points already swallows it and falls back to `undefined`. But that fallback is **silent** in the docgen worker and **mislabeled** in the singleton (`"TypeScript not available"`, when TS *is* installed) — so a TS 7 user just gets empty component docs with no explanation.

This PR makes that path explicit and diagnosable:

- **Fail fast at the invariant.** `ComponentMetaManager`'s constructor now asserts the resolved `typescript` actually exposes the compiler API and throws a clear, actionable error otherwise, instead of crashing later on a cryptic `undefined` read. Both call sites already catch and degrade gracefully.
- **Accurate diagnostics.** The singleton no longer claims `"TypeScript not available"`; both entry points now `logger.debug` the real reason, so the TS 7 case is visible when debugging.
- **Removed a stray `console.log({ tsconfigPath })`** in `getTsConfig` that leaked to the dev-server stdout.

### Testing

- Added a regression test: constructing `ComponentMetaManager` with a version-only `typescript` stub (the TS 7 shape) throws the clear compiler-API error. Verified red/green — without the guard the constructor throws the cryptic `Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`.
- `ComponentMetaManager.test.ts` green (20/20).

### Scope

This intentionally does **not** add TS 7 native-preview *support* for docgen (the compiler API genuinely isn't there) — it makes the unsupported path degrade cleanly and legibly instead of crashing. Happy to escalate the `logger.debug` to a one-time `warn` if you'd prefer TS 7 users to see it surfaced.

Closes #35792

---

🤖 **AI disclosure:** Implemented with AI assistance (Claude Code). The root-cause analysis, the red/green reproduction of the TypeScript 7 shape, and all verification were done and reviewed by me.
