### PR TITLE
Core: Make TypeScript's JSDoc semantics canonical for component docgen

### DIFF
--- a/code/core/src/component-meta/index.ts
+++ b/code/core/src/component-meta/index.ts
@@ -1,4 +1,12 @@
 export { ComponentMetaManager, isFileInDir, sortTSConfigs } from './ComponentMetaManager.ts';
+export { extractComponentJsDocInfo, resolveExportedSymbol } from './jsdoc-info.ts';
+export type {
+  ComponentJsDocInfo,
+  JsDocExportCheckerLike,
+  JsDocExportSymbolLike,
+  JsDocHost,
+  JsDocSymbolLike,
+} from './jsdoc-info.ts';
 export { parseTsconfigCommandLine } from './parse-tsconfig.ts';
 export type { FileExtensionInfo, TsconfigParserModule } from './parse-tsconfig.ts';
 export { ProjectFileTracker, filterSourceFilePaths } from './ProjectFileTracker.ts';

--- a/code/core/src/component-meta/jsdoc-info.test.ts
+++ b/code/core/src/component-meta/jsdoc-info.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+
+import ts from 'typescript';
+
+import { extractComponentJsDocInfo, resolveExportedSymbol } from './jsdoc-info.ts';
+
+/**
+ * These tests pin TypeScript's JSDoc semantics as the docgen contract (matching IDE hovers):
+ *
+ * - a bare `@tag` preceded by whitespace starts a tag even mid-sentence, truncating the
+ *   description at that point — including inside fenced code blocks;
+ * - braced inline tags (`{@link Foo}`) stay in the description or tag value, rendered with
+ *   TypeScript's own formatting (a space before the closing brace, `|` captions as spaces);
+ * - multi-line tag values keep their newlines.
+ */
+function extract(docblockBody: string) {
+  const src = `/**\n${docblockBody
+    .split('\n')
+    .map((line) => ` * ${line}`)
+    .join('\n')}\n */\nexport const Probe = () => null;\n`;
+
+  const host = ts.createCompilerHost({});
+  const readSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion) =>
+    name === 'probe.ts'
+      ? ts.createSourceFile(name, src, languageVersion, true)
+      : readSourceFile(name, languageVersion);
+
+  const program = ts.createProgram(['probe.ts'], { target: ts.ScriptTarget.ESNext }, host);
+  const checker = program.getTypeChecker();
+  const statement = program.getSourceFile('probe.ts')!.statements[0] as ts.VariableStatement;
+  const symbol = checker.getSymbolAtLocation(statement.declarationList.declarations[0].name)!;
+
+  return extractComponentJsDocInfo(ts, checker, symbol);
+}
+
+describe('extractComponentJsDocInfo', () => {
+  it('extracts a line-leading block tag', () => {
+    expect(extract('A button.\n\n@since 8.0')).toMatchInlineSnapshot(`
+      {
+        "description": "A button.",
+        "jsDocTags": {
+          "since": [
+            "8.0",
+          ],
+        },
+      }
+    `);
+  });
+
+  it('treats a bare mid-line tag as a block tag, ending the description there', () => {
+    expect(extract('Use together with @see ToggleGroup for accessibility.')).toMatchInlineSnapshot(`
+        {
+          "description": "Use together with",
+          "jsDocTags": {
+            "see": [
+              "ToggleGroup for accessibility.",
+            ],
+          },
+        }
+      `);
+  });
+
+  it('keeps braced inline tags in the description', () => {
+    expect(extract('Works with {@link ToggleGroup} inline.')).toMatchInlineSnapshot(`
+      {
+        "description": "Works with {@link ToggleGroup } inline.",
+        "jsDocTags": {},
+      }
+    `);
+  });
+
+  it('does not treat an email address as a tag', () => {
+    expect(extract('Contact dev@example.com for help.')).toMatchInlineSnapshot(`
+      {
+        "description": "Contact dev@example.com for help.",
+        "jsDocTags": {},
+      }
+    `);
+  });
+
+  it('treats a decorator mention as a tag, even inside a fenced code block', () => {
+    expect(extract('Usage:\n\n```ts\n@Input() foo: string;\n```')).toMatchInlineSnapshot(`
+      {
+        "description": "Usage:
+
+      \`\`\`ts",
+        "jsDocTags": {
+          "Input": [
+            "() foo: string;
+      \`\`\`",
+          ],
+        },
+      }
+    `);
+  });
+
+  it('preserves newlines in multi-line tag values', () => {
+    expect(extract('A button.\n\n@example\n<Button size="large">\n  Click me\n</Button>'))
+      .toMatchInlineSnapshot(`
+        {
+          "description": "A button.",
+          "jsDocTags": {
+            "example": [
+              "<Button size="large">
+          Click me
+        </Button>",
+            ],
+          },
+        }
+      `);
+  });
+
+  it('collects repeated tags in source order', () => {
+    expect(extract('A button.\n\n@example <Button />\n@example <Button disabled />'))
+      .toMatchInlineSnapshot(`
+        {
+          "description": "A button.",
+          "jsDocTags": {
+            "example": [
+              "<Button />",
+              "<Button disabled />",
+            ],
+          },
+        }
+      `);
+  });
+
+  it('reports a valueless tag as an empty string', () => {
+    expect(extract('A button.\n\n@ignore')).toMatchInlineSnapshot(`
+      {
+        "description": "A button.",
+        "jsDocTags": {
+          "ignore": [
+            "",
+          ],
+        },
+      }
+    `);
+  });
+
+  it('renders a {@link url|caption} inside a tag value with the caption separator as a space', () => {
+    expect(extract('A button.\n\n@see {@link https://example.com|the docs} for setup.'))
+      .toMatchInlineSnapshot(`
+        {
+          "description": "A button.",
+          "jsDocTags": {
+            "see": [
+              "{@link https://example.com the docs} for setup.",
+            ],
+          },
+        }
+      `);
+  });
+
+  it('handles a docblock with tags and no description', () => {
+    expect(extract('@deprecated Use NewButton.')).toMatchInlineSnapshot(`
+      {
+        "description": "",
+        "jsDocTags": {
+          "deprecated": [
+            "Use NewButton.",
+          ],
+        },
+      }
+    `);
+  });
+});
+
+describe('resolveExportedSymbol', () => {
+  it('resolves a local export by name', () => {
+    const sourceText = 'export const Button = () => null;';
+    const sourceFile = ts.createSourceFile('button.ts', sourceText, ts.ScriptTarget.ESNext, true);
+    const host = ts.createCompilerHost({});
+    const readSourceFile = host.getSourceFile.bind(host);
+    host.getSourceFile = (name, languageVersion) =>
+      name === 'button.ts' ? sourceFile : readSourceFile(name, languageVersion);
+
+    const program = ts.createProgram(['button.ts'], { target: ts.ScriptTarget.ESNext }, host);
+    const checker = program.getTypeChecker();
+
+    expect(resolveExportedSymbol(ts, checker, sourceFile, 'Button')?.getName()).toBe('Button');
+  });
+
+  it('follows an aliased re-export to the target symbol', () => {
+    const files = {
+      '/button.ts': 'export const Button = () => null;',
+      '/index.ts': "export { Button as PrimaryButton } from './button';",
+    };
+    const host = ts.createCompilerHost({});
+    const readSourceFile = host.getSourceFile.bind(host);
+    host.getSourceFile = (name, languageVersion) =>
+      name in files
+        ? ts.createSourceFile(
+            name,
+            files[name as keyof typeof files],
+            languageVersion,
+            true,
+            ts.ScriptKind.TS
+          )
+        : readSourceFile(name, languageVersion);
+    host.fileExists = (name) => name in files || ts.sys.fileExists(name);
+    host.readFile = (name) => files[name as keyof typeof files] ?? ts.sys.readFile(name);
+    host.getCurrentDirectory = () => '/';
+    host.resolveModuleNames = (moduleNames) =>
+      moduleNames.map((name) =>
+        name === './button'
+          ? { resolvedFileName: '/button.ts', extension: ts.Extension.Ts }
+          : undefined
+      );
+
+    const program = ts.createProgram(
+      ['/button.ts', '/index.ts'],
+      {
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        noEmit: true,
+      },
+      host
+    );
+    const checker = program.getTypeChecker();
+    const sourceFile = program.getSourceFile('/index.ts')!;
+    const symbol = resolveExportedSymbol(ts, checker, sourceFile, 'PrimaryButton');
+
+    expect(symbol?.getName()).toBe('Button');
+    expect(symbol?.declarations?.[0]?.getSourceFile().fileName).toBe('/button.ts');
+  });
+});

