### PR TITLE
React: Resolve (typeof array)[number] indexed access in react-component-meta

### DIFF
--- a/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.props.test.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.props.test.ts
@@ -143,6 +143,31 @@ describe('prop extraction', () => {
         },
       });
     });
+
+    it('resolves (typeof constArray)[number] to a literal union', async () => {
+      const entry = await extract(
+        'Box',
+        dedent`
+          import React from 'react';
+          const SCALE = ['sm', 'md', 'lg'] as const;
+          type Size = (typeof SCALE)[number];
+          export function Box({ size = 'md' }: { size?: Size }) {
+            return <div data-size={size} />;
+          }
+        `
+      );
+
+      expect(entry.component?.reactComponentMeta).toMatchObject({
+        props: {
+          size: {
+            type: {
+              name: 'enum',
+              value: [{ value: '"sm"' }, { value: '"md"' }, { value: '"lg"' }],
+            },
+          },
+        },
+      });
+    });
   });
 
   describe('union types', () => {

--- a/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
@@ -735,7 +735,32 @@ function serializeType(
       nonUndefinedTypes.length === 1 &&
       nonUndefinedTypes.length < type.types.length
     ) {
-      return { name: checker.typeToString(nonUndefinedTypes[0]) };
+      return serializeType(typescript, checker, nonUndefinedTypes[0], isRequired, depth + 1);
+    }
+  }
+
+  // `(typeof SCALE)[number]` and similar indexed-access aliases stringify as
+  // `unknown[number]` unless we evaluate them to the apparent type first.
+  if (type.flags & typescript.TypeFlags.IndexedAccess) {
+    const indexedAccess = type as ts.IndexedAccessType;
+    const apparent = checker.getApparentType(type);
+    if (apparent !== type && (apparent.flags & typescript.TypeFlags.IndexedAccess) === 0) {
+      return serializeType(typescript, checker, apparent, isRequired, depth + 1);
+    }
+
+    const objectType = checker.getApparentType(indexedAccess.objectType);
+    const { indexType } = indexedAccess;
+    const indexKind =
+      indexType.flags & typescript.TypeFlags.NumberLike
+        ? typescript.IndexKind.Number
+        : indexType.flags & typescript.TypeFlags.StringLike
+          ? typescript.IndexKind.String
+          : undefined;
+    if (indexKind !== undefined) {
+      const indexed = checker.getIndexTypeOfType(objectType, indexKind);
+      if (indexed) {
+        return serializeType(typescript, checker, indexed, isRequired, depth + 1);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- `serializeType` stringified unevaluated indexed-access types as `unknown[number]`, so autodocs showed an object control instead of a select.
- Optional aliases like `type Size = (typeof SCALE)[number]` are now evaluated to the apparent type / index type (a literal union) before stringifying.

Fixes https://github.com/storybookjs/storybook/issues/35680

## Test plan
- [x] Added a prop-extraction fixture for `const SCALE = ['sm', 'md', 'lg'] as const; type Size = (typeof SCALE)[number]`
- [ ] Enable `features.experimentalReactComponentMeta` and confirm the Box autodocs `size` prop is a union/select, not `unknown[number]`


Made with [Cursor](https://cursor.com)