### PR TITLE
Core: Centralize import-statement generation in csf-tools

### DIFF
--- a/code/core/src/csf-tools/story-shape/import-statements.test.ts
+++ b/code/core/src/csf-tools/story-shape/import-statements.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, it } from 'vitest';
+
+import { dedent } from 'ts-dedent';
+
+import { loadCsf } from '../CsfFile.ts';
+import {
+  type ImportRef,
+  buildImportStatements,
+  resolveComponentImport,
+} from './import-statements.ts';
+import { collectImportBindings } from './imports.ts';
+
+const bindingsOf = (code: string) =>
+  collectImportBindings(loadCsf(code, { makeTitle: (title) => title ?? 'title' })._file.path);
+
+const resolve = (code: string, componentName: string) =>
+  resolveComponentImport(componentName, bindingsOf(code));
+
+const statementsFor = (code: string, componentNames: string[], packageName?: string) => {
+  const bindings = bindingsOf(code);
+  return buildImportStatements({
+    refs: componentNames.map((name) => resolveComponentImport(name, bindings)),
+    packageName,
+  });
+};
+
+describe('resolveComponentImport', () => {
+  it('resolves a named import', () => {
+    expect(resolve(`import { Button } from './button';`, 'Button')).toMatchInlineSnapshot(`
+      {
+        "componentName": "Button",
+        "importId": "./button",
+        "importName": "Button",
+        "localImportName": "Button",
+      }
+    `);
+  });
+
+  it('keeps the exported name when the local name is an alias', () => {
+    expect(resolve(`import { ButtonComponent as Btn } from './button';`, 'Btn'))
+      .toMatchInlineSnapshot(`
+      {
+        "componentName": "Btn",
+        "importId": "./button",
+        "importName": "ButtonComponent",
+        "localImportName": "Btn",
+      }
+    `);
+  });
+
+  it('resolves a default import', () => {
+    expect(resolve(`import Button from './Button.vue';`, 'Button')).toMatchInlineSnapshot(`
+      {
+        "componentName": "Button",
+        "importId": "./Button.vue",
+        "importName": "default",
+        "localImportName": "Button",
+      }
+    `);
+  });
+
+  it('marks a bare namespace binding as a namespace', () => {
+    expect(resolve(`import * as Icons from './icons';`, 'Icons')).toMatchInlineSnapshot(`
+      {
+        "componentName": "Icons",
+        "importId": "./icons",
+        "importName": "*",
+        "localImportName": "Icons",
+        "namespace": "Icons",
+      }
+    `);
+  });
+
+  it('resolves a compound name through a namespace import to the member export', () => {
+    expect(resolve(`import * as Accordion from './accordion';`, 'Accordion.Root'))
+      .toMatchInlineSnapshot(`
+      {
+        "componentName": "Accordion.Root",
+        "importId": "./accordion",
+        "importName": "Root",
+        "localImportName": "Accordion",
+        "member": "Root",
+        "namespace": "Accordion",
+      }
+    `);
+  });
+
+  it('resolves a compound name through a named import to the base export', () => {
+    expect(resolve(`import { Accordion } from './accordion';`, 'Accordion.Root'))
+      .toMatchInlineSnapshot(`
+      {
+        "componentName": "Accordion.Root",
+        "importId": "./accordion",
+        "importName": "Accordion",
+        "localImportName": "Accordion",
+        "member": "Root",
+      }
+    `);
+  });
+
+  it('splits a compound name on the first dot only', () => {
+    expect(resolve(`import * as A from './a';`, 'A.B.C')).toMatchObject({
+      importName: 'B.C',
+      member: 'B.C',
+      namespace: 'A',
+    });
+  });
+
+  it('reports no binding for a component declared in the story file', () => {
+    expect(resolve(`const Button = () => null;`, 'Button')).toMatchInlineSnapshot(`
+      {
+        "componentName": "Button",
+      }
+    `);
+  });
+
+  it('reports no binding for a compound name whose base is not imported', () => {
+    expect(resolve(`const Accordion = {};`, 'Accordion.Root')).toMatchInlineSnapshot(`
+      {
+        "componentName": "Accordion.Root",
+        "member": "Root",
+      }
+    `);
+  });
+
+  it('reports no binding for a type-only import', () => {
+    expect(resolve(`import type { Button } from './button';`, 'Button')).toMatchInlineSnapshot(`
+      {
+        "componentName": "Button",
+      }
+    `);
+  });
+});
+
+describe('buildImportStatements', () => {
+  it('emits nothing for refs without a source', () => {
+    expect(buildImportStatements({ refs: [{ localImportName: 'Button' }] })).toEqual([]);
+  });
+
+  it('emits single-quoted declarations per specifier kind', () => {
+    expect(
+      statementsFor(
+        dedent`
+        import { Button } from './button';
+        import { ButtonComponent as Btn } from './aliased';
+        import Panel from './Panel.vue';
+        import * as Icons from './icons';
+      `,
+        ['Button', 'Btn', 'Panel', 'Icons']
+      )
+    ).toMatchInlineSnapshot(`
+      [
+        "import { Button } from './button';",
+        "import { ButtonComponent as Btn } from './aliased';",
+        "import Panel from './Panel.vue';",
+        "import * as Icons from './icons';",
+      ]
+    `);
+  });
+
+  it('merges a default and named specifiers from the same source into one declaration', () => {
+    expect(
+      statementsFor(
+        dedent`
+        import Link, { Banner, Dialog } from '@primer/react';
+        import { CopilotIcon } from '@primer/octicons-react';
+      `,
+        ['Banner', 'CopilotIcon', 'Dialog', 'Link']
+      )
+    ).toMatchInlineSnapshot(`
+      [
+        "import Link, { Banner, Dialog } from '@primer/react';",
+        "import { CopilotIcon } from '@primer/octicons-react';",
+      ]
+    `);
+  });
+
+  it('keeps a namespace declaration separate from named specifiers of the same source', () => {
+    expect(
+      statementsFor(
+        dedent`
+        import * as PR from '@primer/react';
+        import { Banner } from '@primer/react';
+      `,
+        ['Banner', 'PR.Box']
+      )
+    ).toMatchInlineSnapshot(`
+      [
+        "import * as PR from '@primer/react';",
+        "import { Banner } from '@primer/react';",
+      ]
+    `);
+  });
+
+  it('emits a namespace import once for several members', () => {
+    expect(statementsFor(`import * as A from './a';`, ['A.Root', 'A.Item', 'A.Trigger']))
+      .toMatchInlineSnapshot(`
+      [
+        "import * as A from './a';",
+      ]
+    `);
+  });
+
+  it('deduplicates repeated refs', () => {
+    const ref: ImportRef = {
+      importId: './button',
+      importName: 'Button',
+      localImportName: 'Button',
+    };
+    expect(buildImportStatements({ refs: [ref, { ...ref }] })).toMatchInlineSnapshot(`
+      [
+        "import { Button } from './button';",
+      ]
+    `);
+  });
+
+  it('wraps a declaration that exceeds the print width', () => {
+    const names = [
+      'Aaaaaaaaaaaaaaaaaaaaaaaa',
+      'Bbbbbbbbbbbbbbbbbbbbbbbb',
+      'Cccccccccccccccccccccccc',
+      'Dddddddddddddddddddddddd',
+    ];
+    expect(
+      buildImportStatements({
+        refs: names.map((name) => ({
+          importId: './ui',
+          importName: name,
+          localImportName: name,
+        })),
+      })
+    ).toMatchInlineSnapshot(`
+      [
+        "import {
+        Aaaaaaaaaaaaaaaaaaaaaaaa,
+        Bbbbbbbbbbbbbbbbbbbbbbbb,
+        Cccccccccccccccccccccccc,
+        Dddddddddddddddddddddddd,
+      } from './ui';",
+      ]
+    `);
+  });
+
+  it('buckets by first-seen source order', () => {
+    expect(
+      statementsFor(
+        dedent`
+        import { A } from './a';
+        import { B } from './b';
+        import { A2 } from './a';
+      `,
+        ['B', 'A', 'A2']
+      )
+    ).toMatchInlineSnapshot(`
+      [
+        "import { B } from './b';",
+        "import { A, A2 } from './a';",
+      ]
+    `);
+  });
+
+  describe('packageName rewriting', () => {
+    it('rewrites a relative source to the package name', () => {
+      expect(statementsFor(`import { Button } from './button';`, ['Button'], 'my-design-system'))
+        .toMatchInlineSnapshot(`
+        [
+          "import { Button } from 'my-design-system';",
+        ]
+      `);
+    });
+
+    it('leaves a source that already resolves as a package alone', () => {
+      expect(
+        buildImportStatements({
+          refs: [
+            {
+              importId: '@primer/react',
+              importName: 'Banner',
+              localImportName: 'Banner',
+              isPackage: true,
+            },
+          ],
+          packageName: 'my-design-system',
+        })
+      ).toMatchInlineSnapshot(`
+        [
+          "import { Banner } from '@primer/react';",
+        ]
+      `);
+    });
+
+    it('turns a rewritten default import into a named import using the local name', () => {
+      expect(statementsFor(`import Button from './button';`, ['Button'], 'my-design-system'))
+        .toMatchInlineSnapshot(`
+        [
+          "import { Button } from 'my-design-system';",
+        ]
+      `);
+    });
+
+    it('turns a rewritten namespace member into a named import', () => {
+      expect(statementsFor(`import * as A from './a';`, ['A.Root'], 'my-design-system'))
+        .toMatchInlineSnapshot(`
+        [
+          "import { Root } from 'my-design-system';",
+        ]
+      `);
+    });
+
+    it('keeps a rewritten namespace that has no single member to name', () => {
+      expect(statementsFor(`import * as Icons from './icons';`, ['Icons'], 'my-design-system'))
+        .toMatchInlineSnapshot(`
+        [
+          "import * as Icons from 'my-design-system';",
+        ]
+      `);
+    });
+
+    it('keeps a rewritten namespace when the member is a nested path', () => {
+      expect(statementsFor(`import * as A from './a';`, ['A.B.C'], 'my-design-system'))
+        .toMatchInlineSnapshot(`
+        [
+          "import * as A from 'my-design-system';",
+        ]
+      `);
+    });
+  });
+
+  describe('importOverride', () => {
+    const button: ImportRef = {
+      importId: './button',
+      importName: 'Button',
+      localImportName: 'Button',
+    };
+
+    it('takes precedence over packageName for the source', () => {
+      expect(
+        buildImportStatements({
+          refs: [{ ...button, importOverride: `import { Button } from 'my-design-system';` }],
+          packageName: 'ignored',
+        })
+      ).toMatchInlineSnapshot(`
+        [
+          "import { Button } from 'my-design-system';",
+        ]
+      `);
+    });
+
+    it('aliases the overridden export to the local name', () => {
+      expect(
+        buildImportStatements({
+          refs: [{ ...button, importOverride: `import { PublicButton } from 'ds';` }],
+        })
+      ).toMatchInlineSnapshot(`
+        [
+          "import { PublicButton as Button } from 'ds';",
+        ]
+      `);
+    });
+
+    it('forces a default import while keeping the local name', () => {
+      expect(
+        buildImportStatements({
+          refs: [{ ...button, importOverride: `import Whatever from 'ds';` }],
+        })
+      ).toMatchInlineSnapshot(`
+        [
+          "import Button from 'ds';",
+        ]
+      `);
+    });
+
+    it('uses a namespace override as written', () => {
+      expect(
+        buildImportStatements({
+          refs: [{ ...button, importOverride: `import * as DS from 'ds';` }],
+        })
+      ).toMatchInlineSnapshot(`
+        [
+          "import * as DS from 'ds';",
+        ]
+      `);
+    });
+
+    it('keeps the overridden source when it carries no specifier', () => {
+      expect(buildImportStatements({ refs: [{ ...button, importOverride: `import 'ds';` }] }))
+        .toMatchInlineSnapshot(`
+        [
+          "import { Button } from 'ds';",
+        ]
+      `);
+    });
+
+    it('falls back to the declared import when the override does not parse', () => {
+      expect(buildImportStatements({ refs: [{ ...button, importOverride: 'not an import' }] }))
+        .toMatchInlineSnapshot(`
+        [
+          "import { Button } from './button';",
+        ]
+      `);
+    });
+
+    it('merges components overridden onto the same source', () => {
+      expect(
+        buildImportStatements({
+          refs: [
+            { ...button, importOverride: `import { Button } from 'ds';` },
+            {
+              importId: './card',
+              importName: 'Card',
+              localImportName: 'Card',
+              importOverride: `import { Card } from 'ds';`,
+            },
+          ],
+        })
+      ).toMatchInlineSnapshot(`
+        [
+          "import { Button, Card } from 'ds';",
+        ]
+      `);
+    });
+  });
+});

