### PR TITLE
Vue: Fix docgen slot, exposed-member, and add warning for snippet losses

### DIFF
--- a/code/core/src/csf-tools/story-shape/index.ts
+++ b/code/core/src/csf-tools/story-shape/index.ts
@@ -31,6 +31,7 @@ export {
 } from './resolve-members.ts';
 export {
   createStoryArgsResolver,
+  noSnippetWarning,
   unresolvedWarning,
   type ResolvedStoryArgs,
   type StoryArgsResolver,

--- a/code/core/src/csf-tools/story-shape/resolve-story-args.ts
+++ b/code/core/src/csf-tools/story-shape/resolve-story-args.ts
@@ -102,3 +102,11 @@ export const unresolvedWarning = (unresolved: readonly string[]): string | undef
     ? undefined
     : `Incomplete snippet: ${sources.map((source) => `\`${source}\``).join(', ')} could not be resolved statically.`;
 };
+
+/** {@link unresolvedWarning} for a story that gets no snippet at all instead of a partial one. */
+export const noSnippetWarning = (unresolved: readonly string[]): string | undefined => {
+  const sources = [...new Set(unresolved)];
+  return sources.length === 0
+    ? undefined
+    : `No static snippet: ${sources.map((source) => `\`${source}\``).join(', ')} could not be resolved statically.`;
+};

--- a/code/core/src/shared/open-service/services/story-docs/types.ts
+++ b/code/core/src/shared/open-service/services/story-docs/types.ts
@@ -26,9 +26,9 @@ export interface StoryDoc {
   description?: string;
   summary?: string;
   /**
-   * Why the snippet is an incomplete example: what a static pass could not resolve, in the source
-   * text it was written as. A story that carries this still carries a `snippet`; an `error` means
-   * there is no snippet at all.
+   * What a static pass could not resolve, in the source text it was written as. Next to a
+   * `snippet` it marks the example as partial; on its own it says why no static snippet could be
+   * produced at all. An `error` means the provider itself failed.
    */
   warning?: string;
   error?: StoryDocsError;

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-literal-bindings/cm-snippet-ScopedIconBinding.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-literal-bindings/cm-snippet-ScopedIconBinding.snapshot
@@ -1,5 +1,6 @@
 <template>
-  <DefineSlotsLiteralBindings > Save
-
-<template #icon="{ size, fill }"><i>{{ size }} {{ fill }}</i></template> </DefineSlotsLiteralBindings>
+  <DefineSlotsLiteralBindings>
+    Save
+    <template #icon="{ size, fill }"><i>{{ size }} {{ fill }}</i></template>
+  </DefineSlotsLiteralBindings>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-literal-bindings/snippet-ScopedIconBinding.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-literal-bindings/snippet-ScopedIconBinding.snapshot
@@ -1,5 +1,6 @@
 <template>
-  <DefineSlotsLiteralBindings > Save
-
-<template #icon="{ size, fill }"><i>{{ size }} {{ fill }}</i></template> </DefineSlotsLiteralBindings>
+  <DefineSlotsLiteralBindings>
+    Save
+    <template #icon="{ size, fill }"><i>{{ size }} {{ fill }}</i></template>
+  </DefineSlotsLiteralBindings>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-literal-bindings/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/define-slots-literal-bindings/story-docs.payload.snapshot
@@ -8,6 +8,7 @@
       "id": "forms-define-slots-literal-bindings--scoped-icon-binding",
       "name": "Scoped Icon Binding",
       "summary": undefined,
+      "warning": "No static snippet: a slot function could not be resolved statically.",
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/ExposeEventCollision.vue
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/ExposeEventCollision.vue
@@ -4,7 +4,7 @@ import { ref } from 'vue';
 const inputRef = ref<HTMLInputElement>();
 
 defineProps<{ label?: string }>();
-defineEmits<{ focus: []; blur: [] }>();
+defineEmits<{ focus: []; blur: []; boarding: [] }>();
 
 function focus(): void {
   inputRef.value?.focus();
@@ -12,10 +12,14 @@ function focus(): void {
 function blur(): void {
   inputRef.value?.blur();
 }
+function onboarding(): void {
+  inputRef.value?.select();
+}
 
-// The exposed members share their names with the declared events on purpose: the argTypes
-// dedup must only strip `onX` handler duplicates, never authored `defineExpose` members.
-defineExpose({ focus, blur });
+// The exposed members collide with the declared events on purpose: the dedup must only strip
+// `onX` handler duplicates, never authored members named like an event (`focus`) or with a
+// lowercase `on` continuation (`onboarding` beside a `boarding` event).
+defineExpose({ focus, blur, onboarding });
 </script>
 
 <template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/ExposeEventCollision.vue
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/ExposeEventCollision.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const inputRef = ref<HTMLInputElement>();
+
+defineProps<{ label?: string }>();
+defineEmits<{ focus: []; blur: [] }>();
+
+function focus(): void {
+  inputRef.value?.focus();
+}
+function blur(): void {
+  inputRef.value?.blur();
+}
+
+// The exposed members share their names with the declared events on purpose: the argTypes
+// dedup must only strip `onX` handler duplicates, never authored `defineExpose` members.
+defineExpose({ focus, blur });
+</script>
+
+<template>
+  <input ref="inputRef" :aria-label="label" />
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/argtypes.snapshot
@@ -17,6 +17,24 @@
       "value": "",
     },
   },
+  "boarding": {
+    "control": {
+      "disable": true,
+    },
+    "description": undefined,
+    "name": "boarding",
+    "table": {
+      "category": "events",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
   "focus": {
     "control": {
       "disable": true,
@@ -49,6 +67,23 @@
     "type": {
       "name": "string",
       "required": false,
+    },
+  },
+  "onboarding": {
+    "control": {
+      "disable": true,
+    },
+    "description": undefined,
+    "name": "onboarding",
+    "table": {
+      "category": "expose",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "value": "",
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/argtypes.snapshot
@@ -1,0 +1,54 @@
+{
+  "blur": {
+    "control": {
+      "disable": true,
+    },
+    "description": undefined,
+    "name": "blur",
+    "table": {
+      "category": "events",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+  "focus": {
+    "control": {
+      "disable": true,
+    },
+    "description": undefined,
+    "name": "focus",
+    "table": {
+      "category": "events",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+  "label": {
+    "description": undefined,
+    "name": "label",
+    "table": {
+      "category": "props",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": {
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+      "required": false,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/cm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/cm-argtypes.snapshot
@@ -1,0 +1,52 @@
+{
+  "blur": {
+    "control": {
+      "disable": true,
+    },
+    "description": "",
+    "name": "blur",
+    "table": {
+      "category": "events",
+      "type": {
+        "summary": "[]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "[]",
+    },
+  },
+  "focus": {
+    "control": {
+      "disable": true,
+    },
+    "description": "",
+    "name": "focus",
+    "table": {
+      "category": "events",
+      "type": {
+        "summary": "[]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "[]",
+    },
+  },
+  "label": {
+    "defaultValue": undefined,
+    "description": "",
+    "name": "label",
+    "table": {
+      "category": "props",
+      "defaultValue": undefined,
+      "type": {
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+      "required": false,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/cm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/cm-argtypes.snapshot
@@ -16,6 +16,23 @@
       "value": "[]",
     },
   },
+  "boarding": {
+    "control": {
+      "disable": true,
+    },
+    "description": "",
+    "name": "boarding",
+    "table": {
+      "category": "events",
+      "type": {
+        "summary": "[]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "[]",
+    },
+  },
   "focus": {
     "control": {
       "disable": true,
@@ -47,6 +64,23 @@
     "type": {
       "name": "string",
       "required": false,
+    },
+  },
+  "onboarding": {
+    "control": {
+      "disable": true,
+    },
+    "description": "",
+    "name": "onboarding",
+    "table": {
+      "category": "exposed",
+      "type": {
+        "summary": "() => void",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "() => void",
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/cm-snippet-Primary.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/cm-snippet-Primary.snapshot
@@ -1,0 +1,3 @@
+<template>
+  <ExposeEventCollision label="Name" />
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/input.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import ExposeEventCollision from './ExposeEventCollision.vue';
+
+const meta = {
+  title: 'VueFixtures/ExposeEventCollision',
+  component: ExposeEventCollision,
+} satisfies Meta<typeof ExposeEventCollision>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: { label: 'Name' },
+};

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/snippet-Primary.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/snippet-Primary.snapshot
@@ -1,0 +1,3 @@
+<template>
+  <ExposeEventCollision label="Name" />
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/expose-event-collision/story-docs.payload.snapshot
@@ -1,0 +1,20 @@
+{
+  "id": "expose-event-collision",
+  "name": "ExposeEventCollision",
+  "path": "__PATH__",
+  "stories": {
+    "forms-expose-event-collision--primary": {
+      "description": undefined,
+      "id": "forms-expose-event-collision--primary",
+      "name": "Primary",
+      "snippet": "<script lang="ts" setup>
+import ExposeEventCollision from './ExposeEventCollision.vue';
+</script>
+
+<template>
+  <ExposeEventCollision label="Name" />
+</template>",
+      "summary": undefined,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/prop-slot-name-collision/cm-snippet-IconPropAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/prop-slot-name-collision/cm-snippet-IconPropAsWritten.snapshot
@@ -1,3 +1,5 @@
 <template>
-  <PropSlotNameCollision > <template #icon>pi pi-check</template> </PropSlotNameCollision>
+  <PropSlotNameCollision>
+    <template #icon>pi pi-check</template>
+  </PropSlotNameCollision>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/prop-slot-name-collision/snippet-IconPropAsWritten.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/prop-slot-name-collision/snippet-IconPropAsWritten.snapshot
@@ -1,3 +1,5 @@
 <template>
-  <PropSlotNameCollision > <template #icon>pi pi-check</template> </PropSlotNameCollision>
+  <PropSlotNameCollision>
+    <template #icon>pi pi-check</template>
+  </PropSlotNameCollision>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/props-ts-enum/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/props-ts-enum/story-docs.payload.snapshot
@@ -15,7 +15,7 @@ import TsEnumProps from './TsEnumProps.vue';
   <TsEnumProps :level="1" />
 </template>",
       "summary": undefined,
-      "warning": "Omitted args that cannot be resolved statically: severity: Severity.Warning",
+      "warning": "Incomplete snippet: `severity: Severity.Warning` could not be resolved statically.",
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/OptionsApiSlots.vue
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/OptionsApiSlots.vue
@@ -14,6 +14,7 @@ export default {
     <h2>{{ heading }}</h2>
     <!-- @slot Rendered above the content. -->
     <slot name="header" />
+    <!-- @slot The main content area. -->
     <slot />
     <ul>
       <li v-for="(entry, index) in ['first', 'second']" :key="entry">

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/OptionsApiSlots.vue
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/OptionsApiSlots.vue
@@ -1,0 +1,25 @@
+<script>
+// Options API on purpose: Volar only infers template slots for `<script setup>` components, so
+// this fixture guards the vue-docgen-api fallback that restores them on the successor engines.
+export default {
+  name: 'OptionsApiSlots',
+  props: {
+    heading: { type: String, default: 'Title' },
+  },
+};
+</script>
+
+<template>
+  <section>
+    <h2>{{ heading }}</h2>
+    <!-- @slot Rendered above the content. -->
+    <slot name="header" />
+    <slot />
+    <ul>
+      <li v-for="(entry, index) in ['first', 'second']" :key="entry">
+        <!-- @slot Renders one entry; receives the entry and its position. -->
+        <slot name="item" :entry="entry" :index="index" />
+      </li>
+    </ul>
+  </section>
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/argtypes.snapshot
@@ -1,6 +1,6 @@
 {
   "default": {
-    "description": "Rendered above the content.",
+    "description": "The main content area.",
     "name": "default",
     "table": {
       "category": "slots",

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/argtypes.snapshot
@@ -1,0 +1,68 @@
+{
+  "default": {
+    "description": "Rendered above the content.",
+    "name": "default",
+    "table": {
+      "category": "slots",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+  "header": {
+    "description": "Rendered above the content.",
+    "name": "header",
+    "table": {
+      "category": "slots",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+  "heading": {
+    "description": undefined,
+    "name": "heading",
+    "table": {
+      "category": "props",
+      "defaultValue": {
+        "detail": undefined,
+        "summary": "'Title'",
+      },
+      "jsDocTags": undefined,
+      "type": {
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "item": {
+    "description": "Renders one entry; receives the entry and its position.",
+    "name": "item",
+    "table": {
+      "category": "slots",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": {
+        "summary": "{ entry: unknown; index: unknown }",
+      },
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "{ entry: unknown; index: unknown }",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/cm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/cm-argtypes.snapshot
@@ -1,6 +1,6 @@
 {
   "default": {
-    "description": "Rendered above the content.",
+    "description": "The main content area.",
     "name": "default",
     "table": {
       "category": "slots",

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/cm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/cm-argtypes.snapshot
@@ -1,6 +1,6 @@
 {
   "default": {
-    "description": "",
+    "description": "Rendered above the content.",
     "name": "default",
     "table": {
       "category": "slots",
@@ -27,18 +27,38 @@
       "value": "{}",
     },
   },
+  "heading": {
+    "defaultValue": {
+      "summary": "'Title'",
+    },
+    "description": "",
+    "name": "heading",
+    "table": {
+      "category": "props",
+      "defaultValue": {
+        "summary": "'Title'",
+      },
+      "type": {
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+      "required": false,
+    },
+  },
   "item": {
     "description": "Renders one entry; receives the entry and its position.",
     "name": "item",
     "table": {
       "category": "slots",
       "type": {
-        "summary": "{ entry: string; index: number; }",
+        "summary": "{ entry: unknown; index: unknown }",
       },
     },
     "type": {
       "name": "other",
-      "value": "{ entry: string; index: number; }",
+      "value": "{ entry: unknown; index: unknown }",
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/cm-snippet-ScopedBindings.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/cm-snippet-ScopedBindings.snapshot
@@ -1,5 +1,5 @@
 <template>
-  <TemplateOnlySlots>
+  <OptionsApiSlots>
     <template #item="{ entry, index }"><em>{{ index }}: {{ entry }}</em></template>
-  </TemplateOnlySlots>
+  </OptionsApiSlots>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/cm-snippet-StringChild.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/cm-snippet-StringChild.snapshot
@@ -1,6 +1,6 @@
 <template>
-  <TemplateOnlySlots>
+  <OptionsApiSlots heading="Entries">
     Plain text content
     <template #header>Header text</template>
-  </TemplateOnlySlots>
+  </OptionsApiSlots>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/input.stories.ts
@@ -1,0 +1,24 @@
+import { h } from 'vue';
+
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import OptionsApiSlots from './OptionsApiSlots.vue';
+
+const meta = {
+  title: 'VueFixtures/OptionsApiSlots',
+  component: OptionsApiSlots,
+} satisfies Meta<typeof OptionsApiSlots>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const StringChild: Story = {
+  args: { heading: 'Entries', default: 'Plain text content', header: 'Header text' },
+};
+
+export const ScopedBindings: Story = {
+  args: {
+    item: ({ entry, index }: { entry: string; index: number }) => h('em', `${index}: ${entry}`),
+  },
+};

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/input.stories.ts
@@ -1,7 +1,7 @@
 import { h } from 'vue';
 
 import type { Meta, StoryObj } from '@storybook/vue3';
-
+// @ts-expect-error component doesn't have lang=ts
 import OptionsApiSlots from './OptionsApiSlots.vue';
 
 const meta = {

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/snippet-ScopedBindings.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/snippet-ScopedBindings.snapshot
@@ -1,5 +1,5 @@
 <template>
-  <TemplateOnlySlots>
+  <OptionsApiSlots>
     <template #item="{ entry, index }"><em>{{ index }}: {{ entry }}</em></template>
-  </TemplateOnlySlots>
+  </OptionsApiSlots>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/snippet-StringChild.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/snippet-StringChild.snapshot
@@ -1,6 +1,6 @@
 <template>
-  <TemplateOnlySlots>
+  <OptionsApiSlots heading="Entries">
     Plain text content
     <template #header>Header text</template>
-  </TemplateOnlySlots>
+  </OptionsApiSlots>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/story-docs.payload.snapshot
@@ -1,0 +1,31 @@
+{
+  "id": "slots-options-api",
+  "name": "OptionsApiSlots",
+  "path": "__PATH__",
+  "stories": {
+    "forms-slots-options-api--scoped-bindings": {
+      "description": undefined,
+      "id": "forms-slots-options-api--scoped-bindings",
+      "name": "Scoped Bindings",
+      "summary": undefined,
+    },
+    "forms-slots-options-api--string-child": {
+      "description": undefined,
+      "id": "forms-slots-options-api--string-child",
+      "name": "String Child",
+      "snippet": "<script lang="ts" setup>
+import OptionsApiSlots from './OptionsApiSlots.vue';
+</script>
+
+<template>
+  <OptionsApiSlots heading="Entries">
+    Plain text content
+    <template #header>
+      Header text
+    </template>
+  </OptionsApiSlots>
+</template>",
+      "summary": undefined,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-options-api/story-docs.payload.snapshot
@@ -8,6 +8,7 @@
       "id": "forms-slots-options-api--scoped-bindings",
       "name": "Scoped Bindings",
       "summary": undefined,
+      "warning": "No static snippet: a slot function could not be resolved statically.",
     },
     "forms-slots-options-api--string-child": {
       "description": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-template-only/snippet-ScopedBindings.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-template-only/snippet-ScopedBindings.snapshot
@@ -1,3 +1,5 @@
 <template>
-  <TemplateOnlySlots > <template #item="{ entry, index }"><em>{{ index }}: {{ entry }}</em></template> </TemplateOnlySlots>
+  <TemplateOnlySlots>
+    <template #item="{ entry, index }"><em>{{ index }}: {{ entry }}</em></template>
+  </TemplateOnlySlots>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-template-only/snippet-StringChild.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-template-only/snippet-StringChild.snapshot
@@ -1,5 +1,6 @@
 <template>
-  <TemplateOnlySlots > Plain text content
-
-<template #header>Header text</template> </TemplateOnlySlots>
+  <TemplateOnlySlots>
+    Plain text content
+    <template #header>Header text</template>
+  </TemplateOnlySlots>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-template-only/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-template-only/story-docs.payload.snapshot
@@ -8,6 +8,7 @@
       "id": "forms-slots-template-only--scoped-bindings",
       "name": "Scoped Bindings",
       "summary": undefined,
+      "warning": "No static snippet: a slot function could not be resolved statically.",
     },
     "forms-slots-template-only--string-child": {
       "description": undefined,

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/cm-snippet-ScopedBindings.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/cm-snippet-ScopedBindings.snapshot
@@ -1,3 +1,5 @@
 <template>
-  <SlotsShowcase heading="Scoped"> <template #item="{ entry, index }"><em>{{ index }}: {{ entry.label }}</em></template> </SlotsShowcase>
+  <SlotsShowcase heading="Scoped">
+    <template #item="{ entry, index }"><em>{{ index }}: {{ entry.label }}</em></template>
+  </SlotsShowcase>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/cm-snippet-StringChild.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/cm-snippet-StringChild.snapshot
@@ -1,3 +1,5 @@
 <template>
-  <SlotsShowcase heading="Plain"> Plain text content </SlotsShowcase>
+  <SlotsShowcase heading="Plain">
+    Plain text content
+  </SlotsShowcase>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/cm-snippet-VNodeChild.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/cm-snippet-VNodeChild.snapshot
@@ -1,5 +1,6 @@
 <template>
-  <SlotsShowcase heading="Structured"> <p class="body">Body content</p>
-
-<template #header><strong>Header content</strong></template> </SlotsShowcase>
+  <SlotsShowcase heading="Structured">
+    <p class="body">Body content</p>
+    <template #header><strong>Header content</strong></template>
+  </SlotsShowcase>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/snippet-ScopedBindings.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/snippet-ScopedBindings.snapshot
@@ -1,3 +1,5 @@
 <template>
-  <SlotsShowcase heading="Scoped"> <template #item="{ entry, index }"><em>{{ index }}: {{ entry.label }}</em></template> </SlotsShowcase>
+  <SlotsShowcase heading="Scoped">
+    <template #item="{ entry, index }"><em>{{ index }}: {{ entry.label }}</em></template>
+  </SlotsShowcase>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/snippet-StringChild.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/snippet-StringChild.snapshot
@@ -1,3 +1,5 @@
 <template>
-  <SlotsShowcase heading="Plain"> Plain text content </SlotsShowcase>
+  <SlotsShowcase heading="Plain">
+    Plain text content
+  </SlotsShowcase>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/snippet-VNodeChild.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/snippet-VNodeChild.snapshot
@@ -1,5 +1,6 @@
 <template>
-  <SlotsShowcase heading="Structured"> <p class="body">Body content</p>
-
-<template #header><strong>Header content</strong></template> </SlotsShowcase>
+  <SlotsShowcase heading="Structured">
+    <p class="body">Body content</p>
+    <template #header><strong>Header content</strong></template>
+  </SlotsShowcase>
 </template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots/story-docs.payload.snapshot
@@ -8,6 +8,7 @@
       "id": "forms-slots--scoped-bindings",
       "name": "Scoped Bindings",
       "summary": undefined,
+      "warning": "No static snippet: a slot function could not be resolved statically.",
     },
     "forms-slots--string-child": {
       "description": undefined,

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/args-references/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/args-references/story-docs.payload.snapshot
@@ -39,6 +39,7 @@ const options = {
       "id": "forms-args-references--unreadable-spread-arg",
       "name": "Unreadable Spread Arg",
       "summary": undefined,
+      "warning": "No static snippet: `options: { ...buildOptions(), tone: 'neutral' }`, `...buildOptions()` could not be resolved statically.",
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/component-not-imported/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/component-not-imported/input.stories.ts
@@ -1,0 +1,19 @@
+import { defineComponent, h } from 'vue';
+
+// Declared in the story file on purpose: no import statement exists for the snippet to
+// reconstruct, so the story has to explain the missing snippet instead of blaming a slot.
+const LocalCard = defineComponent({
+  props: { label: String },
+  setup: (props) => () => h('div', props.label),
+});
+
+const meta = {
+  component: LocalCard,
+  title: 'Forms/component-not-imported',
+};
+
+export default meta;
+
+export const Primary = {
+  args: { label: 'Hi' },
+};

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/component-not-imported/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/component-not-imported/story-docs.payload.snapshot
@@ -1,0 +1,14 @@
+{
+  "id": "component-not-imported",
+  "name": "LocalCard",
+  "path": "__PATH__",
+  "stories": {
+    "forms-component-not-imported--primary": {
+      "description": undefined,
+      "id": "forms-component-not-imported--primary",
+      "name": "Primary",
+      "summary": undefined,
+      "warning": "No static snippet: the component's import could not be resolved statically.",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/function-slot-bail/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/function-slot-bail/story-docs.payload.snapshot
@@ -8,6 +8,7 @@
       "id": "forms-function-slot-bail--primary",
       "name": "Primary",
       "summary": undefined,
+      "warning": "No static snippet: a slot function could not be resolved statically.",
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/render-setup-h/SetupRenderButton.vue
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/render-setup-h/SetupRenderButton.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{
+  label?: string;
+}>();
+</script>
+
+<template>
+  <button type="button">{{ label }}</button>
+</template>

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/render-setup-h/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/render-setup-h/input.stories.ts
@@ -1,0 +1,26 @@
+import { h } from 'vue';
+
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import SetupRenderButton from './SetupRenderButton.vue';
+
+const meta = {
+  component: SetupRenderButton,
+  title: 'Forms/render-setup-h',
+} satisfies Meta<typeof SetupRenderButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The render closure a `setup` returns is the other common home for an `h()` tree.
+export const Primary: Story = {
+  args: {
+    label: 'Click me',
+  },
+  render: (args) => ({
+    setup() {
+      return () => h(SetupRenderButton, { label: args.label });
+    },
+  }),
+};

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/render-setup-h/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/render-setup-h/story-docs.payload.snapshot
@@ -1,0 +1,20 @@
+{
+  "id": "render-setup-h",
+  "name": "SetupRenderButton",
+  "path": "__PATH__",
+  "stories": {
+    "forms-render-setup-h--primary": {
+      "description": undefined,
+      "id": "forms-render-setup-h--primary",
+      "name": "Primary",
+      "snippet": "<script lang="ts" setup>
+import SetupRenderButton from './SetupRenderButton.vue';
+</script>
+
+<template>
+  <SetupRenderButton label="Click me" />
+</template>",
+      "summary": undefined,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/slot-scoped/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/slot-scoped/story-docs.payload.snapshot
@@ -8,6 +8,7 @@
       "id": "forms-slot-scoped--primary",
       "name": "Primary",
       "summary": undefined,
+      "warning": "No static snippet: a slot function could not be resolved statically.",
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-inherit-attrs/InheritAttrsPanel.vue
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-inherit-attrs/InheritAttrsPanel.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{
+  label?: string;
+}>();
+</script>
+
+<template>
+  <section>{{ label }}</section>
+</template>

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-inherit-attrs/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-inherit-attrs/input.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import InheritAttrsPanel from './InheritAttrsPanel.vue';
+
+const meta = {
+  component: InheritAttrsPanel,
+  title: 'Forms/template-inherit-attrs',
+} satisfies Meta<typeof InheritAttrsPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// `inheritAttrs` only tunes runtime attribute fallthrough, so it must not cost the snippet.
+export const Primary: Story = {
+  args: {
+    label: 'Panel',
+  },
+  render: (args) => ({
+    inheritAttrs: false,
+    components: { InheritAttrsPanel },
+    setup() {
+      return { args };
+    },
+    template: '<InheritAttrsPanel :label="args.label" />',
+  }),
+};

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-inherit-attrs/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-inherit-attrs/story-docs.payload.snapshot
@@ -1,0 +1,20 @@
+{
+  "id": "template-inherit-attrs",
+  "name": "InheritAttrsPanel",
+  "path": "__PATH__",
+  "stories": {
+    "forms-template-inherit-attrs--primary": {
+      "description": undefined,
+      "id": "forms-template-inherit-attrs--primary",
+      "name": "Primary",
+      "snippet": "<script lang="ts" setup>
+import InheritAttrsPanel from './InheritAttrsPanel.vue';
+</script>
+
+<template>
+  <InheritAttrsPanel label="Panel" />
+</template>",
+      "summary": undefined,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-unsupported/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-unsupported/story-docs.payload.snapshot
@@ -8,6 +8,7 @@
       "id": "forms-template-unsupported--primary",
       "name": "Primary",
       "summary": undefined,
+      "warning": "No static snippet: the `render` function could not be resolved statically.",
     },
   },
 }

--- a/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
@@ -198,4 +198,35 @@ describe('vue3 api description from real vue-component-meta output', () => {
       \`\`\`"
     `);
   });
