### PR TITLE
Angular: resolve story-docs snippets through the core/docgen service instead of a second analyzer

### DIFF
--- a/code/frameworks/angular-vite/src/docgen/build-docgen.integration.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.integration.test.ts
@@ -43,7 +43,7 @@ it('builds a real payload through the TypeScript-backed analyzer', async () => {
       name: 'label',
       table: { category: 'inputs' },
     });
-    expect(payload?.angularComponentMeta?.name).toBe('ButtonComponent');
+    expect(payload?.angularComponentMeta?.entry.name).toBe('ButtonComponent');
   } finally {
     manager.dispose();
   }

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.test.ts
@@ -102,7 +102,7 @@ describe('buildDocgenPayload', () => {
       name: 'label',
       table: { category: 'inputs', defaultValue: { summary: 'Click me' } },
     });
-    expect(payload?.angularComponentMeta).toBe(classMeta);
+    expect(payload?.angularComponentMeta?.entry).toBe(classMeta);
     expect(payload?.compodoc).toBeUndefined();
     expect(payload?.subcomponents).toBeUndefined();
     expect(payload?.error).toBeUndefined();

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.ts
@@ -11,6 +11,7 @@ import { resolve } from 'node:path';
 import type {
   AngularClassMeta,
   AngularComponentMetaResult,
+  MetadataJson,
   ParsingLogger,
 } from '@storybook/angular-cm';
 import { extractArgTypesFromData } from '@storybook/angular-cm';
@@ -24,6 +25,11 @@ export interface AngularDocgenOptions {
 export type AngularDocgenPayload = DocgenPayload & {
   // The analyzer's record for the class, not filtered by `angularFilterNonInputControls`.
   angularComponentMeta?: AngularClassMeta;
+  // The analyzer's record for the whole file, so a second in-process consumer (`core/story-docs`)
+  // can resolve enum member values without re-running the analyzer itself. Stored on the docgen
+  // payload rather than a separate service so both consumers share the one extraction this
+  // provider already ran.
+  angularComponentMetaJson?: MetadataJson;
 };
 
 // Structural on purpose: tests hand in a stub instead of a real TypeScript-backed analyzer.
@@ -151,5 +157,6 @@ export const buildDocgenPayload = (
     jsDocTags,
     argTypes,
     angularComponentMeta: meta.entry,
+    angularComponentMetaJson: meta.json,
   };
 };

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.ts
@@ -22,15 +22,23 @@ export interface AngularDocgenOptions {
   angularFilterNonInputControls?: boolean;
 }
 
+/**
+ * The analyzer's record for the class (not filtered by `angularFilterNonInputControls`), plus the
+ * file's enum declarations it references. `enums` isn't part of the analyzer's own class record —
+ * enums are a file-level declaration, not a class property, so the analyzer collects them once per
+ * file rather than per class — but it always accompanies `entry` here since a second in-process
+ * consumer (`core/story-docs`) needs both to resolve `Enum.Member` args without re-running the
+ * analyzer itself. Only this slice of the analyzer's file-level output is carried, not the whole
+ * `MetadataJson` (which also lists every other component/directive/pipe in the file) — story-docs
+ * never touches that.
+ */
+export interface AngularComponentSnippetMeta {
+  entry: AngularClassMeta;
+  enums: EnumType[];
+}
+
 export type AngularDocgenPayload = DocgenPayload & {
-  // The analyzer's record for the class, not filtered by `angularFilterNonInputControls`.
-  angularComponentMeta?: AngularClassMeta;
-  // The file's enum declarations (not part of `angularComponentMeta`: enums aren't a class
-  // property, the analyzer collects them once per file). Lets a second in-process consumer
-  // (`core/story-docs`) resolve `Enum.Member` args without re-running the analyzer itself. Only
-  // this slice of the analyzer's file-level output is carried, not the whole `MetadataJson` (which
-  // also lists every other component/directive/pipe in the file) — story-docs never touches that.
-  angularComponentEnums?: EnumType[];
+  angularComponentMeta?: AngularComponentSnippetMeta;
 };
 
 // Structural on purpose: tests hand in a stub instead of a real TypeScript-backed analyzer.
