### PR TITLE
Angular: Migrate Analog projects to angular-vite instead of refusing them

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
@@ -13,6 +13,7 @@ import { add } from '../../add.ts';
 import { updateMainConfig } from '../helpers/mainConfigFile.ts';
 import type { CheckOptions } from './index.ts';
 import {
+  ANALOG_PACKAGE,
   ANGULAR_PACKAGE,
   ANGULAR_VITE_PACKAGE,
   angularToAngularVite,
@@ -253,24 +254,91 @@ describe('angular-to-angular-vite', () => {
       expect(result?.hasWebpackFinal).toBe(false);
     });
 
-    // `@analogjs/storybook-angular` carries `@storybook/angular` as a peer, so the dependency alone
-    // does not identify the framework the project renders with.
-    it('returns null and says why when the framework is not @storybook/angular', async () => {
+    it('accepts an @analogjs/storybook-angular project and records it as the source framework', async () => {
       vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
         [ANGULAR_PACKAGE]: '^9.0.0',
-        '@analogjs/storybook-angular': '^1.0.0',
+        [ANALOG_PACKAGE]: '^2.6.3',
+      });
+      vi.mocked(mockPackageManager.getDependencyVersion).mockReturnValue('^21.0.0');
+      mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await angularToAngularVite.check({
+        packageManager: mockPackageManager,
+        mainConfig: { framework: ANALOG_PACKAGE },
+      } as CheckOptions);
+
+      expect(result?.framework).toBe(ANALOG_PACKAGE);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    // `main.ts` conventionally writes `getAbsolutePath('<pkg>')`, and Storybook only maps that path
+    // back to a package name for frameworks it ships, so a third-party one arrives as a path.
+    it.each([
+      ['a resolved package directory', `/repo/node_modules/${ANALOG_PACKAGE}`],
+      [
+        'a pnpm virtual-store directory',
+        `/repo/node_modules/.pnpm/@analogjs+storybook-angular@2.6.3_x/node_modules/${ANALOG_PACKAGE}`,
+      ],
+    ])('resolves an Analog framework named by %s', async (_label, frameworkPath) => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
+        [ANALOG_PACKAGE]: '^2.6.3',
+      });
+      vi.mocked(mockPackageManager.getDependencyVersion).mockReturnValue('^21.0.0');
+      mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await angularToAngularVite.check({
+        packageManager: mockPackageManager,
+        mainConfig: { framework: { name: frameworkPath } },
+      } as CheckOptions);
+
+      expect(result?.framework).toBe(ANALOG_PACKAGE);
+    });
+
+    it('does not mistake a resolved @storybook/angular-vite path for @storybook/angular', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
+        [ANGULAR_PACKAGE]: '^9.0.0',
       });
       vi.mocked(mockPackageManager.getDependencyVersion).mockReturnValue('^21.0.0');
 
       const result = await angularToAngularVite.check({
         packageManager: mockPackageManager,
-        mainConfig: { framework: '@analogjs/storybook-angular' },
+        mainConfig: { framework: { name: `/repo/node_modules/${ANGULAR_VITE_PACKAGE}` } },
       } as CheckOptions);
 
       expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('@analogjs/storybook-angular')