--- a/code/core/src/component-meta/jsdoc-info.ts
+++ b/code/core/src/component-meta/jsdoc-info.ts
@@ -1,0 +1,91 @@
+/**
+ * Canonical component-level JSDoc extraction for the TS-backed docgen providers.
+ *
+ * TypeScript's own JSDoc semantics are the contract: whatever `getDocumentationComment` /
+ * `getJsDocTags` report is what Storybook documents, matching IDE hovers. Notably, a bare
+ * `@tag` preceded by whitespace starts a tag even mid-sentence, while braced inline tags
+ * (`{@link Foo}`) stay in the description.
+ *
+ * Like the rest of this module, no type here names the `typescript` package: callers pass their
+ * own `typescript` module and checker, which satisfy these structural subsets.
+ *
+ * Docblocks with no TS symbol (CSF story/meta docblocks, TS-less docgen engines) are parsed by
+ * `csf-tools`' `extractJSDocInfo` instead, whose semantics differ on malformed input.
+ */
+
+/** Structural subset of `ts.SymbolDisplayPart`. */
+export interface JsDocDisplayPart {
+  text: string;
+  kind: string;
+}
+
+/** Structural subset of `ts.JSDocTagInfo`. */
+export interface JsDocTagInfoLike {
+  name: string;
+  text?: JsDocDisplayPart[];
+}
+
+/** Structural subset of `ts.Symbol` used for export resolution. */
+export interface JsDocExportSymbolLike {
+  flags: number;
+  getName(): string;
+}
+
+/** Structural subset of `ts.Symbol` — the two documentation accessors. */
+export interface JsDocSymbolLike<TChecker> extends JsDocExportSymbolLike {
+  getDocumentationComment(typeChecker: TChecker | undefined): JsDocDisplayPart[];
+  getJsDocTags(checker?: TChecker): JsDocTagInfoLike[];
+}
+
+/** The part of the `typescript` module the extractor needs. */
+export interface JsDocHost {
+  SymbolFlags: { Alias: number };
+  displayPartsToString(displayParts: JsDocDisplayPart[] | undefined): string;
+}
+
+/** Structural subset of `ts.TypeChecker` used for export resolution. */
+export interface JsDocExportCheckerLike<TSourceFile, TSymbol extends JsDocExportSymbolLike> {
+  getAliasedSymbol(symbol: TSymbol): TSymbol;
+  getExportsOfModule(moduleSymbol: TSymbol): TSymbol[];
+  getSymbolAtLocation(node: TSourceFile): TSymbol | undefined;
+}
+
+export interface ComponentJsDocInfo {
+  description: string;
+  /** Tag name → one trimmed value per occurrence, in source order. Empty when the symbol has no tags. */
+  jsDocTags: Record<string, string[]>;
+}
+
+/** Resolve a module export by name, following alias symbols to the declared target. */
+export function resolveExportedSymbol<TSourceFile, TSymbol extends JsDocExportSymbolLike>(
+  typescript: JsDocHost,
+  checker: JsDocExportCheckerLike<TSourceFile, TSymbol>,
+  sourceFile: TSourceFile,
+  exportName: string
+): TSymbol | undefined {
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  const symbol = moduleSymbol
+    ? checker
+        .getExportsOfModule(moduleSymbol)
+        .find((candidate) => candidate.getName() === exportName)
+    : undefined;
+
+  return symbol && symbol.flags & typescript.SymbolFlags.Alias
+    ? checker.getAliasedSymbol(symbol)
+    : symbol;
+}
+
+export function extractComponentJsDocInfo<TChecker>(
+  typescript: JsDocHost,
+  checker: TChecker,
+  symbol: JsDocSymbolLike<TChecker>
+): ComponentJsDocInfo {
+  const description = typescript.displayPartsToString(symbol.getDocumentationComment(checker));
+
+  const jsDocTags: Record<string, string[]> = {};
+  for (const tag of symbol.getJsDocTags(checker)) {
+    (jsDocTags[tag.name] ??= []).push(typescript.displayPartsToString(tag.text ?? []).trim());
+  }
+
+  return { description, jsDocTags };
+}

