### PR TITLE
Docgen server: Fix the MCP snapshot CI break, and two snippet-printing bugs from review

### DIFF
--- a/code/core/src/csf-tools/story-shape/resolve-arg-value.test.ts
+++ b/code/core/src/csf-tools/story-shape/resolve-arg-value.test.ts
@@ -98,6 +98,19 @@ describe('resolveArgValue', () => {
     });
   });
 
+  it('keeps a shorthand property shorthand while writing out a sibling spread', () => {
+    expect(
+      valueOf(
+        `import { dep } from './helpers'; const base = { size: 'md' };`,
+        `{ dep, nested: { ...base } }`
+      )
+    ).toEqual({
+      node: "{ dep, nested: { size: 'md' } }",
+      imports: ['dep:./helpers'],
+      unresolved: [],
+    });
+  });
+
   it('leaves a literal alone', () => {
     expect(valueOf('', `{ a: 1, b: [2, 3] }`)).toEqual({
       node: '{ a: 1, b: [2, 3] }',

--- a/code/core/src/csf-tools/story-shape/resolve-arg-value.ts
+++ b/code/core/src/csf-tools/story-shape/resolve-arg-value.ts
@@ -157,11 +157,15 @@ const objectFrom = (
     if (!t.isObjectProperty(property) || !t.isExpression(property.value)) {
       return undefined;
     }
+    const value = inlineSpreads(property.value, ctx, unresolved) as t.Expression;
+    // A shorthand prints its key and nothing else, so it may only stay shorthand while its value is
+    // still the one the key stands for.
     rebuilt.push(
       t.objectProperty(
         property.key,
-        inlineSpreads(property.value, ctx, unresolved) as t.Expression,
-        property.computed
+        value,
+        property.computed,
+        property.shorthand && value === property.value
       )
     );
   }

--- a/code/frameworks/angular-vite/src/docgen/story-docs-args.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-args.ts
@@ -1,5 +1,5 @@
 // Turns a resolved arg node into the Angular template expression a binding carries. Reading the args
-// themselves - following spreads and names - is the shared CSF pass in `story-shape/resolve-args`.
+// themselves - following spreads and names - is the shared CSF pass in `story-shape`.
 import { babelPrint, types as t } from 'storybook/internal/babel';
 import { keyOf, unwrapExpression } from 'storybook/internal/csf-tools';
 

--- a/code/frameworks/angular-vite/src/docgen/story-docs-markup.ts
+++ b/code/frameworks/angular-vite/src/docgen/story-docs-markup.ts
@@ -1,6 +1,6 @@
 // Reads the markup a story supplies itself - `template`, a `render` that returns one, or the CSF2
 // function form - so a snippet shows the story as written. Which members the story and its meta hold
-// is the shared CSF pass in `story-shape/resolve-args`, spreads and names already followed.
+// is the shared CSF pass in `story-shape`, spreads and names already followed.
 import { type NodePath, types as t } from 'storybook/internal/babel';
 import type { CsfFile, ResolvedMembers } from 'storybook/internal/csf-tools';
 import { sourceOf, unwrapExpression } from 'storybook/internal/csf-tools';

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -871,3 +871,35 @@ test('a meta-level spread that may carry args is reported', () => {
     ]
   `);
 });
+
+test('a body still reading args after a partial inline keeps the parameter', () => {
+  const input = withCSF3(dedent`
+    export function Usage(args) {
+      return <Button {...args} title={args.notAnArg} />;
+    }
+    Usage.args = { label: 'assigned' };
+  `);
+  expect(generateExample(input)).toMatchInlineSnapshot(`
+    "function Usage(args) {
+        return <Button label="assigned" title={args.notAnArg}>Click me</Button>;
+    }"
+  `);
+});
+
+test('an arg value keeps a shorthand property shorthand', () => {
+  const input = withCSF3(dedent`
+    import { dep } from './dep';
+    const base = { size: 'md' };
+    export const Shorthand: Story = { args: { cfg: { dep, nested: { ...base } } } };
+  `);
+  expect(generateExample(input)).toMatchInlineSnapshot(`
+    "const Shorthand = () => <Button
+        cfg={{
+            dep,
+
+            nested: {
+                size: 'md'
+            }
+        }}>Click me</Button>;"
+  `);
+});

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
@@ -99,7 +99,11 @@ function buildSnippetNode(
       const spreadRes = transformArgsSpreadsInJsx(fn.body, merged);
       const inlineRes = inlineArgsInJsx(spreadRes.node, merged);
       if (spreadRes.changed || inlineRes.changed) {
-        const newFn = t.arrowFunctionExpression([], inlineRes.node, fn.async);
+        const newFn = t.arrowFunctionExpression(
+          remainingParams(fn, inlineRes.node),
+          inlineRes.node,
+          fn.async
+        );
         return t.variableDeclaration('const', [
           t.variableDeclarator(t.identifier(storyName), newFn),
         ]);
@@ -134,18 +138,14 @@ function buildSnippetNode(
       });
 
       if (changed) {
+        const body = t.blockStatement(newBody);
+        const params = remainingParams(fn, body);
         return t.isFunctionDeclaration(fn)
-          ? t.functionDeclaration(
-              t.identifier(storyName),
-              [],
-              t.blockStatement(newBody),
-              fn.generator,
-              fn.async
-            )
+          ? t.functionDeclaration(t.identifier(storyName), params, body, fn.generator, fn.async)
           : t.variableDeclaration('const', [
               t.variableDeclarator(
                 t.identifier(storyName),
-                t.arrowFunctionExpression([], t.blockStatement(newBody), fn.async)
+                t.arrowFunctionExpression(params, body, fn.async)
               ),
             ]);
       }
@@ -180,6 +180,43 @@ function buildSnippetNode(
   );
 
   return t.variableDeclaration('const', [t.variableDeclarator(t.identifier(storyName), arrow)]);
+}
+
+type StoryFunction =
+  | t.ArrowFunctionExpression
+  | t.FunctionExpression
+  | t.FunctionDeclaration
+  | t.ObjectMethod;
+
+/**
+ * Parameters the rewritten story function still needs.
+ *
+ * Inlining the args removes the reason the story took an `args` parameter, so the snippet drops it
+ * - unless something the rewrite could not inline still reads from it, which would leave the
+ * snippet naming a binding it no longer declares.
+ */
+function remainingParams(fn: StoryFunction, body: t.Node): StoryFunction['params'] {
+  return readsArgs(body) ? fn.params : [];
+}
+
+function readsArgs(node: t.Node): boolean {
+  // A key or a member name spelled `args` names a property, not the parameter.
+  const named = new Set<t.Node>();
+  let reads = false;
+
+  t.traverseFast(node, (current) => {
+    if (t.isMemberExpression(current) && !current.computed) {
+      named.add(current.property);
+    }
+    if ((t.isObjectProperty(current) || t.isObjectMethod(current)) && !current.computed) {
+      named.add(current.key);
+    }
+    if (t.isIdentifier(current) && current.name === 'args' && !named.has(current)) {
+      reads = true;
+    }
+  });
+
+  return reads;
 }
 
 /** Build a spread `{...{k: v}}` for props that aren't valid JSX attributes. */

--- a/test-storybooks/mcp/tests/mcp-composition-auth.e2e.test.ts
+++ b/test-storybooks/mcp/tests/mcp-composition-auth.e2e.test.ts
@@ -150,6 +150,7 @@ describe('MCP Composition Auth E2E Tests', () => {
 
 				\`\`\`
 				import { Button } from '@my-org/my-component-library';
+				import { fn } from 'storybook/test';
 
 				const Primary = () => <Button onClick={fn()} primary label="Button" />;
 				\`\`\`
@@ -160,6 +161,7 @@ describe('MCP Composition Auth E2E Tests', () => {
 
 				\`\`\`
 				import { Button } from '@my-org/my-component-library';
+				import { fn } from 'storybook/test';
 
 				const Secondary = () => <Button onClick={fn()} label="Button" />;
 				\`\`\`
@@ -170,6 +172,7 @@ describe('MCP Composition Auth E2E Tests', () => {
 
 				\`\`\`
 				import { Button } from '@my-org/my-component-library';
+				import { fn } from 'storybook/test';
 
 				const Large = () => <Button onClick={fn()} size="large" label="Button" />;
 				\`\`\`

--- a/test-storybooks/mcp/tests/mcp-composition.e2e.test.ts
+++ b/test-storybooks/mcp/tests/mcp-composition.e2e.test.ts
@@ -92,6 +92,7 @@ describe('MCP Composition E2E Tests', () => {
 
 				\`\`\`
 				import { Button } from '@my-org/my-component-library';
+				import { fn } from 'storybook/test';
 
 				const Primary = () => <Button onClick={fn()} primary label="Button" />;
 				\`\`\`
@@ -102,6 +103,7 @@ describe('MCP Composition E2E Tests', () => {
 
 				\`\`\`
 				import { Button } from '@my-org/my-component-library';
+				import { fn } from 'storybook/test';
 
 				const Secondary = () => <Button onClick={fn()} label="Button" />;
 				\`\`\`
@@ -112,6 +114,7 @@ describe('MCP Composition E2E Tests', () => {
 
 				\`\`\`
 				import { Button } from '@my-org/my-component-library';
+				import { fn } from 'storybook/test';
 
 				const Large = () => <Button onClick={fn()} size="large" label="Button" />;
 				\`\`\`


### PR DESCRIPTION
Follow-up to #35930, which was merged before these three commits landed on the branch. Two of them apply CodeRabbit findings from that review; the third fixes the one red job on `valentin/sb-1789-server-side-code-snippets-resolve-spreads-and-identifier` today. Targets that branch, not `next`.

## What I did

### The red CI job

`test-storybooks-mcp` is failing on the base branch. #35923 made an arg value's own import join the snippet's import block, so a story with `args: { onClick: fn() }` now ships `import { fn } from 'storybook/test';` beside the component import. That PR updated the unit-level expectations for it, but two inline snapshots live in `test-storybooks/mcp/tests/` rather than under `code/`, so they only run in the `test-storybooks-mcp` CircleCI job and were missed:

```diff
  ```
  import { Button } from '@my-org/my-component-library';
+ import { fn } from 'storybook/test';

  const Primary = () => <Button onClick={fn()} primary label="Button" />;
  ```
```

Six lines across the two files, recorded by running the job's own command rather than by hand:

```
cd test-storybooks/mcp && yarn install --no-immutable && yarn vitest run --project=e2e
# before:  Tests  2 failed | 44 passed (46)
# after:   Tests  46 passed (46)
```

The neighbouring `mcp-composition-docgen-server.e2e.test.ts` asserts with `toContain` instead of an inline snapshot, which is why it stayed green through the change and did not flag it.

### Two snippet-printing bugs from review

Both were reproduced before fixing, both have regression tests.

**A partial arg inline left the snippet naming a binding it no longer declared.** Inlining dropped the story function's parameter list unconditionally. When one arg inlined and another did not, the body kept reading `args.somethingElse` while the parameter was gone:

```diff
# export function Usage(args) { return <Button {...args} title={args.notAnArg} />; }
# Usage.args = { label: 'assigned' };

- function Usage() {
+ function Usage(args) {
      return <Button label="assigned" title={args.notAnArg}>Click me</Button>;
  }
```

The parameters now survive exactly when the rewritten body still reads from `args`, so the fully-inlined case keeps its clean `function Usage()` output. Taking `fn.params` unconditionally would have left an unused parameter behind in that far more common case. The two arrow-function rewrite paths had the same hole and got the same treatment.

**Rebuilding an object to write out a nested spread dropped the shorthand flag**, so `{ dep, nested: { ...base } }` printed `dep: dep`. Shorthand is kept while the value is still the one the key stands for:

```ts
t.objectProperty(property.key, value, property.computed, property.shorthand && value === property.value)
```

The identity guard matters beyond tidiness: a shorthand prints its key and nothing else, so if a rewrite ever did replace the value, carrying the flag over would silently discard it. Today the guard is always true for a shorthand, since its value is an identifier that `inlineSpreads` returns untouched.

## Checklist for Contributors

### Testing

| Command | What it covers | Run from |
| -- | -- | -- |
| `yarn vitest run code/core/src/csf-tools/story-shape` | the shared pass, including the shorthand case | repo root |
| `yarn vitest run --project @storybook/react` | the snippet generator, including the partial-inline case | repo root |
| `yarn install --no-immutable && yarn vitest run --project=e2e` | the MCP snapshots the CI job runs | `test-storybooks/mcp` |

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [x] end-to-end tests

#### Manual testing

1. `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. In the sandbox, add to `src/stories/Button.stories.ts`:
   ```tsx
   export function Partial(args) {
     return <Button {...args} title={args.notAnArg} />;
   }
   Partial.args = { label: 'assigned' };
   ```
3. Start the sandbox with `experimentalDocgenServer` enabled and open the Docs page for Button. The `Partial` snippet should read `function Partial(args)`; on the base branch it declares no parameter while the body still uses `args`.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user-facing docs change: the snippet-printing fixes restore output that was already intended, and the snapshot update records behaviour #35923 already documented.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01948zU9aDMuAFA9eFnQRk9L
