### PR TITLE
Core: Close a websocket client that errors instead of crashing

### DIFF
--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -58,6 +58,23 @@ describe('ServerChannelTransport', () => {
     expect(handler).toHaveBeenCalledWith('hello');
   });
 
+  // An 'error' event with no listener is rethrown by Node, which took the dev server
+  // down with whichever client sent the bad frame.
+  it('closes a client that errors instead of crashing', () => {
+    const server = new EventEmitter() as any as Server;
+    const socket = Object.assign(new EventEmitter(), { terminate: vi.fn() });
+    const transport = new ServerChannelTransport(server, options);
+
+    // @ts-expect-error (an internal API)
+    transport.socket.emit('connection', socket);
+
+    const error = Object.assign(new RangeError('Max payload size exceeded'), {
+      code: 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH',
+    });
+    expect(() => socket.emit('error', error)).not.toThrow();
+    expect(socket.terminate).toHaveBeenCalled();
+  });
+
   it('parses object JSON', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter();

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -62,6 +62,13 @@ export class ServerChannelTransport {
     });
 
     this.socket.on('connection', (wss) => {
+      // Node rethrows an 'error' event that nothing is listening for, which would take
+      // the dev server down with the offending client.
+      wss.on('error', (error) => {
+        logger.warn(`WebSocket client error, closing the connection: ${error}`);
+        wss.terminate();
+      });
+
       wss.on('message', (raw) => {
         const data = raw.toString();
         const event = typeof data === 'string' && isJSON(data) ? parse(data, {}) : data;


### PR DESCRIPTION
Closes #35862

## What I did

Each client socket got a `message` handler but no `error` handler. Node rethrows an `'error'` event that nothing is listening for, so one bad frame from one client took down the entire `storybook dev` process:

```
RangeError: Max payload size exceeded
    at Receiver.haveLength (.../ws/lib/receiver.js)
Emitted 'error' event on WebSocket instance at:
{ code: 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH', [Symbol(status-code)]: 1009 }
```

The socket that misbehaved is now logged and terminated, and the server keeps running.

I did not touch `maxPayload`. `ws` defaults it to 100MB and lowering it is a behaviour change worth deciding separately — the crash happens regardless of where the limit sits, and any invalid frame reaches the same path.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests

Added a case to `code/core/src/core-server/utils/__tests__/server-channel.test.ts`. It reproduces the crash directly rather than approximating it: an `EventEmitter` with no `'error'` listener throws on `emit('error')`, which is the exact Node behaviour that kills the process. Reverting the fix fails it with `RangeError: Max payload size exceeded` — the error from the issue.

`src/core-server` is green: 518 passed, no type errors.

#### Manual testing

1. Start a sandbox: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. With Storybook running, send an oversized frame to the server channel from a node script:

```js
import WebSocket from 'ws'
const ws = new WebSocket('ws://localhost:6006/storybook-server-channel')
ws.on('open', () => ws.send(Buffer.alloc(200 * 1024 * 1024)))
```

Before this change the `storybook dev` process exits with the `RangeError` above. After it, the connection is dropped, a warning is logged, and Storybook stays up — the browser reconnects on its own.

The issue also notes this is reachable without crafting a frame: stale browser tabs reconnecting after port reuse across local workspaces will do it.

### Documentation

- [ ] Add or update documentation reflecting your changes

No documentation change — this is a crash fix with no API surface.

## AI disclosure

Claude Code assisted with this PR, per the policy in CONTRIBUTING.md. There is a real person behind it and I'll respond to review.
