### PR TITLE
Angular: Skip the runtime source decorator when the docgen server produces snippets

### DIFF
--- a/code/frameworks/angular-vite/src/client/docs/config.test.ts
+++ b/code/frameworks/angular-vite/src/client/docs/config.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const languageWithFeatures = async (features: Record<string, boolean> | undefined) => {
+const configWithFeatures = async (features: Record<string, boolean> | undefined) => {
   vi.stubGlobal('FEATURES', features);
   vi.resetModules();
-  const { parameters } = await import('./config.ts');
-  return parameters.docs.source.language;
+  const { parameters, decorators } = await import('./config.ts');
+  return { language: parameters.docs.source.language, decorators };
 };
+
+const featureOffCases: [string, Record<string, boolean> | undefined][] = [
+  ['the feature is off', { experimentalDocgenServer: false }],
+  ['no features are set', undefined],
+];
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -14,13 +19,26 @@ afterEach(() => {
 
 describe('docs source parameters', () => {
   it('labels the snippet TypeScript when the docgen server produces it', async () => {
-    expect(await languageWithFeatures({ experimentalDocgenServer: true })).toBe('ts');
+    expect((await configWithFeatures({ experimentalDocgenServer: true })).language).toBe('ts');
   });
 
-  it.each([
-    ['the feature is off', { experimentalDocgenServer: false }],
-    ['no features are set', undefined],
-  ])('labels the runtime template HTML when %s', async (_name, features) => {
-    expect(await languageWithFeatures(features)).toBe('html');
+  it.each(featureOffCases)('labels the runtime template HTML when %s', async (_name, features) => {
+    expect((await configWithFeatures(features)).language).toBe('html');
   });
+});
+
+describe('docs decorators', () => {
+  it('drops the runtime source decorator when the docgen server produces snippets', async () => {
+    expect((await configWithFeatures({ experimentalDocgenServer: true })).decorators).toEqual([]);
+  });
+
+  it.each(featureOffCases)(
+    'keeps the runtime source decorator when %s',
+    async (_name, features) => {
+      const { decorators } = await configWithFeatures(features);
+      const { sourceDecorator } = await import('./sourceDecorator.ts');
+
+      expect(decorators).toEqual([sourceDecorator]);
+    }
+  );
 });

--- a/code/frameworks/angular-vite/src/client/docs/config.ts
+++ b/code/frameworks/angular-vite/src/client/docs/config.ts
@@ -7,15 +7,15 @@ import { sourceDecorator } from './sourceDecorator';
 // the TypeScript host component that renders the story; without it they show the template the
 // runtime source decorator builds. Read at module scope because the preview's <head> assigns
 // `FEATURES` from a blocking script, before any preview module evaluates.
-const language = globalThis.FEATURES?.experimentalDocgenServer ? 'ts' : 'html';
+const useStaticServiceSnippets = globalThis.FEATURES?.experimentalDocgenServer === true;
 
 export const parameters: Parameters = {
   docs: {
     source: {
       type: SourceType.DYNAMIC,
-      language,
+      language: useStaticServiceSnippets ? 'ts' : 'html',
     },
   },
 };
 
-export const decorators: DecoratorFunction[] = [sourceDecorator];
+export const decorators: DecoratorFunction[] = useStaticServiceSnippets ? [] : [sourceDecorator];


### PR DESCRIPTION
Follow-up to #35807.

## What I did

With `experimentalDocgenServer` on, Angular produces two different code snippets for the same story: the story-docs snippet the server builds (a TypeScript host component) and the HTML template the runtime `sourceDecorator` computes in a post-render effect.
Both are pushed to the manager over the same `SNIPPET_RENDERED` channel event.
The Source block is safe because it reads the story-docs service directly and prefers it, but the Code panel keeps whichever event arrives last, so what it shows depends on which emit wins the race - while the panel is labelled `ts` either way.

This gates the decorator on the feature flag, the way `@storybook/react` already gates `jsxDecorator`, so exactly one producer is registered.

### Before

```
experimentalDocgenServer: true

core/story-docs (server)          ┌────────────▶ Source block ─── serviceSnippet || snippet ──▶ TS host component
  TS host component ── beforeEach ┤
                  emitTransformCode└──┐
                                      ├── last SNIPPET_RENDERED wins ──▶ Code panel ──▶ whichever landed second
sourceDecorator ─────── useEffect ────┘
  <my-cmp [label]="…">
                  emitTransformCode
```

### After

```
experimentalDocgenServer: true            experimentalDocgenServer: false

core/story-docs (server)                  sourceDecorator
  TS host component, or                     <my-cmp [label]="…">
  parameters.docs.source.originalSource
        │ beforeEach                              │ useEffect
        │ emitTransformCode                       │ emitTransformCode
        ├──▶ Source block                         ├──▶ Source block
        └──▶ Code panel                           └──▶ Code panel
```

The decision, in `code/frameworks/angular-vite/src/client/docs/config.ts`:

```diff
-const language = globalThis.FEATURES?.experimentalDocgenServer ? 'ts' : 'html';
+const useStaticServiceSnippets = globalThis.FEATURES?.experimentalDocgenServer === true;

 export const parameters: Parameters = {
   docs: {
     source: {
       type: SourceType.DYNAMIC,
-      language,
+      language: useStaticServiceSnippets ? 'ts' : 'html',
     },
   },
 };

-export const decorators: DecoratorFunction[] = [sourceDecorator];
+export const decorators: DecoratorFunction[] = useStaticServiceSnippets ? [] : [sourceDecorator];
```

### What no longer holds

With the docgen server on, the runtime template no longer reaches the Source block or the Code panel at all, under any timing.
For a story the analyzer produces no snippet for, both surfaces now fall back to raw CSF (`parameters.docs.source.originalSource`, emitted by the same `beforeEach` hook) instead of the runtime template.
That is the same trade-off `@storybook/react` already makes under this flag.

With the flag off, nothing changes.

### What a bad run looks like

Reverting the decorator gate while keeping the tests:

```
 FAIL  src/client/docs/config.test.ts > docs decorators > drops the runtime source decorator when the docgen server produces snippets
AssertionError: expected [ [Function sourceDecorator] ] to deeply equal []

- Expected
+ Received

- []
+ [
+   [Function sourceDecorator],
+ ]
```

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run the docgen-server sandbox: `yarn task --task sandbox --start-from auto --template angular-vite/docgen-server-ts`
2. The Code panel is opt-in, so add it to the sandbox's `.storybook/preview.ts`:
   ```ts
   export const parameters = { docs: { codePanel: true } };
   ```
3. Open **Example / Button → Primary** and select the **Code** panel.
4. The panel shows the TypeScript host component (a `@Component` class binding the story's args), highlighted as TypeScript. It must never show the `<storybook-button …>` HTML template, and it must not flip between the two across reloads or navigation between stories.
5. Open the **Docs** tab for the same component and expand **Show code** under the story. It shows the same TypeScript host component.
6. Run the stock sandbox: `yarn task --task sandbox --start-from auto --template angular-vite/default-ts`
7. Repeat steps 2-5. Both surfaces now show the `<storybook-button …>` HTML template, highlighted as HTML, exactly as before this PR.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation change: this is internal wiring behind the experimental `experimentalDocgenServer` flag, and the user-facing behaviour it describes (server snippets replace the runtime template) is what was already documented.