@@ -157,7 +165,6 @@ export const buildDocgenPayload = (
     summary: jsDocTags.summary?.[0],
     jsDocTags,
     argTypes,
-    angularComponentMeta: meta.entry,
-    angularComponentEnums: meta.json.miscellaneous?.enumerations ?? [],
+    angularComponentMeta: { entry: meta.entry, enums: meta.json.miscellaneous?.enumerations ?? [] },
   };
 };

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.ts
@@ -8,10 +8,10 @@ import type {
 
 import { resolve } from 'node:path';
 
+import type { EnumType } from '@storybook/angular-compodoc';
 import type {
   AngularClassMeta,
   AngularComponentMetaResult,
-  MetadataJson,
   ParsingLogger,
 } from '@storybook/angular-cm';
 import { extractArgTypesFromData } from '@storybook/angular-cm';
@@ -25,11 +25,12 @@ export interface AngularDocgenOptions {
 export type AngularDocgenPayload = DocgenPayload & {
   // The analyzer's record for the class, not filtered by `angularFilterNonInputControls`.
   angularComponentMeta?: AngularClassMeta;
-  // The analyzer's record for the whole file, so a second in-process consumer (`core/story-docs`)
-  // can resolve enum member values without re-running the analyzer itself. Stored on the docgen
-  // payload rather than a separate service so both consumers share the one extraction this
-  // provider already ran.
-  angularComponentMetaJson?: MetadataJson;
+  // The file's enum declarations (not part of `angularComponentMeta`: enums aren't a class
+  // property, the analyzer collects them once per file). Lets a second in-process consumer
+  // (`core/story-docs`) resolve `Enum.Member` args without re-running the analyzer itself. Only
+  // this slice of the analyzer's file-level output is carried, not the whole `MetadataJson` (which
+  // also lists every other component/directive/pipe in the file) — story-docs never touches that.
+  angularComponentEnums?: EnumType[];
 };
 
 // Structural on purpose: tests hand in a stub instead of a real TypeScript-backed analyzer.
@@ -157,6 +158,6 @@ export const buildDocgenPayload = (
     jsDocTags,
     argTypes,
     angularComponentMeta: meta.entry,
-    angularComponentMetaJson: meta.json,
+    angularComponentEnums: meta.json.miscellaneous?.enumerations ?? [],
   };
 };

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.ts
@@ -22,16 +22,6 @@ export interface AngularDocgenOptions {
   angularFilterNonInputControls?: boolean;
 }
 
-/**
- * The analyzer's record for the class (not filtered by `angularFilterNonInputControls`), plus the
- * file's enum declarations it references. `enums` isn't part of the analyzer's own class record —
- * enums are a file-level declaration, not a class property, so the analyzer collects them once per
- * file rather than per class — but it always accompanies `entry` here since a second in-process
- * consumer (`core/story-docs`) needs both to resolve `Enum.Member` args without re-running the
- * analyzer itself. Only this slice of the analyzer's file-level output is carried, not the whole
- * `MetadataJson` (which also lists every other component/directive/pipe in the file) — story-docs
- * never touches that.
- */
 export interface AngularComponentSnippetMeta {
   entry: AngularClassMeta;
   enums: EnumType[];

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
@@ -95,7 +95,7 @@ describe('buildStoryDocsPayload', () => {
           inputsClass: [{ name: 'label' }],
           outputsClass: [],
         },
-        angularComponentMetaJson: { miscellaneous: { typealiases: [], enumerations: [] } },
+        angularComponentEnums: [],
       }) as AngularDocgenPayload;
 
     const payload = await buildStoryDocsPayload({ entry }, { getDocgenPayload });

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { vol } from 'memfs';
 
-import type { AngularComponentMetaSource } from './build-docgen.ts';
+import type { AngularDocgenPayload } from './build-docgen.ts';
 import { buildStoryDocsPayload } from './story-docs-build.ts';
 
 vi.mock('node:fs', { spy: true });
@@ -42,7 +42,7 @@ const givenStoryFile = (source: string) => {
 };
 
 describe('buildStoryDocsPayload', () => {
-  it('returns undefined for entries without a story file or with an unparsable one', () => {
+  it('returns undefined for entries without a story file or with an unparsable one', async () => {
     const docsEntry: IndexEntry = {
       id: 'docs--page',
       name: 'Page',
@@ -52,20 +52,22 @@ describe('buildStoryDocsPayload', () => {
       storiesImports: [],
       tags: [],
     };
-    expect(buildStoryDocsPayload({ entry: docsEntry }, { manager: undefined })).toBeUndefined();
+    expect(
+      await buildStoryDocsPayload({ entry: docsEntry }, { getDocgenPayload: undefined })
+    ).toBeUndefined();
 
     givenStoryFile('export default { title: "Broken" ');
-    expect(buildStoryDocsPayload({ entry }, { manager: undefined })).toBeUndefined();
+    expect(await buildStoryDocsPayload({ entry }, { getDocgenPayload: undefined })).toBeUndefined();
   });
 
-  it('still emits description-only stories when the analyzer is unavailable', () => {
+  it('still emits description-only stories when core/docgen is unavailable', async () => {
     givenStoryFile(`
       export default { title: 'Example/Button' };
       /** Documented without a component. */
       export const Default = {};
     `);
 
-    const payload = buildStoryDocsPayload({ entry }, { manager: undefined });
+    const payload = await buildStoryDocsPayload({ entry }, { getDocgenPayload: undefined });
 
     expect(payload?.name).toBe('Button');
     expect(Object.values(payload!.stories)[0]).toEqual({
@@ -75,19 +77,45 @@ describe('buildStoryDocsPayload', () => {
     });
   });
 
-  it('drops the snippet without erroring when the analyzer throws', () => {
+  it('builds a snippet from the raw analyzer fields core/docgen carries alongside argTypes', async () => {
     givenStoryFile(`
       import { ButtonComponent } from './button.component';
       export default { title: 'Example/Button', component: ButtonComponent };
       export const Default = { args: { label: 'Save' } };
     `);
-    const manager: AngularComponentMetaSource = {
-      extractComponentMeta: () => {
-        throw new Error('ts blew up');
-      },
+    const getDocgenPayload = async (): Promise<AngularDocgenPayload> =>
+      ({
+        id: 'example-button',
+        name: 'ButtonComponent',
+        path: STORY_PATH,
+        jsDocTags: {},
+        angularComponentMeta: {
+          name: 'ButtonComponent',
+          selector: 'sb-button',
+          inputsClass: [{ name: 'label' }],
+          outputsClass: [],
+        },
+        angularComponentMetaJson: { miscellaneous: { typealiases: [], enumerations: [] } },
+      }) as AngularDocgenPayload;
+
+    const payload = await buildStoryDocsPayload({ entry }, { getDocgenPayload });
+
+    const story = Object.values(payload!.stories)[0];
+    expect(story.snippet).toContain('sb-button');
+    expect(story.snippet).toContain(`[label]="'Save'"`);
+  });
+
+  it('drops the snippet without erroring when querying core/docgen throws', async () => {
+    givenStoryFile(`
+      import { ButtonComponent } from './button.component';
+      export default { title: 'Example/Button', component: ButtonComponent };
+      export const Default = { args: { label: 'Save' } };
+    `);
+    const getDocgenPayload = async (): Promise<AngularDocgenPayload | undefined> => {
+      throw new Error('core/docgen query failed');
     };
 
-    const payload = buildStoryDocsPayload({ entry }, { manager });
+    const payload = await buildStoryDocsPayload({ entry }, { getDocgenPayload });
 
     const story = Object.values(payload!.stories)[0];
     expect(story.snippet).toBeUndefined();

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
@@ -90,12 +90,14 @@ describe('buildStoryDocsPayload', () => {
         path: STORY_PATH,
         jsDocTags: {},
         angularComponentMeta: {
-          name: 'ButtonComponent',
-          selector: 'sb-button',
-          inputsClass: [{ name: 'label' }],
-          outputsClass: [],
+          entry: {
+            name: 'ButtonComponent',
+            selector: 'sb-button',
+            inputsClass: [{ name: 'label' }],
+            outputsClass: [],
+          },
+          enums: [],
         },
-        angularComponentEnums: [],
       }) as AngularDocgenPayload;
 
     const payload = await buildStoryDocsPayload({ entry }, { getDocgenPayload });

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
@@ -12,7 +12,7 @@ import type { StoryDoc, StoryDocsPayload, StoryDocsProviderInput } from 'storybo
 import { resolve } from 'node:path';
 
 import type { EnumType, Property } from '@storybook/angular-compodoc';
-import type { AngularClassMeta, AngularComponentMetaResult } from '@storybook/angular-cm';
+import type { AngularClassMeta } from '@storybook/angular-cm';
 import type { AngularDocgenPayload } from './build-docgen.ts';
 import { parseStoryFile, resolveComponentOf } from './resolve-component.ts';
 import { buildComponentOutletTemplate } from '../template-grammar.ts';
@@ -58,21 +58,18 @@ export const buildStoryDocsPayload = async (
   const resolution = resolveComponentOf(csf, storyPath);
   const component = 'reason' in resolution ? undefined : resolution.component;
 
-  let meta: AngularComponentMetaResult | undefined;
+  let entry: AngularClassMeta | undefined;
+  let enums: EnumType[] = [];
   if (component?.path && context.getDocgenPayload) {
     try {
       const docgenPayload = await context.getDocgenPayload(getComponentIdFromEntry(input.entry));
-      if (docgenPayload?.angularComponentMeta && docgenPayload.angularComponentMetaJson) {
-        meta = {
-          entry: docgenPayload.angularComponentMeta,
-          json: docgenPayload.angularComponentMetaJson,
-        };
-      }
+      entry = docgenPayload?.angularComponentMeta;
+      enums = docgenPayload?.angularComponentEnums ?? [];
     } catch {
-      meta = undefined;
+      entry = undefined;
     }
   }
-  const snippetContext = meta ? createSnippetContext(meta) : undefined;
+  const snippetContext = entry ? createSnippetContext(entry, enums) : undefined;
 
   const displayName =
     component && (component.exportName === 'default' ? component.localName : component.exportName);
@@ -113,7 +110,7 @@ export const buildStoryDocsPayload = async (
   return {
     id: getComponentIdFromEntry(input.entry),
     // The analyzer knows the class name even when the story file imported it as a default export.
-    name: meta?.entry.name ?? displayName ?? titleName,
+    name: entry?.name ?? displayName ?? titleName,
     path: storyImportPath,
     stories,
   };
@@ -134,10 +131,10 @@ const inputsOf = (entry: AngularClassMeta): Property[] =>
 const outputsOf = (entry: AngularClassMeta): Property[] =>
   'outputsClass' in entry ? (entry.outputsClass ?? []) : [];
 
-const createSnippetContext = (meta: AngularComponentMetaResult): SnippetContext => {
-  const inputNames = new Set(inputsOf(meta.entry).map((input) => input.name));
+const createSnippetContext = (entry: AngularClassMeta, enums: EnumType[]): SnippetContext => {
+  const inputNames = new Set(inputsOf(entry).map((input) => input.name));
   const outputs: string[] = [];
-  for (const output of outputsOf(meta.entry)) {
+  for (const output of outputsOf(entry)) {
     // model() lands under the same bare name in both arrays; its output binds as `${name}Change`.
     const bindingName = inputNames.has(output.name) ? `${output.name}Change` : output.name;
     if (!outputs.includes(bindingName)) {
@@ -145,11 +142,11 @@ const createSnippetContext = (meta: AngularComponentMetaResult): SnippetContext 
     }
   }
   return {
-    selector: meta.entry.selector,
-    componentName: meta.entry.name,
+    selector: entry.selector,
+    componentName: entry.name,
     inputNames,
     outputs,
-    enums: meta.json.miscellaneous?.enumerations ?? [],
+    enums,
   };
 };
 

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
@@ -23,12 +23,6 @@ import {
 } from './story-docs-snippet.ts';
 
 export interface BuildStoryDocsContext {
-  /**
-   * Resolves the already-registered `core/docgen` service's payload for one component id, so this
-   * provider reuses the analyzer run that already backs argTypes instead of re-analyzing the file.
-   * `undefined` when `core/docgen` never registered (e.g. the compiled docgen worker script is
-   * unavailable); descriptions still extract without it.
-   */
   getDocgenPayload:
     | ((componentId: string) => Promise<AngularDocgenPayload | undefined>)
     | undefined;

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
@@ -13,7 +13,7 @@ import { resolve } from 'node:path';
 
 import type { EnumType, Property } from '@storybook/angular-compodoc';
 import type { AngularClassMeta } from '@storybook/angular-cm';
-import type { AngularDocgenPayload } from './build-docgen.ts';
+import type { AngularComponentSnippetMeta, AngularDocgenPayload } from './build-docgen.ts';
 import { parseStoryFile, resolveComponentOf } from './resolve-component.ts';
 import { buildComponentOutletTemplate } from '../template-grammar.ts';
 import {
@@ -58,18 +58,16 @@ export const buildStoryDocsPayload = async (
   const resolution = resolveComponentOf(csf, storyPath);
   const component = 'reason' in resolution ? undefined : resolution.component;
 
-  let entry: AngularClassMeta | undefined;
-  let enums: EnumType[] = [];
+  let snippetMeta: AngularComponentSnippetMeta | undefined;
   if (component?.path && context.getDocgenPayload) {
     try {
       const docgenPayload = await context.getDocgenPayload(getComponentIdFromEntry(input.entry));
-      entry = docgenPayload?.angularComponentMeta;
-      enums = docgenPayload?.angularComponentEnums ?? [];
+      snippetMeta = docgenPayload?.angularComponentMeta;
     } catch {
-      entry = undefined;
+      snippetMeta = undefined;
     }
   }
-  const snippetContext = entry ? createSnippetContext(entry, enums) : undefined;
+  const snippetContext = snippetMeta ? createSnippetContext(snippetMeta) : undefined;
 
   const displayName =
     component && (component.exportName === 'default' ? component.localName : component.exportName);
@@ -110,7 +108,7 @@ export const buildStoryDocsPayload = async (
   return {
     id: getComponentIdFromEntry(input.entry),
     // The analyzer knows the class name even when the story file imported it as a default export.
-    name: entry?.name ?? displayName ?? titleName,
+    name: snippetMeta?.entry.name ?? displayName ?? titleName,
     path: storyImportPath,
     stories,
   };
@@ -131,7 +129,7 @@ const inputsOf = (entry: AngularClassMeta): Property[] =>
 const outputsOf = (entry: AngularClassMeta): Property[] =>
   'outputsClass' in entry ? (entry.outputsClass ?? []) : [];
 
-const createSnippetContext = (entry: AngularClassMeta, enums: EnumType[]): SnippetContext => {
+const createSnippetContext = ({ entry, enums }: AngularComponentSnippetMeta): SnippetContext => {
   const inputNames = new Set(inputsOf(entry).map((input) => input.name));
   const outputs: string[] = [];
   for (const output of outputsOf(entry)) {

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
@@ -13,7 +13,7 @@ import { resolve } from 'node:path';
 
 import type { EnumType, Property } from '@storybook/angular-compodoc';
 import type { AngularClassMeta, AngularComponentMetaResult } from '@storybook/angular-cm';
-import type { AngularComponentMetaSource } from './build-docgen.ts';
+import type { AngularDocgenPayload } from './build-docgen.ts';
 import { parseStoryFile, resolveComponentOf } from './resolve-component.ts';
 import { buildComponentOutletTemplate } from '../template-grammar.ts';
 import {
@@ -23,17 +23,24 @@ import {
 } from './story-docs-snippet.ts';
 
 export interface BuildStoryDocsContext {
-  // `undefined` when the analyzer could not be created; descriptions still extract without it.
-  manager: AngularComponentMetaSource | undefined;
+  /**
+   * Resolves the already-registered `core/docgen` service's payload for one component id, so this
+   * provider reuses the analyzer run that already backs argTypes instead of re-analyzing the file.
+   * `undefined` when `core/docgen` never registered (e.g. the compiled docgen worker script is
+   * unavailable); descriptions still extract without it.
+   */
+  getDocgenPayload:
+    | ((componentId: string) => Promise<AngularDocgenPayload | undefined>)
+    | undefined;
   resolvePath?: (importPath: string) => string;
 }
 
 // Stories that declare their own `render` get no snippet: their template is a runtime value static
 // analysis cannot see, and a component-derived one would misrepresent it.
-export const buildStoryDocsPayload = (
+export const buildStoryDocsPayload = async (
   input: StoryDocsProviderInput,
   context: BuildStoryDocsContext
-): StoryDocsPayload | undefined => {
+): Promise<StoryDocsPayload | undefined> => {
   const storyImportPath = getStoryImportPathFromEntry(input.entry);
   if (!storyImportPath) {
     return undefined;
@@ -52,12 +59,15 @@ export const buildStoryDocsPayload = (
   const component = 'reason' in resolution ? undefined : resolution.component;
 
   let meta: AngularComponentMetaResult | undefined;
-  if (component?.path && context.manager) {
+  if (component?.path && context.getDocgenPayload) {
     try {
-      meta = context.manager.extractComponentMeta(component.path, {
-        exportName: component.exportName,
-        localName: component.localName,
-      });
+      const docgenPayload = await context.getDocgenPayload(getComponentIdFromEntry(input.entry));
+      if (docgenPayload?.angularComponentMeta && docgenPayload.angularComponentMetaJson) {
+        meta = {
+          entry: docgenPayload.angularComponentMeta,
+          json: docgenPayload.angularComponentMetaJson,
+        };
+      }
     } catch {
       meta = undefined;
     }

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
@@ -14,9 +14,7 @@ let warnedMissingDocgenService = false;
 const getDocgenPayload = async (componentId: string): Promise<AngularDocgenPayload | undefined> => {
   try {
     const docgenService = getService('core/docgen', { internal: true });
-    return (await docgenService.queries.docgen.loaded({ id: componentId })) as
-      | AngularDocgenPayload
-      | undefined;
+    return await docgenService.queries.docgen.loaded({ id: componentId });
   } catch (error) {
     if (!warnedMissingDocgenService) {
       warnedMissingDocgenService = true;

--- a/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-preset.ts
@@ -1,39 +1,43 @@
 import { STORY_FILE_TEST_REGEXP, getStoryImportPathFromEntry } from 'storybook/internal/common';
+import { getService } from 'storybook/internal/core-server';
 import { logger } from 'storybook/internal/node-logger';
 import type { StoryDocsProviderPreset } from 'storybook/internal/types';
 
-import { AngularComponentMetaManager } from '@storybook/angular-cm';
+import type { AngularDocgenPayload } from './build-docgen.ts';
 import { buildStoryDocsPayload } from './story-docs-build.ts';
 
-const createManager = async (): Promise<AngularComponentMetaManager | undefined> => {
+// `core/docgen` is only registered when `experimentalDocgenServer` set up its worker (see
+// `common-preset.ts`); both services are gated by the same feature, but registration order isn't
+// a type-level guarantee, so this stays defensive rather than asserting the service exists.
+let warnedMissingDocgenService = false;
+
+const getDocgenPayload = async (componentId: string): Promise<AngularDocgenPayload | undefined> => {
   try {
-    const typescript = await import('typescript');
-    return new AngularComponentMetaManager(typescript.default ?? typescript);
+    const docgenService = getService('core/docgen', { internal: true });
+    return (await docgenService.queries.docgen.loaded({ id: componentId })) as
+      | AngularDocgenPayload
+      | undefined;
   } catch (error) {
-    logger.warn(
-      `Angular story snippets are unavailable: the component meta analyzer could not be created. ${
-        error instanceof Error ? error.message : String(error)
-      }`
-    );
+    if (!warnedMissingDocgenService) {
+      warnedMissingDocgenService = true;
+      logger.warn(
+        `Angular story snippets are unavailable: querying core/docgen failed. ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
     return undefined;
   }
 };
 
 export const experimental_storyDocsProvider: StoryDocsProviderPreset = async (nextStoryDocs) => {
-  // Scoped to the composed chain rather than the module, so the manager has one owner and one
-  // lifetime.
-  let managerPromise: Promise<AngularComponentMetaManager | undefined> | undefined;
-
   return async (input) => {
     const storyImportPath = getStoryImportPathFromEntry(input.entry);
     if (!storyImportPath || !STORY_FILE_TEST_REGEXP.test(storyImportPath)) {
       return nextStoryDocs(input);
     }
 
-    const manager = await (managerPromise ??= createManager());
-    const ours = buildStoryDocsPayload(input, { manager });
-    // The language service holds large type caches; check heap pressure after each extraction.
-    manager?.recycleIfHeapPressured();
+    const ours = await buildStoryDocsPayload(input, { getDocgenPayload });
 
     if (!ours) {
       return nextStoryDocs(input);

--- a/code/lib/angular-cm/src/index.ts
+++ b/code/lib/angular-cm/src/index.ts
@@ -1,4 +1,4 @@
 export { extractArgTypesFromData } from './extract-arg-types.ts';
 export type { ExtractArgTypesOptions, ParsingLogger } from './extract-arg-types.ts';
 export { AngularComponentMetaManager } from './manager.ts';
-export type { AngularClassMeta, AngularComponentMetaResult } from './types.ts';
+export type { AngularClassMeta, AngularComponentMetaResult, MetadataJson } from './types.ts';

--- a/code/lib/angular-cm/src/index.ts
+++ b/code/lib/angular-cm/src/index.ts
@@ -1,4 +1,4 @@
 export { extractArgTypesFromData } from './extract-arg-types.ts';
 export type { ExtractArgTypesOptions, ParsingLogger } from './extract-arg-types.ts';
 export { AngularComponentMetaManager } from './manager.ts';
-export type { AngularClassMeta, AngularComponentMetaResult, MetadataJson } from './types.ts';
+export type { AngularClassMeta, AngularComponentMetaResult } from './types.ts';

--- a/code/lib/docgen-harness/src/angular/angular-story-docs-snippets.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-story-docs-snippets.test.ts
@@ -58,7 +58,7 @@ const buildGetDocgenPayload =
       path: storyPath,
       jsDocTags: {},
       angularComponentMeta: meta.entry,
-      angularComponentMetaJson: meta.json,
+      angularComponentEnums: meta.json.miscellaneous?.enumerations ?? [],
     };
   };
 

--- a/code/lib/docgen-harness/src/angular/angular-story-docs-snippets.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-story-docs-snippets.test.ts
@@ -57,8 +57,10 @@ const buildGetDocgenPayload =
       name: meta.entry.name,
       path: storyPath,
       jsDocTags: {},
-      angularComponentMeta: meta.entry,
-      angularComponentEnums: meta.json.miscellaneous?.enumerations ?? [],
+      angularComponentMeta: {
+        entry: meta.entry,
+        enums: meta.json.miscellaneous?.enumerations ?? [],
+      },
     };
   };
 

--- a/code/lib/docgen-harness/src/angular/angular-story-docs-snippets.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-story-docs-snippets.test.ts
@@ -12,7 +12,12 @@ import { loadCsf } from 'storybook/internal/csf-tools';
 import type { IndexEntry } from 'storybook/internal/types';
 
 import { AngularComponentMetaManager } from '@storybook/angular-cm';
+import type { AngularDocgenPayload } from '../../../../frameworks/angular-vite/src/docgen/build-docgen.ts';
 import { buildStoryDocsPayload } from '../../../../frameworks/angular-vite/src/docgen/story-docs-build.ts';
+import {
+  parseStoryFile,
+  resolveComponentOf,
+} from '../../../../frameworks/angular-vite/src/docgen/resolve-component.ts';
 import {
   expectNoStaleSnippets,
   fixtureCases,
@@ -23,6 +28,39 @@ import {
 // One manager for the whole suite: each fixture directory carries its own tsconfig.json, so every
 // component file resolves to its own per-fixture project.
 const manager = new AngularComponentMetaManager(ts);
+
+// In production `getDocgenPayload` queries the already-registered `core/docgen` service, which is
+// keyed by component id and resolves the story's component internally. There is no service here,
+// so this stands in for it: resolve the same component `buildStoryDocsPayload` would (the fixture
+// carries exactly one), then extract straight off the manager, matching what `buildDocgenPayload`
+// stores on `AngularDocgenPayload` in production.
+const buildGetDocgenPayload =
+  (storyPath: string, title: string) => async (): Promise<AngularDocgenPayload | undefined> => {
+    const parsed = parseStoryFile(storyPath, title);
+    if (!parsed) {
+      return undefined;
+    }
+    const resolution = resolveComponentOf(parsed.csf, storyPath);
+    const component = 'reason' in resolution ? undefined : resolution.component;
+    if (!component?.path) {
+      return undefined;
+    }
+    const meta = manager.extractComponentMeta(component.path, {
+      exportName: component.exportName,
+      localName: component.localName,
+    });
+    if (!meta) {
+      return undefined;
+    }
+    return {
+      id: 'fixture',
+      name: meta.entry.name,
+      path: storyPath,
+      jsDocTags: {},
+      angularComponentMeta: meta.entry,
+      angularComponentMetaJson: meta.json,
+    };
+  };
 
 afterAll(() => {
   manager.dispose();
@@ -47,7 +85,10 @@ describe('angular story-docs server snippets', () => {
       subtype: 'story',
       importPath: storyPath,
     };
-    const payload = buildStoryDocsPayload({ entry }, { manager, resolvePath: (path) => path });
+    const payload = await buildStoryDocsPayload(
+      { entry },
+      { getDocgenPayload: buildGetDocgenPayload(storyPath, title), resolvePath: (path) => path }
+    );
     expect(payload).toBeDefined();
 
     for (const [exportName, story] of storyExports) {

--- a/code/lib/docgen-harness/src/angular/story-docs/build-story-docs.test.ts
+++ b/code/lib/docgen-harness/src/angular/story-docs/build-story-docs.test.ts
@@ -46,8 +46,10 @@ const buildGetDocgenPayload =
       name: meta.entry.name,
       path: storyPath,
       jsDocTags: {},
-      angularComponentMeta: meta.entry,
-      angularComponentEnums: meta.json.miscellaneous?.enumerations ?? [],
+      angularComponentMeta: {
+        entry: meta.entry,
+        enums: meta.json.miscellaneous?.enumerations ?? [],
+      },
     };
   };
 

--- a/code/lib/docgen-harness/src/angular/story-docs/build-story-docs.test.ts
+++ b/code/lib/docgen-harness/src/angular/story-docs/build-story-docs.test.ts
@@ -47,7 +47,7 @@ const buildGetDocgenPayload =
       path: storyPath,
       jsDocTags: {},
       angularComponentMeta: meta.entry,
-      angularComponentMetaJson: meta.json,
+      angularComponentEnums: meta.json.miscellaneous?.enumerations ?? [],
     };
   };
 

--- a/code/lib/docgen-harness/src/angular/story-docs/build-story-docs.test.ts
+++ b/code/lib/docgen-harness/src/angular/story-docs/build-story-docs.test.ts
@@ -8,6 +8,11 @@ import ts from 'typescript';
 import type { IndexEntry } from 'storybook/internal/types';
 
 import { AngularComponentMetaManager } from '@storybook/angular-cm';
+import type { AngularDocgenPayload } from '../../../../../frameworks/angular-vite/src/docgen/build-docgen.ts';
+import {
+  parseStoryFile,
+  resolveComponentOf,
+} from '../../../../../frameworks/angular-vite/src/docgen/resolve-component.ts';
 import { buildStoryDocsPayload } from '../../../../../frameworks/angular-vite/src/docgen/story-docs-build.ts';
 import { listFixtureCases } from '../snippet-recorder.ts';
 
@@ -15,6 +20,36 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), '__testfixtur
 
 // One manager for the whole suite; the fixtures share a single tsconfig.json at the tree root.
 const manager = new AngularComponentMetaManager(ts);
+
+// Stands in for the `core/docgen` service query `getDocgenPayload` hits in production: resolve the
+// same component `buildStoryDocsPayload` would, then extract straight off the manager.
+const buildGetDocgenPayload =
+  (storyPath: string, title: string) => async (): Promise<AngularDocgenPayload | undefined> => {
+    const parsed = parseStoryFile(storyPath, title);
+    if (!parsed) {
+      return undefined;
+    }
+    const resolution = resolveComponentOf(parsed.csf, storyPath);
+    const component = 'reason' in resolution ? undefined : resolution.component;
+    if (!component?.path) {
+      return undefined;
+    }
+    const meta = manager.extractComponentMeta(component.path, {
+      exportName: component.exportName,
+      localName: component.localName,
+    });
+    if (!meta) {
+      return undefined;
+    }
+    return {
+      id: 'fixture',
+      name: meta.entry.name,
+      path: storyPath,
+      jsDocTags: {},
+      angularComponentMeta: meta.entry,
+      angularComponentMetaJson: meta.json,
+    };
+  };
 
 afterAll(() => {
   manager.dispose();
@@ -32,9 +67,11 @@ const makeEntry = (storyPath: string, title: string): IndexEntry => ({
 describe('angular story-docs payload baselines', () => {
   it.each(listFixtureCases(FIXTURES_DIR))('%s', async (fixtureCase) => {
     const testDir = join(FIXTURES_DIR, fixtureCase);
-    const payload = buildStoryDocsPayload(
-      { entry: makeEntry(join(testDir, 'input.stories.ts'), `StoryDocs/${fixtureCase}`) },
-      { manager, resolvePath: (path) => path }
+    const storyPath = join(testDir, 'input.stories.ts');
+    const title = `StoryDocs/${fixtureCase}`;
+    const payload = await buildStoryDocsPayload(
+      { entry: makeEntry(storyPath, title) },
+      { getDocgenPayload: buildGetDocgenPayload(storyPath, title), resolvePath: (path) => path }
     );
 
     await expect(payload && { ...payload, path: '__PATH__' }).toMatchFileSnapshot(


### PR DESCRIPTION
Closes #

## What I did

Alternative to #35841 for the same problem: story-docs built its own `AngularComponentMetaManager` right next to the one `docgen-worker.ts` already owns, so we ran two warm TypeScript language services over the same files, and story-docs's copy never called `startWatching()`, so its snippets went stale after a component edit while docgen kept updating live.

#35841 fixes that by widening the docgen worker protocol with a third message kind so story-docs can query the worker directly. This PR takes a different angle: `core/docgen` is already a registered OSA service, and story-docs already runs in the same main-thread process that service lives in. So instead of reaching into the worker, `story-docs-preset.ts` just resolves `core/docgen` as an internal service dependency:

```
 story render requested
        │
        ▼
core/story-docs query ──▶ experimental_storyDocsProvider (angular-vite, main thread)
        │
        │ getService('core/docgen', { internal: true })
        ▼
core/docgen query 'docgen' ──▶ .loaded({ id }) ──▶ extractDocgen command
        │                                                  │
        │ (already registered, already cached                docgenProvider(input)
        │  once docgen has run for this id)                   │
        │                                                     ▼
        │                                          docgenWorker.extract(entry)
        │                                          (angular-vite's worker-hosted
        │                                           analyzer - the ONE
        │                                           AngularComponentMetaManager)
        ▼
AngularDocgenPayload { argTypes, ..., angularComponentMeta: { entry, enums } }
        │
        ▼
story-docs reads entry (selector, inputsClass/outputsClass)
       + enums (for resolving Enum.Member args) straight off it
```

`build-docgen.ts` already attached the analyzer's class record to the stored docgen payload as `angularComponentMeta`. It now carries `{ entry, enums }` rather than the bare class record: `enums` is the file's enum declarations, needed to resolve args like `kind: ButtonKind.Secondary` (enums aren't a property of the class - the analyzer collects them once per file, as a sibling of the class record, not nested inside it). That's deliberately just the one slice of the analyzer's file-level output story-docs reads, not the whole file metadata (which also lists every other component/directive/pipe the analyzer found in the file) - no point duplicating data already stored elsewhere for those. `entry` and `enums` are bundled into one field rather than two independent ones because they're always set or read together; two siblings would only rely on the two call sites agreeing by convention. `core/docgen`'s schema is a `v.looseObject`, so the extra field passes through validation into service state untouched.

```ts
// story-docs-preset.ts, before
const manager = await (managerPromise ??= createManager());
const ours = buildStoryDocsPayload(input, { manager });

// after
const getDocgenPayload = async (componentId: string) => {
  const docgenService = getService('core/docgen', { internal: true });
  return docgenService.queries.docgen.loaded({ id: componentId });
};
const ours = await buildStoryDocsPayload(input, { getDocgenPayload });
```

Because the lookup is now keyed by component id (matching how `core/docgen` stores its state) rather than component path plus export/local name, `buildStoryDocsPayload` derives the id the same way docgen does (`getComponentIdFromEntry`) and no longer needs a manager-shaped dependency at all.

One extraction serves both consumers: querying story-docs for a component transparently triggers (or reuses the cached result of) the exact same `docgenWorker.extract()` call docgen would have made anyway. No second manager, no protocol change, and `common-preset.ts` is untouched, since `getService` resolves against the process-global registry at query time rather than needing anything threaded through preset composition.

### Where this differs from #35841 (worth comparing before picking one)

- Footprint: this PR touches 7 files, all inside `angular-cm` / `angular-vite` / `docgen-harness`. #35841 touches those plus 7 files in `code/core` (protocol, worker, client, preset wiring). If we want the smallest diff, this wins.
- Coupling: this PR piggybacks Angular-specific analyzer data onto `core/docgen`'s cross-framework payload schema (a `looseObject`, so it's already loosely typed, but it does mean `core/docgen`'s state now carries two fields no other framework's docgen provider populates). #35841 keeps that data on a purpose-built, explicitly "framework-specific and opaque to core" worker message instead, so the generic docgen service stays framework-agnostic.
- Freshness: both fixes share the same underlying manager and get the same `startWatching()` live-reload fix, since both ultimately route through the one `docgenWorker.extract()` call.
- Failure mode: here, a story-docs snippet silently depends on `core/docgen` having successfully extracted for the same component; if docgen's own extraction failed for an unrelated reason, story-docs loses its snippet too (falls back the same way it already does when `meta` is undefined, so behavior isn't broken, just the failure surface is now shared). #35841 keeps the two failure paths independent.

I don't have a strong preference yet, happy to close whichever we don't go with once we've talked it through.

### What a bad run looks like

Dropping the enum table in `createSnippetContext` in `story-docs-build.ts` (passing `[]` instead of the real `enums` off `angularComponentMeta`, simulating "forgot to carry the enum table through") breaks the harness parity gate on the one fixture that actually exercises enum resolution:

```console
$ yarn test --project "@storybook/docgen-harness" angular-story-docs-snippets

 FAIL  |@storybook/docgen-harness| src/angular/angular-story-docs-snippets.test.ts > angular story-docs server snippets > decorator-union-enum
Error: Snapshot `angular story-docs server snippets > decorator-union-enum 1` mismatched

Expected: "<sb-decorator-union-enum [size]="'large'" [tone]="'warn'" [kind]="'secondary'"></sb-decorator-union-enum>"
Received: "<sb-decorator-union-enum [size]="'large'" [tone]="'warn'" [kind]="ButtonKind.Secondary"></sb-decorator-union-enum>"

  Snapshots  1 failed
 Test Files  1 failed (1)
      Tests  1 failed | 10 passed (11)
```

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Check out this branch and run `yarn && yarn nx run-many -t compile`.
2. Run `yarn task sandbox --template angular-vite/docgen-server-ts --start-from auto` (the sandbox with `experimentalDocgenServer` and `componentsManifest` on). Open a story's Docs page - argTypes and the Source block snippet should render exactly as they did before this PR.
3. Without restarting the dev server, edit the story's component (e.g. add an `@Input()`). Both the argTypes table and the Source block snippet should pick up the change on the next load.
4. `yarn test docgen-worker story-docs-build angular-story-docs-snippets build-story-docs common-preset docgen` should all pass.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Internal worker plumbing behind an experimental flag, so nothing user-facing to document here.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
