### PR TITLE
Core-Server: Handle server-channel WebSocket errors so a bad frame can't crash the dev server

### DIFF
--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -364,4 +364,20 @@ describe('ServerChannelTransport', () => {
     expect(destroySpy).not.toHaveBeenCalled();
     expect(handleUpgradeSpy).toHaveBeenCalled();
   });
+
+  it('does not crash when a socket emits an error', () => {
+    const server = new EventEmitter() as any as Server;
+    const socket = new EventEmitter();
+    const transport = new ServerChannelTransport(server, options);
+    const handler = vi.fn();
+    transport.setHandler(handler);
+
+    // @ts-expect-error (an internal API)
+    transport.socket.emit('connection', socket);
+
+    // A frame that exceeds the ws default maxPayload (or any other transport error) makes ws emit
+    // an 'error' event on the socket. Without an 'error' listener, Node treats an emitted 'error'
+    // as an unhandled error and crashes the whole process, taking `storybook dev` down with it.
+    expect(() => socket.emit('error', new Error('Max payload size exceeded'))).not.toThrow();
+  });
 });

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -62,6 +62,14 @@ export class ServerChannelTransport {
     });
 
     this.socket.on('connection', (wss) => {
+      wss.on('error', (error) => {
+        // An 'error' event with no listener is fatal in Node.js and crashes the process. ws emits
+        // 'error' on a socket when a frame is malformed or exceeds the max payload size
+        // (WS_ERR_UNSUPPORTED_MESSAGE_LENGTH), so a single bad client would otherwise kill the
+        // whole `storybook dev` server. Log the error and let ws close the socket.
+        logger.warn(`WebSocket error on server channel: ${error}`);
+      });
+
       wss.on('message', (raw) => {
         const data = raw.toString();
         const event = typeof data === 'string' && isJSON(data) ? parse(data, {}) : data;


### PR DESCRIPTION
## What

When a connected browser tab sends a frame exceeding the `ws` default `maxPayload` (100 MB) — or any otherwise malformed frame — `ws` emits an `error` event on that socket (e.g. `WS_ERR_UNSUPPORTED_MESSAGE_LENGTH`). The server channel transport in `code/core/src/core-server/utils/get-server-channel.ts` only attaches a `message` listener inside the `connection` handler. In Node.js an `error` event with no listener is fatal, so a single bad frame from one stale/buggy browser tab crashes the entire `storybook dev` process.

## Fix

Attach an `error` listener on each server-channel socket that logs the error via the already-imported `logger` and does not rethrow. `ws` still closes the offending socket itself, so the dev server keeps running.

## Test

Added a regression test in `server-channel.test.ts` that connects a mock socket and emits an `error` event on it, asserting it does not throw. Without the fix, `EventEmitter` throws an unhandled `error` (the exact process-crash behaviour reported); with the fix, the error is handled and the test passes.

#### Manual testing

1. Start `storybook dev` and open the preview in a browser.
2. From a connected tab, send an oversized or malformed WebSocket frame (e.g. a message exceeding the `ws` default `maxPayload` of 100 MB).
3. Without this fix the `storybook dev` process crashes on the unhandled socket `error`; with this fix the error is logged and the dev server keeps running.

Fixes #35862

Note: this is a one-handler fix verified against the current `next` source; the full `server-channel.test.ts` suite will run on CI here.
