### PR TITLE
Nextjs-Vite: Support % in next/font/local declarations

### DIFF
--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-font/plugin.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-font/plugin.test.ts
@@ -4,17 +4,9 @@ import type { PluginContext } from 'rollup';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./local/get-font-face-declarations.ts', { spy: true });
-vi.mock('./google/get-font-face-declarations.ts', { spy: true });
 
 import { getFontFaceDeclarations as getLocalFontFaceDeclarations } from './local/get-font-face-declarations.ts';
 import { vitePluginNextFont } from './plugin.ts';
-
-function encodeBase64Url(str: string): string {
-  const base64 = Buffer.from(str).toString('base64');
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
-
-const virtualFontId = (rawQuery: string) => `\0virtual:next-font:${encodeBase64Url(rawQuery)}`;
 
 describe('vitePluginNextFont resolveId', () => {
   const createContext = () => ({}) as PluginContext;
@@ -59,7 +51,7 @@ describe('vitePluginNextFont resolveId', () => {
       id: string;
     };
 
-    expect(result.id).toBe(virtualFontId(rawQuery));
+    expect(result.id).toMatch(/^\0virtual:next-font:/);
     expect(result.id).not.toContain('%');
   });
 
@@ -92,8 +84,6 @@ describe('vitePluginNextFont resolveId', () => {
       importer
     )) as { id: string };
 
-    expect(a.id).toBe(virtualFontId(queryA));
-    expect(b.id).toBe(virtualFontId(queryB));
     expect(a.id).not.toEqual(b.id);
   });
 });

