### PR TITLE
Angular: Harden story-shape reading against unreadable configs

### DIFF
--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
@@ -373,10 +373,10 @@ describe('buildStoryDocsPayload', () => {
       expect((await templatesOf(STORY_SHAPES_FILE)).get(storyName)).toBe(expected);
     });
 
-    it('falls back to generated bindings for an imported template it cannot follow', async () => {
-      expect((await templatesOf(STORY_SHAPES_FILE)).get('Imported Template')).toBe(
-        `<sb-button [label]="'meta'" [count]="5" (clicked)="clicked($event)"></sb-button>`
-      );
+    // Fabricated bindings would misrepresent the imported markup, so no snippet is emitted and
+    // the runtime source fallback stays authoritative.
+    it('emits no snippet for an imported template it cannot follow', async () => {
+      expect((await templatesOf(STORY_SHAPES_FILE)).get('Imported Template')).toBeUndefined();
     });
 
     it('reads args CSF2 assigned after the declaration', async () => {
@@ -421,10 +421,10 @@ describe('buildStoryDocsPayload', () => {
       );
     });
 
-    it('falls back when an interpolation needs the story to run', async () => {
-      expect((await templatesOf(STORY_SHAPES_FILE)).get('Unreadable Interpolation')).toBe(
-        `<sb-button [label]="'Save'" (clicked)="clicked($event)"></sb-button>`
-      );
+    it('emits no snippet when an interpolation needs the story to run', async () => {
+      expect(
+        (await templatesOf(STORY_SHAPES_FILE)).get('Unreadable Interpolation')
+      ).toBeUndefined();
     });
 
     it('declares handlers only for the outputs the markup binds', async () => {
@@ -436,6 +436,298 @@ describe('buildStoryDocsPayload', () => {
 
       expect(byName.get('Args To Template')).toContain('clicked(event: unknown) {}');
       expect(byName.get('Own Template')).not.toContain('clicked(event: unknown) {}');
+    });
+  });
+
+  describe('story shapes that cannot be read statically', () => {
+    it('reads the template a render method shorthand returns', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        export const Default = {
+          args: { label: 'Save' },
+          render(args) {
+            return { template: '<div class="only-in-render"><sb-button></sb-button></div>' };
+          },
+        };
+      `);
+      expect(extractHostComponentTemplate(story.snippet!)).toBe(
+        '<div class="only-in-render"><sb-button></sb-button></div>'
+      );
+    });
+
+    // At runtime, reading `render` invokes the getter; the accessor itself is not the function.
+    it('emits no snippet for a render accessor', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        export const Default = {
+          args: { label: 'Save' },
+          get render() {
+            return () => ({ template: '<sb-button from-getter></sb-button>' });
+          },
+        };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+
+    // `{ render: fn, ...base }` runs base.render when the spread carries one, so the explicit
+    // property cannot be trusted.
+    it('emits no snippet when a later spread can shadow the render', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const base = {};
+        export const Default = {
+          render: () => ({ template: '<sb-button from-story></sb-button>' }),
+          ...base,
+        };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+
+    it('emits no snippet for a config that is only a spread', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const base = { args: { label: 'From base' } };
+        export const Default = { ...base };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+
+    it('reads a template written after a harmless earlier spread', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const base = {};
+        export const Default = { ...base, template: '<sb-button explicit></sb-button>' };
+      `);
+      expect(extractHostComponentTemplate(story.snippet!)).toBe('<sb-button explicit></sb-button>');
+    });
+
+    it('emits no snippet when a spread makes the args unknowable', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const extra = { count: 9 };
+        export const Default = { args: { label: 'Save', ...extra } };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+
+    it('emits no snippet when a meta args spread makes the merge unknowable', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        const shared = { label: 'shared' };
+        export default { title: 'Example/Button', component: ButtonComponent, args: { ...shared } };
+        export const Default = { args: { label: 'Save' } };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+
+    // Which branch runs depends on the story's args at runtime.
+    it('emits no snippet for a render with more than one exit', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        export const Default = {
+          args: { label: 'Save' },
+          render: (args) => {
+            if (args.label) {
+              return { template: '<sb-button first></sb-button>' };
+            }
+            return { template: '<sb-button second></sb-button>' };
+          },
+        };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+
+    it('emits no snippet when argsToTemplate options need the story to run', async () => {
+      const story = await soleStory(`
+        import { argsToTemplate } from '@storybook/angular-vite';
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const INCLUDES = ['label'];
+        export const Default = {
+          args: { label: 'Save' },
+          render: (args) => ({
+            props: args,
+            template: \`<sb-button \${argsToTemplate(args, { include: INCLUDES })}></sb-button>\`,
+          }),
+        };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+
+    it('emits no snippet when argsToTemplate is given a derived object', async () => {
+      const story = await soleStory(`
+        import { argsToTemplate } from '@storybook/angular-vite';
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        export const Default = {
+          args: { label: 'Save' },
+          render: (args) => ({
+            props: args,
+            template: \`<sb-button \${argsToTemplate({ ...args, extra: 1 })}></sb-button>\`,
+          }),
+        };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+  });
+
+  describe('config keys resolve with runtime object semantics', () => {
+    it('reads a member-assigned render, which runs after the declaration', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        export const Default = { args: { label: 'Save' } };
+        Default.render = () => ({ template: '<div class="assigned"><sb-button></sb-button></div>' });
+      `);
+      expect(extractHostComponentTemplate(story.snippet!)).toBe(
+        '<div class="assigned"><sb-button></sb-button></div>'
+      );
+    });
+
+    it('resolves duplicate template keys to the last occurrence', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        export const Default = {
+          template: '<sb-button first></sb-button>',
+          template: '<sb-button second></sb-button>',
+        };
+      `);
+      expect(extractHostComponentTemplate(story.snippet!)).toBe('<sb-button second></sb-button>');
+    });
+
+    it('reads a string-literal computed key the way the runtime does', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        export const Default = { ['template']: '<sb-button computed></sb-button>' };
+      `);
+      expect(extractHostComponentTemplate(story.snippet!)).toBe('<sb-button computed></sb-button>');
+    });
+
+    it('emits no snippet when a dynamic key could carry the template', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const key = 'template';
+        export const Default = { args: { label: 'Save' }, [key]: '<sb-button dynamic></sb-button>' };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+  });
+
+  describe('interpolated identifiers resolve by scope', () => {
+    it('substitutes a module-level constant the template interpolates', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const HEADER = '<h1>Hi</h1>';
+        export const Default = {
+          args: { label: 'Save' },
+          render: (args) => ({ props: args, template: \`\${HEADER}<sb-button></sb-button>\` }),
+        };
+      `);
+      expect(extractHostComponentTemplate(story.snippet!)).toBe(
+        '<h1>Hi</h1><sb-button></sb-button>'
+      );
+    });
+
+    // The render does not destructure `footer`, so the runtime reads the module constant, not the
+    // same-named arg.
+    it('prefers the module constant over a same-named arg the render never binds', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const footer = 'module value';
+        export const Default = {
+          args: { label: 'Save', footer: 'arg value' },
+          render: (args) => ({ props: args, template: \`<sb-button>\${footer}</sb-button>\` }),
+        };
+      `);
+      expect(extractHostComponentTemplate(story.snippet!)).toBe(
+        '<sb-button>module value</sb-button>'
+      );
+    });
+
+    // A reassigned binding's value at render time is not its initializer.
+    it('emits no snippet when the interpolated binding is reassigned', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        let footer = 'first';
+        footer = 'second';
+        export const Default = {
+          args: { label: 'Save' },
+          render: (args) => ({ props: args, template: \`<sb-button>\${footer}</sb-button>\` }),
+        };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+
+    it('emits no snippet for a template identifier that is reassigned', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        let TEMPLATE = '<sb-button first></sb-button>';
+        TEMPLATE = '<sb-button second></sb-button>';
+        export const Default = { template: TEMPLATE };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+
+    // The body-local declaration shadows the module constant the program scope would resolve.
+    it('emits no snippet when the render body declares the interpolated name', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const footer = 'module value';
+        export const Default = {
+          args: { label: 'Save' },
+          render: (args) => {
+            const footer = 'local value';
+            return { props: args, template: \`<sb-button>\${footer}</sb-button>\` };
+          },
+        };
+      `);
+      expect(story.snippet).toBeUndefined();
+    });
+  });
+
+  describe('legacy CSF2 idioms', () => {
+    it('follows Template.bind({}) to the template the story renders', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        const Template = (args) => ({ props: args, template: '<div class="bound"><sb-button></sb-button></div>' });
+        export const Default = Template.bind({});
+        Default.args = { label: 'Save' };
+      `);
+      expect(extractHostComponentTemplate(story.snippet!)).toBe(
+        '<div class="bound"><sb-button></sb-button></div>'
+      );
+    });
+  });
+
+  describe('binding values survive the attribute position', () => {
+    it.each([
+      ["it's fine", "[label]=\"'it\\\\'s fine'\""],
+      ['say "hi"', '[label]="\'say &quot;hi&quot;\'"'],
+      ['Tom &amp; Jerry', '[label]="\'Tom &amp;amp; Jerry\'"'],
+      ['broken &#65 reference', '[label]="\'broken &amp;#65 reference\'"'],
+    ])('escapes %s losslessly', async (value, expected) => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        export const Default = { args: { label: ${JSON.stringify(value)} } };
+      `);
+      expect(story.snippet).toContain(expected);
     });
   });
 });

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
@@ -3,12 +3,10 @@ import { getComponentIdFromEntry, getStoryImportPathFromEntry } from 'storybook/
 import { storyNameFromExport } from 'storybook/internal/csf';
 import type { CsfFile } from 'storybook/internal/csf-tools';
 import {
-  argsRecordFromNode,
   buildImportStatements,
   collectImportBindings,
   extractStoryJSDocInfo,
   keyOf,
-  mergeArgsRecords,
   resolveComponentImport,
   unwrapExpression,
 } from 'storybook/internal/csf-tools';
@@ -26,8 +24,8 @@ import { buildHostComponentSnippet } from './story-docs-snippet.ts';
 import {
   buildComponentOutletTemplate,
   buildTemplate,
-  formatInputValue,
   formatPropInTemplate,
+  isValidIdentifier,
 } from '../template-grammar.ts';
 
 export interface BuildStoryDocsContext {
@@ -64,7 +62,7 @@ export const buildStoryDocsPayload = async (
   const deps: StoryDocDeps = {
     csf,
     source,
-    metaArgs: argsRecordFromNode(csf._metaAnnotations.args),
+    metaArgs: argsProperties(csf._metaAnnotations.args),
     snippetMeta: docgenPayload?.angularComponentMeta,
     componentName,
     componentImport:
@@ -115,7 +113,7 @@ const componentNameOf = (node: t.Node | undefined): string | undefined => {
 interface StoryDocDeps {
   csf: CsfFile;
   source: string;
-  metaArgs: Record<string, t.Node>;
+  metaArgs: ArgsRecord;
   snippetMeta: AngularComponentSnippetMeta | undefined;
   componentName: string | undefined;
   componentImport: string | undefined;
@@ -131,11 +129,13 @@ const buildStoryDoc = (
   try {
     const { description, summary } = extractStoryJSDocInfo(csf._storyStatements[exportName]);
     const annotations = csf._storyAnnotations[exportName] ?? {};
+    const storyArgs = argsProperties(annotations.args);
     const shape: StoryShape = {
       csf,
       exportName,
       annotations,
-      args: mergeArgsRecords(deps.metaArgs, argsRecordFromNode(annotations.args)),
+      args: { ...deps.metaArgs.properties, ...storyArgs.properties },
+      argsReadable: deps.metaArgs.complete && storyArgs.complete,
       source: deps.source,
     };
     const snippet = snippetMeta
@@ -186,23 +186,31 @@ interface StoryShape {
   annotations: Record<string, t.Node>;
   /** Meta args merged under story args, keyed by arg name. */
   args: Record<string, t.Node>;
+  /** `false` when a spread or computed key makes the merged args unknowable statically. */
+  argsReadable: boolean;
   source: string;
 }
 
 /**
  * Snippets show the markup a story supplies itself - through `template`, a `render` that returns
- * one, or the CSF2 function form - as written; only markup that cannot be read without running the
- * story falls back to the component-derived bindings.
+ * one, or the CSF2 function form - as written. Markup or args that cannot be read without running
+ * the story yield no snippet at all, so the runtime source fallback stays authoritative rather
+ * than a fabricated element misrepresenting what the story renders.
  */
 const renderStorySnippet = (
   snippetMeta: AngularComponentSnippetMeta,
   shape: StoryShape,
   componentImport: string | undefined
-): string => {
+): string | undefined => {
   // The story file's local name is what the import binds, so an aliased import stays consistent
   // between the import statement, the `imports` array and the template.
   const localName = componentNameOf(shape.csf._metaAnnotations.component) ?? snippetMeta.name;
-  if (!snippetMeta.selector) {
+  const bindings = shape.argsReadable ? collectBindings(snippetMeta, shape) : undefined;
+  const userMarkup = userTemplate(shape, bindings);
+  if (userMarkup?.kind === 'unresolvable') {
+    return undefined;
+  }
+  if (userMarkup === undefined && !snippetMeta.selector) {
     return buildHostComponentSnippet({
       template: buildComponentOutletTemplate(localName),
       componentName: localName,
@@ -211,15 +219,15 @@ const renderStorySnippet = (
       outputs: [],
     });
   }
-
-  const bindings = collectBindings(snippetMeta, shape);
-  const userMarkup = userTemplate(shape, bindings);
+  if (userMarkup === undefined && bindings === undefined) {
+    return undefined;
+  }
   const template =
     userMarkup?.kind === 'literal'
       ? userMarkup.markup
-      : buildTemplate(snippetMeta.selector, {
-          inputs: bindings.inputs,
-          outputs: bindings.outputs,
+      : buildTemplate(snippetMeta.selector!, {
+          inputs: bindings!.inputs,
+          outputs: bindings!.outputs,
         });
   // The host only needs handlers for the outputs the markup actually binds.
   const boundOutputs = snippetMeta.outputs.filter((name) => template.includes(`(${name})=`));
@@ -280,44 +288,110 @@ type TemplateResult =
   /** A `template` or `render` exists, but its markup needs the story to run. */
   | { kind: 'unresolvable' };
 
+/** What the function owning a template literal binds, deciding how `${name}` resolves. */
+interface FunctionScope {
+  /** Names bound from the function's parameters; they resolve to story args. */
+  paramNames: ReadonlySet<string>;
+  /** Names its body declares; their value at render time is not statically knowable. */
+  bodyDeclared: ReadonlySet<string>;
+  /**
+   * Names `argsToTemplate` may expand, each mapped to the arg names its value does not carry: the
+   * whole args parameter excludes nothing, a rest binding excludes what was destructured off it.
+   */
+  argsExpansions: ReadonlyMap<string, readonly string[]>;
+}
+
+const NO_SCOPE: FunctionScope = {
+  paramNames: new Set(),
+  bodyDeclared: new Set(),
+  argsExpansions: new Map(),
+};
+
 /**
  * Markup the story supplies itself, falling back to the meta's.
  *
  * Returns `undefined` when neither declares one, which is the plain `{ args }` story the generated
  * bindings are built for.
  */
-const userTemplate = (shape: StoryShape, bindings: Bindings): TemplateResult | undefined =>
-  templateOf(shape.annotations, shape, bindings) ??
-  // CSF2: the story is the function, and Angular's idiom is to return `{ template }`.
-  templateFrom(propertyOf(csf2Return(shape), 'template'), shape, bindings) ??
-  templateOf(shape.csf._metaAnnotations, shape, bindings);
-
-/** The template a config declares directly, or through a `render` that returns one. */
-const templateOf = (
-  annotations: Record<string, t.Node>,
+const userTemplate = (
   shape: StoryShape,
-  bindings: Bindings
+  bindings: Bindings | undefined
 ): TemplateResult | undefined => {
-  const own = templateFrom(declaredValue(shape, annotations.template), shape, bindings);
+  const own = shapeTemplate(storyConfigObject(shape), shape.annotations, shape, bindings);
   if (own) {
     return own;
   }
-  if (annotations.render === undefined) {
-    return undefined;
+
+  // CSF2: the story is the function, and Angular's idiom is to return `{ template }`.
+  const csf2 = csf2Shape(shape);
+  if (csf2) {
+    const templateProperty = resolvedProperty(csf2.returned, 'template');
+    if (templateProperty.kind === 'unresolvable') {
+      return { kind: 'unresolvable' };
+    }
+    const fromCsf2 = templateFrom(
+      templateProperty.kind === 'value' ? templateProperty.node : undefined,
+      shape,
+      bindings,
+      functionScope(csf2.fn)
+    );
+    if (fromCsf2) {
+      return fromCsf2;
+    }
   }
 
+  return shapeTemplate(metaConfigObject(shape.csf), shape.csf._metaAnnotations, shape, bindings);
+};
+
+/** The template one config level declares, directly or through a `render` that returns one. */
+const shapeTemplate = (
+  config: t.ObjectExpression | undefined,
+  annotations: Record<string, t.Node>,
+  shape: StoryShape,
+  bindings: Bindings | undefined
+): TemplateResult | undefined => {
+  const template = resolveAnnotation(config, annotations, 'template');
+  if (template.kind === 'unresolvable') {
+    return { kind: 'unresolvable' };
+  }
+  if (template.kind === 'value') {
+    const own = templateFrom(declaredValue(shape, template.node), shape, bindings, NO_SCOPE);
+    if (own) {
+      return own;
+    }
+  }
+
+  const render = resolveAnnotation(config, annotations, 'render');
+  if (render.kind === 'missing') {
+    return undefined;
+  }
   // A story whose `render` exists but cannot be read must not inherit the meta's markup, which is
   // for code the story never runs.
-  const returned = returnedObject(declaredValue(shape, annotations.render));
-  return returned
-    ? templateFrom(propertyOf(returned, 'template'), shape, bindings)
-    : { kind: 'unresolvable' };
+  if (render.kind === 'unresolvable') {
+    return { kind: 'unresolvable' };
+  }
+
+  const fn = declaredValue(shape, render.node);
+  const returned = returnedObject(fn);
+  if (!returned) {
+    return { kind: 'unresolvable' };
+  }
+  const templateProperty = resolvedProperty(returned, 'template');
+  return templateProperty.kind === 'unresolvable'
+    ? { kind: 'unresolvable' }
+    : templateFrom(
+        templateProperty.kind === 'value' ? templateProperty.node : undefined,
+        shape,
+        bindings,
+        functionScope(fn)
+      );
 };
 
 const templateFrom = (
   node: t.Node | undefined,
   shape: StoryShape,
-  bindings: Bindings
+  bindings: Bindings | undefined,
+  scope: FunctionScope
 ): TemplateResult | undefined => {
   if (
     node === undefined ||
@@ -330,7 +404,7 @@ const templateFrom = (
     return { kind: 'literal', markup: node.value };
   }
   if (t.isTemplateLiteral(node)) {
-    const markup = interpolate(node, shape, bindings);
+    const markup = interpolate(node, shape, bindings, scope);
     return markup === undefined ? { kind: 'unresolvable' } : { kind: 'literal', markup };
   }
   return { kind: 'unresolvable' };
@@ -340,12 +414,13 @@ const templateFrom = (
 const interpolate = (
   node: t.TemplateLiteral,
   shape: StoryShape,
-  bindings: Bindings
+  bindings: Bindings | undefined,
+  scope: FunctionScope
 ): string | undefined => {
   let markup = node.quasis[0]?.value.cooked ?? '';
 
   for (const [index, expression] of node.expressions.entries()) {
-    const substituted = substituteExpression(expression, shape, bindings);
+    const substituted = substituteExpression(expression, shape, bindings, scope);
     if (substituted === undefined) {
       return undefined;
     }
@@ -362,46 +437,86 @@ const interpolate = (
  * the bindings this generator already emits - so a template built around it is fully readable
  * rather than opaque. Values are inlined instead of referenced by name, which drops the story's
  * `props: args` requirement and leaves the snippet standing on its own.
+ *
+ * An interpolated name substitutes the story's arg only when the render function actually binds
+ * that name from its parameters; otherwise it is the module-level declaration the runtime would
+ * read, followed the same way `template: HOISTED` is.
  */
 const substituteExpression = (
   expression: t.Node,
   shape: StoryShape,
-  bindings: Bindings
+  bindings: Bindings | undefined,
+  scope: FunctionScope
 ): string | undefined => {
   if (
     t.isCallExpression(expression) &&
     t.isIdentifier(expression.callee) &&
     expression.callee.name === 'argsToTemplate'
   ) {
-    const options = expression.arguments[1];
-    const filter: BindingFilter = {
-      include: stringArray(propertyOf(options, 'include')),
-      exclude: stringArray(propertyOf(options, 'exclude')),
-    };
-    return bindingAttributes(bindings, filter).join(' ');
+    // Only the args parameter (whole, or as a rest binding) has a knowable expansion; a derived
+    // object expands to whatever the story computes at runtime.
+    const argument = expression.arguments[0];
+    const excluded = t.isIdentifier(argument) ? scope.argsExpansions.get(argument.name) : undefined;
+    if (!bindings || excluded === undefined) {
+      return undefined;
+    }
+    const filter = bindingFilterOf(expression.arguments[1]);
+    if (filter === undefined) {
+      return undefined;
+    }
+    // Destructured-off names are absent from the rest object, so they cannot expand from it.
+    const withRest = { ...filter, exclude: [...(filter.exclude ?? []), ...excluded] };
+    const allowed = filter.include
+      ? { ...withRest, include: filter.include.filter((name) => !excluded.includes(name)) }
+      : withRest;
+    return bindingAttributes(bindings, allowed).join(' ');
   }
 
-  // `render: ({ footer, ...args }) => …` destructures an arg and interpolates it as slot content.
-  return t.isIdentifier(expression) ? literalText(shape.args[expression.name]) : undefined;
-};
-
-/** Named property of an object literal, if it has one. */
-const propertyOf = (node: t.Node | undefined, name: string): t.Node | undefined => {
-  const unwrapped = node && unwrapExpression(node);
-  if (!unwrapped || !t.isObjectExpression(unwrapped)) {
+  if (!t.isIdentifier(expression)) {
     return undefined;
   }
-  const property = unwrapped.properties.find(
-    (candidate): candidate is t.ObjectProperty =>
-      t.isObjectProperty(candidate) && keyOf(candidate) === name
-  );
-  return property?.value;
+  if (scope.paramNames.has(expression.name)) {
+    return shape.argsReadable ? literalText(shape.args[expression.name]) : undefined;
+  }
+  // A name the body declares has a render-time value this pass cannot know.
+  if (scope.bodyDeclared.has(expression.name)) {
+    return undefined;
+  }
+  const declared = declaredValue(shape, expression);
+  return declared === expression ? undefined : literalText(declared);
+};
+
+/** Filter for `argsToTemplate` options, or `undefined` when the options need the story to run. */
+const bindingFilterOf = (options: t.Node | undefined): BindingFilter | undefined => {
+  if (options === undefined) {
+    return {};
+  }
+  const unwrapped = unwrapExpression(options);
+  if (!t.isObjectExpression(unwrapped) || unwrapped.properties.some(t.isSpreadElement)) {
+    return undefined;
+  }
+
+  const filter: BindingFilter = {};
+  for (const key of ['include', 'exclude'] as const) {
+    const node = resolvedProperty(unwrapped, key);
+    if (node.kind === 'unresolvable') {
+      return undefined;
+    }
+    if (node.kind === 'value') {
+      const names = stringArray(node.node);
+      if (names === undefined) {
+        return undefined;
+      }
+      filter[key] = names;
+    }
+  }
+  return filter;
 };
 
 /** String array literal, for `argsToTemplate`'s `include` / `exclude` options. */
 const stringArray = (node: t.Node | undefined): string[] | undefined =>
-  t.isArrayExpression(node)
-    ? node.elements.filter((element) => t.isStringLiteral(element)).map((element) => element.value)
+  t.isArrayExpression(node) && node.elements.every((element) => t.isStringLiteral(element))
+    ? node.elements.map((element) => (element as t.StringLiteral).value)
     : undefined;
 
 /** Text an interpolated arg contributes, for slot content like `<span>${footer}</span>`. */
@@ -415,33 +530,259 @@ const literalText = (node: t.Node | undefined): string | undefined => {
     : undefined;
 };
 
-/** Object literal a story or `render` function returns, when it returns one directly. */
+/** How one annotation resolved against its config object. */
+type AnnotationResolution =
+  | { kind: 'value'; node: t.Node }
+  | { kind: 'missing' }
+  /** A spread may shadow or supply the property, or it is an accessor; the value is unknowable. */
+  | { kind: 'unresolvable' };
+
+/**
+ * A named property of a config object, with runtime object semantics: the last occurrence wins, a
+ * spread written after it (or standing in for a missing one) makes the value unknowable, and a
+ * getter/setter/generator is not a value at all. Falls back to the parser's annotation record when
+ * the config is not a plain object literal (CSF2 functions, re-exports).
+ */
+const resolveAnnotation = (
+  config: t.ObjectExpression | undefined,
+  annotations: Record<string, t.Node>,
+  key: string
+): AnnotationResolution => {
+  const annotated = annotations[key];
+  if (!config) {
+    return annotated === undefined ? { kind: 'missing' } : { kind: 'value', node: annotated };
+  }
+  const own = resolvedProperty(config, key);
+  // An annotation node the literal does not contain is a `Story.render = ...` member assignment,
+  // which runs after the declaration and wins over everything in the literal.
+  if (annotated !== undefined && annotated !== (own.kind === 'value' ? own.node : undefined)) {
+    return { kind: 'value', node: annotated };
+  }
+  return own;
+};
+
+// A spread or a dynamically-keyed member can supply or shadow any property at runtime.
+const isOpaqueMember = (property: t.ObjectExpression['properties'][number]): boolean =>
+  t.isSpreadElement(property) ||
+  ((t.isObjectProperty(property) || t.isObjectMethod(property)) &&
+    keyNameOf(property) === undefined);
+
+const resolvedProperty = (object: t.ObjectExpression, key: string): AnnotationResolution => {
+  let found: { index: number; property: t.ObjectMethod | t.ObjectProperty } | undefined;
+  object.properties.forEach((property, index) => {
+    if (
+      (t.isObjectProperty(property) || t.isObjectMethod(property)) &&
+      keyNameOf(property) === key
+    ) {
+      found = { index, property };
+    }
+  });
+
+  if (!found) {
+    return object.properties.some(isOpaqueMember) ? { kind: 'unresolvable' } : { kind: 'missing' };
+  }
+  if (
+    object.properties.some((property, index) => index > found!.index && isOpaqueMember(property))
+  ) {
+    return { kind: 'unresolvable' };
+  }
+  if (t.isObjectMethod(found.property)) {
+    return found.property.kind === 'method' && !found.property.generator
+      ? { kind: 'value', node: found.property }
+      : { kind: 'unresolvable' };
+  }
+  return { kind: 'value', node: found.property.value };
+};
+
+// A string-literal computed key has the exact runtime semantics of a plain string key.
+const keyNameOf = (property: t.ObjectMethod | t.ObjectProperty): string | undefined => {
+  if (t.isIdentifier(property.key) && !property.computed) {
+    return property.key.name;
+  }
+  return t.isStringLiteral(property.key) ? property.key.value : undefined;
+};
+
+/**
+ * The story's own config object literal: the export's initializer, the statement a re-export
+ * resolved to, or the argument of a `meta.story(...)` factory call.
+ */
+const storyConfigObject = (shape: StoryShape): t.ObjectExpression | undefined => {
+  const declared = shape.csf._storyExports[shape.exportName];
+  const candidates = [
+    t.isVariableDeclarator(declared) ? declared.init : declared,
+    shape.csf._storyStatements[shape.exportName],
+  ];
+  for (const candidate of candidates) {
+    const unwrapped = candidate ? unwrapExpression(candidate) : undefined;
+    if (unwrapped && t.isObjectExpression(unwrapped)) {
+      return unwrapped;
+    }
+    if (unwrapped && t.isCallExpression(unwrapped) && isStoryFactoryCall(unwrapped)) {
+      const argument = unwrapped.arguments[0];
+      const config = argument && unwrapExpression(argument);
+      if (config && t.isObjectExpression(config)) {
+        return config;
+      }
+    }
+  }
+  return undefined;
+};
+
+const isStoryFactoryCall = (call: t.CallExpression): boolean =>
+  t.isMemberExpression(call.callee) &&
+  t.isIdentifier(call.callee.property) &&
+  ['story', 'extend'].includes(call.callee.property.name);
+
+const metaConfigObject = (csf: CsfFile): t.ObjectExpression | undefined => {
+  const node = csf._metaNode;
+  return node && t.isObjectExpression(node) ? node : undefined;
+};
+
+/**
+ * Object literal a story or `render` function returns.
+ *
+ * Only a single-exit body is readable: any statement that could return earlier (a conditional, a
+ * loop) means the markup depends on which branch the story takes at runtime.
+ */
 const returnedObject = (fn: t.Node | undefined): t.ObjectExpression | undefined => {
+  const isPlainMethod = t.isObjectMethod(fn) && fn.kind === 'method' && !fn.generator;
   if (
     !t.isArrowFunctionExpression(fn) &&
     !t.isFunctionExpression(fn) &&
-    !t.isFunctionDeclaration(fn)
+    !t.isFunctionDeclaration(fn) &&
+    !isPlainMethod
   ) {
     return undefined;
   }
-  const returned = t.isBlockStatement(fn.body)
-    ? fn.body.body.find((statement) => t.isReturnStatement(statement))?.argument
-    : fn.body;
-  const unwrapped = returned && unwrapExpression(returned);
+
+  if (!t.isBlockStatement(fn.body)) {
+    const unwrapped = unwrapExpression(fn.body);
+    return t.isObjectExpression(unwrapped) ? unwrapped : undefined;
+  }
+
+  const statements = fn.body.body;
+  const last = statements.at(-1);
+  if (!t.isReturnStatement(last) || !last.argument) {
+    return undefined;
+  }
+  const singleExit = statements
+    .slice(0, -1)
+    .every((statement) => t.isVariableDeclaration(statement) || t.isExpressionStatement(statement));
+  if (!singleExit) {
+    return undefined;
+  }
+  const unwrapped = unwrapExpression(last.argument);
   return t.isObjectExpression(unwrapped) ? unwrapped : undefined;
 };
 
-/** The object a CSF2 function story returns, for `export const S = () => ({ template })`. */
-const csf2Return = (shape: StoryShape): t.ObjectExpression | undefined => {
+/** The CSF2 function story and the object it returns, for `export const S = () => ({ template })`. */
+const csf2Shape = (shape: StoryShape): { fn: t.Node; returned: t.ObjectExpression } | undefined => {
   const declared = shape.csf._storyExports[shape.exportName];
-  if (t.isVariableDeclarator(declared)) {
-    return returnedObject(declared.init ?? undefined);
+  const candidates: (t.Node | undefined | null)[] = t.isVariableDeclarator(declared)
+    ? [declared.init]
+    : // `export { S }` records no declarator; the statement is the initializer it resolved to.
+      [declared, shape.csf._storyStatements[shape.exportName]];
+
+  for (const candidate of candidates) {
+    let fn = candidate ? unwrapExpression(candidate) : undefined;
+    // `Template.bind({})` renders Template; the bound copy shares its body.
+    if (fn && t.isCallExpression(fn) && isBindCall(fn)) {
+      fn = declaredValue(shape, unwrapExpression((fn.callee as t.MemberExpression).object));
+    }
+    const returned = returnedObject(fn);
+    if (fn && returned) {
+      return { fn, returned };
+    }
   }
-  if (t.isFunctionDeclaration(declared)) {
-    return returnedObject(declared);
+  return undefined;
+};
+
+const isBindCall = (call: t.CallExpression): boolean =>
+  t.isMemberExpression(call.callee) && t.isIdentifier(call.callee.property, { name: 'bind' });
+
+/** What a render function binds, as far as it can be enumerated statically. */
+const functionScope = (fn: t.Node | undefined): FunctionScope => {
+  if (
+    !t.isArrowFunctionExpression(fn) &&
+    !t.isFunctionExpression(fn) &&
+    !t.isFunctionDeclaration(fn) &&
+    !t.isObjectMethod(fn)
+  ) {
+    return NO_SCOPE;
   }
-  // `export { S }` records no declarator; the statement is the initializer it resolved to.
-  return returnedObject(shape.csf._storyStatements[shape.exportName]);
+
+  const paramNames = new Set<string>();
+  const collect = (pattern: t.Node): void => {
+    if (t.isIdentifier(pattern)) {
+      paramNames.add(pattern.name);
+    } else if (t.isObjectPattern(pattern)) {
+      for (const property of pattern.properties) {
+        if (t.isRestElement(property)) {
+          collect(property.argument);
+        } else {
+          collect(property.value);
+        }
+      }
+    } else if (t.isArrayPattern(pattern)) {
+      pattern.elements.forEach((element) => element && collect(element));
+    } else if (t.isAssignmentPattern(pattern)) {
+      collect(pattern.left);
+    } else if (t.isRestElement(pattern)) {
+      collect(pattern.argument);
+    }
+  };
+  fn.params.forEach(collect);
+
+  const bodyDeclared = new Set<string>();
+  if (t.isBlockStatement(fn.body)) {
+    for (const statement of fn.body.body) {
+      if (t.isVariableDeclaration(statement)) {
+        for (const declarator of statement.declarations) {
+          collectPatternNames(declarator.id, bodyDeclared);
+        }
+      }
+    }
+  }
+
+  const argsExpansions = new Map<string, readonly string[]>();
+  const [firstParam] = fn.params;
+  if (t.isIdentifier(firstParam)) {
+    argsExpansions.set(firstParam.name, []);
+  } else if (t.isObjectPattern(firstParam)) {
+    const destructured: string[] = [];
+    let rest: string | undefined;
+    for (const property of firstParam.properties) {
+      if (t.isRestElement(property) && t.isIdentifier(property.argument)) {
+        rest = property.argument.name;
+      } else if (t.isObjectProperty(property)) {
+        const key = keyNameOf(property);
+        if (key !== undefined) {
+          destructured.push(key);
+        }
+      }
+    }
+    if (rest !== undefined) {
+      argsExpansions.set(rest, destructured);
+    }
+  }
+
+  return { paramNames, bodyDeclared, argsExpansions };
+};
+
+const collectPatternNames = (pattern: t.Node, into: Set<string>): void => {
+  if (t.isIdentifier(pattern)) {
+    into.add(pattern.name);
+  } else if (t.isObjectPattern(pattern)) {
+    for (const property of pattern.properties) {
+      collectPatternNames(t.isRestElement(property) ? property.argument : property.value, into);
+    }
+  } else if (t.isArrayPattern(pattern)) {
+    pattern.elements.forEach((element) => element && collectPatternNames(element, into));
+  } else if (t.isAssignmentPattern(pattern)) {
+    collectPatternNames(pattern.left, into);
+  } else if (t.isRestElement(pattern)) {
+    collectPatternNames(pattern.argument, into);
+  }
 };
 
 /**
@@ -449,37 +790,103 @@ const csf2Return = (shape: StoryShape): t.ObjectExpression | undefined => {
  *
  * `template: HOISTED_TEMPLATE` is markup the story really did write, so refusing to look through
  * the name would replace it with a fabricated element. An imported name has no initializer here,
- * so it stays an identifier and the snippet falls back to the generated bindings.
+ * so it stays an identifier and no snippet is generated.
  */
 const declaredValue = (shape: StoryShape, node: t.Node | undefined): t.Node | undefined => {
   if (!t.isIdentifier(node)) {
     return node;
   }
   const program: NodePath<t.Program> = shape.csf._file.path;
-  const declaration = program.scope.getBinding(node.name)?.path.node;
+  const binding = program.scope.getBinding(node.name);
+  // A reassigned binding's value at render time is not its initializer.
+  if (!binding?.constant) {
+    return node;
+  }
+  const declaration = binding.path.node;
   if (t.isVariableDeclarator(declaration)) {
     return declaration.init ?? node;
   }
   return t.isFunctionDeclaration(declaration) ? declaration : node;
 };
 
+interface ArgsRecord {
+  properties: Record<string, t.Node>;
+  complete: boolean;
+}
+
+/** Named properties of an `args` object literal, and whether the record is statically complete. */
+const argsProperties = (node: t.Node | undefined): ArgsRecord => {
+  const properties: Record<string, t.Node> = {};
+  if (node === undefined) {
+    return { properties, complete: true };
+  }
+  const unwrapped = unwrapExpression(node);
+  if (!t.isObjectExpression(unwrapped)) {
+    return { properties, complete: false };
+  }
+
+  let complete = true;
+  for (const property of unwrapped.properties) {
+    const key = t.isObjectProperty(property) ? keyNameOf(property) : undefined;
+    if (!t.isObjectProperty(property) || key === undefined) {
+      // A spread, accessor, or dynamic key can add or override args this pass cannot see.
+      complete = false;
+      continue;
+    }
+    properties[key] = property.value;
+  }
+  return { properties, complete };
+};
+
 const EVAL_FAILED = Symbol('story-docs-eval-failed');
 
-// An arg no static evaluation could reduce to a value falls back to its source text. Binding values
-// are delimited by double quotes, so a raw expression containing one would close its own attribute;
-// the entity survives the template parser and reads back as the original quote.
+// An arg no static evaluation could reduce to a value falls back to its source text. Every
+// expression is escaped for the attribute position it lands in: the double-quote delimiter and
+// text Angular's lexer would decode as a character reference survive the round-trip unchanged.
 const evaluateArgExpression = (node: t.Node, source: string, enums: SnippetEnum[]): string => {
   const unwrapped = unwrapExpression(node);
   const value = evaluateNode(unwrapped, enums);
   if (value !== EVAL_FAILED) {
-    return formatInputValue(value);
+    return escapeAttributeExpression(printExpressionValue(value, new Set()));
   }
   const text =
     unwrapped.start != null && unwrapped.end != null
       ? source.slice(unwrapped.start, unwrapped.end)
       : undefined;
-  return (text ?? 'undefined').replace(/"/g, '&quot;');
+  return escapeAttributeExpression(text ?? 'undefined');
 };
+
+// Angular expression strings support backslash escapes, so quoting stays lossless.
+const quoteExpressionString = (value: string): string =>
+  `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+
+// Renders an evaluated arg as a template expression, in the same shape the runtime generator
+// prints, but losslessly for strings carrying quotes.
+const printExpressionValue = (value: unknown, seen: Set<unknown>): string => {
+  if (typeof value === 'string') {
+    return quoteExpressionString(value);
+  }
+  if (typeof value !== 'object' || value === null) {
+    return `${value}`;
+  }
+  if (seen.has(value)) {
+    return quoteExpressionString('[Circular]');
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return `[${value.map((element) => printExpressionValue(element ?? null, seen)).join(', ')}]`;
+  }
+  const entries = Object.entries(value)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .map(
+      ([key, entryValue]) =>
+        `${isValidIdentifier(key) ? key : quoteExpressionString(key)}: ${printExpressionValue(entryValue, seen)}`
+    );
+  return `{${entries.join(', ')}}`;
+};
+
+const escapeAttributeExpression = (expression: string): string =>
+  expression.replace(/&(?=#|\w+;)/g, '&amp;').replace(/"/g, '&quot;');
 
 const evaluateNode = (node: t.Node, enums: SnippetEnum[]): unknown => {
   const unwrapped = unwrapExpression(node);

--- a/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-limitations.md
@@ -34,15 +34,28 @@ The snippet is built by reading the story file rather than by running it.
 Literals, arrays, objects and enum members are resolved to the value the browser generator would have shown, but an arg whose value needs the story to run - a call expression, or a constant imported from another file - is printed as the expression as written.
 
 Args assigned in the older CSF2 style (`MyStory.args = { ... }`) are read, even though the assignment sits outside the story's own initializer.
+The same goes for `MyStory.render` and `MyStory.template` assignments, and for the `Template.bind({})` idiom, which is followed to the function it copies.
+
+String values are escaped for the attribute position they land in, so quotes and character-reference text (`&amp;`) survive a round-trip through Angular's template parser unchanged.
+
+## What cannot be read yields no snippet at all
+
+The guiding rule is that a wrong snippet is worse than no snippet: whenever the story's markup or args cannot be read statically, no snippet is generated and Storybook falls back to showing the story's own source.
+That covers:
+
+- a spread or dynamically-keyed member in the story config or in an `args` object (`{ ...base }` may carry or shadow anything this pass would read)
+- a `template` or `render` bound to an imported name, or to a binding that is reassigned after its declaration
+- a `render` written as a getter, a setter, or a generator (reading `render` invokes a getter; the accessor itself is not the function)
+- a `render` body with more than one exit, where the branch taken depends on the story's runtime args
+- a `${…}` interpolation or `argsToTemplate` options that need the story to run
 
 ## Stories that supply their own template are untouched
 
-A story with a `template` (directly, or returned from an inline `render`) is shown as written, including an empty one.
+A story with a `template` (directly, or returned from an inline `render`, including the `render(args) { … }` method shorthand) is shown as written, including an empty one.
 That matches what the browser generator does today.
 
 A name declared in the same file is followed to what it holds, so `template: HOISTED_TEMPLATE` and `render: renderFn` are read rather than replaced by a fabricated element.
-An imported one cannot be followed, and neither can a template built from an expression that needs the story to run.
-In those cases the snippet falls back to the generated bindings rather than printing the variable name as if it were markup.
+The same scope rule applies to interpolated names: `${HEADER}` substitutes the module-level constant the runtime would read, and an interpolated name substitutes a story arg only when the render function actually binds it from its parameters.
 
 ## `argsToTemplate` is expanded, not given up on
 
@@ -66,7 +79,8 @@ Two differences from what runs in the browser, both deliberate:
 - `include` and `exclude` are honoured when written as array literals
 
 An interpolated arg used as slot content (`<span>${footer}</span>`) is substituted when its value is a string, number or boolean.
-Any other `${…}` needs the story to run, so the template is dropped and the generated bindings stand in.
+Any other `${…}` needs the story to run, so no snippet is generated and the story's own source stands in.
+`argsToTemplate` itself expands only when given the render's args parameter - whole, or as a rest binding, in which case the destructured names are excluded the way the runtime's rest object excludes them.
 
 ## The component's metadata has to be available
 

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/input.stories.ts
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/input.stories.ts
@@ -1,0 +1,130 @@
+// The story shapes the server snippet generator has to tell apart, one export per shape. Shapes
+// whose markup or args cannot be read statically must yield NO snippet (recorded as a sentinel),
+// never a fabricated element.
+import { ShapeButtonComponent } from './shape-button.component.ts';
+import { IMPORTED_TEMPLATE } from './templates.ts';
+
+// This file is only ever parsed, not executed; a declaration keeps the package's client tree out
+// of the harness type graph while the generator matches the call by name.
+declare function argsToTemplate(
+  args: unknown,
+  options?: { include?: readonly string[]; exclude?: readonly string[] }
+): string;
+
+type LooseStory = {
+  args?: Record<string, unknown>;
+  render?: (args: Record<string, unknown>) => unknown;
+  template?: string;
+};
+
+const HOISTED_TEMPLATE = '<sb-shape-button hoisted></sb-shape-button>';
+const HEADER = '<h1>Shapes</h1>';
+const INCLUDES = ['label'];
+const base = { args: { label: 'From base' } };
+const Template = (args: Record<string, unknown>) => ({
+  props: args,
+  template: '<div class="bound"><sb-shape-button></sb-shape-button></div>',
+});
+let MUTABLE_TEMPLATE = '<sb-shape-button first></sb-shape-button>';
+MUTABLE_TEMPLATE = '<sb-shape-button second></sb-shape-button>';
+const extraArgs = { count: 3 };
+
+export default {
+  title: 'AngularShapes/button-shapes',
+  component: ShapeButtonComponent,
+};
+
+export const OwnTemplate = { template: '<sb-shape-button emphasis>hi</sb-shape-button>' };
+
+export const RenderTemplate = {
+  render: () => ({ template: '<sb-shape-button rendered></sb-shape-button>' }),
+};
+
+export const MethodRender = {
+  args: { label: 'Save' },
+  render(_args: Record<string, unknown>) {
+    return { template: '<div class="wrap"><sb-shape-button></sb-shape-button></div>' };
+  },
+};
+
+export const ArgsToTemplateWrapper = {
+  args: { label: 'Save', count: 7 },
+  render: (args: Record<string, unknown>) => ({
+    props: args,
+    template: `<div class="wrap"><sb-shape-button ${argsToTemplate(args)}></sb-shape-button></div>`,
+  }),
+};
+
+export const ArgsToTemplateInclude = {
+  args: { label: 'Save', count: 7 },
+  render: (args: Record<string, unknown>) => ({
+    props: args,
+    template: `<sb-shape-button ${argsToTemplate(args, { include: ['label'] })}></sb-shape-button>`,
+  }),
+};
+
+export const SlotInterpolation = {
+  args: { label: 'Save', footer: 'Bye' },
+  render: ({ footer, ...args }: Record<string, unknown>) => ({
+    props: args,
+    template: `<sb-shape-button>${footer}</sb-shape-button>`,
+  }),
+};
+
+export const ModuleConstant = {
+  args: { label: 'Save' },
+  render: (args: Record<string, unknown>) => ({
+    props: args,
+    template: `${HEADER}<sb-shape-button></sb-shape-button>`,
+  }),
+};
+
+export const HoistedTemplate = { template: HOISTED_TEMPLATE };
+
+export const QuotedArgs = {
+  args: { label: `it's "quoted" & Tom &amp; Jerry` },
+};
+
+export const ImportedTemplate = { template: IMPORTED_TEMPLATE, args: { count: 5 } };
+
+export const SpreadShadowedRender = {
+  render: () => ({ template: '<sb-shape-button from-story></sb-shape-button>' }),
+  ...base,
+};
+
+export const SpreadArgs = { args: { label: 'Save', ...extraArgs } };
+
+export const AccessorRender = {
+  args: { label: 'Save' },
+  get render() {
+    return () => ({ template: '<sb-shape-button from-getter></sb-shape-button>' });
+  },
+};
+
+export const MultiExitRender = {
+  args: { count: 1 },
+  render: (args: { count?: number }) => {
+    if (args.count) {
+      return { template: '<sb-shape-button first></sb-shape-button>' };
+    }
+    return { template: '<sb-shape-button second></sb-shape-button>' };
+  },
+};
+
+export const DynamicOptions = {
+  args: { label: 'Save' },
+  render: (args: Record<string, unknown>) => ({
+    props: args,
+    template: `<sb-shape-button ${argsToTemplate(args, { include: INCLUDES })}></sb-shape-button>`,
+  }),
+};
+
+export const TemplateBind = Template.bind({}) as typeof Template & LooseStory;
+TemplateBind.args = { label: 'Bound' };
+
+export const MemberAssignedRender: LooseStory = { args: { label: 'Save' } };
+MemberAssignedRender.render = () => ({
+  template: '<div class="assigned"><sb-shape-button></sb-shape-button></div>',
+});
+
+export const ReassignedTemplate = { template: MUTABLE_TEMPLATE };

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-AccessorRender.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-AccessorRender.snapshot
@@ -1,0 +1,1 @@
+(no snippet: the runtime source fallback stays authoritative)

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ArgsToTemplateInclude.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ArgsToTemplateInclude.snapshot
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<sb-shape-button [label]="'Save'"></sb-shape-button>`,
+})
+export class DemoComponent {}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ArgsToTemplateWrapper.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ArgsToTemplateWrapper.snapshot
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<div class="wrap"><sb-shape-button [label]="'Save'" [count]="7" (clicked)="clicked($event)"></sb-shape-button></div>`,
+})
+export class DemoComponent {
+  clicked(event: unknown) {}
+}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-DynamicOptions.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-DynamicOptions.snapshot
@@ -1,0 +1,1 @@
+(no snippet: the runtime source fallback stays authoritative)

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-HoistedTemplate.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-HoistedTemplate.snapshot
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<sb-shape-button hoisted></sb-shape-button>`,
+})
+export class DemoComponent {}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ImportedTemplate.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ImportedTemplate.snapshot
@@ -1,0 +1,1 @@
+(no snippet: the runtime source fallback stays authoritative)

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-MemberAssignedRender.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-MemberAssignedRender.snapshot
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<div class="assigned"><sb-shape-button></sb-shape-button></div>`,
+})
+export class DemoComponent {}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-MethodRender.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-MethodRender.snapshot
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<div class="wrap"><sb-shape-button></sb-shape-button></div>`,
+})
+export class DemoComponent {}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ModuleConstant.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ModuleConstant.snapshot
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<h1>Shapes</h1><sb-shape-button></sb-shape-button>`,
+})
+export class DemoComponent {}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-MultiExitRender.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-MultiExitRender.snapshot
@@ -1,0 +1,1 @@
+(no snippet: the runtime source fallback stays authoritative)

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-OwnTemplate.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-OwnTemplate.snapshot
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<sb-shape-button emphasis>hi</sb-shape-button>`,
+})
+export class DemoComponent {}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-QuotedArgs.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-QuotedArgs.snapshot
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<sb-shape-button [label]="'it\\'s &quot;quoted&quot; & Tom &amp;amp; Jerry'" (clicked)="clicked($event)"></sb-shape-button>`,
+})
+export class DemoComponent {
+  clicked(event: unknown) {}
+}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ReassignedTemplate.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-ReassignedTemplate.snapshot
@@ -1,0 +1,1 @@
+(no snippet: the runtime source fallback stays authoritative)

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-RenderTemplate.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-RenderTemplate.snapshot
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<sb-shape-button rendered></sb-shape-button>`,
+})
+export class DemoComponent {}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-SlotInterpolation.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-SlotInterpolation.snapshot
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<sb-shape-button>Bye</sb-shape-button>`,
+})
+export class DemoComponent {}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-SpreadArgs.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-SpreadArgs.snapshot
@@ -1,0 +1,1 @@
+(no snippet: the runtime source fallback stays authoritative)

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-SpreadShadowedRender.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-SpreadShadowedRender.snapshot
@@ -1,0 +1,1 @@
+(no snippet: the runtime source fallback stays authoritative)

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-TemplateBind.snapshot
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/server-snippet-TemplateBind.snapshot
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { ShapeButtonComponent } from './shape-button.component.ts';
+
+@Component({
+  selector: 'app-demo',
+  imports: [ShapeButtonComponent],
+  template: `<div class="bound"><sb-shape-button></sb-shape-button></div>`,
+})
+export class DemoComponent {}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/shape-button.component.ts
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/shape-button.component.ts
@@ -1,0 +1,13 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'sb-shape-button',
+  template: '<button (click)="clicked.emit(label)">{{ label }} {{ count }}</button>',
+})
+export class ShapeButtonComponent {
+  @Input() label = 'Button';
+
+  @Input() count?: number;
+
+  @Output() clicked = new EventEmitter<string>();
+}

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/templates.ts
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/templates.ts
@@ -1,0 +1,1 @@
+export const IMPORTED_TEMPLATE = '<sb-shape-button imported></sb-shape-button>';

--- a/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/tsconfig.json
+++ b/code/lib/docgen-harness/src/angular/__storyshapes__/button-shapes/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["./*.ts"]
+}

--- a/code/lib/docgen-harness/src/angular/angular-story-docs-shapes.test.ts
+++ b/code/lib/docgen-harness/src/angular/angular-story-docs-shapes.test.ts
@@ -1,0 +1,82 @@
+// Gates the server-generated snippets for stories that supply their own markup. These fixtures
+// live in their own tree (`__storyshapes__`): the `__testfixtures__` recorders JIT-mount their
+// stories and gate against legacy runtime recordings, neither of which exists for template-shaped
+// stories - the correct baseline here is the authored markup itself, so snapshots gate
+// byte-for-byte. A story whose markup cannot be read statically must yield NO snippet, recorded
+// as an explicit sentinel so a disappearing bail can never hide behind a missing file.
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { loadCsf } from 'storybook/internal/csf-tools';
+import type { IndexEntry } from 'storybook/internal/types';
+
+import { buildStoryDocsPayload } from '../../../../frameworks/angular-vite/src/docgen/story-docs-build.ts';
+import { createFixtureDocgen } from './docgen-fixture.ts';
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__storyshapes__');
+
+const fixtureCases = readdirSync(fixturesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+const NO_SNIPPET_SENTINEL = '(no snippet: the runtime source fallback stays authoritative)';
+
+// One manager for the whole suite: each fixture directory carries its own tsconfig.json, so every
+// component file resolves to its own per-fixture project.
+const docgen = createFixtureDocgen();
+
+afterAll(() => {
+  docgen.dispose();
+});
+
+describe('angular story-docs snippets for stories that supply their own markup', () => {
+  it.each(fixtureCases)('%s', async (fixtureCase) => {
+    const testDir = join(fixturesDir, fixtureCase);
+    const storyPath = join(testDir, 'input.stories.ts');
+    expect(existsSync(storyPath)).toBe(true);
+
+    // The same parse the builder runs, used here only to map story ids back to export names.
+    const csf = loadCsf(readFileSync(storyPath, 'utf8'), {
+      makeTitle: () => `AngularShapes/${fixtureCase}`,
+    }).parse();
+    const storyExports = Object.entries(csf._stories);
+    expect(storyExports.length).toBeGreaterThan(0);
+
+    const entry: IndexEntry = {
+      id: storyExports[0][1].id,
+      name: storyExports[0][1].name ?? storyExports[0][0],
+      title: `AngularShapes/${fixtureCase}`,
+      type: 'story',
+      subtype: 'story',
+      importPath: storyPath,
+    };
+    const payload = await buildStoryDocsPayload(
+      { entry },
+      { getDocgenPayload: docgen.getDocgenPayload(entry), resolvePath: (path) => path }
+    );
+    expect(payload).toBeDefined();
+
+    for (const [exportName, story] of storyExports) {
+      const storyDoc = payload!.stories[story.id];
+      expect(storyDoc, `${exportName} missing from payload`).toBeDefined();
+      expect(storyDoc?.error, `${exportName} produced an error`).toBeUndefined();
+      await expect(storyDoc?.snippet ?? NO_SNIPPET_SENTINEL).toMatchFileSnapshot(
+        join(testDir, `server-snippet-${exportName}.snapshot`)
+      );
+    }
+
+    // toMatchFileSnapshot files sit outside vitest's obsolete-snapshot detection, so a renamed or
+    // removed story export would silently leave its old recording behind.
+    const snippetFilesOnDisk = readdirSync(testDir)
+      .filter((file) => file.startsWith('server-snippet-') && file.endsWith('.snapshot'))
+      .sort();
+    const expectedSnippetFiles = storyExports
+      .map(([exportName]) => `server-snippet-${exportName}.snapshot`)
+      .sort();
+    expect(snippetFilesOnDisk).toEqual(expectedSnippetFiles);
+  });
+});


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Follow-up to #35797, stacked on `valentin/angular-story-docs-2-story-shapes` so the diff reads as a delta on top of it. It applies the findings from the [thermo-nuclear review of the Vue snippet generator](https://github.com/storybookjs/storybook/pull/35823#pullrequestreview-4919394947) to the Angular story-shape provider, plus what two adversarial review rounds found in this branch itself.

The guiding rule: a snippet showing markup the story never renders is strictly worse than no snippet. Wherever the story cannot be read statically, the provider now emits nothing and the docs fall back to the story's own source - instead of fabricating a `<selector [input]>` element.

The issue, concretely - each of these previously emitted a wrong or invalid snippet:

```text
{ render: fn, ...base }                  -> snippet from fn, but base.render wins at runtime
{ ...base }                              -> fabricated bindings; base may carry a template
Story.render = () => ({ template })     -> member assignment invisible, fabricated bindings
render(args) { return { template } }    -> method shorthand invisible, fabricated bindings
get render() { ... }                    -> accessor treated as the function
let TPL = a; TPL = b; template: TPL     -> snippet shows a, runtime renders b
const footer = 'x' (module) + arg footer -> wrong value substituted into ${footer}
label: 'say "hi"'                        -> [label]="'say "hi"'" - attribute closes early
label: 'broken &#65 ref'                 -> Angular's lexer rejects the emitted attribute
render with two conditional returns      -> snippet from an arbitrary branch
argsToTemplate({ ...args, extra: 1 })    -> expands as if it were plain args
selectorless component with template     -> template ignored, outlet snippet fabricated
```

The fix, per class:

- Config keys resolve with runtime object semantics: last occurrence wins, string-literal computed keys are read, a spread or dynamic key after (or instead of) the property makes it unreadable, and `Story.render`/`Story.template` member assignments override the declaration they follow.
- Interpolated `${name}` resolves by scope: a name the render binds from its parameters substitutes the story arg, a *constant* module binding is followed (new: `${HEADER}` now works), and reassigned or body-declared names bail.
- `argsToTemplate` expands only for the args parameter - whole, or as a rest binding with the destructured names excluded, which is exactly what the runtime's rest object excludes.
- Binding values are escaped losslessly for the attribute position: `'` via expression escapes, `"` as `&quot;`, and `&` only where Angular's lexer would decode or reject it (`&amp;`, `&#65`), so `a && b` stays readable.
- Newly supported, since the machinery was already there: `render(args) { }` method shorthand, `Template.bind({})` (the dominant pre-CSF3 idiom), and a selectorless component's own template.

## Before / after

From a 41-case authoring-pattern matrix run against the real provider: 8 wrong-output cases became correct output, 8 fabricated-bindings cases became correct bails, 0 regressions among the previously-correct cases. Two adversarial review rounds (9 + 7 agents) verified every finding end-to-end before it was fixed; the second round caught three blockers in my own first implementation (stale `let` substitution, member-assignment regression, the `&#` escaping hole) - all covered by tests below.

Real recordings from the new harness fixture tree (`server-snippet-*.snapshot`):

```text
QuotedArgs        template: `<sb-shape-button [label]="'it\'s &quot;quoted&quot; & Tom &amp;amp; Jerry'" ...`
TemplateBind      template: `<div class="bound"><sb-shape-button></sb-shape-button></div>`
MemberAssigned    template: `<div class="assigned"><sb-shape-button></sb-shape-button></div>`
SpreadShadowed    (no snippet: the runtime source fallback stays authoritative)
ReassignedTemplate (no snippet: the runtime source fallback stays authoritative)
```

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Suites run locally: `angular-vite` docgen (102, including 24 new hardening tests), docgen-harness angular (69 + 5 expected-fail), with a new `__storyshapes__` fixture tree recording 18 byte-exact snapshots including explicit no-snippet sentinels - it lives outside `__testfixtures__` on purpose, since the JIT-mount recorders and legacy-parity gates there have no baseline for template-shaped stories.

#### Manual testing

1. Run a sandbox: `yarn task sandbox --template angular-cli/default-ts --start-from auto` with `features.experimentalDocgenServer` enabled
2. Give a story a template render: `render: (args) => ({ props: args, template: \`<div class="wrap"><storybook-button ${argsToTemplate(args)}></storybook-button></div>\` })`
3. Open the docs page: the snippet should show the wrapper markup with inlined bindings inside the host component
4. Change the story to `{ render: () => ({ template: '...' }), ...somethingElse }` and confirm the snippet disappears in favour of the story source
5. Add `label: 'say "hi"'` to args of a plain story and confirm the snippet compiles as written

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

`story-docs-limitations.md` is updated to describe the no-fabrication rule and the scope semantics.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

Note for reviewers: #35797's merge conflict with its base is resolved in the same push - the story-shapes feature is re-expressed on the reworked provider (async `getDocgenPayload`, host-component snippets), so this PR only carries the hardening delta. WDYT? :slightly_smiling_face:

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNDMPmTCtfVnLKqqDAAKQ9
