### PR TITLE
Mcp: Consume apiDescription menifest fragments in component docs

### DIFF
--- a/code/core/src/shared/open-service/toolsets/docs/manifest-formatter/manifest-types.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/manifest-formatter/manifest-types.ts
@@ -70,6 +70,12 @@ const BaseInlineComponentProperties = v.object({
   path: v.optional(v.string()),
   summary: v.optional(v.string()),
   import: v.optional(v.string()),
+  /**
+   * API documentation in Markdown format.
+   * Prefer ## level headings for sections (Props, Events, Slots, etc.) and TypeScript-like types for structured data.
+   */
+  apiDescription: v.optional(v.string()),
+  renderer: v.optional(v.string()),
   // Mirrors the docgen-engine payloads, which the parsers narrow structurally at runtime.
   reactDocgen: v.optional(v.any()),
   reactDocgenTypescript: v.optional(v.any()),

--- a/code/core/src/shared/open-service/toolsets/docs/manifest-formatter/markdown.test.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/manifest-formatter/markdown.test.ts
@@ -1064,6 +1064,136 @@ describe('MarkdownFormatter - formatComponentManifest', () => {
 			\`\`\`"
 		`);
   });
+
+  describe('apiDescription fragment (framework-rendered)', () => {
+    const VUE_FRAGMENT = [
+      '## Props',
+      '',
+      '| Name | Type | Required | Default | Description |',
+      '| --- | --- | --- | --- | --- |',
+      '| label | string | no |  |  |',
+      '',
+      '## Slots',
+      '',
+      '| Name | Bindings | Description |',
+      '| --- | --- | --- |',
+      '| default | text: string | The default slot |',
+    ].join('\n');
+
+    it('inserts the fragment verbatim where the Props section goes and skips the legacy path', () => {
+      const manifest: ComponentManifest = {
+        id: 'my-slot',
+        name: 'MySlotComponent',
+        path: 'src/MySlotComponent.vue',
+        renderer: 'vue3',
+        apiDescription: VUE_FRAGMENT,
+        // A react-docgen payload is present but MUST be ignored when apiDescription exists.
+        reactDocgen: { props: { ignored: { type: { name: 'string' } } } },
+      };
+
+      const result = formatComponentManifest(manifest);
+
+      expect(result).toContain(VUE_FRAGMENT);
+      expect(result).toContain('## Slots');
+      expect(result).not.toContain('ignored');
+      expect(result).not.toContain('export type Props');
+    });
+
+    it('caps stories at 3 when a fragment is present, regardless of react-docgen props', () => {
+      const stories = ['A', 'B', 'C', 'D', 'E'].map((n) => ({
+        name: n,
+        id: `s--${n.toLowerCase()}`,
+        snippet: `<C>${n}</C>`,
+      }));
+      const manifest: ComponentManifest = {
+        id: 'capped',
+        name: 'Capped',
+        path: 'src/Capped.vue',
+        renderer: 'vue3',
+        apiDescription: VUE_FRAGMENT,
+        stories,
+      };
+
+      const result = formatComponentManifest(manifest);
+
+      expect(result).toContain('### Other Stories');
+      expect(result).toContain('- D (s--d)');
+      expect(result).toContain('- E (s--e)');
+    });
+
+    it('does NOT cap stories when the fragment is absent and there is no docgen (undocumented API)', () => {
+      const stories = ['A', 'B', 'C', 'D', 'E'].map((n) => ({
+        name: n,
+        id: `s--${n.toLowerCase()}`,
+        snippet: `<C>${n}</C>`,
+      }));
+      const manifest: ComponentManifest = {
+        id: 'undocumented',
+        name: 'Undocumented',
+        path: 'src/Undocumented.vue',
+        renderer: 'vue3',
+        stories,
+      };
+
+      const result = formatComponentManifest(manifest);
+
+      expect(result).not.toContain('### Other Stories');
+      expect(result).toContain('### D');
+      expect(result).toContain('### E');
+    });
+
+    it('inserts a subcomponent fragment verbatim and skips its legacy props path', () => {
+      const manifest: ComponentManifest = {
+        id: 'parent',
+        name: 'Parent',
+        path: 'src/Parent.vue',
+        renderer: 'vue3',
+        subcomponents: {
+          Child: {
+            name: 'Child',
+            path: 'src/Child.vue',
+            apiDescription: '## Props\n\n| Name | Type |\n| --- | --- |\n| open | boolean |',
+            reactDocgen: { props: { ignored: { type: { name: 'string' } } } },
+          },
+        },
+      };
+
+      const result = formatComponentManifest(manifest);
+
+      expect(result).toContain('| open | boolean |');
+      expect(result).not.toContain('ignored');
+      expect(result).not.toContain('export type ChildProps');
+    });
+
+    it('uses the fragment for the component but the legacy path for a fragment-less subcomponent', () => {
+      const manifest: ComponentManifest = {
+        id: 'mixed',
+        name: 'Mixed',
+        path: 'src/Mixed.tsx',
+        apiDescription: VUE_FRAGMENT,
+        subcomponents: {
+          Legacy: {
+            name: 'Legacy',
+            path: 'src/Legacy.tsx',
+            reactDocgen: { props: { size: { type: { name: 'string' } } } },
+          },
+        },
+      };
+
+      const result = formatComponentManifest(manifest);
+
+      expect(result).toContain(VUE_FRAGMENT);
+      expect(result).toContain('export type LegacyProps');
+      expect(result).toContain('size: string');
+    });
+
+    it('leaves fragment-less fixtures byte-identical (regression: legacy path unchanged)', () => {
+      const button = fullManifestFixture.components.button as ComponentManifest;
+      const clone = JSON.parse(JSON.stringify(button)) as ComponentManifest;
+      expect(clone.apiDescription).toBeUndefined();
+      expect(formatComponentManifest(clone)).toBe(formatComponentManifest(button));
+    });
+  });
 });
 
 describe('MarkdownFormatter - formatManifestsToLists', () => {

--- a/code/core/src/shared/open-service/toolsets/docs/manifest-formatter/markdown.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/manifest-formatter/markdown.ts
@@ -217,9 +217,14 @@ function formatSubcomponentsSection(
       continue;
     }
 
-    const parsedDocgen = getParsedDocgen(subcomponent);
-    const typeName = `${(subcomponent.name || key).replace(/\W+/g, '')}Props`;
-    parts.push(...formatPropsSection(parsedDocgen, { title: '#### Props', typeName }));
+    if (subcomponent.apiDescription != null) {
+      parts.push(subcomponent.apiDescription);
+      parts.push('');
+    } else {
+      const parsedDocgen = getParsedDocgen(subcomponent);
+      const typeName = `${(subcomponent.name || key).replace(/\W+/g, '')}Props`;
+      parts.push(...formatPropsSection(parsedDocgen, { title: '#### Props', typeName }));
+    }
   }
 
   return parts;
@@ -245,8 +250,10 @@ export function formatComponentManifest(componentManifest: ComponentManifest): s
 
   parts.push(...formatSubcomponentsSection(componentManifest.subcomponents));
 
-  // Parse docgen data (from either engine)
-  const parsedDocgen = getParsedDocgen(componentManifest);
+  const hasApiDescription = Boolean(componentManifest.apiDescription);
+
+  // Parse docgen data (from either engine) — only for the legacy/fallback path.
+  const parsedDocgen = hasApiDescription ? undefined : getParsedDocgen(componentManifest);
 
   // Stories section
   const stories = Array.isArray(componentManifest.stories) ? componentManifest.stories : [];
@@ -256,13 +263,13 @@ export function formatComponentManifest(componentManifest: ComponentManifest): s
 
     const storiesWithSnippets = stories.filter((s) => s.snippet);
 
-    // Check if component has props - if not, show all stories fully
     const hasProps = parsedDocgen && Object.keys(parsedDocgen.props).length > 0;
+    const capStories = hasApiDescription || hasProps;
 
-    const storiesToShow = hasProps
+    const storiesToShow = capStories
       ? storiesWithSnippets.slice(0, MAX_STORIES_TO_SHOW)
       : storiesWithSnippets;
-    const remainingStories = hasProps ? storiesWithSnippets.slice(MAX_STORIES_TO_SHOW) : [];
+    const remainingStories = capStories ? storiesWithSnippets.slice(MAX_STORIES_TO_SHOW) : [];
 
     // Show first X stories in full detail (or all if no props)
     for (const story of storiesToShow) {
@@ -292,7 +299,12 @@ export function formatComponentManifest(componentManifest: ComponentManifest): s
     }
   }
 
-  parts.push(...formatPropsSection(parsedDocgen));
+  if (hasApiDescription) {
+    parts.push(componentManifest.apiDescription!);
+    parts.push('');
+  } else {
+    parts.push(...formatPropsSection(parsedDocgen));
+  }
 
   // Attached docs section
   if (componentManifest.docs && Object.keys(componentManifest.docs).length > 0) {


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Makes MCP consume `apiMd` to get a component API documentation. 

linked to https://github.com/storybookjs/storybook/pull/35585/changes
 
## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests
 

#### Manual testing

no manual testing for now, no frameworks/renderer inject apiMd yet

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->
  
### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
 

****