--- a/code/core/src/csf-tools/jsdoc.test.ts
+++ b/code/core/src/csf-tools/jsdoc.test.ts
@@ -12,7 +12,7 @@ it('should extract @summary tag', () => {
       "description": "description",
       "tags": {
         "summary": [
-          " my summary",
+          "my summary",
         ],
       },
     }
@@ -105,5 +105,14 @@ it('lets non-empty docgen JSDoc tags win over matching docblock tags', () => {
       describe: ['Component describe.'],
       summary: ['Component summary.'],
     },
+  });
+});
+
+it('trims a single-word tag value, whose name and empty description would otherwise join with a space', () => {
+  expect(
+    extractJSDocInfo('A button.\n\n@summary Clickable\n@deprecated Use NewButton.').tags
+  ).toEqual({
+    summary: ['Clickable'],
+    deprecated: ['Use NewButton.'],
   });
 });

--- a/code/core/src/csf-tools/jsdoc.test.ts
+++ b/code/core/src/csf-tools/jsdoc.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from 'vitest';
 
 import { dedent } from 'ts-dedent';
 
-import { extractJSDocInfo } from './jsdoc.ts';
+import { extractComponentDescription, extractJSDocInfo } from './jsdoc.ts';
 
 it('should extract @summary tag', () => {
   const code = dedent`description\n@summary\n my summary`;
@@ -63,4 +63,47 @@ it('preserves blank lines and newlines in the description so Markdown survives',
     ].join('\n')
   );
   expect(tags).toEqual({ summary: ['short summary'] });
+});
+
+it('uses docblock tags when docgen JSDoc tags are empty', () => {
+  const metaJsDoc = dedent`
+    Meta description.
+
+    @summary Meta summary.
+    @describe Meta describe.
+  `;
+
+  expect(extractComponentDescription(metaJsDoc, 'Component description.', {})).toEqual({
+    description: 'Meta describe.',
+    summary: 'Meta summary.',
+    jsDocTags: {
+      describe: ['Meta describe.'],
+      summary: ['Meta summary.'],
+    },
+  });
+});
+
+it('lets non-empty docgen JSDoc tags win over matching docblock tags', () => {
+  const metaJsDoc = dedent`
+    Meta description.
+
+    @summary Meta summary.
+    @describe Meta describe.
+    @deprecated Use NewButton.
+  `;
+
+  expect(
+    extractComponentDescription(metaJsDoc, 'Component description.', {
+      describe: ['Component describe.'],
+      summary: ['Component summary.'],
+    })
+  ).toEqual({
+    description: 'Component describe.',
+    summary: 'Component summary.',
+    jsDocTags: {
+      deprecated: ['Use NewButton.'],
+      describe: ['Component describe.'],
+      summary: ['Component summary.'],
+    },
+  });
 });