-      );
+    });
+
+    it('records @storybook/angular as the source framework for a webpack project', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
+        [ANGULAR_PACKAGE]: '^9.0.0',
+      });
+      vi.mocked(mockPackageManager.getDependencyVersion).mockReturnValue('^21.0.0');
+      mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await angularToAngularVite.check({
+        packageManager: mockPackageManager,
+        mainConfig: { framework: ANGULAR_PACKAGE },
+      } as CheckOptions);
+
+      expect(result?.framework).toBe(ANGULAR_PACKAGE);
+    });
+
+    // Another Angular framework can carry `@storybook/angular` as a peer, so the dependency alone
+    // does not identify the framework the project renders with.
+    it('returns null and says why for an Angular framework it cannot rewrite', async () => {
+      vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({
+        [ANGULAR_PACKAGE]: '^9.0.0',
+        '@acme/storybook-angular': '^1.0.0',
+      });
+      vi.mocked(mockPackageManager.getDependencyVersion).mockReturnValue('^21.0.0');
+
+      const result = await angularToAngularVite.check({
+        packageManager: mockPackageManager,
+        mainConfig: { framework: '@acme/storybook-angular' },
+      } as CheckOptions);
+
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('@acme/storybook-angular'));
     });
 
     it('stays quiet about a non-Angular project that merely carries the dependency', async () => {
@@ -300,6 +368,7 @@ describe('angular-to-angular-vite', () => {
 
   describe('run function', () => {
     const baseResult = {
+      framework: ANGULAR_PACKAGE,
       angularUnsupportedVersion: false,
       angularVersion: '21.0.0',
       hasWebpackFinal: false,
@@ -790,6 +859,73 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
       );
     });
 
+    it('rewrites an @analogjs/storybook-angular executor and renames its zoneless option', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+
+      // eslint-disable-next-line depend/ban-dependencies
+      const { globby } = await import('globby');
+      vi.mocked(globby).mockResolvedValueOnce(['/project/libs/soba/project.json']);
+
+      const projectJsonContent = JSON.stringify({
+        name: 'soba',
+        targets: {
+          storybook: {
+            executor: `${ANALOG_PACKAGE}:start-storybook`,
+            options: { experimentalZoneless: true },
+          },
+        },
+      });
+
+      mockReadFile.mockImplementation(
+        (filePath: any) =>
+          Promise.resolve(
+            String(filePath).endsWith('project.json')
+              ? projectJsonContent
+              : `export default { framework: '${ANALOG_PACKAGE}' };`
+          ) as any
+      );
+
+      await angularToAngularVite.run!({
+        result: { ...baseResult, framework: ANALOG_PACKAGE },
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        storiesPaths: [],
+        configDir: '.storybook',
+        storybookVersion: '9.0.0',
+      } as any);
+
+      const written = vi
+        .mocked(mockWriteFile)
+        .mock.calls.find(([file]) => String(file).endsWith('project.json'))?.[1];
+      expect(written).toContain(`${ANGULAR_VITE_PACKAGE}:start-storybook`);
+      expect(written).not.toContain(ANALOG_PACKAGE);
+      // `experimentalZoneless` is Analog's spelling; angular-vite's schema only accepts `zoneless`,
+      // and rejects unknown keys outright.
+      expect(written).toContain('"zoneless": true');
+      expect(written).not.toContain('experimentalZoneless');
+    });
+
+    it('drops both the Analog framework and the @storybook/angular peer it required', async () => {
+      mockPromptConfirm.mockResolvedValue(false);
+      mockReadFile.mockResolvedValue(`export default { framework: '${ANALOG_PACKAGE}' };`);
+
+      await angularToAngularVite.run!({
+        result: { ...baseResult, framework: ANALOG_PACKAGE },
+        dryRun: false,
+        packageManager: mockPackageManager,
+        mainConfigPath: '/project/.storybook/main.ts',
+        storiesPaths: [],
+        configDir: '.storybook',
+        storybookVersion: '9.0.0',
+      } as any);
+
+      expect(mockPackageManager.removeDependencies).toHaveBeenCalledWith([
+        ANALOG_PACKAGE,
+        ANGULAR_PACKAGE,
+      ]);
+    });
+
     it('leaves a storybook target owned by another framework package alone', async () => {
       mockPromptConfirm.mockResolvedValue(false);
 
@@ -801,7 +937,7 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         name: 'soba',
         targets: {
           storybook: {
-            executor: '@analogjs/storybook-angular:start-storybook',
+            executor: '@acme/storybook-angular:start-storybook',
             options: { experimentalZoneless: true },
           },
         },

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -427,8 +427,6 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
     const frameworkPackageName = getFrameworkPackageName(mainConfig);
     const framework = matchMigratableFramework(frameworkPackageName);
     if (!framework) {
-      // Only nag a project that is actually Angular: a React one carrying `@storybook/angular` as a
-      // stray dependency has nothing to migrate and no reason to hear about it.
       if (angularVersionRaw) {
         logger.warn(
           `Skipped ${ANGULAR_VITE_PACKAGE} migration: this project's Storybook framework is ` +

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -33,13 +33,6 @@ export const ANALOG_PACKAGE = '@analogjs/storybook-angular';
 export const ANGULAR_VITE_PACKAGE = '@storybook/angular-vite';
 const ANALOG_VITE_PLUGIN_PACKAGE = '@analogjs/vite-plugin-angular';
 
-/**
- * The frameworks this migration can rewrite into `@storybook/angular-vite`.
- *
- * Both render Angular through a builder whose targets `@storybook/angular-vite` also accepts, so
- * the rewrite is the same shape for either: repoint the framework, the builder refs and the
- * imports. Anything else stays put, because a hybrid is worse than an untouched project.
- */
 const MIGRATABLE_FRAMEWORKS = [ANGULAR_PACKAGE, ANALOG_PACKAGE] as const;
 type MigratableFramework = (typeof MIGRATABLE_FRAMEWORKS)[number];
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -7,6 +7,7 @@ import {
   editJsonText,
   isStorybookTarget,
   type JSONEditPath,
+  type StorybookBuilderTarget,
 } from 'storybook/internal/cli';
 import { formatFileContent, getProjectRoot, transformImportFiles } from 'storybook/internal/common';
 import { formatConfig, readConfig } from 'storybook/internal/csf-tools';
@@ -28,13 +29,26 @@ import {
 import { findCompodocSetup, removeCompodocSetup } from './angular-vite-remove-compodoc.ts';
 
 export const ANGULAR_PACKAGE = '@storybook/angular';
+export const ANALOG_PACKAGE = '@analogjs/storybook-angular';
 export const ANGULAR_VITE_PACKAGE = '@storybook/angular-vite';
 const ANALOG_VITE_PLUGIN_PACKAGE = '@analogjs/vite-plugin-angular';
+
+/**
+ * The frameworks this migration can rewrite into `@storybook/angular-vite`.
+ *
+ * Both render Angular through a builder whose targets `@storybook/angular-vite` also accepts, so
+ * the rewrite is the same shape for either: repoint the framework, the builder refs and the
+ * imports. Anything else stays put, because a hybrid is worse than an untouched project.
+ */
+const MIGRATABLE_FRAMEWORKS = [ANGULAR_PACKAGE, ANALOG_PACKAGE] as const;
+type MigratableFramework = (typeof MIGRATABLE_FRAMEWORKS)[number];
 
 const FRAMEWORK_DOC_URL = 'https://storybook.js.org/docs/get-started/frameworks/angular-vite';
 const VITE_CONFIG_DOC_URL = 'https://storybook.js.org/docs/builders/vite#configure';
 
 interface AngularToAngularViteOptions {
+  /** The framework the project renders with today, and the one every rewrite below keys off. */
+  framework: MigratableFramework;
   /** True when @angular/core is not found or is outside the 21.x range. */
   angularUnsupportedVersion: boolean;
   /** The detected @angular/core version string, or null if not found. */
@@ -50,9 +64,13 @@ interface AngularToAngularViteOptions {
  * `angular.json` architect entries and `package.json` scripts.
  */
 const rewriteBuilderRefs = (content: string): string =>
-  content
-    .replace(/@storybook\/angular:start-storybook/g, `${ANGULAR_VITE_PACKAGE}:start-storybook`)
-    .replace(/@storybook\/angular:build-storybook/g, `${ANGULAR_VITE_PACKAGE}:build-storybook`);
+  MIGRATABLE_FRAMEWORKS.reduce(
+    (acc, framework) =>
+      acc
+        .replaceAll(`${framework}:start-storybook`, `${ANGULAR_VITE_PACKAGE}:start-storybook`)
+        .replaceAll(`${framework}:build-storybook`, `${ANGULAR_VITE_PACKAGE}:build-storybook`),
+    content
+  );
 
 /**
  * Repoint an existing `test-storybook` package.json script at standalone Vitest. The
@@ -136,17 +154,24 @@ export default defineConfig({
 });
 `;
 
-const transformMainConfig = async (mainConfigPath: string, dryRun: boolean): Promise<boolean> => {
+const transformMainConfig = async (
+  mainConfigPath: string,
+  dryRun: boolean,
+  framework: MigratableFramework
+): Promise<boolean> => {
   try {
     const content = await readFile(mainConfigPath, 'utf-8');
 
-    if (!content.includes(ANGULAR_PACKAGE)) {
+    if (!content.includes(framework)) {
       return false;
     }
 
-    // Replace @storybook/angular with @storybook/angular-vite using a negative
-    // lookahead so references that are already @storybook/angular-vite are left alone.
-    const transformed = content.replace(/@storybook\/angular(?!-vite)/g, ANGULAR_VITE_PACKAGE);
+    // Only `@storybook/angular` is a prefix of `@storybook/angular-vite`, so only it needs the
+    // negative lookahead that leaves already-migrated references alone.
+    const transformed =
+      framework === ANGULAR_PACKAGE
+        ? content.replace(/@storybook\/angular(?!-vite)/g, ANGULAR_VITE_PACKAGE)
+        : content.replaceAll(framework, ANGULAR_VITE_PACKAGE);
 
     if (transformed !== content && !dryRun) {
       await writeFile(mainConfigPath, transformed);
@@ -165,15 +190,46 @@ interface JsonTargetTransformResult {
   allStorybookTargetsZonelessTrue: boolean;
 }
 
-/** Map the old @storybook/angular builder/executor ref to its angular-vite equivalent, or `null` if unrelated. */
+/** Map a migratable builder/executor ref to its angular-vite equivalent, or `null` if unrelated. */
 const rewriteStorybookBuilderRef = (ref: string): string | null => {
-  if (ref === `${ANGULAR_PACKAGE}:start-storybook`) {
-    return `${ANGULAR_VITE_PACKAGE}:start-storybook`;
-  }
-  if (ref === `${ANGULAR_PACKAGE}:build-storybook`) {
-    return `${ANGULAR_VITE_PACKAGE}:build-storybook`;
+  for (const framework of MIGRATABLE_FRAMEWORKS) {
+    if (ref === `${framework}:start-storybook`) {
+      return `${ANGULAR_VITE_PACKAGE}:start-storybook`;
+    }
+    if (ref === `${framework}:build-storybook`) {
+      return `${ANGULAR_VITE_PACKAGE}:build-storybook`;
+    }
   }
   return null;
+};
+
+/** Whether `target` runs Storybook through a framework this migration can rewrite. */
+const isMigratableStorybookTarget = (target: unknown): target is StorybookBuilderTarget =>
+  MIGRATABLE_FRAMEWORKS.some((framework) => isStorybookTarget(target, framework));
+
+/**
+ * Resolve what `main.ts` names as its framework to one this migration can rewrite.
+ *
+ * `getFrameworkPackageName` maps a resolved path back to a package name only for frameworks
+ * Storybook itself ships, so a third-party one like `@analogjs/storybook-angular` arrives as
+ * whatever `getAbsolutePath()` returned: the installed package directory, or a pnpm virtual-store
+ * dir that spells the scope slash as `+`.
+ */
+const matchMigratableFramework = (
+  frameworkPackageName: string | null
+): MigratableFramework | undefined => {
+  if (!frameworkPackageName) {
+    return undefined;
+  }
+  const normalized = frameworkPackageName.replace(/\\/g, '/');
+  return MIGRATABLE_FRAMEWORKS.find(
+    (framework) =>
+      normalized === framework ||
+      // `@storybook/angular` must not match a path ending in `@storybook/angular-vite`, which the
+      // leading slash guarantees.
+      normalized.endsWith(`/${framework}`) ||
+      normalized.includes(`/.pnpm/${framework.replace('/', '+')}@`)
+  );
 };
 
 /** Applies a single format-preserving edit; shared by `AngularJSON` and `TextJsonEditor` below. */
@@ -214,7 +270,7 @@ const processStorybookTargets = (
       // tree the first project already rewrote, and a narrower gate would report no Storybook
       // target at all and skip the zone.js injection.
       if (
-        !isStorybookTarget(target, ANGULAR_PACKAGE) &&
+        !isMigratableStorybookTarget(target) &&
         !isStorybookTarget(target, ANGULAR_VITE_PACKAGE)
       ) {
         continue;
@@ -231,7 +287,7 @@ const processStorybookTargets = (
         allZonelessTrue = false;
       }
 
-      if (!isStorybookTarget(target, ANGULAR_PACKAGE)) {
+      if (!isMigratableStorybookTarget(target)) {
         continue;
       }
 
@@ -357,23 +413,27 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
   async check({ packageManager, mainConfig }): Promise<AngularToAngularViteOptions | null> {
     const allDeps = packageManager.getAllDependencies();
 
-    // Only apply when @storybook/angular is present and @storybook/angular-vite is not.
-    if (!allDeps[ANGULAR_PACKAGE] || allDeps[ANGULAR_VITE_PACKAGE]) {
+    // Only apply when a migratable framework is present and @storybook/angular-vite is not.
+    if (allDeps[ANGULAR_VITE_PACKAGE] || MIGRATABLE_FRAMEWORKS.every((pkg) => !allDeps[pkg])) {
       return null;
     }
 
     // Detect @angular/core version for the Angular 21 prerequisite check.
     const angularVersionRaw = packageManager.getDependencyVersion('@angular/core');
 
-    // Other Angular frameworks declare `@storybook/angular` as their peer, so the dependency alone
-    // does not say which framework the project renders with. Rewriting one of those produces a
-    // half-migrated hybrid, so only the framework this migration knows how to rewrite qualifies.
+    // `@analogjs/storybook-angular` declares `@storybook/angular` as its peer, so the dependency
+    // alone does not say which framework the project renders with, and a framework this migration
+    // cannot rewrite would come out a half-migrated hybrid. Only the `framework` field decides.
     const frameworkPackageName = getFrameworkPackageName(mainConfig);
-    if (frameworkPackageName !== ANGULAR_PACKAGE) {
+    const framework = matchMigratableFramework(frameworkPackageName);
+    if (!framework) {
+      // Only nag a project that is actually Angular: a React one carrying `@storybook/angular` as a
+      // stray dependency has nothing to migrate and no reason to hear about it.
       if (angularVersionRaw) {
         logger.warn(
           `Skipped ${ANGULAR_VITE_PACKAGE} migration: this project's Storybook framework is ` +
-            `\`${frameworkPackageName ?? 'not set'}\`, and only \`${ANGULAR_PACKAGE}\` projects can be ` +
+            `\`${frameworkPackageName ?? 'not set'}\`, and only ` +
+            `${MIGRATABLE_FRAMEWORKS.map((pkg) => `\`${pkg}\``).join(' and ')} projects can be ` +
             `migrated automatically. See ${FRAMEWORK_DOC_URL} to switch frameworks by hand.`
         );
       }
@@ -413,14 +473,14 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
       }
     }
 
-    // Collect package.json files that reference @storybook/angular.
+    // Collect package.json files that reference a migratable framework.
     const packageJsonFiles: string[] = [];
     for (const pkgJsonPath of packageManager.packageJsonPaths) {
       try {
         const raw = await readFile(pkgJsonPath, 'utf-8');
         const pkg = JSON.parse(raw);
         const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
-        if (Object.keys(deps).includes(ANGULAR_PACKAGE)) {
+        if (MIGRATABLE_FRAMEWORKS.some((pkg) => pkg in deps)) {
           packageJsonFiles.push(pkgJsonPath);
         }
       } catch {
@@ -429,6 +489,7 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
     }
 
     return {
+      framework,
       angularUnsupportedVersion,
       angularVersion,
       hasWebpackFinal,
@@ -437,7 +498,7 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
   },
 
   prompt() {
-    return 'Migrate from @storybook/angular (Webpack) to @storybook/angular-vite (in preview).';
+    return 'Migrate from @storybook/angular (Webpack) or @analogjs/storybook-angular to @storybook/angular-vite (in preview).';
   },
 
   async run({
@@ -495,17 +556,17 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
       }
     }
 
-    logger.step(`Migrating from ${ANGULAR_PACKAGE} to ${ANGULAR_VITE_PACKAGE}...`);
+    logger.step(`Migrating from ${result.framework} to ${ANGULAR_VITE_PACKAGE}...`);
 
     // 1. Patch .storybook/main.ts(.js). This comes first because everything below assumes the
     // framework already says angular-vite: `check()` reads it off the evaluated config, so the
     // field can be inherited from a shared base file rather than spelled out in this one.
     logger.debug('Updating main config...');
-    if (!mainConfigPath || !(await transformMainConfig(mainConfigPath, dryRun))) {
+    if (!mainConfigPath || !(await transformMainConfig(mainConfigPath, dryRun, result.framework))) {
       logger.error(
         dedent`
           Migration stopped: the \`framework\` field could not be rewritten in ${mainConfigPath ?? 'your Storybook main config'}.
-          That file names no \`${ANGULAR_PACKAGE}\`, so it most likely inherits the framework from a shared config.
+          That file names no \`${result.framework}\`, so it most likely inherits the framework from a shared config.
           Point \`framework\` at \`${ANGULAR_VITE_PACKAGE}\` where it is declared, then run this migration again.
         `
       );
@@ -517,7 +578,11 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
       logger.debug('Dry run: Skipping dependency updates.');
     } else {
       logger.debug('Updating dependencies...');
-      await packageManager.removeDependencies([ANGULAR_PACKAGE]);
+      // `@analogjs/storybook-angular` declares `@storybook/angular` as a peer, so an Analog project
+      // carries both and neither renders anything once the framework points at angular-vite.
+      await packageManager.removeDependencies(
+        result.framework === ANALOG_PACKAGE ? [ANALOG_PACKAGE, ANGULAR_PACKAGE] : [ANGULAR_PACKAGE]
+      );
 
       const allDeps = packageManager.getAllDependencies();
       await packageManager.addDependencies({ type: 'devDependencies', skipInstall: true }, [
@@ -595,7 +660,7 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
           mainConfig,
           previewConfigPath,
           packageManager,
-          builderPackages: [ANGULAR_VITE_PACKAGE, ANGULAR_PACKAGE],
+          builderPackages: [ANGULAR_VITE_PACKAGE, ...MIGRATABLE_FRAMEWORKS],
         });
         if (compodocSetup) {
           await removeCompodocSetup({
@@ -632,7 +697,7 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
 
     const transformErrors = await transformImportFiles(
       allFiles,
-      { [ANGULAR_PACKAGE]: ANGULAR_VITE_PACKAGE },
+      Object.fromEntries(MIGRATABLE_FRAMEWORKS.map((pkg) => [pkg, ANGULAR_VITE_PACKAGE])),
       !!dryRun
     );
 


### PR DESCRIPTION
Closes #

## What I did

`angular-to-angular-vite` refuses Analog projects and tells them to switch frameworks by hand. That refusal was the right call while the migration only knew how to rewrite `@storybook/angular` refs, but the gap was never large: an Analog project's builder targets, its zoneless option and its story imports all map onto `@storybook/angular-vite` exactly the way the webpack framework's do. This teaches the same pass to rewrite both.

```
main.ts framework ──┬── @storybook/angular ─────────┐
                    └── @analogjs/storybook-angular ┤
                                                    ├──► @storybook/angular-vite
executor / builder ─┬── @storybook/angular:*        ┤     · framework field
                    └── @analogjs/storybook-angular:*┘    · executor + builder refs
                                                          · experimentalZoneless -> zoneless
                                                          · Compodoc teardown
                                                          · story + config imports
```

An Analog project also drops `@storybook/angular`, which it only carried to satisfy its framework's peer.

Matching the framework needed its own step, and this is the part worth reviewing:

```ts
// `getFrameworkPackageName` maps a resolved path back to a package name only for frameworks
// Storybook ships, so a third-party one arrives as an installed directory or a pnpm
// virtual-store path, and a bare equality check never fires.
const normalized = frameworkPackageName.replace(/\\/g, '/');
return MIGRATABLE_FRAMEWORKS.find(
  (framework) =>
    normalized === framework ||
    // `@storybook/angular` must not match a path ending in `@storybook/angular-vite`, which the
    // leading slash guarantees.
    normalized.endsWith(`/${framework}`) ||
    normalized.includes(`/.pnpm/${framework.replace('/', '+')}@`)
);
```

I hit this the hard way: with the framework list widened but the match still a bare equality, radix-ng was *still* skipped, and the message showed why - it reported the framework as `/Users/…/node_modules/.pnpm/@analogjs+storybook-angular@2.6.3_…/node_modules/@analogjs/storybook-angular`.

## Real evidence behind the fix

Run against a real Analog repo, `radix-ng/radix-ng-primitives` (395 stories, Nx + pnpm), reset to its pristine upstream state first - Storybook 10.5.2, `@analogjs/storybook-angular` 2.6.3, `@storybook/angular` 10.5.2, Angular 22.

Before, the whole run was one line:

```
▲  Skipped @storybook/angular-vite migration: this project's Storybook framework is
   `@analogjs/storybook-angular`, and only `@storybook/angular` projects can be migrated
   automatically. See … to switch frameworks by hand.
▲  No migrations were applicable to your project
```

After:

```
◇  Migrating from @analogjs/storybook-angular to @storybook/angular-vite...
◇  Removed the Compodoc builder options from …/apps/radix-storybook/project.json
◇  Removed @compodoc/compodoc
◇  Migration completed successfully!

* 2 dependencies were added:   @storybook/angular-vite, @storybook/addon-vitest
* 3 dependencies were removed: @analogjs/storybook-angular@2.6.3, @compodoc/compodoc@^1.2.1,
                               @storybook/angular@10.5.2
```

What it did to the project's Nx target:

```diff
         "storybook": {
-            "executor": "@analogjs/storybook-angular:start-storybook",
+            "executor": "@storybook/angular-vite:start-storybook",
             "options": {
                 "port": 4400,
                 "configDir": "apps/radix-storybook/.storybook",
-                "experimentalZoneless": true,
-                "compodoc": true,
-                "compodocArgs": [
-                    "-e", "json", "--disablePrivate", "--disableProtected",
-                    "--disableLifeCycleHooks", "--disableInternal", "--disableDependencies",
-                    "-d", "apps/radix-storybook/.storybook"
-                ],
-                "styles": ["apps/radix-storybook/.storybook/main.css"]
+                "styles": ["apps/radix-storybook/.storybook/main.css"],
+                "zoneless": true
             },
```

and to its main config:

```diff
-import type { StorybookConfig } from '@analogjs/storybook-angular';
+import type { StorybookConfig } from '@storybook/angular-vite';
-        name: getAbsolutePath('@analogjs/storybook-angular'),
+        name: getAbsolutePath('@storybook/angular-vite'),
```

The migrated repo then starts and serves all 395 stories on `@storybook/angular-vite`, with no Compodoc step - previously it spent ~30s regenerating `documentation.json` on every boot.

Its `static-storybook` target is an `@nx/web:file-server` that also carries an `experimentalZoneless` key; the migration leaves it untouched, which is what a target it does not own should get.

Two things a reviewer should know rather than discover:

- Rewriting a key inside an Nx target makes `editJsonText` reflow its siblings, so `styles` comes back multi-line above. That is existing `editJsonText` behaviour, not new here - it simply had no chance to show on Analog projects before.
- `experimentalZoneless` is Analog's spelling and `@storybook/angular-vite`'s schema sets `additionalProperties: false`, so leaving the key would hard-fail the builder. The rename already existed; it now runs for Analog targets too.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Clone an Analog-based Storybook project (`radix-ng/radix-ng-primitives` is the one used above) and install it as-is, with `@analogjs/storybook-angular` as the `framework` in `.storybook/main.ts`.
2. Run `npx storybook automigrate angular-to-angular-vite --config-dir <path-to>/.storybook --yes`.
3. Expect it to report `Migrating from @analogjs/storybook-angular to @storybook/angular-vite...` rather than skipping. Before this change it prints `Skipped @storybook/angular-vite migration` and exits.
4. Inspect the project's `project.json` (or `angular.json`): expect `@storybook/angular-vite:start-storybook` and `:build-storybook`, `experimentalZoneless` renamed to `zoneless`, and the `compodoc`/`compodocArgs` options gone.
5. Inspect `package.json`: expect `@analogjs/storybook-angular` **and** `@storybook/angular` removed, and `@storybook/angular-vite` added.
6. Start Storybook and confirm it serves the same stories, with no Compodoc generation step.
7. As a negative control, point `framework` at any other Angular framework and re-run: expect the skip message, and no files changed.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below: `feature request`
