### PR TITLE
Docgen server: Share the story-args pass and honor write order in static resolution

### DIFF
--- a/code/core/src/common/index.ts
+++ b/code/core/src/common/index.ts
@@ -33,7 +33,6 @@ export * from './utils/readTemplate.ts';
 export * from './utils/resolve-meta-component.ts';
 export * from './utils/remove.ts';
 export * from './utils/resolve-path-in-sb-cache.ts';
-export * from './utils/story-reference-context.ts';
 export * from './utils/symlinks.ts';
 export * from './utils/template.ts';
 export * from './utils/tsconfig.ts';

--- a/code/core/src/csf-tools/story-shape/index.ts
+++ b/code/core/src/csf-tools/story-shape/index.ts
@@ -13,17 +13,28 @@ export {
 export { extractStoryJSDocInfo, jsDocTagsForPath } from './jsdoc.ts';
 export { normalizeStoryDeclaration, type NormalizedStoryDeclaration } from './normalize-story.ts';
 export {
-  isSelfContained,
+  createStoryReferenceResolver,
+  parseReferenceModule,
+  type StoryReferenceResolverOptions,
+} from './reference-context.ts';
+export { isSelfContained, resolveArgValue, type ResolvedArgValue } from './resolve-arg-value.ts';
+export {
   resolveArgsRecord,
-  resolveArgValue,
   resolveBindingMembers,
   resolveObjectMembers,
   sourceOf,
   type ReferenceContext,
   type ReferenceModule,
-  type ResolvedArgValue,
   type ResolvedMembers,
-} from './resolve-args.ts';
+  type StoryReferenceResolver,
+  type StoryReferences,
+} from './resolve-members.ts';
+export {
+  createStoryArgsResolver,
+  unresolvedWarning,
+  type ResolvedStoryArgs,
+  type StoryArgsResolver,
+} from './resolve-story-args.ts';
 export { resolveRenderFunction, type RenderFunctionPath, type RenderResolution } from './render.ts';
 export {
   keyOf,

--- a/code/core/src/csf-tools/story-shape/reference-context.ts
+++ b/code/core/src/csf-tools/story-shape/reference-context.ts
@@ -1,11 +1,12 @@
 import type { types as t } from 'storybook/internal/babel';
-import type { ReferenceContext, ReferenceModule } from 'storybook/internal/csf-tools';
-import { babelParseFile, isSelfContained } from 'storybook/internal/csf-tools';
 
 import { readFileSync } from 'node:fs';
 
+import { createModuleResolver } from '../../common/utils/module-resolver.ts';
 import { jsTsSourceExtensions } from '../../shared/constants/extensions.ts';
-import { createModuleResolver } from './module-resolver.ts';
+import { babelParseFile } from '../CsfFile.ts';
+import { isSelfContained } from './resolve-arg-value.ts';
+import type { ReferenceModule, StoryReferenceResolver } from './resolve-members.ts';
 
 export interface StoryReferenceResolverOptions {
   /** Extensions tried ahead of the JS/TS set, for single-file-component formats like `.vue`. */
@@ -14,14 +15,12 @@ export interface StoryReferenceResolverOptions {
    * Rewrites a value read out of another module into one that stands on its own. Defaults to
    * accepting exactly the values that already do.
    */
-  externalize?: ReferenceContext['externalize'];
+  externalize?: StoryReferenceResolver['externalize'];
 }
 
-/** The half of a {@link ReferenceContext} that is not specific to one story file. */
-export type StoryReferenceResolver = Pick<ReferenceContext, 'resolveModule' | 'externalize'>;
-
 /**
- * Builds the half of a reference context that lets static arg resolution leave the story file.
+ * Builds the half of a story-file reference context that lets static arg resolution leave the
+ * story file.
  *
  * A story's args can spread or name a value another module owns, so resolving them reads those
  * modules too. The returned function opens a resolver for one build, which parses each module it
@@ -31,7 +30,7 @@ export type StoryReferenceResolver = Pick<ReferenceContext, 'resolveModule' | 'e
  * ```ts
  * const openStoryReferences = createStoryReferenceResolver();
  * // per build:
- * const ctx = { program: csf._file.path, filePath: storyPath, ...openStoryReferences() };
+ * const resolver = createStoryArgsResolver(csf, { filePath: storyPath, ...openStoryReferences() });
  * ```
  */
 export function createStoryReferenceResolver(
@@ -43,7 +42,7 @@ export function createStoryReferenceResolver(
     tsconfig: 'auto',
   });
 
-  return function openStoryReferences() {
+  return function openStoryReferences(): StoryReferenceResolver {
     const parsed = new Map<string, ReferenceModule | undefined>();
 
     return {

--- a/code/core/src/csf-tools/story-shape/render.ts
+++ b/code/core/src/csf-tools/story-shape/render.ts
@@ -4,7 +4,7 @@ import {
   type ReferenceContext,
   type ResolvedMembers,
   resolveObjectMembers,
-} from './resolve-args.ts';
+} from './resolve-members.ts';
 import { keyOf, pathForNode, resolveIdentifierInit } from './utils.ts';
 
 /** A function a story or meta supplies through `render`. */

--- a/code/core/src/csf-tools/story-shape/resolve-arg-value.test.ts
+++ b/code/core/src/csf-tools/story-shape/resolve-arg-value.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { babelParseFile } from '../CsfFile.ts';
+import { resolveArgValue } from './resolve-arg-value.ts';
+import {
+  type ReferenceContext,
+  resolveArgsRecord,
+  resolveBindingMembers,
+  sourceOf,
+} from './resolve-members.ts';
+
+const contextOf = (code: string, filePath = 'entry.ts'): ReferenceContext => ({
+  program: babelParseFile({ code, filename: filePath }).path,
+  filePath,
+});
+
+const valueOf = (code: string, expression: string) => {
+  const ctx = contextOf(`${code}\nexport const Story = { args: { v: ${expression} } };`);
+  const record = resolveArgsRecord(resolveBindingMembers(ctx, 'Story')?.properties.args, ctx);
+  const resolved = resolveArgValue(record.properties.v, ctx);
+  return {
+    node: sourceOf(resolved.node),
+    imports: resolved.imports.map((ref) => `${ref.localImportName}:${ref.importId}`),
+    unresolved: resolved.unresolved,
+  };
+};
+
+describe('resolveArgValue', () => {
+  it('reads a local const through to the value it was declared with', () => {
+    expect(valueOf(`const LOCAL_LABEL = 'local';`, 'LOCAL_LABEL')).toEqual({
+      node: "'local'",
+      imports: [],
+      unresolved: [],
+    });
+  });
+
+  it('follows a chain of local consts', () => {
+    expect(valueOf(`const A = B; const B = 42;`, 'A')).toEqual({
+      node: '42',
+      imports: [],
+      unresolved: [],
+    });
+  });
+
+  it('keeps an imported name and reports the import it needs', () => {
+    expect(valueOf(`import { IMPORTED_LABEL } from './constants';`, 'IMPORTED_LABEL')).toEqual({
+      node: 'IMPORTED_LABEL',
+      imports: ['IMPORTED_LABEL:./constants'],
+      unresolved: [],
+    });
+  });
+
+  it('reports the import a call expression reaches for', () => {
+    expect(valueOf(`import { computeCount } from './helpers';`, 'computeCount(2)')).toEqual({
+      node: 'computeCount(2)',
+      imports: ['computeCount:./helpers'],
+      unresolved: [],
+    });
+  });
+
+  it('reports a local name a larger expression reaches for, which it cannot substitute', () => {
+    expect(valueOf(`const factor = 2;`, 'factor * 3')).toEqual({
+      node: 'factor * 3',
+      imports: [],
+      unresolved: ['factor'],
+    });
+  });
+
+  it('reports the import a nested parameter of the same name does not hide', () => {
+    expect(valueOf(`import { dep } from './helpers';`, '[dep => dep, dep]')).toEqual({
+      node: '[dep => dep, dep]',
+      imports: ['dep:./helpers'],
+      unresolved: [],
+    });
+  });
+
+  it('reads the name a shorthand property reaches for', () => {
+    expect(valueOf(`import { dep } from './helpers';`, '{ dep }')).toEqual({
+      node: '{ dep }',
+      imports: ['dep:./helpers'],
+      unresolved: [],
+    });
+  });
+
+  it('writes out a spread inside an object the arg holds', () => {
+    expect(valueOf(`const base = { size: 'md' };`, `{ ...base, tone: 'neutral' }`)).toEqual({
+      node: "{ size: 'md', tone: 'neutral' }",
+      imports: [],
+      unresolved: [],
+    });
+  });
+
+  it('leaves an object holding a spread it cannot read exactly as written', () => {
+    expect(valueOf('', `{ ...buildBase(), tone: 'neutral' }`)).toEqual({
+      node: "{ ...buildBase(), tone: 'neutral' }",
+      imports: [],
+      unresolved: ['...buildBase()'],
+    });
+  });
+
+  it('leaves a literal alone', () => {
+    expect(valueOf('', `{ a: 1, b: [2, 3] }`)).toEqual({
+      node: '{ a: 1, b: [2, 3] }',
+      imports: [],
+      unresolved: [],
+    });
+  });
+
+  it('names nothing for a global or a parameter the expression declares itself', () => {
+    expect(valueOf('', '(event) => Math.max(event.x, 0)')).toEqual({
+      node: 'event => Math.max(event.x, 0)',
+      imports: [],
+      unresolved: [],
+    });
+  });
+});

--- a/code/core/src/csf-tools/story-shape/resolve-arg-value.ts
+++ b/code/core/src/csf-tools/story-shape/resolve-arg-value.ts
@@ -1,0 +1,218 @@
+// Reads an arg value written as a name through to the definition it refers to, and reports what
+// printing the result still depends on.
+import { type NodePath, traverse, types as t } from 'storybook/internal/babel';
+
+import { type ImportRef } from './import-statements.ts';
+import { type ImportBinding, collectImportBindings } from './imports.ts';
+import { type ReferenceContext, resolveArgsRecord } from './resolve-members.ts';
+import { unwrapExpression } from './utils.ts';
+
+/** An arg value read through to the definition it names, and what printing it still depends on. */
+export interface ResolvedArgValue {
+  /** Node to print in place of what was written. */
+  node: t.Node;
+  /** Imports the printed node needs to resolve where the snippet lands. */
+  imports: ImportRef[];
+  /** Source text of every name the printed node depends on that no import can supply. */
+  unresolved: string[];
+}
+
+/**
+ * The value an arg node stands for, following a name to the definition it refers to.
+ *
+ * A name the story file declares resolves to the value it was declared with, since that name means
+ * nothing where the snippet lands. A name another module owns stays as written and reports the
+ * import that makes it resolve. Names a larger expression reaches for are reported the same way,
+ * except that a locally declared one can only be named, not substituted into the expression.
+ */
+export const resolveArgValue = (node: t.Node, ctx: ReferenceContext): ResolvedArgValue => {
+  const unresolved: string[] = [];
+  const resolved = inlineSpreads(
+    followValue(unwrapExpression(node), ctx, new Set()),
+    ctx,
+    unresolved
+  );
+  const bindings = importBindingsOf(ctx.program);
+  const imports: ImportRef[] = [];
+
+  for (const name of freeNames(resolved)) {
+    const imported = bindings.get(name);
+    if (imported) {
+      imports.push({
+        localImportName: name,
+        importId: imported.importId,
+        importName: imported.importName,
+        ...(imported.importName === '*' ? { namespace: name } : {}),
+      });
+      continue;
+    }
+    if (ctx.program.scope.getBinding(name)) {
+      unresolved.push(name);
+    }
+  }
+
+  return { node: resolved, imports, unresolved };
+};
+
+/**
+ * Whether printing a node needs no name from the scope it was written in.
+ *
+ * This is the bar a value copied out of another module has to clear, since the names that module
+ * declares and imports mean nothing where the snippet lands.
+ */
+export const isSelfContained = (node: t.Node): boolean => freeNames(node).size === 0;
+
+const importBindings = new WeakMap<t.Node, Map<string, ImportBinding>>();
+
+const importBindingsOf = (program: NodePath<t.Program>): Map<string, ImportBinding> => {
+  let bindings = importBindings.get(program.node);
+  if (bindings === undefined) {
+    bindings = collectImportBindings(program);
+    importBindings.set(program.node, bindings);
+  }
+  return bindings;
+};
+
+/**
+ * Writes out the spreads inside a value, so an arg holding an object shows what that object holds.
+ *
+ * A spread this pass cannot read leaves its object exactly as written: printing part of it would
+ * claim the value is something it is not, where printing the source at least shows the story.
+ */
+const inlineSpreads = (node: t.Node, ctx: ReferenceContext, unresolved: string[]): t.Node => {
+  // A value with nothing to pull in is returned as it was parsed, so it keeps the story's own
+  // formatting rather than being reprinted from a rebuilt tree.
+  if (!hasNamedSpread(node)) {
+    return node;
+  }
+
+  if (t.isArrayExpression(node)) {
+    return t.arrayExpression(
+      node.elements.map((element) =>
+        element && t.isExpression(element)
+          ? (inlineSpreads(element, ctx, unresolved) as t.Expression)
+          : element
+      )
+    );
+  }
+
+  if (!t.isObjectExpression(node)) {
+    return node;
+  }
+  if (!node.properties.some((property) => t.isSpreadElement(property))) {
+    return objectFrom(node.properties, ctx, unresolved) ?? node;
+  }
+
+  const members = resolveArgsRecord(node, ctx);
+  if (members.unresolved.length > 0) {
+    unresolved.push(...members.unresolved);
+    return node;
+  }
+  return (
+    objectFrom(
+      Object.entries(members.properties).map(([key, value]) =>
+        t.objectProperty(
+          t.isValidIdentifier(key) ? t.identifier(key) : t.stringLiteral(key),
+          value as t.Expression
+        )
+      ),
+      ctx,
+      unresolved
+    ) ?? node
+  );
+};
+
+/**
+ * Whether a value spreads something it names rather than something written out on the spot.
+ *
+ * Only a named spread is worth writing out: `{ ...{ a: 1 }, b: 2 }` already says what it holds, so
+ * rewriting it would reprint the story's own source for no gain.
+ */
+const hasNamedSpread = (node: t.Node): boolean => {
+  if (t.isArrayExpression(node)) {
+    return node.elements.some(
+      (element) => element !== null && t.isExpression(element) && hasNamedSpread(element)
+    );
+  }
+  return (
+    t.isObjectExpression(node) &&
+    node.properties.some((property) =>
+      t.isSpreadElement(property)
+        ? !t.isObjectExpression(unwrapExpression(property.argument))
+        : t.isObjectProperty(property) &&
+          t.isExpression(property.value) &&
+          hasNamedSpread(property.value)
+    )
+  );
+};
+
+/** An object literal with every member value's own spreads written out, when they all can be. */
+const objectFrom = (
+  properties: t.ObjectExpression['properties'],
+  ctx: ReferenceContext,
+  unresolved: string[]
+): t.ObjectExpression | undefined => {
+  const rebuilt: t.ObjectExpression['properties'] = [];
+  for (const property of properties) {
+    if (!t.isObjectProperty(property) || !t.isExpression(property.value)) {
+      return undefined;
+    }
+    rebuilt.push(
+      t.objectProperty(
+        property.key,
+        inlineSpreads(property.value, ctx, unresolved) as t.Expression,
+        property.computed
+      )
+    );
+  }
+  return t.objectExpression(rebuilt);
+};
+
+/** Reads a bare name through to the value it was declared with, as far as the chain goes. */
+const followValue = (node: t.Node, ctx: ReferenceContext, seen: Set<string>): t.Node => {
+  if (!t.isIdentifier(node) || seen.has(node.name)) {
+    return node;
+  }
+  const binding = ctx.program.scope.getBinding(node.name);
+  if (
+    !binding ||
+    binding.kind === 'module' ||
+    !binding.constant ||
+    !t.isVariableDeclarator(binding.path.node) ||
+    !binding.path.node.init
+  ) {
+    return node;
+  }
+  seen.add(node.name);
+  return followValue(unwrapExpression(binding.path.node.init), ctx, seen);
+};
+
+/**
+ * Names an expression reaches for from outside itself. ES globals count as resolved, since they
+ * mean the same wherever the snippet lands.
+ */
+const freeNames = (node: t.Node): Set<string> => {
+  const expression = t.isExpression(node)
+    ? node
+    : t.isObjectMethod(node)
+      ? t.objectExpression([node])
+      : undefined;
+  if (expression === undefined) {
+    throw new Error(`Cannot read the names a ${node.type} depends on: it is not an expression`);
+  }
+
+  // The clone keeps this traversal from binding scope information to nodes the story file's own
+  // program still owns.
+  const wrapped = t.file(
+    t.program([t.expressionStatement(t.cloneNode(expression, true) as t.Expression)])
+  );
+  const names = new Set<string>();
+  traverse(wrapped, {
+    ReferencedIdentifier(path) {
+      if (!path.scope.hasBinding(path.node.name)) {
+        names.add(path.node.name);
+      }
+    },
+  });
+  return names;
+};

--- a/code/core/src/csf-tools/story-shape/resolve-members.test.ts
+++ b/code/core/src/csf-tools/story-shape/resolve-members.test.ts
@@ -8,11 +8,10 @@ import { babelParseFile } from '../CsfFile.ts';
 import {
   type ReferenceContext,
   type ReferenceModule,
-  resolveArgValue,
   resolveArgsRecord,
   resolveBindingMembers,
   sourceOf,
-} from './resolve-args.ts';
+} from './resolve-members.ts';
 
 const moduleOf = (code: string, filePath: string): ReferenceModule => ({
   program: babelParseFile({ code, filename: filePath }).path,
@@ -159,6 +158,25 @@ describe('spreads inside args', () => {
     });
   });
 
+  it('reports a method a spread copies into args', () => {
+    const code = dedent`
+      const shared = { label: 'shared', count() { return 1; } };
+      export const Spread = { args: { ...shared } };
+    `;
+    expect(argsOf(code, 'Spread')).toEqual({
+      args: { label: "'shared'" },
+      unresolved: ['count() { return 1; }'],
+    });
+  });
+
+  it('drops the member an accessor replaces, whose value only running the story produces', () => {
+    const code = `export const S = { args: { label: 'plain', get label() { return 'x'; } } };`;
+    expect(argsOf(code, 'S')).toEqual({
+      args: {},
+      unresolved: [`get label() { return 'x'; }`],
+    });
+  });
+
   it('reads a spread of an object written out on the spot', () => {
     const code = `export const Inline = { args: { ...{ primary: true }, label: 'inline' } };`;
     expect(argsOf(code, 'Inline')).toEqual({
@@ -260,6 +278,14 @@ describe('spreads at the story config level', () => {
     expect(argsOf(code, 'Assigned')).toEqual({ args: { label: "'assigned'" }, unresolved: [] });
   });
 
+  it('resolves the CSF2 assignment form on a function declaration', () => {
+    const code = dedent`
+      export function Assigned() { return null; }
+      Assigned.args = { label: 'assigned' };
+    `;
+    expect(argsOf(code, 'Assigned')).toEqual({ args: { label: "'assigned'" }, unresolved: [] });
+  });
+
   it('prefers an assignment over the args the declaration carries', () => {
     const code = dedent`
       export const Both = { args: { label: 'declared' } };
@@ -276,6 +302,39 @@ describe('spreads at the story config level', () => {
     expect(resolveBindingMembers(contextOf({ 'entry.ts': code }), 'Deep')?.unresolved).toEqual([
       "Deep.args.label = 'mutated'",
     ]);
+  });
+});
+
+describe('write order', () => {
+  it('marks a member written before an unreadable spread as shadowed', () => {
+    const code = dedent`
+      declare function makeBase(): object;
+      export const S = { template: 'own', ...makeBase() };
+    `;
+    const members = resolveBindingMembers(contextOf({ 'entry.ts': code }), 'S');
+    expect(members?.shadowed).toEqual(['template']);
+    expect(members?.unresolved).toEqual(['...makeBase()']);
+  });
+
+  it('trusts a member written after the unreadable spread', () => {
+    const code = dedent`
+      declare function makeBase(): object;
+      export const S = { ...makeBase(), template: 'own' };
+    `;
+    const members = resolveBindingMembers(contextOf({ 'entry.ts': code }), 'S');
+    expect(members?.shadowed).toEqual([]);
+    expect(members?.unresolved).toEqual(['...makeBase()']);
+  });
+
+  it('unshadows a member a readable spread writes again', () => {
+    const code = dedent`
+      declare function makeBase(): object;
+      const base = { template: 'base' };
+      export const S = { template: 'own', ...makeBase(), ...base };
+    `;
+    const members = resolveBindingMembers(contextOf({ 'entry.ts': code }), 'S');
+    expect(members?.shadowed).toEqual([]);
+    expect(members?.properties.template).toBeDefined();
   });
 });
 
@@ -315,6 +374,24 @@ describe('CSF factories', () => {
     `;
     expect(argsOf(code, 'Bare')).toEqual({ args: {}, unresolved: ['...Base'] });
   });
+
+  // A parent from another module would carry values whose names resolve in that module, not here,
+  // so it must be reported rather than mixed in as if it were local.
+  it('rejects an extend call whose parent another module owns', () => {
+    const ctx = contextOf({
+      'other.stories.ts': dedent`
+        import preview from './preview';
+        const REMOTE_LABEL = 'remote';
+        const meta = preview.meta({ component: 'x' });
+        export const Base = meta.story({ args: { label: REMOTE_LABEL } });
+      `,
+      'entry.ts': dedent`
+        import { Base } from './other.stories';
+        export const Ext = Base.extend({ args: { size: 'lg' } });
+      `,
+    });
+    expect(resolveBindingMembers(ctx, 'Ext')).toBeUndefined();
+  });
 });
 
 describe('externalize', () => {
@@ -334,92 +411,5 @@ describe('externalize', () => {
       (node) => (t.isStringLiteral(node) ? node : undefined)
     );
     expect(argsOf('', 'Reuse', ctx)).toEqual({ args: {}, unresolved: ['...shared'] });
-  });
-});
-
-describe('resolveArgValue', () => {
-  const valueOf = (code: string, expression: string) => {
-    const ctx = contextOf({
-      'entry.ts': `${code}\nexport const Story = { args: { v: ${expression} } };`,
-    });
-    const record = resolveArgsRecord(resolveBindingMembers(ctx, 'Story')?.properties.args, ctx);
-    const resolved = resolveArgValue(record.properties.v, ctx);
-    return {
-      node: sourceOf(resolved.node),
-      imports: resolved.imports.map((ref) => `${ref.localImportName}:${ref.importId}`),
-      unresolved: resolved.unresolved,
-    };
-  };
-
-  it('reads a local const through to the value it was declared with', () => {
-    expect(valueOf(`const LOCAL_LABEL = 'local';`, 'LOCAL_LABEL')).toEqual({
-      node: "'local'",
-      imports: [],
-      unresolved: [],
-    });
-  });
-
-  it('follows a chain of local consts', () => {
-    expect(valueOf(`const A = B; const B = 42;`, 'A')).toEqual({
-      node: '42',
-      imports: [],
-      unresolved: [],
-    });
-  });
-
-  it('keeps an imported name and reports the import it needs', () => {
-    expect(valueOf(`import { IMPORTED_LABEL } from './constants';`, 'IMPORTED_LABEL')).toEqual({
-      node: 'IMPORTED_LABEL',
-      imports: ['IMPORTED_LABEL:./constants'],
-      unresolved: [],
-    });
-  });
-
-  it('reports the import a call expression reaches for', () => {
-    expect(valueOf(`import { computeCount } from './helpers';`, 'computeCount(2)')).toEqual({
-      node: 'computeCount(2)',
-      imports: ['computeCount:./helpers'],
-      unresolved: [],
-    });
-  });
-
-  it('reports a local name a larger expression reaches for, which it cannot substitute', () => {
-    expect(valueOf(`const factor = 2;`, 'factor * 3')).toEqual({
-      node: 'factor * 3',
-      imports: [],
-      unresolved: ['factor'],
-    });
-  });
-
-  it('writes out a spread inside an object the arg holds', () => {
-    expect(valueOf(`const base = { size: 'md' };`, `{ ...base, tone: 'neutral' }`)).toEqual({
-      node: "{ size: 'md', tone: 'neutral' }",
-      imports: [],
-      unresolved: [],
-    });
-  });
-
-  it('leaves an object holding a spread it cannot read exactly as written', () => {
-    expect(valueOf('', `{ ...buildBase(), tone: 'neutral' }`)).toEqual({
-      node: "{ ...buildBase(), tone: 'neutral' }",
-      imports: [],
-      unresolved: ['...buildBase()'],
-    });
-  });
-
-  it('leaves a literal alone', () => {
-    expect(valueOf('', `{ a: 1, b: [2, 3] }`)).toEqual({
-      node: '{ a: 1, b: [2, 3] }',
-      imports: [],
-      unresolved: [],
-    });
-  });
-
-  it('names nothing for a global or a parameter the expression declares itself', () => {
-    expect(valueOf('', '(event) => Math.max(event.x, 0)')).toEqual({
-      node: 'event => Math.max(event.x, 0)',
-      imports: [],
-      unresolved: [],
-    });
   });
 });

--- a/code/core/src/csf-tools/story-shape/resolve-members.ts
+++ b/code/core/src/csf-tools/story-shape/resolve-members.ts
@@ -1,15 +1,19 @@
-// Follows the references a story hides its args behind: a spread of a constant, of a sibling story,
-// or of something another module owns, and an arg value written as a name rather than a value.
+// Follows the references a story hides its config behind: a spread of a constant, of a sibling
+// story, or of something another module owns, applying every write in the order it runs.
 import { generate, type NodePath, types as t } from 'storybook/internal/babel';
 
-import { type ImportRef } from './import-statements.ts';
-import { collectImportBindings, importedName, isTypeSpecifier } from './imports.ts';
+import { importedName, isTypeSpecifier } from './imports.ts';
 import { keyOf, unwrapExpression } from './utils.ts';
 
 /** Members of an object, and what reading it statically could not account for. */
 export interface ResolvedMembers {
-  /** Member name → value node. */
+  /** Member name → value node, as of the last write this pass could read. */
   properties: Record<string, t.Node>;
+  /**
+   * Names whose value an `unresolved` entry written after them may replace at runtime. A member
+   * absent from `properties` is only knowably absent when `unresolved` is empty.
+   */
+  shadowed: string[];
   /** Source text of every member `properties` could not absorb; empty exactly when complete. */
   unresolved: string[];
 }
@@ -36,12 +40,22 @@ export interface ReferenceContext extends ReferenceModule {
   externalize?: (node: t.Node) => t.Node | undefined;
 }
 
+/** The half of a {@link ReferenceContext} that is not specific to one story file. */
+export type StoryReferenceResolver = Pick<ReferenceContext, 'resolveModule' | 'externalize'>;
+
+/** How arg resolution leaves the story file; without it only the story file itself is read. */
+export interface StoryReferences extends StoryReferenceResolver {
+  /** Absolute path of the story file, which every import specifier resolves against. */
+  filePath: string;
+}
+
 /** Source text of a node, for naming an expression a static pass could not read. */
 export const sourceOf = (node: t.Node): string =>
   generate(node, { concise: true, comments: false }).code;
 
 const complete = (properties: Record<string, t.Node> = {}): ResolvedMembers => ({
   properties,
+  shadowed: [],
   unresolved: [],
 });
 
@@ -54,13 +68,13 @@ const complete = (properties: Record<string, t.Node> = {}): ResolvedMembers => (
 export const resolveObjectMembers = (
   object: t.ObjectExpression,
   ctx: ReferenceContext
-): ResolvedMembers => membersOf(object, ctx, new Set(), true);
+): ResolvedMembers => membersOf(object, ctx, new Set());
 
 /**
  * An `args` record, absorbing every spread the context can follow.
  *
  * Unlike {@link resolveObjectMembers} every member has to reduce to a printable value, so a method
- * shorthand is reported rather than kept.
+ * is reported rather than kept, wherever a spread copied it from.
  */
 export const resolveArgsRecord = (
   node: t.Node | undefined,
@@ -71,11 +85,27 @@ export const resolveArgsRecord = (
   }
   const unwrapped = unwrapExpression(node);
   if (t.isObjectExpression(unwrapped)) {
-    return membersOf(unwrapped, ctx, new Set(), false);
+    return asArgsRecord(membersOf(unwrapped, ctx, new Set()));
   }
   // `args: shared` names its record instead of writing one, which reads the same as spreading it.
   const referenced = resolveReference(ctx, unwrapped, node.start ?? undefined, new Set());
-  return referenced ?? { properties: {}, unresolved: [`args: ${sourceOf(unwrapped)}`] };
+  return referenced
+    ? asArgsRecord(referenced)
+    : { properties: {}, shadowed: [], unresolved: [`args: ${sourceOf(unwrapped)}`] };
+};
+
+const asArgsRecord = (members: ResolvedMembers): ResolvedMembers => {
+  const methods = Object.entries(members.properties).filter(([, node]) => t.isObjectMethod(node));
+  if (methods.length === 0) {
+    return members;
+  }
+  const properties = { ...members.properties };
+  const unresolved = [...members.unresolved];
+  for (const [key, node] of methods) {
+    delete properties[key];
+    unresolved.push(sourceOf(node));
+  }
+  return { properties, shadowed: members.shadowed.filter((key) => key in properties), unresolved };
 };
 
 /**
@@ -95,37 +125,54 @@ export const resolveBindingMembers = (
 const membersOf = (
   object: t.ObjectExpression,
   ctx: ReferenceContext,
-  visited: Set<string>,
-  keepMethods: boolean
+  visited: Set<string>
 ): ResolvedMembers => {
   const properties: Record<string, t.Node> = {};
   const unresolved: string[] = [];
+  const shadowed = new Set<string>();
+
+  // A write this pass cannot read may replace any member already written, but a member written
+  // after it wins at runtime, so only the keys known so far become uncertain.
+  const shadowKnownMembers = (source: string) => {
+    unresolved.push(source);
+    for (const key of Object.keys(properties)) {
+      shadowed.add(key);
+    }
+  };
 
   for (const property of object.properties) {
     if (t.isSpreadElement(property)) {
       const spread = spreadMembers(ctx, property, visited);
       if (spread === undefined || spread.unresolved.length > 0) {
-        unresolved.push(sourceOf(property));
+        shadowKnownMembers(sourceOf(property));
         continue;
       }
-      Object.assign(properties, spread.properties);
+      for (const [key, value] of Object.entries(spread.properties)) {
+        properties[key] = value;
+        shadowed.delete(key);
+      }
       continue;
     }
 
-    // A dynamic key, an accessor or a value only calling it produces can supply or shadow any
-    // member at runtime.
-    const opaqueMethod =
-      t.isObjectMethod(property) &&
-      (!keepMethods || property.kind !== 'method' || property.generator);
-    const key = opaqueMethod ? null : keyOf(property);
+    const key = keyOf(property);
     if (key === null) {
+      // A dynamic key can supply or shadow any member at runtime.
+      shadowKnownMembers(sourceOf(property));
+      continue;
+    }
+    if (t.isObjectMethod(property) && (property.kind !== 'method' || property.generator)) {
+      // An accessor or generator replaces exactly the member it names, with a value only running
+      // the story produces.
+      delete properties[key];
+      shadowed.delete(key);
       unresolved.push(sourceOf(property));
       continue;
     }
     properties[key] = t.isObjectMethod(property) ? property : property.value;
+    shadowed.delete(key);
   }
 
-  return { properties, unresolved };
+  return { properties, shadowed: [...shadowed], unresolved };
 };
 
 /** The object a spread copies from, whether it is written out or named. */
@@ -136,7 +183,7 @@ const spreadMembers = (
 ): ResolvedMembers | undefined => {
   const argument = unwrapExpression(spread.argument);
   return t.isObjectExpression(argument)
-    ? membersOf(argument, ctx, visited, true)
+    ? membersOf(argument, ctx, visited)
     : resolveReference(ctx, argument, spread.start ?? undefined, visited);
 };
 
@@ -217,7 +264,7 @@ const unguardedResolveReference = (
     if (!t.isObjectExpression(unwrapped)) {
       return undefined;
     }
-    members = membersOf(unwrapped, located.ctx, visited, true);
+    members = membersOf(unwrapped, located.ctx, visited);
   }
 
   return located.external ? externalized(members, located.ctx) : members;
@@ -293,7 +340,7 @@ const externalized = (
     }
     properties[key] = value;
   }
-  return { properties, unresolved: members.unresolved };
+  return { properties, shadowed: members.shadowed, unresolved: members.unresolved };
 };
 
 type BoundMembers =
@@ -340,15 +387,11 @@ const unguardedBindingMembers = (
     return importedBinding(ctx, binding.path, visited);
   }
 
-  if (!binding.constant || !t.isVariableDeclarator(binding.path.node)) {
-    return undefined;
-  }
-  if (position !== undefined && (binding.path.node.start ?? Number.POSITIVE_INFINITY) > position) {
+  if (!binding.constant) {
     return undefined;
   }
 
-  const init = binding.path.node.init;
-  const declared = init ? declaredMembers(ctx, init, position, visited) : { members: complete() };
+  const declared = declaredBindingMembers(ctx, binding.path.node, position, visited);
   if (declared === undefined) {
     return undefined;
   }
@@ -362,9 +405,29 @@ const unguardedBindingMembers = (
     ...(declared.accessor ? { accessor: declared.accessor } : {}),
     members: {
       properties: { ...declared.members.properties, ...assigned.properties },
+      shadowed: declared.members.shadowed.filter((key) => !(key in assigned.properties)),
       unresolved: [...declared.members.unresolved, ...assigned.unresolved],
     },
   };
+};
+
+const declaredBindingMembers = (
+  ctx: ReferenceContext,
+  node: t.Node,
+  position: number | undefined,
+  visited: Set<string>
+): { members: ResolvedMembers; accessor?: 'input' } | undefined => {
+  if (t.isFunctionDeclaration(node)) {
+    // Hoisted, so it is readable at any position; the CSF2 form gives it members by assignment.
+    return { members: complete() };
+  }
+  if (!t.isVariableDeclarator(node)) {
+    return undefined;
+  }
+  if (position !== undefined && (node.start ?? Number.POSITIVE_INFINITY) > position) {
+    return undefined;
+  }
+  return node.init ? declaredMembers(ctx, node.init, position, visited) : { members: complete() };
 };
 
 /** Members an initializer declares, plus the accessor a CSF factory keeps them behind. */
@@ -377,7 +440,7 @@ const declaredMembers = (
   const unwrapped = unwrapExpression(init);
 
   if (t.isObjectExpression(unwrapped)) {
-    return { members: membersOf(unwrapped, ctx, visited, true) };
+    return { members: membersOf(unwrapped, ctx, visited) };
   }
 
   const factory = factoryCall(unwrapped);
@@ -386,18 +449,29 @@ const declaredMembers = (
     return { members: complete() };
   }
 
-  const config = factory.config ? membersOf(factory.config, ctx, visited, true) : complete();
+  const config = factory.config ? membersOf(factory.config, ctx, visited) : complete();
   if (factory.method === 'story') {
     return { members: config, accessor: 'input' };
   }
 
   const parent = bindingMembers(ctx, factory.parent, position, visited);
-  if (parent === undefined || parent.kind === 'namespace' || parent.accessor !== 'input') {
+  // A parent another module owns would mix nodes whose names resolve elsewhere into a record read
+  // as local, so it is reported instead of merged.
+  if (
+    parent === undefined ||
+    parent.kind === 'namespace' ||
+    parent.accessor !== 'input' ||
+    parent.external
+  ) {
     return undefined;
   }
   return {
     members: {
       properties: mergedAnnotations(parent.members.properties, config.properties),
+      shadowed: [
+        ...parent.members.shadowed.filter((key) => !(key in config.properties)),
+        ...config.shadowed,
+      ],
       unresolved: [...parent.members.unresolved, ...config.unresolved],
     },
     accessor: 'input',
@@ -478,7 +552,7 @@ const assignedMembers = (
   ctx: ReferenceContext,
   name: string,
   position: number | undefined
-): ResolvedMembers => {
+): { properties: Record<string, t.Node>; unresolved: string[] } => {
   const properties: Record<string, t.Node> = {};
   const unresolved: string[] = [];
 
@@ -579,7 +653,7 @@ const exportedBinding = (
             kind: 'members',
             ctx,
             external: true,
-            members: membersOf(declaration, ctx, visited, true),
+            members: membersOf(declaration, ctx, visited),
           }
         : undefined;
     }
@@ -607,227 +681,4 @@ const exportedBinding = (
   return exportName === 'default'
     ? undefined
     : asExternal(bindingMembers(ctx, exportName, undefined, visited));
-};
-
-/** An arg value read through to the definition it names, and what printing it still depends on. */
-export interface ResolvedArgValue {
-  /** Node to print in place of what was written. */
-  node: t.Node;
-  /** Imports the printed node needs to resolve where the snippet lands. */
-  imports: ImportRef[];
-  /** Source text of every name the printed node depends on that no import can supply. */
-  unresolved: string[];
-}
-
-/**
- * The value an arg node stands for, following a name to the definition it refers to.
- *
- * A name the story file declares resolves to the value it was declared with, since that name means
- * nothing where the snippet lands. A name another module owns stays as written and reports the
- * import that makes it resolve. Names a larger expression reaches for are reported the same way,
- * except that a locally declared one can only be named, not substituted into the expression.
- */
-export const resolveArgValue = (node: t.Node, ctx: ReferenceContext): ResolvedArgValue => {
-  const unresolved: string[] = [];
-  const resolved = inlineSpreads(
-    followValue(unwrapExpression(node), ctx, new Set()),
-    ctx,
-    unresolved
-  );
-  const bindings = collectImportBindings(ctx.program);
-  const imports: ImportRef[] = [];
-
-  for (const name of freeNames(resolved)) {
-    const imported = bindings.get(name);
-    if (imported) {
-      imports.push({
-        localImportName: name,
-        importId: imported.importId,
-        importName: imported.importName,
-        ...(imported.importName === '*' ? { namespace: name } : {}),
-      });
-      continue;
-    }
-    if (ctx.program.scope.getBinding(name)) {
-      unresolved.push(name);
-    }
-  }
-
-  return { node: resolved, imports, unresolved };
-};
-
-/**
- * Whether printing a node needs no name from the scope it was written in.
- *
- * This is the bar a value copied out of another module has to clear, since the names that module
- * declares and imports mean nothing where the snippet lands.
- */
-export const isSelfContained = (node: t.Node): boolean => freeNames(node).size === 0;
-
-/**
- * Writes out the spreads inside a value, so an arg holding an object shows what that object holds.
- *
- * A spread this pass cannot read leaves its object exactly as written: printing part of it would
- * claim the value is something it is not, where printing the source at least shows the story.
- */
-const inlineSpreads = (node: t.Node, ctx: ReferenceContext, unresolved: string[]): t.Node => {
-  // A value with nothing to pull in is returned as it was parsed, so it keeps the story's own
-  // formatting rather than being reprinted from a rebuilt tree.
-  if (!hasNamedSpread(node)) {
-    return node;
-  }
-
-  if (t.isArrayExpression(node)) {
-    return t.arrayExpression(
-      node.elements.map((element) =>
-        element && t.isExpression(element)
-          ? (inlineSpreads(element, ctx, unresolved) as t.Expression)
-          : element
-      )
-    );
-  }
-
-  if (!t.isObjectExpression(node)) {
-    return node;
-  }
-  if (!node.properties.some((property) => t.isSpreadElement(property))) {
-    return objectFrom(node.properties, ctx, unresolved) ?? node;
-  }
-
-  const members = membersOf(node, ctx, new Set(), false);
-  if (members.unresolved.length > 0) {
-    unresolved.push(...members.unresolved);
-    return node;
-  }
-  return (
-    objectFrom(
-      Object.entries(members.properties).map(([key, value]) =>
-        t.objectProperty(
-          t.isValidIdentifier(key) ? t.identifier(key) : t.stringLiteral(key),
-          value as t.Expression
-        )
-      ),
-      ctx,
-      unresolved
-    ) ?? node
-  );
-};
-
-/**
- * Whether a value spreads something it names rather than something written out on the spot.
- *
- * Only a named spread is worth writing out: `{ ...{ a: 1 }, b: 2 }` already says what it holds, so
- * rewriting it would reprint the story's own source for no gain.
- */
-const hasNamedSpread = (node: t.Node): boolean => {
-  if (t.isArrayExpression(node)) {
-    return node.elements.some(
-      (element) => element !== null && t.isExpression(element) && hasNamedSpread(element)
-    );
-  }
-  return (
-    t.isObjectExpression(node) &&
-    node.properties.some((property) =>
-      t.isSpreadElement(property)
-        ? !t.isObjectExpression(unwrapExpression(property.argument))
-        : t.isObjectProperty(property) &&
-          t.isExpression(property.value) &&
-          hasNamedSpread(property.value)
-    )
-  );
-};
-
-/** An object literal with every member value's own spreads written out, when they all can be. */
-const objectFrom = (
-  properties: t.ObjectExpression['properties'],
-  ctx: ReferenceContext,
-  unresolved: string[]
-): t.ObjectExpression | undefined => {
-  const rebuilt: t.ObjectExpression['properties'] = [];
-  for (const property of properties) {
-    if (!t.isObjectProperty(property) || !t.isExpression(property.value)) {
-      return undefined;
-    }
-    rebuilt.push(
-      t.objectProperty(
-        property.key,
-        inlineSpreads(property.value, ctx, unresolved) as t.Expression,
-        property.computed
-      )
-    );
-  }
-  return t.objectExpression(rebuilt);
-};
-
-/** Reads a bare name through to the value it was declared with, as far as the chain goes. */
-const followValue = (node: t.Node, ctx: ReferenceContext, seen: Set<string>): t.Node => {
-  if (!t.isIdentifier(node) || seen.has(node.name)) {
-    return node;
-  }
-  const binding = ctx.program.scope.getBinding(node.name);
-  if (
-    !binding ||
-    binding.kind === 'module' ||
-    !binding.constant ||
-    !t.isVariableDeclarator(binding.path.node) ||
-    !binding.path.node.init
-  ) {
-    return node;
-  }
-  seen.add(node.name);
-  return followValue(unwrapExpression(binding.path.node.init), ctx, seen);
-};
-
-/**
- * Names an expression reaches for from outside itself.
- *
- * Property keys and member accesses name nothing, and a name the expression declares itself resolves
- * within it, so none of those are reported.
- */
-const freeNames = (node: t.Node): Set<string> => {
-  const declared = new Set<string>();
-  const skipped = new Set<t.Node>();
-  const candidates: t.Identifier[] = [];
-
-  const declare = (target: t.Node | null | undefined) => {
-    if (t.isIdentifier(target)) {
-      declared.add(target.name);
-      skipped.add(target);
-      return;
-    }
-    if (target) {
-      t.traverseFast(target, (inner) => {
-        if (t.isIdentifier(inner)) {
-          declared.add(inner.name);
-          skipped.add(inner);
-        }
-      });
-    }
-  };
-
-  t.traverseFast(node, (current) => {
-    if (t.isObjectProperty(current) || t.isObjectMethod(current)) {
-      if (!current.computed) {
-        skipped.add(current.key);
-      }
-    }
-    if (t.isMemberExpression(current) && !current.computed) {
-      skipped.add(current.property);
-    }
-    if (t.isFunction(current)) {
-      current.params.forEach(declare);
-    }
-    if (t.isVariableDeclarator(current)) {
-      declare(current.id);
-    }
-    if (t.isIdentifier(current)) {
-      candidates.push(current);
-    }
-  });
-
-  return new Set(
-    candidates
-      .filter((identifier) => !skipped.has(identifier) && !declared.has(identifier.name))
-      .map((identifier) => identifier.name)
-  );
 };

--- a/code/core/src/csf-tools/story-shape/resolve-story-args.ts
+++ b/code/core/src/csf-tools/story-shape/resolve-story-args.ts
@@ -1,0 +1,104 @@
+// The one choreography every renderer's snippet generator shares: resolve the meta's members once,
+// resolve each story's binding, merge their args, and read every value through to something that
+// means the same where the snippet lands.
+import { types as t } from 'storybook/internal/babel';
+
+import type { CsfFile } from '../CsfFile.ts';
+import { type ImportRef } from './import-statements.ts';
+import { resolveArgValue } from './resolve-arg-value.ts';
+import {
+  type ReferenceContext,
+  type ResolvedMembers,
+  type StoryReferences,
+  resolveArgsRecord,
+  resolveBindingMembers,
+  resolveObjectMembers,
+  sourceOf,
+} from './resolve-members.ts';
+
+/** Everything reading one story's args statically produced. */
+export interface ResolvedStoryArgs {
+  /** Meta args merged under story args, keyed by arg name, every value read through. */
+  args: Record<string, t.Node>;
+  /** Imports the arg values need beyond the component, from values that kept a name. */
+  imports: ImportRef[];
+  /** Source text of everything hiding args from this pass; empty when the merged args are known. */
+  unresolved: string[];
+  /** The story's own config members, spreads and names followed. */
+  storyMembers: ResolvedMembers;
+  /** The meta's config members, spreads and names followed. */
+  metaMembers: ResolvedMembers;
+}
+
+export interface StoryArgsResolver {
+  /** The context every resolution in this file runs against. */
+  ctx: ReferenceContext;
+  resolve: (storyExport: string) => ResolvedStoryArgs;
+}
+
+/**
+ * Builds the args resolver for one story file, resolving the meta once for all of its stories.
+ *
+ * Pass `references` to let a story's args resolve names other modules own; without it only the
+ * story file itself is read, and anything it reaches for elsewhere is reported as unresolved.
+ */
+export function createStoryArgsResolver(
+  csf: CsfFile,
+  references?: StoryReferences
+): StoryArgsResolver {
+  const ctx: ReferenceContext = {
+    program: csf._file.path,
+    filePath: csf._file.opts.filename ?? '',
+    ...references,
+  };
+
+  const metaNode = csf._metaNode;
+  const metaMembers =
+    metaNode && t.isObjectExpression(metaNode)
+      ? resolveObjectMembers(metaNode, ctx)
+      : { properties: {}, shadowed: [], unresolved: [] };
+  const metaArgs = resolveArgsRecord(metaMembers.properties.args, ctx);
+
+  return {
+    ctx,
+    resolve: (storyExport) => {
+      // A re-export documents the story under a different name than the binding it reads.
+      const localName = csf._stories[storyExport]?.localName ?? storyExport;
+      const storyMembers = resolveBindingMembers(ctx, localName) ?? {
+        properties: {},
+        shadowed: [],
+        unresolved: [sourceOf(csf._storyStatements[storyExport] ?? t.identifier(storyExport))],
+      };
+      const storyArgs = resolveArgsRecord(storyMembers.properties.args, ctx);
+
+      const args: Record<string, t.Node> = {};
+      const imports: ImportRef[] = [];
+      const unresolved = [
+        ...metaMembers.unresolved,
+        ...metaArgs.unresolved,
+        ...storyMembers.unresolved,
+        ...storyArgs.unresolved,
+      ];
+
+      for (const [key, node] of Object.entries({
+        ...metaArgs.properties,
+        ...storyArgs.properties,
+      })) {
+        const value = resolveArgValue(node, ctx);
+        args[key] = value.node;
+        imports.push(...value.imports);
+        unresolved.push(...value.unresolved);
+      }
+
+      return { args, imports, unresolved, storyMembers, metaMembers };
+    },
+  };
+}
+
+/** Says which source text a static pass could not read, so a reader can see what is missing. */
+export const unresolvedWarning = (unresolved: readonly string[]): string | undefined => {
+  const sources = [...new Set(unresolved)];
+  return sources.length === 0
+    ? undefined
+    : `Incomplete snippet: ${sources.map((source) => `\`${source}\``).join(', ')} could not be resolved statically.`;
+};

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.test.ts
@@ -878,6 +878,22 @@ describe('buildStoryDocsPayload', () => {
       expect(story.snippet).not.toContain('from-story');
     });
 
+    // `{ template: '…', ...makeBase() }` runs the spread after the write, so the template the story
+    // ends up with may be a different one entirely.
+    it('falls back when a later unreadable spread may replace the template', async () => {
+      const story = await soleStory(`
+        import { ButtonComponent } from './button.component';
+        export default { title: 'Example/Button', component: ButtonComponent };
+        declare function makeBase(): object;
+        export const Default = {
+          template: '<sb-button from-story></sb-button>',
+          ...makeBase(),
+        };
+      `);
+      expect(story.warning).toContain('`...makeBase()` could not be resolved statically');
+      expect(story.snippet).not.toContain('from-story');
+    });
+
     it('reads a config that is only a spread', async () => {
       const story = await soleStory(`
         import { ButtonComponent } from './button.component';

--- a/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-build.ts
@@ -1,22 +1,17 @@
 import { types as t } from 'storybook/internal/babel';
-import {
-  createStoryReferenceResolver,
-  getComponentIdFromEntry,
-  getStoryImportPathFromEntry,
-  parseReferenceModule,
-} from 'storybook/internal/common';
+import { getComponentIdFromEntry, getStoryImportPathFromEntry } from 'storybook/internal/common';
 import { storyNameFromExport } from 'storybook/internal/csf';
-import type { CsfFile, ReferenceContext, ResolvedMembers } from 'storybook/internal/csf-tools';
+import type { CsfFile, StoryArgsResolver, StoryReferences } from 'storybook/internal/csf-tools';
 import {
   buildImportStatements,
   collectImportBindings,
+  createStoryArgsResolver,
+  createStoryReferenceResolver,
   extractStoryJSDocInfo,
   isSelfContained,
-  resolveArgValue,
-  resolveArgsRecord,
-  resolveBindingMembers,
+  parseReferenceModule,
   resolveComponentImport,
-  resolveObjectMembers,
+  unresolvedWarning,
 } from 'storybook/internal/csf-tools';
 import type { StoryDoc, StoryDocsPayload, StoryDocsProviderInput } from 'storybook/internal/types';
 
@@ -75,30 +70,23 @@ export const buildStoryDocsPayload = async (
     : undefined;
 
   const enums = docgenPayload?.angularComponentMeta?.enums ?? [];
-  const references: ReferenceContext = {
-    program: csf._file.path,
+  const { resolveImport } = context;
+  const references: StoryReferences = {
     filePath: storyFilePath,
     externalize: createArgExternalizer(enums),
-    ...(context.resolveImport
-      ? {
-          resolveModule: (fromFile: string, specifier: string) => {
-            const target = context.resolveImport!(fromFile, specifier);
-            return target === undefined ? undefined : parseReferenceModule(target);
-          },
+    resolveModule: resolveImport
+      ? (fromFile, specifier) => {
+          const target = resolveImport(fromFile, specifier);
+          return target === undefined ? undefined : parseReferenceModule(target);
         }
-      : { resolveModule: openStoryReferences().resolveModule }),
+      : openStoryReferences().resolveModule,
   };
 
   const componentName = componentNameOf(componentNode);
   const importBindings = collectImportBindings(csf._file.path);
-  const metaNode = csf._metaNode;
   const deps: StoryDocDeps = {
     csf,
-    references,
-    metaMembers:
-      metaNode && t.isObjectExpression(metaNode)
-        ? resolveObjectMembers(metaNode, references)
-        : { properties: {}, unresolved: [] },
+    resolveStoryArgs: createStoryArgsResolver(csf, references),
     snippetMeta: docgenPayload?.angularComponentMeta,
     componentName,
     componentImport:
@@ -150,10 +138,8 @@ const componentNameOf = (node: t.Node | undefined): string | undefined => {
 
 interface StoryDocDeps {
   csf: CsfFile;
-  /** How args follow a spread or a name, out of the story file when it has to. */
-  references: ReferenceContext;
-  /** The meta's config members, spreads and names followed. */
-  metaMembers: ResolvedMembers;
+  /** Resolves each story's args, following a spread or a name out of the story file. */
+  resolveStoryArgs: StoryArgsResolver;
   snippetMeta: AngularComponentSnippetMeta | undefined;
   componentName: string | undefined;
   componentImport: string | undefined;
@@ -196,49 +182,29 @@ const buildStoryDoc = (
   }
 };
 
-/**
- * Everything reading the story statically produced: its config members, its merged args, and the
- * source text of whatever hid an arg from this pass.
- *
- * A story whose binding cannot be read at all - a re-export the parser resolved but scope does not
- * bind - has no members, which reads as a story that declares nothing rather than as an error.
- */
 const storyShape = (exportName: string, deps: StoryDocDeps): StoryShape => {
-  const { csf, references, metaMembers } = deps;
-  // A re-export documents the story under a different name than the binding it reads.
-  const localName = csf._stories[exportName]?.localName ?? exportName;
-  const members = resolveBindingMembers(references, localName) ?? {
-    properties: {},
-    unresolved: [sourceOf(csf._storyStatements[exportName] ?? t.identifier(exportName))],
-  };
-  const metaArgs = resolveArgsRecord(metaMembers.properties.args, references);
-  const storyArgs = resolveArgsRecord(members.properties.args, references);
-
-  const args: Record<string, t.Node> = {};
-  const unresolved = [
-    ...metaMembers.unresolved,
-    ...metaArgs.unresolved,
-    ...members.unresolved,
-    ...storyArgs.unresolved,
-  ];
+  const resolved = deps.resolveStoryArgs.resolve(exportName);
   const enums = deps.snippetMeta?.enums ?? [];
-  for (const [name, node] of Object.entries({
-    ...metaArgs.properties,
-    ...storyArgs.properties,
-  })) {
-    // A name the story file declares becomes the value it was declared with.
-    const value = resolveArgValue(node, references).node;
-    args[name] = value;
-    // A name that is left has to be reported: an Angular binding is evaluated against the host
-    // component the snippet ships, so a name that component does not have reads as `undefined`
-    // there rather than failing to compile. An enum member still resolves, and an expression that
-    // only names what it declares itself - a handler's own parameters - needs nothing from the host.
+  const unresolved = [...resolved.unresolved];
+  for (const value of Object.values(resolved.args)) {
+    // An arg that still carries a name has to be reported: an Angular binding is evaluated against
+    // the host component the snippet ships, so a name that component does not have reads as
+    // `undefined` there rather than failing to compile. An enum member still resolves, and an
+    // expression that only names what it declares itself - a handler's own parameters - needs
+    // nothing from the host.
     if (evaluateArgLiteral(value, enums) === undefined && !isSelfContained(value)) {
       unresolved.push(sourceOf(value));
     }
   }
 
-  return { csf, exportName, members, metaMembers, args, unresolvedArgs: unresolved };
+  return {
+    csf: deps.csf,
+    exportName,
+    members: resolved.storyMembers,
+    metaMembers: resolved.metaMembers,
+    args: resolved.args,
+    unresolvedArgs: unresolved,
+  };
 };
 
 /**
@@ -336,12 +302,6 @@ const referencedArgFields = (
 
   return { fields, unresolved };
 };
-
-/** Says which source text a static pass could not read, so a reader can see what is missing. */
-const unresolvedWarning = (unresolved: readonly string[]): string =>
-  `Incomplete snippet: ${[...new Set(unresolved)]
-    .map((source) => `\`${source}\``)
-    .join(', ')} could not be resolved statically.`;
 
 const withUnresolved = (
   rendered: HostComponentSnippet,

--- a/code/frameworks/angular-vite/src/docgen/story-docs-markup.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-markup.ts
@@ -331,13 +331,16 @@ type AnnotationResolution =
  * A named member of a resolved config record.
  *
  * The record already applied every spread it could read in source order, so a present member is the
- * value the story really ends up with. A member the record does not have is only knowably absent
- * when the record is complete: otherwise something this pass could not read may still supply it.
+ * value the story really ends up with - unless the record marks it shadowed, meaning something this
+ * pass could not read runs after the write and may replace it. A member the record does not have is
+ * only knowably absent when the record is complete.
  */
 export const resolvedMember = (members: ResolvedMembers, key: string): AnnotationResolution => {
   const node = members.properties[key];
   if (node !== undefined) {
-    return { kind: 'value', node };
+    return members.shadowed.includes(key)
+      ? { kind: 'unresolvable', node }
+      : { kind: 'value', node };
   }
   return members.unresolved.length > 0 ? { kind: 'unresolvable' } : { kind: 'missing' };
 };

--- a/code/renderers/react/src/componentManifest/buildReactComponentDocgen.ts
+++ b/code/renderers/react/src/componentManifest/buildReactComponentDocgen.ts
@@ -1,6 +1,7 @@
-import { createStoryReferenceResolver, getComponentIdFromEntry } from 'storybook/internal/common';
+import { getComponentIdFromEntry } from 'storybook/internal/common';
 import {
   buildImportStatements,
+  createStoryReferenceResolver,
   extractComponentDescription,
   extractDescription,
 } from 'storybook/internal/csf-tools';

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -837,3 +837,37 @@ test('args assembled at runtime are reported rather than dropped', () => {
     ]
   `);
 });
+
+test('args assigned to a function-declaration story are inlined', () => {
+  const input = withCSF3(dedent`
+    export function Usage(args) {
+      return <Button {...args}></Button>;
+    }
+    Usage.args = { label: 'assigned' };
+  `);
+  expect(generateExample(input)).toMatchInlineSnapshot(`
+    "function Usage() {
+        return <Button label="assigned">Click me</Button>;
+    }"
+  `);
+});
+
+test('a meta-level spread that may carry args is reported', () => {
+  const input = dedent`
+    import { Button } from '@design-system/button';
+    declare function sharedMeta(): object;
+    export default { component: Button, ...sharedMeta() };
+    export const Default = { args: { label: 'x' } };
+  `;
+  expect(generateResolved(input)).toMatchInlineSnapshot(`
+    [
+      {
+        "imports": [],
+        "snippet": "const Default = () => <Button label="x" />;",
+        "unresolved": [
+          "...sharedMeta()",
+        ],
+      },
+    ]
+  `);
+});

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
@@ -1,17 +1,14 @@
 import { type NodePath, types as t } from 'storybook/internal/babel';
-import type { StoryReferenceResolver } from 'storybook/internal/common';
 import {
+  createStoryArgsResolver,
   type CsfFile,
   type ImportRef,
   metaObjectPath,
   normalizeStoryDeclaration,
   type ReferenceContext,
   type RenderResolution,
-  resolveArgValue,
-  resolveArgsRecord,
-  resolveBindingMembers,
-  resolveObjectMembers,
   resolveRenderFunction,
+  type StoryArgsResolver,
 } from 'storybook/internal/csf-tools';
 
 import { invariant } from './utils.ts';
@@ -21,12 +18,6 @@ function renderFunctionOf(resolution: RenderResolution) {
     return resolution.path;
   }
   return resolution.kind === 'unresolved' ? resolution.shadowedRender : undefined;
-}
-
-/** How arg resolution leaves the story file; omitted when only the story file itself is read. */
-export interface StoryReferences extends StoryReferenceResolver {
-  /** Absolute path of the story file, which every import specifier resolves against. */
-  filePath: string;
 }
 
 /** A story's snippet, and what showing it as a complete example still depends on. */
@@ -42,50 +33,14 @@ export function getCodeSnippet(
   csf: CsfFile,
   storyName: string,
   componentName?: string,
-  references?: StoryReferences
+  resolver: StoryArgsResolver = createStoryArgsResolver(csf)
 ): CodeSnippet {
-  const ctx: ReferenceContext = { program: csf._file.path, filePath: '', ...references };
-  const { merged, imports, unresolved } = collectArgs(csf, storyName, ctx);
+  const { args, imports, unresolved } = resolver.resolve(storyName);
   return {
-    node: buildSnippetNode(csf, storyName, componentName, merged, ctx),
+    node: buildSnippetNode(csf, storyName, componentName, args, resolver.ctx),
     imports,
     unresolved,
   };
-}
-
-/**
- * The story's args as the snippet prints them: spreads followed, and every value read through to
- * something that means the same where the snippet lands.
- */
-function collectArgs(
-  csf: CsfFile,
-  storyName: string,
-  ctx: ReferenceContext
-): { merged: Record<string, t.Node>; imports: ImportRef[]; unresolved: string[] } {
-  const metaObj = csf._metaNode;
-  const metaMembers = metaObj ? resolveObjectMembers(metaObj, ctx) : undefined;
-  const metaArgs = resolveArgsRecord(metaMembers?.properties.args, ctx);
-  // A re-export documents the story under a different name than the binding it reads.
-  const localName = csf._stories[storyName]?.localName ?? storyName;
-  const storyMembers = resolveBindingMembers(ctx, localName);
-  const storyArgs = resolveArgsRecord(storyMembers?.properties.args, ctx);
-
-  const merged: Record<string, t.Node> = {};
-  const imports: ImportRef[] = [];
-  const unresolved = [
-    ...metaArgs.unresolved,
-    ...(storyMembers?.unresolved ?? []),
-    ...storyArgs.unresolved,
-  ];
-
-  for (const [key, node] of Object.entries({ ...metaArgs.properties, ...storyArgs.properties })) {
-    const value = resolveArgValue(node, ctx);
-    merged[key] = value.node;
-    imports.push(...value.imports);
-    unresolved.push(...value.unresolved);
-  }
-
-  return { merged, imports, unresolved };
 }
 
 function buildSnippetNode(

--- a/code/renderers/react/src/componentManifest/resolveComponents.ts
+++ b/code/renderers/react/src/componentManifest/resolveComponents.ts
@@ -1,9 +1,14 @@
 import { recast } from 'storybook/internal/babel';
 import { storyNameFromExport } from 'storybook/internal/csf';
-import type { ImportRef } from 'storybook/internal/csf-tools';
-import { extractStoryJSDocInfo, loadCsf } from 'storybook/internal/csf-tools';
+import type { ImportRef, StoryReferences } from 'storybook/internal/csf-tools';
+import {
+  createStoryArgsResolver,
+  extractStoryJSDocInfo,
+  loadCsf,
+  unresolvedWarning,
+} from 'storybook/internal/csf-tools';
 
-import { type StoryReferences, getCodeSnippet } from './generateCodeSnippet.ts';
+import { getCodeSnippet } from './generateCodeSnippet.ts';
 import {
   type ComponentRef,
   type DocgenEngine,
@@ -146,13 +151,6 @@ export interface ExtractedStorySnippets {
   imports: ImportRef[];
 }
 
-/** Says which source text a static pass could not read, so a reader can see what is missing. */
-function unresolvedWarning(unresolved: readonly string[]): string {
-  return `Incomplete snippet: ${[...new Set(unresolved)]
-    .map((source) => `\`${source}\``)
-    .join(', ')} could not be resolved statically.`;
-}
-
 /**
  * Extract per-story code snippets + JSDoc metadata from a parsed CSF file.
  *
@@ -168,14 +166,16 @@ export function extractStorySnippets(
   references?: StoryReferences
 ): ExtractedStorySnippets {
   const imports: ImportRef[] = [];
+  const resolver = createStoryArgsResolver(csf, references);
   const stories = Object.entries(csf._stories)
     .filter(([, story]) => !filterStoryIds || filterStoryIds.has(story.id))
     .map(([storyExport, story]): ResolvedStory => {
       const name = story.name ?? storyNameFromExport(storyExport);
       try {
         const { description, summary } = extractStoryJSDocInfo(csf._storyStatements[storyExport]);
-        const snippet = getCodeSnippet(csf, storyExport, componentName, references);
+        const snippet = getCodeSnippet(csf, storyExport, componentName, resolver);
         imports.push(...snippet.imports);
+        const warning = unresolvedWarning(snippet.unresolved);
 
         return {
           id: story.id,
@@ -183,9 +183,7 @@ export function extractStorySnippets(
           snippet: recast.print(snippet.node).code,
           description,
           summary,
-          ...(snippet.unresolved.length > 0
-            ? { warning: unresolvedWarning(snippet.unresolved) }
-            : {}),
+          ...(warning ? { warning } : {}),
         };
       } catch (e) {
         const err = e instanceof Error ? e : new Error(String(e));

--- a/code/renderers/vue3/src/story-docs/build-story-docs.test.ts
+++ b/code/renderers/vue3/src/story-docs/build-story-docs.test.ts
@@ -206,4 +206,33 @@ export const Primary = { args: { ...buildArgs(), label: 'Hi' } };
       'Incomplete snippet: `...buildArgs()` could not be resolved statically.'
     );
   });
+
+  // The meta spread cannot supply a render here - the story brings its own - but it can still
+  // carry args the snippet does not show, so it has to be named.
+  it('reports a meta-level spread that may carry args', async () => {
+    vol.fromJSON({
+      [STORY_PATH]: `
+import { h } from 'vue';
+import MyButton from './MyButton.vue';
+
+declare function sharedMeta(): object;
+
+export default { component: MyButton, title: 'Example/MyButton', ...sharedMeta() };
+
+export const Primary = {
+  args: { label: 'Hi' },
+  render: (args) => h(MyButton, { label: args.label }),
+};
+`,
+    });
+    const payload = await buildStoryDocsPayload(
+      { entry: ENTRY },
+      { readDocgen: async (id) => docgen(id) }
+    );
+    const story = payload?.stories[STORY_ID];
+    expect(story?.snippet).toBeDefined();
+    expect(story?.warning).toBe(
+      'Incomplete snippet: `...sharedMeta()` could not be resolved statically.'
+    );
+  });
 });

--- a/code/renderers/vue3/src/story-docs/build-story-docs.ts
+++ b/code/renderers/vue3/src/story-docs/build-story-docs.ts
@@ -2,10 +2,8 @@ import { readFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 
 import { types as t, type NodePath } from 'storybook/internal/babel';
-import type { StoryReferenceResolver } from 'storybook/internal/common';
 import {
   STORY_FILE_TEST_REGEXP,
-  createStoryReferenceResolver,
   getComponentIdFromEntry,
   getStoryImportPathFromEntry,
 } from 'storybook/internal/common';
@@ -14,24 +12,25 @@ import { storyNameFromExport } from 'storybook/internal/csf';
 import {
   buildImportStatements,
   collectImportBindings,
+  createStoryArgsResolver,
+  createStoryReferenceResolver,
   extractStoryJSDocInfo,
   jsDocTagsForPath,
   loadCsf,
   metaObjectPath,
   normalizeStoryDeclaration,
   propertyValue,
-  resolveArgValue,
-  resolveArgsRecord,
-  resolveBindingMembers,
   resolveComponentImport,
-  resolveObjectMembers,
   resolveRenderFunction,
   resolveReturnedObjectExpression,
   returnedExpressionPath,
+  unresolvedWarning,
   type ImportBinding,
   type ReferenceContext,
   type RenderFunctionPath,
   type RenderResolution,
+  type StoryArgsResolver,
+  type StoryReferenceResolver,
 } from 'storybook/internal/csf-tools';
 import type { StoryDoc, StoryDocsPayload, StoryDocsProviderInput } from 'storybook/internal/types';
 import type { DocgenPayload, DocgenService } from 'storybook/open-service';
@@ -70,8 +69,8 @@ interface StoryDocsContext {
   snippet: StorySnippetContext | undefined;
   importBindings: Map<string, ImportBinding>;
   metaPath: NodePath<t.ObjectExpression> | undefined;
-  /** How arg resolution follows a spread or a name out of the story file. */
-  references: ReferenceContext;
+  /** Resolves each story's args, following a spread or a name out of the story file. */
+  resolver: StoryArgsResolver;
 }
 
 // Vue's single-file-component format is tried ahead of the JS/TS extensions, matching how a story
@@ -153,11 +152,10 @@ export async function buildStoryDocsPayload(
     snippet,
     importBindings,
     metaPath,
-    references: {
-      program: csf._file.path,
+    resolver: createStoryArgsResolver(csf, {
       filePath: storyPath,
       ...(context.references ?? openStoryReferences()),
-    },
+    }),
   });
 
   return {
@@ -297,7 +295,7 @@ function enrichStoryDoc(
     storyConfigPath,
     options.metaPath,
     csf._storyDeclarationPath[storyExport],
-    options.references
+    options.resolver.ctx
   );
   const renderer =
     effectiveRender.kind === 'resolved'
@@ -309,7 +307,7 @@ function enrichStoryDoc(
     return plain;
   }
 
-  const resolved = resolveStaticStoryArgs(csf, storyExport, docgenArgInfo, options);
+  const resolved = resolveStaticStoryArgs(storyExport, docgenArgInfo, options);
   const classified = resolved.classified;
   if (classified.defer) {
     return plain;
@@ -335,14 +333,6 @@ function enrichStoryDoc(
     snippet: rendered.snippet,
     ...(warning ? { warning } : {}),
   };
-}
-
-/** Says which source text a static pass could not read, so a reader can see what is missing. */
-function unresolvedWarning(unresolved: readonly string[]): string | undefined {
-  const sources = [...new Set(unresolved)];
-  return sources.length === 0
-    ? undefined
-    : `Incomplete snippet: ${sources.map((source) => `\`${source}\``).join(', ')} could not be resolved statically.`;
 }
 
 function staticRendererForRenderFunction(
@@ -371,36 +361,16 @@ function staticRendererForRenderFunction(
 }
 
 function resolveStaticStoryArgs(
-  csf: ParsedCsf,
   storyExport: string,
   docgenArgInfo: VueDocgenArgInfo,
   options: StoryDocsContext
 ): StaticStoryArgs {
-  const ctx = options.references;
-  const metaMembers = options.metaPath
-    ? resolveObjectMembers(options.metaPath.node, ctx)
-    : undefined;
-  const metaArgs = resolveArgsRecord(metaMembers?.properties.args, ctx);
-  const localName = csf._stories[storyExport]?.localName ?? storyExport;
-  const storyMembers = resolveBindingMembers(ctx, localName);
-  const storyArgs = resolveArgsRecord(storyMembers?.properties.args, ctx);
-  const unresolved = [
-    ...metaArgs.unresolved,
-    ...(storyMembers?.unresolved ?? []),
-    ...storyArgs.unresolved,
-  ];
-
-  const args: Record<string, t.Node> = {};
-  for (const [name, node] of Object.entries({
-    ...metaArgs.properties,
-    ...storyArgs.properties,
-  })) {
-    // An arg naming a value the story file declares carries that value instead, since the name
-    // resolves nowhere in a snippet. A name another module owns stays for the classifier to report.
-    args[name] = resolveArgValue(node, ctx).node;
-  }
-
-  return { classified: classifyArgs(args, docgenArgInfo), unresolved };
+  // A name another module owns stays as written, for the classifier to report.
+  const resolved = options.resolver.resolve(storyExport);
+  return {
+    classified: classifyArgs(resolved.args, docgenArgInfo),
+    unresolved: resolved.unresolved,
+  };
 }
 
 function renderStaticStorySnippet(


### PR DESCRIPTION
Follow-up to #35923, addressing the code-quality review findings on that branch. Best reviewed commit-on-top; it targets the PR branch, not `next`.

## What I did

#35923 introduced the static pass that follows spreads and identifier references when the docgen server builds snippets. The review surfaced three kinds of problems on that branch: one case where the pass produced a silently wrong snippet, one place where the "shared" pass was actually three per-renderer copies that had already drifted apart, and a handful of resolution gaps. This PR fixes all of them without changing what the pass is for.

### One choreography instead of three

React, Vue and Angular each re-implemented the same sequence: resolve the meta members, resolve the story binding, merge the args, read every value through. The copies already disagreed:

|  | meta-level unreadable spread reported? | meta resolved |
| -- | -- | -- |
| Angular | yes | once per file |
| React | silently dropped | once per story |
| Vue | silently dropped | once per story |

`createStoryArgsResolver(csf, references)` in `story-shape` is now the only entry, and the renderers keep exactly the part that is theirs: JSX printing (React), the classifier (Vue), enum evaluation and host-binding reporting (Angular). The warning text has a single owner too. Captured from the React suite after the change:

```tsx
export default { component: Button, ...sharedMeta() };
export const Default = { args: { label: 'x' } };

// snippet:  const Default = () => <Button label="x" />;
// warning:  Incomplete snippet: `...sharedMeta()` could not be resolved statically.
```

On the base branch, React and Vue said nothing here, although `sharedMeta()` may carry or replace args at runtime.

### A cross-module `extend` leaked names that resolve nowhere

The `extend` merge hardcoded `external: false`, so a parent story another module owns was folded in as if its value nodes were local: no `externalize` vetting, references resolved against the wrong program. Captured from the resolver, same story shape, before and after:

```ts
// entry.ts
import { Base } from './other.stories';
const Variant = Base.extend({ args: { size: 'lg' } });
export const Ext = { args: { ...Variant.input.args } };

// other.stories.ts
const REMOTE_LABEL = 'remote';   // private to this module
export const Base = meta.story({ args: { label: REMOTE_LABEL, primary: true } });
```

```jsonc
// before                                      // after
"args": {                                      "args": {},
  "label":   { "node": "REMOTE_LABEL",         "unresolved": ["...Variant.input.args"],
               "imports": [],                  "warning": "Incomplete snippet:
               "unresolved": [] },  // silent      `...Variant.input.args` could not
  "primary": { "node": "true" },                   be resolved statically."
  "size":    { "node": "'lg'" }
},
"unresolved": []
```

`REMOTE_LABEL` compiled into the snippet with no import and no warning, which is exactly the failure class #35923 exists to eliminate. The fix is conservative rejection at the merge:

```diff
  const parent = bindingMembers(ctx, factory.parent, position, visited);
  if (
    parent === undefined ||
    parent.kind === 'namespace' ||
-   parent.accessor !== 'input'
+   parent.accessor !== 'input' ||
+   parent.external
  ) {
    return undefined;
  }
```

### Member resolution now knows write order

`{ template: 'own', ...makeBase() }` and `{ ...makeBase(), template: 'own' }` resolved to the same record, although only the second one is definitively known at runtime. `ResolvedMembers` now carries `shadowed`: the member names written before an unreadable write that may replace them. The Angular markup pass is the consumer that was trusting the first form; its new expectation:

```ts
export const Default = {
  template: '<sb-button from-story></sb-button>',
  ...makeBase(),
};
// before: snippet shows `from-story` markup the runtime may replace
// after:  falls back, warning names `...makeBase()`
```

### Three resolution gaps

- A CSF2 story written as a function declaration lost its assigned args (a regression against the assignment scanner #35923 deleted). Captured from the React suite: `export function Usage(args) { return <Button {...args} />; }` with `Usage.args = { label: 'assigned' }` renders `<Button label="assigned">Click me</Button>` again.
- The free-name analysis was not lexically scoped, so `[dep => dep, dep]` hid the outer imported `dep` and `{ dep }` shorthand was missed entirely. It now runs on Babel's own scope analysis; the hand-rolled declared/skipped pseudo-scope model is gone.
- A method could slip through a spread into args with no warning: `{ args: { ...shared } }` admitted `shared.count()`. The `keepMethods` mode is deleted; members are expanded first and the final record is validated as args, so a method is reported wherever a spread copied it from.

### Two snippet-printing fixes on top (from review)

Both reproduced before fixing, both covered by tests:

- Inlining an arg dropped the story function's parameter list unconditionally. When one arg inlined and another did not, the body kept reading `args.somethingElse` while the snippet no longer declared `args`. The parameters now survive exactly when the rewritten body still reads from them, so the fully-inlined case keeps its clean `function Usage()` output and the partial case stays valid:

  ```diff
  # export function Usage(args) { return <Button {...args} title={args.notAnArg} />; }
  # Usage.args = { label: 'assigned' };

  - function Usage() {
  + function Usage(args) {
        return <Button label="assigned" title={args.notAnArg}>Click me</Button>;
    }
  ```

- Rebuilding an object to write out a nested spread lost the shorthand flag, so `{ dep, nested: { ...base } }` printed `dep: dep`. Shorthand is preserved while the value is still the one the key stands for.

### Module layout

- `common/utils/story-reference-context.ts` imported the full `storybook/internal/csf-tools` barrel while `csf-tools` already imports `common`, an entrypoint cycle. The disk-backed reference context now lives in `csf-tools/story-shape/reference-context.ts`; `common` stays the one-way generic dependency. The `oxc-resolver`-based module resolution is untouched.
- The 833-line `resolve-args.ts` is three units now, each with its own test file:

```text
story-shape/
  resolve-members.ts     one record per binding - writes applied in run order,
        |                `shadowed` names members a later unreadable write may replace
  resolve-arg-value.ts   a value read through to what it means where the snippet lands
        |
  resolve-story-args.ts  createStoryArgsResolver(csf, references)
        |                meta once per file; per story: merge, read values, report
  ------+--------+----------------+
React (JSX)   Vue (classifier)   Angular (enum evaluation + host bindings)
```

### Behavior that changed, spelled out

- React and Vue now warn about a meta-level spread the pass cannot read; Angular already did.
- React and Vue now report a story binding that cannot be read at all, instead of treating it as a story that declares nothing; Angular already did.
- An Angular `template` (or `render`) written before an unreadable spread falls back with a warning instead of printing as certain.
- A locally declared `X.extend(...)` whose parent comes from another module is reported as unresolved instead of resolving with wrong-scope values. A cross-file `extend` written directly as a story export was never reachable: `loadCsf` rejects that form outright.
- Internal import paths moved: `createStoryReferenceResolver`, `parseReferenceModule`, `StoryReferenceResolver` and `StoryReferences` live in `storybook/internal/csf-tools` now, not `storybook/internal/common`.

## Checklist for Contributors

### Testing

| Command | What it covers | Run from |
| -- | -- | -- |
| `yarn vitest run code/core/src/csf-tools/story-shape` | the shared pass, including the new write-order, extend, scoping and method cases | repo root |
| `yarn vitest run --project @storybook/react --project @storybook/vue3 --project @storybook/angular-vite` | each renderer on the shared facade | repo root |
| `yarn vitest run --project @storybook/docgen-harness` | the recorded payload baselines (unchanged by this PR) | repo root |

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. In the sandbox, add to `src/stories/Button.stories.ts`:
   ```tsx
   export function Assigned(args) {
     return <Button {...args} />;
   }
   Assigned.args = { label: 'assigned' };
   ```
3. Start the sandbox with `experimentalDocgenServer` on and open the Docs page for Button. The `Assigned` snippet should carry `label="assigned"`; on the base branch of this PR the assignment is dropped.
4. Change the default export to `export default { ...({} as object), title: 'Example/Button', component: Button };` and reload. Every story on the page should now carry the note that the spread could not be resolved statically; on the base branch nothing is said.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user-facing docs change: everything stays within the `StoryDoc.warning` channel #35923 already established. The moved exports are internal API.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01948zU9aDMuAFA9eFnQRk9L
