### PR TITLE
CI: Parse Yarn publish output when lines include ANSI color codes

### DIFF
--- a/scripts/release/__tests__/npm-registry.test.ts
+++ b/scripts/release/__tests__/npm-registry.test.ts
@@ -149,4 +149,15 @@ describe('packagesAcceptedByRegistry', () => {
       )
     ).toEqual(['storybook', '@storybook/react']);
   });
+
+  it('extracts workspaces when Yarn prefixes lines with ANSI color codes', () => {
+    expect(
+      packagesAcceptedByRegistry(
+        [
+          '\u001b[38;5;167m[storybook]:\u001b[39m YN0035: Cannot publish over previously staged version "10.5.9".',
+          '\u001b[38;5;73m[@storybook/react]:\u001b[39m Package archive published',
+        ].join('\n')
+      )
+    ).toEqual(['storybook', '@storybook/react']);
+  });
 });

--- a/scripts/release/npm-registry.ts
+++ b/scripts/release/npm-registry.ts
@@ -118,10 +118,12 @@ export const waitForPackagesToBePublished = async ({
   return missing;
 };
 
+const stripAnsi = (value: string) => value.replace(/\u001b\[[0-9;]*m/g, '');
+
 export const packagesAcceptedByRegistry = (output: string) => {
   const accepted = new Set<string>();
   for (const line of output.split('\n')) {
-    const prefix = line.match(/^\[([^\]]+)\]:/);
+    const prefix = stripAnsi(line).match(/\[([^\]]+)\]:/);
     if (!prefix) {
       continue;
     }


### PR DESCRIPTION
## What I did

Follow-up to #437866 / #35810 publish recovery: release logs prefix workspace names with ANSI escapes (`\u001b[38;5;167m[storybook]:\u001b[39m`), so `packagesAcceptedByRegistry` missed accepted packages and could still retry PUTs after a staged 409.

Strip ANSI before parsing the `[workspace]:` prefix.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual test. Same unit test added in this PR.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:

### 🦋 Canary release

This PR does not have a canary release associated.