### PR TITLE
CI: Fix staged npm publish retries on latest-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: Publish
-run-name: "${{ github.event_name == 'workflow_dispatch' && format('Publish Canary on PR #{0}, triggered by {1}', inputs.pr, github.triggering_actor) || format('Publish new version on {0}, triggered by {1}', github.ref_name, github.triggering_actor) }}"
+run-name: "${{ github.event_name == 'workflow_dispatch' && inputs.skip_publish && format('Finish release bookkeeping on {0}, triggered by {1}', github.ref_name, github.triggering_actor) || github.event_name == 'workflow_dispatch' && format('Publish Canary on PR #{0}, triggered by {1}', inputs.pr, github.triggering_actor) || format('Publish new version on {0}, triggered by {1}', github.ref_name, github.triggering_actor) }}"
 
 on:
   push:
@@ -8,12 +8,16 @@ on:
       - latest-release
       - next-release
   workflow_dispatch:
-    # Manual canary releases on PRs
     inputs:
       pr:
         description: '⚠️ CANARY RELEASES ONLY - Enter the pull request number to create a canary release for'
-        required: true
+        required: false
         type: number
+      skip_publish:
+        description: 'Skip npm publish and finish GitHub Release / merge / Sentry / DX for an already-published version. Run this from next-release or latest-release.'
+        required: false
+        type: boolean
+        default: false
 
 env:
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -27,8 +31,8 @@ concurrency:
   #   so a newer canary supersedes an older one for the same PR. Only runs
   #   that actually publish a canary join this group.
   # - Pushes to release branches are grouped by branch name and never cancelled.
-  group: ${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.workflow, inputs.pr) || format('{0}-{1}', github.workflow, github.ref_name) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch'}}
+  group: ${{ github.event_name == 'workflow_dispatch' && inputs.pr && format('{0}-{1}', github.workflow, inputs.pr) || format('{0}-{1}', github.workflow, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_publish != true }}
 
 jobs:
   publish-normal:
@@ -36,9 +40,18 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.repository_owner == 'storybookjs' &&
-      github.event_name == 'push' &&
       (github.ref_name == 'latest-release' || github.ref_name == 'next-release') &&
-      contains(github.event.head_commit.message, '[skip ci]') != true
+      (
+        (
+          github.event_name == 'push' &&
+          contains(github.event.head_commit.message, '[skip ci]') != true
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.skip_publish == true &&
+          inputs.pr == ''
+        )
+      )
     environment: Release
     permissions:
       contents: write
@@ -99,7 +112,6 @@ jobs:
         run: yarn release:is-version-published "$CURRENT_VERSION"
 
       - name: Check release vs prerelease
-        if: steps.publish-needed.outputs.published == 'false'
         id: is-prerelease
         env:
           CURRENT_VERSION: ${{ steps.version.outputs.current-version }}
@@ -108,14 +120,15 @@ jobs:
       - name: Publish
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-        if: steps.publish-needed.outputs.published == 'false'
+        if: |
+          steps.publish-needed.outputs.published == 'false' &&
+          !(github.event_name == 'workflow_dispatch' && inputs.skip_publish == true)
         run: yarn release:publish --tag ${{ steps.is-prerelease.outputs.prerelease == 'true' && 'next' || 'latest' }} --verbose
 
       # Bookkeeping for DX deployment tracking, not part of publishing itself, so it runs
       # continue-on-error to avoid aborting an already-published release. Failure is alerted below.
       - name: Register release in DX
         id: register-dx-release
-        if: steps.publish-needed.outputs.published == 'false'
         continue-on-error: true
         env:
           DX_DATACLOUD_API_KEY: ${{ secrets.DX_DATACLOUD_API_KEY }}
@@ -187,7 +200,6 @@ jobs:
         run: echo "target=${{ github.ref_name == 'next-release' && 'next' || 'main' }}" >> $GITHUB_OUTPUT
 
       - name: Get changelog for ${{ steps.version.outputs.current-version }}
-        if: steps.publish-needed.outputs.published == 'false'
         id: changelog
         env:
           CURRENT_VERSION: ${{ steps.version.outputs.current-version }}
@@ -220,7 +232,6 @@ jobs:
           args: 'Publishing v${{ steps.version.outputs.current-version }} succeeded, but labeling patch PRs as "patch:done" failed. They must be labeled manually or they will reappear in the next patch changelog. See run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
       - name: Create GitHub Release
-        if: steps.publish-needed.outputs.published == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT_VERSION: ${{ steps.version.outputs.current-version }}
@@ -229,6 +240,10 @@ jobs:
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}
           IS_PRERELEASE: ${{ steps.is-prerelease.outputs.prerelease == 'true' && '--prerelease' || '' }}
         run: |