+  it('expose-event-collision keeps authored exposed members named like events', async () => {
+    expect(await apiDescriptionFor('expose-event-collision')).toMatchInlineSnapshot(`
+      "## Props
+
+      \`\`\`
+      export type ExposeEventCollisionProps = {
+        label?: string;
+      }
+      \`\`\`
+
+      ## Events
+
+      \`\`\`
+      export type ExposeEventCollisionEvents = {
+        focus: [];
+        blur: [];
+      }
+      \`\`\`
+
+      ## Exposed
+
+      Available on the component instance through a template ref.
+
+      \`\`\`
+      export type ExposeEventCollisionExposed = {
+        focus: () => void;
+        blur: () => void;
+      }
+      \`\`\`"
+    `);
+  });
 });

--- a/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
@@ -214,6 +214,7 @@ describe('vue3 api description from real vue-component-meta output', () => {
       export type ExposeEventCollisionEvents = {
         focus: [];
         blur: [];
+        boarding: [];
       }
       \`\`\`
 
@@ -225,6 +226,7 @@ describe('vue3 api description from real vue-component-meta output', () => {
       export type ExposeEventCollisionExposed = {
         focus: () => void;
         blur: () => void;
+        onboarding: () => void;
       }
       \`\`\`"
     `);

--- a/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
@@ -11,8 +11,8 @@ import {
   TypeMeta,
   createCheckerByJson,
 } from 'vue-component-meta';
-import { parseMulti } from 'vue-docgen-api';
 
+import { applyVueDocgenApiTempFixes } from '../../../../renderers/vue3/src/docgen/component-meta.ts';
 import { extractArgTypes } from '../../../../renderers/vue3/src/extractArgTypes.ts';
 import { generateSourceCode } from '../../../../renderers/vue3/src/docs/sourceDecorator.ts';
 import { expectCurrentOrBetter } from '../compare/expect-current-or-better.ts';
@@ -65,26 +65,22 @@ async function buildComponentMetaDocgen(sfcPath: string): Promise<object | undef
     }
     meta = checker.getComponentMeta(sfcPath, 'default');
 
