### PR TITLE
Core: Warn when multiple story files collapse onto one componentId

### DIFF
--- a/code/core/src/common/utils/select-component-entry.test.ts
+++ b/code/core/src/common/utils/select-component-entry.test.ts
@@ -10,16 +10,12 @@ import {
   selectComponentEntriesByComponentId,
 } from './select-component-entry.ts';
 
-vi.mock('storybook/internal/node-logger', () => ({
-  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-  once: Object.assign(vi.fn(), {
-    verbose: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    clear: vi.fn(),
-  }),
-}));
+vi.mock('storybook/internal/node-logger', { spy: true });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(once.warn).mockImplementation(() => undefined);
+});
 
 function makeStoryEntry(id: string, title = 'Comp'): IndexEntry {
   return {
@@ -75,10 +71,6 @@ describe('selectComponentEntriesByComponentId', () => {
 });
 
 describe('componentId collision warning', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('warns with the colliding files and the winner when several story files share a componentId', () => {
     const first = {
       ...makeStoryEntry('collide--a'),

--- a/code/core/src/common/utils/select-component-entry.test.ts
+++ b/code/core/src/common/utils/select-component-entry.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { once } from 'storybook/internal/node-logger';
 
 import { Tag } from '../../shared/constants/tags.ts';
 import type { DocsIndexEntry, IndexEntry } from '../../types/modules/indexer.ts';
@@ -7,6 +9,17 @@ import {
   getStoryImportPathFromEntry,
   selectComponentEntriesByComponentId,
 } from './select-component-entry.ts';
+
+vi.mock('storybook/internal/node-logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  once: Object.assign(vi.fn(), {
+    verbose: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    clear: vi.fn(),
+  }),
+}));
 
 function makeStoryEntry(id: string, title = 'Comp'): IndexEntry {
   return {
@@ -58,5 +71,115 @@ describe('selectComponentEntriesByComponentId', () => {
 
     const map = selectComponentEntriesByComponentId([first, second]);
     expect(map.get('comp')).toEqual(second);
+  });
+});
+
+describe('componentId collision warning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('warns with the colliding files and the winner when several story files share a componentId', () => {
+    const first = {
+      ...makeStoryEntry('collide--a'),
+      importPath: './first.stories.tsx',
+    };
+    const second = {
+      ...makeStoryEntry('collide--b'),
+      importPath: './second.stories.tsx',
+    };
+
+    selectComponentEntriesByComponentId([first, second]);
+
+    expect(once.warn).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(once.warn).mock.calls[0][0];
+    expect(message).toContain('collide');
+    expect(message).toContain('./first.stories.tsx');
+    expect(message).toContain('./second.stories.tsx');
+    expect(message).toMatch(/'\.\/second\.stories\.tsx' only/);
+  });
+
+  it('does not warn when all stories of a componentId come from one file', () => {
+    const first = {
+      ...makeStoryEntry('collide--a'),
+      importPath: './same.stories.tsx',
+    };
+    const second = {
+      ...makeStoryEntry('collide--b'),
+      importPath: './same.stories.tsx',
+    };
+
+    selectComponentEntriesByComponentId([first, second]);
+
+    expect(once.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not count attached docs import paths toward the story-file collision', () => {
+    const storyEntry = {
+      ...makeStoryEntry('collide--default'),
+      importPath: './collide.stories.tsx',
+    };
+    const docsEntry = {
+      id: 'collide--docs',
+      name: 'Docs',
+      title: 'Comp/Docs',
+      type: 'docs',
+      importPath: './collide.mdx',
+      storiesImports: ['./collide.stories.tsx'],
+      tags: [Tag.ATTACHED_MDX, 'docs'],
+    } satisfies DocsIndexEntry;
+
+    selectComponentEntriesByComponentId([storyEntry, docsEntry]);
+
+    expect(once.warn).not.toHaveBeenCalled();
+  });
+
+  it('emits a byte-identical, sorted message for the same collision regardless of entry order', () => {
+    const zebra = { ...makeStoryEntry('collide--a'), importPath: './zebra.stories.tsx' };
+    const xylo = { ...makeStoryEntry('collide--b'), importPath: './xylo.stories.tsx' };
+    const winner = { ...makeStoryEntry('collide--c'), importPath: './main.stories.tsx' };
+
+    selectComponentEntriesByComponentId([zebra, xylo, winner]);
+    selectComponentEntriesByComponentId([xylo, zebra, winner]);
+
+    expect(once.warn).toHaveBeenCalledTimes(2);
+    const [firstMessage] = vi.mocked(once.warn).mock.calls[0];
+    const [secondMessage] = vi.mocked(once.warn).mock.calls[1];
+    expect(secondMessage).toBe(firstMessage);
+    expect(firstMessage.indexOf('./main.stories.tsx')).toBeLessThan(
+      firstMessage.indexOf('./xylo.stories.tsx')
+    );
+    expect(firstMessage.indexOf('./xylo.stories.tsx')).toBeLessThan(
+      firstMessage.indexOf('./zebra.stories.tsx')
+    );
+  });
+
+  it('produces a new message when another story file joins the collision', () => {
+    const first = { ...makeStoryEntry('collide--a'), importPath: './one.stories.tsx' };
+    const second = { ...makeStoryEntry('collide--b'), importPath: './two.stories.tsx' };
+    const third = { ...makeStoryEntry('collide--c'), importPath: './three.stories.tsx' };
+
+    selectComponentEntriesByComponentId([first, second]);
+    selectComponentEntriesByComponentId([first, second, third]);
+
+    expect(once.warn).toHaveBeenCalledTimes(2);
+    const [firstMessage] = vi.mocked(once.warn).mock.calls[0];
+    const [secondMessage] = vi.mocked(once.warn).mock.calls[1];
+    expect(secondMessage).not.toBe(firstMessage);
+    expect(secondMessage).toContain('./three.stories.tsx');
+  });
+
+  it('produces a new message naming the new winner when the winning file changes', () => {
+    const first = { ...makeStoryEntry('collide--a'), importPath: './one.stories.tsx' };
+    const second = { ...makeStoryEntry('collide--b'), importPath: './two.stories.tsx' };
+
+    selectComponentEntriesByComponentId([first, second]);
+    selectComponentEntriesByComponentId([second, first]);
+
+    expect(once.warn).toHaveBeenCalledTimes(2);
+    const [firstMessage] = vi.mocked(once.warn).mock.calls[0];
+    const [secondMessage] = vi.mocked(once.warn).mock.calls[1];
+    expect(firstMessage).toMatch(/'\.\/two\.stories\.tsx' only/);
+    expect(secondMessage).toMatch(/'\.\/one\.stories\.tsx' only/);
   });
 });