+          if gh release view "v$CURRENT_VERSION" --repo "$REPOSITORY" >/dev/null 2>&1; then
+            echo "GitHub release v$CURRENT_VERSION already exists, skipping create"
+            exit 0
+          fi
           gh release create \
           "v$CURRENT_VERSION" \
             --repo "$REPOSITORY" \
@@ -250,7 +265,13 @@ jobs:
           git push origin "$TARGET_BRANCH"
 
       - name: Force push from 'next' to 'latest-release' and 'main' on minor/major releases
-        if: github.ref_name == 'next-release' && steps.is-prerelease.outputs.prerelease == 'false'
+        if: |
+          github.ref_name == 'next-release' &&
+          steps.is-prerelease.outputs.prerelease == 'false' &&
+          (
+            steps.publish-needed.outputs.published == 'false' ||
+            (github.event_name == 'workflow_dispatch' && inputs.skip_publish == true)
+          )
         run: |
           git checkout next
           git pull
@@ -272,7 +293,7 @@ jobs:
           git push origin next
 
       - name: Create Sentry release
-        if: steps.publish-needed.outputs.published == 'false'
+        continue-on-error: true
         uses: getsentry/action-release@5657c9e888b4e2cc85f4d29143ea4131fde4a73a # v3.6.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -296,7 +317,8 @@ jobs:
     if: |
       github.repository_owner == 'storybookjs' &&
       github.event_name == 'workflow_dispatch' &&
-      contains(github.event.head_commit.message, '[skip ci]') != true
+      inputs.skip_publish != true &&
+      inputs.pr != ''
     environment: Release
     permissions:
       contents: read

--- a/scripts/release/__tests__/is-version-published.test.ts
+++ b/scripts/release/__tests__/is-version-published.test.ts
@@ -1,0 +1,49 @@
+import { setOutput } from '@actions/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getCodeWorkspaces } from '../../utils/workspace.ts';
+import { run as isVersionPublished } from '../is-version-published.ts';
+import { listUnpublishedPackages } from '../npm-registry.ts';
+
+vi.mock('@actions/core', { spy: true });
+vi.mock('../../utils/workspace.ts', { spy: true });
+vi.mock('../npm-registry.ts', { spy: true });
+
+beforeEach(() => {
+  vi.mocked(getCodeWorkspaces).mockReset();
+  vi.mocked(listUnpublishedPackages).mockReset();
+  vi.mocked(setOutput).mockReset();
+  vi.mocked(setOutput).mockImplementation(() => {});
+  vi.stubEnv('GITHUB_ACTIONS', '');
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.mocked(getCodeWorkspaces).mockResolvedValue([
+    { name: 'storybook', location: '.' },
+    { name: '@storybook/react', location: 'renderers/react' },
+  ]);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('is-version-published', () => {
+  it('reports published when every public workspace is on npm', async () => {
+    vi.mocked(listUnpublishedPackages).mockResolvedValue([]);
+
+    await expect(isVersionPublished(['1.0.0'], {})).resolves.toBe(true);
+    expect(listUnpublishedPackages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageNames: ['storybook', '@storybook/react'],
+        version: '1.0.0',
+      })
+    );
+  });
+
+  it('reports unpublished when any public workspace is missing', async () => {
+    vi.mocked(listUnpublishedPackages).mockResolvedValue(['storybook']);
+
+    await expect(isVersionPublished(['1.0.0'], {})).resolves.toBe(false);
+  });
+});

