### PR TITLE
Nextjs-Vite: Recover from Next.js 16.3 raw config cache

### DIFF
--- a/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
@@ -145,5 +145,11 @@ describe('VitePlugin', () => {
       },
     });
     expect(config?.resolve).not.toHaveProperty('alias');
+    expect(config?.test?.alias).toEqual(
+      expect.objectContaining({
+        'next/dist/compiled/react': expect.any(String),
+        'next/dist/compiled/react-dom': expect.any(String),
+      })
+    );
   });
 });

--- a/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
@@ -147,8 +147,8 @@ describe('VitePlugin', () => {
     expect(config?.resolve).not.toHaveProperty('alias');
     expect(config?.test?.alias).toEqual(
       expect.objectContaining({
-        'next/dist/compiled/react': expect.any(String),
-        'next/dist/compiled/react-dom': expect.any(String),
+        'next/dist/compiled/react': '/resolved/next/dist/compiled',
+        'next/dist/compiled/react-dom': '/resolved/next/dist/compiled',
       })
     );
   });

--- a/code/lib/vite-plugin-storybook-nextjs/src/index.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/index.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'pathe';
+import { dirname, resolve } from 'pathe';
 
 import { createRequire } from 'node:module';
 import type { NextConfigComplete } from 'next/dist/server/config-shared.js';
