### PR TITLE
Angular: share one component-meta analyzer between docgen and story-docs

### DIFF
--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -386,13 +386,10 @@ export const services = async (_value: void, options: Options): Promise<void> =>
   // produce docgen files that wouldn't be served anywhere). Mirrors the !options.ignorePreview
   // gate around index.json and writeManifests in build-static.ts.
   if (features?.experimentalDocgenServer && !options.ignorePreview) {
-    const [docgenDescriptors, storyDocsProvider] = await Promise.all([
-      options.presets.apply<DocgenProviderDescriptor[]>('experimental_docgenProvider', []),
-      options.presets.apply<StoryDocsProvider>(
-        'experimental_storyDocsProvider',
-        async () => undefined
-      ),
-    ]);
+    const docgenDescriptors = await options.presets.apply<DocgenProviderDescriptor[]>(
+      'experimental_docgenProvider',
+      []
+    );
 
     // Docgen extraction runs in a long-lived worker so its CPU-bound TypeScript work never starves
     // the dev-server event loop. The worker composes the descriptor chain; here we forward one
@@ -409,6 +406,14 @@ export const services = async (_value: void, options: Options): Promise<void> =>
         workingDir: process.cwd(),
       });
     }
+
+    // Resolved after the docgen worker so a story-docs provider can query it (via `options.docgenWorker`)
+    // for raw analyzer metadata instead of building its own second, unwatched analyzer.
+    const storyDocsProvider = await options.presets.apply<StoryDocsProvider>(
+      'experimental_storyDocsProvider',
+      async () => undefined,
+      { docgenWorker }
+    );
 
     registerStoryDocsService({
       getIndex: () => storyIndexGenerator.getIndex(),

--- a/code/core/src/shared/open-service/services/docgen/types.ts
+++ b/code/core/src/shared/open-service/services/docgen/types.ts
@@ -105,10 +105,31 @@ export interface DocgenProviderDescriptor<TOptions = unknown> {
 }
 
 /**
+ * A single exported class to resolve against a worker module's analyzer, for callers that need raw
+ * analyzer metadata rather than a converted {@link DocgenPayload} (e.g. a story-docs provider
+ * recovering a component's selector or enum table). Generic across worker modules: any module whose
+ * analyzer resolves "one exported class in one file" can implement {@link DocgenWorkerModule.queryComponentMeta}
+ * against this shape.
+ */
+export interface DocgenComponentMetaQuery {
+  componentPath: string;
+  exportName: string;
+  localName?: string;
+}
+
+/**
  * Contract a worker-target docgen module must satisfy. The worker imports the descriptor's
  * `moduleSpecifier` and calls `createDocgenProvider()` once to build the middleware it folds into
  * the provider chain. Integrations implement only this factory — they never touch threading.
  */
 export interface DocgenWorkerModule<TOptions = unknown> {
   createDocgenProvider: (options?: TOptions) => DocgenMiddleware | Promise<DocgenMiddleware>;
+  /**
+   * Resolve one component's raw analyzer metadata against the same analyzer instance
+   * `createDocgenProvider` warms, so a second consumer (e.g. `core/story-docs`) can reuse it instead
+   * of building its own. Optional: modules with nothing to expose beyond `DocgenPayload` omit it.
+   * The result is opaque to core and crosses the worker boundary as-is — the caller casts it back to
+   * its own framework-specific shape.
+   */
+  queryComponentMeta?: (query: DocgenComponentMetaQuery) => unknown | Promise<unknown>;
 }

--- a/code/core/src/shared/open-service/services/docgen/types.ts
+++ b/code/core/src/shared/open-service/services/docgen/types.ts
@@ -127,9 +127,7 @@ export interface DocgenWorkerModule<TOptions = unknown> {
   /**
    * Resolve one component's raw analyzer metadata against the same analyzer instance
    * `createDocgenProvider` warms, so a second consumer (e.g. `core/story-docs`) can reuse it instead
-   * of building its own. Optional: modules with nothing to expose beyond `DocgenPayload` omit it.
-   * The result is opaque to core and crosses the worker boundary as-is — the caller casts it back to
-   * its own framework-specific shape.
+   * of building its own.
    */
   queryComponentMeta?: (query: DocgenComponentMetaQuery) => unknown | Promise<unknown>;
 }

--- a/code/core/src/shared/open-service/services/docgen/worker/docgen-worker-client.ts
+++ b/code/core/src/shared/open-service/services/docgen/worker/docgen-worker-client.ts
@@ -7,7 +7,11 @@ import { logger } from 'storybook/internal/node-logger';
 import type { IndexEntry } from '../../../../../types/modules/indexer.ts';
 import { importMetaResolve } from '../../../../utils/module.ts';
 import type { ErrorLike } from '../../module-graph/types.ts';
-import type { DocgenPayload, DocgenProviderDescriptor } from '../types.ts';
+import type {
+  DocgenComponentMetaQuery,
+  DocgenPayload,
+  DocgenProviderDescriptor,
+} from '../types.ts';
 import type { DocgenWorkerRequest, DocgenWorkerResponse } from './protocol.ts';
 
 // Resolved via the export map, not a hard-coded dist path, so strict layouts like pnpm's work.
@@ -16,13 +20,20 @@ const WORKER_SPECIFIER = 'storybook/internal/docgen-worker';
 const DEFAULT_TASK_TIMEOUT_MS = 120_000;
 
 interface Pending {
-  resolve: (payload: DocgenPayload | undefined) => void;
+  resolve: (result: unknown) => void;
   reject: (error: unknown) => void;
   timer?: NodeJS.Timeout;
 }
 
 export interface DocgenWorkerClient {
   extract(entry: IndexEntry): Promise<DocgenPayload | undefined>;
+  /**
+   * Resolve one component's raw analyzer metadata against the same analyzer `extract` uses, for
+   * callers (e.g. a story-docs provider) that need fields no `DocgenPayload` carries. The result is
+   * whatever the composed module's `queryComponentMeta` returned — cast it back to the
+   * framework-specific shape you expect.
+   */
+  query(query: DocgenComponentMetaQuery): Promise<unknown>;
 }
 
 function errorLikeToError(errorLike: ErrorLike): Error {
@@ -85,24 +96,36 @@ class DocgenWorker implements DocgenWorkerClient {
   }
 
   async extract(entry: IndexEntry): Promise<DocgenPayload | undefined> {
+    const payload = await this.request('extract', (id) => ({ type: 'extract', id, entry }));
+    return payload as DocgenPayload | undefined;
+  }
+
+  async query(query: DocgenComponentMetaQuery): Promise<unknown> {
+    return this.request('query', (id) => ({ type: 'query', id, query }));
+  }
+
+  private async request(
+    kind: 'extract' | 'query',
+    buildMessage: (id: number) => DocgenWorkerRequest
+  ): Promise<unknown> {
     if (this.dead) {
       throw new Error('docgen worker is no longer running');
     }
     await this.ready;
-    return new Promise<DocgenPayload | undefined>((resolve, reject) => {
+    return new Promise<unknown>((resolve, reject) => {
       const id = this.nextId++;
       const pending: Pending = { resolve, reject };
       if (this.taskTimeoutMs > 0) {
         pending.timer = setTimeout(() => {
           this.pending.delete(id);
           this.keepProcessAliveWhileBusy();
-          reject(new Error(`docgen worker extract ${id} timed out after ${this.taskTimeoutMs}ms`));
+          reject(new Error(`docgen worker ${kind} ${id} timed out after ${this.taskTimeoutMs}ms`));
         }, this.taskTimeoutMs);
         pending.timer.unref?.();
       }
       this.pending.set(id, pending);
       this.keepProcessAliveWhileBusy();
-      this.post({ type: 'extract', id, entry });
+      this.post(buildMessage(id));
     });
   }
 
@@ -119,7 +142,7 @@ class DocgenWorker implements DocgenWorkerClient {
   }
 
   private handleMessage(msg: DocgenWorkerResponse): void {
-    if (msg.type !== 'extract') {
+    if (msg.type !== 'extract' && msg.type !== 'query') {
       return;
     }
     const pending = this.pending.get(msg.id);
@@ -134,7 +157,7 @@ class DocgenWorker implements DocgenWorkerClient {
     if (msg.error) {
       pending.reject(errorLikeToError(msg.error));
     } else {
-      pending.resolve(msg.payload);
+      pending.resolve(msg.type === 'extract' ? msg.payload : msg.result);
     }
   }
 
@@ -190,6 +213,10 @@ export function createDocgenWorkerClient(
     async extract(entry) {
       worker ??= new DocgenWorker(scriptPath, descriptors);
       return worker.extract(entry);
+    },
+    async query(query) {
+      worker ??= new DocgenWorker(scriptPath, descriptors);
+      return worker.query(query);
     },
   };
 }

--- a/code/core/src/shared/open-service/services/docgen/worker/docgen-worker.ts
+++ b/code/core/src/shared/open-service/services/docgen/worker/docgen-worker.ts
@@ -4,9 +4,11 @@
  * Spawned once by {@link ./docgen-worker-client.ts} and kept alive for the dev server's lifetime so
  * the TypeScript program(s) each provider builds stay warm across requests. On `init` it imports
  * every {@link DocgenProviderDescriptor}'s module and folds them into a single provider chain; on
- * `extract` it runs that chain for one component and posts the resulting payload back. Running here
- * keeps the synchronous, CPU-bound TypeScript work off the main event loop so it never starves the
- * Vite dev server during first render.
+ * `extract` it runs that chain for one component and posts the resulting payload back. On `query` it
+ * forwards to whichever composed module exposed `queryComponentMeta`, so a second consumer (e.g.
+ * `core/story-docs`) can reuse the same warm analyzer instead of building its own. Running here keeps
+ * the synchronous, CPU-bound TypeScript work off the main event loop so it never starves the Vite dev
+ * server during first render.
  */
 import { parentPort } from 'node:worker_threads';
 import { pathToFileURL } from 'node:url';
@@ -14,6 +16,7 @@ import { pathToFileURL } from 'node:url';
 import type { IndexEntry } from '../../../../../types/modules/indexer.ts';
 import { errorToErrorLike } from '../../module-graph/types.ts';
 import type {
+  DocgenComponentMetaQuery,
   DocgenMiddleware,
   DocgenProvider,
   DocgenProviderDescriptor,
@@ -32,11 +35,15 @@ const port = parentPort;
 /** Identity provider that seeds the chain; the bottom of the stack has no docgen to contribute. */
 const seedProvider: DocgenProvider = async () => undefined;
 
-/** Resolved once per worker on `init`; every `extract` awaits it. */
+/** Resolved once per worker on `init`; every `extract` and `query` awaits it. */
 let providerPromise: Promise<DocgenProvider> | undefined;
+
+/** One `queryComponentMeta` per composed module that exposed it, in registration order. */
+let queryFns: NonNullable<DocgenWorkerModule['queryComponentMeta']>[] = [];
 
 async function composeProvider(descriptors: DocgenProviderDescriptor[]): Promise<DocgenProvider> {
   let provider = seedProvider;
+  queryFns = [];
   for (const descriptor of descriptors) {
     const moduleUrl = pathToFileURL(descriptor.moduleSpecifier).href;
     const mod = (await import(moduleUrl)) as Partial<DocgenWorkerModule>;
@@ -47,6 +54,9 @@ async function composeProvider(descriptors: DocgenProviderDescriptor[]): Promise
     }
     const middleware: DocgenMiddleware = await mod.createDocgenProvider(descriptor.options);
     provider = middleware(provider);
+    if (typeof mod.queryComponentMeta === 'function') {
+      queryFns.push(mod.queryComponentMeta);
+    }
   }
   return provider;
 }
@@ -82,6 +92,29 @@ async function handleExtract(id: number, entry: IndexEntry): Promise<void> {
   }
 }
 
+async function handleQuery(id: number, query: DocgenComponentMetaQuery): Promise<void> {
+  try {
+    if (!providerPromise) {
+      throw new Error('docgen worker received a query request before init');
+    }
+    await providerPromise;
+    let result: unknown;
+    for (const queryFn of queryFns) {
+      result = await queryFn(query);
+      if (result !== undefined) {
+        break;
+      }
+    }
+    port.postMessage({ type: 'query', id, result } satisfies DocgenWorkerResponse);
+  } catch (error) {
+    port.postMessage({
+      type: 'query',
+      id,
+      error: errorToErrorLike(error),
+    } satisfies DocgenWorkerResponse);
+  }
+}
+
 port.on('message', (msg: DocgenWorkerRequest) => {
   switch (msg.type) {
     case 'init':
@@ -89,6 +122,9 @@ port.on('message', (msg: DocgenWorkerRequest) => {
       return;
     case 'extract':
       void handleExtract(msg.id, msg.entry);
+      return;
+    case 'query':
+      void handleQuery(msg.id, msg.query);
       return;
     default: {
       const _exhaustive: never = msg;

--- a/code/core/src/shared/open-service/services/docgen/worker/protocol.ts
+++ b/code/core/src/shared/open-service/services/docgen/worker/protocol.ts
@@ -9,7 +9,11 @@
  */
 import type { IndexEntry } from '../../../../../types/modules/indexer.ts';
 import type { ErrorLike } from '../../module-graph/types.ts';
-import type { DocgenPayload, DocgenProviderDescriptor } from '../types.ts';
+import type {
+  DocgenComponentMetaQuery,
+  DocgenPayload,
+  DocgenProviderDescriptor,
+} from '../types.ts';
 
 /** Sent once, right after spawn, to compose the provider chain inside the worker. */
 export interface DocgenWorkerInitRequest {
@@ -24,7 +28,20 @@ export interface DocgenWorkerExtractRequest {
   entry: IndexEntry;
 }
 
-export type DocgenWorkerRequest = DocgenWorkerInitRequest | DocgenWorkerExtractRequest;
+/**
+ * Sent by a main-thread caller (e.g. a story-docs provider) that needs a component's raw analyzer
+ * metadata rather than a converted {@link DocgenPayload}. `id` correlates the response.
+ */
+export interface DocgenWorkerQueryRequest {
+  type: 'query';
+  id: number;
+  query: DocgenComponentMetaQuery;
+}
+
+export type DocgenWorkerRequest =
+  | DocgenWorkerInitRequest
+  | DocgenWorkerExtractRequest
+  | DocgenWorkerQueryRequest;
 
 /** Chain composition succeeded; the worker is ready for extract requests. */
 export interface DocgenWorkerInitSuccess {
@@ -57,4 +74,28 @@ export interface DocgenWorkerExtractFailure {
 
 export type DocgenWorkerExtractResponse = DocgenWorkerExtractSuccess | DocgenWorkerExtractFailure;
 
-export type DocgenWorkerResponse = DocgenWorkerInitResponse | DocgenWorkerExtractResponse;
+/**
+ * Query succeeded; `result` is whatever the composed module's `queryComponentMeta` returned
+ * (`undefined` when no registered module resolved the query). Opaque to core — the caller casts it
+ * back to its own framework-specific shape.
+ */
+export interface DocgenWorkerQuerySuccess {
+  type: 'query';
+  id: number;
+  result?: unknown;
+  error?: undefined;
+}
+
+/** Query threw; `error` describes the failure. */
+export interface DocgenWorkerQueryFailure {
+  type: 'query';
+  id: number;
+  error: ErrorLike;
+}
+
+export type DocgenWorkerQueryResponse = DocgenWorkerQuerySuccess | DocgenWorkerQueryFailure;
+
+export type DocgenWorkerResponse =
+  | DocgenWorkerInitResponse
+  | DocgenWorkerExtractResponse
+  | DocgenWorkerQueryResponse;

--- a/code/core/src/shared/open-service/services/story-docs/types.ts
+++ b/code/core/src/shared/open-service/services/story-docs/types.ts
@@ -1,5 +1,6 @@
 import type { Options } from '../../../../types/modules/core-common.ts';
 import type { IndexEntry } from '../../../../types/modules/indexer.ts';
+import type { DocgenWorkerClient } from '../docgen/worker/docgen-worker-client.ts';
 
 /**
  * Caller-facing input to a story-docs provider middleware.
@@ -63,9 +64,20 @@ export type StoryDocsProvider = (
 ) => Promise<StoryDocsPayload | undefined>;
 
 /**
+ * `Options` plus the shared docgen worker, when `experimentalDocgenServer` registered one (core
+ * resolves `experimental_docgenProvider` before composing this preset and passes the client through
+ * `presets.apply`'s `args`). A framework provider that needs raw analyzer metadata no
+ * `DocgenPayload` field carries — a selector, a resolved enum table — queries it here instead of
+ * building a second, unwatched analyzer instance of its own.
+ */
+export interface StoryDocsProviderOptions extends Options {
+  docgenWorker?: DocgenWorkerClient;
+}
+
+/**
  * Preset signature for `experimental_storyDocsProvider`.
  */
 export type StoryDocsProviderPreset = (
   nextStoryDocs: StoryDocsProvider,
-  options: Options
+  options: StoryDocsProviderOptions
 ) => StoryDocsProvider | Promise<StoryDocsProvider>;

--- a/code/core/src/shared/open-service/services/story-docs/types.ts
+++ b/code/core/src/shared/open-service/services/story-docs/types.ts
@@ -63,13 +63,6 @@ export type StoryDocsProvider = (
   input: StoryDocsProviderInput
 ) => Promise<StoryDocsPayload | undefined>;
 
-/**
- * `Options` plus the shared docgen worker, when `experimentalDocgenServer` registered one (core
- * resolves `experimental_docgenProvider` before composing this preset and passes the client through
- * `presets.apply`'s `args`). A framework provider that needs raw analyzer metadata no
- * `DocgenPayload` field carries — a selector, a resolved enum table — queries it here instead of
- * building a second, unwatched analyzer instance of its own.
- */
 export interface StoryDocsProviderOptions extends Options {
   docgenWorker?: DocgenWorkerClient;
 }

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -18,6 +18,7 @@ import type { Indexer, StoriesEntry } from './indexer.ts';
 import type { SupportedRenderer } from './renderers.ts';
 
 export type {
+  DocgenComponentMetaQuery,
   DocgenError,
   DocgenJsDocTags,
   DocgenMiddleware,
@@ -28,6 +29,7 @@ export type {
   DocgenSubcomponent,
   DocgenWorkerModule,
 } from '../../shared/open-service/services/docgen/types.ts';
+export type { DocgenWorkerClient } from '../../shared/open-service/services/docgen/worker/docgen-worker-client.ts';
 export type {
   StoryDoc,
   StoryDocsById,
@@ -35,6 +37,7 @@ export type {
   StoryDocsPayload,
   StoryDocsProvider,
   StoryDocsProviderInput,
+  StoryDocsProviderOptions,
   StoryDocsProviderPreset,
 } from '../../shared/open-service/services/story-docs/types.ts';
 

--- a/code/frameworks/angular-vite/src/docgen/docgen-worker.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/docgen-worker.test.ts
@@ -4,7 +4,12 @@ import type { DocgenPayload, DocgenProvider, IndexEntry } from 'storybook/intern
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildDocgenPayload } from './build-docgen.ts';
-import { createDocgenProvider } from './docgen-worker.ts';
+
+// `docgen-worker.ts` now shares one module-scoped manager for the worker's lifetime (so
+// `queryComponentMeta` reuses the same analyzer `createDocgenProvider` warms). Each test needs its
+// own manager lifecycle, so the module is reset and re-imported fresh per test rather than sharing
+// one top-level import.
+const loadModule = async () => await import('./docgen-worker.ts');
 
 // A structural fake keeps these tests runnable without a real TypeScript-backed analyzer.
 const { analyzer } = vi.hoisted(() => {
@@ -44,6 +49,7 @@ beforeEach(() => {
   analyzer.instances = [];
   analyzer.constructions = 0;
   analyzer.failConstruction = false;
+  vi.resetModules();
 });
 
 afterEach(() => {
@@ -87,6 +93,7 @@ const passthrough: DocgenProvider = async () => undefined;
 
 describe('createDocgenProvider', () => {
   it('falls through for a file that is not a story, without creating the analyzer', async () => {
+    const { createDocgenProvider } = await loadModule();
     const next = vi.fn(passthrough);
 
     await expect(
@@ -99,6 +106,7 @@ describe('createDocgenProvider', () => {
   });
 
   it('merges over downstream output on success', async () => {
+    const { createDocgenProvider } = await loadModule();
     vi.mocked(buildDocgenPayload).mockReturnValue(ours);
 
     const payload = await createDocgenProvider()(async () => ({
@@ -112,6 +120,7 @@ describe('createDocgenProvider', () => {
   });
 
   it('keeps another provider`s payload when our own extraction fails', async () => {
+    const { createDocgenProvider } = await loadModule();
     vi.mocked(buildDocgenPayload).mockReturnValue(errored);
     const next = vi.fn<DocgenProvider>(async () => downstream);
 
@@ -120,12 +129,14 @@ describe('createDocgenProvider', () => {
   });
 
   it('reports its own error only when no other provider described the component', async () => {
+    const { createDocgenProvider } = await loadModule();
     vi.mocked(buildDocgenPayload).mockReturnValue(errored);
 
     await expect(createDocgenProvider()(passthrough)({ entry })).resolves.toEqual(errored);
   });
 
   it('delegates downstream when it has no payload for the component', async () => {
+    const { createDocgenProvider } = await loadModule();
     vi.mocked(buildDocgenPayload).mockReturnValue(undefined);
     const next = vi.fn<DocgenProvider>(async () => downstream);
 
@@ -134,6 +145,7 @@ describe('createDocgenProvider', () => {
   });
 
   it('lets an unexpected failure propagate, since core records it against this component', async () => {
+    const { createDocgenProvider } = await loadModule();
     const failure = new TypeError('unexpected');
     vi.mocked(buildDocgenPayload).mockImplementation(() => {
       throw failure;
@@ -143,6 +155,7 @@ describe('createDocgenProvider', () => {
   });
 
   it('owns one watching analyzer for its lifetime and recycles after each extraction', async () => {
+    const { createDocgenProvider } = await loadModule();
     vi.mocked(buildDocgenPayload).mockReturnValue(ours);
     const provider = createDocgenProvider()(passthrough);
 
@@ -157,6 +170,7 @@ describe('createDocgenProvider', () => {
   });
 
   it('threads a structured-cloneable options bag and the manager into the payload builder', async () => {
+    const { createDocgenProvider } = await loadModule();
     vi.mocked(buildDocgenPayload).mockReturnValue(ours);
 
     await createDocgenProvider(structuredClone({ angularFilterNonInputControls: true }))(
@@ -177,6 +191,7 @@ describe('createDocgenProvider', () => {
   });
 
   it('passes through permanently when the analyzer cannot be created', async () => {
+    const { createDocgenProvider } = await loadModule();
     analyzer.failConstruction = true;
     vi.mocked(logger.warn).mockImplementation(() => {});
     const next = vi.fn<DocgenProvider>(async () => downstream);
@@ -191,5 +206,15 @@ describe('createDocgenProvider', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Angular docgen is unavailable')
     );
+  });
+
+  it('shares the same analyzer between the docgen middleware and queryComponentMeta', async () => {
+    const { createDocgenProvider, queryComponentMeta } = await loadModule();
+    vi.mocked(buildDocgenPayload).mockReturnValue(ours);
+
+    await createDocgenProvider()(passthrough)({ entry });
+    await queryComponentMeta({ componentPath: 'button.component.ts', exportName: 'default' });
+
+    expect(analyzer.constructions).toBe(1);
   });
 });

--- a/code/frameworks/angular-vite/src/docgen/docgen-worker.ts
+++ b/code/frameworks/angular-vite/src/docgen/docgen-worker.ts
@@ -1,8 +1,12 @@
 import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
-import type { DocgenMiddleware, DocgenProvider } from 'storybook/internal/types';
+import type {
+  DocgenComponentMetaQuery,
+  DocgenMiddleware,
+  DocgenProvider,
+} from 'storybook/internal/types';
 
-import type { ParsingLogger } from '@storybook/angular-cm';
+import type { AngularComponentMetaResult, ParsingLogger } from '@storybook/angular-cm';
 import { AngularComponentMetaManager } from '@storybook/angular-cm';
 import type { AngularDocgenOptions } from './build-docgen.ts';
 import { buildDocgenPayload } from './build-docgen.ts';
@@ -30,13 +34,19 @@ const createManager = async (): Promise<AngularComponentMetaManager | undefined>
   }
 };
 
+// Module-scoped (not per-`createDocgenProvider`-call) so `queryComponentMeta` shares the same
+// warm analyzer instead of each getting its own. Node evaluates this module once per worker
+// thread, and the worker imports it once, so this is the one owner for the worker's lifetime.
+let managerPromise: Promise<AngularComponentMetaManager | undefined> | undefined;
+
+const getManager = (): Promise<AngularComponentMetaManager | undefined> =>
+  (managerPromise ??= createManager());
+
 /**
  * Build the Angular docgen middleware, holding one analyzer for the worker's lifetime so its
  * language services stay warm across components.
  */
 export const createDocgenProvider = (options: AngularDocgenOptions = {}): DocgenMiddleware => {
-  let managerPromise: Promise<AngularComponentMetaManager | undefined> | undefined;
-
   return (nextDocgen: DocgenProvider): DocgenProvider =>
     async (input) => {
       const storyImportPath = getStoryImportPathFromEntry(input.entry);
@@ -44,7 +54,7 @@ export const createDocgenProvider = (options: AngularDocgenOptions = {}): Docgen
         return nextDocgen(input);
       }
 
-      const manager = await (managerPromise ??= createManager());
+      const manager = await getManager();
       if (!manager) {
         return nextDocgen(input);
       }
@@ -63,4 +73,27 @@ export const createDocgenProvider = (options: AngularDocgenOptions = {}): Docgen
       }
       return { ...(await nextDocgen(input)), ...ours };
     };
+};
+
+/**
+ * Resolve one component's raw analyzer metadata for `core/story-docs`, which needs fields no
+ * `DocgenPayload` carries (a selector, the file's resolved enum table) to build a snippet. Shares
+ * `getManager()` with {@link createDocgenProvider} rather than owning a second analyzer.
+ */
+export const queryComponentMeta = async (
+  query: DocgenComponentMetaQuery
+): Promise<AngularComponentMetaResult | undefined> => {
+  const manager = await getManager();
+  if (!manager) {
+    return undefined;
+  }
+  try {
+    return manager.extractComponentMeta(query.componentPath, {
+      exportName: query.exportName,
+      localName: query.localName,
+    });
+  } finally {
+    // Same reasoning as `createDocgenProvider`: no batch surface, so check once per query.
+    manager.recycleIfHeapPressured();
+  }
 };

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { vol } from 'memfs';
 
-import type { AngularComponentMetaSource } from './build-docgen.ts';
+import type { AngularComponentMetaQuerySource } from './story-docs-build.ts';
 import { buildStoryDocsPayload } from './story-docs-build.ts';
 
 vi.mock('node:fs', { spy: true });
@@ -42,7 +42,7 @@ const givenStoryFile = (source: string) => {
 };
 
 describe('buildStoryDocsPayload', () => {
-  it('returns undefined for entries without a story file or with an unparsable one', () => {
+  it('returns undefined for entries without a story file or with an unparsable one', async () => {
     const docsEntry: IndexEntry = {
       id: 'docs--page',
       name: 'Page',
@@ -52,20 +52,22 @@ describe('buildStoryDocsPayload', () => {
       storiesImports: [],
       tags: [],
     };
-    expect(buildStoryDocsPayload({ entry: docsEntry }, { manager: undefined })).toBeUndefined();
+    expect(
+      await buildStoryDocsPayload({ entry: docsEntry }, { manager: undefined })
+    ).toBeUndefined();
 
     givenStoryFile('export default { title: "Broken" ');
-    expect(buildStoryDocsPayload({ entry }, { manager: undefined })).toBeUndefined();
+    expect(await buildStoryDocsPayload({ entry }, { manager: undefined })).toBeUndefined();
   });
 
-  it('still emits description-only stories when the analyzer is unavailable', () => {
+  it('still emits description-only stories when the analyzer is unavailable', async () => {
     givenStoryFile(`
       export default { title: 'Example/Button' };
       /** Documented without a component. */
       export const Default = {};
     `);
 
-    const payload = buildStoryDocsPayload({ entry }, { manager: undefined });
+    const payload = await buildStoryDocsPayload({ entry }, { manager: undefined });
 
     expect(payload?.name).toBe('Button');
     expect(Object.values(payload!.stories)[0]).toEqual({
@@ -75,19 +77,19 @@ describe('buildStoryDocsPayload', () => {
     });
   });
 
-  it('drops the snippet without erroring when the analyzer throws', () => {
+  it('drops the snippet without erroring when the analyzer throws', async () => {
     givenStoryFile(`
       import { ButtonComponent } from './button.component';
       export default { title: 'Example/Button', component: ButtonComponent };
       export const Default = { args: { label: 'Save' } };
     `);
-    const manager: AngularComponentMetaSource = {
-      extractComponentMeta: () => {
+    const manager: AngularComponentMetaQuerySource = {
+      extractComponentMeta: async () => {
         throw new Error('ts blew up');
       },
     };
 
-    const payload = buildStoryDocsPayload({ entry }, { manager });
+    const payload = await buildStoryDocsPayload({ entry }, { manager });
 
     const story = Object.values(payload!.stories)[0];
     expect(story.snippet).toBeUndefined();

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
@@ -13,7 +13,6 @@ import { resolve } from 'node:path';
 
 import type { EnumType, Property } from '@storybook/angular-compodoc';
 import type { AngularClassMeta, AngularComponentMetaResult } from '@storybook/angular-cm';
-import type { AngularComponentMetaSource } from './build-docgen.ts';
 import { parseStoryFile, resolveComponentOf } from './resolve-component.ts';
 import { buildComponentOutletTemplate } from '../template-grammar.ts';
 import {
@@ -22,18 +21,30 @@ import {
   renderComponentSnippet,
 } from './story-docs-snippet.ts';
 
+/**
+ * A component-meta lookup reached through the shared docgen worker rather than an in-process
+ * analyzer, so `extractComponentMeta` is Promise-returning here (a real `AngularComponentMetaManager`
+ * resolves synchronously; `await`ing a non-Promise value is a no-op).
+ */
+export interface AngularComponentMetaQuerySource {
+  extractComponentMeta(
+    componentPath: string,
+    names: { exportName: string; localName?: string }
+  ): Promise<AngularComponentMetaResult | undefined>;
+}
+
 export interface BuildStoryDocsContext {
-  // `undefined` when the analyzer could not be created; descriptions still extract without it.
-  manager: AngularComponentMetaSource | undefined;
+  // `undefined` when the docgen worker is unavailable; descriptions still extract without it.
+  manager: AngularComponentMetaQuerySource | undefined;
   resolvePath?: (importPath: string) => string;
 }
 
 // Stories that declare their own `render` get no snippet: their template is a runtime value static
 // analysis cannot see, and a component-derived one would misrepresent it.
-export const buildStoryDocsPayload = (
+export const buildStoryDocsPayload = async (
   input: StoryDocsProviderInput,
   context: BuildStoryDocsContext
-): StoryDocsPayload | undefined => {
+): Promise<StoryDocsPayload | undefined> => {
   const storyImportPath = getStoryImportPathFromEntry(input.entry);
   if (!storyImportPath) {
     return undefined;
@@ -54,7 +65,7 @@ export const buildStoryDocsPayload = (
   let meta: AngularComponentMetaResult | undefined;
   if (component?.path && context.manager) {
     try {
-      meta = context.manager.extractComponentMeta(component.path, {
+      meta = await context.manager.extractComponentMeta(component.path, {
         exportName: component.exportName,
         localName: component.localName,
       });

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
@@ -2,27 +2,37 @@ import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/i
 import { logger } from 'storybook/internal/node-logger';
 import type { StoryDocsProviderPreset } from 'storybook/internal/types';
 
-import { AngularComponentMetaManager } from '@storybook/angular-cm';
+import type { AngularComponentMetaResult } from '@storybook/angular-cm';
+import type { AngularComponentMetaQuerySource } from './story-docs-build.ts';
 import { buildStoryDocsPayload } from './story-docs-build.ts';
 
-const createManager = async (): Promise<AngularComponentMetaManager | undefined> => {
-  try {
-    const typescript = await import('typescript');
-    return new AngularComponentMetaManager(typescript.default ?? typescript);
-  } catch (error) {
-    logger.warn(
-      `Angular story snippets are unavailable: the component meta analyzer could not be created. ${
-        error instanceof Error ? error.message : String(error)
-      }`
-    );
-    return undefined;
-  }
-};
-
-export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (nextStoryDocs) => {
-  // Scoped to the composed chain rather than the module, so the manager has one owner and one
-  // lifetime.
-  let managerPromise: Promise<AngularComponentMetaManager | undefined> | undefined;
+export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (
+  nextStoryDocs,
+  options
+) => {
+  const docgenWorker = options.docgenWorker;
+  // Proxies component-meta lookups to the analyzer the docgen worker already warmed and watches,
+  // rather than constructing a second `AngularComponentMetaManager` here. `undefined` when the
+  // worker itself is unavailable (e.g. running from source without a build); descriptions still
+  // extract without it.
+  const manager: AngularComponentMetaQuerySource | undefined = docgenWorker && {
+    extractComponentMeta: async (componentPath, names) => {
+      try {
+        return (await docgenWorker.query({
+          componentPath,
+          exportName: names.exportName,
+          localName: names.localName,
+        })) as AngularComponentMetaResult | undefined;
+      } catch (error) {
+        logger.warn(
+          `Angular story snippets are unavailable for ${componentPath}: the docgen worker query failed. ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+        return undefined;
+      }
+    },
+  };
 
   return async (input) => {
     const storyImportPath = getStoryImportPathFromEntry(input.entry);
@@ -30,10 +40,7 @@ export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (ne
       return nextStoryDocs(input);
     }
 
-    const manager = await (managerPromise ??= createManager());
-    const ours = buildStoryDocsPayload(input, { manager });
-    // The language service holds large type caches; check heap pressure after each extraction.
-    manager?.recycleIfHeapPressured();
+    const ours = await buildStoryDocsPayload(input, { manager });
 
     if (!ours) {
       return nextStoryDocs(input);

--- a/code/lib/docgen-harness/src/angular/angular-story-docs-snippets.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-story-docs-snippets.test.ts
@@ -12,6 +12,7 @@ import { loadCsf } from 'storybook/internal/csf-tools';
 import type { IndexEntry } from 'storybook/internal/types';
 
 import { AngularComponentMetaManager } from '@storybook/angular-cm';
+import type { AngularComponentMetaQuerySource } from '../../../../frameworks/angular-vite/src/docgen/story-docs-build.ts';
 import { buildStoryDocsPayload } from '../../../../frameworks/angular-vite/src/docgen/story-docs-build.ts';
 import {
   expectNoStaleSnippets,
@@ -23,6 +24,13 @@ import {
 // One manager for the whole suite: each fixture directory carries its own tsconfig.json, so every
 // component file resolves to its own per-fixture project.
 const manager = new AngularComponentMetaManager(ts);
+
+// `buildStoryDocsPayload` expects a Promise-returning source (it queries the shared docgen worker
+// in production); the real manager resolves synchronously, so wrap it to match the interface.
+const querySource: AngularComponentMetaQuerySource = {
+  extractComponentMeta: async (componentPath, names) =>
+    manager.extractComponentMeta(componentPath, names),
+};
 
 afterAll(() => {
   manager.dispose();
@@ -47,7 +55,10 @@ describe('angular story-docs server snippets', () => {
       subtype: 'story',
       importPath: storyPath,
     };
-    const payload = buildStoryDocsPayload({ entry }, { manager, resolvePath: (path) => path });
+    const payload = await buildStoryDocsPayload(
+      { entry },
+      { manager: querySource, resolvePath: (path) => path }
+    );
     expect(payload).toBeDefined();
 
     for (const [exportName, story] of storyExports) {

--- a/code/lib/docgen-harness/src/angular/story-docs/build-story-docs.test.ts
+++ b/code/lib/docgen-harness/src/angular/story-docs/build-story-docs.test.ts
@@ -8,6 +8,7 @@ import ts from 'typescript';
 import type { IndexEntry } from 'storybook/internal/types';
 
 import { AngularComponentMetaManager } from '@storybook/angular-cm';
+import type { AngularComponentMetaQuerySource } from '../../../../../frameworks/angular-vite/src/docgen/story-docs-build.ts';
 import { buildStoryDocsPayload } from '../../../../../frameworks/angular-vite/src/docgen/story-docs-build.ts';
 import { listFixtureCases } from '../snippet-recorder.ts';
 
@@ -15,6 +16,13 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), '__testfixtur
 
 // One manager for the whole suite; the fixtures share a single tsconfig.json at the tree root.
 const manager = new AngularComponentMetaManager(ts);
+
+// `buildStoryDocsPayload` expects a Promise-returning source (it queries the shared docgen worker
+// in production); the real manager resolves synchronously, so wrap it to match the interface.
+const querySource: AngularComponentMetaQuerySource = {
+  extractComponentMeta: async (componentPath, names) =>
+    manager.extractComponentMeta(componentPath, names),
+};
 
 afterAll(() => {
   manager.dispose();
@@ -32,9 +40,9 @@ const makeEntry = (storyPath: string, title: string): IndexEntry => ({
 describe('angular story-docs payload baselines', () => {
   it.each(listFixtureCases(FIXTURES_DIR))('%s', async (fixtureCase) => {
     const testDir = join(FIXTURES_DIR, fixtureCase);
-    const payload = buildStoryDocsPayload(
+    const payload = await buildStoryDocsPayload(
       { entry: makeEntry(join(testDir, 'input.stories.ts'), `StoryDocs/${fixtureCase}`) },
-      { manager, resolvePath: (path) => path }
+      { manager: querySource, resolvePath: (path) => path }
     );
 
     await expect(payload && { ...payload, path: '__PATH__' }).toMatchFileSnapshot(


### PR DESCRIPTION
Closes #

## What I did

Follow-up on #35807. `story-docs-preset.ts` built its own `AngularComponentMetaManager` right next to the one `docgen-worker.ts` already owns, so the dev server ends up running two warm TypeScript language services over the same files, per default, whenever `experimentalDocgenServer` is on.

The docgen worker already runs one persistent `node:worker_threads` `Worker` and imports each `DocgenProviderDescriptor`'s module by `moduleSpecifier` into it. Node caches ES module evaluation per resolved URL within a thread, so colocating both exports in the same worker-entry module gets them the same manager instance for free. No second worker, no new descriptor system, just a third message kind on a protocol that's already there:

```
                              ┌─ docgen-worker.ts (angular-vite) ─┐
                              │                                    │
init (moduleSpecifier import) │  let managerPromise (module scope) │
        │                     │        │           │               │
        ▼                     │        ▼           ▼               │
 core worker thread ──────────┤  createDocgenProvider  queryComponentMeta
        │                     └────────┬───────────┬───────────────┘
        │                              │           │
   'extract' (docgen)             (existing)   'query' (new)
        │                              │           │
        ▼                              ▼           ▼
 core/docgen payload            DocgenPayload   AngularComponentMetaResult
                                                  (selector, enum table -
                                                   fields DocgenPayload
                                                   never carried)
```

`story-docs-preset.ts` now proxies through `options.docgenWorker.query(...)` instead of constructing its own analyzer:

```ts
// before
const createManager = async () => new AngularComponentMetaManager(typescript.default ?? typescript);
// ...
const manager = await (managerPromise ??= createManager());

// after
const manager: AngularComponentMetaQuerySource | undefined = docgenWorker && {
  extractComponentMeta: async (componentPath, names) =>
    (await docgenWorker.query({ componentPath, ...names })) as AngularComponentMetaResult | undefined,
};
```

`options.docgenWorker` is threaded in from `common-preset.ts`, which now resolves the docgen descriptors and builds the worker client before composing `experimental_storyDocsProvider`, passing the client through `presets.apply`'s `args` parameter (merged into the callee's `options`):

```ts
const storyDocsProvider = await options.presets.apply<StoryDocsProvider>(
  'experimental_storyDocsProvider',
  async () => undefined,
  { docgenWorker }
);
```

One wrinkle worth flagging: since `buildStoryDocsPayload`'s manager call now crosses a `postMessage` boundary, `AngularComponentMetaQuerySource.extractComponentMeta` returns a `Promise` (a real `AngularComponentMetaManager` still resolves synchronously, and awaiting a non-Promise value is a no-op), so `buildStoryDocsPayload` itself is now `async`. I would argue that's a fair trade for one shared, watched analyzer instead of two.

One manager, one `startWatching()`, one `recycleIfHeapPressured()`. Docgen and story-docs now invalidate together instead of story-docs going stale on its own after edits, and the dev server holds one warm TypeScript program for Angular analysis instead of two.

### What a bad run looks like

Reverting `docgen-worker.ts`'s module-scoped `managerPromise` back to a per-call local variable (so `queryComponentMeta` builds its own manager again) breaks the new coverage in `docgen-worker.test.ts`:

```console
$ yarn test docgen-worker

 FAIL  |@storybook/angular-vite| src/docgen/docgen-worker.test.ts > createDocgenProvider > shares the same analyzer between the docgen middleware and queryComponentMeta
AssertionError: expected 2 to be 1 // Object.is equality

- Expected
+ Received

- 1
+ 2

 ❯ src/docgen/docgen-worker.test.ts:199:31
```

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Check out this branch and run `yarn && yarn nx run-many -t compile`.
2. Run `yarn task sandbox --template angular-vite/docgen-server-ts --start-from auto` (the sandbox with `experimentalDocgenServer` and `componentsManifest` on). Open a story's Docs page - argTypes and the Source block snippet should render exactly as they did before this PR.
3. Without restarting the dev server, edit the story's component (e.g. add an `@Input()`). Both the argTypes table and the Source block snippet should pick up the change on the next load - previously only argTypes updated live.
4. `yarn test docgen-worker story-docs-build angular-story-docs-snippets build-story-docs common-preset docgen` should all pass.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Internal worker plumbing behind an experimental flag, so nothing user-facing to document here.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