--- a/scripts/release/__tests__/npm-registry.test.ts
+++ b/scripts/release/__tests__/npm-registry.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  isPackageVersionPublished,
+  listUnpublishedPackages,
+  packagesAcceptedByRegistry,
+  waitForPackagesToBePublished,
+} from '../npm-registry.ts';
+
+const fetchMock = vi.fn();
+
+const jsonResponse = (status: number, body: unknown) =>
+  Promise.resolve({
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('isPackageVersionPublished', () => {
+  it('returns false on 404', async () => {
+    fetchMock.mockImplementation(() => jsonResponse(404, { error: 'Not found' }));
+
+    await expect(
+      isPackageVersionPublished({ packageName: 'storybook', version: '10.6.0-alpha.6' })
+    ).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://registry.npmjs.org/storybook/10.6.0-alpha.6',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('returns true on 200 with a matching version', async () => {
+    fetchMock.mockImplementation(() => jsonResponse(200, { version: '10.6.0-alpha.6' }));
+
+    await expect(
+      isPackageVersionPublished({ packageName: 'storybook', version: '10.6.0-alpha.6' })
+    ).resolves.toBe(true);
+  });
+
+  it('returns false on 429 and 5xx so polling can continue', async () => {
+    fetchMock.mockImplementation(() => jsonResponse(500, { error: 'down' }));
+
+    await expect(
+      isPackageVersionPublished({ packageName: 'storybook', version: '10.6.0-alpha.6' })
+    ).resolves.toBe(false);
+
+    fetchMock.mockImplementation(() => jsonResponse(429, { error: 'slow down' }));
+
+    await expect(
+      isPackageVersionPublished({ packageName: 'storybook', version: '10.6.0-alpha.6' })
+    ).resolves.toBe(false);
+  });
+
+  it('returns false when the registry request fails or times out', async () => {
+    fetchMock.mockRejectedValue(new Error('The operation was aborted'));
+
+    await expect(
+      isPackageVersionPublished({ packageName: 'storybook', version: '10.6.0-alpha.6' })
+    ).resolves.toBe(false);
+  });
+
+  it('throws on unexpected status codes', async () => {
+    fetchMock.mockImplementation(() => jsonResponse(401, { error: 'unauthorized' }));
+
+    await expect(
+      isPackageVersionPublished({ packageName: 'storybook', version: '10.6.0-alpha.6' })
+    ).rejects.toThrow('Unexpected status code when checking the current version on npm: 401');
+  });
+});
+
+describe('listUnpublishedPackages', () => {
+  it('returns only packages that are not yet on npm', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === 'https://registry.npmjs.org/storybook/1.0.0') {
+        return jsonResponse(200, { version: '1.0.0' });
+      }
+      return jsonResponse(404, { error: 'Not found' });
+    });
+
+    await expect(
+      listUnpublishedPackages({
+        packageNames: ['storybook', '@storybook/react'],
+        version: '1.0.0',
+      })
+    ).resolves.toEqual(['@storybook/react']);
+  });
+});
+
+describe('waitForPackagesToBePublished', () => {
+  it('returns an empty list once every package becomes visible', async () => {
+    let t = 0;
+    fetchMock.mockImplementation(() => jsonResponse(404, { error: 'Not found' }));
+
+    const missing = waitForPackagesToBePublished({
+      packageNames: ['storybook'],
+      version: '1.0.0',
+      timeoutMs: 30,
+      intervalMs: 10,
+      now: () => t,
+      sleep: async () => {
+        t += 10;
+        fetchMock.mockImplementation(() => jsonResponse(200, { version: '1.0.0' }));
+      },
+    });
+
+    await expect(missing).resolves.toEqual([]);
+  });
+
+  it('returns remaining names when the timeout expires', async () => {
+    let t = 0;
+    fetchMock.mockImplementation(() => jsonResponse(404, { error: 'Not found' }));
+
+    await expect(
+      waitForPackagesToBePublished({
+        packageNames: ['storybook', '@storybook/react'],
+        version: '1.0.0',
+        timeoutMs: 20,
+        intervalMs: 10,
+        now: () => t,
+        sleep: async () => {
+          t += 10;
+        },
+      })
+    ).resolves.toEqual(['storybook', '@storybook/react']);
+  });
+});
+
+describe('packagesAcceptedByRegistry', () => {
+  it('extracts workspaces npm already reserved or published', () => {
+    expect(
+      packagesAcceptedByRegistry(
+        [
+          '[storybook]: YN0035: Cannot publish over previously staged version',
+          '[@storybook/react]: Package archive published',
+          '[@storybook/vue3]: YN0033: network error',
+        ].join('\n')
+      )
+    ).toEqual(['storybook', '@storybook/react']);
+  });
+});

--- a/scripts/release/__tests__/npm-registry.test.ts
+++ b/scripts/release/__tests__/npm-registry.test.ts
@@ -149,4 +149,15 @@ describe('packagesAcceptedByRegistry', () => {
       )
     ).toEqual(['storybook', '@storybook/react']);
   });
+
+  it('extracts workspaces when Yarn prefixes lines with ANSI color codes', () => {
+    expect(
+      packagesAcceptedByRegistry(
+        [
+          '\u001b[38;5;167m[storybook]:\u001b[39m YN0035: Cannot publish over previously staged version "10.5.9".',
+          '\u001b[38;5;73m[@storybook/react]:\u001b[39m Package archive published',
+        ].join('\n')
+      )
+    ).toEqual(['storybook', '@storybook/react']);
+  });
 });

