### PR TITLE
Core: Scope in-flight open-service loads to their runtime

### DIFF
--- a/code/core/src/shared/open-service/query-runtime.ts
+++ b/code/core/src/shared/open-service/query-runtime.ts
@@ -76,10 +76,12 @@ type LoadedSession = {
  */
 export const inFlightLoads = new Map<string, Promise<unknown>>();
 
-/** Distinguishes runtimes that share a service id, so their in-flight loads never collide. */
+/**
+ * Monotonic instance id for {@link makeInFlightKey}. The load key already names the service;
+ * this token only has to be unique among live runtimes.
+ */
 let nextRuntimeSequence = 0;
-export const nextRuntimeId = (serviceId: ServiceId): string =>
-  `${serviceId}#${(nextRuntimeSequence += 1)}`;
+export const nextRuntimeId = (): string => String((nextRuntimeSequence += 1));
 
 /**
  * Active session for `.loaded()` while a sync handler is being re-run for dependency discovery.

--- a/code/core/src/shared/open-service/query-runtime.ts
+++ b/code/core/src/shared/open-service/query-runtime.ts
@@ -63,13 +63,23 @@ type LoadedSession = {
 };
 
 /**
- * Process-global registry of in-flight `load` promises keyed by `${serviceId}::${queryName}::${hash}`.
+ * Process-global registry of in-flight `load` promises keyed by
+ * `${runtimeId}::${serviceId}::${queryName}::${hash}`.
  *
  * The dedup is in-flight only: once a load settles, its entry is removed so a subsequent call can
  * refire it. The same registry is consulted by both same-service and cross-service callers so two
  * queries that depend on the same dependency share one load.
+ *
+ * The runtime scope is what keeps that sharing honest. A load body writes through the `self` of the
+ * runtime it started on, so joining a load in flight on a different runtime would resolve against
+ * state that load never wrote.
  */
 export const inFlightLoads = new Map<string, Promise<unknown>>();
+
+/** Distinguishes runtimes that share a service id, so their in-flight loads never collide. */
+let nextRuntimeSequence = 0;
+export const nextRuntimeId = (serviceId: ServiceId): string =>
+  `${serviceId}#${(nextRuntimeSequence += 1)}`;
 
 /**
  * Active session for `.loaded()` while a sync handler is being re-run for dependency discovery.
@@ -112,6 +122,16 @@ function stableHash(value: unknown): string {
   };
 
   return JSON.stringify(encode(value));
+}
+
+/**
+ * Scopes a load key to one runtime instance for {@link inFlightLoads}.
+ *
+ * The unscoped {@link makeLoadKey} stays the identity used for cycle detection and settled-key
+ * bookkeeping, which are per-load-graph rather than per-runtime.
+ */
+export function makeInFlightKey(runtimeId: string, loadKey: string): string {
+  return `${runtimeId}::${loadKey}`;
 }
 
 export function makeLoadKey(
@@ -220,6 +240,14 @@ function detachSnapshot<TValue>(value: TValue): TValue {
  */
 export type QueryRuntimeRefs<TState> = {
   serviceId: ServiceId;
+  /**
+   * Identity of this runtime instance, used to scope {@link inFlightLoads}.
+   *
+   * A load body writes through the `self` of the runtime it started on, so a load in flight on one
+   * runtime says nothing about another runtime's state. The static build stands up a throwaway
+   * runtime per snapshot next to the live registry's runtime, which is where the two meet.
+   */
+  runtimeId: string;
   commandSelf: CommandSelf<TState>;
   /** Deep reactive proxy backing this service's state; reads inside a computed track fine-grained. */
   state: TState;
@@ -405,7 +433,8 @@ function triggerLoad<TState>(
   loadKey: string,
   parentAncestorChain: ReadonlySet<string>
 ): Promise<unknown> {
-  const existing = inFlightLoads.get(loadKey);
+  const inFlightKey = makeInFlightKey(refs.runtimeId, loadKey);
+  const existing = inFlightLoads.get(inFlightKey);
   if (existing) {
     return existing;
   }
@@ -424,12 +453,12 @@ function triggerLoad<TState>(
     .finally(() => {
       // Only clear the entry if it still points at this promise — another caller may have already
       // overwritten it with a fresh in-flight load for the next round.
-      if (inFlightLoads.get(loadKey) === promise) {
-        inFlightLoads.delete(loadKey);
+      if (inFlightLoads.get(inFlightKey) === promise) {
+        inFlightLoads.delete(inFlightKey);
       }
     });
 
-  inFlightLoads.set(loadKey, promise);
+  inFlightLoads.set(inFlightKey, promise);
   return promise;
 }
 

--- a/code/core/src/shared/open-service/service-runtime.test.ts
+++ b/code/core/src/shared/open-service/service-runtime.test.ts
@@ -1237,6 +1237,86 @@ describe('service runtime', () => {
     });
   });
 
+  /**
+   * A load body writes to the state of the runtime it was started on. The static build stands up a
+   * throwaway runtime per snapshot alongside the live registry's runtime, so the same
+   * `(service, query, input)` can be loading on two runtimes at once.
+   */
+  describe('in-flight loads are scoped to their runtime', () => {
+    const gatedCounterServiceDef = (gate: Promise<void>, loadBodySpy: () => void) =>
+      defineService({
+        id: 'internal-fixture/cross-runtime-in-flight',
+        description: 'Fixture: a load body that parks on a gate before writing state.',
+        initialState: { count: 0 },
+        queries: {
+          value: {
+            input: v.undefined(),
+            output: v.number(),
+            handler: (_input, ctx) => ctx.self.state.count,
+            load: async (_input, ctx) => {
+              loadBodySpy();
+              await gate;
+              await ctx.self.commands.bump(undefined);
+            },
+          },
+        },
+        commands: {
+          bump: {
+            input: v.undefined(),
+            output: v.void(),
+            handler: (_input, ctx) =>
+              ctx.self.setState((state) => {
+                state.count += 1;
+              }),
+          },
+        },
+      });
+
+    it('runs the load body on each runtime rather than joining the other one`s', async () => {
+      let release: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const loadBodySpy = vi.fn();
+      const def = gatedCounterServiceDef(gate, loadBodySpy);
+
+      const first = createServiceRuntime(def, { registryApi: serviceRegistryApi }, { count: 0 });
+      const second = createServiceRuntime(def, { registryApi: serviceRegistryApi }, { count: 0 });
+
+      // `second` asks while `first`'s load is still parked on the gate.
+      const firstLoaded = first.queries.value.loaded(undefined);
+      const secondLoaded = second.queries.value.loaded(undefined);
+      release();
+
+      expect(await firstLoaded).toBe(1);
+      expect(await secondLoaded).toBe(1);
+      expect(second.getStateSnapshot().count).toBe(1);
+      expect(loadBodySpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('still dedupes concurrent callers on the same runtime', async () => {
+      let release: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const loadBodySpy = vi.fn();
+      const runtime = createServiceRuntime(
+        gatedCounterServiceDef(gate, loadBodySpy),
+        { registryApi: serviceRegistryApi },
+        { count: 0 }
+      );
+
+      const both = Promise.all([
+        runtime.queries.value.loaded(undefined),
+        runtime.queries.value.loaded(undefined),
+      ]);
+      release();
+
+      expect(await both).toEqual([1, 1]);
+      expect(loadBodySpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // The `subscriptions`/`reactive load` suites assert the emitted *data* sequence (via collectData).
   // This suite asserts the orthogonal axis: the per-subscription `QueryState` lifecycle that wraps
   // that data (status / loadStatus / error and the derived booleans).

--- a/code/core/src/shared/open-service/service-runtime.ts
+++ b/code/core/src/shared/open-service/service-runtime.ts
@@ -381,7 +381,7 @@ export function createServiceRuntime<
     return routed as CommandSelf<TState>['commands'];
   };
 
-  const runtimeId = nextRuntimeId(def.id);
+  const runtimeId = nextRuntimeId();
 
   const refs: QueryRuntimeRefs<TState> = {
     serviceId: def.id,

--- a/code/core/src/shared/open-service/service-runtime.ts
+++ b/code/core/src/shared/open-service/service-runtime.ts
@@ -39,8 +39,8 @@
  *
  * ## Why each piece exists
  *
- * - **{@link inFlightLoads}** dedups concurrent calls for the same `(service, query, input)` so
- *   two consumers asking for the same data share one load.
+ * - **{@link inFlightLoads}** dedups concurrent calls for the same `(runtime, service, query,
+ *   input)` so two consumers asking for the same data share one load.
  * - **{@link LoadedSession.ancestorChain}** breaks cycles: a dep whose load key is already on the
  *   call chain is skipped (not added to any collector) so two queries that read each other do
  *   not self-deadlock.
@@ -70,7 +70,9 @@ import {
   buildQueries,
   buildReactiveLoadQueries,
   inFlightLoads,
+  makeInFlightKey,
   makeLoadKey,
+  nextRuntimeId,
   runLoadBody,
 } from './query-runtime.ts';
 import type { QueryRuntimeRefs, RuntimeQueryDefinition } from './query-runtime.ts';
@@ -379,8 +381,11 @@ export function createServiceRuntime<
     return routed as CommandSelf<TState>['commands'];
   };
 
+  const runtimeId = nextRuntimeId(def.id);
+
   const refs: QueryRuntimeRefs<TState> = {
     serviceId: def.id,
+    runtimeId,
     commandSelf,
     state,
     registryApi,
@@ -436,23 +441,17 @@ export function createServiceRuntime<
 
     const loadKey = makeLoadKey(def.id, queryName, validatedInput);
     const ancestorChain = new Set<string>([loadKey]) as ReadonlySet<string>;
+    const inFlightKey = makeInFlightKey(runtimeId, loadKey);
 
-    // Register this runtime's root load without joining an unrelated in-flight entry from another
-    // runtime instance (e.g. the live singleton during parallel staticInputs resolution).
-    const previous = inFlightLoads.get(loadKey);
     const promise = Promise.resolve()
       .then(() => runLoadBody(refs, queryName, queryDef, validatedInput, ancestorChain))
       .finally(() => {
-        if (inFlightLoads.get(loadKey) === promise) {
-          if (previous) {
-            inFlightLoads.set(loadKey, previous);
-          } else {
-            inFlightLoads.delete(loadKey);
-          }
+        if (inFlightLoads.get(inFlightKey) === promise) {
+          inFlightLoads.delete(inFlightKey);
         }
       });
 
-    inFlightLoads.set(loadKey, promise);
+    inFlightLoads.set(inFlightKey, promise);
     await promise;
   };
 


### PR DESCRIPTION
Closes #

## What I did

`query.loaded(input)` can resolve against state its load never wrote. The in-flight load registry is process-global and keyed by `(serviceId, queryName, input)` with no notion of *which runtime* is loading, so when two runtimes exist for the same service — which is exactly what the static build creates — one runtime's `loaded()` joins the other's in-flight promise, awaits it, and then reads its own untouched state. The caller gets `undefined` and no error.

This scopes the registry key by runtime instance. Cycle detection and settled-key bookkeeping keep using the unscoped key, because those are per-load-graph rather than per-runtime.

```
                    inFlightLoads  (module-global)
                          │
   ┌──────────────────────┴──────────────────────┐
   │  key: core/docgen::docgen::{"id":"button"}  │   ← before: one slot, two runtimes
   └──────────────────────┬──────────────────────┘
                          │
      live runtime ───────┤ joins ──► throwaway runtime's load body
      (reads its state)   │           (writes throwaway's state)
                          ▼
                    resolves undefined
```

```ts
// code/core/src/shared/open-service/query-runtime.ts
const inFlightKey = makeInFlightKey(refs.runtimeId, loadKey);
const existing = inFlightLoads.get(inFlightKey);
if (existing) {
  return existing;
}
```

`runLoadOnce` already worked around one direction of this by hand — it saved and restored any pre-existing entry so a build runtime would not clobber "an unrelated in-flight entry from another runtime instance". With the key scoped, that dance is unnecessary and the function loses a branch.

## How it shows up

`buildStaticFiles()` stands up a fresh runtime per snapshot so one load path cannot leak state into another's output. The Angular story-docs provider reaches sideways into the live registry (`getService('core/docgen')`) to fetch the component metadata its snippet renderer needs. During a static build those two runtimes race for the same key, and the provider loses.

I probed it by calling the same query twice in a row from the provider, on a real `angular-vite/docgen-server-ts` build:

```
  74 first=false second=false     ← template stories with no Angular docgen, correct
  38 first=false second=true      ← every real Angular component
```

Every component's first call came back empty and the immediately following one came back populated. Downstream, `snippetMeta` is undefined, so this branch never fires:

```ts
// code/frameworks/angular-vite/src/docgen/story-docs-build.ts
const rendered =
  snippetMeta && !hasRender
    ? renderStorySnippet(snippetMeta, args, annotations.decorators, deps)
    : undefined;
```

A third probe confirmed it: 281 of 281 story builds logged `meta=false`. Snippets were not rendering badly, they were never attempted.

## Effect

The symptom is nondeterminism, not a constant failure. Counting files under `storybook-static/services/core/story-docs/` that carry a `snippet` key, six clean rebuilds of the same sandbox each way:

| | 1 | 2 | 3 | 4 | 5 | 6 |
| --- | --- | --- | --- | --- | --- | --- |
| before | 0 | 0 | 0 | **33** | 0 | 0 |
| after | 33 | 33 | 33 | 33 | 33 | 33 |

Out of 112. 33 is every component the sandbox documents; the other 79 are template stories with no Angular docgen.

It is bimodal rather than partial — every component in a build resolves the same way, because they all contend for the same live runtime against the same concurrent docgen snapshot task. So a single run on `next` has a real chance of looking fine. **If you are reproducing by hand, build several times.** The deterministic evidence is the unit test, which fails on `next` every time.

There is no build-time cost. The static pipeline already drives docgen extraction on both the throwaway snapshot runtime and the live runtime that answers cross-service reads; before this change the two occasionally collapsed into one by accident, which is the bug. Wall clock on the same sandbox, two runs each:

| | Run 1 | Run 2 |
| --- | --- | --- |
| before | 24s | 23s |
| after | 23s | 22s |

So a hosted or static Storybook served agents component APIs with no story code at all. `docs-show` for the same component, dev server versus `@storybook/mcp` reading the static build:

```diff
  # ColorPickerComponent

  ID: stories-frameworks-angular-vite-model-signal-color-picker

  ## Stories

- ### Controls And Actions
-
- Story ID: stories-frameworks-angular-vite-model-signal-color-picker--controls-and-actions
-
- ```
- import { Component } from '@angular/core';
- ...
- ```
-
  ## Inputs
```

After the fix the two outputs are byte-identical.

Adding a `console.log` was enough to flip the outcome, which is the signature of an ordering bug rather than a genuine data race, and is why the probe above is the trustworthy evidence rather than the build counts.

## Not Angular-specific

Any consumer that calls `.loaded()` on a service the static build is concurrently snapshotting can hit this. Angular is simply the first framework whose story-docs provider reads across services during a static build; Vue's will do the same when it lands.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Two tests in `service-runtime.test.ts`, under `in-flight loads are scoped to their runtime`. Both drive a load body that parks on a gate so the second caller provably arrives while the first load is still in flight:

| Test | Holds |
| --- | --- |
| `runs the load body on each runtime rather than joining the other one's` | the regression. On `next` it fails with `expected +0 to be 1` |
| `still dedupes concurrent callers on the same runtime` | the behaviour worth keeping — one load body for two concurrent `loaded()` calls on one runtime |

#### Manual testing

The unit test is the real gate — it is the only deterministic check. The steps below reproduce the user-visible symptom, but the symptom itself is intermittent, so treat a single passing run as inconclusive.

1. `yarn task sandbox --template angular-vite/docgen-server-ts --start-from auto`
2. `cd ../storybook-sandboxes/angular-vite-docgen-server-ts && yarn build-storybook`
3. Count the story-docs snapshots that carry a snippet, **repeating the build at least four or five times** — a single run on `next` can come out correct:
   ```bash
   for i in 1 2 3 4 5; do
     rm -rf storybook-static && yarn build-storybook --quiet > /dev/null
     echo "$(grep -l '"snippet"' storybook-static/services/core/story-docs/*.json | wc -l) of $(ls storybook-static/services/core/story-docs/*.json | wc -l)"
   done
   ```
   On `next` the count flips between `0 of N` and the full count. With this branch it is the full count every time.
4. Render one component through the hosted path and compare it with the dev server:
   ```bash
   node code/lib/mcp/bin.ts --manifestsDir ./storybook-static/manifests
   ```
   The `## Stories` section must carry the same snippet the dev server returns, rather than being empty.

> [!NOTE]
> A linked `angular-vite` sandbox currently cannot boot on `next` — `yarn storybook` and `yarn build-storybook` both die with ``value `"builtin:vite-wasm-fallback"` does not match any variant of enum `BindingBuiltinPluginName` ``. Yarn's portal linking needs `--preserve-symlinks`, which makes the repo's nested `rolldown@1.0.3` load the sandbox root's `@rolldown/binding-darwin-arm64@1.2.0`. Work around it by adding `"resolutions": { "vite": "8.0.16", "rolldown": "1.0.3" }` to the generated sandbox's `package.json` and re-running `yarn install`. Unrelated to this PR, and worth its own issue.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user-facing surface changes. The module docs in `query-runtime.ts` and `service-runtime.ts` that describe the registry's key shape are updated in the diff.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

`bug`. Found while verifying #35896 — that PR does not depend on this one, but its "static output matches the dev server" criterion is only fully true once this lands.