@@ -28,6 +28,8 @@ import {
 import { loadNextConfig } from './utils/next-config.ts';
 
 const require = createRequire(import.meta.url);
+const compiledReactDir = dirname(require.resolve('next/dist/compiled/react'));
+const compiledReactDomDir = dirname(require.resolve('next/dist/compiled/react-dom'));
 
 export type PluginOptions = {
   /**
@@ -167,6 +169,8 @@ function VitePlugin({ dir = process.cwd(), image }: PluginOptions = {}): PluginO
           },
           test: {
             alias: {
+              'next/dist/compiled/react': compiledReactDir,
+              'next/dist/compiled/react-dom': compiledReactDomDir,
               'react/jsx-dev-runtime':
                 require.resolve('next/dist/compiled/react/jsx-dev-runtime.js'),
               'react/jsx-runtime': require.resolve('next/dist/compiled/react/jsx-runtime.js'),

--- a/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.test.ts
@@ -22,7 +22,7 @@ describe('loadNextConfig', () => {
   });
 
   it('uses Next.js config loading unchanged by default', async () => {
-    const config = { distDir: '.next', experimental: {} };
+    const config = { distDir: '.next', experimental: {}, configFileName: 'next.config.js' };
     loadConfigMock.mockResolvedValue(config);
 
     await expect(loadNextConfig(phase, dir)).resolves.toBe(config);
@@ -104,6 +104,31 @@ describe('loadNextConfig', () => {
     expect(loadConfigMock).toHaveBeenNthCalledWith(2, phase, dir, {
       customConfig: {
         distDir: '.next',
+        experimental: { typedEnv: true },
+      },
+    });
+  });
+
+  it('normalizes a cached raw config that already has a user experimental option', async () => {
+    const cachedRawConfig = { experimental: { typedEnv: true } };
+    const normalizedConfig = {
+      experimental: {
+        turbopackRustReactCompiler: true,
+        typedEnv: true,
+      },
+    };
+    const resolvedConfig = {
+      experimental: { typedEnv: true },
+      configFileName: 'next.config.js',
+    };
+
+    loadConfigMock.mockResolvedValueOnce(cachedRawConfig).mockResolvedValueOnce(resolvedConfig);
+    normalizeConfigMock.mockResolvedValue(normalizedConfig);
+
+    await expect(loadNextConfig(phase, dir)).resolves.toBe(resolvedConfig);
+    expect(normalizeConfigMock).toHaveBeenCalledWith(phase, cachedRawConfig);
+    expect(loadConfigMock).toHaveBeenNthCalledWith(2, phase, dir, {
+      customConfig: {
         experimental: { typedEnv: true },
       },
     });

--- a/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.test.ts
@@ -22,7 +22,7 @@ describe('loadNextConfig', () => {
   });
 
   it('uses Next.js config loading unchanged by default', async () => {
-    const config = { distDir: '.next' };
+    const config = { distDir: '.next', experimental: {} };
     loadConfigMock.mockResolvedValue(config);
 
     await expect(loadNextConfig(phase, dir)).resolves.toBe(config);
@@ -78,6 +78,34 @@ describe('loadNextConfig', () => {
     expect(normalizedConfig.experimental).toEqual({
       turbopackRustReactCompiler: true,
       typedEnv: true,
+    });
+  });
+
+  it('normalizes a cached raw config module that is missing Next.js defaults', async () => {
+    const cachedRawConfig = { distDir: '.next' };
+    const normalizedConfig = {
+      distDir: '.next',
+      experimental: {
+        turbopackRustReactCompiler: true,
+        typedEnv: true,
+      },
+    };
+    const resolvedConfig = {
+      distDir: '.next',
+      experimental: { typedEnv: true },
+    };
+
+    loadConfigMock.mockResolvedValueOnce(cachedRawConfig).mockResolvedValueOnce(resolvedConfig);
+    normalizeConfigMock.mockResolvedValue(normalizedConfig);
+
+    await expect(loadNextConfig(phase, dir)).resolves.toBe(resolvedConfig);
+    expect(loadConfigMock).toHaveBeenNthCalledWith(1, phase, dir);
+    expect(normalizeConfigMock).toHaveBeenCalledWith(phase, cachedRawConfig);
+    expect(loadConfigMock).toHaveBeenNthCalledWith(2, phase, dir, {
+      customConfig: {
+        distDir: '.next',
+        experimental: { typedEnv: true },
+      },
     });
   });
 });

--- a/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.ts
@@ -21,21 +21,20 @@ export async function loadNextConfig(
       throw error;
     }
 
-    return loadConfigWithoutTurbopackRustReactCompiler(phase, dir);
+    return loadNormalizedNextConfig(phase, dir);
   }
 
-  // Next 16.3+ can reuse a rawConfig:true cache entry, which has no Next defaults.
-  if (nextConfig.experimental !== undefined) {
+  if (!isMissingNextConfigDefaults(nextConfig)) {
     return nextConfig;
   }
 
-  return loadConfigWithoutTurbopackRustReactCompiler(phase, dir, nextConfig);
+  return loadNormalizedNextConfig(phase, dir, nextConfig);
 }
 
-async function loadConfigWithoutTurbopackRustReactCompiler(
+async function loadNormalizedNextConfig(
   phase: Parameters<typeof loadConfig>[0],
   dir: string,
-  cachedRawConfigModule?: NextConfigComplete
+  cachedRawConfigModule?: unknown
 ): Promise<NextConfigComplete> {
   const rawConfigModule =
     cachedRawConfigModule ?? (await loadConfig(phase, dir, { rawConfig: true }));
@@ -52,10 +51,18 @@ async function loadConfigWithoutTurbopackRustReactCompiler(
   });
 }
 
+function isMissingNextConfigDefaults(config: NextConfigComplete): boolean {
+  return config.experimental === undefined;
+}
+
 function isTurbopackRustReactCompilerError(error: unknown): boolean {
   return error instanceof Error && error.message.startsWith(TURBOPACK_RUST_REACT_COMPILER_ERROR);
 }
 
-function interopDefault<T>(module: T | { default: T }): T {
-  return (module as { default?: T }).default ?? (module as T);
+function interopDefault(module: unknown): unknown {
+  if (typeof module === 'object' && module !== null && 'default' in module) {
+    return (module as { default: unknown }).default ?? module;
+  }
+
+  return module;
 }

--- a/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.ts
@@ -12,15 +12,33 @@ export async function loadNextConfig(
   phase: Parameters<typeof loadConfig>[0],
   dir: string
 ): Promise<NextConfigComplete> {
+  let nextConfig: NextConfigComplete;
+
   try {
-    return await loadConfig(phase, dir);
+    nextConfig = await loadConfig(phase, dir);
   } catch (error) {
     if (!isTurbopackRustReactCompilerError(error)) {
       throw error;
     }
+
+    return loadConfigWithoutTurbopackRustReactCompiler(phase, dir);
   }
 
-  const rawConfigModule = await loadConfig(phase, dir, { rawConfig: true });
+  // Next 16.3+ can reuse a rawConfig:true cache entry, which has no Next defaults.
+  if (nextConfig.experimental !== undefined) {
+    return nextConfig;
+  }
+
+  return loadConfigWithoutTurbopackRustReactCompiler(phase, dir, nextConfig);
+}
+
+async function loadConfigWithoutTurbopackRustReactCompiler(
+  phase: Parameters<typeof loadConfig>[0],
+  dir: string,
+  cachedRawConfigModule?: NextConfigComplete
+): Promise<NextConfigComplete> {
+  const rawConfigModule =
+    cachedRawConfigModule ?? (await loadConfig(phase, dir, { rawConfig: true }));
   const rawConfig = interopDefault(rawConfigModule);
   const normalizedConfig = await normalizeConfig(phase, rawConfig);
   const { turbopackRustReactCompiler: _turbopackRustReactCompiler, ...experimental } =

--- a/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/utils/next-config.ts
@@ -24,7 +24,7 @@ export async function loadNextConfig(
     return loadNormalizedNextConfig(phase, dir);
   }
 
-  if (!isMissingNextConfigDefaults(nextConfig)) {
+  if (isResolvedNextConfig(nextConfig)) {
     return nextConfig;
   }
 
@@ -51,8 +51,8 @@ async function loadNormalizedNextConfig(
   });
 }
 
-function isMissingNextConfigDefaults(config: NextConfigComplete): boolean {
-  return config.experimental === undefined;
+function isResolvedNextConfig(config: NextConfigComplete): boolean {
+  return typeof config.configFileName === 'string';
 }
 
 function isTurbopackRustReactCompilerError(error: unknown): boolean {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Port of [storybookjs/vite-plugin-storybook-nextjs#144](https://github.com/storybookjs/vite-plugin-storybook-nextjs/pull/144) by @Stanzilla, now that `vite-plugin-storybook-nextjs` lives in this monorepo.

Next.js 16.3.0 stores a `rawConfig: true` load under the same cache key as a normal config load. A later Storybook project can then receive the raw module without Next.js defaults, and `loadJsConfig` fails while reading `config.experimental.useTypeScriptCli`.

This normalizes that cached raw result through the existing Turbopack React Compiler fallback, and aliases `next/dist/compiled/react` and `react-dom` directories so Vitest pre-bundles a single compiled React instance.

The standalone repo's Next 16.3.0 dependency bump and `example/` integration test are not ported: the monorepo already manages Next versions per sandbox, and the cache-misshape path is covered by a unit test instead.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Generate a Next.js Vite sandbox on Next 16.3: `yarn task sandbox --template nextjs-vite/default-ts --start-from auto` (or a Next 16.3 prerelease template if that is the one that reproduces the cache issue).
2. Start Storybook and confirm it boots without `loadJsConfig` / `experimental.useTypeScriptCli` errors in the terminal.
3. Run Vitest in that sandbox (`yarn test` / Storybook Vitest) and confirm there are no invalid hook call errors from duplicate compiled React copies.

Worth extra scrutiny: a second Storybook/Vitest process in the same Next project after a failed Turbopack React Compiler config load, which is how the raw config ended up cached.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->