### PR TITLE
Core: Fetch static open-service snapshots relative to the document

### DIFF
--- a/code/core/src/preview/preview-navigator.ts
+++ b/code/core/src/preview/preview-navigator.ts
@@ -24,7 +24,7 @@ export async function maybeSetupPreviewNavigator() {
   (globalThis as any).__STORYBOOK_PREVIEW_NAVIGATOR__ = true;
 
   // TODO: custom story sort is not respected
-  const index = (await (await fetch('/index.json')).json()) as StoryIndex;
+  const index = (await (await fetch('./index.json')).json()) as StoryIndex;
 
   const currentEntryId = url.searchParams.get('id');
   if (!currentEntryId) {

--- a/code/core/src/shared/open-service/static-fetch.test.ts
+++ b/code/core/src/shared/open-service/static-fetch.test.ts
@@ -63,7 +63,7 @@ describe('createBrowserStaticLoader', () => {
     expect(createBrowserStaticLoader()).toBeUndefined();
   });
 
-  it('fetches snapshots from /services/<logicalPath> in production', async () => {
+  it('fetches snapshots from ./services/<logicalPath> in production', async () => {
     globalThis.CONFIG_TYPE = 'PRODUCTION';
     const fetchMock = vi.fn(async () => ({
       ok: true,
@@ -74,8 +74,27 @@ describe('createBrowserStaticLoader', () => {
     const loader = createBrowserStaticLoader();
     const snapshot = await loader!('internal-fixture/static-fetch/alpha.json', staticLoaderContext);
 
-    expect(fetchMock).toHaveBeenCalledWith('/services/internal-fixture/static-fetch/alpha.json');
+    expect(fetchMock).toHaveBeenCalledWith('./services/internal-fixture/static-fetch/alpha.json');
     expect(snapshot).toEqual({ entries: { alpha: 'from-file' } });
+  });
+
+  // A Storybook deployed below the origin root - a GitHub Pages project site, a docs site mounted
+  // under a path - must still reach its own snapshots, and the manager and the preview iframe must
+  // agree on where those are. An origin-absolute request would leave the deployment entirely.
+  it('resolves under the deployment directory from both the manager and the preview iframe', async () => {
+    globalThis.CONFIG_TYPE = 'PRODUCTION';
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await createBrowserStaticLoader()!('core/story-docs/button.json', staticLoaderContext);
+    const [requested] = fetchMock.mock.calls[0] as unknown as [string];
+
+    const managerDocument = 'https://acme.github.io/design-system/';
+    const previewDocument = 'https://acme.github.io/design-system/iframe.html?id=button--primary';
+    const expected = 'https://acme.github.io/design-system/services/core/story-docs/button.json';
+
+    expect(new URL(requested, managerDocument).href).toBe(expected);
+    expect(new URL(requested, previewDocument).href).toBe(expected);
   });
 
   it('rejects when the response is not ok', async () => {
@@ -97,7 +116,7 @@ describe('createBrowserStaticLoader', () => {
         queryName: 'entry',
         input: { id: 'alpha' },
         logicalPath: 'missing.json',
-        url: '/services/missing.json',
+        url: './services/missing.json',
         cause: { status: 404, statusText: 'Not Found' },
         status: 404,
         statusText: 'Not Found',
@@ -123,7 +142,7 @@ describe('createBrowserStaticLoader', () => {
         queryName: 'entry',
         input: { id: 'alpha' },
         logicalPath: 'network.json',
-        url: '/services/network.json',
+        url: './services/network.json',
         cause,
       },
     });
@@ -150,7 +169,7 @@ describe('createBrowserStaticLoader', () => {
         queryName: 'entry',
         input: { id: 'alpha' },
         logicalPath: 'broken.json',
-        url: '/services/broken.json',
+        url: './services/broken.json',
         cause,
       },
     });
@@ -179,7 +198,7 @@ describe('createBrowserStaticLoader', () => {
         queryName: 'entry',
         input: { id: 'alpha' },
         logicalPath: 'invalid.json',
-        url: '/services/invalid.json',
+        url: './services/invalid.json',
         received,
       },
     });

--- a/code/core/src/shared/open-service/static-fetch.ts
+++ b/code/core/src/shared/open-service/static-fetch.ts
@@ -22,7 +22,11 @@ export type StaticLoader = (
   context: StaticLoaderContext
 ) => Promise<Record<string, unknown>>;
 
-const STATIC_SERVICES_PREFIX = '/services/';
+// Document-relative, like `STORY_INDEX_PATH`: the manager and the preview iframe are siblings in
+// the build output, so both resolve this against the directory Storybook was deployed into. An
+// origin-absolute prefix would resolve against the origin root instead, which is the wrong place
+// whenever Storybook is not deployed at it (a GitHub Pages project site, for one).
+const STATIC_SERVICES_PREFIX = './services/';
 
 function shouldUseBrowserStaticLoader(): boolean {
   return globalThis.CONFIG_TYPE === 'PRODUCTION';
@@ -31,8 +35,9 @@ function shouldUseBrowserStaticLoader(): boolean {
 /**
  * Returns a fetch-based loader for static build output, or `undefined` in development.
  *
- * Snapshot paths are logical keys such as `core/docgen/foo.json`, resolved from the Storybook
- * origin (absolute `/services/...` so preview iframes and the manager share the same base).
+ * Snapshot paths are logical keys such as `core/docgen/foo.json`, resolved relative to the
+ * document (`./services/...`), so the manager and preview iframes share the same base wherever
+ * the build is deployed.
  */
 export function createBrowserStaticLoader(): StaticLoader | undefined {
   if (!shouldUseBrowserStaticLoader()) {

--- a/code/core/src/shared/open-service/static-fetch.ts
+++ b/code/core/src/shared/open-service/static-fetch.ts
@@ -22,10 +22,6 @@ export type StaticLoader = (
   context: StaticLoaderContext
 ) => Promise<Record<string, unknown>>;
 
-// Document-relative, like `STORY_INDEX_PATH`: the manager and the preview iframe are siblings in
-// the build output, so both resolve this against the directory Storybook was deployed into. An
-// origin-absolute prefix would resolve against the origin root instead, which is the wrong place
-// whenever Storybook is not deployed at it (a GitHub Pages project site, for one).
 const STATIC_SERVICES_PREFIX = './services/';
 
 function shouldUseBrowserStaticLoader(): boolean {


### PR DESCRIPTION
## What I did

Static open-service snapshots were fetched from `/services/<path>`, an origin-absolute URL.
A Storybook served below the origin root - a GitHub Pages project site, a docs site mounted under a path - therefore asked for its snapshots at a location belonging to a different site, and every static open-service load 404'd.

Every other build artifact is already document-relative. `STORY_INDEX_PATH` is `./index.json`, in both the preview and the manager. This aligns the services prefix with that.

```
Deployed at  https://acme.github.io/design-system/

  index.json      ./index.json      -> /design-system/index.json      200
  snapshots       /services/…       -> /services/…                    404   <- before
  snapshots       ./services/…      -> /design-system/services/…      200   <- after
```

The same defect in the preview navigator's index fetch is fixed alongside it, since it is the identical one-line mistake.

## The failure, captured

A real `storybook build` served under `/storybook/`, before the fix. The Open Service static-load story renders its query results:

| | Entry alpha | Entry beta |
| --- | --- | --- |
| before | `null` | `null` |
| after | `"static-load:alpha"` | `"static-load:beta"` |

Network for that page, before:

```
GET http://localhost:8099/services/storybook/internal/open-service-static-load-demo/alpha.json   404
GET http://localhost:8099/services/storybook/internal/open-service-static-load-demo/beta.json    404
```

After:

```
GET http://localhost:8099/storybook/services/storybook/internal/open-service-static-load-demo/alpha.json   200
GET http://localhost:8099/storybook/services/storybook/internal/open-service-static-load-demo/beta.json    200
GET http://localhost:8099/storybook/services/core/docgen/core-shared-open-service-sync-test-static-load.json      200
GET http://localhost:8099/storybook/services/core/story-docs/core-shared-open-service-sync-test-static-load.json  200
```

The user-facing consequence is wider than the demo story: with `experimentalDocgenServer` on, `core/story-docs` is what fills the Code panel and autodocs source blocks, so on a sub-path deploy those went blank.
`@storybook/angular-vite` turns that flag on from its own preset, so the regression shipped there by default.

## The change

```diff
-const STATIC_SERVICES_PREFIX = '/services/';
+const STATIC_SERVICES_PREFIX = './services/';
```

Relative resolution is what makes the manager and the preview agree: `index.html` and `iframe.html` are siblings in the build output, so `./services/…` resolves to the same place from either document. That is the property the old comment claimed the absolute path was needed for.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`code/core/src/shared/open-service/static-fetch.test.ts` gains a case asserting the request resolves under the deployment directory from both the manager document URL and the preview iframe document URL. The existing cases that pinned the absolute URL are updated.

Not covered by an e2e: the existing static-build specs serve Storybook at the origin root, so none of them can observe this. Adding a sub-path variant means teaching the e2e harness to serve under a prefix, which is more than this fix should carry.

#### Manual testing

Requires a build made with the docgen server on, since that is what populates `services/`.

1. `cd code && STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true yarn storybook:ui:build`
2. Stage it under a sub-path, so the layout matches a GitHub Pages project site:
   ```bash
   mkdir -p /tmp/sb-site/storybook
   cp -r code/storybook-static/. /tmp/sb-site/storybook/
   ```
3. `cd /tmp/sb-site && python3 -m http.server 8101`
   (Use `python3 -m http.server`, not `npx serve` - the latter strips `.html` by default and 301s `iframe.html`, which breaks the preview for unrelated reasons.)
4. Open `http://localhost:8101/storybook/?path=/story/core-shared-open-service-sync-test-static-load--static-load-sync`
5. `Entry alpha` and `Entry beta` should read `"static-load:alpha"` and `"static-load:beta"`. On `next` they read `null`.
6. Open `http://localhost:8101/storybook/?path=/story/addons-docs-codepanel--default` and select the Code tab. The snippet should render. On `next` the panel stays empty.
7. In devtools, every `services/…` request should be under `/storybook/services/…` and return 200.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation change: this restores the behavior the docs already describe. `docs/sharing/publish-storybook.mdx` lists GitHub Pages as a supported target.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