--- a/code/core/src/csf-tools/jsdoc.ts
+++ b/code/core/src/csf-tools/jsdoc.ts
@@ -56,8 +56,8 @@ export function extractJSDocInfo(jsdocComment: string) {
     tags: Object.fromEntries(
       Array.from(groupByTag(parsed[0].tags), ([tag, specs]) => [
         tag,
-        specs.map(
-          (spec) => (spec.type ? `{${spec.type}} ` : '') + `${spec.name} ${spec.description}`
+        specs.map((spec) =>
+          ((spec.type ? `{${spec.type}} ` : '') + `${spec.name} ${spec.description}`).trim()
         ),
       ])
     ) as JsDocTagMap,

--- a/code/core/src/csf-tools/jsdoc.ts
+++ b/code/core/src/csf-tools/jsdoc.ts
@@ -17,11 +17,27 @@ function groupByTag(specs: Spec[]): Map<string, Spec[]> {
   return groups;
 }
 
+function hasTags(tags: JsDocTagMap | undefined): tags is JsDocTagMap {
+  return !!tags && Object.keys(tags).length > 0;
+}
+
+function mergeTags(
+  docgenJsDocTags: JsDocTagMap | undefined,
+  extractedTags: JsDocTagMap | undefined
+): JsDocTagMap {
+  if (!hasTags(docgenJsDocTags)) {
+    return extractedTags ?? {};
+  }
+  return { ...(extractedTags ?? {}), ...docgenJsDocTags };
+}
+
 /**
  * Splits a bare docblock body (no `/**` markers) into its description and a compact tag map.
  *
- * Shared by the server-side docgen providers so component descriptions and `@summary` / `@import`
- * style tags read the same across renderers.
+ * For docblocks that only exist as raw text — CSF story/meta docblocks and TS-less docgen engines.
+ * When a TS checker and symbol are available, `extractComponentJsDocInfo` in
+ * `core/src/component-meta/jsdoc-info.ts` is the canonical extractor instead; the two differ on
+ * malformed input (this one only treats line-leading `@tags` as tags).
  */
 export function extractJSDocInfo(jsdocComment: string) {
   const lines = jsdocComment.split('\n');
@@ -49,10 +65,12 @@ export function extractJSDocInfo(jsdocComment: string) {
 }
 
 /**
- * Resolves the component-level description, summary, and tag map a docgen payload reports.
+ * Resolves the description, summary, and tag map a docgen payload reports.
  *
  * The CSF `meta` docblock wins over the docgen engine's own component description, and an explicit
- * `@describe` / `@desc` tag wins over the block description.
+ * `@describe` / `@desc` tag wins over the block description. Docgen/provider tags win over same
+ * named docblock tags, but a provider that found no tags must not suppress the docblock's own.
+ * `extractStoryJSDocInfo` reuses this for story docblocks, so both resolve tags identically.
  */
 export function extractComponentDescription(
   metaJsDoc: string | undefined,
@@ -61,7 +79,7 @@ export function extractComponentDescription(
 ) {
   const jsdocComment = metaJsDoc || docgenDescription;
   const extracted = jsdocComment ? extractJSDocInfo(jsdocComment) : undefined;
-  const tags = docgenJsDocTags ?? extracted?.tags ?? {};
+  const tags = mergeTags(docgenJsDocTags, extracted?.tags);
   const description = extracted?.description;
 
   return {

--- a/code/core/src/csf-tools/story-shape/jsdoc.ts
+++ b/code/core/src/csf-tools/story-shape/jsdoc.ts
@@ -1,7 +1,7 @@
 import type { NodePath, types as t } from 'storybook/internal/babel';
 
 import { extractDescription } from '../enrichCsf.ts';
-import { extractJSDocInfo } from '../jsdoc.ts';
+import { extractComponentDescription, extractJSDocInfo } from '../jsdoc.ts';
 
 /**
  * JSDoc tags on the docblock of the statement a path belongs to.
@@ -21,12 +21,11 @@ export function extractStoryJSDocInfo(storyStatement?: t.Node): {
   description?: string;
   summary?: string;
 } {
-  const jsdocComment = extractDescription(storyStatement);
-  const { tags = {}, description } = jsdocComment ? extractJSDocInfo(jsdocComment) : {};
-  const finalDescription = (tags?.describe?.[0] || tags?.desc?.[0]) ?? description;
+  // A story docblock resolves exactly like a `meta` one; only the tag map is component-specific.
+  const { description, summary } = extractComponentDescription(
+    extractDescription(storyStatement) || undefined,
+    undefined
+  );
 
-  return {
-    description: finalDescription?.trim(),
-    summary: tags.summary?.[0],
-  };
+  return { description, summary };
 }

--- a/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
+++ b/code/renderers/react/src/componentManifest/componentMeta/componentMetaExtractor.ts
@@ -23,8 +23,9 @@
  */
 import type ts from 'typescript';
 
+import { extractComponentJsDocInfo } from 'storybook/internal/component-meta';
+
 import type { ComponentRef, ResolvedComponentTarget } from '../types.ts';
-import { groupBy } from '../utils.ts';
 
 // ---------------------------------------------------------------------------
 // Output types — compatible with react-docgen-typescript's ComponentDoc shape
@@ -1371,25 +1372,6 @@ function computeDisplayName({
   return exportName;
 }
 
-function extractComponentJsDocTags(
-  typescript: typeof ts,
-  checker: ts.TypeChecker,
-  symbol: ts.Symbol
-): Record<string, string[]> | undefined {
-  const tags = symbol.getJsDocTags(checker);
-  if (tags.length === 0) {
-    return undefined;
-  }
-
-  const groupedTags = groupBy(tags, (tag) => tag.name);
-  return Object.fromEntries(
-    Object.entries(groupedTags).map(([name, grouped]) => [
-      name,
-      (grouped ?? []).map((tag) => typescript.displayPartsToString(tag.text ?? []).trim()),
-    ])
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Props type → ComponentDoc serialization
 // ---------------------------------------------------------------------------
@@ -1560,14 +1542,15 @@ export function serializeComponentDoc(
     }) ??
     displayNameOverride;
 
-  const description = typescript.displayPartsToString(resolved.getDocumentationComment(checker));
-  const selectedJsDocTags = extractComponentJsDocTags(typescript, checker, resolved);
+  const resolvedJsDocInfo = extractComponentJsDocInfo(typescript, checker, resolved);
+  const description = resolvedJsDocInfo.description;
+  const selectedJsDocTags = resolvedJsDocInfo.jsDocTags;
   const exportResolved =
     exportSymbol && exportSymbol !== resolved
       ? resolveAliasedSymbol(typescript, checker, exportSymbol)
       : undefined;
   const exportJsDocTags = exportResolved
-    ? extractComponentJsDocTags(typescript, checker, exportResolved)
+    ? extractComponentJsDocInfo(typescript, checker, exportResolved).jsDocTags
     : undefined;
   const jsDocTags =
     selectedJsDocTags?.import || !exportJsDocTags?.import


### PR DESCRIPTION

## What I did

The JSDoc spec is loose, it never says a block tag has to start a line, so parsers disagree and both look compliant. 

Our docgen providers will now all sit on TypeScript infrastructure, so we drop our hand-rolled parsing and take whatever TS's JSDoc APIs give us as the spec.

**The stack:** this PR adds the shared extractor in `core` and adopts it in React. PR 2 does Angular, PR 3 does Vue.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Extraction is server-side, so verify through MCP output:

1. `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. In the sandbox `.storybook/main.ts` set `features: { componentsManifest: true }` — it defaults to `false` and gates the MCP docs toolset.
3. Add `@deprecated Use NewButton instead.` and `@since 8.0` to `Button`'s docblock.
4. `yarn storybook`, then call the `docs-show` MCP tool for `example-button` against `http://localhost:6006/mcp`.
5. Expect a `> **Deprecated:** …` callout above the description and `> **Since:** 8.0` below it. Repeat with `experimentalDocgenServer: true` — output should be identical.

If a feature seems missing in the sandbox, check the dev-server log for a preset load error: after a branch switch you need `yarn nx run-many -t compile`, not just `yarn nx compile core`.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

None here — author guidance ("block tags on their own line, fence code samples") is worth a docs section once the stack lands.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below