### PR TITLE
Angular: Stop marking a defaulted input as required in the props table

### DIFF
--- a/code/lib/angular-cm/src/analyzer/members.test.ts
+++ b/code/lib/angular-cm/src/analyzer/members.test.ts
@@ -77,6 +77,18 @@ describe('@Input and @Output aliases', () => {
     expect(byName(inputs, 'buttonLabel').required).toBeUndefined();
   });
 
+  it('does not mark an input required just because `@Input()` carries no `required` key', () => {
+    const argTypes = extractArgTypesFromData(componentIn(SOURCE), {
+      metadataJson: undefined,
+      ...ANALYZER_EXTRACT_OPTIONS,
+    }) as Record<string, { table?: { type?: { required?: boolean } } }>;
+
+    // An initializer is what settles it: `buttonLabel` has one, so binding it is optional.
+    expect(argTypes.buttonLabel?.table?.type?.required).toBe(false);
+    expect(argTypes.tone?.table?.type?.required).toBe(true);
+    expect(argTypes.hint?.table?.type?.required).toBe(false);
+  });
+
   it('leaves an accessor input’s `@default` tag as its only default carrier', () => {
     // A getter has no initializer, so without the tag there would be nothing to show.
     expect(byName(componentIn(SOURCE).inputsClass, 'anotherDefaultValue')).toMatchObject({

--- a/code/lib/angular-cm/src/extract-arg-types.ts
+++ b/code/lib/angular-cm/src/extract-arg-types.ts
@@ -82,8 +82,10 @@ const SECTION_ORDER = [
 const isMethod = (methodOrProp: Method | Property): methodOrProp is Method =>
   (methodOrProp as Method).args !== undefined;
 
-// Compodoc's `required` tracks the `@Input({...})` key's presence, so `optional` must agree.
-const isRequired = (item: Property): boolean => (item.required ?? true) && !item.optional;
+// Compodoc's `required` tracks the `@Input({...})` key's presence, so `optional` must agree. With
+// the key absent an initializer settles it: a defaulted input is never mandatory to bind.
+const isRequired = (item: Property): boolean =>
+  (item.required ?? item.defaultValue === undefined) && !item.optional;
 
 const hasDecorator = (item: Property, decoratorName: string) =>
   item.decorators && item.decorators.find((x: Decorator) => x.name === decoratorName);

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/acm-argtypes-filtered.snapshot
@@ -8,7 +8,7 @@
         "summary": false,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "boolean",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/acm-argtypes.snapshot
@@ -8,7 +8,7 @@
         "summary": false,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "boolean",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/acm-argtypes-filtered.snapshot
@@ -8,7 +8,7 @@
         "summary": false,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "boolean",
       },
     },
@@ -25,7 +25,7 @@
         "summary": "",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/acm-argtypes.snapshot
@@ -9,7 +9,7 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "EventEmitter",
       },
     },
@@ -27,7 +27,7 @@
         "summary": false,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "boolean",
       },
     },
@@ -44,7 +44,7 @@
         "summary": "",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/acm-argtypes-filtered.snapshot
@@ -8,7 +8,7 @@
         "summary": "[]",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "T[]",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/acm-argtypes.snapshot
@@ -8,7 +8,7 @@
         "summary": "[]",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "T[]",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes-filtered.snapshot
@@ -60,7 +60,7 @@
         "summary": "Badge",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes.snapshot
@@ -9,7 +9,7 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "EventEmitter",
       },
     },
@@ -79,7 +79,7 @@
         "summary": "Badge",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/acm-argtypes-filtered.snapshot
@@ -8,7 +8,7 @@
         "summary": "ButtonKind.Primary",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "ButtonKind",
       },
     },
@@ -29,7 +29,7 @@
         "summary": "small",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": ""small" | "large"",
       },
     },
@@ -50,7 +50,7 @@
         "summary": "info",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "ToneOption",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/acm-argtypes.snapshot
@@ -8,7 +8,7 @@
         "summary": "ButtonKind.Primary",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "ButtonKind",
       },
     },
@@ -29,7 +29,7 @@
         "summary": "small",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": ""small" | "large"",
       },
     },
@@ -50,7 +50,7 @@
         "summary": "info",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "ToneOption",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/acm-argtypes-filtered.snapshot
@@ -8,7 +8,7 @@
         "summary": "Math.max(1, 3)",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "number",
       },
     },
@@ -25,7 +25,7 @@
         "summary": "5 * 60 * 1000",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "number",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/acm-argtypes.snapshot
@@ -8,7 +8,7 @@
         "summary": "Math.max(1, 3)",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "number",
       },
     },
@@ -26,7 +26,7 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "EventEmitter",
       },
     },
@@ -44,7 +44,7 @@
         "summary": "5 * 60 * 1000",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "number",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/acm-argtypes-filtered.snapshot
@@ -28,7 +28,7 @@
         "deprecated": "Use `label` on the parent panel instead.",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/acm-argtypes.snapshot
@@ -28,7 +28,7 @@
         "deprecated": "Use `label` on the parent panel instead.",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/acm-argtypes-filtered.snapshot
@@ -8,7 +8,7 @@
         "summary": "compact",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },
@@ -25,7 +25,7 @@
         "summary": "",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/acm-argtypes.snapshot
@@ -26,7 +26,7 @@
         "summary": 1,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "number",
       },
     },
@@ -43,7 +43,7 @@
         "summary": "compact",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },
@@ -61,7 +61,7 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "EventEmitter",
       },
     },
@@ -79,7 +79,7 @@
         "summary": "Next page",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },
@@ -114,7 +114,7 @@
         "summary": false,
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "boolean",
       },
     },
@@ -131,7 +131,7 @@
         "summary": "signal(false)",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "WritableSignal<boolean>",
       },
     },
