### PR TITLE
Core: Insert saved args after a spread in CSF

### DIFF
--- a/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.test.ts
+++ b/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.test.ts
@@ -67,6 +67,11 @@ describe('success', () => {
       +   render: (args) => <MyComponent {...args} />,
       + } satisfies Story;
       + 
+      + export const SpreadsAnotherStoryDuplicated = {
+      +   ...OnlyArgs,
+      +   render: (args) => <MyComponent {...args} />,
+      + } satisfies Story;
+      + 
       + export const HasPlayFunctionDuplicated = {
       +   play: async ({ canvasElement }) => {
       +     console.log("play");
@@ -100,12 +105,16 @@ describe('success', () => {
     // check if the code was updated correctly
     expect(getDiff(before, after)).toMatchInlineSnapshot(`
       "  ...
-            foo: "bar",
-          },
+        export const SpreadsAnotherStory = meta.story({
+          ...WithArgs,
         });
         
       + export const EmptyDuplicated = meta.story({});
       + export const WithArgsDuplicated = meta.story({});
+      + 
+      + export const SpreadsAnotherStoryDuplicated = meta.story({
+      +   ...WithArgs,
+      + });
       + "
     `);
   });

--- a/code/core/src/core-server/utils/save-story/mocks/csf-variances.stories.tsx
+++ b/code/core/src/core-server/utils/save-story/mocks/csf-variances.stories.tsx
@@ -59,6 +59,12 @@ export const OrderedArgs = {
   render: (args) => <MyComponent {...args} />,
 } satisfies Story;
 
+// A spread carries its own args, so saved args have to land after it to take effect
+export const SpreadsAnotherStory = {
+  ...OnlyArgs,
+  render: (args) => <MyComponent {...args} />,
+} satisfies Story;
+
 // The order of both the properties of the story and the order of args should be preserved
 export const HasPlayFunction = {
   args: {

--- a/code/core/src/core-server/utils/save-story/mocks/csf4-variances.stories.tsx
+++ b/code/core/src/core-server/utils/save-story/mocks/csf4-variances.stories.tsx
@@ -13,3 +13,7 @@ export const WithArgs = meta.story({
     foo: 'bar',
   },
 });
+// A spread carries its own args, so saved args have to land after it to take effect
+export const SpreadsAnotherStory = meta.story({
+  ...WithArgs,
+});

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
@@ -217,7 +217,22 @@ describe('success', () => {
           },
           render: (args) => <MyComponent {...args} />,
         } satisfies Story;
-      ...
+        
+        // A spread carries its own args, so saved args have to land after it to take effect
+        export const SpreadsAnotherStory = {
+          ...OnlyArgs,
+        
+      + 
+      +   args: {
+      +     bordered: true,
+      +     initial: "test1",
+      +   },
+      + 
+      + 
+          render: (args) => <MyComponent {...args} />,
+        } satisfies Story;
+        
+        // The order of both the properties of the story and the order of args should be preserved
         export const HasPlayFunction = {
           args: {
             bordered: true,
@@ -281,6 +296,17 @@ describe('success', () => {
       +     initial: "test1",
       + 
           },
+        });
+        // A spread carries its own args, so saved args have to land after it to take effect
+        export const SpreadsAnotherStory = meta.story({
+          ...WithArgs,
+        
+      + 
+      +   args: {
+      +     bordered: true,
+      +     initial: "test1",
+      +   },
+      + 
         });
         "
     `);

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
@@ -55,7 +55,17 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
         }
       }
     } else {
-      properties.unshift(
+      // A spread can carry its own args, so it would override anything placed before it.
+      let index = 0;
+      properties.forEach((property, i) => {
+        if (t.isSpreadElement(property)) {
+          index = i + 1;
+        }
+      });
+
+      properties.splice(
+        index,
+        0,
         t.objectProperty(
           t.identifier('args'),
           t.objectExpression(
@@ -107,15 +117,26 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
           }
         }
       } else {
-        path.unshiftContainer(
-          'properties',
-          t.objectProperty(
-            t.identifier('args'),
-            t.objectExpression(
-              Object.entries(args).map(([key, value]) => t.objectProperty(t.identifier(key), value))
-            )
+        const newArgs = t.objectProperty(
+          t.identifier('args'),
+          t.objectExpression(
+            Object.entries(args).map(([key, value]) => t.objectProperty(t.identifier(key), value))
           )
         );
+
+        // A spread can carry its own args, so it would override anything placed before it.
+        let lastSpread;
+        properties.forEach((property) => {
+          if (property.isSpreadElement()) {
+            lastSpread = property;
+          }
+        });
+
+        if (lastSpread) {
+          (lastSpread as (typeof properties)[number]).insertAfter(newArgs);
+        } else {
+          path.unshiftContainer('properties', newArgs);
+        }
       }
     },
 


### PR DESCRIPTION
Closes #35447

## What I did

Save from Controls wrote the `args` property to the front of the story object:

```js
properties.unshift(t.objectProperty(t.identifier('args'), ...));
```

If the story spreads another story that carries its own `args`, the spread is applied after and wins, so the saved value never takes effect. The story stays dirty across a refresh and a restart, because the file on disk really does resolve to the old args:

```ts
export const MyStory = {
  args: { /* just saved */ },
  ...PrimaryStory,      // carries args, so it overrides
};
```

Args are now inserted after the last spread element instead. When there is no spread the position is unchanged, so existing files keep their current formatting.

`updateArgsInCsfFile` has two paths that both did this — the direct `ObjectExpression` branch and the `traverse` branch used for the other story shapes — so both are fixed.

I did not change the case where an `args` property already exists *before* a spread. That has the same root cause, but fixing it means relocating a property the user wrote rather than choosing where to put a new one, which felt like a separate decision. Happy to fold it in if you'd like it.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests

Added a story that spreads another story to both `mocks/csf-variances.stories.tsx` and `mocks/csf4-variances.stories.tsx`, which covers both code paths. The inline snapshots in `update-args-in-csf-file.test.ts` now show `args` landing after the spread.

Reverting the fix fails both `CSF Variances` and `CSF4 Variances` with the property back in front of the spread. `src/core-server` is green — 517 passed, no type errors.

The snapshot change in `duplicate-story-with-new-name.test.ts` is just the two new mock stories being duplicated by that test; no behaviour change there.

#### Manual testing

1. Start a sandbox: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. In a stories file, add a story that spreads another story which has args:

```ts
export const Primary = { args: { label: 'primary' } };
export const Spread = { ...Primary };
```

3. Open **Spread**, change `label` in the Controls panel, and use Save from Controls
4. Reload the page

Before this change the story still shows as modified and the control reverts to `primary`, because the written file has `args` above the spread. After it, the saved value survives the reload and the story is clean.

### Documentation

- [ ] Add or update documentation reflecting your changes

No documentation change — this restores the documented behaviour of Save from Controls.

## AI disclosure

Claude Code assisted with this PR, per the policy in CONTRIBUTING.md. There is a real person behind it and I'll respond to review.
