### PR TITLE
Angular: Print unevaluable story args instead of slicing the file

### DIFF
--- a/code/frameworks/angular-vite/src/docgen/resolve-component.ts
+++ b/code/frameworks/angular-vite/src/docgen/resolve-component.ts
@@ -28,14 +28,10 @@ export function resolveStoryImport(fromFile: string, specifier: string): string 
   }
 }
 
-export interface ParsedStoryFile {
-  csf: CsfFile;
-}
-
-export function parseStoryFile(storyFilePath: string, title: string): ParsedStoryFile | undefined {
+export function parseStoryFile(storyFilePath: string, title: string): CsfFile | undefined {
   try {
     const source = readFileSync(storyFilePath, 'utf8');
-    return { csf: loadCsf(source, { makeTitle: () => title }).parse() };
+    return loadCsf(source, { makeTitle: () => title }).parse();
   } catch {
     return undefined;
   }
@@ -51,10 +47,10 @@ export function resolveStoryComponent(
   storyFilePath: string,
   title = 'Docgen'
 ): MetaComponentResolution {
-  const parsed = parseStoryFile(storyFilePath, title);
-  if (!parsed) {
+  const csf = parseStoryFile(storyFilePath, title);
+  if (!csf) {
     return { reason: 'no-meta-component' };
   }
 
-  return resolveMetaComponent(parsed.csf, storyFilePath);
+  return resolveMetaComponent(csf, storyFilePath);
 }

--- a/code/frameworks/angular-vite/src/docgen/resolve-component.ts
+++ b/code/frameworks/angular-vite/src/docgen/resolve-component.ts
@@ -29,14 +29,13 @@ export function resolveStoryImport(fromFile: string, specifier: string): string 
 }
 
 export interface ParsedStoryFile {
-  source: string;
   csf: CsfFile;
 }
 
 export function parseStoryFile(storyFilePath: string, title: string): ParsedStoryFile | undefined {
   try {
     const source = readFileSync(storyFilePath, 'utf8');
-    return { source, csf: loadCsf(source, { makeTitle: () => title }).parse() };
+    return { csf: loadCsf(source, { makeTitle: () => title }).parse() };
   } catch {
     return undefined;
   }

--- a/code/frameworks/angular-vite/src/docgen/story-docs-args.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-args.ts
@@ -1,6 +1,6 @@
 // Resolves a story's args statically: named properties, spreads of other stories' args (in this
 // file or another), and the literal values the generated bindings inline.
-import { types as t } from 'storybook/internal/babel';
+import { recast, types as t } from 'storybook/internal/babel';
 import type { CsfFile } from 'storybook/internal/csf-tools';
 import { keyOf, unwrapExpression } from 'storybook/internal/csf-tools';
 
@@ -385,20 +385,22 @@ const EVAL_FAILED = Symbol('story-docs-eval-failed');
 // An arg no static evaluation could reduce to a value falls back to its source text. Every
 // expression is escaped for the attribute position it lands in: the double-quote delimiter and
 // text Angular's lexer would decode as a character reference survive the round-trip unchanged.
-export const evaluateArgExpression = (
-  node: t.Node,
-  source: string,
-  enums: SnippetEnum[]
-): string => {
+//
+// Printed rather than sliced out of the file: `babelParse` runs the source through recast, which
+// parses a copy with tabs expanded and CRLF collapsed, so node offsets do not address the bytes on
+// disk. recast reproduces an unmodified node verbatim, whatever the file's whitespace looks like.
+export const evaluateArgExpression = (node: t.Node, enums: SnippetEnum[]): string => {
   const unwrapped = unwrapExpression(node);
   const value = evaluateNode(unwrapped, enums);
   if (value !== EVAL_FAILED) {
     return escapeAttributeExpression(printExpressionValue(value, new Set()));
   }
-  const text =
-    unwrapped.start != null && unwrapped.end != null
-      ? source.slice(unwrapped.start, unwrapped.end)
-      : undefined;
+  let text: string | undefined;
+  try {
+    text = recast.print(unwrapped).code;
+  } catch {
+    text = undefined;
+  }
   return escapeAttributeExpression(text ?? 'undefined');
 };
 

--- a/code/frameworks/angular-vite/src/docgen/story-docs-args.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-args.ts
@@ -1,6 +1,6 @@
 // Resolves a story's args statically: named properties, spreads of other stories' args (in this
 // file or another), and the literal values the generated bindings inline.
-import { recast, types as t } from 'storybook/internal/babel';
+import { babelPrint, types as t } from 'storybook/internal/babel';
 import type { CsfFile } from 'storybook/internal/csf-tools';
 import { keyOf, unwrapExpression } from 'storybook/internal/csf-tools';
 
@@ -111,17 +111,17 @@ export const createSpreadArgsResolver =
       return undefined;
     }
     const targetPath = ctx.resolveImport(ctx.filePath, imported.importId);
-    const parsed = targetPath === undefined ? undefined : parseStoryFile(targetPath, 'StoryDocs');
-    if (!parsed) {
+    const target = targetPath === undefined ? undefined : parseStoryFile(targetPath, 'StoryDocs');
+    if (!target) {
       return undefined;
     }
-    const targetCtx: SpreadArgsContext = { ...ctx, csf: parsed.csf, filePath: targetPath! };
+    const targetCtx: SpreadArgsContext = { ...ctx, csf: target, filePath: targetPath! };
     const record = storyArgsAt(targetCtx, storyName, accessorOf(accessorPath), undefined, visited);
     if (record === undefined || !record.complete) {
       return undefined;
     }
-    // Nodes from another file carry that file's source offsets, so they must reduce to values that
-    // stand on their own before they may join this file's args record.
+    // A binding the snippet prints names nothing outside itself, so an arg copied from another
+    // file may only join this record once it reduces to a value that stands on its own.
     const properties: Record<string, t.Node> = {};
     for (const [key, node] of Object.entries(record.properties)) {
       const value = evaluateNode(node, ctx.enums);
@@ -385,24 +385,19 @@ const EVAL_FAILED = Symbol('story-docs-eval-failed');
 // An arg no static evaluation could reduce to a value falls back to its source text. Every
 // expression is escaped for the attribute position it lands in: the double-quote delimiter and
 // text Angular's lexer would decode as a character reference survive the round-trip unchanged.
-//
-// Printed rather than sliced out of the file: `babelParse` runs the source through recast, which
-// parses a copy with tabs expanded and CRLF collapsed, so node offsets do not address the bytes on
-// disk. recast reproduces an unmodified node verbatim, whatever the file's whitespace looks like.
 export const evaluateArgExpression = (node: t.Node, enums: SnippetEnum[]): string => {
   const unwrapped = unwrapExpression(node);
   const value = evaluateNode(unwrapped, enums);
-  if (value !== EVAL_FAILED) {
-    return escapeAttributeExpression(printExpressionValue(value, new Set()));
-  }
-  let text: string | undefined;
-  try {
-    text = recast.print(unwrapped).code;
-  } catch {
-    text = undefined;
-  }
-  return escapeAttributeExpression(text ?? 'undefined');
+  return escapeAttributeExpression(
+    value === EVAL_FAILED ? printArgSource(unwrapped) : printExpressionValue(value, new Set())
+  );
 };
+
+// recast parses a normalised copy of the file, so a node's offsets do not address the file itself;
+// printing the node is what keeps the text free of the file's tabs and line endings. Cloning costs
+// that verbatim reprint, so it buys only the one thing a binding cannot hold: comments.
+const printArgSource = (node: t.Node): string =>
+  babelPrint(node.leadingComments?.length ? t.cloneNode(node, true) : node);
 
 // Angular expression strings support backslash escapes, so quoting stays lossless.
 const quoteExpressionString = (value: string): string =>

--- a/code/frameworks/angular-vite/src/docgen/story-docs-args.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-args.ts
@@ -418,11 +418,10 @@ export const evaluateArgExpression = (node: t.Node, enums: SnippetEnum[]): strin
   );
 };
 
-// recast parses a normalised copy of the file, so a node's offsets do not address the file itself;
-// printing the node is what keeps the text free of the file's tabs and line endings. Cloning costs
-// that verbatim reprint, so it buys only the one thing a binding cannot hold: comments.
-const printArgSource = (node: t.Node): string =>
-  babelPrint(node.leadingComments?.length ? t.cloneNode(node, true) : node);
+// recast reprints a node it parsed straight from the file's own text, comments and indentation
+// included. A clone drops the bookkeeping that path relies on and is formatted from the AST
+// instead, which is what leaves a binding holding the expression and nothing else.
+const printArgSource = (node: t.Node): string => babelPrint(t.cloneNode(node, true));
 
 // Angular expression strings support backslash escapes, so quoting stays lossless.
 const quoteExpressionString = (value: string): string =>

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
@@ -171,30 +171,6 @@ const soleStory = async (source: string, getDocgenPayload = buttonDocgen()) => {
 };
 
 describe('buildStoryDocsPayload', () => {
-  // An arg that cannot be evaluated falls back to its source text. That text used to be sliced out
-  // of the file by AST offset, but `babelParse` runs the source through recast, which parses a copy
-  // with tabs expanded and CRLF collapsed - so the offsets addressed the wrong bytes and the
-  // snippet came out mangled on Windows checkouts and tab-indented files.
-  it.each([
-    ['LF', '\n', '  '],
-    ['CRLF', '\r\n', '  '],
-    ['tabs', '\n', '\t'],
-  ])('prints an unevaluable arg verbatim with %s whitespace', async (_name, eol, indent) => {
-    const story = await soleStory(
-      [
-        `import { ButtonComponent } from './button.component';`,
-        `export default { title: 'Example/Button', component: ButtonComponent };`,
-        `export const Default = {`,
-        `${indent}args: {`,
-        `${indent}${indent}label: (value) => value.replace('a', 'b'),`,
-        `${indent}},`,
-        `};`,
-      ].join(eol)
-    );
-
-    expect(story.snippet).toContain(`[label]="(value) => value.replace('a', 'b')"`);
-  });
-
   it('returns undefined for entries without a story file or with an unparsable one', async () => {
     const docsEntry: IndexEntry = {
       id: 'docs--page',
@@ -983,6 +959,39 @@ describe('buildStoryDocsPayload', () => {
         export const Default = { args: { label: ${JSON.stringify(value)} } };
       `);
       expect(story.snippet).toContain(expected);
+    });
+
+    it('binds an unevaluable arg the same way whatever whitespace the file uses', async () => {
+      const storyFile = (eol: string, indent: string) =>
+        [
+          `import { ButtonComponent } from './button.component';`,
+          `export default { title: 'Example/Button', component: ButtonComponent };`,
+          `export const Default = {`,
+          `${indent}args: {`,
+          `${indent}${indent}label: (value) => value.replace('a', 'b'),`,
+          `${indent}},`,
+          `};`,
+        ].join(eol);
+
+      const lf = await soleStory(storyFile('\n', '  '));
+      const crlf = await soleStory(storyFile('\r\n', '  '));
+      const tabs = await soleStory(storyFile('\n', '\t'));
+
+      expect(lf.snippet).toContain(`[label]="(value) => value.replace('a', 'b')"`);
+      expect(crlf.snippet).toBe(lf.snippet);
+      expect(tabs.snippet).toBe(lf.snippet);
+    });
+
+    it.each([
+      ['on its own line', `label:\n          // why\n          (value) => value.trim(),`],
+      ['inline', `label: /* why */ (value) => value.trim(),`],
+    ])('leaves a comment %s out of the binding', async (_name, property) => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        export const Default = { args: { ${property} } };
+      `);
+      expect(story.snippet).toContain(`[label]="(value) => value.trim()"`);
     });
   });
 

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
@@ -1016,7 +1016,9 @@ describe('buildStoryDocsPayload', () => {
           `export default { title: 'Example/Button', component: ButtonComponent };`,
           `export const Default = {`,
           `${indent}args: {`,
-          `${indent}${indent}label: (value) => value.replace('a', 'b'),`,
+          `${indent}${indent}label: (value) => {`,
+          `${indent}${indent}${indent}return value.replace('a', 'b');`,
+          `${indent}${indent}},`,
           `${indent}},`,
           `};`,
         ].join(eol);
@@ -1025,14 +1027,18 @@ describe('buildStoryDocsPayload', () => {
       const crlf = await soleStory(storyFile('\r\n', '  '));
       const tabs = await soleStory(storyFile('\n', '\t'));
 
-      expect(lf.snippet).toContain(`[label]="(value) => value.replace('a', 'b')"`);
+      expect(lf.snippet).toContain(
+        `[label]="(value) => {\n      return value.replace('a', 'b');\n    }"`
+      );
       expect(crlf.snippet).toBe(lf.snippet);
       expect(tabs.snippet).toBe(lf.snippet);
     });
 
     it.each([
-      ['on its own line', `label:\n          // why\n          (value) => value.trim(),`],
-      ['inline', `label: /* why */ (value) => value.trim(),`],
+      ['above the arg', `label:\n          // why\n          (value) => value.trim(),`],
+      ['before the arg', `label: /* why */ (value) => value.trim(),`],
+      ['inside the arg', `label: (value) => /* why */ value.trim(),`],
+      ['inside the parameter list', `label: (/* why */ value) => value.trim(),`],
     ])('leaves a comment %s out of the binding', async (_name, property) => {
       const story = await soleStory(`
         import { ButtonComponent } from './button.component';

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
@@ -171,6 +171,30 @@ const soleStory = async (source: string, getDocgenPayload = buttonDocgen()) => {
 };
 
 describe('buildStoryDocsPayload', () => {
+  // An arg that cannot be evaluated falls back to its source text. That text used to be sliced out
+  // of the file by AST offset, but `babelParse` runs the source through recast, which parses a copy
+  // with tabs expanded and CRLF collapsed - so the offsets addressed the wrong bytes and the
+  // snippet came out mangled on Windows checkouts and tab-indented files.
+  it.each([
+    ['LF', '\n', '  '],
+    ['CRLF', '\r\n', '  '],
+    ['tabs', '\n', '\t'],
+  ])('prints an unevaluable arg verbatim with %s whitespace', async (_name, eol, indent) => {
+    const story = await soleStory(
+      [
+        `import { ButtonComponent } from './button.component';`,
+        `export default { title: 'Example/Button', component: ButtonComponent };`,
+        `export const Default = {`,
+        `${indent}args: {`,
+        `${indent}${indent}label: (value) => value.replace('a', 'b'),`,
+        `${indent}},`,
+        `};`,
+      ].join(eol)
+    );
+
+    expect(story.snippet).toContain(`[label]="(value) => value.replace('a', 'b')"`);
+  });
+
   it('returns undefined for entries without a story file or with an unparsable one', async () => {
     const docsEntry: IndexEntry = {
       id: 'docs--page',

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
@@ -55,11 +55,10 @@ export const buildStoryDocsPayload = async (
   const resolvePath =
     context.resolvePath ?? ((importPath: string) => resolve(process.cwd(), importPath));
   const storyFilePath = resolvePath(storyImportPath);
-  const parsed = parseStoryFile(storyFilePath, input.entry.title);
-  if (!parsed) {
+  const csf = parseStoryFile(storyFilePath, input.entry.title);
+  if (!csf) {
     return undefined;
   }
-  const { csf } = parsed;
 
   const componentNode = csf._metaAnnotations.component;
   const docgenPayload = componentNode

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
@@ -59,7 +59,7 @@ export const buildStoryDocsPayload = async (
   if (!parsed) {
     return undefined;
   }
-  const { source, csf } = parsed;
+  const { csf } = parsed;
 
   const componentNode = csf._metaAnnotations.component;
   const docgenPayload = componentNode
@@ -79,7 +79,6 @@ export const buildStoryDocsPayload = async (
   const importBindings = collectImportBindings(csf._file.path);
   const deps: StoryDocDeps = {
     csf,
-    source,
     resolveArgs,
     metaArgs: resolveArgs(csf._metaAnnotations.args),
     snippetMeta: docgenPayload?.angularComponentMeta,
@@ -133,7 +132,6 @@ const componentNameOf = (node: t.Node | undefined): string | undefined => {
 
 interface StoryDocDeps {
   csf: CsfFile;
-  source: string;
   resolveArgs: (node: t.Node | undefined) => ArgsRecord;
   metaArgs: ArgsRecord;
   snippetMeta: AngularComponentSnippetMeta | undefined;
@@ -163,7 +161,6 @@ const buildStoryDoc = (
         deps.metaArgs.complete &&
         storyArgs.complete &&
         !hasAssignmentInto(csf, exportName, 2, undefined),
-      source: deps.source,
     };
     const rendered = snippetMeta
       ? renderStorySnippet(snippetMeta, shape, annotations.decorators, deps)
@@ -250,7 +247,7 @@ const collectBindings = (snippetMeta: AngularComponentSnippetMeta, shape: StoryS
     .filter(([argName]) => inputNames.has(argName))
     .map(([argName, node]) => ({
       name: argName,
-      expression: evaluateArgExpression(node, shape.source, snippetMeta.enums),
+      expression: evaluateArgExpression(node, snippetMeta.enums),
     }));
   return { inputs, outputs: snippetMeta.outputs };
 };

--- a/code/frameworks/angular-vite/src/docgen/story-docs-markup.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-markup.ts
@@ -15,7 +15,6 @@ export interface StoryShape {
   args: Record<string, t.Node>;
   /** `false` when a spread or computed key makes the merged args unknowable statically. */
   argsReadable: boolean;
-  source: string;
 }
 
 /** Bindings the generated snippet would carry, which is also what `argsToTemplate` expands to. */

--- a/code/lib/docgen-harness/src/angular/story-docs/__testfixtures__/args-formatting/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/angular/story-docs/__testfixtures__/args-formatting/story-docs.payload.snapshot
@@ -20,7 +20,7 @@ import { ArgsFormattingComponent } from './args-formatting.component.ts';
         [data]="{id: 7, nested: {deep: true}}"
         [tags]="['a', 'b']"
         [greeting]="'hello'"
-        [formatter]="(value) => value.replace('&quot;', &quot;'&quot;)">
+        [formatter]="(value) => value.replace('&quot;', '\\'')">
     </sb-args-formatting>`,
 })
 export class DemoComponent {}",


### PR DESCRIPTION
Closes #

## What I did

Angular story-docs snippets came out mangled on Windows checkouts and in tab-indented files.

An arg that static evaluation cannot reduce to a value falls back to its source text. That text was sliced out of the file by AST offset:

```ts
source.slice(unwrapped.start, unwrapped.end)
```

`babelParse` runs the source through recast, and recast parses a **copy** with tabs expanded and CRLF collapsed. The offsets therefore address the wrong bytes of the string on disk. Every preceding CRLF shifts the slice by one character, every tab by three.

This is what the `args-formatting` baseline produced on the Windows unit job, 21 characters adrift, one per preceding line:

```diff
- [formatter]="(value) => value.replace('&quot;', &quot;'&quot;)">
+ [formatter]="ace('&quot;', &quot;'&quot;),
+       },
+     };
+     ">
```

recast reproduces an unmodified node verbatim, so printing the node drops the dependency on offsets:

```ts
text = recast.print(unwrapped).code;
```

The source string had no other reader, so it comes out of the payload builder, out of `StoryDocDeps`, and out of `ParsedStoryFile`.

## Measured

The same expression through the same code path, before and after:

```
                before                                          after
LF     (value) => value.replace('"', "'")            (value) => value.replace('"', "'")
CRLF   lo`,                                          (value) => value.replace('"', "'")
tabs    => v.replace("x", "y"),\n}                   (value) => value.replace('"', "'")
```

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Three cases in `story-docs-build.test.ts`, one per whitespace style. Reverting the fix fails the CRLF and tabs cases and leaves LF passing, so they pin the bug rather than the code.

#### Manual testing

1. Check out the repo with CRLF line endings, or set `core.autocrlf=true` on Windows.
2. Run `yarn test --project @storybook/docgen-harness build-story-docs`.
3. The `args-formatting` baseline must pass. Before this change it fails with the `[formatter]` binding cut mid-token.

An equivalent check without a Windows machine: add a tab-indented arg whose value is an arrow function to any Angular story fixture, and confirm the generated snippet reproduces it intact.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user-facing behaviour to document: this restores the output that was always intended.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
