### PR TITLE
Build: Fix React Native sandbox generation under age gate

### DIFF
--- a/.github/workflows/generate-sandboxes.yml
+++ b/.github/workflows/generate-sandboxes.yml
@@ -80,12 +80,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      # Node's bundled npm is older than 11.10.0 and silently ignores
-      # NPM_CONFIG_MIN_RELEASE_AGE during scaffold. Keep in sync with
-      # BEFORE_SANDBOX_NPM_MIN_VERSION in scripts/sandbox/utils/yarn.ts.
+      # Node's bundled npm is older than 11.17.0 and silently ignores
+      # NPM_CONFIG_MIN_RELEASE_AGE / min-release-age-exclude during scaffold.
+      # Keep in sync with BEFORE_SANDBOX_NPM_MIN_VERSION in scripts/sandbox/utils/yarn.ts.
       - name: Install npm with min-release-age support
         working-directory: ${{ github.workspace }}
-        run: npm install -g npm@11.10.0
+        run: npm install -g npm@11.17.0
 
       - name: Setup git user
         run: |

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -990,11 +990,13 @@ export const baseTemplates = {
     // create-expo-app pins the current SDK, whose packages are released
     // together and are routinely younger than the gate window.
     // `babel-preset-expo` is part of that set despite not matching `expo-*`.
+    // `multitars` is pulled in transitively by the Expo CLI toolchain.
     minAgeGateExemptions: [
       'expo',
       'expo-*',
       '@expo/*',
       'babel-preset-expo',
+      'multitars',
       'react-native',
       '@react-native/*',
     ],
@@ -1021,17 +1023,12 @@ export const baseTemplates = {
     },
   },
   'react-native-web-vite/rn-cli-ts': {
-    // NOTE: create-expo-app installs React 18.2.0. But yarn portal
-    // expects 18.3.1 (dunno why). Therefore to run this in dev you
-    // must either:
-    //  - edit the sandbox package.json to depend on react 18.3.1, OR
-    //  - build/run the sandbox in --no-link mode, which is fine
-    //
-    // Users & CI won't see this limitation because they are not using
-    // yarn portals.
     name: 'React Native CLI Latest (Vite | TypeScript)',
     script:
       'npx @react-native-community/cli@latest init --skip-install --install-pods=false --directory={{beforeDir}} rnapp',
+    // The CLI downloads `@react-native-community/template` during init even with
+    // --skip-install; those packages ship in lockstep with each RN release.
+    minAgeGateExemptions: ['@react-native-community/*', 'react-native', '@react-native/*'],
     expected: {
       framework: '@storybook/react-native-web-vite',
       renderer: '@storybook/react',

--- a/scripts/sandbox/generate.ts
+++ b/scripts/sandbox/generate.ts
@@ -38,6 +38,7 @@ import {
   preapproveLocallyPublishedPackages,
   refreshBeforeStorybookLockfile,
   setupYarn,
+  writeScaffoldNpmrc,
 } from './utils/yarn.ts';
 
 const isCI = process.env.GITHUB_ACTIONS === 'true' || process.env.CI === 'true';
@@ -296,6 +297,14 @@ const runGenerators = async (
             YARN_NPM_MINIMAL_AGE_GATE: BEFORE_SANDBOX_MIN_AGE_GATE,
             NPM_CONFIG_MIN_RELEASE_AGE: String(BEFORE_SANDBOX_NPM_MIN_RELEASE_AGE_DAYS),
           };
+
+          const scaffoldCwd = script.includes('{{beforeDir}}') ? createBaseDir : createBeforeDir;
+          if (minAgeGateExemptions?.length) {
+            if (scaffoldCwd === createBeforeDir) {
+              await mkdir(createBeforeDir, { recursive: true });
+            }
+            await writeScaffoldNpmrc(scaffoldCwd, minAgeGateExemptions);
+          }
 
           // Some tools refuse to run inside an existing directory and replace the contents,
           // where as others are very picky about what directories can be called. So we need to

--- a/scripts/sandbox/utils/yarn.test.ts
+++ b/scripts/sandbox/utils/yarn.test.ts
@@ -14,6 +14,7 @@ import {
   ensureNpmSupportsMinReleaseAge,
   preapproveLocallyPublishedPackages,
   refreshBeforeStorybookLockfile,
+  writeScaffoldNpmrc,
 } from './yarn.ts';
 
 vi.mock('node:fs/promises', { spy: true });
@@ -240,7 +241,7 @@ describe('ensureNpmSupportsMinReleaseAge', () => {
   });
 
   it(`accepts npm ${BEFORE_SANDBOX_NPM_MIN_VERSION} and newer`, async () => {
-    vi.mocked(runCommand).mockResolvedValue({ stdout: '11.10.0\n' } as never);
+    vi.mocked(runCommand).mockResolvedValue({ stdout: '11.17.0\n' } as never);
 
     await expect(ensureNpmSupportsMinReleaseAge()).resolves.toBeUndefined();
 
@@ -249,10 +250,26 @@ describe('ensureNpmSupportsMinReleaseAge', () => {
   });
 
   it('fails when npm is older than the min-release-age floor', async () => {
-    vi.mocked(runCommand).mockResolvedValue({ stdout: '10.9.8\n' } as never);
+    vi.mocked(runCommand).mockResolvedValue({ stdout: '11.10.0\n' } as never);
 
     await expect(ensureNpmSupportsMinReleaseAge()).rejects.toThrow(
-      new RegExp(`npm >= ${BEFORE_SANDBOX_NPM_MIN_VERSION}.*found 10\\.9\\.8`)
+      new RegExp(`npm >= ${BEFORE_SANDBOX_NPM_MIN_VERSION}.*found 11\\.10\\.0`)
     );
+  });
+});
+
+describe('writeScaffoldNpmrc', () => {
+  it('writes min-release-age and exclude patterns for npm scaffolds', async () => {
+    await writeScaffoldNpmrc(SANDBOX, ['@react-native-community/*', 'multitars']);
+
+    expect(vol.readFileSync(`${SANDBOX}/.npmrc`, 'utf-8')).toBe(
+      'min-release-age=7\nmin-release-age-exclude[]=@react-native-community/*\nmin-release-age-exclude[]=multitars\n'
+    );
+  });
+
+  it('does nothing when the allowlist is empty', async () => {
+    await writeScaffoldNpmrc(SANDBOX, []);
+
+    expect(vol.existsSync(`${SANDBOX}/.npmrc`)).toBe(false);
   });
 });

--- a/scripts/sandbox/utils/yarn.ts
+++ b/scripts/sandbox/utils/yarn.ts
@@ -67,17 +67,39 @@ export const BEFORE_SANDBOX_MIN_AGE_GATE = '7d';
 export const BEFORE_SANDBOX_MIN_AGE_MINUTES = 7 * 24 * 60;
 /** npm `min-release-age` is in days (npm 11.10+). */
 export const BEFORE_SANDBOX_NPM_MIN_RELEASE_AGE_DAYS = 7;
-/** npm below this version silently ignores `NPM_CONFIG_MIN_RELEASE_AGE`. */
-export const BEFORE_SANDBOX_NPM_MIN_VERSION = '11.10.0';
+/**
+ * npm below this version silently ignores `NPM_CONFIG_MIN_RELEASE_AGE`.
+ * 11.17+ is required for `min-release-age-exclude`, which templates with
+ * `minAgeGateExemptions` rely on during npx/npm scaffolds.
+ */
+export const BEFORE_SANDBOX_NPM_MIN_VERSION = '11.17.0';
 
 export async function ensureNpmSupportsMinReleaseAge() {
   const { stdout } = await runCommand('npm --version', { cwd: process.cwd() });
   const version = String(stdout).trim();
   if (!semver.gte(version, BEFORE_SANDBOX_NPM_MIN_VERSION)) {
     throw new Error(
-      `Sandbox generation requires npm >= ${BEFORE_SANDBOX_NPM_MIN_VERSION} so NPM_CONFIG_MIN_RELEASE_AGE is honored (found ${version}). Upgrade with: npm install -g npm@${BEFORE_SANDBOX_NPM_MIN_VERSION}`
+      `Sandbox generation requires npm >= ${BEFORE_SANDBOX_NPM_MIN_VERSION} so NPM_CONFIG_MIN_RELEASE_AGE and min-release-age-exclude are honored (found ${version}). Upgrade with: npm install -g npm@${BEFORE_SANDBOX_NPM_MIN_VERSION}`
     );
   }
+}
+
+/**
+ * Templates with a Yarn allowlist also need matching npm exclusions when their
+ * before-script runs through npx/npm. Array config cannot be expressed reliably
+ * via environment variables, so write a scratch `.npmrc` in the scaffold cwd.
+ */
+export async function writeScaffoldNpmrc(cwd: string, minAgeGateExemptions: string[]) {
+  if (!minAgeGateExemptions.length) {
+    return;
+  }
+
+  const lines = [
+    `min-release-age=${BEFORE_SANDBOX_NPM_MIN_RELEASE_AGE_DAYS}`,
+    ...minAgeGateExemptions.map((pattern) => `min-release-age-exclude[]=${pattern}`),
+  ];
+
+  await writeFile(join(cwd, '.npmrc'), `${lines.join('\n')}\n`);
 }
 
 interface RefreshLockfileOptions {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/actions/runs/32093433272/job/95580068842
## What I did

Fixes the scheduled **Generate and publish sandboxes** workflow failures for the two React Native Web + Vite templates blocked by the 7-day package age gate:

- **`react-native-web-vite/expo-ts`**: add `multitars` to the Yarn/npm allowlist. Expo depends on it transitively, and recent releases fall inside the gate window.
- **`react-native-web-vite/rn-cli-ts`**: add a React Native allowlist and write a scratch `.npmrc` with `min-release-age-exclude` during scaffold so `npx @react-native-community/cli init` can download `@react-native-community/template` while the gate stays enabled for everything else.
- Bump the sandbox workflow npm floor to **11.17.0**, which is when npm gained `min-release-age-exclude`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual UI testing is needed. To verify end-to-end, re-run the **Generate and publish sandboxes** workflow after merge (or dispatch it against this branch) and confirm `react-native-web-vite/expo-ts` and `react-native-web-vite/rn-cli-ts` complete successfully.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->