--- a/code/core/src/common/utils/select-component-entry.ts
+++ b/code/core/src/common/utils/select-component-entry.ts
@@ -1,3 +1,7 @@
+import { dedent } from 'ts-dedent';
+
+import { once } from 'storybook/internal/node-logger';
+
 import { Tag } from '../../shared/constants/tags.ts';
 import type { DocsIndexEntry, IndexEntry } from '../../types/modules/indexer.ts';
 
@@ -38,20 +42,51 @@ export function getStoryImportPathFromEntry(entry: IndexEntry): string | undefin
   return undefined;
 }
 
+// The paths are sorted so the same collision produces a byte-identical message regardless of index
+// order, which is what `once` deduplicates on.
+function buildCollisionWarning(
+  componentId: string,
+  importPaths: Set<string>,
+  winner: IndexEntry
+): string {
+  const sortedPaths = Array.from(importPaths).sort();
+  return dedent`
+    Multiple story files share the component id '${componentId}':
+    ${sortedPaths.map((path) => `  - ${path}`).join('\n')}
+    Component-level docs (props tables, code snippets, manifests, MCP docs) for this id are generated from '${winner.importPath}' only, so stories in the other files are left out of them. If these files document different components, give each file a unique title so every component keeps its docs.
+  `;
+}
+
 /**
  * Picks one index entry per componentId: story entries win; attached docs fill gaps only where no
  * story exists for that componentId.
+ *
+ * Several story files can collapse onto one componentId by sharing a title. The selection cannot
+ * represent that, so it warns (deduplicated per distinct collision) that component-level docs cover
+ * only the winning file.
  */
 export function selectComponentEntriesByComponentId(
   indexEntries: IndexEntry[]
 ): Map<string, IndexEntry> {
   const entriesByComponentId = new Map<string, IndexEntry>();
+  const storyImportPathsByComponentId = new Map<string, Set<string>>();
 
   for (const entry of indexEntries) {
     if (!isEligibleStoryEntry(entry)) {
       continue;
     }
-    entriesByComponentId.set(getComponentIdFromEntry(entry), entry);
+    const componentId = getComponentIdFromEntry(entry);
+    entriesByComponentId.set(componentId, entry);
+    const importPaths = storyImportPathsByComponentId.get(componentId) ?? new Set();
+    importPaths.add(entry.importPath);
+    storyImportPathsByComponentId.set(componentId, importPaths);
+  }
+
+  for (const [componentId, importPaths] of storyImportPathsByComponentId) {
+    const winner = entriesByComponentId.get(componentId);
+    if (importPaths.size > 1 && winner) {
+      once.warn(buildCollisionWarning(componentId, importPaths, winner));
+    }
   }
 
   for (const entry of indexEntries) {


### PR DESCRIPTION
Closes [SB-1847](https://linear.app/chromaui/issue/SB-1847/bug-core-multiple-csf-files-sharing-one-title-collapse-to-one)

## What I did

When several CSF files share one `title`, they all map to the same componentId (the title-derived prefix of every story id), and the component-entry selection keeps exactly one file per componentId - last one wins.
Every other file's component silently loses its docgen payload, story snippets, component manifest entry, and MCP docs, while the sidebar and preview render all stories normally, so nothing looks wrong.
This PR makes the data loss visible: the selection now warns once per collision, naming the colliding files and the winner.

```text
button.stories.ts            (title: 'Example/Button', component: ButtonComponent)  ─┐
                                                                                     ├─> componentId 'example-button' ──> one entry survives ──> docgen / snippets /
button-secondary.stories.ts  (title: 'Example/Button', component: HeaderComponent) ──┘        (last set() wins)             manifest / MCP for ONE component only
```

The warning, captured from a real `angular-vite/docgen-server-ts` sandbox build with exactly that setup:

```text
▲  Multiple story files share the component id 'example-button':
│  - ./src/stories/button-secondary.stories.ts
│  - ./src/stories/button.stories.ts
│  Component-level docs (props tables, code snippets, manifests, MCP
│  docs) for this id are generated from './src/stories/button.stories.ts'
│  only, so stories in the other files are left out of them. If these
│  files document different components, give each file a unique title so
│  every component keeps its docs.
```

The loss it points at, verified in the same build's artifacts: `index.json` lists 5 stories under `example-button`, but `services/core/story-docs/example-button.json` only carries the 4 stories from the winning file, and `services/core/docgen/example-button.json` documents `ButtonComponent` only - `HeaderComponent`'s 4 documented inputs are gone.
After giving the second file a unique title, the warning disappears and both components come back with their full argTypes.

The single decision that matters is the collision predicate - distinct `importPath`s of eligible story entries per componentId - paired with `once.warn` for deduplication, so the several services that share this selection (docgen, story-docs, manifests, MCP access, refresh subscriptions) don't repeat the same warning:

```ts
for (const [componentId, importPaths] of storyImportPathsByComponentId) {
  const winner = entriesByComponentId.get(componentId);
  if (importPaths.size > 1 && winner) {
    once.warn(buildCollisionWarning(componentId, importPaths, winner));
  }
}
```

`once` deduplicates on the exact message, and the message contains the sorted file list plus the winner - so the same collision warns once per process regardless of index order, while a changed file set or a changed winner produces a fresh, corrected warning. Each of those properties is pinned by a unit test (a mutation probe confirmed the earlier hand-rolled dedup key was untestable, which is why this now reuses `once` instead).

Two things worth knowing:

- Splitting one component's stories across same-title CSF files is a supported pattern (our own docs fixture `multiple-csf-files-{a,b}.stories.ts` uses it), and sandbox builds now show this warning for it. That is deliberate and truthful: even with the same component in both files, the non-winning file's stories are missing from `story-docs` today. The message states the unconditional consequence (stories left out) and scopes the rename advice to the case where the files document different components.
- The warning is the visibility half of SB-1847. The real fix - letting the selection represent multiple components per componentId - changes the payload and manifest shapes and deserves its own design discussion; I would rather ship the warning now than hold it hostage to that.

In the field this hit 2 of 22 repos in the Angular QA sweep, and badly: alauda/ui has 25 of 37 titles spanning multiple CSF files, losing 65% of its story snippets with zero warnings anywhere.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

The tests were written first (red on the unpatched selection): warning content including the winner, no warning for single-file components, attached-docs import paths not counted as colliding story files, a byte-identical sorted message for the same collision regardless of entry order (the dedup key), and a fresh message when a file joins the collision or the winner changes.

#### Manual testing

1. Generate a sandbox: `yarn task sandbox --template angular-vite/docgen-server-ts --start-from auto`.
2. In the sandbox, copy `src/stories/button.stories.ts` to `src/stories/button-secondary.stories.ts`, keep `title: 'Example/Button'`, and point `component` at `HeaderComponent` (rename the story exports so story ids stay unique).
3. Run `yarn build-storybook` and find the warning above in the log; confirm `storybook-static/services/core/docgen/example-button.json` documents only one of the two components.
4. Give the copy a unique title, rebuild, and confirm the warning is gone and both `example-button` and the new id have full docgen payloads.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrtpW9f2Uj5c3KKFTB4po3
