### PR TITLE
Core: Filter addon panels when no story is resolved

### DIFF
--- a/code/core/src/manager/container/Panel.test.tsx
+++ b/code/core/src/manager/container/Panel.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import React from 'react';
+
+import * as api from 'storybook/manager-api';
+
+import Panel from './Panel.tsx';
+
+vi.mock('storybook/manager-api');
+vi.mock('../components/panel/Panel.tsx', () => ({
+  AddonPanel: ({ panels }: any) => <div data-testid="panels">{Object.keys(panels).join(',')}</div>,
+}));
+
+const mockedApi = vi.mocked(api);
+
+const panels = {
+  always: { id: 'always', type: 'panel' },
+  optIn: {
+    id: 'optIn',
+    type: 'panel',
+    disabled: (parameters: any) => !parameters?.docs?.codePanel,
+  },
+} as any;
+
+const renderWith = (story: any) => {
+  mockedApi.useStorybookApi.mockReturnValue({
+    getElements: () => panels,
+    getCurrentStoryData: () => story,
+    getSelectedPanel: () => 'always',
+    getShortcutKeys: () => ({}),
+    setSelectedPanel: vi.fn(),
+    getIsPanelShown: () => true,
+    togglePanel: vi.fn(),
+    togglePanelPosition: vi.fn(),
+    focusOnUIElement: vi.fn(),
+  } as any);
+  mockedApi.useStorybookState.mockReturnValue({ layout: { panelPosition: 'bottom' } } as any);
+  mockedApi.useChannel.mockReturnValue(vi.fn() as any);
+
+  return render(<Panel />).getByTestId('panels').textContent;
+};
+
+describe('Panel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('hides a panel whose disabled predicate rejects the story parameters', () => {
+    expect(renderWith({ type: 'story', parameters: {} })).toBe('always');
+  });
+
+  it('shows a panel that the story opts into', () => {
+    expect(renderWith({ type: 'story', parameters: { docs: { codePanel: true } } })).toBe(
+      'always,optIn'
+    );
+  });
+
+  // The panel set is also filtered before a story resolves, otherwise an opt-in
+  // panel is rendered until the parameters arrive.
+  it('hides an opt-in panel when there is no story data yet', () => {
+    expect(renderWith(undefined)).toBe('always');
+  });
+
+  it('hides an opt-in panel on a docs entry', () => {
+    expect(renderWith({ type: 'docs' })).toBe('always');
+  });
+});

--- a/code/core/src/manager/container/Panel.tsx
+++ b/code/core/src/manager/container/Panel.tsx
@@ -23,7 +23,7 @@ const Panel: FC<any> = (props) => {
     []
   );
 
-  const { parameters, type } = story ?? {};
+  const { parameters } = story ?? {};
 
   const panelActions = useMemo(
     () => ({
@@ -47,7 +47,7 @@ const Panel: FC<any> = (props) => {
   const panels = useMemo(() => {
     const allPanels = api.getElements(Addon_TypesEnum.PANEL);
 
-    if (!allPanels || type !== 'story') {
+    if (!allPanels) {
       return allPanels;
     }
 
@@ -64,7 +64,7 @@ const Panel: FC<any> = (props) => {
     });
 
     return filteredPanels;
-  }, [api, type, parameters]);
+  }, [api, parameters]);
 
   return (
     <AddonPanel


### PR DESCRIPTION
Closes #35774

## What I did

`Panel.tsx` returned the whole panel set whenever the current entry was not a resolved story, so the filter below it never ran on that path and `parameters` was always `undefined` there. The default-installed Code panel from addon-docs declares:

```ts
disabled: (parameters) => !parameters?.docs?.codePanel,
```

which means it should stay hidden unless a story opts in. Instead it rendered on a cold deep link until the story resolved, and on composed refs it never went away. Setting `docs.codePanel: false` at any level made no difference, because that predicate was never reached.

Removing the `type !== 'story'` condition lets the existing filter run in every case. Both `disabled` predicates in the repo already handle `undefined` parameters: `isInteractionsDisabled` returns `false` either way, so the Interactions panel is unaffected, and addon-docs' returns `true`, which is the fix. The `paramKey` branch just above already guards on `parameters` being truthy, so it is unchanged too.

`type` is no longer read, so I dropped it from the destructure and from the memo dependencies.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests

There were no tests for this container, so I added `code/core/src/manager/container/Panel.test.tsx` with four cases: a panel rejected by its predicate is hidden, a panel the story opts into is shown, and the two paths that were broken — no story data yet, and a docs entry. Reverting the fix fails exactly those last two with `expected 'always,optIn' to be 'always'`.

`src/manager` and `src/component-testing` are green (513 passed).

#### Manual testing

1. Start a sandbox: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook and hard-reload directly on a story URL, so it is a cold deep link rather than a client-side navigation
3. Watch the addon panel tabs while the page loads

Before this change a **Code** tab is visible for roughly a second and then disappears. After it, it is never shown.

4. Add `parameters: { docs: { codePanel: true } }` to that story and reload — the Code tab should appear and stay.

For the composed-refs case in the issue, add a `refs` entry in `.storybook/main.ts` pointing at another Storybook and open a story from that ref; before the change the Code tab stays for the whole session with an empty body.

### Documentation

- [ ] Add or update documentation reflecting your changes

No user-facing documentation change — `docs.codePanel` already documents itself as opt-in, and this makes the behaviour match that.

## AI disclosure

Claude Code assisted with this PR, per the policy in CONTRIBUTING.md. There is a real person behind it — I'll respond to anything you raise in review.
