### PR TITLE
Docs: Declare the font on overlay surfaces so docs tooltips are not left to inherit

### DIFF
--- a/code/core/src/components/components/Popover/Popover.tsx
+++ b/code/core/src/components/components/Popover/Popover.tsx
@@ -48,7 +48,6 @@ const Wrapper = styled.div<{
             drop-shadow(0 1px 3px rgba(0,0,0,0.1))
           `,
           borderRadius: theme.appBorderRadius + 2,
-          // Portal-rendered; see TooltipNote for why the font is declared rather than inherited.
           fontFamily: theme.typography.fonts.base,
           fontSize: theme.typography.size.s1,
         }

--- a/code/core/src/components/components/Popover/Popover.tsx
+++ b/code/core/src/components/components/Popover/Popover.tsx
@@ -48,6 +48,8 @@ const Wrapper = styled.div<{
             drop-shadow(0 1px 3px rgba(0,0,0,0.1))
           `,
           borderRadius: theme.appBorderRadius + 2,
+          // Portal-rendered; see TooltipNote for why the font is declared rather than inherited.
+          fontFamily: theme.typography.fonts.base,
           fontSize: theme.typography.size.s1,
         }
       : {},

--- a/code/core/src/components/components/tooltip/TooltipNote.tsx
+++ b/code/core/src/components/components/tooltip/TooltipNote.tsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { styled } from 'storybook/theming';
 
 const Note = styled.div(({ theme }) => ({
+  // Portal-rendered, so it cannot rely on inheriting a base font: the preview iframe root has
+  // none, and a user's own styles may sit there instead.
+  fontFamily: theme.typography.fonts.base,
   padding: '2px 6px',
   lineHeight: '16px',
   fontSize: 10,

--- a/code/core/src/components/components/tooltip/TooltipNote.tsx
+++ b/code/core/src/components/components/tooltip/TooltipNote.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 import { styled } from 'storybook/theming';
 
 const Note = styled.div(({ theme }) => ({
-  // Portal-rendered, so it cannot rely on inheriting a base font: the preview iframe root has
-  // none, and a user's own styles may sit there instead.
   fontFamily: theme.typography.fonts.base,
   padding: '2px 6px',
   lineHeight: '16px',

--- a/code/core/src/components/components/tooltip/WithTooltip.tsx
+++ b/code/core/src/components/components/tooltip/WithTooltip.tsx
@@ -120,7 +120,6 @@ const Wrapper = styled.div<WrapperProps>(
             drop-shadow(0 1px 3px rgba(0,0,0,0.1))
           `,
           borderRadius: theme.appBorderRadius + 2,
-          // Portal-rendered; see TooltipNote for why the font is declared rather than inherited.
           fontFamily: theme.typography.fonts.base,
           fontSize: theme.typography.size.s1,
         }

--- a/code/core/src/components/components/tooltip/WithTooltip.tsx
+++ b/code/core/src/components/components/tooltip/WithTooltip.tsx
@@ -120,6 +120,8 @@ const Wrapper = styled.div<WrapperProps>(
             drop-shadow(0 1px 3px rgba(0,0,0,0.1))
           `,
           borderRadius: theme.appBorderRadius + 2,
+          // Portal-rendered; see TooltipNote for why the font is declared rather than inherited.
+          fontFamily: theme.typography.fonts.base,
           fontSize: theme.typography.size.s1,
         }
       : {}


### PR DESCRIPTION
Closes #

## What I did

Every tooltip on a docs page renders in the browser's default serif. Not a Storybook font at all - Times.

The cause is that overlays render through a portal at the document root, and they were left to inherit their typography from wherever that portal lands. In the manager the root carries Storybook's font stack, so tooltips looked correct and nobody noticed. In the preview iframe the root carries nothing, so they fall back to the UA default. The same gap means a user's own preview styles can reach into Storybook's overlays.

Three overlay surfaces now state their own `font-family` instead of inheriting it.

### Measured, on the "Open canvas in new tab" button of any autodocs page

| | `getComputedStyle(tooltip).fontFamily` |
| --- | --- |
| Manager (addon panel) | `"Nunito Sans", -apple-system, …` |
| Docs iframe, before | `Times` |
| Docs iframe, after | `"Nunito Sans", -apple-system, …` |

The preview iframe's `document.body` computes `font-family: Times` either way. The point of the change is that the overlay no longer depends on it.

### The same tooltip, same crop

Before:

![Docs tooltip rendered in the default serif](https://raw.githubusercontent.com/valentinpalkovic/storybook/assets/sb-1804-warning-screenshots/docs-overlay-typography/01-before-serif-tooltip.png)

After:

![Docs tooltip rendered in the Storybook font](https://raw.githubusercontent.com/valentinpalkovic/storybook/assets/sb-1804-warning-screenshots/docs-overlay-typography/02-after-sans-tooltip.png)

In context:

![Autodocs page with the toolbar tooltip open](https://raw.githubusercontent.com/valentinpalkovic/storybook/assets/sb-1804-warning-screenshots/docs-overlay-typography/03-after-docs-page.jpg)

### The change

```diff
 const Note = styled.div(({ theme }) => ({
+  // Portal-rendered, so it cannot rely on inheriting a base font: the preview iframe root has
+  // none, and a user's own styles may sit there instead.
+  fontFamily: theme.typography.fonts.base,
   padding: '2px 6px',
```

Seven lines in total, the same idea in `TooltipNote`, `Popover` and `WithTooltip`'s chrome. Nothing changes in the manager, where the computed value was already this stack.

### Not covered here

`ListItem` (the content of `TooltipLinkList`) has the same gap, but it renders as a `<button>`, whose UA font is a separate problem, and it does not appear on a docs page today. Worth a follow-up rather than an unverified fix bundled into this one.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

> [!NOTE]
> This is a computed-style regression that no current test asserts, and the existing tooltip stories render in the manager, where the bug never reproduced. I verified it by hand in a sandbox, measured above. A test that pins overlay typography would need to run inside the preview iframe; happy to add one if a reviewer wants it.

#### Manual testing

1. Generate any sandbox: `yarn task sandbox --template angular-vite/default-ts --start-from auto`
2. Run `yarn storybook` and open any component's **Docs** page
3. Hover the "open canvas in new tab" icon in the top-right of a story canvas
4. Before this change the tooltip renders in a serif face; after it, in Storybook's sans stack
5. To confirm the root cause rather than the symptom, run this in the console and note that the body font is unchanged either way:

   ```js
   const d = document.getElementById('storybook-preview-iframe').contentDocument;
   getComputedStyle(d.body).fontFamily;                      // "Times"
   getComputedStyle(d.querySelector('[role="tooltip"] > *')).fontFamily;
   ```

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
