### PR TITLE
Core: Recover from a docgen worker death instead of going dark for the session

### DIFF
--- a/code/core/src/shared/open-service/services/docgen/worker/docgen-worker-client.test.ts
+++ b/code/core/src/shared/open-service/services/docgen/worker/docgen-worker-client.test.ts
@@ -215,4 +215,52 @@ describe('DocgenWorkerClient.extract', () => {
 
     await expect(promise).rejects.toThrow(/exited unexpectedly/);
   });
+
+  it('names the death in every extract that follows it', async () => {
+    const { createDocgenWorkerClient } = await loadModule();
+    const client = createDocgenWorkerClient(DESCRIPTORS)!;
+
+    const first = client.extract({ id: 'x' } as any);
+    ackInit(fakeWorkers[0]);
+    await Promise.resolve();
+    fakeWorkers[0].emit('error', new Error('worker ran out of memory'));
+    await expect(first).rejects.toThrow('worker ran out of memory');
+
+    // Never served a request, so the next extract reuses the corpse rather than respawning into
+    // the same failure - and says what that failure was.
+    await expect(client.extract({ id: 'y' } as any)).rejects.toThrow(
+      'docgen worker is no longer running: worker ran out of memory'
+    );
+    expect(fakeWorkers).toHaveLength(1);
+  });
+
+  it('spawns a replacement once a dead worker had served requests', async () => {
+    const { createDocgenWorkerClient } = await loadModule();
+    const client = createDocgenWorkerClient(DESCRIPTORS)!;
+
+    const first = client.extract({ id: 'x' } as any);
+    ackInit(fakeWorkers[0]);
+    await Promise.resolve();
+    const extractMsg = fakeWorkers[0].posted.find((m) => m.type === 'extract') as { id: number };
+    fakeWorkers[0].emit('message', {
+      type: 'extract',
+      id: extractMsg.id,
+      payload: { id: 'x', name: 'X', path: './x.stories.ts', jsDocTags: {} },
+    } satisfies DocgenWorkerResponse);
+    await expect(first).resolves.toMatchObject({ id: 'x' });
+
+    fakeWorkers[0].emit('error', new Error('worker ran out of memory'));
+
+    const second = client.extract({ id: 'y' } as any);
+    expect(fakeWorkers).toHaveLength(2);
+    ackInit(fakeWorkers[1]);
+    await Promise.resolve();
+    const retryMsg = fakeWorkers[1].posted.find((m) => m.type === 'extract') as { id: number };
+    fakeWorkers[1].emit('message', {
+      type: 'extract',
+      id: retryMsg.id,
+      payload: { id: 'y', name: 'Y', path: './y.stories.ts', jsDocTags: {} },
+    } satisfies DocgenWorkerResponse);
+    await expect(second).resolves.toMatchObject({ id: 'y' });
+  });
 });

