### PR TITLE
Vue: Deprecate vue-docgen-api

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -533,9 +533,18 @@
 
 ### Vue 3: `vue-docgen-api` is deprecated
 
-`vue-docgen-api` is the docgen engine `@storybook/vue3-vite` uses to document props, events, slots and exposes. It is deprecated and will be removed in Storybook 12, leaving [`vue-component-meta`](https://github.com/vuejs/language-tools/tree/master/packages/component-meta) — the extractor maintained by the Vue team — as the only engine. It documents more of your components: `.ts`, `.tsx`, `.js` and `.jsx` components as well as SFCs, named exports next to default ones, and richer prop, event, slot and exposed types.
+`vue-docgen-api` is the docgen engine `@storybook/vue3-vite` uses to document props, events, slots and exposes. It is deprecated and will be removed in the next major version of Storybook, leaving [`vue-component-meta`](https://github.com/vuejs/language-tools/tree/master/packages/component-meta) — the extractor maintained by the Vue team — as the only engine. It documents more of your components: `.ts`, `.tsx`, `.js` and `.jsx` components as well as SFCs, named exports next to default ones, and richer prop, event, slot and exposed types.
 
-`vue-docgen-api` is still the default, so Storybook logs the deprecation whenever it runs, including when you never set the `docgen` framework option. Switch to the supported engine:
+`vue-docgen-api` is still the default, so Storybook logs the deprecation whenever it runs, including when you never set the `docgen` framework option.
+
+The path we recommend is server-side docgen, which becomes the default in Storybook 11. It runs `vue-component-meta` on the Storybook server instead of in the builder, and also feeds the component manifest that AI agents read:
+
+```ts
+// .storybook/main.ts
+features: { experimentalDocgenServer: true },
+```
+
+To stay on builder-side docgen for now, select the engine explicitly instead:
 
 ```ts
 // .storybook/main.ts

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,7 @@
 <h1>Migration</h1>
 
 - [From version 10.5.x to 10.6.0](#from-version-105x-to-1060)
+  - [Vue 3: `vue-docgen-api` is deprecated](#vue-3-vue-docgen-api-is-deprecated)
   - [Experimental Playwright CT integration removed](#experimental-playwright-ct-integration-removed)
   - [`@storybook/csf-plugin` removed](#storybookcsf-plugin-removed)
 - [From version 10.4.0 to 10.5.0](#from-version-1040-to-1050)
@@ -529,6 +530,38 @@
   - [Deprecated embedded addons](#deprecated-embedded-addons)
 
 ## From version 10.5.x to 10.6.0
+
+### Vue 3: `vue-docgen-api` is deprecated
+
+`vue-docgen-api` is the docgen engine `@storybook/vue3-vite` uses to document props, events, slots and exposes. It is deprecated and will be removed in Storybook 12, leaving [`vue-component-meta`](https://github.com/vuejs/language-tools/tree/master/packages/component-meta) — the extractor maintained by the Vue team — as the only engine. It documents more of your components: `.ts`, `.tsx`, `.js` and `.jsx` components as well as SFCs, named exports next to default ones, and richer prop, event, slot and exposed types.
+
+`vue-docgen-api` is still the default, so Storybook logs the deprecation whenever it runs, including when you never set the `docgen` framework option. Switch to the supported engine:
+
+```ts
+// .storybook/main.ts
+framework: {
+  name: '@storybook/vue3-vite',
+  options: {
+    docgen: 'vue-component-meta',
+  },
+},
+```
+
+If your main `tsconfig.json` only references other tsconfig files, such as `tsconfig.app.json`, point the engine at the one that resolves your components, or import aliases will not resolve:
+
+```ts
+// .storybook/main.ts
+framework: {
+  name: '@storybook/vue3-vite',
+  options: {
+    docgen: { plugin: 'vue-component-meta', tsconfig: 'tsconfig.app.json' },
+  },
+},
+```
+
+`docgen: true` is an alias for `vue-docgen-api` and is deprecated with it. `docgen: false`, which turns docgen off entirely, is unaffected and logs nothing.
+
+The two engines emit different `__docgenInfo` shapes. Storybook's own argTypes extraction handles both, but code of yours that reads `__docgenInfo` directly needs updating: the `expose` entries become `exposed`, and props, events and slots carry `vue-component-meta`'s type information. The `VueDocgenInfo` and `VueDocgenInfoEntry` types exported from `@storybook/vue3` are parameterized by engine (`VueDocgenInfo<'vue-component-meta'>`) to help with that.
 
 ### Angular Vite: a new `propsTable` framework option
 

--- a/code/frameworks/vue3-vite/src/docgen/options.ts
+++ b/code/frameworks/vue3-vite/src/docgen/options.ts
@@ -4,6 +4,10 @@ import type { FrameworkOptions, VueDocgenPlugin } from '../types.ts';
 
 export const VUE_COMPONENT_META = 'vue-component-meta' satisfies VueDocgenPlugin;
 
+export const VUE_DOCGEN_API_DEPRECATION =
+  `\`vue-docgen-api\` is deprecated and will be removed in Storybook 12. It is still the default docgen engine, so this also applies when you have not set the \`docgen\` framework option. ` +
+  `Switch to \`vue-component-meta\`, with \`framework: { name: '@storybook/vue3-vite', options: { docgen: 'vue-component-meta' } }\` in your \`.storybook/main.ts\`.`;
+
 export type ResolvedDocgenOptions = false | { plugin: VueDocgenPlugin; tsconfig?: string };
 
 export interface DocgenContext {

--- a/code/frameworks/vue3-vite/src/docgen/options.ts
+++ b/code/frameworks/vue3-vite/src/docgen/options.ts
@@ -6,7 +6,8 @@ export const VUE_COMPONENT_META = 'vue-component-meta' satisfies VueDocgenPlugin
 
 export const VUE_DOCGEN_API_DEPRECATION =
   `\`vue-docgen-api\` is deprecated and will be removed in the next major release of Storybook. It is still the default docgen engine, so this also applies when you have not set the \`docgen\` framework option. ` +
-  `Switch to \`vue-component-meta\`, with \`framework: { name: '@storybook/vue3-vite', options: { docgen: 'vue-component-meta' } }\` in your \`.storybook/main.ts\`.`;
+  `Enable server-side docgen with \`features: { experimentalDocgenServer: true }\` in your \`.storybook/main.ts\`, which becomes the default in Storybook 11, ` +
+  `or set \`framework: { name: '@storybook/vue3-vite', options: { docgen: 'vue-component-meta' } }\` to keep docgen in the builder.`;
 
 export type ResolvedDocgenOptions = false | { plugin: VueDocgenPlugin; tsconfig?: string };
 

--- a/code/frameworks/vue3-vite/src/docgen/options.ts
+++ b/code/frameworks/vue3-vite/src/docgen/options.ts
@@ -5,7 +5,7 @@ import type { FrameworkOptions, VueDocgenPlugin } from '../types.ts';
 export const VUE_COMPONENT_META = 'vue-component-meta' satisfies VueDocgenPlugin;
 
 export const VUE_DOCGEN_API_DEPRECATION =
-  `\`vue-docgen-api\` is deprecated and will be removed in Storybook 12. It is still the default docgen engine, so this also applies when you have not set the \`docgen\` framework option. ` +
+  `\`vue-docgen-api\` is deprecated and will be removed in the next major release of Storybook. It is still the default docgen engine, so this also applies when you have not set the \`docgen\` framework option. ` +
   `Switch to \`vue-component-meta\`, with \`framework: { name: '@storybook/vue3-vite', options: { docgen: 'vue-component-meta' } }\` in your \`.storybook/main.ts\`.`;
 
 export type ResolvedDocgenOptions = false | { plugin: VueDocgenPlugin; tsconfig?: string };

--- a/code/frameworks/vue3-vite/src/preset.test.ts
+++ b/code/frameworks/vue3-vite/src/preset.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { deprecate } from 'storybook/internal/node-logger';
+
 import type { Options } from 'storybook/internal/types';
 
 import { vueComponentMeta } from './plugins/vue-component-meta.ts';
@@ -13,7 +15,10 @@ vi.mock('./plugins/vue-template.ts', { spy: true });
 vi.mock('./plugins/vue-component-meta.ts', { spy: true });
 vi.mock('./plugins/vue-docgen.ts', { spy: true });
 
+vi.mock('storybook/internal/node-logger', () => ({ deprecate: vi.fn() }));
+
 beforeEach(() => {
+  vi.mocked(deprecate).mockClear();
   vi.mocked(templateCompilation).mockResolvedValue({ name: 'template' });
   vi.mocked(vueComponentMeta).mockResolvedValue({ name: 'vue-component-meta' });
   vi.mocked(vueDocgen).mockResolvedValue({ name: 'vue-docgen-api' });
@@ -57,5 +62,28 @@ describe('viteFinal', () => {
 
   it('keeps template compilation when docgen is disabled', async () => {
     expect(await pluginNames(false)).toEqual(['template']);
+  });
+});
+
+describe('vue-docgen-api deprecation', () => {
+  it.each([undefined, true as const, 'vue-docgen-api' as const])(
+    'warns for docgen: %s',
+    async (docgen) => {
+      await pluginNames(docgen);
+      expect(vi.mocked(deprecate).mock.calls.map(([message]) => message)).toMatchInlineSnapshot(`
+        [
+          "\`vue-docgen-api\` is deprecated and will be removed in Storybook 12. It is still the default docgen engine, so this also applies when you have not set the \`docgen\` framework option. Switch to \`vue-component-meta\`, with \`framework: { name: '@storybook/vue3-vite', options: { docgen: 'vue-component-meta' } }\` in your \`.storybook/main.ts\`.",
+        ]
+      `);
+    }
+  );
+
+  it.each([
+    ['vue-component-meta' as const, {}],
+    [false as const, {}],
+    [undefined, { experimentalDocgenServer: true }],
+  ])('stays quiet for docgen: %s with features %o', async (docgen, features) => {
+    await pluginNames(docgen, features);
+    expect(deprecate).not.toHaveBeenCalled();
   });
 });

--- a/code/frameworks/vue3-vite/src/preset.test.ts
+++ b/code/frameworks/vue3-vite/src/preset.test.ts
@@ -15,10 +15,10 @@ vi.mock('./plugins/vue-template.ts', { spy: true });
 vi.mock('./plugins/vue-component-meta.ts', { spy: true });
 vi.mock('./plugins/vue-docgen.ts', { spy: true });
 
-vi.mock('storybook/internal/node-logger', () => ({ deprecate: vi.fn() }));
+vi.mock('storybook/internal/node-logger', { spy: true });
 
 beforeEach(() => {
-  vi.mocked(deprecate).mockClear();
+  vi.mocked(deprecate).mockImplementation(() => {});
   vi.mocked(templateCompilation).mockResolvedValue({ name: 'template' });
   vi.mocked(vueComponentMeta).mockResolvedValue({ name: 'vue-component-meta' });
   vi.mocked(vueDocgen).mockResolvedValue({ name: 'vue-docgen-api' });
@@ -72,7 +72,7 @@ describe('vue-docgen-api deprecation', () => {
       await pluginNames(docgen);
       expect(vi.mocked(deprecate).mock.calls.map(([message]) => message)).toMatchInlineSnapshot(`
         [
-          "\`vue-docgen-api\` is deprecated and will be removed in Storybook 12. It is still the default docgen engine, so this also applies when you have not set the \`docgen\` framework option. Switch to \`vue-component-meta\`, with \`framework: { name: '@storybook/vue3-vite', options: { docgen: 'vue-component-meta' } }\` in your \`.storybook/main.ts\`.",
+          "\`vue-docgen-api\` is deprecated and will be removed in the next major release of Storybook. It is still the default docgen engine, so this also applies when you have not set the \`docgen\` framework option. Enable server-side docgen with \`features: { experimentalDocgenServer: true }\` in your \`.storybook/main.ts\`, which becomes the default in Storybook 11, or set \`framework: { name: '@storybook/vue3-vite', options: { docgen: 'vue-component-meta' } }\` to keep docgen in the builder.",
         ]
       `);
     }
@@ -84,6 +84,6 @@ describe('vue-docgen-api deprecation', () => {
     [undefined, { experimentalDocgenServer: true }],
   ])('stays quiet for docgen: %s with features %o', async (docgen, features) => {
     await pluginNames(docgen, features);
-    expect(deprecate).not.toHaveBeenCalled();
+    expect(vi.mocked(deprecate)).not.toHaveBeenCalled();
   });
 });

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -1,8 +1,13 @@
+import { deprecate } from 'storybook/internal/node-logger';
 import type { PresetProperty } from 'storybook/internal/types';
 
 import type { Plugin } from 'vite';
 
-import { VUE_COMPONENT_META, resolveDocgenContext } from './docgen/options.ts';
+import {
+  VUE_COMPONENT_META,
+  VUE_DOCGEN_API_DEPRECATION,
+  resolveDocgenContext,
+} from './docgen/options.ts';
 import { type VueDocgenEngine, vueComponentMeta } from './plugins/vue-component-meta.ts';
 import { vueDocgen } from './plugins/vue-docgen.ts';
 import { templateCompilation } from './plugins/vue-template.ts';
@@ -26,6 +31,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
     if (docgen.plugin === VUE_COMPONENT_META) {
       plugins.push(await vueComponentMeta(engine, docgen.tsconfig));
     } else {
+      deprecate(VUE_DOCGEN_API_DEPRECATION);
       plugins.push(await vueDocgen(engine));
     }
   }

--- a/code/frameworks/vue3-vite/src/types.ts
+++ b/code/frameworks/vue3-vite/src/types.ts
@@ -18,8 +18,7 @@ export type FrameworkOptions = {
    * Storybook 8, the official vue plugin "vue-component-meta" (Volar) can be used which supports
    * more complex types, better type docs, support for js(x)/ts(x) components and more.
    *
-   * "vue-component-meta" will become the new default in the future and "vue-docgen-api" will be
-   * removed.
+   * "vue-docgen-api" is deprecated and will be removed in Storybook 12
    *
    * Set to `false` to disable docgen processing entirely for improved build performance.
    *

--- a/code/frameworks/vue3-vite/src/types.ts
+++ b/code/frameworks/vue3-vite/src/types.ts
@@ -18,7 +18,7 @@ export type FrameworkOptions = {
    * Storybook 8, the official vue plugin "vue-component-meta" (Volar) can be used which supports
    * more complex types, better type docs, support for js(x)/ts(x) components and more.
    *
-   * "vue-docgen-api" is deprecated and will be removed in Storybook 12
+   * "vue-docgen-api" is deprecated and will be removed in the next major release of Storybook
    *
    * Set to `false` to disable docgen processing entirely for improved build performance.
    *

--- a/docs/get-started/frameworks/vue3-vite.mdx
+++ b/docs/get-started/frameworks/vue3-vite.mdx
@@ -71,7 +71,7 @@ setup((app) => {
 
 <Callout variant="info">
 
-`vue-component-meta` is only available in Storybook ≥ 8. It is currently an opt-in, but it will become the default in a future version of Storybook.
+`vue-component-meta` is only available in Storybook ≥ 8. It is currently an opt-in, but it will become the default in a future version of Storybook. The `vue-docgen-api` default is deprecated since Storybook 10.6 and will be removed in Storybook 12, so we recommend switching to `vue-component-meta`.
 
 </Callout>
 
@@ -286,6 +286,12 @@ Default: `'vue-docgen-api'`
 Since: `8.0`
 
 Choose which docgen tool to use when generating controls for your components. See [Using `vue-component-meta`](#using-vue-component-meta) for more information.
+
+<Callout variant="warning">
+
+`'vue-docgen-api'` (the current default, also selected by `true`) is deprecated since Storybook 10.6 and will be removed in Storybook 12. Set `docgen: 'vue-component-meta'` to migrate.
+
+</Callout>
 
 Set to `false` to disable docgen processing entirely for improved build performance.
 

--- a/docs/get-started/frameworks/vue3-vite.mdx
+++ b/docs/get-started/frameworks/vue3-vite.mdx
@@ -71,7 +71,7 @@ setup((app) => {
 
 <Callout variant="info">
 
-`vue-component-meta` is only available in Storybook ≥ 8. It is currently an opt-in, but it will become the default in a future version of Storybook. The `vue-docgen-api` default is deprecated since Storybook 10.6 and will be removed in Storybook 12, so we recommend switching to `vue-component-meta`.
+`vue-component-meta` is only available in Storybook ≥ 8. It is currently an opt-in, but it will become the default in a future version of Storybook. The `vue-docgen-api` default is deprecated since Storybook 10.6 and will be removed in the next major version of Storybook, so we recommend switching to `vue-component-meta`.
 
 </Callout>
 
@@ -289,7 +289,7 @@ Choose which docgen tool to use when generating controls for your components. Se
 
 <Callout variant="warning">
 
-`'vue-docgen-api'` (the current default, also selected by `true`) is deprecated since Storybook 10.6 and will be removed in Storybook 12. Set `docgen: 'vue-component-meta'` to migrate.
+`'vue-docgen-api'` (the current default, also selected by `true`) is deprecated since Storybook 10.6 and will be removed in the next major version of Storybook. Set `docgen: 'vue-component-meta'` to migrate, or enable [server-side docgen](../../api/main-config/main-config-features.mdx) with `features: { experimentalDocgenServer: true }`, which becomes the default in Storybook 11 and also uses `vue-component-meta`.
 
 </Callout>
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did


This PR deprecate vue-docgen-api in favor of vue-component-meta.

It logs a warning when users will use vue-docgen-api

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests
- [ ] 
#### Manual testing

1. Create a Vue 3 Vite sandbox: `yarn task sandbox --template vue3-vite/default-ts --start-from auto`
2. `cd ../storybook-sandboxes/vue3-vite-default-ts && yarn storybook`
3. The template leaves the `docgen` framework option unset, so the default engine is `vue-docgen-api`. Before `Storybook ready!`, the startup output should contain:

   > ▲ `vue-docgen-api` is deprecated and will be removed in Storybook 12. It is still the default docgen engine, so this also applies when you have not set the `docgen` framework option. Switch to `vue-component-meta`, which documents more of your components, with `` framework: { name: '@storybook/vue3-vite', options: { docgen: 'vue-component-meta' } } `` in your `.storybook/main.ts`.


Automated coverage for the same matrix is in `code/frameworks/vue3-vite/src/preset.test.ts`.
> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
