### PR TITLE
Vue: Inject component import directly in script for story-docs

### DIFF
--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-composed-utility/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-composed-utility/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "cross-file-composed-utility",
-  "import": "import UtilityComposedProps from './UtilityComposedProps.vue';",
   "name": "UtilityComposedProps",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-cross-file-composed-utility--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import UtilityComposedProps from './UtilityComposedProps.vue';
+</script>
+
+<template>
   <UtilityComposedProps label="Picked" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-extended-interface/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-extended-interface/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "cross-file-extended-interface",
-  "import": "import ExtendedInterfaceProps from './ExtendedInterfaceProps.vue';",
   "name": "ExtendedInterfaceProps",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-cross-file-extended-interface--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import ExtendedInterfaceProps from './ExtendedInterfaceProps.vue';
+</script>
+
+<template>
   <ExtendedInterfaceProps extra :id="7" name="Chained" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-imported-interface/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-imported-interface/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "cross-file-imported-interface",
-  "import": "import ImportedInterfaceProps from './ImportedInterfaceProps.vue';",
   "name": "ImportedInterfaceProps",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-cross-file-imported-interface--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import ImportedInterfaceProps from './ImportedInterfaceProps.vue';
+</script>
+
+<template>
   <ImportedInterfaceProps :count="2" label="Imported" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-props-spread/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-props-spread/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "cross-file-props-spread",
-  "import": "import CrossFilePropsSpread from './CrossFilePropsSpread.vue';",
   "name": "CrossFilePropsSpread",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-cross-file-props-spread--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import CrossFilePropsSpread from './CrossFilePropsSpread.vue';
+</script>
+
+<template>
   <CrossFilePropsSpread label="Text label" :optional="false" value="hello" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-runtime-props/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-runtime-props/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "cross-file-runtime-props",
-  "import": "import CrossFileRuntimeProps from './CrossFileRuntimeProps.vue';",
   "name": "CrossFileRuntimeProps",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-cross-file-runtime-props--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import CrossFileRuntimeProps from './CrossFileRuntimeProps.vue';
+</script>
+
+<template>
   <CrossFileRuntimeProps :count="3" label="Imported" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-union-alias/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/cross-file-union-alias/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "cross-file-union-alias",
-  "import": "import CrossFileUnionAlias from './CrossFileUnionAlias.vue';",
   "name": "CrossFileUnionAlias",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-cross-file-union-alias--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import CrossFileUnionAlias from './CrossFileUnionAlias.vue';
+</script>
+
+<template>
   <CrossFileUnionAlias size="small" variant="danger" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/define-expose/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/define-expose/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "define-expose",
-  "import": "import DefineExpose from './DefineExpose.vue';",
   "name": "DefineExpose",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-define-expose--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import DefineExpose from './DefineExpose.vue';
+</script>
+
+<template>
   <DefineExpose label="Increment" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/define-props-destructured/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/define-props-destructured/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "define-props-destructured",
-  "import": "import DestructuredProps from './DestructuredProps.vue';",
   "name": "DestructuredProps",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-define-props-destructured--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import DestructuredProps from './DestructuredProps.vue';
+</script>
+
+<template>
   <DestructuredProps label="Sized" size="large" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/define-props-runtime-array/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/define-props-runtime-array/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "define-props-runtime-array",
-  "import": "import RuntimeArrayProps from './RuntimeArrayProps.vue';",
   "name": "RuntimeArrayProps",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-define-props-runtime-array--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RuntimeArrayProps from './RuntimeArrayProps.vue';
+</script>
+
+<template>
   <RuntimeArrayProps appearance="primary" label="Go" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/define-props-runtime-object/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/define-props-runtime-object/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "define-props-runtime-object",
-  "import": "import RuntimeObjectProps from './RuntimeObjectProps.vue';",
   "name": "RuntimeObjectProps",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-define-props-runtime-object--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RuntimeObjectProps from './RuntimeObjectProps.vue';
+</script>
+
+<template>
   <RuntimeObjectProps :count="3" label="Total" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-literal-bindings/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-literal-bindings/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "define-slots-literal-bindings",