--- a/code/core/src/shared/open-service/services/docgen/worker/docgen-worker-client.ts
+++ b/code/core/src/shared/open-service/services/docgen/worker/docgen-worker-client.ts
@@ -44,7 +44,8 @@ class DocgenWorker implements DocgenWorkerClient {
   private readonly ready: Promise<void>;
   private rejectReady: (error: unknown) => void = () => undefined;
   private nextId = 0;
-  private dead = false;
+  private death: Error | undefined;
+  private served = false;
 
   constructor(
     scriptPath: string,
@@ -55,7 +56,7 @@ class DocgenWorker implements DocgenWorkerClient {
     this.worker.on('message', (msg: DocgenWorkerResponse) => this.handleMessage(msg));
     this.worker.on('error', (error) => this.fail(error));
     this.worker.on('exit', (code) => {
-      if (!this.dead) {
+      if (!this.death) {
         this.fail(new Error(`docgen worker exited unexpectedly with code ${code}`));
       }
     });
@@ -84,9 +85,24 @@ class DocgenWorker implements DocgenWorkerClient {
     this.post({ type: 'init', descriptors, logLevel: logger.getLogLevel() });
   }
 
+  /**
+   * Whether a fresh worker would be worth spawning in this one's place.
+   *
+   * Only once it has served an extract: a worker that died without ever answering died of something
+   * a replacement would hit again, and respawning would rebuild a multi-second TypeScript program
+   * per request to fail the same way.
+   */
+  get replaceable(): boolean {
+    return this.death !== undefined && this.served;
+  }
+
   async extract(entry: IndexEntry): Promise<DocgenPayload | undefined> {
-    if (this.dead) {
-      throw new Error('docgen worker is no longer running');
+    if (this.death) {
+      // Carries the death forward: the crash itself is one event, but every later extract fails on
+      // it, so a bare "no longer running" is the only thing anyone downstream ever sees.
+      throw new Error(`docgen worker is no longer running: ${this.death.message}`, {
+        cause: this.death,
+      });
     }
     await this.ready;
     return new Promise<DocgenPayload | undefined>((resolve, reject) => {
@@ -130,6 +146,7 @@ class DocgenWorker implements DocgenWorkerClient {
       clearTimeout(pending.timer);
     }
     this.pending.delete(msg.id);
+    this.served = true;
     this.keepProcessAliveWhileBusy();
     if (msg.error) {
       pending.reject(errorLikeToError(msg.error));
@@ -139,11 +156,11 @@ class DocgenWorker implements DocgenWorkerClient {
   }
 
   private fail(error: Error): void {
-    if (this.dead) {
+    if (this.death) {
       return;
     }
-    logger.debug(`docgen worker failure: ${error.message}`);
-    this.dead = true;
+    logger.warn(`docgen worker died, so component docs are unavailable: ${error.message}`);
+    this.death = error;
     // Without this, an `extract` awaiting `ready` hangs when the worker dies before `init`.
     this.rejectReady(error);
     this.rejectAllPending(error);
@@ -188,6 +205,10 @@ export function createDocgenWorkerClient(
 
   return {
     async extract(entry) {
+      if (worker?.replaceable) {
+        logger.debug('docgen worker died after serving requests; spawning a replacement');
+        worker = undefined;
+      }
       worker ??= new DocgenWorker(scriptPath, descriptors);
       return worker.extract(entry);
     },


### PR DESCRIPTION
Closes #

## What I did

When the docgen worker thread dies, it is never replaced. One transient death therefore takes props tables, story snippets and MCP docs down for as long as the dev server runs, and the only thing anyone sees is `docgen worker is no longer running`, which names nothing. This PR makes the client respawn after a death it can safely retry, and makes the real cause visible.

```
extract() ──► worker alive? ──yes──► serve
                  │
                  no
                  │
      before ─────┴──► throw "no longer running"   (forever, for every later extract)

       after ─────┬──► served >= 1 request? ──yes──► spawn a replacement ──► serve
                  │
                  └──no──► throw "no longer running: <the actual error>"
```

The `served >= 1` condition is the whole design. A worker that died without ever answering died of something a replacement will hit again, and each respawn rebuilds a multi-second TypeScript program only to fail identically, so that case stays dead. A worker that died after doing real work is worth replacing.

```ts
// code/core/src/shared/open-service/services/docgen/worker/docgen-worker-client.ts
get replaceable(): boolean {
  return this.death !== undefined && this.served;
}
```

## Real evidence behind the fix

This came out of a CI flake on the `angular-cli-server-docgen` dev sandbox, where a worker died mid-run and the job then failed with three "retries" that were really one event: `dead` is latched, so Playwright retrying can only re-observe the same corpse.

Reproduced against the `angular-vite/docgen-server-ts` sandbox by injecting a worker death after its first served extract, then asking `docs-show` for three different components in a row. Same sandbox, same injection, only the client differs.

```
                             before                              after
call 1 (worker dies after)   # ColorPickerComponent              # ColorPickerComponent
call 2                       Error: docgen worker is no          # ButtonComponent
                             longer running
call 3                       Error: docgen worker is no          # DocButtonComponent
                             longer running
```

What the dev server printed. The `before` line is byte-identical to what the failing CI job logged, which is exactly the problem: it never says why.

```
before
▲  Angular story snippets are unavailable: querying core/docgen failed.
│  docgen worker is no longer running
■  MCP tool "docs-show" failed: Error: docgen worker is no longer running

after
▲  docgen worker died, so component docs are unavailable: docgen worker
│  exited unexpectedly with code 7
```

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

The docgen worker only dies on a fault, so reproducing it needs one injected. From a built checkout:

1. Generate the sandbox: `yarn task sandbox --template angular-vite/docgen-server-ts --start-from auto`.
2. In `code/core/dist/shared/open-service/services/docgen/worker/docgen-worker.js`, directly after `port.postMessage({ type: "extract", id, payload });`, add:
   `if (!globalThis.__k) { globalThis.__k = true; setTimeout(() => process.exit(7), 100); }`
3. Start the sandbox dev server, then POST `docs-show` to `/mcp` for three different component ids in turn, e.g.
   `curl -s -X POST http://localhost:6006/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"docs-show","arguments":{"id":"example-button"}}}'`
4. Expect all three to return real component docs, and the terminal to warn `docgen worker died, so component docs are unavailable: docgen worker exited unexpectedly with code 7` between them. Before this change, only the first call succeeds and the rest return `Error: docgen worker is no longer running`.
5. Undo the edit in step 2 (or re-run `yarn nx compile core`).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below: `bug`
