### PR TITLE
React: Defer jsxDecorator source extraction behind the skip guard

### DIFF
--- a/code/renderers/react/src/docs/jsxDecorator.test.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.test.tsx
@@ -379,6 +379,40 @@ describe('jsxDecorator', () => {
     expect(result).toEqual(<div>Test Story</div>);
   });
 
+  it('does not re-invoke the story function when JSX rendering is skipped', () => {
+    const originalStoryFn = vi.fn().mockReturnValue(<div>Test Story</div>);
+    const context = {
+      ...mockContext,
+      parameters: {
+        docs: { source: { type: 'code' } },
+      },
+      originalStoryFn,
+    };
+
+    jsxDecorator(mockStoryFn, context);
+
+    // Source extraction is skipped, so the story function must not be invoked
+    // a second time just to capture JSX for a snippet nobody consumes.
+    expect(originalStoryFn).not.toHaveBeenCalled();
+    expect(mockedEmitTransformCode).not.toHaveBeenCalled();
+  });
+
+  it('re-invokes the story function once to extract source when not skipped', () => {
+    const originalStoryFn = vi.fn().mockReturnValue(<div>Test Story</div>);
+    const context = {
+      ...mockContext,
+      parameters: {
+        __isArgsStory: true,
+      },
+      originalStoryFn,
+    };
+
+    jsxDecorator(mockStoryFn, context as any);
+
+    expect(originalStoryFn).toHaveBeenCalledTimes(1);
+    expect(mockedEmitTransformCode).toHaveBeenCalled();
+  });
+
   it('should skip JSX rendering when source code is provided', () => {
     const context = {
       ...mockContext,

--- a/code/renderers/react/src/docs/jsxDecorator.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.tsx
@@ -257,19 +257,24 @@ export const jsxDecorator = (
 
   const skip = skipJsxRender(context);
 
-  const options = {
-    ...defaultOpts,
-    ...(context?.parameters.jsx || {}),
-    parentComponent: context?.component,
-  } as Required<JSXOptions>;
-
-  const storyJsx = context.originalStoryFn(context.args, context);
-
   useEffect(() => {
     if (skip) {
       return;
     }
 
+    // Capturing the JSX source re-invokes the story function and walks the
+    // rendered tree to serialize it. That work is only needed when a snippet
+    // is actually consumed, so it's deferred into the effect behind the `skip`
+    // guard — otherwise every commit (state changes, scrolling, animation
+    // frames) pays for a second story invocation and a full tree walk even
+    // when no source is rendered.
+    const options = {
+      ...defaultOpts,
+      ...(context?.parameters.jsx || {}),
+      parentComponent: context?.component,
+    } as Required<JSXOptions>;
+
+    const storyJsx = context.originalStoryFn(context.args, context);
     const sourceJsx = mdxToJsx(storyJsx);
 
     const rendered = renderJsx(sourceJsx, options);


### PR DESCRIPTION
## What I did

Addresses part of #34598.

`jsxDecorator` is registered as a global decorator by `addon-docs`, so it runs for every story on every commit. Today it re-invokes the story function a second time (`context.originalStoryFn(...)`) and computes `options` on every render, *before* the `useEffect` — while the `skip` guard is only checked *inside* the effect. So a story with `docs.source.type: 'code'`, a non-args story, or a portable story (all `skipJsxRender === true`) still pays for a second full story invocation on every state change, scroll, or animation frame, even though nothing consumes the resulting snippet.

### The change

Move the `options` object and the `context.originalStoryFn(...)` capture (plus the `mdxToJsx`/`renderJsx` work that was already there) inside the effect, after the `if (skip) return`. `storyJsx` and `options` are only used to produce the source snippet, so nothing observable changes — the source is still extracted and emitted identically whenever `skip` is `false` (Docs tab, args stories, the story-view Code panel). The only difference is that skipped stories no longer re-invoke the story function or walk the tree.

This is a focused, behavior-preserving trim in the same spirit as the `__isPortableStory` early-out already in `skipJsxRender`.

## How to test

Added two unit tests in `jsxDecorator.test.tsx`:
- when JSX rendering is skipped, `originalStoryFn` is not called (fails on `next`, passes with the fix);
- when it's not skipped (args story), `originalStoryFn` is still called exactly once and the source is emitted (regression guard).

```
nx test react -- jsxDecorator
```

## Note / follow-up

This does not yet cover the reporter's other ask — a *plain args story with the Docs tab closed* in the default config still has `skip === false`, so it keeps extracting on every commit (the story-view Code panel and pre-warming the Docs snippet legitimately want it). Fully addressing that (lazy/on-demand extraction when the panel isn't visible, or an addon-level opt-out) is a larger design change; happy to follow up on it separately if you'd like a direction.

<!-- AI disclosure -->
This change was prepared with AI assistance (analysis, patch and tests); authored and verified by me.