@@ -202,7 +202,7 @@
         "summary": "",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes.snapshot
@@ -95,7 +95,7 @@
         "summary": "v1",
       },
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
     },


### PR DESCRIPTION
Closes #

## What I did

An Angular `@Input()` that carries an initializer was reported as a required prop.
The props table showed a `*` next to it and `table.type.required: true`, even though the component has a perfectly good default and a template binding it is entirely optional.
This makes the in-process Angular analyzer (ACM) read the initializer it already records and stop calling those inputs required.

The extractor had two independent signals about an input and only consulted one:

```text
  @Input() label = 'default label'
            │
            ▼
  analyzer ──► { name: 'label', type: 'string', optional: false, defaultValue: "'default label'" }
                                                    │                    │
                            "no `?` on the field" ──┘                    └── "there is a default"
                                                    │                    ╎
                                    isRequired() ◄──┘                    ╎  (never read)
                                                    │
                                                    ▼
                                    table.type.required: true   ✗
```

`required` is only ever set when the source spells it out (`@Input({ required: true })`, `input.required<T>()`).
When the key is absent the old fallback guessed `true`, and an initializer is exactly the evidence that settles the guess:

```diff
-const isRequired = (item: Property): boolean => (item.required ?? true) && !item.optional;
+const isRequired = (item: Property): boolean =>
+  (item.required ?? item.defaultValue === undefined) && !item.optional;
```

An explicit `required` still wins, so `@Input({ required: true })` and `input.required<T>()` are untouched.

### What the extraction produces now

Captured from the reported component, via `AngularComponentMetaManager` + `extractArgTypesFromData` at `propsTable: 'api'`:

```ts
export class Template {
  @Input() label = 'default label';
  @Input() label2 = 'default label2';
  @Output() changed = new EventEmitter<string>();
  inc() { this.changed.emit('Increase'); }
}
```

Before:

```text
label    category=inputs   required=true  default="default label"
label2   category=inputs   required=true  default="default label2"
changed  category=outputs  required=true  default=undefined
inc      category=methods  required=false default=undefined
```

After:

```text
label    category=inputs   required=false default="default label"
label2   category=inputs   required=false default="default label2"
changed  category=outputs  required=false default=undefined
inc      category=methods  required=false default=undefined
```

### Scope

| Declaration | Before | After |
| --- | --- | --- |
| `@Input() label = 'x'` | ✗ required | optional |
| `@Input() label!: string` | required | required |
| `@Input({ required: true }) label` | required | required |
| `input.required<T>()` | required | required |
| `input('default')` | optional | optional |
| `@Output() changed = new EventEmitter<T>()` | ✗ required | optional |
| `currentPage = 1` (plain property) | ✗ required | optional |

`@storybook/angular-compodoc` keeps the old behaviour on purpose.
Its extractor is frozen on the legacy rules its committed baselines pin, and the module header of the ACM fork already states that fixes belong in the fork rather than being mirrored back.

### Baselines

The nine ACM fixtures that declare an initializer re-record. The whole diff across 17 snapshot files is 35 lines, all of them the same flip:

```diff
       "type": {
-        "required": true,
+        "required": false,
         "summary": "string",
       },
```

Every re-recorded member has an initializer in its fixture source: `@Input() emphasis = false`, `@Input() items: T[] = []`, `@Input() size: 'small' | 'large' = 'small'`, `@Input() rows = Math.max(1, 3)`, `@Output() clicked = new EventEmitter<string>()`, `currentPage = 1`, `protected helperLabel = 'Next page'`, `readonly version = 'v1'`, and so on.

Worth knowing for reviewers: `-u` alone cannot re-record these. The `strictTable` self-ratchet gates `table.type.required` `true -> false` as a `lost-required` violation, and the gate runs before the snapshot write, so an update run fails instead of persisting:

```text
Error: expectCurrentOrBetter found 7 violation(s):
- [lost-required] currentPage: the baseline records table.type.required true but the candidate does not
- [lost-required] density: the baseline records table.type.required true but the candidate does not
- [lost-required] densityChange: the baseline records table.type.required true but the candidate does not
- [lost-required] helperLabel: the baseline records table.type.required true but the candidate does not
- [lost-required] isActive: the baseline records table.type.required true but the candidate does not
- [lost-required] loading: the baseline records table.type.required true but the candidate does not
- [lost-required] title: the baseline records table.type.required true but the candidate does not
```

That is the ratchet behaving correctly: a required flip is a regression in the general case, and this one is the exception. The snapshots here were re-recorded with the gate temporarily neutralised, and the gate is armed again in the committed tree, so the suite is green with the ratchet fully in place.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

`code/lib/angular-cm/src/analyzer/members.test.ts` gains a case that drives the real analyzer over inline Angular source and asserts the props-table `required` for an initialized input, an `@Input({ alias, required: true })`, and an `@Input({ required: false })` in one go. It fails on `next` with `expected true to be false`.

The `angular-component-meta-baselines.test.ts` recorder is the integration leg.

### Manual testing

1. Generate an Angular sandbox: `yarn task sandbox --template angular-vite/default-ts --start-from auto`
2. Add a component with an input that has a default and one that does not:

   ```ts
   @Component({ selector: 'app-template', standalone: true, template: '{{ label }}' })
   export class Template {
     @Input() label = 'default label';
     @Input({ required: true }) mandatory!: string;
   }
   ```

3. Write a story for it and open Storybook
4. Open the **Docs** page for the story and look at the props table
5. `label` should have no `*` next to it; `mandatory` should still have one

To see this in the **Controls** panel rather than Docs, set `parameters: { controls: { expanded: true } }`. The panel renders compact by default and omits the Description and Default columns entirely.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
