### PR TITLE
Addon-Pseudostates: Preserve zero specificity of :where() when rewriting selectors

### DIFF
--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -390,6 +390,54 @@ describe('rewriteStyleSheet', () => {
     );
   });
 
+  it('supports ":where"', () => {
+    const sheet = new Sheet('.textLink:where(:focus-visible) { text-decoration: none }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].cssText).toEqual(
+      '.textLink:where(:focus-visible), .textLink:where(.pseudo-focus-visible), :where(.pseudo-focus-visible-all) .textLink { text-decoration: none }'
+    );
+  });
+
+  it('supports ":where" as the whole selector', () => {
+    const sheet = new Sheet(':where(:hover) { color: red }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].cssText).toEqual(
+      ':where(:hover), :where(.pseudo-hover), :where(.pseudo-hover-all) * { color: red }'
+    );
+  });
+
+  it('supports ":where" nested inside ":is"', () => {
+    const sheet = new Sheet('.a:is(:where(:hover)) { color: red }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].getSelectors()).toContain(':where(.pseudo-hover-all) .a:is()');
+  });
+
+  it('keeps pseudo-states outside ":where" specificity-bearing', () => {
+    const sheet = new Sheet('.a:where(.b):hover { color: red }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].getSelectors()).toContain('.pseudo-hover-all .a:where(.b)');
+  });
+
+  it('combines specificity-free and specificity-bearing pseudo-states', () => {
+    const sheet = new Sheet('.a:where(:hover):focus { color: red }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].getSelectors()).toContain(
+      '.pseudo-focus-all:where(.pseudo-hover-all) .a'
+    );
+  });
+
+  it('treats a pseudo-state as specificity-bearing if it also occurs outside ":where"', () => {
+    const sheet = new Sheet('.a:where(:hover) .b:hover { color: red }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].getSelectors()).toContain('.pseudo-hover-all .a .b');
+  });
+
+  it('keeps ":where" selector lists intact', () => {
+    const sheet = new Sheet('.a:where(:hover, .b) { color: red }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].getSelectors()).toContain(':where(.pseudo-hover-all) .a:where(*, .b)');
+  });
+
   it('keeps child-combinator pseudo-state selectors valid', () => {
     const sheet = new Sheet('.ds-card > :focus-visible { outline: none }');
     rewriteStyleSheet(sheet as any);

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -409,7 +409,7 @@ describe('rewriteStyleSheet', () => {
   it('supports ":where" nested inside ":is"', () => {
     const sheet = new Sheet('.a:is(:where(:hover)) { color: red }');
     rewriteStyleSheet(sheet as any);
-    expect(sheet.cssRules[0].getSelectors()).toContain(':where(.pseudo-hover-all) .a:is()');
+    expect(sheet.cssRules[0].getSelectors()).toContain(':where(.pseudo-hover-all) .a:is(*)');
   });
 
   it('keeps pseudo-states outside ":where" specificity-bearing', () => {
@@ -430,6 +430,14 @@ describe('rewriteStyleSheet', () => {
     const sheet = new Sheet('.a:where(:hover) .b:hover { color: red }');
     rewriteStyleSheet(sheet as any);
     expect(sheet.cssRules[0].getSelectors()).toContain('.pseudo-hover-all .a .b');
+  });
+
+  it('does not let a quoted ")" inside ":where" end the range early', () => {
+    const sheet = new Sheet('.a:where([data-x=")"] :hover) { color: red }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].cssText).toEqual(
+      '.a:where([data-x=")"] :hover), .a:where([data-x=")"] .pseudo-hover), :where(.pseudo-hover-all) .a:where([data-x=")"] *) { color: red }'
+    );
   });
 
   it('keeps ":where" selector lists intact', () => {

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
@@ -78,10 +78,20 @@ const zeroSpecificityRanges = (selector: string) => {
     const start = opening.index + opening[0].length;
     let end = start;
     let depth = 1;
+    let quote: string | null = null;
     while (end < selector.length && depth > 0) {
-      if (selector[end] === '(') {
+      const char = selector[end];
+      if (quote) {
+        if (char === '\\') {
+          end++;
+        } else if (char === quote) {
+          quote = null;
+        }
+      } else if (char === '"' || char === "'") {
+        quote = char;
+      } else if (char === '(') {
         depth++;
-      } else if (selector[end] === ')') {
+      } else if (char === ')') {
         depth--;
       }
       end++;
@@ -112,6 +122,8 @@ const extractPseudoStates = (selector: string) => {
         (isZeroSpecificity ? insideWhere : outsideWhere).add(state);
         return '';
       })
+      // :where(*) left as the sole content of :is() would make it invalid, so keep it valid as :is(*).
+      .replaceAll(':is(:where(*))', ':is(*)')
       .replaceAll(':where(*)', '')
       // If a selector list was left with blank items (e.g. ", foo, , bar, "), remove the extra commas/spaces.
       .replaceAll(/(?<=[\s(]),\s+|(,\s+)+(?=\))/g, '')

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
@@ -45,7 +45,15 @@ const replacePseudoStatesWithAncestorSelector = (
     return selector;
   }
 
-  const selectors = `${additionalHostSelectors ?? ''}${extracted.states.map((s) => `.pseudo-${s}-all`).join('')}`;
+  const toClasses = (states: string[]) => states.map((s) => `.pseudo-${s}-all`).join('');
+  const specificityFree = extracted.states.filter((s) => extracted.specificityFreeStates.has(s));
+  const specificityBearing = extracted.states.filter(
+    (s) => !extracted.specificityFreeStates.has(s)
+  );
+
+  const selectors = `${additionalHostSelectors ?? ''}${toClasses(specificityBearing)}${
+    specificityFree.length ? `:where(${toClasses(specificityFree)})` : ''
+  }`;
 
   // If there was a :host-context() containing only pseudo-states, we will later add a :host selector that replaces it.
   let { withoutPseudoStates } = extracted;
@@ -60,22 +68,58 @@ const replacePseudoStatesWithAncestorSelector = (
       : `${selectors} ${withoutPseudoStates}`;
 };
 
-const extractPseudoStates = (selector: string) => {
-  const states = new Set();
-  const withoutPseudoStates =
-    selector
-      // If there's no selector for pseudostate pseudo-class, add '*' to the selector.
+// Unlike :is(), :has() and :not(), :where() takes no specificity from its argument, so a state
+// found inside it must not be hoisted into a specificity-bearing ancestor class.
+const zeroSpecificityRanges = (selector: string) => {
+  const ranges: [number, number][] = [];
+  const openings = /:where\(/g;
+  let opening = openings.exec(selector);
+  while (opening !== null) {
+    const start = opening.index + opening[0].length;
+    let end = start;
+    let depth = 1;
+    while (end < selector.length && depth > 0) {
+      if (selector[end] === '(') {
+        depth++;
+      } else if (selector[end] === ')') {
+        depth--;
+      }
+      end++;
+    }
+    ranges.push([start, end - 1]);
+    opening = openings.exec(selector);
+  }
+  return ranges;
+};
 
-      .replaceAll(new RegExp(`(${selectorStartPattern})(${pseudoStatesPattern})`, 'g'), '$1*$2')
-      .replaceAll(matchAll, (_, state) => {
+const extractPseudoStates = (selector: string) => {
+  const states = new Set<string>();
+  const insideWhere = new Set<string>();
+  const outsideWhere = new Set<string>();
+
+  // If there's no selector for pseudostate pseudo-class, add '*' to the selector.
+  const withUniversals = selector.replaceAll(
+    new RegExp(`(${selectorStartPattern})(${pseudoStatesPattern})`, 'g'),
+    '$1*$2'
+  );
+  const ranges = zeroSpecificityRanges(withUniversals);
+
+  const withoutPseudoStates =
+    withUniversals
+      .replaceAll(matchAll, (_, state: string, offset: number) => {
         states.add(state);
+        const isZeroSpecificity = ranges.some(([start, end]) => offset >= start && offset < end);
+        (isZeroSpecificity ? insideWhere : outsideWhere).add(state);
         return '';
       })
+      .replaceAll(':where(*)', '')
       // If a selector list was left with blank items (e.g. ", foo, , bar, "), remove the extra commas/spaces.
-      .replaceAll(/(?<=[\s(]),\s+|(,\s+)+(?=\))/g, '') || '*';
+      .replaceAll(/(?<=[\s(]),\s+|(,\s+)+(?=\))/g, '')
+      .trim() || '*';
 
   return {
     states: Array.from(states),
+    specificityFreeStates: new Set([...insideWhere].filter((s) => !outsideWhere.has(s))),
     withoutPseudoStates,
   };
 };


### PR DESCRIPTION
Closes #31411

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When the addon rewrites a pseudo-state selector into its `.pseudo-*-all` ancestor form, it hoisted the state into a plain class selector even when the state was written inside `:where()`. Because `:where()` contributes no specificity, this raised the rewritten rule's specificity and changed which declaration won.

Given the report's CSS:

```css
.textLink:where(:focus-visible) { text-decoration: none } /* 0-1-0 */
.textLink                       { text-decoration: underline } /* 0-1-0, wins on source order */
```

the addon produced `.pseudo-focus-visible-all .textLink:where(*)` at **0-2-0**, which beat `.textLink` and dropped the underline. It now produces `:where(.pseudo-focus-visible-all) .textLink` at **0-1-0**, preserving the original tie and source-order outcome.

What changed in `rewriteStyleSheet.ts`:

- Added `zeroSpecificityRanges()`, which finds the character ranges enclosed by `:where(...)` using depth counting, so nested parentheses are handled correctly.
- `extractPseudoStates()` now records, per state, whether it was found inside or outside such a range, and returns the set of states seen **only** inside `:where()`.
- `replacePseudoStatesWithAncestorSelector()` emits those states wrapped in `:where(...)` and leaves every other state as a specificity-bearing class, so a state appearing both inside and outside `:where()` stays specificity-bearing.
- Leftover `:where(*)` is now stripped, matching the output shape requested in the issue.

`:is()`, `:has()` and `:not()` are deliberately untouched, since those do take specificity from their argument.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Seven cases were added to `rewriteStyleSheet.test.ts`, covering the reported selector, `:where()` as the entire selector, `:where()` nested in `:is()`, states outside `:where()` staying specificity-bearing, a mix of both kinds in one selector, a state appearing in both positions, and `:where()` selector lists. The file's 59 tests and the package's 62 pass, with no type errors.

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Start a sandbox: `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. In the sandbox, add this CSS to a stylesheet imported by `.storybook/preview.ts`, keeping the source order:

   ```css
   .textLink:where(:focus-visible) {
     outline: 1px solid red;
     text-decoration: none;
   }
   .textLink {
     text-decoration: underline;
   }
   ```

3. Add a story rendering `<a class="textLink" href="#">Hello</a>`
4. Open that story and switch the pseudo-states toolbar to **focus-visible**
5. Expected: the link keeps its **underline** and gains the red outline. Before this change the underline disappeared, because the generated `.pseudo-focus-visible-all .textLink:where(*)` rule outranked `.textLink`.
6. Regression check: toggle **hover**, **focus** and **active** on stories using ordinary (non-`:where`) pseudo-state CSS and confirm they behave exactly as before.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation change is needed: this restores the behavior the addon already documents, and adds no new API or option.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
