### PR TITLE
fix(nextjs-vite): normalize Windows backslashes in next/image virtual paths

### DIFF
--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.test.ts
@@ -89,7 +89,7 @@ describe('vitePluginNextImage resolveId', () => {
     // On Windows, Vite's resolver returns native paths with backslashes. Those
     // must be normalized before being embedded in the virtual id, otherwise the
     // generated `import ... from "<path>"` keeps backslashes and Rollup mangles
-    // them (`git\voyages` -> `gitoyages`), breaking resolution. See #35872.
+    // them (`git\voyages` -> `gitoyages`), breaking resolution.
     const plugin = vitePluginNextImage(nextConfigResolver);
     const windowsPath = 'C:\\Users\\me\\git\\voyages\\src\\assets\\Foo.svg';
     const resolve = vi.fn().mockResolvedValue({ id: windowsPath });

--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.test.ts
@@ -16,10 +16,12 @@ vi.mock('node:module', () => ({
 
 vi.mock('node:fs', { spy: true });
 
-import { encodeBase64Url } from '../../utils/base64-url.ts';
+import { decodeBase64Url, encodeBase64Url } from '../../utils/base64-url.ts';
 import { vitePluginNextImage } from './plugin.ts';
 
-const virtualImageId = (imagePath: string) => `\0virtual:next-image:${encodeBase64Url(imagePath)}`;
+const virtualImagePrefix = '\0virtual:next-image:';
+const virtualImageId = (imagePath: string) => `${virtualImagePrefix}${encodeBase64Url(imagePath)}`;
+const decodeVirtualImageId = (id: string) => decodeBase64Url(id.slice(virtualImagePrefix.length));
 
 describe('vitePluginNextImage resolveId', () => {
   const nextConfigResolver = {
@@ -81,6 +83,26 @@ describe('vitePluginNextImage resolveId', () => {
       paths: [path.dirname(importer.split('?')[0])],
     });
     expect(result).toBe(virtualImageId(resolvedPath));
+  });
+
+  it('normalizes Windows backslashes in resolved image paths', async () => {
+    // On Windows, Vite's resolver returns native paths with backslashes. Those
+    // must be normalized before being embedded in the virtual id, otherwise the
+    // generated `import ... from "<path>"` keeps backslashes and Rollup mangles
+    // them (`git\voyages` -> `gitoyages`), breaking resolution. See #35872.
+    const plugin = vitePluginNextImage(nextConfigResolver);
+    const windowsPath = 'C:\\Users\\me\\git\\voyages\\src\\assets\\Foo.svg';
+    const resolve = vi.fn().mockResolvedValue({ id: windowsPath });
+
+    const result = await plugin.resolveId!.call(
+      createContext(resolve),
+      '@myorg/assets/Foo.svg',
+      'C:\\Users\\me\\git\\voyages\\src\\Component.tsx'
+    );
+
+    const decoded = decodeVirtualImageId(result as string);
+    expect(decoded).toBe('C:/Users/me/git/voyages/src/assets/Foo.svg');
+    expect(decoded).not.toContain('\\');
   });
 });
 

--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.ts
@@ -142,10 +142,17 @@ export function vitePluginNextImage(
           return null;
         }
 
+        // Normalize Windows backslashes to forward slashes before embedding the
+        // path in the virtual module ID. The decoded path is later interpolated
+        // into a generated `import ... from "<path>"`, and Rollup mangles native
+        // backslashes (e.g. `git\voyages` -> `gitoyages`), breaking resolution.
+        // Forward slashes are accepted by both Rollup imports and fs on Windows.
+        const normalizedImagePath = imagePath.replace(/\\/g, '/');
+
         // Use null byte prefix to embed the image path in the virtual module ID
         // Use URL-safe base64 encoding to avoid issues with special characters like
         // square brackets that get decoded by Vite's decodeURI
-        return `${virtualImagePrefix}${encodeBase64Url(imagePath)}`;
+        return `${virtualImagePrefix}${encodeBase64Url(normalizedImagePath)}`;
       }
 
       if (id === 'next/image' && importer !== virtualNextImage) {


### PR DESCRIPTION
## What I did

Fixes #35872.

On Windows, any story rendering a `next/image` with a **static import** crashes the Vite build/dev with a Rollup resolve error, because the virtual-image path keeps OS-native backslashes:

```
[vite]: Rollup failed to resolve import "C:\Users\me\git\voyages\src\assets\Foo.svg?ignore"
```

The backslashes get eaten downstream (`git\voyages` → `gitoyages`), so resolution fails and `storybook dev` / `storybook build` crash.

### Root cause

In `next-image/plugin.ts`, the image path round-trips through the virtual id without separator normalization. `resolveId` may obtain `imagePath` from Vite's resolver or `require.resolve`, which on Windows return native paths with `\`. That path is base64-encoded into the virtual id as-is, decoded back to `\` in `load`, and interpolated into a generated `import ... from "${imagePath}?ignore"`, where Rollup mangles the backslashes.

This regressed when the plugin was rewritten to the base64-id form (the earlier Windows normalization from #57 wasn't carried forward), so it's present in the latest release.

### The fix

Normalize `\` → `/` once, at the point where the path enters the virtual id (`resolveId`), so both the generated `import` and the `fs.readFile` in `load` receive forward slashes. Forward slashes are accepted by Rollup imports and by `fs` on Windows, and this is a no-op on POSIX.

## How to test

Added a unit test asserting a resolved Windows path is normalized in the virtual id. It fails on `next` (decoded path keeps `\`) and passes with the fix.

```
vitest run --config code/lib/vite-plugin-storybook-nextjs/vitest.config.ts \
  code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.test.ts
```

Reproduced natively on Windows 10. Thanks to @constantinow for the detailed root-cause analysis in the issue.

## Checklist

- [x] Made changes based on the correct branch: `next`
- [x] Added a unit test (red on `next`, green with the fix)

<!-- AI disclosure -->
This change was prepared with AI assistance (diagnosis, patch and test); authored and verified by me.