--- a/scripts/release/__tests__/publish.test.ts
+++ b/scripts/release/__tests__/publish.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// eslint-disable-next-line depend/ban-dependencies
+import { execaCommand } from 'execa';
+
+import { listUnpublishedPackages, waitForPackagesToBePublished } from '../npm-registry.ts';
+import { publishAllPackages, publishCommand } from '../publish.ts';
+
+vi.mock('execa', { spy: true });
+vi.mock('../npm-registry.ts', { spy: true });
+
+beforeEach(() => {
+  vi.mocked(execaCommand).mockReset();
+  vi.mocked(listUnpublishedPackages).mockReset();
+  vi.mocked(waitForPackagesToBePublished).mockReset();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('publishAllPackages', () => {
+  const options = {
+    tag: 'next',
+    currentVersion: '10.6.0-alpha.6',
+    packageNames: ['storybook', '@storybook/react'],
+  };
+
+  it('succeeds when Yarn publish succeeds', async () => {
+    vi.mocked(execaCommand).mockResolvedValue({} as never);
+
+    await publishAllPackages(options);
+
+    expect(execaCommand).toHaveBeenCalledTimes(1);
+    expect(execaCommand).toHaveBeenCalledWith(
+      publishCommand('next', ['storybook', '@storybook/react']),
+      expect.any(Object)
+    );
+    expect(listUnpublishedPackages).not.toHaveBeenCalled();
+  });
+
+  it('treats a Yarn failure as success when every package is already on npm', async () => {
+    vi.mocked(execaCommand).mockRejectedValue(new Error('foreach exited 1'));
+    vi.mocked(listUnpublishedPackages).mockResolvedValue([]);
+
+    await publishAllPackages(options);
+
+    expect(waitForPackagesToBePublished).not.toHaveBeenCalled();
+    expect(execaCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for staged packages instead of immediately retrying publish', async () => {
+    vi.mocked(execaCommand).mockRejectedValue(new Error('foreach exited 1'));
+    vi.mocked(listUnpublishedPackages).mockResolvedValue(['storybook']);
+    vi.mocked(waitForPackagesToBePublished).mockResolvedValue([]);
+
+    await publishAllPackages(options);
+
+    expect(waitForPackagesToBePublished).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageNames: ['storybook'],
+        version: '10.6.0-alpha.6',
+      })
+    );
+    expect(execaCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries publish only for packages that are still missing after waiting', async () => {
+    vi.mocked(execaCommand)
+      .mockRejectedValueOnce(new Error('foreach exited 1'))
+      .mockResolvedValueOnce({} as never);
+    vi.mocked(listUnpublishedPackages).mockResolvedValue(['storybook']);
+    vi.mocked(waitForPackagesToBePublished).mockResolvedValue(['storybook']);
+
+    await publishAllPackages(options);
+
+    expect(execaCommand).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(execaCommand).mock.calls[0][0]).toBe(
+      publishCommand('next', ['storybook', '@storybook/react'])
+    );
+    expect(vi.mocked(execaCommand).mock.calls[1][0]).toBe(publishCommand('next', ['storybook']));
+    expect(vi.mocked(execaCommand).mock.calls[1][0]).not.toContain('--include=@storybook/react');
+  });
+
+  it('does not retry PUT for packages npm already accepted with a staged 409', async () => {
+    const staged = Object.assign(new Error('foreach exited 1'), {
+      stderr: [
+        '[storybook]: YN0035: Cannot publish over previously staged version',
+        '[@storybook/react]: YN0033: Publish failed',
+      ].join('\n'),
+    });
+    vi.mocked(execaCommand)
+      .mockRejectedValueOnce(staged)
+      .mockResolvedValueOnce({} as never);
+    vi.mocked(listUnpublishedPackages).mockResolvedValue(['storybook', '@storybook/react']);
+    vi.mocked(waitForPackagesToBePublished).mockResolvedValue(['storybook', '@storybook/react']);
+
+    await publishAllPackages(options);
+
+    expect(vi.mocked(execaCommand).mock.calls[1][0]).toBe(
+      publishCommand('next', ['@storybook/react'])
+    );
+    expect(vi.mocked(execaCommand).mock.calls[1][0]).not.toContain('--include=storybook');
+  });
+
+  it('fails with the missing package list after retries are exhausted', async () => {
+    vi.mocked(execaCommand).mockRejectedValue(new Error('foreach exited 1'));
+    vi.mocked(listUnpublishedPackages).mockResolvedValue(['storybook']);
+    vi.mocked(waitForPackagesToBePublished).mockResolvedValue(['storybook']);
+
+    await expect(publishAllPackages(options)).rejects.toThrow(
+      'Failed to publish version 10.6.0-alpha.6. Still missing: storybook'
+    );
+    expect(execaCommand).toHaveBeenCalledTimes(3);
+  });
+});

--- a/scripts/release/is-version-published.ts
+++ b/scripts/release/is-version-published.ts
@@ -3,75 +3,34 @@ import { program } from 'commander';
 import picocolors from 'picocolors';
 
 import { esMain } from '../utils/esmain.ts';
