### PR TITLE
Core: Quote non-identifier arg keys when saving stories

### DIFF
--- a/code/core/src/core-server/utils/save-story/mocks/kebab-case-args-csf4.stories.tsx
+++ b/code/core/src/core-server/utils/save-story/mocks/kebab-case-args-csf4.stories.tsx
@@ -1,0 +1,19 @@
+// @ts-expect-error this is just a mock file
+import preview from '#.storybook/preview';
+
+const meta = preview.meta({
+  title: 'MyComponent',
+});
+
+export const QuotedKebabArg = meta.story({
+  args: {
+    'data-testid': 'before',
+  },
+});
+export const NestedCollision = meta.story({
+  args: {
+    nested: {
+      'aria-label': 'inner',
+    },
+  },
+});

--- a/code/core/src/core-server/utils/save-story/mocks/kebab-case-args.stories.tsx
+++ b/code/core/src/core-server/utils/save-story/mocks/kebab-case-args.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { FC } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+export default {
+  title: 'MyComponent',
+} satisfies Meta<typeof MyComponent>;
+
+type Story = StoryObj<typeof MyComponent>;
+
+// dummy component
+const MyComponent: FC<{ label: string; 'data-testid': string; 'aria-label': string }> = (props) => (
+  <pre>{JSON.stringify(props)}</pre>
+);
+
+export const NoArgs = {} satisfies Story;
+
+export const QuotedKebabArg = {
+  args: {
+    'data-testid': 'before',
+    label: 'foo',
+  },
+} satisfies Story;