-  "import": "import DefineSlotsLiteralBindings from './DefineSlotsLiteralBindings.vue';",
   "name": "DefineSlotsLiteralBindings",
   "path": "__PATH__",
   "stories": {

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-with-props/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-with-props/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "define-slots-with-props",
-  "import": "import DefineSlotsWithProps from './DefineSlotsWithProps.vue';",
   "name": "DefineSlotsWithProps",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-define-slots-with-props--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import DefineSlotsWithProps from './DefineSlotsWithProps.vue';
+</script>
+
+<template>
   <DefineSlotsWithProps disabled label="Save" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/events-jsdoc/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/events-jsdoc/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "events-jsdoc",
-  "import": "import EventsJsdoc from './EventsJsdoc.vue';",
   "name": "EventsJsdoc",
   "path": "__PATH__",
   "stories": {
@@ -9,6 +8,8 @@
       "id": "forms-events-jsdoc--with-handlers",
       "name": "With Handlers",
       "snippet": "<script lang="ts" setup>
+import EventsJsdoc from './EventsJsdoc.vue';
+
 const onCancel = () => {};
 
 const onSave = () => {};

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/jsdoc-tags/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/jsdoc-tags/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "jsdoc-tags",
-  "import": "import JsdocTags from './JsdocTags.vue';",
   "name": "JsdocTags",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-jsdoc-tags--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import JsdocTags from './JsdocTags.vue';
+</script>
+
+<template>
   <JsdocTags label="Old label" title="New title" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/prop-slot-name-collision/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/prop-slot-name-collision/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "prop-slot-name-collision",
-  "import": "import PropSlotNameCollision from './PropSlotNameCollision.vue';",
   "name": "PropSlotNameCollision",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-prop-slot-name-collision--icon-prop-as-written",
       "name": "Icon Prop As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import PropSlotNameCollision from './PropSlotNameCollision.vue';
+</script>
+
+<template>
   <PropSlotNameCollision icon="pi pi-check" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/props-basic-types/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/props-basic-types/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "props-basic-types",
-  "import": "import PropsBasicTypes from './PropsBasicTypes.vue';",
   "name": "PropsBasicTypes",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-props-basic-types--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import PropsBasicTypes from './PropsBasicTypes.vue';
+</script>
+
+<template>
   <PropsBasicTypes :count="2" enabled label="Hello" />
 </template>",
       "summary": undefined,
@@ -18,6 +21,8 @@
       "id": "forms-props-basic-types--unrepresentable-args",
       "name": "Unrepresentable Args",
       "snippet": "<script lang="ts" setup>
+import PropsBasicTypes from './PropsBasicTypes.vue';
+
 const big = BigInt('9007199254740993');
 
 const config = { theme: 'dark', dense: true };

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/props-generic/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/props-generic/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "props-generic",
-  "import": "import PropsGeneric from './PropsGeneric.vue';",
   "name": "PropsGeneric",
   "path": "__PATH__",
   "stories": {
@@ -9,6 +8,8 @@
       "id": "forms-props-generic--props-as-written",
       "name": "Props As Written",
       "snippet": "<script lang="ts" setup>
+import PropsGeneric from './PropsGeneric.vue';
+
 const items = ['alpha', 'beta'];
 </script>
 

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/props-ts-enum/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/props-ts-enum/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "props-ts-enum",
-  "import": "import TsEnumProps from './TsEnumProps.vue';",
   "name": "TsEnumProps",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-props-ts-enum--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import TsEnumProps from './TsEnumProps.vue';
+</script>
+
+<template>
   <TsEnumProps :level="1" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/props-union-enum/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/props-union-enum/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "props-union-enum",
-  "import": "import PropsUnionEnum from './PropsUnionEnum.vue';",
   "name": "PropsUnionEnum",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-props-union-enum--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import PropsUnionEnum from './PropsUnionEnum.vue';
+</script>
+
+<template>
   <PropsUnionEnum size="medium" status="ok" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/recursive-type/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/recursive-type/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "recursive-type",
-  "import": "import RecursiveTree from './RecursiveTree.vue';",
   "name": "RecursiveTree",
   "path": "__PATH__",
   "stories": {
@@ -9,6 +8,8 @@
       "id": "forms-recursive-type--props-as-written",
       "name": "Props As Written",
       "snippet": "<script lang="ts" setup>
+import RecursiveTree from './RecursiveTree.vue';
+
 const node = {
   value: 'root',
   children: [{ value: 'leaf', children: [] }],

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/runtime-multi-constructor/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/runtime-multi-constructor/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "runtime-multi-constructor",
-  "import": "import RuntimeMultiConstructor from './RuntimeMultiConstructor.vue';",
   "name": "RuntimeMultiConstructor",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-runtime-multi-constructor--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RuntimeMultiConstructor from './RuntimeMultiConstructor.vue';
+</script>
+
+<template>
   <RuntimeMultiConstructor :width="200" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/runtime-proptype-cast/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/runtime-proptype-cast/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "runtime-proptype-cast",
-  "import": "import RuntimePropTypeCast from './RuntimePropTypeCast.vue';",
   "name": "RuntimePropTypeCast",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-runtime-proptype-cast--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RuntimePropTypeCast from './RuntimePropTypeCast.vue';
+</script>
+
+<template>
   <RuntimePropTypeCast kind="secondary" :measure="42" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-template-only/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-template-only/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "slots-template-only",
-  "import": "import TemplateOnlySlots from './TemplateOnlySlots.vue';",
   "name": "TemplateOnlySlots",
   "path": "__PATH__",
   "stories": {
@@ -14,7 +13,11 @@
       "description": undefined,
       "id": "forms-slots-template-only--string-child",
       "name": "String Child",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import TemplateOnlySlots from './TemplateOnlySlots.vue';
+</script>
+
+<template>
   <TemplateOnlySlots>
     Plain text content
     <template #header>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "slots",
-  "import": "import SlotsShowcase from './SlotsShowcase.vue';",
   "name": "SlotsShowcase",
   "path": "__PATH__",
   "stories": {
@@ -14,7 +13,11 @@
       "description": undefined,
       "id": "forms-slots--string-child",
       "name": "String Child",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import SlotsShowcase from './SlotsShowcase.vue';
+</script>
+
+<template>
   <SlotsShowcase heading="Plain">
     Plain text content
   </SlotsShowcase>
@@ -25,7 +28,11 @@
       "description": undefined,
       "id": "forms-slots--v-node-child",
       "name": "V Node Child",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import SlotsShowcase from './SlotsShowcase.vue';
+</script>
+
+<template>
   <SlotsShowcase heading="Structured">
     <p class="body">Body content</p>
     <template #header>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/type-intersection-whole/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/type-intersection-whole/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "type-intersection-whole",
-  "import": "import TypeIntersectionWhole from './TypeIntersectionWhole.vue';",
   "name": "TypeIntersectionWhole",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-type-intersection-whole--props-as-written",
       "name": "Props As Written",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import TypeIntersectionWhole from './TypeIntersectionWhole.vue';
+</script>
+
+<template>
   <TypeIntersectionWhole id="save-button" size="medium" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/type-intersection/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/type-intersection/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "type-intersection",
-  "import": "import IntersectionProps from './IntersectionProps.vue';",
   "name": "IntersectionProps",
   "path": "__PATH__",
   "stories": {
@@ -9,6 +8,8 @@
       "id": "forms-type-intersection--props-as-written",
       "name": "Props As Written",
       "snippet": "<script lang="ts" setup>
+import IntersectionProps from './IntersectionProps.vue';
+
 const mixed = { label: 'Intersected', count: 2, extra: true };
 </script>
 

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/v-model/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/v-model/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "v-model",
-  "import": "import VModelInput from './VModelInput.vue';",
   "name": "VModelInput",
   "path": "__PATH__",
   "stories": {
@@ -10,6 +9,7 @@
       "name": "V Model Binding",
       "snippet": "<script lang="ts" setup>
 import { ref } from "vue";
+import VModelInput from './VModelInput.vue';
 
 const checked = ref(true);
 

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/args-formatting/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/args-formatting/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "args-formatting",
-  "import": "import ArgsFormattingButton from './ArgsFormattingButton.vue';",
   "name": "ArgsFormattingButton",
   "path": "__PATH__",
   "stories": {
@@ -9,6 +8,8 @@
       "id": "forms-args-formatting--primary",
       "name": "Primary",
       "snippet": "<script lang="ts" setup>
+import ArgsFormattingButton from './ArgsFormattingButton.vue';
+
 const items = ['one', 'two'];
 
 const options = { tone: 'neutral', compact: true };
@@ -25,7 +26,11 @@ const quotationLabel = 'She said "hi" and it\'s fine';
       "description": undefined,
       "id": "forms-args-formatting--unset-arg",
       "name": "Unset Arg",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import ArgsFormattingButton from './ArgsFormattingButton.vue';
+</script>
+
+<template>
   <ArgsFormattingButton :count="3" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/as-cast/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/as-cast/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "as-cast",
-  "import": "import AsCastButton from './AsCastButton.vue';",
   "name": "AsCastButton",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": "Cast story description.",
       "id": "forms-as-cast--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import AsCastButton from './AsCastButton.vue';
+</script>
+
+<template>
   <AsCastButton label="Cast" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/basic/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/basic/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "basic",
-  "import": "import BasicButton from './BasicButton.vue';",
   "name": "BasicButton",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": "Primary button description.",
       "id": "forms-basic--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import BasicButton from './BasicButton.vue';
+</script>
+
+<template>
   <BasicButton label="Submit" />
 </template>",
       "summary": "Primary button summary.",

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/csf1-legacy/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/csf1-legacy/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "csf1-legacy",
-  "import": "import CsfOneButton from './CsfOneButton.vue';",
   "name": "CsfOneButton",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-csf1-legacy--assigned-args",
       "name": "Assigned Args",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import CsfOneButton from './CsfOneButton.vue';
+</script>
+
+<template>
   <CsfOneButton label="Assigned" />
 </template>",
       "summary": undefined,
@@ -17,7 +20,11 @@
       "description": undefined,
       "id": "forms-csf1-legacy--assigned-args-override-inline",
       "name": "Assigned Args Override Inline",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import CsfOneButton from './CsfOneButton.vue';
+</script>
+
+<template>
   <CsfOneButton label="Assigned wins" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/csf4/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/csf4/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "csf4",
-  "import": "import CsfFourButton from './CsfFourButton.vue';",
   "name": "CsfFourButton",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": "Empty CSF4 story description.",
       "id": "forms-csf4--empty",
       "name": "Empty",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import CsfFourButton from './CsfFourButton.vue';
+</script>
+
+<template>
   <CsfFourButton />
 </template>",
       "summary": undefined,
@@ -17,7 +20,11 @@
       "description": "CSF4 button description.",
       "id": "forms-csf4--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import CsfFourButton from './CsfFourButton.vue';
+</script>
+
+<template>
   <CsfFourButton label="Save" />
 </template>",
       "summary": "CSF4 button summary.",

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/docgen-unavailable/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/docgen-unavailable/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "docgen-unavailable",
-  "import": "import DocgenUnavailableButton from './DocgenUnavailableButton.vue';",
   "name": "DocgenUnavailableButton",
   "path": "__PATH__",
   "stories": {

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/event-listener/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/event-listener/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "event-listener",
-  "import": "import EventListenerForm from './EventListenerForm.vue';",
   "name": "EventListenerForm",
   "path": "__PATH__",
   "stories": {
@@ -9,6 +8,8 @@
       "id": "forms-event-listener--primary",
       "name": "Primary",
       "snippet": "<script lang="ts" setup>
+import EventListenerForm from './EventListenerForm.vue';
+
 const formatter = (value: string) => value.toUpperCase();
 
 const onSubmit = (payload: { value: string }) => console.log(payload);

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/function-slot-bail/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/function-slot-bail/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "function-slot-bail",
-  "import": "import FunctionSlotBailPanel from './FunctionSlotBailPanel.vue';",
   "name": "FunctionSlotBailPanel",
   "path": "__PATH__",
   "stories": {

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/function-slot/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/function-slot/story-docs.payload.snapshot
@@ -1,7 +1,5 @@
 {
   "id": "function-slot",
-  "import": "import FunctionSlotPanel from './FunctionSlotPanel.vue';
-import ChildButton from './ChildButton.vue';",
   "name": "FunctionSlotPanel",
   "path": "__PATH__",
   "stories": {
@@ -9,7 +7,12 @@ import ChildButton from './ChildButton.vue';",
       "description": undefined,
       "id": "forms-function-slot--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import ChildButton from './ChildButton.vue';
+import FunctionSlotPanel from './FunctionSlotPanel.vue';
+</script>
+
+<template>
   <FunctionSlotPanel>
     <ChildButton label="Click me" />
   </FunctionSlotPanel>

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/import-override-render/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/import-override-render/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "import-override-render",
-  "import": "import { OverrideButton as ImportOverrideRenderButton } from 'my-design-system';",
   "name": "ImportOverrideRenderButton",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-import-override-render--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import { OverrideButton as ImportOverrideRenderButton } from 'my-design-system';
+</script>
+
+<template>
   <ImportOverrideRenderButton label="Override" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/import-override/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/import-override/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "import-override",
-  "import": "import { ImportOverride as ImportOverrideButton } from 'my-design-system';",
   "name": "ImportOverrideButton",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-import-override--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import { ImportOverride as ImportOverrideButton } from 'my-design-system';
+</script>
+
+<template>
   <ImportOverrideButton label="Override" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/prop-slot-collision/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/prop-slot-collision/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "prop-slot-collision",
-  "import": "import PropSlotCollision from './PropSlotCollision.vue';",
   "name": "PropSlotCollision",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-prop-slot-collision--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import PropSlotCollision from './PropSlotCollision.vue';
+</script>
+
+<template>
   <PropSlotCollision default="fallback text" icon="pi pi-check" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/render-function/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/render-function/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "render-function",
-  "import": "import RenderFunctionButton from './RenderFunctionButton.vue';",
   "name": "RenderFunctionButton",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-render-function--args-member",
       "name": "Args Member",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RenderFunctionButton from './RenderFunctionButton.vue';
+</script>
+
+<template>
   <div>
     <RenderFunctionButton label="From args" />
   </div>
@@ -19,7 +22,11 @@
       "description": undefined,
       "id": "forms-render-function--args-on-wrapper-and-component",
       "name": "Args On Wrapper And Component",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RenderFunctionButton from './RenderFunctionButton.vue';
+</script>
+
+<template>
   <section class="toolbar" label="Confirm">
     <RenderFunctionButton label="Confirm" />
   </section>
@@ -30,7 +37,11 @@
       "description": undefined,
       "id": "forms-render-function--nested",
       "name": "Nested",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RenderFunctionButton from './RenderFunctionButton.vue';
+</script>
+
+<template>
   <section class="toolbar">
     <h2>Actions</h2>
     <RenderFunctionButton label="Confirm" />
@@ -43,7 +54,11 @@
       "description": undefined,
       "id": "forms-render-function--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RenderFunctionButton from './RenderFunctionButton.vue';
+</script>
+
+<template>
   <RenderFunctionButton label="Render" />
 </template>",
       "summary": undefined,
@@ -52,7 +67,11 @@
       "description": undefined,
       "id": "forms-render-function--slot-children",
       "name": "Slot Children",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RenderFunctionButton from './RenderFunctionButton.vue';
+</script>
+
+<template>
   <RenderFunctionButton label="Confirm">
     <span>Extra</span>
     <template #footer>
@@ -66,7 +85,11 @@
       "description": undefined,
       "id": "forms-render-function--spread-override",
       "name": "Spread Override",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import RenderFunctionButton from './RenderFunctionButton.vue';
+</script>
+
+<template>
   <RenderFunctionButton label="Overridden" />
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/slot-scoped/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/slot-scoped/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "slot-scoped",
-  "import": "import ScopedList from './ScopedList.vue';",
   "name": "ScopedList",
   "path": "__PATH__",
   "stories": {

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/slots/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/slots/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "slots",
-  "import": "import SlotsPanel from './SlotsPanel.vue';",
   "name": "SlotsPanel",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-slots--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import SlotsPanel from './SlotsPanel.vue';
+</script>
+
+<template>
   <SlotsPanel :footer="42">
     Body copy
     <template #header>

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-meta-render/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-meta-render/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "template-meta-render",
-  "import": "import MetaRenderButton from './MetaRenderButton.vue';",
   "name": "MetaRenderButton",
   "path": "__PATH__",
   "stories": {
@@ -8,7 +7,11 @@
       "description": undefined,
       "id": "forms-template-meta-render--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import MetaRenderButton from './MetaRenderButton.vue';
+</script>
+
+<template>
   <section class="preview"><MetaRenderButton label="Primary" variant="primary" /></section>
 </template>",
       "summary": undefined,
@@ -17,7 +20,11 @@
       "description": undefined,
       "id": "forms-template-meta-render--secondary",
       "name": "Secondary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import MetaRenderButton from './MetaRenderButton.vue';
+</script>
+
+<template>
   <section class="preview"><MetaRenderButton label="Secondary" variant="secondary" /></section>
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-string/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-string/story-docs.payload.snapshot
@@ -1,7 +1,5 @@
 {
   "id": "template-string",
-  "import": "import TemplateStringButton from './TemplateStringButton.vue';
-import TemplateStringBadge from './TemplateStringBadge.vue';",
   "name": "TemplateStringButton",
   "path": "__PATH__",
   "stories": {
@@ -9,7 +7,11 @@ import TemplateStringBadge from './TemplateStringBadge.vue';",
       "description": undefined,
       "id": "forms-template-string--assigned-args",
       "name": "Assigned Args",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import TemplateStringButton from './TemplateStringButton.vue';
+</script>
+
+<template>
   <TemplateStringButton label="Assigned template" />
 </template>",
       "summary": undefined,
@@ -18,7 +20,12 @@ import TemplateStringBadge from './TemplateStringBadge.vue';",
       "description": undefined,
       "id": "forms-template-string--primary",
       "name": "Primary",
-      "snippet": "<template>
+      "snippet": "<script lang="ts" setup>
+import TemplateStringBadge from './TemplateStringBadge.vue';
+import TemplateStringButton from './TemplateStringButton.vue';
+</script>
+
+<template>
   <div class="wrap"><TemplateStringBadge text="New" /><TemplateStringButton label="Template" /></div>
 </template>",
       "summary": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-unsupported/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-unsupported/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "template-unsupported",
-  "import": "import TemplateUnsupportedPanel from './TemplateUnsupportedPanel.vue';",
   "name": "TemplateUnsupportedPanel",
   "path": "__PATH__",
   "stories": {

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/unsupported-args/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/unsupported-args/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "unsupported-args",
-  "import": "import UnsupportedArgsButton from './UnsupportedArgsButton.vue';",
   "name": "UnsupportedArgsButton",
   "path": "__PATH__",
   "stories": {

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/v-model/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/v-model/story-docs.payload.snapshot
@@ -1,6 +1,5 @@
 {
   "id": "v-model",
-  "import": "import ModelToggle from './ModelToggle.vue';",
   "name": "ModelToggle",
   "path": "__PATH__",
   "stories": {
@@ -10,6 +9,7 @@
       "name": "Primary",
       "snippet": "<script lang="ts" setup>
 import { ref } from "vue";
+import ModelToggle from './ModelToggle.vue';
 
 const checked = ref(true);
 

--- a/code/renderers/vue3/src/story-docs/build-story-docs.ts
+++ b/code/renderers/vue3/src/story-docs/build-story-docs.ts
@@ -39,7 +39,6 @@ import {
   type ClassifyArgsResult,
   type VueDocgenArgInfo,
 } from './classify-args.ts';
-import { importStatementForBinding } from './render-primitives.ts';
 import { renderSfcSnippet } from './render-sfc.ts';
 import { transformH } from './transform-h.ts';
 import {
@@ -57,6 +56,7 @@ export interface BuildStoryDocsContext {
 
 interface StorySnippetContext {
   componentName: string;
+  componentImportStatement: string | undefined;
   docgenArgInfo: VueDocgenArgInfo;
 }
 
@@ -69,8 +69,7 @@ interface StoryDocsContext {
 
 type ParsedCsf = ReturnType<ReturnType<typeof loadCsf>['parse']>;
 type ArgsObjectPath = NodePath<t.ObjectExpression>;
-type StoryDocResult = { doc: StoryDoc; imports: string[] };
-type ExtractStoriesResult = { stories: Record<string, StoryDoc>; imports: string[] };
+type ExtractStoriesResult = { stories: Record<string, StoryDoc> };
 type StaticStoryRenderer =
   | { kind: 'h'; argsParam?: string; expression: t.Expression }
   | { kind: 'sfc' }
@@ -79,7 +78,7 @@ type StaticStoryRenderer =
       componentImports: TemplateRenderConfig['componentImports'];
       template: string;
     };
-type StorySnippetResult = { snippet: string; imports: string[] };
+type StorySnippetResult = { snippet: string };
 type StaticStoryArgs =
   | { kind: 'error'; error: NonNullable<StoryDoc['error']> }
   | { kind: 'classified'; classified: ClassifyArgsResult };
@@ -136,23 +135,16 @@ export async function buildStoryDocsPayload(
   );
   const docgenArgInfo =
     docgenPayload && !docgenPayload.error ? vueDocgenArgInfo(docgenPayload) : undefined;
-  const snippet = componentName && docgenArgInfo ? { componentName, docgenArgInfo } : undefined;
+  const snippet =
+    componentName && docgenArgInfo
+      ? { componentName, componentImportStatement: importStatement, docgenArgInfo }
+      : undefined;
   const extracted = extractStories(csf, { snippet, importBindings, metaPath });
-  // meta statement already binds this name (an `@import` override may redirect it)
-  // drop the snippet-derived duplicate.
-  const componentBindingImport = componentName
-    ? importStatementForBinding(componentName, importBindings.get(componentName))
-    : undefined;
-  const snippetImports = extracted.imports.filter((line) => line !== componentBindingImport);
-  const importCode = Array.from(
-    new Set([importStatement, ...snippetImports].filter((line): line is string => Boolean(line)))
-  ).join('\n');
 
   return {
     id,
     name: componentName ?? docgenPayload?.name ?? fallbackTitle(input.entry.title),
     path: storyFilePath,
-    ...(importCode ? { import: importCode } : {}),
     stories: extracted.stories,
   };
 }
@@ -261,7 +253,6 @@ function argsObjectHasSpread(object: t.ObjectExpression | undefined): boolean {
  * Maps every CSF story export to its StoryDoc, enriched with a snippet or error where possible.
  */
 function extractStories(csf: ParsedCsf, options: StoryDocsContext): ExtractStoriesResult {
-  const imports = new Set<string>();
   const stories = Object.fromEntries(
     Object.entries(csf._stories).map(([storyExport, story]): [string, StoryDoc] => {
       const { description, summary } = extractStoryJSDocInfo(csf._storyStatements[storyExport]);
@@ -272,14 +263,11 @@ function extractStories(csf: ParsedCsf, options: StoryDocsContext): ExtractStori
         summary,
       };
       const enriched = enrichStoryDoc(csf, storyExport, storyDoc, options);
-      for (const importStatement of enriched.imports) {
-        imports.add(importStatement);
-      }
-      return [story.id, enriched.doc];
+      return [story.id, enriched];
     })
   );
 
-  return { imports: Array.from(imports), stories };
+  return { stories };
 }
 
 /**
@@ -290,8 +278,8 @@ function enrichStoryDoc(
   storyExport: string,
   storyDoc: StoryDoc,
   options: StoryDocsContext
-): StoryDocResult {
-  const plain: StoryDocResult = { doc: storyDoc, imports: [] };
+): StoryDoc {
+  const plain = storyDoc;
 
   if (!options.snippet) {
     return plain;
@@ -334,9 +322,7 @@ function enrichStoryDoc(
   );
   if (resolved.kind === 'error') {
     // Only the SFC path reports arg errors; render-function stories defer to runtime source.
-    return renderer.kind === 'sfc'
-      ? { doc: { ...storyDoc, error: resolved.error }, imports: [] }
-      : plain;
+    return renderer.kind === 'sfc' ? { ...storyDoc, error: resolved.error } : plain;
   }
 
   const classified = resolved.classified;
@@ -356,12 +342,9 @@ function enrichStoryDoc(
   }
 
   return {
-    doc: {
-      ...storyDoc,
-      snippet: rendered.snippet,
-      ...(classified.warning ? { warning: classified.warning } : {}),
-    },
-    imports: rendered.imports,
+    ...storyDoc,
+    snippet: rendered.snippet,
+    ...(classified.warning ? { warning: classified.warning } : {}),
   };
 }
 
@@ -371,7 +354,10 @@ function staticRendererForRenderFunction(
 ): StaticStoryRenderer | undefined {
   const renderObject = resolveReturnedObjectExpression(renderFunction);
   const templateConfig = renderObject
-    ? readTemplateRenderConfig(renderObject, options.importBindings)
+    ? readTemplateRenderConfig(renderObject, options.importBindings, {
+        componentImportStatement: options.snippet?.componentImportStatement,
+        componentName: options.snippet?.componentName,
+      })
     : undefined;
   if (templateConfig) {
     return { kind: 'template', ...templateConfig };
@@ -434,8 +420,17 @@ function renderStaticStorySnippet(
   docgenArgInfo: VueDocgenArgInfo,
   options: StoryDocsContext
 ): StorySnippetResult | undefined {
+  const componentImportStatement = options.snippet?.componentImportStatement;
+
   if (renderer.kind === 'sfc') {
-    return renderSfcSnippet({ args, componentName, importBindings: options.importBindings });
+    return componentImportStatement
+      ? renderSfcSnippet({
+          args,
+          componentImportStatement,
+          componentName,
+          importBindings: options.importBindings,
+        })
+      : undefined;
   }
 
   if (renderer.kind === 'template') {
@@ -449,6 +444,7 @@ function renderStaticStorySnippet(
   return transformH({
     args,
     argsParam: renderer.argsParam,
+    componentImportStatement,
     componentName,
     docgen: docgenArgInfo,
     importBindings: options.importBindings,

--- a/code/renderers/vue3/src/story-docs/render-primitives.ts
+++ b/code/renderers/vue3/src/story-docs/render-primitives.ts
@@ -213,9 +213,11 @@ export function escapeTextContent(text: string): string {
 
 function renderScript(ctx: RenderContext): string | undefined {
   const importsCode = Object.entries(ctx.imports)
+    .sort(([a], [b]) => a.localeCompare(b))
     .map(([packageName, imports]) => {
       return `import { ${Array.from(imports.values()).sort().join(', ')} } from "${packageName}";`;
     })
+    .concat(Array.from(ctx.componentImports).sort())
     .join('\n');
   const variablesCode = Array.from(ctx.variables.entries())
     .map(([name, value]) => `const ${name} = ${value};`)
@@ -225,8 +227,13 @@ function renderScript(ctx: RenderContext): string | undefined {
     return undefined;
   }
 
+  const scriptCode =
+    importsCode && variablesCode
+      ? `${importsCode}\n\n${variablesCode}`
+      : importsCode || variablesCode;
+
   return `<script lang="ts" setup>
-${importsCode ? `${importsCode}\n\n${variablesCode}` : variablesCode}
+${scriptCode}
 </script>`;
 }
 

--- a/code/renderers/vue3/src/story-docs/render-sfc.test.ts
+++ b/code/renderers/vue3/src/story-docs/render-sfc.test.ts
@@ -91,6 +91,25 @@ import C from './C.vue';
 </template>`);
   });
 
+  it('uses the overridden component import inside function slots', () => {
+    const result = renderSfcSnippet({
+      args: [slot('default', `() => h(C, { label: 'Nested' })`, 'function-slot')],
+      componentImportStatement: "import C from '@example/C.vue';",
+      componentName: 'C',
+      importBindings: new Map([['C', { importId: './C.vue', importName: 'default' }]]),
+    });
+
+    expect(result?.snippet).toBe(`<script lang="ts" setup>
+import C from '@example/C.vue';
+</script>
+
+<template>
+  <C>
+    <C label="Nested" />
+  </C>
+</template>`);
+  });
+
   it('interpolates a hoisted slot value', () => {
     const snippet = render([slot('default', `['a']`, 'hoist')]);
 
@@ -153,7 +172,11 @@ function prop(name: string, code: string, kind: 'hoist' | 'inline' = 'inline'): 
   return { name, value: expression(code), role: 'prop', plan: { kind } };
 }
 
-function slot(name: string, code: string, kind: 'hoist' | 'inline' = 'inline'): ClassifiedArg {
+function slot(
+  name: string,
+  code: string,
+  kind: 'function-slot' | 'hoist' | 'inline' = 'inline'
+): ClassifiedArg {
   return { name, value: expression(code), role: 'slot', plan: { kind } };
 }
 

--- a/code/renderers/vue3/src/story-docs/render-sfc.test.ts
+++ b/code/renderers/vue3/src/story-docs/render-sfc.test.ts
@@ -14,12 +14,20 @@ describe('renderSfcSnippet', () => {
     ['false', ':label="false"'],
     ['null', ':label="null"'],
   ])('%s -> %s', (input, output) => {
-    expect(render([prop('label', input)])).toBe(`<template>\n  <C ${output} />\n</template>`);
+    expect(render([prop('label', input)])).toBe(`<script lang="ts" setup>
+import C from './C.vue';
+</script>
+
+<template>
+  <C ${output} />
+</template>`);
   });
 
   it('hoists a value that needs script scope', () => {
     expect(render([prop('options', `{\n    tone: "neutral"\n}`, 'hoist')]))
       .toBe(`<script lang="ts" setup>
+import C from './C.vue';
+
 const options = {
     tone: "neutral"
 };
@@ -48,6 +56,7 @@ const options = {
 
     expect(snippet).toBe(`<script lang="ts" setup>
 import { ref } from "vue";
+import MyComponent from './MyComponent.vue';
 
 const ariaLabel = {};
 
@@ -68,7 +77,11 @@ const ref2 = {};
   it('renders slots as children and named slots as templates', () => {
     const snippet = render([slot('header', `'Title'`), slot('default', `'Body'`)]);
 
-    expect(snippet).toBe(`<template>
+    expect(snippet).toBe(`<script lang="ts" setup>
+import C from './C.vue';
+</script>
+
+<template>
   <C>
     Body
     <template #header>
@@ -90,7 +103,7 @@ const ref2 = {};
     const snippet = render([slot('default', `'<script>{{ evil }}</script>'`)]);
 
     expect(snippet).toContain('<C>\n    &lt;script&gt;&#123;&#123; evil }}&lt;/script&gt;\n  </C>');
-    expect(snippet).not.toContain('<script lang="ts" setup>');
+    expect(snippet).toContain("import C from './C.vue';");
   });
 
   it('escapes an inlined slot string so it stays text', () => {
@@ -110,6 +123,8 @@ const ref2 = {};
     const snippet = render([event('onSubmit', 'submit', '() => null')]);
 
     expect(snippet).toBe(`<script lang="ts" setup>
+import C from './C.vue';
+
 const onSubmit = () => null;
 </script>
 
@@ -126,10 +141,12 @@ const onSubmit = () => null;
 });
 
 function render(args: ClassifiedArg[], componentName = 'C'): string {
-  return renderSfcSnippet({ componentName, args, importBindings: new Map() })!.snippet.replaceAll(
-    '\r\n',
-    '\n'
-  );
+  return renderSfcSnippet({
+    args,
+    componentImportStatement: `import ${componentName} from './${componentName}.vue';`,
+    componentName,
+    importBindings: new Map(),
+  })!.snippet.replaceAll('\r\n', '\n');
 }
 
 function prop(name: string, code: string, kind: 'hoist' | 'inline' = 'inline'): ClassifiedArg {

--- a/code/renderers/vue3/src/story-docs/render-sfc.ts
+++ b/code/renderers/vue3/src/story-docs/render-sfc.ts
@@ -17,6 +17,8 @@ import { renderSlotArgContent } from './transform-h.ts';
 export interface RenderSfcInput {
   /** Component identifier from CSF meta.component. */
   componentName: string;
+  /** Import statement for the rendered component tag. */
+  componentImportStatement: string;
   /** Classified args to render into the SFC snippet. */
   args: ClassifiedArg[];
   /** Import bindings from the CSF module, used to import components a slot renders. */
@@ -26,13 +28,12 @@ export interface RenderSfcInput {
 export interface RenderSfcResult {
   /** Vue SFC snippet for the docs payload. */
   snippet: string;
-  /** Import statements for components the snippet references. */
-  imports: string[];
 }
 
 /** Render classified CSF args into the same SFC block shape as Vue's runtime source decorator. */
 export function renderSfcSnippet(input: RenderSfcInput): RenderSfcResult | undefined {
   const ctx = createRenderContext();
+  ctx.componentImports.add(input.componentImportStatement);
   const partitioned = partitionArgsByRole(input.args);
   const props = partitioned.props.map((arg) => formatRenderedProp(renderPropLikeArg(arg, ctx)));
   const events = partitioned.events.map((arg) => formatRenderedProp(renderEventArg(arg, ctx)));
@@ -56,7 +57,6 @@ export function renderSfcSnippet(input: RenderSfcInput): RenderSfcResult | undef
 
   return {
     snippet: renderPreparedSfcSnippet({ templateCode, ctx }),
-    imports: Array.from(ctx.componentImports),
   };
 }
 

--- a/code/renderers/vue3/src/story-docs/render-sfc.ts
+++ b/code/renderers/vue3/src/story-docs/render-sfc.ts
@@ -34,13 +34,16 @@ export interface RenderSfcResult {
 export function renderSfcSnippet(input: RenderSfcInput): RenderSfcResult | undefined {
   const ctx = createRenderContext();
   ctx.componentImports.add(input.componentImportStatement);
+  const componentImportStatements = new Map([
+    [input.componentName, input.componentImportStatement],
+  ]);
   const partitioned = partitionArgsByRole(input.args);
   const props = partitioned.props.map((arg) => formatRenderedProp(renderPropLikeArg(arg, ctx)));
   const events = partitioned.events.map((arg) => formatRenderedProp(renderEventArg(arg, ctx)));
 
   const slotSource: string[] = [];
   for (const arg of partitioned.slots) {
-    const rendered = renderSlotArg(arg, ctx, input.importBindings);
+    const rendered = renderSlotArg(arg, ctx, input.importBindings, componentImportStatements);
     // Only function-slot plans fail to render; without their content the snippet would misrepresent
     // the story, so bail and leave it to runtime source.
     if (rendered === undefined) {
@@ -63,8 +66,9 @@ export function renderSfcSnippet(input: RenderSfcInput): RenderSfcResult | undef
 function renderSlotArg(
   arg: ClassifiedSlotArg,
   ctx: RenderContext,
-  importBindings: Map<string, ImportBinding>
+  importBindings: Map<string, ImportBinding>,
+  componentImportStatements: Map<string, string>
 ): string | undefined {
-  const content = renderSlotArgContent(arg, ctx, importBindings);
+  const content = renderSlotArgContent(arg, ctx, importBindings, componentImportStatements);
   return content === undefined ? undefined : wrapSlotContent(arg.name, content);
 }

--- a/code/renderers/vue3/src/story-docs/transform-h.test.ts
+++ b/code/renderers/vue3/src/story-docs/transform-h.test.ts
@@ -36,13 +36,15 @@ function renderStory(
   storySource: string,
   docgen: VueDocgenArgInfo = DEFAULT_DOCGEN,
   importSource = "import MyButton from './MyButton.vue';",
-  metaRender?: string
+  metaRender?: string,
+  componentImportStatement = "import MyButton from './MyButton.vue';"
 ): TransformHResult | undefined {
   const parsed = parseRender(storySource, docgen, importSource, metaRender);
   return parsed.expression
     ? transformH({
         args: parsed.args,
         argsParam: parsed.argsParam,
+        componentImportStatement,
         componentName: 'MyButton',
         docgen,
         importBindings: parsed.importBindings,

--- a/code/renderers/vue3/src/story-docs/transform-h.test.ts
+++ b/code/renderers/vue3/src/story-docs/transform-h.test.ts
@@ -136,7 +136,11 @@ export const Primary = {
 };
 `)?.snippet
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <MyButton active label="Render" />
       </template>"
     `);
@@ -154,7 +158,11 @@ export const Primary = {
 };
 `)?.snippet
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <MyButton active :count="2" label="Override" />
       </template>"
     `);
@@ -175,7 +183,11 @@ export const Primary = {
         `(args) => h(MyButton, args)`
       )?.snippet
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <MyButton active label="Render" />
       </template>"
     `);
@@ -197,7 +209,11 @@ export const Primary = {
         `() => h('div', 'Meta')`
       )?.snippet
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <MyButton active label="Story" />
       </template>"
     `);
@@ -212,6 +228,8 @@ export const Primary = {
 `)?.snippet
     ).toMatchInlineSnapshot(`
       "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+
       const date = new Date('2020-01-01');
 
       const label = \`a\${1}b\`;
@@ -250,7 +268,11 @@ export const Primary = {
 };
 `)?.snippet
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <MyButton>
           <span>Body</span>
           <template #footer>
@@ -273,11 +295,12 @@ export const Primary = {
         "import ChildButton from './ChildButton.vue';\nimport MyButton from './MyButton.vue';"
       )
     ).toEqual({
-      imports: [
-        "import MyButton from './MyButton.vue';",
-        "import ChildButton from './ChildButton.vue';",
-      ],
-      snippet: `<template>
+      snippet: `<script lang="ts" setup>
+import ChildButton from './ChildButton.vue';
+import MyButton from './MyButton.vue';
+</script>
+
+<template>
   <MyButton>
     <ChildButton label="Click me" />
   </MyButton>
@@ -300,7 +323,11 @@ export const Primary = {
         "import ChildButton from './ChildButton.vue';\nimport MyButton from './MyButton.vue';"
       )?.snippet
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import ChildButton from './ChildButton.vue';
+      </script>
+
+      <template>
         <section>
           <div default="Body"></div>
           <ChildButton default="Inner" />
@@ -337,7 +364,12 @@ export const Primary = {
         "import ChildButton from './ChildButton.vue';\nimport MyButton from './MyButton.vue';"
       )?.snippet
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import ChildButton from './ChildButton.vue';
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <MyButton>
           <ChildButton label="Click me" />
         </MyButton>

--- a/code/renderers/vue3/src/story-docs/transform-h.ts
+++ b/code/renderers/vue3/src/story-docs/transform-h.ts
@@ -38,6 +38,8 @@ export interface TransformHInput {
   argsParam?: string;
   /** Story component tag the docgen roles describe. */
   componentName: string;
+  /** Import statement for the story component tag, after any `@import` override. */
+  componentImportStatement?: string;
   /** Docgen roles used to classify values written directly into the render tree. */
   docgen: VueDocgenArgInfo;
   /** Import bindings from the CSF module. */
@@ -47,8 +49,6 @@ export interface TransformHInput {
 export interface TransformHResult {
   /** Vue SFC snippet for the docs payload. */
   snippet: string;
-  /** Import statements for components used by the h tree. */
-  imports: string[];
 }
 
 type HRenderOptions = {
@@ -56,6 +56,7 @@ type HRenderOptions = {
   argsParam?: string;
   /** Story component tag the docgen roles apply to; absent in slot content. */
   componentName?: string;
+  componentImportStatements: Map<string, string>;
   ctx: RenderContext;
   docgen: VueDocgenArgInfo;
   importBindings: Map<string, ImportBinding>;
@@ -102,10 +103,14 @@ const isComponentName = (name: string): boolean => /^[A-Z]/.test(name);
 /** Transform a statically decidable Vue `h()` tree into an SFC snippet. */
 export function transformH(input: TransformHInput): TransformHResult | undefined {
   const ctx = createRenderContext();
+  const componentImportStatements = input.componentImportStatement
+    ? new Map([[input.componentName, input.componentImportStatement]])
+    : new Map<string, string>();
   const templateCode = renderHNode(input.node, {
     args: input.args,
     argsParam: input.argsParam,
     componentName: input.componentName,
+    componentImportStatements,
     ctx,
     docgen: input.docgen,
     importBindings: input.importBindings,
@@ -114,7 +119,6 @@ export function transformH(input: TransformHInput): TransformHResult | undefined
   return templateCode
     ? {
         snippet: renderPreparedSfcSnippet({ templateCode, ctx }),
-        imports: Array.from(ctx.componentImports),
       }
     : undefined;
 }
@@ -123,21 +127,25 @@ export function transformH(input: TransformHInput): TransformHResult | undefined
 export function renderSlotArgContent(
   arg: ClassifiedSlotArg,
   ctx: RenderContext,
-  importBindings: Map<string, ImportBinding>
+  importBindings: Map<string, ImportBinding>,
+  componentImportStatements: Map<string, string> = new Map()
 ): string | undefined {
   if (arg.plan.kind !== 'function-slot') {
     return renderSlotContent(arg, arg.plan, ctx);
   }
 
   const value = unwrapExpression(arg.value);
-  return isFunctionExpression(value) ? renderHSlotFunction(value, ctx, importBindings) : undefined;
+  return isFunctionExpression(value)
+    ? renderHSlotFunction(value, ctx, importBindings, componentImportStatements)
+    : undefined;
 }
 
 /** Render a zero-argument slot function whose body is a static `h()` child tree. */
 function renderHSlotFunction(
   node: t.ArrowFunctionExpression | t.FunctionExpression,
   ctx: RenderContext,
-  importBindings: Map<string, ImportBinding>
+  importBindings: Map<string, ImportBinding>,
+  componentImportStatements: Map<string, string>
 ): string | undefined {
   if (node.params.length > 0) {
     return undefined;
@@ -150,6 +158,7 @@ function renderHSlotFunction(
 
   return renderHNode(returned, {
     args: [],
+    componentImportStatements,
     ctx,
     // Slot content renders children of components the story does not describe, so nothing here can
     // be resolved to a declared slot, event, or v-model.
@@ -235,7 +244,9 @@ function renderTag(node: t.Node | undefined | null, options: HRenderOptions): HT
  * compile where a reader pastes it.
  */
 function componentTag(name: string, options: HRenderOptions): HTag | undefined {
-  const importStatement = importStatementForBinding(name, options.importBindings.get(name));
+  const importStatement =
+    options.componentImportStatements.get(name) ??
+    importStatementForBinding(name, options.importBindings.get(name));
   if (!importStatement) {
     return undefined;
   }
@@ -295,7 +306,12 @@ function renderProps(
   ];
   const slotChildren: string[] = [];
   for (const slot of partitioned.slots) {
-    const content = renderSlotArgContent(slot, options.ctx, options.importBindings);
+    const content = renderSlotArgContent(
+      slot,
+      options.ctx,
+      options.importBindings,
+      options.componentImportStatements
+    );
     // A function slot without renderable content would misrepresent the story, so bail.
     if (content === undefined) {
       return undefined;
@@ -437,7 +453,12 @@ function renderSlotsObject(
       return undefined;
     }
 
-    const content = renderHSlotFunction(slotFunction, options.ctx, options.importBindings);
+    const content = renderHSlotFunction(
+      slotFunction,
+      options.ctx,
+      options.importBindings,
+      options.componentImportStatements
+    );
     if (content === undefined) {
       return undefined;
     }

--- a/code/renderers/vue3/src/story-docs/transform-template.test.ts
+++ b/code/renderers/vue3/src/story-docs/transform-template.test.ts
@@ -110,6 +110,8 @@ export const Primary = {
 `)
     ).toMatchInlineSnapshot(`
       "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+
       const onClick = () => {};
       </script>
 
@@ -132,7 +134,11 @@ export const Primary = {
 };
 `)
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <MyButton modelValue="Typed text" />
       </template>"
     `);
@@ -169,7 +175,11 @@ export const Primary = {
 };
 `)
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <div class="wrap"><!-- keep --><MyButton disabled label="Hi" data-x="a &amp; b" /></div>
       </template>"
     `);
@@ -190,7 +200,11 @@ export const Primary = {
 };
 `)
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <div>
           <MyButton label="Hi" />
         </div>
@@ -250,6 +264,8 @@ export const Primary = {
 `)
     ).toMatchInlineSnapshot(`
       "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+
       const options = { density: 'compact' };
       </script>
 
@@ -272,7 +288,11 @@ export const Primary = {
 };
 `)
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <MyButton label='say "hi"' />
       </template>"
     `);
@@ -291,7 +311,11 @@ export const Primary = {
 };
 `)
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <MyButton label="Hi"><template #header>Static header</template></MyButton>
       </template>"
     `);
@@ -311,6 +335,8 @@ export const Primary = {
 `)
     ).toMatchInlineSnapshot(`
       "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+
       const onClick = () => {};
       </script>
 
@@ -335,6 +361,7 @@ export const Primary = {
     ).toMatchInlineSnapshot(`
       "<script lang="ts" setup>
       import { ref } from "vue";
+      import MyButton from './MyButton.vue';
 
       const modelValue = ref('Typed text');
       </script>
@@ -363,6 +390,7 @@ export const Primary = {
     ).toMatchInlineSnapshot(`
       "<script lang="ts" setup>
       import { ref } from "vue";
+      import MyButton from './MyButton.vue';
 
       const modelValue = ref('Typed text');
 
@@ -495,6 +523,8 @@ export const Primary = {
 `)
     ).toMatchInlineSnapshot(`
       "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+
       const label = 'Tom &amp; Jerry';
       </script>
 
@@ -565,7 +595,11 @@ export const Primary = {
 };
 `)
     ).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
         <section><MyButton label="Hi" /></section>
       </template>"
     `);
@@ -603,9 +637,13 @@ export const Primary = {
       "import MyButton from './MyButton.vue';\nimport OtherButton from './OtherButton.vue';"
     );
 
-    expect(payload?.import).toContain("import OtherButton from './OtherButton.vue';");
+    expect(payload.import).toBeUndefined();
     expect(payload.stories['example-mybutton--primary']?.snippet).toMatchInlineSnapshot(`
-      "<template>
+      "<script lang="ts" setup>
+      import OtherButton from './OtherButton.vue';
+      </script>
+
+      <template>
         <other-button label="Saved" />
       </template>"
     `);

--- a/code/renderers/vue3/src/story-docs/transform-template.ts
+++ b/code/renderers/vue3/src/story-docs/transform-template.ts
@@ -37,6 +37,13 @@ export interface TemplateRenderConfig {
   componentImports: Map<string, string>;
 }
 
+export interface ReadTemplateRenderConfigOptions {
+  /** Meta component identifier from CSF meta.component. */
+  componentName?: string;
+  /** Import statement for the meta component, after any `@import` override. */
+  componentImportStatement?: string;
+}
+
 export interface TransformTemplateInput {
   /** Static Vue template markup from a render object. */
   template: string;
@@ -49,8 +56,6 @@ export interface TransformTemplateInput {
 export interface TransformTemplateResult {
   /** Vue SFC snippet for the docs payload. */
   snippet: string;
-  /** Import statements for components actually used by the transformed template. */
-  imports: string[];
 }
 
 interface Edit {
@@ -63,7 +68,6 @@ interface TransformState {
   argsByName: Map<string, ClassifiedArg>;
   ctx: RenderContext;
   edits: Edit[];
-  usedImports: Set<string>;
   componentImports: Map<string, string>;
   template: string;
 }
@@ -76,7 +80,8 @@ const SETUP_PROPERTY = 'setup';
 /** Read a transformable template-render object without resolving the render function itself. */
 export function readTemplateRenderConfig(
   renderObject: t.ObjectExpression,
-  importBindings: Map<string, ImportBinding>
+  importBindings: Map<string, ImportBinding>,
+  options: ReadTemplateRenderConfigOptions = {}
 ): TemplateRenderConfig | undefined {
   if (!hasOnlySupportedRenderProperties(renderObject)) {
     return undefined;
@@ -94,7 +99,8 @@ export function readTemplateRenderConfig(
 
   const componentImports = readComponentImports(
     propertyValue(renderObject, 'components'),
-    importBindings
+    importBindings,
+    options
   );
   return componentImports ? { template, componentImports } : undefined;
 }
@@ -121,7 +127,6 @@ export function transformTemplate(
     argsByName: new Map(input.args.map((arg) => [arg.name, arg])),
     ctx: createRenderContext(),
     edits: [],
-    usedImports: new Set(),
     componentImports: input.componentImports,
     template: input.template,
   };
@@ -135,7 +140,6 @@ export function transformTemplate(
       templateCode: applyEdits(input.template, state.edits),
       ctx: state.ctx,
     }),
-    imports: Array.from(state.usedImports),
   };
 }
 
@@ -195,7 +199,7 @@ function transformElement(node: ElementNode, state: TransformState): boolean {
 
   const importStatement = componentImportForTag(node.tag, state.componentImports);
   if (importStatement) {
-    state.usedImports.add(importStatement);
+    state.ctx.componentImports.add(importStatement);
   }
 
   const nameCounts = attributeNameCounts(node);
@@ -393,9 +397,13 @@ function hasOnlySupportedRenderProperties(renderObject: t.ObjectExpression): boo
 // { Button, 'my-button': Button }
 function readComponentImports(
   value: t.Node | undefined,
-  importBindings: Map<string, ImportBinding>
+  importBindings: Map<string, ImportBinding>,
+  options: ReadTemplateRenderConfigOptions
 ): Map<string, string> | undefined {
   const componentImports = new Map<string, string>();
+  if (options.componentName && options.componentImportStatement) {
+    componentImports.set(options.componentName, options.componentImportStatement);
+  }
   if (!value) {
     return componentImports;
   }
@@ -414,10 +422,10 @@ function readComponentImports(
       return undefined;
     }
 
-    const importStatement = importStatementForBinding(
-      component.name,
-      importBindings.get(component.name)
-    );
+    const importStatement =
+      component.name === options.componentName
+        ? options.componentImportStatement
+        : importStatementForBinding(component.name, importBindings.get(component.name));
     if (!importStatement) {
       return undefined;
     }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR remove the usage of `import` in story-docs payload to have the vue integration directly inject the component import into the script tag. 

this prevents such kind of code snippet being displayed

<img width="1510" height="530" alt="image" src="https://github.com/user-attachments/assets/f4c9d930-01d7-40e8-b998-e698ac82fc0a" />


<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

---

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