+import { getCodeWorkspaces } from '../utils/workspace.ts';
 import { getCurrentVersion } from './get-current-version.ts';
+import { listUnpublishedPackages } from './npm-registry.ts';
 
 program
-  .name('is-prerelease [version]')
-  .description('returns true if the current version is a prerelease')
+  .name('is-version-published [version]')
+  .description('returns true if the current version is published on npm for every public workspace')
   .arguments('[version]');
-
-const isVersionPublished = async ({
-  packageName,
-  version,
-  verbose,
-}: {
-  packageName: string;
-  version: string;
-  verbose?: boolean;
-}) => {
-  const prettyPackage = `${picocolors.blue(packageName)}@${picocolors.green(version)}`;
-  console.log(`⛅ Checking if ${prettyPackage} is published...`);
-
-  if (verbose) {
-    console.log(`Fetching from npm:`);
-    console.log(
-      `https://registry.npmjs.org/${picocolors.blue(packageName)}/${picocolors.green(version)}`
-    );
-  }
-  const response = await fetch(`https://registry.npmjs.org/${packageName}/${version}`);
-  if (response.status === 404) {
-    console.log(`🌤️ ${prettyPackage} is not published`);
-    return false;
-  }
-  if (response.status !== 200) {
-    console.error(
-      `Unexpected status code when checking the current version on npm: ${response.status}`
-    );
-    console.error(await response.text());
-    throw new Error(
-      `Unexpected status code when checking the current version on npm: ${response.status}`
-    );
-  }
-  const data: any = await response.json();
-  if (verbose) {
-    console.log(`Response from npm:`);
-    console.log(data);
-  }
-  if (data.version !== version) {
-    // this should never happen
-    console.error(
-      `Unexpected version received when checking the current version on npm: ${data.version}`
-    );
-    console.error(JSON.stringify(data, null, 2));
-    throw new Error(
-      `Unexpected version received when checking the current version on npm: ${data.version}`
-    );
-  }
-
-  console.log(`⛈️ ${prettyPackage} is published`);
-  return true;
-};
 
 export const run = async (args: unknown[], options: unknown) => {
   const { verbose } = options as { verbose?: boolean };
 
   const version = (args[0] as string) || (await getCurrentVersion());
-
-  const isAlreadyPublished = await isVersionPublished({
+  const workspaces = await getCodeWorkspaces(false);
+  const unpublished = await listUnpublishedPackages({
+    packageNames: workspaces.map((workspace) => workspace.name),
     version,
-    packageName: 'storybook',
     verbose,
   });
+
+  const isAlreadyPublished = unpublished.length === 0;
+  if (isAlreadyPublished) {
+    console.log(`⛈️ All public packages are published at ${picocolors.green(version)}`);
+  } else {
+    console.log(
+      `🌤️ ${unpublished.length} public package(s) are not published at ${picocolors.green(version)}: ${unpublished.join(', ')}`
+    );
+  }
 
   if (process.env.GITHUB_ACTIONS === 'true') {
     setOutput('published', isAlreadyPublished);

--- a/scripts/release/npm-registry.ts
+++ b/scripts/release/npm-registry.ts
@@ -118,10 +118,12 @@ export const waitForPackagesToBePublished = async ({
   return missing;
 };
 
+const stripAnsi = (value: string) => value.replace(/\u001b\[[0-9;]*m/g, '');
+
 export const packagesAcceptedByRegistry = (output: string) => {
   const accepted = new Set<string>();
   for (const line of output.split('\n')) {
-    const prefix = line.match(/^\[([^\]]+)\]:/);
+    const prefix = stripAnsi(line).match(/\[([^\]]+)\]:/);
     if (!prefix) {
       continue;
     }

--- a/scripts/release/npm-registry.ts
+++ b/scripts/release/npm-registry.ts
@@ -1,0 +1,138 @@
+import picocolors from 'picocolors';
+
+const NPM_REGISTRY = 'https://registry.npmjs.org';
+const REGISTRY_FETCH_TIMEOUT_MS = 30_000;
+
+export const isPackageVersionPublished = async ({
+  packageName,
+  version,
+  verbose,
+}: {
+  packageName: string;
+  version: string;
+  verbose?: boolean;
+}) => {
+  const prettyPackage = `${picocolors.blue(packageName)}@${picocolors.green(version)}`;
+  const url = `${NPM_REGISTRY}/${packageName}/${version}`;
+
+  if (verbose) {
+    console.log(`Fetching from npm: ${url}`);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS) });
+  } catch (error) {
+    console.log(
+      `⚠️ Failed to reach npm for ${prettyPackage} (${error instanceof Error ? error.message : 'unknown error'}), treating as not yet visible`
+    );
+    return false;
+  }
+
+  if (response.status === 404 || response.status === 429 || response.status >= 500) {
+    if (response.status === 404) {
+      console.log(`🌤️ ${prettyPackage} is not published`);
+    } else {
+      console.log(
+        `⚠️ Transient status ${response.status} when checking ${prettyPackage}, treating as not yet visible`
+      );
+    }
+    return false;
+  }
+  if (response.status !== 200) {
+    const body = await response.text();
+    console.error(
+      `Unexpected status code when checking the current version on npm: ${response.status}`
+    );
+    console.error(body);
+    throw new Error(
+      `Unexpected status code when checking the current version on npm: ${response.status}`
+    );
+  }
+
+  const data: { version?: string } = await response.json();
+  if (verbose) {
+    console.log(`Response from npm:`, data);
+  }
+  if (data.version !== version) {
+    console.error(
+      `Unexpected version received when checking the current version on npm: ${data.version}`
+    );
+    console.error(JSON.stringify(data, null, 2));
+    throw new Error(
+      `Unexpected version received when checking the current version on npm: ${data.version}`
+    );
+  }
+
+  console.log(`⛈️ ${prettyPackage} is published`);
+  return true;
+};
+
+export const listUnpublishedPackages = async ({
+  packageNames,
+  version,
+  verbose,
+}: {
+  packageNames: string[];
+  version: string;
+  verbose?: boolean;
+}) => {
+  const published = await Promise.all(
+    packageNames.map((packageName) =>
+      isPackageVersionPublished({ packageName, version, verbose }).then((isPublished) =>
+        isPublished ? null : packageName
+      )
+    )
+  );
+  return published.filter((name): name is string => name !== null);
+};
+
+export const waitForPackagesToBePublished = async ({
+  packageNames,
+  version,
+  timeoutMs,
+  intervalMs,
+  verbose,
+  now = Date.now,
+  sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+}: {
+  packageNames: string[];
+  version: string;
+  timeoutMs: number;
+  intervalMs: number;
+  verbose?: boolean;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}) => {
+  const deadline = now() + timeoutMs;
+  let missing = [...packageNames];
+
+  while (missing.length > 0 && now() < deadline) {
+    console.log(
+      `⏳ Waiting ${intervalMs / 1000}s for ${missing.length} package(s) to appear on npm: ${missing.join(', ')}`
+    );
+    await sleep(intervalMs);
+    missing = await listUnpublishedPackages({ packageNames: missing, version, verbose });
+  }
+
+  return missing;
+};
+
+export const packagesAcceptedByRegistry = (output: string) => {
+  const accepted = new Set<string>();
+  for (const line of output.split('\n')) {
+    const prefix = line.match(/^\[([^\]]+)\]:/);
+    if (!prefix) {
+      continue;
+    }
+    if (
+      line.includes('Package archive published') ||
+      line.includes('Registry already knows about version') ||
+      line.includes('previously staged version') ||
+      line.includes('previously published versions')
+    ) {
+      accepted.add(prefix[1]);
+    }
+  }
+  return [...accepted];
+};

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -4,13 +4,18 @@ import { join } from 'node:path';
 import { program } from 'commander';
 // eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
-import pRetry from 'p-retry';
 import picocolors from 'picocolors';
 import semver from 'semver';
 import { dedent } from 'ts-dedent';
 import { z } from 'zod';
 
 import { esMain } from '../utils/esmain.ts';
+import { getCodeWorkspaces } from '../utils/workspace.ts';
+import {
+  listUnpublishedPackages,
+  packagesAcceptedByRegistry,
+  waitForPackagesToBePublished,
+} from './npm-registry.ts';
 
 program
   .name('publish')
@@ -42,6 +47,10 @@ type Options = {
 const CODE_DIR_PATH = join(__dirname, '..', '..', 'code');
 const CODE_PACKAGE_JSON_PATH = join(CODE_DIR_PATH, 'package.json');
 
+const MAX_PUBLISH_ATTEMPTS = 3;
+const REGISTRY_POLL_INTERVAL_MS = 15_000;
+const REGISTRY_POLL_TIMEOUT_MS = 15 * 60 * 1000;
+
 const validateOptions = (options: { [key: string]: any }): options is Options => {
   optionsSchema.parse(options);
   return true;
@@ -57,58 +66,6 @@ const getCurrentVersion = async (verbose?: boolean) => {
   return version;
 };
 
-const isCurrentVersionPublished = async ({
-  packageName,
-  currentVersion,
-  verbose,
-}: {
-  packageName: string;
-  currentVersion: string;
-  verbose?: boolean;
-}) => {
-  const prettyPackage = `${picocolors.blue(packageName)}@${picocolors.green(currentVersion)}`;
-  console.log(`⛅ Checking if ${prettyPackage} is published...`);
-
-  if (verbose) {
-    console.log(`Fetching from npm:`);
-    console.log(
-      `https://registry.npmjs.org/${picocolors.blue(packageName)}/${picocolors.green(currentVersion)}`
-    );
-  }
-  const response = await fetch(`https://registry.npmjs.org/${packageName}/${currentVersion}`);
-  if (response.status === 404) {
-    console.log(`🌤️ ${prettyPackage} is not published`);
-    return false;
-  }
-  if (response.status !== 200) {
-    console.error(
-      `Unexpected status code when checking the current version on npm: ${response.status}`
-    );
-    console.error(await response.text());
-    throw new Error(
-      `Unexpected status code when checking the current version on npm: ${response.status}`
-    );
-  }
-  const data: any = await response.json();
-  if (verbose) {
-    console.log(`Response from npm:`);
-    console.log(data);
-  }
-  if (data.version !== currentVersion) {
-    // this should never happen
-    console.error(
-      `Unexpected version received when checking the current version on npm: ${data.version}`
-    );
-    console.error(JSON.stringify(data, null, 2));
-    throw new Error(
-      `Unexpected version received when checking the current version on npm: ${data.version}`
-    );
-  }
-
-  console.log(`⛈️ ${prettyPackage} is published`);
-  return true;
-};
-
 const buildAllPackages = async () => {
   console.log(`🏗️ Building all packages...`);
   await execaCommand('yarn task --task=compile --start-from=compile --no-link', {
@@ -119,52 +76,125 @@ const buildAllPackages = async () => {
   console.log(`🏗️ Packages successfully built`);
 };
 
-const publishAllPackages = async ({
+export const publishCommand = (tag: string, packageNames: string[]) => {
+  const include = packageNames.map((name) => `--include=${name}`).join(' ');
+  return `yarn workspaces foreach --all --parallel --no-private ${include} --verbose npm publish --provenance --tolerate-republish --tag ${tag}`;
+};
+
+const execaOutput = (error: unknown) => {
+  if (!error || typeof error !== 'object') {
+    return '';
+  }
+  const { stdout, stderr, all } = error as { stdout?: string; stderr?: string; all?: string };
+  return [all, stdout, stderr].filter(Boolean).join('\n');
+};
+
+export const publishAllPackages = async ({
   tag,
   verbose,
   dryRun,
+  currentVersion,
+  packageNames,
 }: {
   tag: string;
   verbose?: boolean;
   dryRun?: boolean;
+  currentVersion: string;
+  packageNames: string[];
 }) => {
   console.log(`📦 Publishing all packages...`);
-  const command = `yarn workspaces foreach --all --parallel --no-private --verbose npm publish --provenance --tolerate-republish --tag ${tag}`;
-  if (verbose) {
-    console.log(`📦 Executing: ${command}`);
-  }
   if (dryRun) {
     console.log(`📦 Dry run, skipping publish. Would have executed:
-    ${picocolors.blue(command)}`);
+    ${picocolors.blue(publishCommand(tag, packageNames))}`);
     return;
   }
 
-  /**
-   * 'yarn npm publish' will fail if just one package fails to publish. But it will continue through
-   * with all the other packages, and --tolerate-republish makes it okay to publish the same version
-   * again. So we can safely retry the whole publishing process if it fails. It's not uncommon for
-   * the registry to fail often, which Yarn catches by checking the registry after a package has
-   * been published.
-   */
-  await pRetry(
-    () =>
-      execaCommand(command, {
-        stdio: 'inherit',
+  // Staged versions are reserved but not in the packument yet; a retry PUT 409s.
+  let toPublish = [...packageNames];
+  let unpublished = [...packageNames];
+  const accepted = new Set<string>();
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_PUBLISH_ATTEMPTS; attempt += 1) {
+    const command = publishCommand(tag, toPublish);
+    if (verbose) {
+      console.log(`📦 Executing: ${command}`);
+    }
+
+    try {
+      await execaCommand(command, {
         cleanup: true,
         cwd: CODE_DIR_PATH,
-      }),
-    {
-      retries: 4,
-      onFailedAttempt: (error) =>
+        stdout: ['pipe', 'inherit'],
+        stderr: ['pipe', 'inherit'],
+      });
+      console.log(`📦 Packages successfully published`);
+      return;
+    } catch (error) {
+      lastError = error;
+      for (const name of packagesAcceptedByRegistry(execaOutput(error))) {
+        accepted.add(name);
+      }
+      toPublish = toPublish.filter((name) => !accepted.has(name));
+
+      unpublished = await listUnpublishedPackages({
+        packageNames,
+        version: currentVersion,
+        verbose,
+      });
+
+      if (unpublished.length === 0) {
         console.log(
-          picocolors.yellow(
-            dedent`❗One or more packages failed to publish, retrying...
-            This was attempt number ${error.attemptNumber}, there are ${error.retriesLeft} retries left. 🤞`
-          )
-        ),
+          `📦 All packages are on npm even though Yarn exited non-zero (registry lag after a staged 409). Treating as success.`
+        );
+        return;
+      }
+
+      console.log(
+        picocolors.yellow(
+          dedent`❗ ${unpublished.length} package(s) are not yet visible on npm: ${unpublished.join(', ')}
+          This was attempt number ${attempt}, there are ${MAX_PUBLISH_ATTEMPTS - attempt} retries left.
+          Waiting for the registry instead of publishing over a staged version.`
+        )
+      );
+
+      unpublished = await waitForPackagesToBePublished({
+        packageNames: unpublished,
+        version: currentVersion,
+        timeoutMs: REGISTRY_POLL_TIMEOUT_MS,
+        intervalMs: REGISTRY_POLL_INTERVAL_MS,
+        verbose,
+      });
+
+      if (unpublished.length === 0) {
+        console.log(`📦 All packages became visible on npm. Treating as success.`);
+        return;
+      }
+
+      toPublish = unpublished.filter((name) => !accepted.has(name));
+      if (toPublish.length === 0) {
+        throw new Error(
+          `Failed to publish version ${currentVersion}. Still missing after staging wait: ${unpublished.join(', ')}`,
+          { cause: lastError }
+        );
+      }
+
+      if (attempt === MAX_PUBLISH_ATTEMPTS) {
+        break;
+      }
+
+      console.log(
+        picocolors.yellow(
+          `❗ Still missing ${toPublish.join(', ')}. Retrying publish for those packages only.`
+        )
+      );
     }
+  }
+
+  throw new Error(
+    `Failed to publish version ${currentVersion}. Still missing: ${unpublished.join(', ')}`,
+    { cause: lastError }
   );
-  console.log(`📦 Packages successfully published`);
 };
 
 export const run = async (options: unknown) => {
@@ -173,20 +203,30 @@ export const run = async (options: unknown) => {
   }
   const { tag, dryRun, verbose } = options;
 
-  // Get the current version from code/package.json
   const currentVersion = await getCurrentVersion(verbose);
-  const isAlreadyPublished = await isCurrentVersionPublished({
-    currentVersion,
-    packageName: 'storybook',
+  const workspaces = await getCodeWorkspaces(false);
+  const packageNames = workspaces.map((workspace) => workspace.name);
+  const unpublished = await listUnpublishedPackages({
+    packageNames,
+    version: currentVersion,
     verbose,
   });
-  if (isAlreadyPublished) {
-    throw new Error(
-      `⛔ Current version (${picocolors.green(currentVersion)}) is already published, aborting.`
+
+  if (unpublished.length === 0) {
+    console.log(
+      `✅ All packages already published at ${picocolors.green(currentVersion)}, skipping publish`
     );
+    return;
   }
+
   await buildAllPackages();
-  await publishAllPackages({ tag, verbose, dryRun });
+  await publishAllPackages({
+    tag,
+    verbose,
+    dryRun,
+    currentVersion,
+    packageNames: unpublished,
+  });
 
   console.log(
     `✅ Published all packages with version ${picocolors.green(currentVersion)}${


### PR DESCRIPTION
## What I did

Backport the publish recovery work from `next` (`437866a`, `10d7f1e`) onto `latest-release`, plus a small follow-up so Yarn log parsing works when CI output includes ANSI color codes.

This prevents the 10.5.9 failure mode:

1. Attempt 1 PUTs packages successfully.
2. foreach exits non-zero (or a subset fails).
3. Old `pRetry` re-PUTs the whole monorepo → `409 previously staged` → Publish step fails → GitHub Release / merge / `patch:done` skip.

The new flow:

- Check **all** public workspaces on npm, not just `storybook`.
- On failure, classify accepted workspaces from Yarn output (including 409/403) and **wait for the packument** instead of PUTting again.
- Retry publish only for packages still missing, via `--include`.
- Add `workflow_dispatch` **`skip_publish`** to finish release bookkeeping when npm already has the version.
- Un-gate DX / GitHub Release / Sentry from `published == false` so a recovered publish can still finalize.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual test. Verified locally:

```bash
yarn test scripts/release/__tests__/npm-registry.test.ts scripts/release/__tests__/publish.test.ts scripts/release/__tests__/is-version-published.test.ts
```

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:

### 🦋 Canary release

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_