--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-font/plugin.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-font/plugin.test.ts
@@ -1,0 +1,99 @@
+import path from 'node:path';
+
+import type { PluginContext } from 'rollup';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./local/get-font-face-declarations.ts', { spy: true });
+vi.mock('./google/get-font-face-declarations.ts', { spy: true });
+
+import { getFontFaceDeclarations as getLocalFontFaceDeclarations } from './local/get-font-face-declarations.ts';
+import { vitePluginNextFont } from './plugin.ts';
+
+function encodeBase64Url(str: string): string {
+  const base64 = Buffer.from(str).toString('base64');
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+const virtualFontId = (rawQuery: string) => `\0virtual:next-font:${encodeBase64Url(rawQuery)}`;
+
+describe('vitePluginNextFont resolveId', () => {
+  const createContext = () => ({}) as PluginContext;
+
+  beforeEach(() => {
+    vi.mocked(getLocalFontFaceDeclarations).mockResolvedValue({
+      id: 'font-test',
+      fontFamily: 'font-test',
+      fontFaceCSS: '@font-face {}',
+      weights: ['200'],
+      styles: ['normal'],
+    });
+  });
+
+  it('encodes the SWC query so a % in font declarations cannot reach Vite URL parsing', async () => {
+    const plugin = vitePluginNextFont();
+
+    const rawQuery = JSON.stringify({
+      path: 'src/fonts/Overpass.ts',
+      import: '',
+      arguments: [
+        {
+          declarations: [{ prop: 'ascent-override', value: '100%' }],
+          display: 'swap',
+          src: [
+            {
+              path: './Overpass/overpass-thin.woff2',
+              style: 'normal',
+              weight: '200',
+            },
+          ],
+          variable: '--font-overpass',
+        },
+      ],
+      variableName: 'overpassFont',
+    });
+
+    const source = `${path.join('node_modules', 'next', 'font', 'local', 'target.css')}?${rawQuery}`;
+    const importer = '/project/.storybook/preview.tsx';
+
+    const result = (await plugin.resolveId!.call(createContext(), source, importer)) as {
+      id: string;
+    };
+
+    expect(result.id).toBe(virtualFontId(rawQuery));
+    expect(result.id).not.toContain('%');
+  });
+
+  it('produces distinct virtual ids for different font option payloads', async () => {
+    const plugin = vitePluginNextFont();
+    const importer = '/project/.storybook/preview.tsx';
+    const sourcePrefix = path.join('node_modules', 'next', 'font', 'local', 'target.css');
+
+    const queryA = JSON.stringify({
+      path: 'a.ts',
+      import: '',
+      arguments: [{ src: './a.woff2' }],
+      variableName: 'a',
+    });
+    const queryB = JSON.stringify({
+      path: 'b.ts',
+      import: '',
+      arguments: [{ src: './b.woff2' }],
+      variableName: 'b',
+    });
+
+    const a = (await plugin.resolveId!.call(
+      createContext(),
+      `${sourcePrefix}?${queryA}`,
+      importer
+    )) as { id: string };
+    const b = (await plugin.resolveId!.call(
+      createContext(),
+      `${sourcePrefix}?${queryB}`,
+      importer
+    )) as { id: string };
+
+    expect(a.id).toBe(virtualFontId(queryA));
+    expect(b.id).toBe(virtualFontId(queryB));
+    expect(a.id).not.toEqual(b.id);
+  });
+});

--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-font/plugin.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-font/plugin.ts
@@ -7,6 +7,7 @@ import {
   type LoaderOptions,
   getFontFaceDeclarations as getLocalFontFaceDeclarations,
 } from './local/get-font-face-declarations.ts';
+import { encodeBase64Url } from '../../utils/base64-url.ts';
 import { getCSSMeta } from './utils/get-css-meta.ts';
 import { setFontDeclarationsInHead } from './utils/set-font-declarations-in-head.ts';
 
@@ -31,11 +32,6 @@ type FontOptions = {
 const includePattern = /next(\\|\/|\\\\).*(\\|\/|\\\\)target\.css\?.*$/;
 
 const virtualFontPrefix = '\0virtual:next-font:';
-
-function encodeBase64Url(str: string): string {
-  const base64 = Buffer.from(str).toString('base64');
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
 
 export function vitePluginNextFont() {
   let devMode = true;

--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-font/plugin.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-font/plugin.ts
@@ -30,7 +30,12 @@ type FontOptions = {
 
 const includePattern = /next(\\|\/|\\\\).*(\\|\/|\\\\)target\.css\?.*$/;
 
-const virtualModuleId = 'virtual:next-font';
+const virtualFontPrefix = '\0virtual:next-font:';
+
+function encodeBase64Url(str: string): string {
+  const base64 = Buffer.from(str).toString('base64');
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
 
 export function vitePluginNextFont() {
   let devMode = true;
@@ -135,16 +140,14 @@ export function vitePluginNextFont() {
       }
 
       return {
-        id: `${virtualModuleId}?${rawQuery}`,
+        id: `${virtualFontPrefix}${encodeBase64Url(rawQuery)}`,
         meta: {
           fontFaceDeclaration,
         },
       };
     },
     load(id) {
-      // Check if the file matches the specific pattern
-      const [source] = id.split('?');
-      if (source !== virtualModuleId) {
+      if (!id.startsWith(virtualFontPrefix)) {
         return undefined;
       }
 

--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.test.ts
@@ -16,12 +16,8 @@ vi.mock('node:module', () => ({
 
 vi.mock('node:fs', { spy: true });
 
+import { encodeBase64Url } from '../../utils/base64-url.ts';
 import { vitePluginNextImage } from './plugin.ts';
-
-function encodeBase64Url(str: string): string {
-  const base64 = Buffer.from(str).toString('base64');
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
 
 const virtualImageId = (imagePath: string) => `\0virtual:next-image:${encodeBase64Url(imagePath)}`;
 

--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.ts
@@ -6,6 +6,7 @@ import path from 'pathe';
 import probeSync from 'probe-image-size/sync.js';
 import { dedent } from 'ts-dedent';
 import type { Plugin } from 'vite';
+import { decodeBase64Url, encodeBase64Url } from '../../utils/base64-url.ts';
 import { VITEST_PLUGIN_NAME, isVitestEnv } from '../../utils.ts';
 import { getAlias } from './alias/index.tsx';
 
@@ -27,21 +28,6 @@ const virtualImagePrefix = '\0virtual:next-image:';
 const virtualImage = 'virtual:next-image';
 const virtualNextImage = 'virtual:next/image';
 const virtualNextLegacyImage = 'virtual:next/legacy/image';
-
-// URL-safe base64 encoding/decoding functions
-function encodeBase64Url(str: string): string {
-  const base64 = Buffer.from(str).toString('base64');
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
-
-function decodeBase64Url(str: string): string {
-  // Add back padding if needed
-  const padding = (4 - (str.length % 4)) % 4;
-  const withPadding = str + '='.repeat(padding);
-  // Convert URL-safe base64 back to standard base64
-  const base64 = withPadding.replace(/-/g, '+').replace(/_/g, '/');
-  return Buffer.from(base64, 'base64').toString();
-}
 
 const require = createRequire(import.meta.url);
 

--- a/code/lib/vite-plugin-storybook-nextjs/src/utils/base64-url.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/utils/base64-url.ts
@@ -1,0 +1,11 @@
+export function encodeBase64Url(str: string): string {
+  const base64 = Buffer.from(str).toString('base64');
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+export function decodeBase64Url(str: string): string {
+  const padding = (4 - (str.length % 4)) % 4;
+  const withPadding = str + '='.repeat(padding);
+  const base64 = withPadding.replace(/-/g, '+').replace(/_/g, '/');
+  return Buffer.from(base64, 'base64').toString();
+}


### PR DESCRIPTION
Closes #34847

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Port of [storybookjs/vite-plugin-storybook-nextjs#128](https://github.com/storybookjs/vite-plugin-storybook-nextjs/pull/128) by @yatishgoel, now that `vite-plugin-storybook-nextjs` lives in this monorepo.

SWC encodes `next/font` options as raw JSON in the virtual module query. A `declarations` value like `100%` then reaches Vite's HTTP layer unencoded, and `decodeURI` rejects it with `Malformed URI sequence`.

This matches the current `next-image` plugin: virtual IDs use a `\0` prefix plus URL-safe base64, so `%` never appears in the module id. The encode/decode helpers are shared in `src/utils/base64-url.ts`.

**Merge before [#35885](https://github.com/storybookjs/storybook/pull/35885).** Both touch `next-image/plugin.ts`. This PR points image IDs at the shared helper; #35885 then replaces image IDs with a short hash. After both land, the helper stays for `next/font` only.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Generate a Next.js Vite sandbox: `yarn task sandbox --template nextjs-vite/default-ts --start-from auto`
2. Add a local font with a percent declaration, for example:

```ts
import localFont from 'next/font/local';

export const overpassFont = localFont({
  src: './overpass.woff2',
  declarations: [{ prop: 'ascent-override', value: '100%' }],
});
```

3. Import that font from `.storybook/preview.ts` or a story and start Storybook.
4. Confirm the browser console has no `Malformed URI sequence` / failed `virtual:next-font` load, and that the generated `@font-face` includes `ascent-override: 100%`.

Worth extra scrutiny: the same font without `declarations` should still load, and Google fonts should be unchanged.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->