--- a/code/core/src/core-server/utils/save-story/mocks/kebab-case-args.stories.tsx
+++ b/code/core/src/core-server/utils/save-story/mocks/kebab-case-args.stories.tsx
@@ -10,9 +10,12 @@ export default {
 type Story = StoryObj<typeof MyComponent>;
 
 // dummy component
-const MyComponent: FC<{ label: string; 'data-testid': string; 'aria-label': string }> = (props) => (
-  <pre>{JSON.stringify(props)}</pre>
-);
+const MyComponent: FC<{
+  label: string;
+  'data-testid': string;
+  'aria-label': string;
+  123: string;
+}> = (props) => <pre>{JSON.stringify(props)}</pre>;
 
 export const NoArgs = {} satisfies Story;
 
@@ -20,5 +23,11 @@ export const QuotedKebabArg = {
   args: {
     'data-testid': 'before',
     label: 'foo',
+  },
+} satisfies Story;
+
+export const NumericKeyArg = {
+  args: {
+    123: 'before',
   },
 } satisfies Story;

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
@@ -20,6 +20,7 @@ const FILES = {
   exportVariances: join(__dirname, 'mocks/export-variances.stories.tsx'),
   dataVariances: join(__dirname, 'mocks/data-variances.stories.tsx'),
   kebabCaseArgs: join(__dirname, 'mocks/kebab-case-args.stories.tsx'),
+  kebabCaseArgsCsf4: join(__dirname, 'mocks/kebab-case-args-csf4.stories.tsx'),
 };
 
 describe('success', () => {
@@ -386,6 +387,55 @@ describe('success', () => {
       + 
           },
         } satisfies Story;
+        "
+    `);
+  });
+  test('Kebab-case args (CSF4)', async () => {
+    const newArgs = { 'aria-label': 'button' };
+
+    const before = await format(await readFile(FILES.kebabCaseArgsCsf4, 'utf-8'), {
+      parser: 'typescript',
+    });
+    const CSF = await readCsf(FILES.kebabCaseArgsCsf4, { makeTitle });
+
+    const parsed = CSF.parse();
+    const names = Object.keys(parsed._stories);
+    const nodes = names.map((name) => CSF.getStoryExport(name));
+
+    nodes.forEach((node) => {
+      updateArgsInCsfFile(node, newArgs);
+    });
+
+    const after = await format(printCsf(parsed).code, {
+      parser: 'typescript',
+    });
+
+    // check if the code was updated at all
+    expect(after).not.toBe(before);
+
+    // check if the code was updated correctly: the nested 'aria-label' must stay
+    // untouched and the new arg must be added at the top level
+    expect(getDiff(before, after)).toMatchInlineSnapshot(`
+      "  ...
+        export const QuotedKebabArg = meta.story({
+          args: {
+            "data-testid": "before",
+        
+      +     "aria-label": "button",
+      + 
+          },
+        });
+        export const NestedCollision = meta.story({
+          args: {
+            nested: {
+              "aria-label": "inner",
+            },
+        
+      + 
+      +     "aria-label": "button",
+      + 
+          },
+        });
         "
     `);
   });

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
@@ -334,7 +334,14 @@ describe('success', () => {
     `);
   });
   test('Kebab-case args', async () => {
-    const newArgs = { 'data-testid': 'after', 'aria-label': 'button', label: 'bar', '123': 'baz' };
+    const newArgs = {
+      'data-testid': 'after',
+      'aria-label': 'button',
+      label: 'bar',
+      '123': 'baz',
+      default: 'reserved',
+      '123abc': 'mixed',
+    };
 
     const before = await format(await readFile(FILES.kebabCaseArgs, 'utf-8'), {
       parser: 'typescript',
@@ -372,6 +379,8 @@ describe('success', () => {
       +     "data-testid": "after",
       +     "aria-label": "button",
       +     label: "bar",
+      +     default: "reserved",
+      +     "123abc": "mixed",
       +   },
       + } satisfies Story;
       + 
@@ -386,6 +395,8 @@ describe('success', () => {
       +     label: "bar",
       +     "123": "baz",
       +     "aria-label": "button",
+      +     default: "reserved",
+      +     "123abc": "mixed",
       + 
           },
         } satisfies Story;
@@ -399,6 +410,8 @@ describe('success', () => {
       +     "data-testid": "after",
       +     "aria-label": "button",
       +     label: "bar",
+      +     default: "reserved",
+      +     "123abc": "mixed",
       + 
           },
         } satisfies Story;

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
@@ -334,7 +334,7 @@ describe('success', () => {
     `);
   });
   test('Kebab-case args', async () => {
-    const newArgs = { 'data-testid': 'after', 'aria-label': 'button', label: 'bar' };
+    const newArgs = { 'data-testid': 'after', 'aria-label': 'button', label: 'bar', '123': 'baz' };
 
     const before = await format(await readFile(FILES.kebabCaseArgs, 'utf-8'), {
       parser: 'typescript',
@@ -360,7 +360,7 @@ describe('success', () => {
     // check if the code was updated correctly
     expect(getDiff(before, after)).toMatchInlineSnapshot(`
       "  ...
-          "aria-label": string;
+          123: string;
         }> = (props) => <pre>{JSON.stringify(props)}</pre>;
         
         
@@ -368,6 +368,7 @@ describe('success', () => {
       - 
       + export const NoArgs = {
       +   args: {
+      +     "123": "baz",
       +     "data-testid": "after",
       +     "aria-label": "button",
       +     label: "bar",
@@ -383,7 +384,21 @@ describe('success', () => {
       - 
       +     "data-testid": "after",
       +     label: "bar",
+      +     "123": "baz",
       +     "aria-label": "button",
+      + 
+          },
+        } satisfies Story;
+        
+        export const NumericKeyArg = {
+          args: {
+        
+      -     123: "before",
+      - 
+      +     123: "baz",
+      +     "data-testid": "after",
+      +     "aria-label": "button",
+      +     label: "bar",
       + 
           },
         } satisfies Story;

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
@@ -19,6 +19,7 @@ const FILES = {
   unsupportedCsfVariances: join(__dirname, 'mocks/unsupported-csf-variances.stories.tsx'),
   exportVariances: join(__dirname, 'mocks/export-variances.stories.tsx'),
   dataVariances: join(__dirname, 'mocks/data-variances.stories.tsx'),
+  kebabCaseArgs: join(__dirname, 'mocks/kebab-case-args.stories.tsx'),
 };
 
 describe('success', () => {
@@ -329,6 +330,63 @@ describe('success', () => {
         
         const BlockExport: Story = {
         ..."
+    `);
+  });
+  test('Kebab-case args', async () => {
+    const newArgs = { 'data-testid': 'after', 'aria-label': 'button', label: 'bar' };
+
+    const before = await format(await readFile(FILES.kebabCaseArgs, 'utf-8'), {
+      parser: 'typescript',
+    });
+    const CSF = await readCsf(FILES.kebabCaseArgs, { makeTitle });
+
+    const parsed = CSF.parse();
+    const names = Object.keys(parsed._stories);
+    const nodes = names.map((name) => CSF.getStoryExport(name));
+
+    nodes.forEach((node) => {
+      updateArgsInCsfFile(node, newArgs);
+    });
+
+    // formatting would throw if the generated keys were emitted unquoted
+    const after = await format(printCsf(parsed).code, {
+      parser: 'typescript',
+    });
+
+    // check if the code was updated at all
+    expect(after).not.toBe(before);
+
+    // check if the code was updated correctly
+    expect(getDiff(before, after)).toMatchInlineSnapshot(`
+      "  ...
+          "aria-label": string;
+        }> = (props) => <pre>{JSON.stringify(props)}</pre>;
+        
+        
+      - export const NoArgs = {} satisfies Story;
+      - 
+      + export const NoArgs = {
+      +   args: {
+      +     "data-testid": "after",
+      +     "aria-label": "button",
+      +     label: "bar",
+      +   },
+      + } satisfies Story;
+      + 
+        
+        export const QuotedKebabArg = {
+          args: {
+        
+      -     "data-testid": "before",
+      -     label: "foo",
+      - 
+      +     "data-testid": "after",
+      +     label: "bar",
+      +     "aria-label": "button",
+      + 
+          },
+        } satisfies Story;
+        "
     `);
   });
   test('Data Variances', async () => {

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
@@ -356,8 +356,13 @@ describe('success', () => {
       updateArgsInCsfFile(node, newArgs);
     });
 
+    const rawAfter = printCsf(parsed).code;
+
+    // reserved-word keys are emitted quoted; prettier strips the optional quotes below
+    expect(rawAfter).toContain('"default":');
+
     // formatting would throw if the generated keys were emitted unquoted
-    const after = await format(printCsf(parsed).code, {
+    const after = await format(rawAfter, {
       parser: 'typescript',
     });
 

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
@@ -101,15 +101,15 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
         if (argsProperty.isObjectProperty()) {
           const a = argsProperty.get('value');
           if (a.isObjectExpression()) {
-            a.traverse({
-              ObjectProperty(p) {
+            // only direct properties, so nested keys cannot consume args meant for the top level
+            a.get('properties').forEach((p) => {
+              if (p.isObjectProperty()) {
                 const keyName = argKeyName(p.node.key);
                 if (keyName !== null && keyName in args) {
                   p.get('value').replaceWith(args[keyName]);
                   delete args[keyName];
                 }
-              },
-              noScope: true,
+              }
             });
 
             const remainder = Object.entries(args);

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
@@ -3,6 +3,20 @@ import { types as t, traverse } from 'storybook/internal/babel';
 import { SaveStoryError } from './utils.ts';
 import { valueToAST } from './valueToAST.ts';
 
+// Non-identifier keys like 'data-testid' must be quoted or the generated code is invalid syntax.
+const argKey = (key: string) =>
+  t.isValidIdentifier(key) ? t.identifier(key) : t.stringLiteral(key);
+
+const argKeyName = (key: t.ObjectProperty['key']): string | null => {
+  if (t.isIdentifier(key)) {
+    return key.name;
+  }
+  if (t.isStringLiteral(key)) {
+    return key.value;
+  }
+  return null;
+};
+
 export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, any>) => {
   let found = false;
   const args = Object.fromEntries(
@@ -38,10 +52,10 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
         if (t.isObjectExpression(a)) {
           a.properties.forEach((p) => {
             if (t.isObjectProperty(p)) {
-              const key = p.key;
-              if (t.isIdentifier(key) && key.name in args) {
-                p.value = args[key.name];
-                delete args[key.name];
+              const keyName = argKeyName(p.key);
+              if (keyName !== null && keyName in args) {
+                p.value = args[keyName];
+                delete args[keyName];
               }
             }
           });
@@ -49,7 +63,7 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
           const remainder = Object.entries(args);
           if (Object.keys(args).length) {
             remainder.forEach(([key, value]) => {
-              a.properties.push(t.objectProperty(t.identifier(key), value));
+              a.properties.push(t.objectProperty(argKey(key), value));
             });
           }
         }
@@ -59,7 +73,7 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
         t.objectProperty(
           t.identifier('args'),
           t.objectExpression(
-            Object.entries(args).map(([key, value]) => t.objectProperty(t.identifier(key), value))
+            Object.entries(args).map(([key, value]) => t.objectProperty(argKey(key), value))
           )
         )
       );
@@ -89,10 +103,10 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
           if (a.isObjectExpression()) {
             a.traverse({
               ObjectProperty(p) {
-                const key = p.get('key');
-                if (key.isIdentifier() && key.node.name in args) {
-                  p.get('value').replaceWith(args[key.node.name]);
-                  delete args[key.node.name];
+                const keyName = argKeyName(p.node.key);
+                if (keyName !== null && keyName in args) {
+                  p.get('value').replaceWith(args[keyName]);
+                  delete args[keyName];
                 }
               },
               noScope: true,
@@ -101,7 +115,7 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
             const remainder = Object.entries(args);
             if (Object.keys(args).length) {
               remainder.forEach(([key, value]) => {
-                a.pushContainer('properties', t.objectProperty(t.identifier(key), value));
+                a.pushContainer('properties', t.objectProperty(argKey(key), value));
               });
             }
           }
@@ -112,7 +126,7 @@ export const updateArgsInCsfFile = async (node: t.Node, input: Record<string, an
           t.objectProperty(
             t.identifier('args'),
             t.objectExpression(
-              Object.entries(args).map(([key, value]) => t.objectProperty(t.identifier(key), value))
+              Object.entries(args).map(([key, value]) => t.objectProperty(argKey(key), value))
             )
           )
         );

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.ts
@@ -14,6 +14,9 @@ const argKeyName = (key: t.ObjectProperty['key']): string | null => {
   if (t.isStringLiteral(key)) {
     return key.value;
   }
+  if (t.isNumericLiteral(key)) {
+    return String(key.value);
+  }
   return null;
 };
 


### PR DESCRIPTION
Closes #31018

## What I did

When saving args from the UI (update story / create new story), every arg
key was built with `t.identifier()`, so a kebab-case key like `data-testid`
was written into the story file as unquoted invalid syntax:

```ts
// Before this PR:
args: {
  data-testid: "value", // SyntaxError
},

// After this PR:
args: {
  "data-testid": "value",
},
```

The broken file could then no longer be parsed, so the new story never
showed up and the UI reported "Timed out waiting for response" (the symptom
in the issue). Existing quoted keys had a related problem: the arg-matching
logic only recognized identifier keys, so updating `'data-testid': ...`
missed the existing entry and appended a duplicate.

This PR:

- Builds arg keys as string literals when they are not valid identifiers
  (`data-testid`, `aria-label`, and also previously-broken keys like `123abc`).
- Matches existing string-literal keys when updating args, so quoted keys
  are replaced in place instead of duplicated.
- `valueToAST` (nested object values) already used string-literal keys, so
  the bug was limited to top-level arg keys.

Notes for reviewers:

- Reserved-word keys (e.g. `class`) are now emitted quoted. Both forms are
  valid syntax; existing unquoted keys in user files are not rewritten —
  this only affects newly added keys.
- Computed identifier keys (`[x]: ...`) were already matched by name before
  this change; that pre-existing quirk is untouched and out of scope here.

AI disclosure: developed with the assistance of Claude Code.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. In any sandbox (e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`), add a story whose component takes a kebab-case prop, e.g. `'data-testid'`
2. Run storybook, open the story, change any control value, and use "Create new story" (or save args to the existing story)
3. Before this PR: the request times out and the story file is written with unquoted `data-testid:` (invalid syntax). After: the file gets `"data-testid": ...` and the new story appears immediately
4. Save again on a story that already has `'data-testid'` in its args: the value is updated in place instead of being duplicated

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
