### PR TITLE
Build: Restore the node_modules cache behaviour from #35828

### DIFF
--- a/scripts/ci/utils/helpers.ts
+++ b/scripts/ci/utils/helpers.ts
@@ -258,12 +258,7 @@ export const npm = {
       'node/install-packages': {
         'app-dir': appDir,
         'pkg-manager': pkgManager,
-        'cache-only-lockfile': true,
-        // The orb restores its node_modules on top of the one CACHE_KEYS already
-        // restored, skipping paths that exist rather than replacing them, so a
-        // package hoisted differently in the older tree survives the merge. Both
-        // caches are versioned together: v4 pairs with v10 below.
-        'cache-version': 'v4',
+        'with-cache': false,
       },
     };
   },
@@ -404,7 +399,7 @@ export type CachePlatform = 'linux' | 'windows';
  */
 export const NODE_MODULES_CACHE_KEY = (platform: CachePlatform = 'linux') =>
   [
-    `v10-${platform}-node_modules`,
+    `v11-${platform}-node_modules`,
     '{{ checksum ".nvmrc" }}',
     '{{ checksum ".yarnrc.yml" }}',
     '{{ checksum "yarn.lock" }}',


### PR DESCRIPTION
Closes #

## What I did

CI installs restore `node_modules` from a single cache key built from the lockfile, with no fallback prefixes, so a tree that came from a different lockfile can never be restored on top of the current one. That property was landed in #35828, but a conflicted merge the next day (`8d260f0206f`) resolved `scripts/ci/utils/helpers.ts` against the pre-#35828 side and switched the CircleCI node orb's own `node_modules` cache back on. The orb's last restore key is a bare prefix, so it reintroduces exactly the fallback the PR removed, and it overlays its tree on top of the restored one instead of replacing it.

This restores the merged behaviour: the orb cache is off again, and the cache namespace moves to `v11` so trees saved while the overlay was active are not reused.

```
                     yarn.lock ─┐
                        .nvmrc ─┼─► v11-<platform>-node_modules/<checksums>  ─► restore_cache (one key, no prefixes)
                    .yarnrc.yml ─┘                                                     │
                                                                                       ▼
                                                     node/install-packages (with-cache: false)  ─► yarn install --immutable
```

Generated CircleCI config for the `build--linux` job, `yarn dlx jiti ./scripts/ci/main.ts -w normal`:

```diff
             - restore_cache:
                   keys:
-                      - v10-linux-node_modules/{{ checksum ".nvmrc" }}/{{ checksum ".yarnrc.yml" }}/{{ checksum "yarn.lock" }}
+                      - v11-linux-node_modules/{{ checksum ".nvmrc" }}/{{ checksum ".yarnrc.yml" }}/{{ checksum "yarn.lock" }}
             - node/install-packages:
                   app-dir: .
                   pkg-manager: yarn
-                  cache-only-lockfile: true
-                  cache-version: v4
+                  with-cache: false
```

The one decision in the diff:

```diff
       'node/install-packages': {
         'app-dir': appDir,
         'pkg-manager': pkgManager,
-        'cache-only-lockfile': true,
-        'cache-version': 'v4',
+        'with-cache': false,
       },
```

The JSDoc directly above that block already documented `with-cache: false` as the behaviour, so the file has been self-contradictory since the bad merge. It is consistent again now.

Windows stays namespaced separately: `v11-windows-node_modules`. Nothing in `scripts/ci/common-jobs.ts` needed changing, that half of #35828 survived the merge intact.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

CI itself is the test: the generated config is what runs every job in this PR.

#### Manual testing

Run from the repository root.

| Command | What it does |
| --- | --- |
| `yarn dlx jiti ./scripts/ci/main.ts -w normal` | Writes `.circleci/config.generated.yml` for the normal workflow |
| `yarn dlx jiti ./scripts/ci/main.ts -w daily` | Same, for the daily workflow, which is the one that includes the Windows jobs |

1. Run `yarn dlx jiti ./scripts/ci/main.ts -w normal`.
2. Open `.circleci/config.generated.yml` and find the `build--linux` job. Its `node/install-packages` step should carry `with-cache: false` and no `cache-version`.
3. Confirm no orb cache config is left anywhere: `grep -c cache-version .circleci/config.generated.yml` prints `0`.
4. Confirm every restore key is exact and has no fallback prefixes: `grep -A2 restore_cache .circleci/config.generated.yml` shows a single `keys:` entry per block, always ending in the three checksums.
5. Run `yarn dlx jiti ./scripts/ci/main.ts -w daily` and confirm both namespaces appear, Linux and Windows separately: `grep -o "v11-[a-z]*-node_modules" .circleci/config.generated.yml | sort | uniq -c` prints `2 v11-linux-node_modules` and `1 v11-windows-node_modules`.
6. Watch this PR's own CI. The first run on each platform misses the `v11` cache and installs from scratch, which is expected for a namespace bump. Subsequent runs on an unchanged lockfile should hit it.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

This is build tooling only, no user-facing documentation applies.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