--- a/code/core/src/csf-tools/story-shape/import-statements.ts
+++ b/code/core/src/csf-tools/story-shape/import-statements.ts
@@ -1,0 +1,249 @@
+import { babelParse, babelPrint, types as t } from 'storybook/internal/babel';
+
+import { type ImportBinding, importedName, isTypeSpecifier } from './imports.ts';
+
+/** A component reference resolved to the module binding it comes from. */
+export interface ImportRef {
+  /** Module specifier. Refs without one contribute no import statement. */
+  importId?: string;
+  /** Exported name; `'default'` for default imports and `'*'` for whole-namespace bindings. */
+  importName?: string;
+  /** Local identifier the import is bound to. */
+  localImportName?: string;
+  /** Local identifier of the `import * as` binding this ref reaches through. */
+  namespace?: string;
+  /** Import statement replacing the derived source and specifier, e.g. from an `@import` tag. */
+  importOverride?: string;
+  /** Whether `importId` already resolves as a package, which suppresses `packageName` rewriting. */
+  isPackage?: boolean;
+}
+
+/** An {@link ImportRef} together with the component expression it was resolved from. */
+export interface ComponentImportRef extends ImportRef {
+  /** Component as written in the story file, e.g. `Button` or `Accordion.Root`. */
+  componentName: string;
+  /** Accessed member of a compound name, e.g. `Root` for `Accordion.Root`. */
+  member?: string;
+}
+
+/**
+ * Resolve a component expression as written in a story file to the import it binds to.
+ *
+ * A compound name resolves through its base identifier, so `Accordion.Root` reached through
+ * `import * as Accordion` exports `Root`, while the same name reached through
+ * `import { Accordion }` exports `Accordion` and carries `Root` as the member.
+ */
+export function resolveComponentImport(
+  componentName: string,
+  bindings: Map<string, ImportBinding>
+): ComponentImportRef {
+  const dot = componentName.indexOf('.');
+  const base = dot === -1 ? componentName : componentName.slice(0, dot);
+  const member = dot === -1 ? undefined : componentName.slice(dot + 1);
+  const binding = bindings.get(base);
+
+  if (!binding) {
+    return { componentName, ...(member ? { member } : {}) };
+  }
+
+  const isNamespace = binding.importName === '*';
+  return {
+    componentName,
+    ...(member ? { member } : {}),
+    localImportName: base,
+    importId: binding.importId,
+    importName: isNamespace && member ? member : binding.importName,
+    ...(isNamespace ? { namespace: base } : {}),
+  };
+}
+
+type OverrideSpecifier =
+  | { kind: 'namespace'; local: string }
+  | { kind: 'default' }
+  | { kind: 'named'; imported: string };
+
+interface ParsedOverride {
+  source: string;
+  specifier?: OverrideSpecifier;
+}
+
+function parseImportOverride(code: string): ParsedOverride | undefined {
+  let declaration: t.ImportDeclaration | undefined;
+  try {
+    declaration = babelParse(code).program.body.find((node): node is t.ImportDeclaration =>
+      t.isImportDeclaration(node)
+    );
+  } catch {
+    return undefined;
+  }
+
+  if (!declaration) {
+    return undefined;
+  }
+
+  const source = declaration.source.value;
+  const specifier = (declaration.specifiers ?? []).find((s) => !isTypeSpecifier(s));
+
+  if (t.isImportNamespaceSpecifier(specifier)) {
+    return { source, specifier: { kind: 'namespace', local: specifier.local.name } };
+  }
+  if (t.isImportDefaultSpecifier(specifier)) {
+    return { source, specifier: { kind: 'default' } };
+  }
+  if (t.isImportSpecifier(specifier)) {
+    return { source, specifier: { kind: 'named', imported: importedName(specifier.imported) } };
+  }
+  return { source };
+}
+
+interface Bucket {
+  source: t.StringLiteral;
+  defaults: t.Identifier[];
+  namespaces: t.Identifier[];
+  named: t.ImportSpecifier[];
+}
+
+function addUniqueBy<T>(list: T[], item: T, eq: (candidate: T) => boolean) {
+  if (!list.find(eq)) {
+    list.push(item);
+  }
+}
+
+function addNamed(bucket: Bucket, local: string, imported: string) {
+  addUniqueBy(
+    bucket.named,
+    t.importSpecifier(t.identifier(local), t.identifier(imported)),
+    (n) => n.local.name === local && importedName(n.imported) === imported
+  );
+}
+
+function addSingle(list: t.Identifier[], name: string) {
+  addUniqueBy(list, t.identifier(name), (n) => n.name === name);
+}
+
+function collectSpecifier(
+  bucket: Bucket,
+  ref: ImportRef,
+  source: string,
+  override: ParsedOverride | undefined
+) {
+  const rewritten = source !== ref.importId;
+
+  if (override?.specifier) {
+    const { specifier } = override;
+    if (specifier.kind === 'namespace') {
+      addSingle(bucket.namespaces, specifier.local);
+      return;
+    }
+    if (!ref.localImportName) {
+      return;
+    }
+    if (specifier.kind === 'default') {
+      addSingle(bucket.defaults, ref.localImportName);
+    } else {
+      addNamed(bucket, ref.localImportName, specifier.imported);
+    }
+    return;
+  }
+
+  if (ref.namespace) {
+    // A rewritten source no longer exposes the module object, so a single member reached through
+    // the namespace becomes a named import. A deeper path still needs the module object.
+    const member = rewritten ? ref.importName : undefined;
+    if (member && member !== '*' && !member.includes('.')) {
+      addNamed(bucket, member, member);
+    } else {
+      addSingle(bucket.namespaces, ref.namespace);
+    }
+    return;
+  }
+
+  if (!ref.localImportName) {
+    return;
+  }
+
+  if (ref.importName === 'default') {
+    if (rewritten) {
+      addNamed(bucket, ref.localImportName, ref.localImportName);
+    } else {
+      addSingle(bucket.defaults, ref.localImportName);
+    }
+    return;
+  }
+
+  if (ref.importName) {
+    addNamed(bucket, ref.localImportName, ref.importName);
+  }
+}
+
+function printBucket({ source, defaults, namespaces, named }: Bucket): string[] {
+  const print = (
+    specifiers: (t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier | t.ImportSpecifier)[]
+  ) => babelPrint(t.importDeclaration(specifiers, source));
+
+  const extraDefaults = defaults.slice(1).map((d) => print([t.importDefaultSpecifier(d)]));
+
+  if (namespaces.length > 0) {
+    const first: (t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier)[] = [];
+    if (defaults[0]) {
+      first.push(t.importDefaultSpecifier(defaults[0]));
+    }
+    first.push(t.importNamespaceSpecifier(namespaces[0]));
+
+    return [
+      print(first),
+      ...(named.length > 0 ? [print(named)] : []),
+      ...extraDefaults,
+      ...namespaces.slice(1).map((ns) => print([t.importNamespaceSpecifier(ns)])),
+    ];
+  }
+
+  if (defaults.length === 0 && named.length === 0) {
+    return [];
+  }
+
+  const first: (t.ImportDefaultSpecifier | t.ImportSpecifier)[] = [];
+  if (defaults[0]) {
+    first.push(t.importDefaultSpecifier(defaults[0]));
+  }
+  first.push(...named);
+
+  return [print(first), ...extraDefaults];
+}
+
+/**
+ * Build the minimal, deduplicated set of import declarations the given references need.
+ *
+ * References are bucketed by their final source, which is the `importOverride` source when one
+ * parses, else `packageName` when the original source is not already a package, else the source as
+ * written. Sources keep first-seen order and declarations keep a fixed order within a source, so
+ * repeated runs produce byte-identical output.
+ */
+export function buildImportStatements({
+  refs,
+  packageName,
+}: {
+  refs: ImportRef[];
+  packageName?: string;
+}): string[] {
+  const buckets = new Map<string, Bucket>();
+
+  refs.forEach((ref) => {
+    if (!ref.importId) {
+      return;
+    }
+
+    const override = ref.importOverride ? parseImportOverride(ref.importOverride) : undefined;
+    const source = override?.source ?? (packageName && !ref.isPackage ? packageName : ref.importId);
+
+    let bucket = buckets.get(source);
+    if (!bucket) {
+      bucket = { source: t.stringLiteral(source), defaults: [], namespaces: [], named: [] };
+      buckets.set(source, bucket);
+    }
+
+    collectSpecifier(bucket, ref, source, override);
+  });
+
+  return Array.from(buckets.values()).flatMap(printBucket);
+}