-    // production's applyTempFixForEventDescriptions
-    if (meta.events.length) {
-      try {
-        const parsed = await parseMulti(sfcPath);
-        const eventsWithDescription = parsed[defaultIndex]?.events;
-        if (eventsWithDescription?.length) {
-          meta.events = meta.events.map((event) => {
-            const description = eventsWithDescription.find(
-              (i) => i.name === event.name
-            )?.description;
-            if (description) {
-              (event as typeof event & { description: string }).description = description;
-            }
-            return event;
-          });
-        }
-      } catch {
-        // noop, as in production
+    // The shared temp-fix pass pairs metas with parseMulti results by export position, so keep
+    // the array aligned with the file's export order the way collectComponentMetaSources does.
+    const metas = exportNames.map((name) => {
+      if (name === 'default') {
+        return meta;
       }
-    }
+      try {
+        return checker.getComponentMeta(sfcPath, name);
+      } catch {
+        return undefined;
+      }
+    });
+    await applyVueDocgenApiTempFixes(
+      sfcPath,
+      metas.filter((entry): entry is ComponentMeta => entry !== undefined)
+    );
   } catch {
     // the production transform swallows checker failures and attaches nothing
     return undefined;

--- a/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
@@ -104,7 +104,7 @@ async function buildComponentMetaDocgen(sfcPath: string): Promise<object | undef
 
   const exposed = meta.exposed
     .filter((expose) => {
-      if (!expose.name.startsWith('on')) {
+      if (!/^on[A-Z]/.test(expose.name)) {
         return true;
       }
       const eventName = lowercaseFirstLetter(expose.name.slice('on'.length));

--- a/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
@@ -104,11 +104,11 @@ async function buildComponentMetaDocgen(sfcPath: string): Promise<object | undef
 
   const exposed = meta.exposed
     .filter((expose) => {
-      let nameWithoutOnPrefix = expose.name;
-      if (nameWithoutOnPrefix.startsWith('on')) {
-        nameWithoutOnPrefix = lowercaseFirstLetter(expose.name.replace('on', ''));
+      if (!expose.name.startsWith('on')) {
+        return true;
       }
-      return !meta.events.find((event) => event.name === nameWithoutOnPrefix);
+      const eventName = lowercaseFirstLetter(expose.name.slice('on'.length));
+      return !meta.events.some((event) => event.name === eventName);
     })
     .filter((expose) => {
       if (expose.name === '$slots') {

--- a/code/renderers/vue3/src/docgen/component-meta.ts
+++ b/code/renderers/vue3/src/docgen/component-meta.ts
@@ -13,14 +13,14 @@ import { join, parse } from 'node:path';
 import { getProjectRoot } from 'storybook/internal/common';
 
 import {
+  TypeMeta,
+  createChecker,
+  createCheckerByJson,
   type ComponentMeta,
   type ComponentMetaChecker,
   type MetaCheckerOptions,
   type PropertyMetaSchema,
   type SlotMeta,
-  TypeMeta,
-  createChecker,
-  createCheckerByJson,
 } from 'vue-component-meta';
 import { parseMulti, type ComponentDoc } from 'vue-docgen-api';
 
@@ -143,7 +143,7 @@ export async function collectComponentMetaSources(
       // duplicate: an exposed member merely named like an event (`focus` beside a `focus` event)
       // is an authored `defineExpose` member and has to stay.
       .filter((expose) => {
-        if (!expose.name.startsWith('on')) {
+        if (!/^on[A-Z]/.test(expose.name)) {
           return true;
         }
 

--- a/code/renderers/vue3/src/docgen/component-meta.ts
+++ b/code/renderers/vue3/src/docgen/component-meta.ts
@@ -17,11 +17,12 @@ import {
   type ComponentMetaChecker,
   type MetaCheckerOptions,
   type PropertyMetaSchema,
+  type SlotMeta,
   TypeMeta,
   createChecker,
   createCheckerByJson,
 } from 'vue-component-meta';
-import { parseMulti } from 'vue-docgen-api';
+import { parseMulti, type ComponentDoc } from 'vue-docgen-api';
 
 // Mirrors the JSON round-trip in toSerializableMeta: methods (e.g. `getDeclarations`) do not
 // survive it, so their keys are dropped rather than kept as unconstructible phantom fields.
@@ -109,7 +110,7 @@ export async function collectComponentMetaSources(
     return [];
   }
 
-  componentsMeta = await applyTempFixForEventDescriptions(id, componentsMeta);
+  componentsMeta = await applyVueDocgenApiTempFixes(id, componentsMeta);
 
   const metaSources: MetaSource[] = [];
 
@@ -192,52 +193,114 @@ async function fileExists(fullPath: string) {
 }
 
 /**
- * Applies a temporary workaround/fix for missing event descriptions because Volar is currently not
- * able to extract them. Will modify the events of the passed meta. Performance note: Based on some
- * quick tests, calling "parseMulti" only takes a few milliseconds (8-20ms) so it should not
- * decrease performance that much. Especially because it is only execute if the component actually
- * has events.
+ * Fills the gaps Volar cannot extract yet from a `vue-docgen-api` parse of the same file:
  *
- * Check status of this Volar issue: https://github.com/vuejs/language-tools/issues/3893 and
- * update/remove this workaround once Volar supports it:
+ * - Event descriptions: https://github.com/vuejs/language-tools/issues/3893
+ * - Template-declared slots: Volar only infers slots for `<script setup>` components, so an
+ *   Options API component loses every template slot, and `@slot` comment descriptions are never
+ *   read for anyone
  *
- * - Delete this function
- * - Uninstall vue-docgen-api dependency
+ * Performance note: `parseMulti` takes a few milliseconds (8-20ms) and only runs when a gap is
+ * actually present in the extracted meta. Delete each merge once Volar covers it, and uninstall
+ * the vue-docgen-api dependency when both are gone.
  */
-async function applyTempFixForEventDescriptions(filename: string, componentMeta: ComponentMeta[]) {
-  // do not apply temp fix if no events exist for performance reasons
-  const hasEvents = componentMeta.some((meta) => meta.events.length);
+export async function applyVueDocgenApiTempFixes(
+  filename: string,
+  componentsMeta: ComponentMeta[]
+): Promise<ComponentMeta[]> {
+  const hasEvents = componentsMeta.some((meta) => meta.events.length > 0);
+  const needsSlots = await hasTemplateSlotGap(filename, componentsMeta);
 
-  if (!hasEvents) {
-    return componentMeta;
+  if (!hasEvents && !needsSlots) {
+    return componentsMeta;
   }
 
   try {
     const parsedComponentDocs = await parseMulti(filename);
 
-    // add event descriptions to the existing Volar meta if available
-    componentMeta.map((meta, index) => {
-      const eventsWithDescription = parsedComponentDocs[index].events;
-
-      if (!meta.events.length || !eventsWithDescription?.length) {
-        return meta;
+    componentsMeta.forEach((meta, index) => {
+      const parsed = parsedComponentDocs[index];
+      if (!parsed) {
+        return;
       }
-
-      meta.events = meta.events.map((event) => {
-        const description = eventsWithDescription.find((i) => i.name === event.name)?.description;
-        if (description) {
-          (event as typeof event & { description: string }).description = description;
-        }
-        return event;
-      });
-
-      return meta;
+      if (hasEvents) {
+        mergeEventDescriptions(meta, parsed.events);
+      }
+      if (needsSlots) {
+        mergeTemplateSlots(meta, parsed.slots);
+      }
     });
   } catch {
     // noop
   }
 
-  return componentMeta;
+  return componentsMeta;
+}
+
+function mergeEventDescriptions(meta: ComponentMeta, events: ComponentDoc['events']): void {
+  if (!meta.events.length || !events?.length) {
+    return;
+  }
+
+  meta.events = meta.events.map((event) => {
+    const description = events.find((i) => i.name === event.name)?.description;
+    if (description) {
+      (event as typeof event & { description: string }).description = description;
+    }
+    return event;
+  });
+}
+
+/**
+ * Whether the SFC template declares slots that the extracted meta misses, entirely or by
+ * description. Reading the source keeps `parseMulti` away from the common slot-less component.
+ */
+async function hasTemplateSlotGap(
+  filename: string,
+  componentsMeta: ComponentMeta[]
+): Promise<boolean> {
+  if (!filename.endsWith('.vue')) {
+    return false;
+  }
+
+  const hasGap = componentsMeta.some(
+    (meta) => meta.slots.length === 0 || meta.slots.some((slot) => !slot.description)
+  );
+  if (!hasGap) {
+    return false;
+  }
+
+  try {
+    const source = await readFile(filename, 'utf-8');
+    return /<slot[\s/>]/.test(source);
+  } catch {
+    return false;
+  }
+}
+
+/** Merges template-derived slots into the meta: descriptions onto known slots, missing slots whole. */
+function mergeTemplateSlots(meta: ComponentMeta, slots: ComponentDoc['slots']): void {
+  for (const slot of slots ?? []) {
+    const existing = meta.slots.find((candidate) => candidate.name === slot.name);
+    if (existing) {
+      if (!existing.description && slot.description) {
+        existing.description = slot.description;
+      }
+      continue;
+    }
+
+    const bindings = (slot.bindings ?? [])
+      .filter((binding) => binding.name)
+      .map((binding) => `${binding.name}: ${binding.type?.name ?? 'unknown'}`);
+    const type = bindings.length > 0 ? `{ ${bindings.join('; ')} }` : '{}';
+    meta.slots.push({
+      name: slot.name,
+      description: slot.description ?? '',
+      type,
+      schema: type,
+      tags: [],
+    } as unknown as SlotMeta);
+  }
 }
 
 /**

--- a/code/renderers/vue3/src/docgen/component-meta.ts
+++ b/code/renderers/vue3/src/docgen/component-meta.ts
@@ -139,15 +139,16 @@ export async function collectComponentMetaSources(
     });
 
     const exposed = meta.exposed
+      // Drop `onX` handler entries duplicating a declared event. Only the prefixed form is a
+      // duplicate: an exposed member merely named like an event (`focus` beside a `focus` event)
+      // is an authored `defineExpose` member and has to stay.
       .filter((expose) => {
-        let nameWithoutOnPrefix = expose.name;
-
-        if (nameWithoutOnPrefix.startsWith('on')) {
-          nameWithoutOnPrefix = lowercaseFirstLetter(expose.name.replace('on', ''));
+        if (!expose.name.startsWith('on')) {
+          return true;
         }
 
-        const hasEvent = meta.events.find((event) => event.name === nameWithoutOnPrefix);
-        return !hasEvent;
+        const eventName = lowercaseFirstLetter(expose.name.slice('on'.length));
+        return !meta.events.some((event) => event.name === eventName);
       })
       // remove duplicated "$slots" expose
       .filter((expose) => {

--- a/code/renderers/vue3/src/docs/sourceDecorator.test.ts
+++ b/code/renderers/vue3/src/docs/sourceDecorator.test.ts
@@ -97,34 +97,22 @@ test('should generate source code for slots', () => {
   };
 
   const expectedCode = `default content
-
 <template #a>a content</template>
-
 <template #b>42</template>
-
 <template #c>true</template>
-
 <template #d><div>d content</div></template>
-
 <template #e><div style="color:red">e content</div></template>
-
 <template #f><div style="color:red">f content</div></template>
-
 <template #g><div style="color:red">child 1
 <span style="color:green">child 2</span></div></template>
-
 <template #h><div style="color:red">child 1
 <span style="color:green">child 2</span></div></template>
-
 <template #i><div style="color:red">child 1
 <span style="color:green">nested child 1
 <p>nested child 2</p></span></div></template>
-
 <template #j>child 1
 child 2</template>
-
 <template #l>{"foo":"bar"}</template>
-
 <template #m>{{ BigInt(9007199254740991) }}</template>`;
 
   let actualCode = generateSlotSourceCode(slots, Object.keys(slots), {
@@ -164,7 +152,6 @@ test('should generate source code for slots with bindings', () => {
   };
 
   const expectedCode = `<template #a="{ foo, bar, boo }">Slot with bindings {{ foo }}, {{ bar }} and {{ boo.mimeType }}</template>
-
 <template #b="{ foo, boo }"><a :href="foo" :target="foo" :type="boo.mimeType" v-bind="boo">Test link: {{ foo }}</a></template>`;
 
   const actualCode = generateSlotSourceCode(slots, Object.keys(slots), {
@@ -205,7 +192,9 @@ const test = [1,2];
 </script>
 
 <template>
-  <MyComponent :a="42" b="foo" v-model:c="c" :d="d"> <template #mySlot><div :d="d1" :test="test" /></template> </MyComponent>
+  <MyComponent :a="42" b="foo" v-model:c="c" :d="d">
+    <template #mySlot><div :d="d1" :test="test" /></template>
+  </MyComponent>
 </template>`);
 });
 

--- a/code/renderers/vue3/src/docs/sourceDecorator.ts
+++ b/code/renderers/vue3/src/docs/sourceDecorator.ts
@@ -77,10 +77,11 @@ export const generateSourceCode = (
   const slotSourceCode = generateSlotSourceCode(ctx.args, slotNames, sourceCodeContext);
   const componentName = displayName || ctx.title.split('/').at(-1)!;
 
+  const openTag = props ? `<${componentName} ${props}` : `<${componentName}`;
   // prefer self closing tag if no slot content exists
   const templateCode = slotSourceCode
-    ? `<${componentName} ${props}> ${slotSourceCode} </${componentName}>`
-    : `<${componentName} ${props} />`;
+    ? `${openTag}>\n${indentLines(slotSourceCode)}\n</${componentName}>`
+    : `${openTag} />`;
 
   const variablesCode = Object.entries(sourceCodeContext.scriptVariables)
     .map(([name, value]) => `const ${name} = ${value};`)
@@ -92,7 +93,7 @@ export const generateSourceCode = (
     })
     .join('\n');
 
-  const template = `<template>\n  ${templateCode}\n</template>`;
+  const template = `<template>\n${indentLines(templateCode)}\n</template>`;
 
   if (!importsCode && !variablesCode) {
     return template;
@@ -104,6 +105,13 @@ ${importsCode ? `${importsCode}\n\n${variablesCode}` : variablesCode}
 
 ${template}`;
 };
+
+/** Indents every non-empty line by one level, so nested markup reads as a block. */
+const indentLines = (source: string): string =>
+  source
+    .split('\n')
+    .map((line) => (line ? `  ${line}` : line))
+    .join('\n');
 
 /**
  * Checks if the source code generation should be skipped for the given Story context. Will be true
@@ -387,7 +395,7 @@ export const generateSlotSourceCode = (
     }
   });
 
-  return slotSourceCodes.join('\n\n');
+  return slotSourceCodes.join('\n');
 };
 
 /**

--- a/code/renderers/vue3/src/story-docs/build-story-docs.ts
+++ b/code/renderers/vue3/src/story-docs/build-story-docs.ts
@@ -16,6 +16,7 @@ import {
   createStoryReferenceResolver,
   extractStoryJSDocInfo,
   jsDocTagsForPath,
+  keyOf,
   loadCsf,
   metaObjectPath,
   normalizeStoryDeclaration,
@@ -23,7 +24,9 @@ import {
   resolveComponentImport,
   resolveRenderFunction,
   resolveReturnedObjectExpression,
+  returnedExpression,
   returnedExpressionPath,
+  unwrapExpression,
   unresolvedWarning,
   type ImportBinding,
   type ReferenceContext,
@@ -350,6 +353,15 @@ function staticRendererForRenderFunction(
     return { kind: 'template', ...templateConfig };
   }
 
+  const setupExpression = renderObject && setupReturnedRenderExpression(renderObject);
+  if (setupExpression) {
+    return {
+      argsParam: argsParameterName(renderFunction.node),
+      expression: setupExpression,
+      kind: 'h',
+    };
+  }
+
   const hExpression = returnedExpressionPath(renderFunction)?.node;
   return hExpression
     ? {
@@ -410,6 +422,46 @@ function renderStaticStorySnippet(
     importBindings: options.importBindings,
     node: renderer.expression,
   });
+}
+
+/**
+ * The `h()` tree a render object's `setup` returns through its render closure, when nothing else
+ * on the object can change what the story renders.
+ *
+ * @example `render: (args) => ({ setup: () => () => h(C, { label: args.label }) })` -> the `h(...)` call
+ */
+function setupReturnedRenderExpression(renderObject: t.ObjectExpression): t.Expression | undefined {
+  const supported = renderObject.properties.every((property) => {
+    if (t.isSpreadElement(property)) {
+      return false;
+    }
+    const key = keyOf(property);
+    return key === 'setup' || key === 'components' || key === 'inheritAttrs';
+  });
+  if (!supported) {
+    return undefined;
+  }
+
+  const setup = renderObject.properties.find(
+    (property) => !t.isSpreadElement(property) && keyOf(property) === 'setup'
+  );
+  const setupFn = t.isObjectMethod(setup)
+    ? setup
+    : t.isObjectProperty(setup)
+      ? unwrapExpression(setup.value)
+      : undefined;
+  if (!setupFn || !t.isFunction(setupFn)) {
+    return undefined;
+  }
+
+  const renderClosure = returnedExpression(setupFn);
+  const closure = renderClosure && unwrapExpression(renderClosure);
+  // A render closure with parameters would receive values the snippet cannot reproduce.
+  if (!closure || !t.isFunction(closure) || closure.params.length > 0) {
+    return undefined;
+  }
+
+  return returnedExpression(closure);
 }
 
 function argsParameterName(renderFunction: RenderFunctionPath['node']): string | undefined {

--- a/code/renderers/vue3/src/story-docs/build-story-docs.ts
+++ b/code/renderers/vue3/src/story-docs/build-story-docs.ts
@@ -85,6 +85,8 @@ const RENDER_UNRESOLVED_WARNING =
   'No static snippet: the `render` function could not be resolved statically.';
 const SLOT_UNRESOLVED_WARNING =
   'No static snippet: a slot function could not be resolved statically.';
+const IMPORT_UNRESOLVED_WARNING =
+  "No static snippet: the component's import could not be resolved statically.";
 
 type ParsedCsf = ReturnType<ReturnType<typeof loadCsf>['parse']>;
 type ExtractStoriesResult = { stories: Record<string, StoryDoc> };
@@ -295,7 +297,7 @@ function enrichStoryDoc(
   if (!options.snippet) {
     return plain;
   }
-  const { componentName, docgenArgInfo } = options.snippet;
+  const { componentName, componentImportStatement, docgenArgInfo } = options.snippet;
 
   let normalized;
   try {
@@ -323,6 +325,12 @@ function enrichStoryDoc(
         : undefined;
   if (!renderer) {
     return withWarning(RENDER_UNRESOLVED_WARNING);
+  }
+
+  // The SFC renderer needs the component's import statement; without one, the bail below would
+  // otherwise blame a slot that was never involved.
+  if (renderer.kind === 'sfc' && !componentImportStatement) {
+    return withWarning(IMPORT_UNRESOLVED_WARNING);
   }
 
   const resolved = resolveStaticStoryArgs(storyExport, docgenArgInfo, options);

--- a/code/renderers/vue3/src/story-docs/build-story-docs.ts
+++ b/code/renderers/vue3/src/story-docs/build-story-docs.ts
@@ -27,6 +27,7 @@ import {
   returnedExpression,
   returnedExpressionPath,
   unwrapExpression,
+  noSnippetWarning,
   unresolvedWarning,
   type ImportBinding,
   type ReferenceContext,
@@ -79,6 +80,11 @@ interface StoryDocsContext {
 // Vue's single-file-component format is tried ahead of the JS/TS extensions, matching how a story
 // file resolves an import of a `.vue` module.
 const openStoryReferences = createStoryReferenceResolver({ extensions: ['.vue'] });
+
+const RENDER_UNRESOLVED_WARNING =
+  'No static snippet: the `render` function could not be resolved statically.';
+const SLOT_UNRESOLVED_WARNING =
+  'No static snippet: a slot function could not be resolved statically.';
 
 type ParsedCsf = ReturnType<ReturnType<typeof loadCsf>['parse']>;
 type ExtractStoriesResult = { stories: Record<string, StoryDoc> };
@@ -267,7 +273,14 @@ function extractStories(csf: ParsedCsf, options: StoryDocsContext): ExtractStori
 }
 
 /**
- * Attaches a synthesized snippet (or an "unsupported args" error) to a story doc.
+ * Attaches a synthesized snippet to a story doc, or a standalone `warning` saying why none could
+ * be produced.
+ *
+ * The runtime source decorator still renders an exact snippet in the browser, but payload
+ * consumers that never run the story (manifests, agents) would otherwise see nothing at all, so
+ * every statically unresolvable story names what could not be read instead of staying silent.
+ * Only stories outside the provider's scope (CSF2 function stories, unreadable declarations,
+ * missing docgen) stay unmarked.
  */
 function enrichStoryDoc(
   csf: ParsedCsf,
@@ -276,6 +289,8 @@ function enrichStoryDoc(
   options: StoryDocsContext
 ): StoryDoc {
   const plain = storyDoc;
+  const withWarning = (warning: string | undefined): StoryDoc =>
+    warning ? { ...storyDoc, warning } : plain;
 
   if (!options.snippet) {
     return plain;
@@ -307,34 +322,30 @@ function enrichStoryDoc(
         ? { kind: 'sfc' as const }
         : undefined;
   if (!renderer) {
-    return plain;
+    return withWarning(RENDER_UNRESOLVED_WARNING);
   }
 
   const resolved = resolveStaticStoryArgs(storyExport, docgenArgInfo, options);
-  const classified = resolved.classified;
-  if (classified.defer) {
-    return plain;
+  const { args, unresolved: classifyUnresolved } = resolved.classified;
+  const unresolved = [...classifyUnresolved, ...resolved.unresolved];
+
+  // A snippet showing none of the args the story actually sets would be a worse example than the
+  // runtime one, so no snippet is emitted and the warning names everything that was dropped.
+  if (args.length === 0 && unresolved.length > 0) {
+    return withWarning(noSnippetWarning(unresolved));
   }
 
-  const rendered = renderStaticStorySnippet(
-    renderer,
-    classified.args,
-    componentName,
-    docgenArgInfo,
-    options
-  );
+  const rendered = renderStaticStorySnippet(renderer, args, componentName, docgenArgInfo, options);
   if (!rendered) {
-    return plain;
+    return withWarning(
+      renderer.kind === 'sfc' ? SLOT_UNRESOLVED_WARNING : RENDER_UNRESOLVED_WARNING
+    );
   }
-
-  const warning = [classified.warning, unresolvedWarning(resolved.unresolved)]
-    .filter((part) => part !== undefined)
-    .join('\n');
 
   return {
     ...storyDoc,
     snippet: rendered.snippet,
-    ...(warning ? { warning } : {}),
+    ...(unresolved.length > 0 ? { warning: unresolvedWarning(unresolved) } : {}),
   };
 }
 

--- a/code/renderers/vue3/src/story-docs/classify-args.test.ts
+++ b/code/renderers/vue3/src/story-docs/classify-args.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { babelParse, types as t } from 'storybook/internal/babel';
 
-import { classifyArgs, type ClassifiedArg, type ClassifyArgsResult } from './classify-args.ts';
+import { classifyArgs, type ClassifiedArg } from './classify-args.ts';
 import { printValue } from './classify-value.ts';
 
 interface DocgenFixture {
@@ -11,8 +11,9 @@ interface DocgenFixture {
   events?: string[];
 }
 
-interface ReadableClassifyArgsResult extends Omit<ClassifyArgsResult, 'args'> {
+interface ReadableClassifyArgsResult {
   args: string[];
+  unresolved?: string[];
 }
 
 describe('classifyArgs', () => {
@@ -43,7 +44,7 @@ describe('classifyArgs', () => {
     { label: 'undefined', value: 'undefined' },
     { label: 'a function', value: '() => null' },
     { label: 'an empty string', value: `''` },
-  ])('drops an arg set to $label without warning', ({ value }) => {
+  ])('drops an arg set to $label without naming it', ({ value }) => {
     expect(classify(`{ a: ${value}, label: 'ok' }`)).toEqual({
       args: [`label: 'ok' -> prop (inline)`],
     });
@@ -52,15 +53,14 @@ describe('classifyArgs', () => {
   it('omits an unresolvable arg, keeps the rest, and names the omission', () => {
     expect(classify(`{ label: 'ok', size: Sizes.LARGE }`)).toEqual({
       args: [`label: 'ok' -> prop (inline)`],
-      warning: 'Omitted args that cannot be resolved statically: size: Sizes.LARGE',
+      unresolved: ['size: Sizes.LARGE'],
     });
   });
 
-  it('names every omitted arg in the warning', () => {
+  it('names every unresolved arg', () => {
     expect(classify(`{ label: 'ok', size: SOME_CONST, items: makeItems(3) }`)).toEqual({
       args: [`label: 'ok' -> prop (inline)`],
-      warning:
-        'Omitted args that cannot be resolved statically: size: SOME_CONST, items: makeItems(3)',
+      unresolved: ['size: SOME_CONST', 'items: makeItems(3)'],
     });
   });
 
@@ -68,11 +68,14 @@ describe('classifyArgs', () => {
     const result = classify(`{ label: 'ok', options: { ...BASE_OPTIONS } }`);
 
     expect(result.args).toEqual([`label: 'ok' -> prop (inline)`]);
-    expect(result.warning).toContain('BASE_OPTIONS');
+    expect(result.unresolved?.[0]).toContain('BASE_OPTIONS');
   });
 
-  it('defers when nothing the story sets can be rendered', () => {
-    expect(classify(`{ label: SOME_CONST }`)).toEqual({ args: [], defer: true });
+  it('names every arg when nothing the story sets can be rendered', () => {
+    expect(classify(`{ label: SOME_CONST }`)).toEqual({
+      args: [],
+      unresolved: ['label: SOME_CONST'],
+    });
   });
 
   it('still renders a story whose only args are dropped silently', () => {
@@ -124,10 +127,10 @@ describe('classifyArgs', () => {
     });
   });
 
-  it('warns when a declared event arg value is not a function expression', () => {
+  it('names a declared event arg whose value is not a function expression', () => {
     expect(classify(`{ label: 'ok', onSubmit: fn() }`, { events: ['submit'] })).toEqual({
       args: [`label: 'ok' -> prop (inline)`],
-      warning: 'Omitted args that cannot be resolved statically: onSubmit: fn()',
+      unresolved: ['onSubmit: fn()'],
     });
   });
 
@@ -138,8 +141,7 @@ describe('classifyArgs', () => {
       })
     ).toEqual({
       args: [`label: 'ok' -> prop (inline)`],
-      warning:
-        'Omitted args that cannot be resolved statically: onSubmit: value => formatHelper(value)',
+      unresolved: ['onSubmit: value => formatHelper(value)'],
     });
   });
 
@@ -148,7 +150,7 @@ describe('classifyArgs', () => {
       classify(`{ label: 'ok', formatter: () => SOME_CONST }`, { props: ['formatter'] })
     ).toEqual({
       args: [`label: 'ok' -> prop (inline)`],
-      warning: 'Omitted args that cannot be resolved statically: formatter: () => SOME_CONST',
+      unresolved: ['formatter: () => SOME_CONST'],
     });
   });
 
@@ -158,7 +160,7 @@ describe('classifyArgs', () => {
     });
   });
 
-  it('reports no warning when every arg renders', () => {
+  it('reports nothing unresolved when every arg renders', () => {
     expect(classify(`{ label: 'ok' }`)).toEqual({
       args: [`label: 'ok' -> prop (inline)`],
     });
@@ -176,8 +178,8 @@ function classify(
   });
 
   return {
-    ...result,
     args: result.args.map(formatArg),
+    ...(result.unresolved.length > 0 ? { unresolved: result.unresolved } : {}),
   };
 }
 

--- a/code/renderers/vue3/src/story-docs/classify-args.ts
+++ b/code/renderers/vue3/src/story-docs/classify-args.ts
@@ -58,7 +58,7 @@ export type ClassifiedArg = ClassifiedPropLikeArg | ClassifiedSlotArg;
  * Outcome of classifying one arg, before any story-level decision is taken.
  *
  * `omit` and `unrepresentable` stay distinct because the story-level aggregation treats them
- * differently: the first is silent, the second is named in a warning.
+ * differently: the first is silent, the second is named in `unresolved`.
  */
 export type ArgClassification =
   | { kind: 'classified'; arg: ClassifiedArg }
@@ -68,27 +68,21 @@ export type ArgClassification =
 export interface ClassifyArgsResult {
   /** Args that can be rendered into a static Vue snippet. */
   args: ClassifiedArg[];
-  /** Story needs a real renderer, so runtime source stays authoritative and no snippet is emitted. */
-  defer?: boolean;
-  /** Args left out of the snippet because their values do not resolve statically. */
-  warning?: string;
+  /** Source text of args dropped because their values do not resolve statically. */
+  unresolved: string[];
 }
 
 /**
  * Classifies merged CSF args by Vue docgen precedence: slot, event, v-model, then prop.
  *
- * Five outcomes, one per reason an arg can fail to render:
+ * Three outcomes, one per reason an arg can fail to render:
  *
  * - dropped silently — no static form exists and the runtime source decorator drops it too
  *   (functions passed as undeclared args, args explicitly set to `undefined`, empty strings)
- * - dropped with a `warning` — the value references something the snippet cannot declare, so the
- *   rest of the story still renders and the omission is named
- * - `defer` — nothing the story sets survived classification, so a static snippet would be a
- *   worse example than the runtime one
+ * - named in `unresolved` — the value references something the snippet cannot declare; the caller
+ *   decides whether that reads as a partial snippet or as no snippet at all
  * - forwarded as a `function-slot` plan — a slot receives function content only a
  *   render-tree-aware renderer can realize; rendering bails back to runtime source otherwise
- * - no result at all — the args container itself is unreadable, which the caller reports as an
- *   `error` (see `argsContainerError`)
  *
  * Function args matching a declared event render as listeners, and declared function props hoist.
  */
@@ -97,7 +91,7 @@ export function classifyArgs(
   docgen: VueDocgenArgInfo
 ): ClassifyArgsResult {
   const classified: ClassifiedArg[] = [];
-  const omitted: string[] = [];
+  const unresolved: string[] = [];
 
   for (const [name, value] of Object.entries(args)) {
     const result = classifyArg(name, value, docgen);
@@ -105,22 +99,11 @@ export function classifyArgs(
     if (result.kind === 'classified') {
       classified.push(result.arg);
     } else if (result.kind === 'unrepresentable') {
-      omitted.push(`${name}: ${printValue(value)}`);
+      unresolved.push(`${name}: ${printValue(value)}`);
     }
   }
 
-  // A snippet showing none of the args the story actually sets is a worse example than the one the
-  // runtime source decorator builds from real values, so leave it to that instead.
-  if (omitted.length > 0 && classified.length === 0) {
-    return { args: [], defer: true };
-  }
-
-  return {
-    args: classified,
-    ...(omitted.length > 0
-      ? { warning: `Omitted args that cannot be resolved statically: ${omitted.join(', ')}` }
-      : {}),
-  };
+  return { args: classified, unresolved };
 }
 
 /**

--- a/code/renderers/vue3/src/story-docs/transform-template.ts
+++ b/code/renderers/vue3/src/story-docs/transform-template.ts
@@ -390,7 +390,10 @@ function hasOnlySupportedRenderProperties(renderObject: t.ObjectExpression): boo
     }
 
     const key = keyOf(property);
-    return key === 'components' || key === SETUP_PROPERTY || key === 'template';
+    // `inheritAttrs` only tunes runtime attribute fallthrough; the markup stays faithful without it.
+    return (
+      key === 'components' || key === SETUP_PROPERTY || key === 'template' || key === 'inheritAttrs'
+    );
   });
 }
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did


 community QA sweep (10 real-world Vue repos) surfaced several cases where Vue's server docgen or the story-snippet provider silently lost data. This PR fixes the ones that reproduced on `next`, and makes every remaining static-snippet gap explain itself instead of staying silent.

### Docgen fixes

- **Options API components lost all their template slots.** Slot names, scoped bindings, and `@slot` descriptions declared in the template are now extracted for every component style, not just `<script setup>`.
- **`@slot` comment descriptions were always empty.** They now appear in argTypes and API docs, matching what the legacy engine extracted.
- **Functions passed to `defineExpose` disappeared from the Exposed API when the component also emitted a same-named event** (e.g. a `focus()` method beside a `focus` event). Both are now kept.

### Snippet fixes

- **Stories using the classic `render: (args) => ({ setup() { return () => h(…) } })` shape got no code snippet.** They now render a proper snippet.
- **A render object containing `inheritAttrs: false` lost its snippet entirely.** The option is harmless for snippets and no longer causes a bail.
- **Runtime-generated code snippets were unreadable** (everything on one line). They're now properly indented and formatted.

### Warnings for everything the static pass cannot resolve

Previously, a story the snippet synthesizer couldn't handle produced nothing at all — indistinguishable from "docgen is off" for manifest and MCP consumers, which never see the browser's runtime-source fallback. Now every statically unresolvable story carries a `warning` naming the reason:

- partial snippet → `` Incomplete snippet: `x` could not be resolved statically. ``
- no snippet at all → `` No static snippet: … `` (unresolvable args with their source text, an unresolvable `render` function, or a slot function only a runtime can realize)

The shared `StoryDoc` contract is updated accordingly: `warning` may now stand alone (why no static snippet exists), while `error` stays reserved for provider failures. The Angular provider already conforms and is unchanged. This gives a future UI feature ("why is there no snippet for this story?") everything it needs from the payload.


Each fix and every warning path is guarded by docgen-harness fixtures.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

----

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
