### PR TITLE
Angular: Resolve builder styles against the workspace root

### DIFF
--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -8,7 +8,15 @@ import { resolve } from 'node:path';
 import { mergeConfig, normalizePath } from 'vite';
 
 import { ensureCompodocDocumentation } from './compodoc/ensure-documentation.ts';
-import { angularOptionsPlugin, compodocJsonStubPlugin, features, viteFinal } from './preset.ts';
+import {
+  angularOptionsPlugin,
+  compodocJsonStubPlugin,
+  experimental_docgenProvider,
+  experimental_manifests,
+  experimental_storyDocsProvider,
+  features,
+  viteFinal,
+} from './preset.ts';
 import type { StandaloneOptions } from './builders/utils/standalone-options.ts';
 
 // The plugin's `config` hook looks up the preview file on disk before reading
@@ -37,6 +45,19 @@ beforeEach(() => {
 });
 
 const WORKSPACE_ROOT = resolve('/workspace');
+
+// Storybook discovers these by reading the preset module's exports, so dropping a re-export is
+// type-valid and silent: docgen extraction simply stops running, and the failure only surfaces as
+// an empty static build several minutes into a sandbox job.
+describe('docgen preset entry points', () => {
+  it.each([
+    ['experimental_docgenProvider', experimental_docgenProvider],
+    ['experimental_manifests', experimental_manifests],
+    ['experimental_storyDocsProvider', experimental_storyDocsProvider],
+  ])('re-exports %s', (_name, entryPoint) => {
+    expect(entryPoint).toBeTypeOf('function');
+  });
+});
 
 const optionsWith = (
   frameworkOptions: Record<string, unknown>,

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -146,6 +146,51 @@ describe('angularOptionsPlugin global styles', () => {
     expect(code).toContain(`import '${resolve(WORKSPACE_ROOT, 'src/theme.scss')}';`);
   });
 
+  // The Vite root is the project directory in a monorepo, while Angular resolves `styles` against
+  // the workspace root above it. Reproduces spartan-ng: `apps/ui-storybook/.storybook/tailwind.css`
+  // reached Vite as a bare specifier and 500'd the whole preview module.
+  it('resolves a workspace-relative style against the workspace root, not the Vite root', async () => {
+    const options = {
+      configDir: resolve(WORKSPACE_ROOT, 'apps/ui-storybook/.storybook'),
+      angularBuilderContext: { workspaceRoot: WORKSPACE_ROOT },
+      angularBuilderOptions: { styles: ['apps/ui-storybook/.storybook/tailwind.css'] },
+    } as unknown as StandaloneOptions;
+    const projectPreview = resolve(WORKSPACE_ROOT, 'apps/ui-storybook/.storybook/preview.ts');
+    vi.mocked(findConfigFile).mockReturnValue(projectPreview);
+
+    const plugin = angularOptionsPlugin(options, { normalizePath, zoneless: true });
+    // The Vite root is the project dir, a level below the workspace root.
+    (plugin.config as (userConfig: unknown) => unknown)({
+      root: resolve(WORKSPACE_ROOT, 'apps/ui-storybook'),
+    });
+    const { code } = (await (plugin.transform as any).call({}, '// preview', projectPreview)) as {
+      code: string;
+    };
+
+    expect(code).toContain(
+      `import '${normalizePath(resolve(WORKSPACE_ROOT, 'apps/ui-storybook/.storybook/tailwind.css'))}';`
+    );
+    expect(code).not.toContain("import 'apps/ui-storybook/.storybook/tailwind.css';");
+    expect(code).not.toContain('apps/ui-storybook/apps/ui-storybook');
+  });
+
+  it('leaves the zone.js package specifier alone', async () => {
+    const options = {
+      configDir: resolve(WORKSPACE_ROOT, '.storybook'),
+      angularBuilderContext: { workspaceRoot: WORKSPACE_ROOT },
+      angularBuilderOptions: { styles: ['src/styles.css'] },
+    } as unknown as StandaloneOptions;
+    vi.mocked(findConfigFile).mockReturnValue(previewPath);
+
+    const plugin = angularOptionsPlugin(options, { normalizePath, zoneless: false });
+    (plugin.config as (userConfig: unknown) => unknown)({ root: WORKSPACE_ROOT });
+    const { code } = (await (plugin.transform as any).call({}, '// preview', previewPath)) as {
+      code: string;
+    };
+
+    expect(code).toContain("import 'zone.js';");
+  });
+
   it('ignores malformed object-form styles from the environment bridge', async () => {
     const { code } = await runTransform([
       {},

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -304,13 +304,16 @@ export function angularOptionsPlugin(
   options: StandaloneOptions,
   { normalizePath, zoneless }: any
 ): Plugin {
-  let resolvedConfig: UserConfig;
   let resolvedPreviewPath: string | undefined;
+  // Angular resolves builder paths against the workspace root, which in a monorepo is a level (or
+  // several) above the Vite root. Both `stylePreprocessorOptions` and `styles` need it.
+  let workspaceRoot: string;
   return {
     name: 'storybook-angular-vite-options-plugin',
     config(userConfig: UserConfig) {
-      resolvedConfig = userConfig;
       resolvedPreviewPath = findConfigFile('preview', options.configDir) ?? undefined;
+      workspaceRoot =
+        options.angularBuilderContext?.workspaceRoot ?? userConfig?.root ?? process.cwd();
       const stylePreprocessorOptions =
         options?.angularBuilderOptions?.stylePreprocessorOptions ?? {};
       // Angular's builder schema (and this framework's builder schema) names the
@@ -324,9 +327,6 @@ export function angularOptionsPlugin(
       if (!Array.isArray(loadPaths) && !sassOptions) {
         return;
       }
-
-      const workspaceRoot =
-        options.angularBuilderContext?.workspaceRoot ?? userConfig?.root ?? process.cwd();
 
       return {
         css: {
@@ -358,7 +358,11 @@ export function angularOptionsPlugin(
                   ? style.input
                   : undefined;
             if (stylePath !== undefined) {
-              imports.push(stylePath);
+              // Every `styles` entry is a path the Angular builder resolves against the workspace
+              // root - the schema has no package-specifier form - and in a monorepo that root sits
+              // above the Vite root. Left unresolved, Vite reads `apps/ui/styles.css` as a bare
+              // specifier and fails to find a package by that name.
+              imports.push(normalizePath(resolve(workspaceRoot, stylePath)));
             }
           });
         }
@@ -367,24 +371,9 @@ export function angularOptionsPlugin(
           imports.push('zone.js');
         }
 
-        // Use vite config root when angularBuilderContext is not available
-        // (e.g., when running via Vitest instead of Angular builders)
-        const projectRoot = resolvedConfig?.root ?? process.cwd();
-
         return {
           code: `
-            ${imports
-              .map((extraImport) => {
-                if (extraImport.startsWith('.') || extraImport.startsWith('src')) {
-                  // relative to root — normalize to forward slashes so the
-                  // generated import specifier is valid on Windows.
-                  return `import '${normalizePath(resolve(projectRoot, extraImport))}';`;
-                }
-
-                // absolute import
-                return `import '${extraImport}';`;
-              })
-              .join('\n')}
+            ${imports.map((extraImport) => `import '${extraImport}';`).join('\n')}
             ${code}
           `,
         };

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -307,7 +307,7 @@ export function angularOptionsPlugin(
   let resolvedPreviewPath: string | undefined;
   // Angular resolves builder paths against the workspace root, which in a monorepo is a level (or
   // several) above the Vite root. Both `stylePreprocessorOptions` and `styles` need it.
-  let workspaceRoot: string;
+  let workspaceRoot = process.cwd();
   return {
     name: 'storybook-angular-vite-options-plugin',
     config(userConfig: UserConfig) {


### PR DESCRIPTION
Closes #

## What I did

Found by migrating a real Angular monorepo to `@storybook/angular-vite` and then actually opening a story: the preview never rendered at all.

An Angular builder's `styles` entry is a path relative to the *workspace* root. angular-vite injects each one as an import into the preview module, but only resolved it when it began with `.` or `src`:

```ts
if (extraImport.startsWith('.') || extraImport.startsWith('src')) {
  return `import '${normalizePath(resolve(projectRoot, extraImport))}';`;
}
return `import '${extraImport}';`;   // everything else, verbatim
```

A single-app project writes `src/styles.css` and takes the resolve branch, so this held up. A monorepo writes `apps/ui-storybook/.storybook/tailwind.css`, takes the second branch, and Vite reads it as a bare package specifier:

```
Vite Internal server error: Failed to resolve import
  "apps/ui-storybook/.storybook/tailwind.css" from "apps/ui-storybook/.storybook/preview.ts"
```

The preview module 500s, so the iframe is blank **with nothing in the browser console** - the failure is server-side, which makes it read like a hung Storybook rather than a config error.

Prefixing the path only moves the break, because the resolve branch used `resolvedConfig.root` - the Vite root, which in a monorepo is the project directory, not the workspace root:

```
Failed to resolve import "/…/spartan/acm/apps/ui-storybook/apps/ui-storybook/.storybook/tailwind.css"
                                            └────────── doubled ──────────┘
```

Every `styles` entry now resolves against the same `workspaceRoot` the sass `loadPaths` a few lines above already used. `zone.js` is pushed onto the same list and stays a bare specifier. The Angular schema has no package-specifier form for `styles`, so resolving unconditionally is safe.

## Verification

The test reproduces spartan's exact shape - Vite root one level below the workspace root - and asserts both that the import resolves and that the doubled-path form never appears. Against `next` it fails with `expected '…import \'apps/ui-storybook…' to contain 'import \'/workspace/apps/ui-storybook…'`, which is the bug verbatim.

The second test in this PR is unrelated to the styles path and guards something else. `preset.ts` re-exports the docgen entry points Storybook discovers by reading the module's exports:

```ts
export { experimental_docgenProvider, experimental_manifests } from './docgen/preset.ts';
export { experimental_storyDocsProvider } from './docgen/story-docs-preset.ts';
```

Dropping one of those lines type-checks fine and every unit test still passes - docgen extraction just silently stops. The only signal is a static build that finishes "successfully" while writing no `services/core/docgen` payloads, which then fails the sandbox baseline job minutes later with an ENOENT:

```
■  Failed to generate manifests
■  Error: Invariant failed: experimental_manifests must supply components.meta.docgen
   when experimentalDocgenServer is enabled
...
Error: No docgen snapshots at .../storybook-static/services/core/docgen.
```

The added test asserts each entry point is still exported, so that becomes a one-second unit failure instead.

Not verified end-to-end on a real repo. I tried, by copying the built `dist/preset.js` over the installed package in spartan-ng, and abandoned it: pnpm's store held three copies of `@storybook/angular-vite`, patching one changed nothing, and patching the rest broke preset resolution outright. Hot-patching a content-addressed store is not a test environment, and I would rather say so than report a green run I do not trust. The captured errors above are all from that repo before any patching.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Needs an Nx or multi-project Angular workspace on `@storybook/angular-vite`, where the Storybook target's `styles` is a workspace-root-relative path (`apps/<project>/.storybook/<file>.css`). `spartan-ng/spartan` after `storybook upgrade` is one.

1. Start Storybook and open any story. Before this change the sidebar fills in but the preview iframe stays on the spinner forever, with an empty browser console; the terminal shows `Failed to resolve import "apps/…/tailwind.css"`. After it, the story renders.
2. Confirm the injected import is absolute: the terminal has no `Failed to resolve import` for the stylesheet, and no path containing the project directory twice.
3. In a project with a zone-based setup (no `zoneless: true` on the target), confirm `zone.js` still loads - it is a package name, not a path, and must not be resolved.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below: `bug`