--- a/code/core/src/csf-tools/story-shape/index.ts
+++ b/code/core/src/csf-tools/story-shape/index.ts
@@ -5,6 +5,12 @@ export {
   storyAssignedArgsPath,
 } from './args.ts';
 export {
+  type ComponentImportRef,
+  type ImportRef,
+  buildImportStatements,
+  resolveComponentImport,
+} from './import-statements.ts';
+export {
   type ImportBinding,
   collectImportBindings,
   importedName,

--- a/code/renderers/react/src/componentManifest/buildReactComponentDocgen.ts
+++ b/code/renderers/react/src/componentManifest/buildReactComponentDocgen.ts
@@ -1,5 +1,9 @@
 import { getComponentIdFromEntry } from 'storybook/internal/common';
-import { extractComponentDescription, extractDescription } from 'storybook/internal/csf-tools';
+import {
+  buildImportStatements,
+  extractComponentDescription,
+  extractDescription,
+} from 'storybook/internal/csf-tools';
 import type {
   ComponentManifest,
   ComponentSubcomponentManifest,
@@ -10,7 +14,7 @@ import type {
 import path from 'pathe';
 
 import type { ComponentDoc, PropItem } from './componentMeta/componentMetaExtractor.ts';
-import { type ComponentRef, getImports } from './getComponentImports.ts';
+import type { ComponentRef } from './getComponentImports.ts';
 import { type DocObj } from './reactDocgen.ts';
 import { type ComponentDocWithExportName } from './reactDocgenTypescript.ts';
 import {
@@ -68,7 +72,11 @@ function getPackageInfo(componentPath: string | undefined, fallbackPath: string)
 
 function getFallbackImport(packageName: string | undefined, componentName: string | undefined) {
   const exportName = componentName?.split('.').at(-1);
-  return packageName && exportName ? `import { ${exportName} } from "${packageName}";` : '';
+  return packageName && exportName
+    ? buildImportStatements({
+        refs: [{ importId: packageName, importName: exportName, localImportName: exportName }],
+      }).join('\n')
+    : '';
 }
 
 /**
@@ -147,7 +155,7 @@ function createSubcomponentDocgen({
   storyFilePath: string;
 }): ReactSubcomponentManifest {
   const imports =
-    getImports({ components: component ? [component] : [], packageName })
+    buildImportStatements({ refs: component ? [component] : [], packageName })
       .join('\n')
       .trim() || getFallbackImport(packageName, component?.componentName);
   const {
@@ -215,7 +223,7 @@ export function buildStoryDocsFromResolved({
   const packageName = getPackageInfo(component?.path, storyPath);
   const fallbackImport = getFallbackImport(packageName, componentName);
   const imports =
-    getImports({ components: allComponents, packageName }).join('\n').trim() || fallbackImport;
+    buildImportStatements({ refs: allComponents, packageName }).join('\n').trim() || fallbackImport;
   const storyEntries = extractStorySnippets(csf, component?.componentName, filterStoryIds);
 
   return {

--- a/code/renderers/react/src/componentManifest/generator.test.ts
+++ b/code/renderers/react/src/componentManifest/generator.test.ts
@@ -53,7 +53,7 @@ test('manifests generates correct id, name, description and examples ', async ()
           "description": "Primary UI component for user interaction",
           "error": undefined,
           "id": "example-button",
-          "import": "import { Button } from "@design-system/components/override";",
+          "import": "import { Button } from '@design-system/components/override';",
           "jsDocTags": {
             "import": [
               "import { Button } from '@design-system/components/override';",
@@ -176,7 +176,7 @@ test('manifests generates correct id, name, description and examples ', async ()
           "description": "Description from meta and very long.",
           "error": undefined,
           "id": "example-header",
-          "import": "import { Header } from "some-package";",
+          "import": "import { Header } from 'some-package';",
           "jsDocTags": {
             "summary": [
               "Component summary",
@@ -366,7 +366,7 @@ test('fall back to index title when no component name', async () => {
       "description": "Primary UI component for user interaction",
       "error": undefined,
       "id": "example-button",
-      "import": "import { Button } from "some-package";",
+      "import": "import { Button } from 'some-package';",
       "jsDocTags": {},
       "name": "Button",
       "path": "./src/stories/Button.stories.ts",
@@ -416,7 +416,7 @@ test('component exported from other file', async () => {
       "description": "Primary UI component for user interaction",
       "error": undefined,
       "id": "example-button",
-      "import": "import { Button } from "some-package";",
+      "import": "import { Button } from 'some-package';",
       "jsDocTags": {},
       "name": "Button",
       "path": "./src/stories/Button.stories.ts",
@@ -471,7 +471,7 @@ test('unknown expressions', async () => {
       "description": "Primary UI component for user interaction",
       "error": undefined,
       "id": "example-button",
-      "import": "import { Button } from "some-package";",
+      "import": "import { Button } from 'some-package';",
       "jsDocTags": {},
       "name": "Button",
       "path": "./src/stories/Button.stories.ts",
@@ -908,7 +908,7 @@ test('generator preserves @import override when reactComponentMeta is enabled', 
   const result = await runManifestsWithOptions(manifestEntries, { presets });
   const button = result?.components?.components?.['example-button'];
 
-  expect(button?.import).toBe('import { Button } from "@design-system/components/override";');
+  expect(button?.import).toBe("import { Button } from '@design-system/components/override';");
   expect(button?.jsDocTags.import).toEqual([
     "import { Button } from '@design-system/components/override';",
   ]);
@@ -998,7 +998,7 @@ test('generator falls back to title-based matching when meta.component aliases a
 
   expect(accordion?.error).toBeUndefined();
   expect(accordion?.name).toBe('Root');
-  expect(accordion?.import).toBe('import { Root } from "some-package";');
+  expect(accordion?.import).toBe("import { Root } from 'some-package';");
   expect(batchExtract).toHaveBeenCalled();
 });
 
@@ -1068,7 +1068,7 @@ test('should create component manifest when only attached-mdx docs have manifest
             "description": "Primary UI component for user interaction",
             "error": undefined,
             "id": "example-button",
-            "import": "import { Button } from "some-package";",
+            "import": "import { Button } from 'some-package';",
             "jsDocTags": {},
             "name": "Button",
             "path": "./src/stories/Button.stories.ts",

--- a/code/renderers/react/src/componentManifest/getComponentImports.test.ts
+++ b/code/renderers/react/src/componentManifest/getComponentImports.test.ts
@@ -4,7 +4,7 @@ import { loadCsf } from 'storybook/internal/csf-tools';
 
 import { dedent } from 'ts-dedent';
 
-import { getImports as buildImports, getComponentData } from './getComponentImports.ts';
+import { getComponentData } from './getComponentImports.ts';
 import { setupMemfsMocks } from './memfs-test-setup.ts';
 
 vi.mock('node:fs');
@@ -69,8 +69,8 @@ test('Get imports from multiple components', async () => {
         },
       ],
       "imports": [
-        "import { Button } from "@design-system/components/override";",
-        "import { ButtonGroup } from "./button-group";",
+        "import { Button } from '@design-system/components/override';",
+        "import { ButtonGroup } from './button-group';",
       ],
     }
   `
@@ -101,7 +101,7 @@ test('Namespace import with member usage', async () => {
         },
       ],
       "imports": [
-        "import * as Accordion from "./accordion";",
+        "import * as Accordion from './accordion';",
       ],
     }
   `
@@ -131,7 +131,7 @@ test('Named import used as namespace object', async () => {
         },
       ],
       "imports": [
-        "import { Accordion } from "./accordion";",
+        "import { Accordion } from './accordion';",
       ],
     }
   `
@@ -162,7 +162,7 @@ test('Default import', async () => {
         },
       ],
       "imports": [
-        "import { Button } from "@design-system/components/override";",
+        "import { Button } from '@design-system/components/override';",
       ],
     }
   `
@@ -202,8 +202,8 @@ test('Alias named import and meta.component inclusion', async () => {
         },
       ],
       "imports": [
-        "import { Button as Btn } from "@design-system/components/override";",
-        "import { Other } from "./other";",
+        "import { Button as Btn } from '@design-system/components/override';",
+        "import { Other } from './other';",
       ],
     }
   `
@@ -234,7 +234,7 @@ test('Strip unused specifiers from the same import statement', async () => {
         },
       ],
       "imports": [
-        "import { Button as Btn } from "@design-system/components/override";",
+        "import { Button as Btn } from '@design-system/components/override';",
       ],
     }
   `
@@ -264,7 +264,7 @@ test('Meta component with member and star import', async () => {
         },
       ],
       "imports": [
-        "import * as Accordion from "./accordion";",
+        "import * as Accordion from './accordion';",
       ],
     }
   `
@@ -304,8 +304,8 @@ test('Keeps multiple named specifiers and drops unused ones from same import', a
         },
       ],
       "imports": [
-        "import { Button } from "@design-system/components/override";",
-        "import { ButtonGroup } from "./button-group";",
+        "import { Button } from '@design-system/components/override';",
+        "import { ButtonGroup } from './button-group';",
       ],
     }
   `
@@ -336,7 +336,7 @@ test('Mixed default + named import: keep only default when only default used', a
         },
       ],
       "imports": [
-        "import { Button } from "@design-system/components/override";",
+        "import { Button } from '@design-system/components/override';",
       ],
     }
   `
@@ -367,7 +367,7 @@ test('Mixed default + named import: keep only named when only named (alias) used
         },
       ],
       "imports": [
-        "import { Button as Btn } from "@design-system/components/override";",
+        "import { Button as Btn } from '@design-system/components/override';",
       ],
     }
   `
@@ -399,7 +399,7 @@ test('Per-specifier type import is dropped when mixing with value specifiers', a
         },
       ],
       "imports": [
-        "import { Button } from "@design-system/components/override";",
+        "import { Button } from '@design-system/components/override';",
       ],
     }
   `
@@ -440,7 +440,7 @@ test('Namespace import used for multiple members kept once', async () => {
         },
       ],
       "imports": [
-        "import * as DS from "./ds";",
+        "import * as DS from './ds';",
       ],
     }
   `
@@ -470,7 +470,7 @@ test('Default import kept when referenced only via meta.component', async () => 
         },
       ],
       "imports": [
-        "import { Button } from "@design-system/components/override";",
+        "import { Button } from '@design-system/components/override';",
       ],
     }
   `
@@ -502,7 +502,7 @@ test('Side-effect-only import is ignored', async () => {
         },
       ],
       "imports": [
-        "import { Button } from "@design-system/components/override";",
+        "import { Button } from '@design-system/components/override';",
       ],
     }
   `
@@ -537,7 +537,7 @@ test('Converts default relative import to import override when provided', async 
         },
       ],
       "imports": [
-        "import { Button } from "@design-system/components/override";",
+        "import { Button } from '@design-system/components/override';",
       ],
     }
   `
@@ -566,7 +566,7 @@ test('Keeps relative import when packageName is missing', async () => {
         },
       ],
       "imports": [
-        "import { Button } from "./components/Button";",
+        "import { Button } from './components/Button';",
       ],
     }
   `
@@ -597,7 +597,7 @@ test('Non-relative import remains unchanged even if packageName provided', async
         },
       ],
       "imports": [
-        "import { Header } from "@ds/header";",
+        "import { Header } from '@ds/header';",
       ],
     }
   `
@@ -626,7 +626,7 @@ test('Rewrites tilde-prefixed source to packageName', async () => {
         },
       ],
       "imports": [
-        "import { Button } from "pkg";",
+        "import { Button } from 'pkg';",
       ],
     }
   `
@@ -655,7 +655,7 @@ test('Rewrites hash-prefixed source to packageName', async () => {
         },
       ],
       "imports": [
-        "import { Btn } from "my-package";",
+        "import { Btn } from 'my-package';",
       ],
     }
   `
@@ -684,7 +684,7 @@ test('Does not rewrite scoped package subpath (valid bare specifier)', async () 
         },
       ],
       "imports": [
-        "import { Button } from "pkg";",
+        "import { Button } from 'pkg';",
       ],
     }
   `
@@ -713,7 +713,7 @@ test('Does not rewrite unscoped package subpath (valid bare specifier)', async (
         },
       ],
       "imports": [
-        "import { Button } from "pkg";",
+        "import { Button } from 'pkg';",
       ],
     }
   `
@@ -789,8 +789,8 @@ test('Merges multiple imports from the same package (defaults and named)', async
         },
       ],
       "imports": [
-        "import Link, { Banner, Dialog, Heading, Stack } from "@primer/react";",
-        "import { CopilotIcon } from "@primer/octicons-react";",
+        "import Link, { Banner, Dialog, Heading, Stack } from '@primer/react';",
+        "import { CopilotIcon } from '@primer/octicons-react';",
       ],
     }
   `
@@ -839,9 +839,9 @@ test('Handle namespace with default and separates named for same package', async
         },
       ],
       "imports": [
-        "import * as PR from "@primer/react";",
-        "import { Banner } from "@primer/react";",
-        "import Link from ".";",
+        "import * as PR from '@primer/react';",
+        "import { Banner } from '@primer/react';",
+        "import Link from '.';",
       ],
     }
   `
@@ -909,142 +909,4 @@ test('Filters out locally defined components', async () => {
     }
     `
   );
-});
-
-test('importOverride: default override forces default import (keeps local name)', async () => {
-  const code = dedent`
-    import { Button } from './Button';
-
-    const meta = {};
-    export default meta;
-    export const S = <Button/>;
-  `;
-  const csf = loadCsf(code, { makeTitle: (t) => t ?? 'No title' }).parse();
-  const base = await getComponentData({
-    csf,
-    packageName: 'my-package',
-    storyFilePath: '/app/src/stories/Button.stories.tsx',
-    docgenEngine: 'react-docgen',
-  });
-  const patched = base.components.map((c) =>
-    c.componentName === 'Button' ? { ...c, importOverride: "import Button from '@pkg/button';" } : c
-  );
-  const out = buildImports({ components: patched, packageName: 'my-package' });
-  expect(out).toMatchInlineSnapshot(`
-    [
-      "import Button from \"@pkg/button\";",
-    ]
-  `);
-});
-
-test('importOverride: named override aliases imported to local name', async () => {
-  const code = dedent`
-    import Button from './Button';
-
-    const meta = {};
-    export default meta;
-    export const S = <Button/>;
-  `;
-  const csf = loadCsf(code, { makeTitle: (t) => t ?? 'No title' }).parse();
-  const base = await getComponentData({
-    csf,
-    packageName: 'pkg',
-    storyFilePath: '/app/src/stories/Button.stories.tsx',
-    docgenEngine: 'react-docgen',
-  });
-  const patched = base.components.map((c) =>
-    c.componentName === 'Button'
-      ? { ...c, importOverride: "import { DSButton } from '@pkg/button';" }
-      : c
-  );
-  const out = buildImports({ components: patched, packageName: 'pkg' });
-  expect(out).toMatchInlineSnapshot(`
-    [
-      "import { DSButton as Button } from \"@pkg/button\";",
-    ]
-  `);
-});
-
-test('importOverride: uses namespace override as-is', async () => {
-  const code = dedent`
-    import * as UI from './ui';
-
-    const meta = {};
-    export default meta;
-    export const S = <UI.Button/>;
-  `;
-  const csf = loadCsf(code, { makeTitle: (t) => t ?? 'No title' }).parse();
-  const discovered = await getComponentData({
-    csf,
-    packageName: 'pkg',
-    storyFilePath: '/app/src/stories/ui.stories.tsx',
-    docgenEngine: 'react-docgen',
-  });
-  const patched = discovered.components.map((c) =>
-    c.componentName === 'UI.Button' ? { ...c, importOverride: "import * as UI from '@pkg/ui';" } : c
-  );
-  const out = buildImports({ components: patched, packageName: 'pkg' });
-  expect(out).toMatchInlineSnapshot(`
-    [
-      "import * as UI from \"@pkg/ui\";",
-    ]
-  `);
-});
-
-test('importOverride: malformed string is ignored and behavior falls back', async () => {
-  const code = dedent`
-    import { Header } from './Header';
-
-    const meta = {};
-    export default meta;
-    export const S = <Header/>;
-  `;
-  const csf = loadCsf(code, { makeTitle: (t) => t ?? 'No title' }).parse();
-  const base = await getComponentData({
-    csf,
-    packageName: 'pkg',
-    storyFilePath: '/app/src/stories/Header.stories.tsx',
-    docgenEngine: 'react-docgen',
-  });
-  const patched = base.components.map((c) =>
-    c.componentName === 'Header' ? { ...c, importOverride: 'import oops not valid' } : c
-  );
-  const out = buildImports({ components: patched, packageName: 'pkg' });
-  expect(out).toMatchInlineSnapshot(`
-    [
-      "import { Header } from \"pkg\";",
-    ]
-  `);
-});
-
-test('importOverride: merges multiple components into a single declaration per source', async () => {
-  const code = dedent`
-    import Button from './Button';
-    import { Header } from './Header';
-
-    const meta = {};
-    export default meta;
-    export const A = <Button/>;
-    export const B = <Header/>;
-  `;
-  const csf = loadCsf(code, { makeTitle: (t) => t ?? 'No title' }).parse();
-  const base = await getComponentData({
-    csf,
-    packageName: 'pkg',
-    storyFilePath: '/app/src/stories/multi.stories.tsx',
-    docgenEngine: 'react-docgen',
-  });
-  const patched = base.components.map((c) =>
-    c.componentName === 'Button'
-      ? { ...c, importOverride: "import { DSButton } from '@ds/ui';" }
-      : c.componentName === 'Header'
-        ? { ...c, importOverride: "import { Header } from '@ds/ui';" }
-        : c
-  );
-  const out = buildImports({ components: patched, packageName: 'pkg' });
-  expect(out).toMatchInlineSnapshot(`
-    [
-      "import { DSButton as Button, Header } from \"@ds/ui\";",
-    ]
-  `);
 });

--- a/code/renderers/react/src/componentManifest/getComponentImports.ts
+++ b/code/renderers/react/src/componentManifest/getComponentImports.ts
@@ -1,11 +1,11 @@
 import { dirname } from 'node:path';
 
-import { type NodePath, babelParse, recast, types as t } from 'storybook/internal/babel';
+import { type NodePath, types as t } from 'storybook/internal/babel';
 import {
   type CsfFile,
+  buildImportStatements,
   collectImportBindings,
-  importedName,
-  isTypeSpecifier,
+  resolveComponentImport,
 } from 'storybook/internal/csf-tools';
 import { logger } from 'storybook/internal/node-logger';
 import type { TypescriptOptions as TypescriptOptionsBase } from 'storybook/internal/types';
@@ -39,12 +39,6 @@ export type StoryRef = {
 };
 
 const baseIdentifier = (component: string) => component.split('.')[0] ?? component;
-
-const addUniqueBy = <T>(arr: T[], item: T, eq: (a: T) => boolean) => {
-  if (!arr.find(eq)) {
-    arr.push(item);
-  }
-};
 
 /**
  * Collects all React component references used by a CSF story file and resolves as much import and
@@ -159,56 +153,10 @@ export const getComponents = async ({
   const componentObjs = (
     await Promise.all(
       filteredComponents.map(async (c) => {
-        const depth = componentDepth.get(c);
-        // Split compound component names (e.g. "Accordion.Root") on the first dot to separate
-        // the namespace/import binding ("Accordion") from the accessed member ("Root").
-        //
-        // Three cases for compound names (dot !== -1):
-        //   1. No import found for the namespace  → keep componentName + member, no import metadata
-        //   2. Namespace import (`import * as Ns`) → importName = member (the actual export name)
-        //   3. Named import (`import { Accordion }`) → importName = original export, member carried separately
-        //
-        // Simple names (dot === -1) just look up the import binding directly.
-        const dot = c.indexOf('.');
-        const component =
-          dot !== -1
-            ? (() => {
-                const ns = c.slice(0, dot);
-                const mem = c.slice(dot + 1);
-                const direct = localToImport.get(ns);
-                return !direct
-                  ? { componentName: c, member: mem, jsxDepth: depth }
-                  : direct.importName === '*'
-                    ? {
-                        componentName: c,
-                        localImportName: ns,
-                        importId: direct.importId,
-                        importName: mem,
-                        namespace: ns,
-                        member: mem,
-                        jsxDepth: depth,
-                      }
-                    : {
-                        componentName: c,
-                        localImportName: ns,
-                        importId: direct.importId,
-                        importName: direct.importName,
-                        member: mem,
-                        jsxDepth: depth,
-                      };
-              })()
-            : (() => {
-                const direct = localToImport.get(c);
-                return direct
-                  ? {
-                      componentName: c,
-                      localImportName: c,
-                      importId: direct.importId,
-                      importName: direct.importName,
-                      jsxDepth: depth,
-                    }
-                  : { componentName: c, jsxDepth: depth };
-              })();
+        const component = {
+          ...resolveComponentImport(c, localToImport),
+          jsxDepth: componentDepth.get(c),
+        };
 
         let path;
         let isPackage = false;
@@ -277,7 +225,6 @@ export const getComponents = async ({
           if (docgenEngine === 'react-component-meta') {
             // RCM fills importOverride later in ComponentMetaProject, where the TypeScript checker
             // is available and we can read the official JSDoc tag data from the resolved symbol.
-            // Step 2 in generator.ts mutates the selected component before Step 3 calls getImports().
             return {
               ...componentWithPackage,
               path,
@@ -292,299 +239,7 @@ export const getComponents = async ({
   return componentObjs;
 };
 
-/**
- * Builds a minimal, deduplicated list of import declarations required for the given components.
- *
- * Behavior:
- *
- * - Components are grouped by their (possibly rewritten) source package/path.
- * - If `packageName` is provided, relative imports are rewritten to that package name.
- * - If a component provides `importOverride`, its source and specifier are respected.
- * - Namespace imports are preserved unless a rewrite forces them to named members actually used.
- * - Default imports rewritten to a package become named imports using their local identifier.
- *
- * Output order:
- *
- * - Buckets preserve first-seen order of sources to keep declarations stable between runs.
- * - Within a bucket, namespace imports are emitted first (optionally coalesced with a default),
- *   followed by named-only, then any remaining defaults/namespaces one-per-declaration.
- *
- * @param components Component references to emit imports for. Only those with an importId are
- *   considered.
- * @param packageName Optional package name to rewrite relative imports to.
- * @returns An array of import declaration strings, formatted by recast.
- * @public
- */
-export const getImports = ({
-  components,
-  packageName,
-}: {
-  components: ComponentRef[];
-  packageName?: string;
-}): string[] => {
-  // Group by source (after potential rewrite)
-  type Bucket = {
-    source: t.StringLiteral;
-    defaults: t.Identifier[];
-    namespaces: t.Identifier[];
-    named: t.ImportSpecifier[];
-    order: number;
-  };
-
-  const withSource = components
-    .filter((c) => Boolean(c.importId))
-    .map((c, idx) => {
-      const importId = c.importId!;
-      // If an importOverride is provided (and not a namespace import), override only the package/source
-      const overrideSource = (() => {
-        if (!c.importOverride) {
-          return undefined;
-        }
-        try {
-          const parsed = babelParse(c.importOverride);
-          const decl = parsed.program.body.find((n) => t.isImportDeclaration(n)) as
-            | t.ImportDeclaration
-            | undefined;
-          const src = decl?.source?.value;
-          return typeof src === 'string' ? src : undefined;
-        } catch {
-          return undefined;
-        }
-      })();
-      const rewritten =
-        overrideSource !== undefined
-          ? overrideSource
-          : // only rewrite to the package name it the import id is not already a valid package
-            // tsconfig paths such as ~/components/Button and components/Button are not seen as packages
-            packageName && !c.isPackage
-            ? packageName
-            : importId;
-      return { c, src: t.stringLiteral(rewritten), key: rewritten, ord: idx };
-    });
-
-  const orderOfSource: Record<string, number> = {};
-  for (const w of withSource) {
-    if (orderOfSource[w.key] === undefined) {
-      orderOfSource[w.key] = w.ord;
-    }
-  }
-
-  const buckets = new Map<string, Bucket>();
-
-  const ensureBucket = (key: string, src: t.StringLiteral): Bucket => {
-    const prev = buckets.get(key);
-
-    if (prev) {
-      return prev;
-    }
-    const b: Bucket = {
-      source: src,
-      defaults: [],
-      namespaces: [],
-      named: [],
-      order: orderOfSource[key] ?? 0,
-    };
-    buckets.set(key, b);
-    return b;
-  };
-
-  for (const { c, src, key } of withSource) {
-    const b = ensureBucket(key, src);
-
-    // Determine if this bucket was rewritten
-    const rewritten = src.value !== c.importId;
-
-    // If an importOverride provides a concrete specifier (default, named, or namespace), respect it.
-    // Do not try to match locals beyond using the bucketed structure. For namespace, just emit as-is.
-    const overrideSpec = (() => {
-      if (!c.importOverride) {
-        return undefined;
-      }
-      try {
-        const parsed = babelParse(c.importOverride);
-        const decl = parsed.program.body.find((n) => t.isImportDeclaration(n)) as
-          | t.ImportDeclaration
-          | undefined;
-        if (!decl) {
-          return undefined;
-        }
-        const spec = (decl.specifiers ?? []).find((s) => !isTypeSpecifier(s));
-        if (!spec) {
-          return undefined;
-        }
-        if (t.isImportNamespaceSpecifier(spec)) {
-          return { kind: 'namespace' as const, local: spec.local.name };
-        }
-        if (t.isImportDefaultSpecifier(spec)) {
-          return { kind: 'default' as const };
-        }
-        if (t.isImportSpecifier(spec)) {
-          const imported = t.isIdentifier(spec.imported) ? spec.imported.name : spec.imported.value;
-          return { kind: 'named' as const, imported };
-        }
-        return undefined;
-      } catch {
-        return undefined;
-      }
-    })();
-
-    if (overrideSpec) {
-      if (overrideSpec.kind === 'namespace') {
-        const ns = t.identifier(overrideSpec.local);
-        addUniqueBy(b.namespaces, ns, (n) => n.name === ns.name);
-        continue;
-      }
-      if (!c.localImportName) {
-        continue;
-      }
-      if (overrideSpec.kind === 'default') {
-        const id = t.identifier(c.localImportName);
-        addUniqueBy(b.defaults, id, (d) => d.name === id.name);
-        continue;
-      }
-      if (overrideSpec.kind === 'named') {
-        const local = t.identifier(c.localImportName);
-        const imported = t.identifier(overrideSpec.imported);
-        addUniqueBy(
-          b.named,
-          t.importSpecifier(local, imported),
-          (n) => n.local.name === local.name && importedName(n.imported) === imported.name
-        );
-        continue;
-      }
-    }
-
-    if (c.namespace) {
-      // Real namespace import usage (only present for `* as` imports)
-      if (rewritten) {
-        // Convert to named members actually used; require a concrete member name
-        if (!c.importName) {
-          continue;
-        }
-        const member = c.importName;
-        const id = t.identifier(member);
-        addUniqueBy(
-          b.named,
-          t.importSpecifier(id, id),
-          (n) => n.local.name === member && importedName(n.imported) === member
-        );
-      } else {
-        // Keep namespace import by base identifier once
-        const ns = t.identifier(c.namespace);
-        addUniqueBy(b.namespaces, ns, (n) => n.name === ns.name);
-      }
-      continue;
-    }
-
-    if (c.importName === 'default') {
-      // localImportName is only emitted for imported components; add a defensive guard for TS
-      if (!c.localImportName) {
-        continue;
-      }
-      if (rewritten) {
-        // default from relative becomes named using local identifier
-        const id = t.identifier(c.localImportName);
-        addUniqueBy(
-          b.named,
-          t.importSpecifier(id, id),
-          (n) => n.local.name === id.name && importedName(n.imported) === id.name
-        );
-      } else {
-        const id = t.identifier(c.localImportName);
-        addUniqueBy(b.defaults, id, (d) => d.name === id.name);
-      }
-      continue;
-    }
-
-    if (c.importName) {
-      // named import (including named used as namespace base)
-      if (!c.localImportName) {
-        continue;
-      }
-      const local = t.identifier(c.localImportName);
-      const imported = t.identifier(c.importName);
-      addUniqueBy(
-        b.named,
-        t.importSpecifier(local, imported),
-        (n) => n.local.name === local.name && importedName(n.imported) === imported.name
-      );
-      continue;
-    }
-  }
-
-  // Print merged declarations
-  const merged: string[] = [];
-  const printDecl = (
-    specs: (t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier | t.ImportSpecifier)[],
-    src: t.StringLiteral
-  ) => {
-    const node = t.importDeclaration(specs, src);
-    const code = recast.print(node, {}).code;
-    merged.push(code);
-  };
-
-  const sortedBuckets = Array.from(buckets.values()).sort((a, b) => a.order - b.order);
-  for (const bucket of sortedBuckets) {
-    const { source, defaults, namespaces, named } = bucket;
-
-    if (defaults.length === 0 && namespaces.length === 0 && named.length === 0) {
-      continue;
-    }
-
-    if (namespaces.length > 0) {
-      const firstSpecs: (t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier)[] = [];
-
-      if (defaults[0]) {
-        firstSpecs.push(t.importDefaultSpecifier(defaults[0]));
-      }
-      firstSpecs.push(t.importNamespaceSpecifier(namespaces[0]));
-      printDecl(firstSpecs, source);
-
-      if (named.length > 0) {
-        printDecl(named, source);
-      }
-
-      for (const d of defaults.slice(1)) {
-        printDecl([t.importDefaultSpecifier(d)], source);
-      }
-
-      for (const ns of namespaces.slice(1)) {
-        printDecl([t.importNamespaceSpecifier(ns)], source);
-      }
-    } else {
-      if (defaults.length > 0 || named.length > 0) {
-        const specs: (t.ImportDefaultSpecifier | t.ImportSpecifier)[] = [];
-
-        if (defaults[0]) {
-          specs.push(t.importDefaultSpecifier(defaults[0]));
-        }
-        specs.push(...named);
-        printDecl(specs, source);
-      }
-
-      for (const d of defaults.slice(1)) {
-        printDecl([t.importDefaultSpecifier(d)], source);
-      }
-    }
-  }
-
-  return merged;
-};
-
-/**
- * Convenience helper that combines `getComponents` and `getImports` in one call.
- *
- * It first discovers component references from the CSF file and then derives the minimal set of
- * import declarations for those components, applying the same rewrite/override rules as
- * `getImports`.
- *
- * @param csf The parsed CSF file instance.
- * @param packageName Optional package name used to rewrite relative imports.
- * @param storyFilePath Optional absolute path of the story file for resolving component import
- *   paths.
- * @returns An object containing the discovered components and the corresponding import statements.
- * @public
- */
+/** Discover the component references of a CSF file and the import declarations they need. */
 export async function getComponentData({
   csf,
   packageName,
@@ -607,6 +262,6 @@ export async function getComponentData({
     typescriptOptions,
     docgenEngine,
   });
-  const imports = getImports({ components, packageName });
+  const imports = buildImportStatements({ refs: components, packageName });
   return { components, imports };
 }

--- a/code/renderers/react/src/componentManifest/types.ts
+++ b/code/renderers/react/src/componentManifest/types.ts
@@ -1,15 +1,9 @@
+import type { ComponentImportRef } from 'storybook/internal/csf-tools';
+
 import type ts from 'typescript';
 
-export type ComponentRef = {
-  componentName: string;
-  localImportName?: string;
-  importId?: string;
+export type ComponentRef = ComponentImportRef & {
   componentJsDocTags?: Record<string, string[]>;
-  importOverride?: string;
-  importName?: string;
-  namespace?: string;
-  /** For member expressions like `Accordion.Root`, the member part (`"Root"`). */
-  member?: string;
   path?: string;
   isPackage: boolean;
   /** Minimum JSX nesting depth where this component first appears (1 = outermost JSX element). */

--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "@storybook/global": "^5.0.0",
     "@vue/language-core": "^3.2.7",
-    "knitwork": "^1.1.0",
     "type-fest": "^5.6.0",
     "vue-component-meta": "^3.2.7",
     "vue-component-type-helpers": "^3.2.9",

--- a/code/renderers/vue3/src/story-docs/build-story-docs.ts
+++ b/code/renderers/vue3/src/story-docs/build-story-docs.ts
@@ -1,8 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 
-import { genImport } from 'knitwork';
-
 import {
   STORY_FILE_TEST_REGEXP,
   getComponentIdFromEntry,
@@ -10,11 +8,13 @@ import {
 } from 'storybook/internal/common';
 import { storyNameFromExport } from 'storybook/internal/csf';
 import {
+  buildImportStatements,
   collectImportBindings,
   extractStoryJSDocInfo,
   keyOf,
   loadCsf,
   metaObjectPath,
+  resolveComponentImport,
 } from 'storybook/internal/csf-tools';
 import type { StoryDoc, StoryDocsPayload, StoryDocsProviderInput } from 'storybook/internal/types';
 
@@ -96,17 +96,8 @@ function createImportStatement(csf: ParsedCsf): string | undefined {
     return undefined;
   }
 
-  const binding = collectImportBindings(csf._file.path).get(componentName);
-  // Namespace imports should never reach here
-  if (!binding || binding.importName === '*') {
-    return undefined;
-  }
-
-  const specifier =
-    binding.importName === 'default'
-      ? componentName
-      : [{ name: binding.importName, as: componentName }];
-  return genImport(binding.importId, specifier, { singleQuotes: true });
+  const ref = resolveComponentImport(componentName, collectImportBindings(csf._file.path));
+  return buildImportStatements({ refs: [ref] }).join('\n') || undefined;
 }
 
 function extractStories(csf: ParsedCsf): Record<string, StoryDoc> {

--- a/test-storybooks/mcp/tests/mcp-composition-auth.e2e.test.ts
+++ b/test-storybooks/mcp/tests/mcp-composition-auth.e2e.test.ts
@@ -149,7 +149,7 @@ describe('MCP Composition Auth E2E Tests', () => {
 				Story ID: example-button--primary
 
 				\`\`\`
-				import { Button } from "@my-org/my-component-library";
+				import { Button } from '@my-org/my-component-library';
 
 				const Primary = () => <Button onClick={fn()} primary label="Button" />;
 				\`\`\`
@@ -159,7 +159,7 @@ describe('MCP Composition Auth E2E Tests', () => {
 				Story ID: example-button--secondary
 
 				\`\`\`
-				import { Button } from "@my-org/my-component-library";
+				import { Button } from '@my-org/my-component-library';
 
 				const Secondary = () => <Button onClick={fn()} label="Button" />;
 				\`\`\`
@@ -169,7 +169,7 @@ describe('MCP Composition Auth E2E Tests', () => {
 				Story ID: example-button--large
 
 				\`\`\`
-				import { Button } from "@my-org/my-component-library";
+				import { Button } from '@my-org/my-component-library';
 
 				const Large = () => <Button onClick={fn()} size="large" label="Button" />;
 				\`\`\`

--- a/test-storybooks/mcp/tests/mcp-composition.e2e.test.ts
+++ b/test-storybooks/mcp/tests/mcp-composition.e2e.test.ts
@@ -91,7 +91,7 @@ describe('MCP Composition E2E Tests', () => {
 				Story ID: example-button--primary
 
 				\`\`\`
-				import { Button } from "@my-org/my-component-library";
+				import { Button } from '@my-org/my-component-library';
 
 				const Primary = () => <Button onClick={fn()} primary label="Button" />;
 				\`\`\`
@@ -101,7 +101,7 @@ describe('MCP Composition E2E Tests', () => {
 				Story ID: example-button--secondary
 
 				\`\`\`
-				import { Button } from "@my-org/my-component-library";
+				import { Button } from '@my-org/my-component-library';
 
 				const Secondary = () => <Button onClick={fn()} label="Button" />;
 				\`\`\`
@@ -111,7 +111,7 @@ describe('MCP Composition E2E Tests', () => {
 				Story ID: example-button--large
 
 				\`\`\`
-				import { Button } from "@my-org/my-component-library";
+				import { Button } from '@my-org/my-component-library';
 
 				const Large = () => <Button onClick={fn()} size="large" label="Button" />;
 				\`\`\`

--- a/yarn.lock
+++ b/yarn.lock
@@ -13038,7 +13038,6 @@ __metadata:
     "@testing-library/vue": "npm:^8.0.0"
     "@vitejs/plugin-vue": "npm:^4.6.2"
     "@vue/language-core": "npm:^3.2.7"
-    knitwork: "npm:^1.1.0"
     type-fest: "npm:^5.6.0"
     typescript: "npm:^6.0.3"
     vue: "npm:^3.2.47"


### PR DESCRIPTION
Closes #

## What I did

Three renderers need to answer the same question - "what is the import statement for this component?" - and today they answer it three different ways. React has a complete implementation buried in its component-manifest code, Vue has a partial one that bails on anything beyond a default or named import, and Angular has none at all. This PR moves the React implementation into `storybook/internal/csf-tools` and points React and Vue at it, so there is one place that decides how an import should look.

The logic itself is not React-specific. It only ever needed `babelParse`, `recast` and two helpers that already live in `csf-tools`, so nothing had to move packages except the code.

| Capability | React (before) | Vue (before) | Angular (before) | All three (after) |
| --- | --- | --- | --- | --- |
| default import | yes | yes | - | yes |
| named import | yes | yes | - | yes |
| local alias (`X as Y`) | yes | yes | - | yes |
| namespace import (`* as NS`) | yes, but invalid output | bails to `undefined` | - | yes |
| member usage (`Accordion.Root`) | yes | - | - | yes |
| `packageName` rewriting | yes | - | - | yes |
| `importOverride` (`@import` tag) | yes | - | - | yes |
| dedup + stable ordering | yes | - | - | yes |

```
                        ┌──────────────────────────────────────────┐
  story file  ──parse──▶│ collectImportBindings  (already shared)  │
                        │   local name → { importId, importName }  │
                        └────────────────────┬─────────────────────┘
                                             │
   component name                            ▼
   'Button' / 'Accordion.Root'  ──▶  resolveComponentImport   ──▶  ImportRef
                                     splits on the first dot,       { importId, importName,
                                     follows the base binding         localImportName,
                                                                      namespace?, member? }
                                             │
   packageName? importOverride?  ────────────┤
                                             ▼
                                     buildImportStatements    ──▶  string[]
                                     bucket by final source,
                                     dedup, print via babelPrint
```

`resolveComponentImport` is the part that was inline in React's `getComponents`, and it is pure JS import semantics, so it moved too. That is what makes the module usable from a renderer that has no JSX at all.

Production code shrinks by about a hundred lines on net (**284 insertions, 381 deletions**), while the test side grows (**461 insertions, 176 deletions**) because the shared unit is now tested directly instead of through React's memfs-mocked pipeline. `@storybook/vue3` also drops its `knitwork` dependency, since `genImport` was its only consumer.

### Vue keeps its exact output and gains the rest

Vue's whole import path is now two lines:

```ts
const ref = resolveComponentImport(componentName, collectImportBindings(csf._file.path));
return buildImportStatements({ refs: [ref] }).join('\n') || undefined;
```

All 45 recorded `story-docs.payload.snapshot` baselines are untouched. `knitwork` already collapsed `{ name: 'X', as: 'X' }` to `import { X }`, so the emitted strings are byte-identical for every case Vue handled before.

### Angular is a one-liner away

Angular's existing `resolveStoryComponent` already returns everything the module needs, so PR #35807 can fill its `import` field without adding any resolution logic:

```ts
const { localName, exportName, importId } = resolved.component;
buildImportStatements({ refs: [{ importId, importName: exportName, localImportName: localName }] });
```

Run against the Angular fixtures already in `docgen-harness`, that produces:

```json
{
  "decorator-union-enum": {
    "localName": "DecoratorUnionEnumComponent",
    "exportName": "DecoratorUnionEnumComponent",
    "importId": "./decorator-union-enum.component.ts",
    "statement": ["import { DecoratorUnionEnumComponent } from './decorator-union-enum.component.ts';"]
  },
  "signal-io": {
    "localName": "SignalIoComponent",
    "exportName": "SignalIoComponent",
    "importId": "./signal-io.component.ts",
    "statement": ["import { SignalIoComponent } from './signal-io.component.ts';"]
  }
}
```

I did not wire that up here, because nothing on `next` consumes it yet and I did not want to ship code that cannot run. Angular's aliased-class case (`import { ImportAliasComponent as Alias }`) is covered by the new test suite.

## Two behaviour changes, both intentional

Everything else is byte-for-byte identical to the old `getImports`. I verified the rest branch by branch against `origin/next`, including override precedence, the `rewritten` flag, type-only specifiers inside an override, dedup predicates, and bucket ordering.

**1. A namespace-imported component used to emit invalid JavaScript.**

```tsx
// input.stories.tsx
import * as Icons from './icons';
const meta = { component: Icons };
```

```js
// getComponentData(...).imports on next
["import { * as Icons } from \"./icons\";"]

// this PR
["import * as Icons from './icons';"]
```

Under a `packageName` rewrite the same input produced `import { * } from "pkg";`. It now emits `import * as Icons from 'pkg';`. A deep member path (`A.B.C`) keeps the namespace import too, since a named import cannot carry a dotted path.

**2. Statements are printed with `babelPrint`, the repo's canonical printer, instead of a bare `recast.print(node, {})`.**

That means single quotes, and it also changes wrapping: recast's defaults are `wrapColumn: 74, tabWidth: 4`, `babelPrint` uses `wrapColumn: 80, tabWidth: 2`.

```js
// recast defaults (before)
import {
    Aaaaaaaaaaaaaaaaaaaaaaaa,
    Bbbbbbbbbbbbbbbbbbbbbbbb,
    Cccccccccccccccccccccccc,
    Dddddddddddddddddddddddd,
} from "./ui";

// babelPrint (this PR)
import {
  Aaaaaaaaaaaaaaaaaaaaaaaa,
  Bbbbbbbbbbbbbbbbbbbbbbbb,
  Cccccccccccccccccccccccc,
  Dddddddddddddddddddddddd,
} from './ui';
```

Vue's snapshots were already single-quoted, so this is the React manifest lining up with the rest of the repo rather than a new convention. React's `getFallbackImport` goes through the same builder now, so it cannot drift again. The wrapping is pinned by a test so it stays a decision rather than an accident.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

31 new tests in `code/core/src/csf-tools/story-shape/import-statements.test.ts`. The five `importOverride:` tests that called React's `getImports` directly moved there, since they were testing the shared unit through a memfs-mocked React pipeline that they did not need.

#### Manual testing

1. Check out this branch and run `yarn && yarn nx run-many -t compile`.
2. Run `yarn task sandbox --template react-vite/default-ts --start-from auto` with `componentsManifest` enabled, and confirm the generated manifest's `import` fields are valid, single-quoted import statements for the sandbox's components.
3. Open a Docs page in that sandbox and confirm the Source block still shows the same import line it does on `next`, modulo the quote style.
4. Repeat with `yarn task sandbox --template vue3-vite/default-ts --start-from auto`. Vue's output should be identical to `next`, quotes included.
5. Verify the namespace fix. Add a story file with `import * as Icons from './icons';` and `component: Icons`, rebuild the manifest, and confirm the emitted import is `import * as Icons from './icons';`. On `next` the same input yields `import { * as Icons } from "./icons";`, which does not parse.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

`buildImportStatements` and `resolveComponentImport` are exported from `storybook/internal/csf-tools`, which is an internal entry point, so there is nothing user-facing to document. The only observable change is the quote and wrap style of generated import snippets.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
