### PR TITLE
Core: Omit __proto__ from URL args instead of replacing the prototype

### DIFF
--- a/code/core/src/preview-api/modules/preview-web/parseArgsParam.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/parseArgsParam.test.ts
@@ -181,6 +181,14 @@ describe('parseArgsParam', () => {
       expect(parseArgsParam('obj.a!b:val')).toStrictEqual({});
     });
 
+    it('omits __proto__, which would otherwise replace the prototype', () => {
+      // `toStrictEqual` compares prototypes, so these also pin that the
+      // returned object is still a plain object.
+      expect(parseArgsParam('__proto__:val')).toStrictEqual({});
+      expect(parseArgsParam('__proto__[]:1;__proto__[]:2')).toStrictEqual({});
+      expect(parseArgsParam('__proto__:val;key:val')).toStrictEqual({ key: 'val' });
+    });
+
     it('completely omits an arg when a (deeply) nested key is invalid', () => {
       expect(parseArgsParam('obj.foo.a!b:val;obj.foo.bar:val;obj.baz:val')).toStrictEqual({});
       expect(parseArgsParam('obj.foo.a!b:val;key:val')).toStrictEqual({ key: 'val' });

--- a/code/core/src/preview-api/modules/preview-web/parseArgsParam.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/parseArgsParam.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { once } from 'storybook/internal/client-logger';
+
 import { parseArgsParam } from './parseArgsParam.ts';
 
 vi.mock('storybook/internal/client-logger', () => ({
@@ -181,12 +183,26 @@ describe('parseArgsParam', () => {
       expect(parseArgsParam('obj.a!b:val')).toStrictEqual({});
     });
 
-    it('omits __proto__, which would otherwise replace the prototype', () => {
-      // `toStrictEqual` compares prototypes, so these also pin that the
-      // returned object is still a plain object.
+    it('omits __proto__ and warns, instead of replacing the prototype', () => {
+      const warn = vi.mocked(once.warn);
+
+      warn.mockClear();
       expect(parseArgsParam('__proto__:val')).toStrictEqual({});
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Omitted potentially unsafe URL args.')
+      );
+
+      warn.mockClear();
       expect(parseArgsParam('__proto__[]:1;__proto__[]:2')).toStrictEqual({});
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Omitted potentially unsafe URL args.')
+      );
+
+      warn.mockClear();
       expect(parseArgsParam('__proto__:val;key:val')).toStrictEqual({ key: 'val' });
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Omitted potentially unsafe URL args.')
+      );
     });
 
     it('completely omits an arg when a (deeply) nested key is invalid', () => {

--- a/code/core/src/preview-api/modules/preview-web/parseArgsParam.ts
+++ b/code/core/src/preview-api/modules/preview-web/parseArgsParam.ts
@@ -20,11 +20,8 @@ const validateArgs = (key = '', value: unknown): boolean => {
     return false;
   }
 
-  // `__proto__` passes VALIDATION_REGEXP because underscores are allowed, but
-  // writing it back with `Object.assign` reaches the setter inherited from
-  // `Object.prototype`: the arg never becomes an entry and the object's own
-  // prototype is replaced instead. Reject it so it takes the same warning path
-  // as any other unsafe key.
+  // `__proto__` passes VALIDATION_REGEXP, but assigning it back reaches the
+  // setter inherited from `Object.prototype` instead of adding an entry.
   if (key === '__proto__') {
     return false;
   }

--- a/code/core/src/preview-api/modules/preview-web/parseArgsParam.ts
+++ b/code/core/src/preview-api/modules/preview-web/parseArgsParam.ts
@@ -20,6 +20,15 @@ const validateArgs = (key = '', value: unknown): boolean => {
     return false;
   }
 
+  // `__proto__` passes VALIDATION_REGEXP because underscores are allowed, but
+  // writing it back with `Object.assign` reaches the setter inherited from
+  // `Object.prototype`: the arg never becomes an entry and the object's own
+  // prototype is replaced instead. Reject it so it takes the same warning path
+  // as any other unsafe key.
+  if (key === '__proto__') {
+    return false;
+  }
+
   if (value === null || value === undefined) {
     return true;
   } // encoded as `!null` or `!undefined` // encoded as `!null` or `!undefined`


### PR DESCRIPTION
## What?

Prevents `__proto__` from being accepted as a key when parsing URL args in `parseArgsParam`.

URL arg names are validated by `validateArgs`, which currently allows underscores. As a result, `__proto__` passes validation and eventually reaches:

```ts
Object.assign(acc, { [key]: value })
```

Assigning that key to a regular object invokes the inherited `__proto__` setter instead of creating an own property.

This leads to two observable cases:

* a scalar `__proto__` arg is silently omitted
* an array-valued `__proto__` arg can replace the prototype of the resulting args object with an array

The change treats `__proto__` the same way as other rejected URL arg keys and omits it before it reaches `Object.assign`.

## Why?

URL arg names are user-controlled, so they should not be able to alter the prototype of the object used to store parsed args.

This is specific to `__proto__`. Other names inherited from `Object.prototype`, such as `constructor`, `toString`, `valueOf`, and `hasOwnProperty`, are assigned as regular own properties here and do not exhibit the same behavior.

## Tests

Added a regression test to the existing key-sanitization coverage in `parseArgsParam.test.ts`.

The test fails without the fix because the resulting object has an unexpected array prototype, and passes with the change.

Validated the relevant test files with Vitest:

```text
78 tests passed
```

I did not run the repository lint command because it requires the full Yarn workspace setup.

I also looked at the sibling logic in `router/utils.ts`, which carries the same synchronization comment. Adding the guard to `validateArgs` there would be dead code: `deepDiff` runs first, and its own `Object.assign(acc, { [key]: diff })` on line 73 swallows the key before `validateArgs` ever sees it, so `buildArgsParam` returns the same string either way. Worth flagging that line 73 has the same hazard, and for the array-valued case the object `deepDiff` returns does come back with an array prototype. I left it out to keep this PR to the path I can reproduce end to end, but I'm happy to cover that one too if you would like it in scope.


### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run any sandbox, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open a story that takes args and copy its URL
3. Append `&args=__proto__[]:1;__proto__[]:2`, reload, and keep the preview console open

On `next` the key passes `validateArgs`, so it is applied through `Object.assign` and the object holding the parsed args comes back with an array on its prototype chain, with nothing logged. With this change the key is rejected like any other unsafe key: the arg is ignored and `Omitted potentially unsafe URL args.` is logged.

`&args=__proto__:1` covers the scalar case, which is dropped silently on `next` and logged with this change.
