### PR TITLE
Angular: Extract component JSDoc through TypeScript's APIs

### DIFF
--- a/code/frameworks/angular-vite/src/docgen/__testfixtures__/button.component.ts
+++ b/code/frameworks/angular-vite/src/docgen/__testfixtures__/button.component.ts
@@ -1,6 +1,16 @@
 /** Fixture: a component in its own file, imported by name from a story file. */
 import { Component, Input } from '@angular/core';
 
+/**
+ * Renders with {@link IconButton} in prose.
+ * Use together with @see ButtonGroup for accessibility.
+ *
+ * @deprecated Use NewButton.
+ * @example
+ * <sb-button label="Save">
+ *   Save
+ * </sb-button>
+ */
 @Component({ selector: 'sb-button', template: '<button>{{ label }}</button>' })
 export class ButtonComponent {
   @Input() label = 'Click me';

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.integration.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.integration.test.ts
@@ -51,6 +51,26 @@ it('builds a real payload through the TypeScript-backed analyzer', async () => {
 
   expect(payload?.error).toBeUndefined();
   expect(payload?.name).toBe('ButtonComponent');
+  expect({ description: payload?.description, jsDocTags: payload?.jsDocTags })
+    .toMatchInlineSnapshot(`
+      {
+        "description": "Renders with {@link IconButton } in prose.
+      Use together with",
+        "jsDocTags": {
+          "deprecated": [
+            "Use NewButton.",
+          ],
+          "example": [
+            "<sb-button label="Save">
+      Save
+      </sb-button>",
+          ],
+          "see": [
+            "ButtonGroup for accessibility.",
+          ],
+        },
+      }
+    `);
   expect(payload?.argTypes?.label).toMatchObject({
     name: 'label',
     table: { category: 'inputs' },

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.test.ts
@@ -192,7 +192,10 @@ describe('buildDocgenPayload', () => {
       expect(payload?.summary).toBe('A clickable button');
     });
 
-    it('does not fall back to analyzer prose when TypeScript reports an empty description', () => {
+    // TypeScript reports an empty description for a docblock that is nothing but tags, and for a
+    // class with no docblock at all. Neither means "the analyzer's description is wrong", so an
+    // empty one falls through rather than overwriting it.
+    it('falls back to analyzer prose when TypeScript reports an empty description', () => {
       givenStoryFile();
       const manager = managerReturning(
         metaFor(componentEntry({ rawdescription: 'Legacy analyzer prose.' }), {
@@ -203,8 +206,22 @@ describe('buildDocgenPayload', () => {
 
       const payload = buildDocgenPayload({ entry }, context(manager));
 
-      expect(payload?.description).toBe('');
+      expect(payload?.description).toBe('Legacy analyzer prose.');
       expect(payload?.jsDocTags).toEqual({ deprecated: ['Use NewButton.'] });
+    });
+
+    it('leaves the description undefined for an undocumented component', () => {
+      givenStoryFile();
+      const manager = managerReturning(
+        metaFor(componentEntry({ rawdescription: undefined, description: undefined }), {
+          description: '',
+          jsDocTags: {},
+        })
+      );
+
+      const payload = buildDocgenPayload({ entry }, context(manager));
+
+      expect(payload?.description).toBeUndefined();
     });
 
     it('falls back to analyzer tags when TypeScript JSDoc is unavailable', () => {

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.test.ts
@@ -80,8 +80,15 @@ const componentEntry = (overrides: Record<string, unknown> = {}): AngularClassMe
     ...overrides,
   }) as unknown as AngularClassMeta;
 
-const metaFor = (classMeta: AngularClassMeta): AngularComponentMetaResult =>
-  ({ entry: classMeta, json: { components: [classMeta] } }) as AngularComponentMetaResult;
+const metaFor = (
+  classMeta: AngularClassMeta,
+  jsDocInfo?: AngularComponentMetaResult['jsDocInfo']
+): AngularComponentMetaResult =>
+  ({
+    entry: classMeta,
+    json: { components: [classMeta] },
+    ...(jsDocInfo ? { jsDocInfo } : {}),
+  }) as AngularComponentMetaResult;
 
 const managerReturning = (meta: AngularComponentMetaResult | undefined) => ({
   extractComponentMeta: vi.fn<AngularComponentMetaSource['extractComponentMeta']>(() => meta),
@@ -142,7 +149,7 @@ describe('buildDocgenPayload', () => {
   describe('description and JSDoc tags', () => {
     it.each([
       [
-        'prefers the trimmed rawdescription',
+        'falls back to the trimmed rawdescription when TypeScript JSDoc is unavailable',
         '\n\nRenders a button.\n',
         'ignored',
         'Renders a button.',
@@ -161,17 +168,55 @@ describe('buildDocgenPayload', () => {
       expect(buildDocgenPayload({ entry }, context(manager))?.description).toBe(expected);
     });
 
-    it('publishes the analyzer`s own tags and sources `summary` from a @summary tag', () => {
+    it('publishes TypeScript-rendered tags and sources `summary` from a @summary tag', () => {
       givenStoryFile();
-      const tag = (name: string, comment?: string) => ({ tagName: { escapedText: name }, comment });
+      const manager = managerReturning(
+        metaFor(componentEntry(), {
+          description: 'Renders a TypeScript-documented button.',
+          jsDocTags: {
+            summary: ['A clickable button'],
+            see: ['a', 'b'],
+            internal: [''],
+          },
+        })
+      );
+
+      const payload = buildDocgenPayload({ entry }, context(manager));
+
+      expect(payload?.description).toBe('Renders a TypeScript-documented button.');
+      expect(payload?.jsDocTags).toEqual({
+        summary: ['A clickable button'],
+        see: ['a', 'b'],
+        internal: [''],
+      });
+      expect(payload?.summary).toBe('A clickable button');
+    });
+
+    it('does not fall back to analyzer prose when TypeScript reports an empty description', () => {
+      givenStoryFile();
+      const manager = managerReturning(
+        metaFor(componentEntry({ rawdescription: 'Legacy analyzer prose.' }), {
+          description: '',
+          jsDocTags: { deprecated: ['Use NewButton.'] },
+        })
+      );
+
+      const payload = buildDocgenPayload({ entry }, context(manager));
+
+      expect(payload?.description).toBe('');
+      expect(payload?.jsDocTags).toEqual({ deprecated: ['Use NewButton.'] });
+    });
+
+    it('falls back to analyzer tags when TypeScript JSDoc is unavailable', () => {
+      givenStoryFile();
       const manager = managerReturning(
         metaFor(
           componentEntry({
             jsdoctags: [
-              tag('summary', 'A clickable button'),
-              tag('see', 'a'),
-              tag('see', 'b'),
-              tag('internal'),
+              { tagName: { escapedText: 'summary' }, comment: 'A clickable button' },
+              { tagName: { escapedText: 'see' }, comment: 'a' },
+              { tagName: { escapedText: 'see' }, comment: 'b' },
+              { tagName: { escapedText: 'internal' } },
               { comment: 'orphan' },
               {},
             ],
@@ -181,12 +226,23 @@ describe('buildDocgenPayload', () => {
 
       const payload = buildDocgenPayload({ entry }, context(manager));
 
-      expect(payload?.jsDocTags).toEqual({
-        summary: ['A clickable button'],
-        see: ['a', 'b'],
-        internal: [''],
-      });
-      expect(payload?.summary).toBe('A clickable button');
+      expect({ summary: payload?.summary, jsDocTags: payload?.jsDocTags }).toMatchInlineSnapshot(`
+          {
+            "jsDocTags": {
+              "internal": [
+                "",
+              ],
+              "see": [
+                "a",
+                "b",
+              ],
+              "summary": [
+                "A clickable button",
+              ],
+            },
+            "summary": "A clickable button",
+          }
+        `);
     });
   });
 
@@ -196,7 +252,6 @@ describe('buildDocgenPayload', () => {
       // reads as an HTML tag.
       givenStoryFile();
       const classMeta = componentEntry({
-        jsdoctags: [{ tagName: { escapedText: 'remarks' }, comment: 'Accepts Array<string>.' }],
         inputsClass: [
           {
             name: 'items',
@@ -209,7 +264,7 @@ describe('buildDocgenPayload', () => {
 
       const payload = buildDocgenPayload({ entry }, context(managerReturning(metaFor(classMeta))));
 
-      expect(payload?.jsDocTags).toEqual({ remarks: ['Accepts Array<string>.'] });
+      expect(payload?.jsDocTags).toEqual({});
       expect(payload?.argTypes?.items?.table?.defaultValue).toEqual({
         summary: '[] as Array<string>',
       });

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.ts
@@ -66,6 +66,19 @@ const inputsOf = (entry: AngularClassMeta) =>
 const outputsOf = (entry: AngularClassMeta) =>
   'outputsClass' in entry ? (entry.outputsClass ?? []) : [];
 
+const analyzerJsDocTags = (entry: AngularClassMeta): DocgenJsDocTags => {
+  const tags: DocgenJsDocTags = {};
+  for (const tag of entry.jsdoctags ?? []) {
+    const name = tag.tagName?.escapedText;
+    if (!name) {
+      continue;
+    }
+    const value = tag.comment === undefined ? '' : String(tag.comment).trim();
+    (tags[name] ??= []).push(value);
+  }
+  return tags;
+};
+
 export const metaToSnippetMeta = (
   meta: AngularComponentMetaResult
 ): AngularComponentSnippetMeta => {
@@ -91,22 +104,6 @@ export const metaToSnippetMeta = (
       members: enumeration.childs.map((child) => ({ name: child.name, value: child.value })),
     })),
   };
-};
-
-// The description is deliberately not parsed for tags: an `@Input()` inside a documentation code
-// block would become a fabricated tag.
-const extractJsDocTags = (entry: AngularClassMeta): DocgenJsDocTags => {
-  const tags: DocgenJsDocTags = {};
-  for (const tag of entry.jsdoctags ?? []) {
-    const name = tag?.tagName?.escapedText;
-    if (!name) {
-      continue;
-    }
-    // The analyzer's comments are plain text, never the Markdown-rendered HTML Compodoc produced.
-    const value = tag.comment === undefined ? '' : String(tag.comment).trim();
-    (tags[name] ??= []).push(value);
-  }
-  return tags;
 };
 
 const errorPayload = (
@@ -234,10 +231,10 @@ export const buildDocgenPayload = (
           logger,
         }) as StrictArgTypes);
 
-  const jsDocTags = extractJsDocTags(meta.entry);
-  // Tags are excluded from `rawdescription`, which is why it wins over `description`.
-  const description =
-    meta.entry.rawdescription?.trim() || (meta.entry.description ?? '').trim() || undefined;
+  const jsDocTags: DocgenJsDocTags = meta.jsDocInfo?.jsDocTags ?? analyzerJsDocTags(meta.entry);
+  const description = meta.jsDocInfo
+    ? meta.jsDocInfo.description
+    : meta.entry.rawdescription?.trim() || meta.entry.description?.trim() || undefined;
 
   return {
     ...base,

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.ts
@@ -66,6 +66,8 @@ const inputsOf = (entry: AngularClassMeta) =>
 const outputsOf = (entry: AngularClassMeta) =>
   'outputsClass' in entry ? (entry.outputsClass ?? []) : [];
 
+const describedBy = (text: string | undefined): string | undefined => text?.trim() || undefined;
+
 const analyzerJsDocTags = (entry: AngularClassMeta): DocgenJsDocTags => {
   const tags: DocgenJsDocTags = {};
   for (const tag of entry.jsdoctags ?? []) {
@@ -232,9 +234,10 @@ export const buildDocgenPayload = (
         }) as StrictArgTypes);
 
   const jsDocTags: DocgenJsDocTags = meta.jsDocInfo?.jsDocTags ?? analyzerJsDocTags(meta.entry);
-  const description = meta.jsDocInfo
-    ? meta.jsDocInfo.description
-    : meta.entry.rawdescription?.trim() || meta.entry.description?.trim() || undefined;
+  const description =
+    describedBy(meta.jsDocInfo?.description) ??
+    describedBy(meta.entry.rawdescription) ??
+    describedBy(meta.entry.description);
 
   return {
     ...base,

--- a/code/lib/angular-cm/src/__testfixtures__/manager/aliased-default.component.ts
+++ b/code/lib/angular-cm/src/__testfixtures__/manager/aliased-default.component.ts
@@ -1,5 +1,10 @@
 import { Component, Input } from '@angular/core';
 
+/**
+ * Aliased default docs.
+ *
+ * @summary Aliased default summary.
+ */
 @Component({
   selector: 'sb-aliased-card',
   template: '<div>{{ note }}</div>',

--- a/code/lib/angular-cm/src/__testfixtures__/manager/default-export.component.ts
+++ b/code/lib/angular-cm/src/__testfixtures__/manager/default-export.component.ts
@@ -1,5 +1,10 @@
 import { Component, Input } from '@angular/core';
 
+/**
+ * Default export docs.
+ *
+ * @summary Named default summary.
+ */
 @Component({
   selector: 'sb-default-card',
   template: '<div>{{ heading }}</div>',

--- a/code/lib/angular-cm/src/manager.test.ts
+++ b/code/lib/angular-cm/src/manager.test.ts
@@ -115,6 +115,71 @@ describe('AngularComponentMetaManager', () => {
     expect(inputsOf(result).map((input) => input.name)).toContain('note');
   });
 
+  it('attaches TypeScript JSDoc info for default-exported components', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'sb-acm-jsdoc-'));
+    scratchDirs.push(dir);
+    const namedDefaultPath = normalize(join(dir, 'named-default.component.ts'));
+    const aliasedDefaultPath = normalize(join(dir, 'aliased-default.component.ts'));
+    await writeFile(
+      namedDefaultPath,
+      [
+        "import { Component } from '@angular/core';",
+        '',
+        '/**',
+        ' * Default export docs.',
+        ' *',
+        ' * @summary Named default summary.',
+        ' */',
+        "@Component({ selector: 'sb-named-default', template: '' })",
+        'export default class NamedDefaultComponent {}',
+        '',
+      ].join('\n')
+    );
+    await writeFile(
+      aliasedDefaultPath,
+      [
+        "import { Component } from '@angular/core';",
+        '',
+        '/**',
+        ' * Aliased default docs.',
+        ' *',
+        ' * @summary Aliased default summary.',
+        ' */',
+        "@Component({ selector: 'sb-aliased-default', template: '' })",
+        'class AliasedDefaultComponent {}',
+        '',
+        'export { AliasedDefaultComponent as default };',
+        '',
+      ].join('\n')
+    );
+
+    const namedDefault = manager.extractComponentMeta(namedDefaultPath, { exportName: 'default' });
+    const aliasedDefault = manager.extractComponentMeta(aliasedDefaultPath, {
+      exportName: 'default',
+    });
+
+    expect(namedDefault?.jsDocInfo).toMatchInlineSnapshot(`
+      {
+        "description": "Default export docs.",
+        "jsDocTags": {
+          "summary": [
+            "Named default summary.",
+          ],
+        },
+      }
+    `);
+    expect(aliasedDefault?.jsDocInfo).toMatchInlineSnapshot(`
+      {
+        "description": "Aliased default docs.",
+        "jsDocTags": {
+          "summary": [
+            "Aliased default summary.",
+          ],
+        },
+      }
+    `);
+  });
+
   it('resolves a component behind a star barrel to its defining file', () => {
     const barrelPath = normalize(join(fixturesDir, 'barrel-star.ts'));
     const result = manager.extractComponentMeta(barrelPath, { exportName: 'ToggleComponent' });

--- a/code/lib/angular-cm/src/manager.test.ts
+++ b/code/lib/angular-cm/src/manager.test.ts
@@ -115,48 +115,15 @@ describe('AngularComponentMetaManager', () => {
     expect(inputsOf(result).map((input) => input.name)).toContain('note');
   });
 
-  it('attaches TypeScript JSDoc info for default-exported components', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'sb-acm-jsdoc-'));
-    scratchDirs.push(dir);
-    const namedDefaultPath = normalize(join(dir, 'named-default.component.ts'));
-    const aliasedDefaultPath = normalize(join(dir, 'aliased-default.component.ts'));
-    await writeFile(
-      namedDefaultPath,
-      [
-        "import { Component } from '@angular/core';",
-        '',
-        '/**',
-        ' * Default export docs.',
-        ' *',
-        ' * @summary Named default summary.',
-        ' */',
-        "@Component({ selector: 'sb-named-default', template: '' })",
-        'export default class NamedDefaultComponent {}',
-        '',
-      ].join('\n')
+  it('attaches TypeScript JSDoc info for default-exported components', () => {
+    const namedDefault = manager.extractComponentMeta(
+      normalize(join(fixturesDir, 'default-export.component.ts')),
+      { exportName: 'default' }
     );
-    await writeFile(
-      aliasedDefaultPath,
-      [
-        "import { Component } from '@angular/core';",
-        '',
-        '/**',
-        ' * Aliased default docs.',
-        ' *',
-        ' * @summary Aliased default summary.',
-        ' */',
-        "@Component({ selector: 'sb-aliased-default', template: '' })",
-        'class AliasedDefaultComponent {}',
-        '',
-        'export { AliasedDefaultComponent as default };',
-        '',
-      ].join('\n')
+    const aliasedDefault = manager.extractComponentMeta(
+      normalize(join(fixturesDir, 'aliased-default.component.ts')),
+      { exportName: 'default' }
     );
-
-    const namedDefault = manager.extractComponentMeta(namedDefaultPath, { exportName: 'default' });
-    const aliasedDefault = manager.extractComponentMeta(aliasedDefaultPath, {
-      exportName: 'default',
-    });
 
     expect(namedDefault?.jsDocInfo).toMatchInlineSnapshot(`
       {

--- a/code/lib/angular-cm/src/project.ts
+++ b/code/lib/angular-cm/src/project.ts
@@ -1,5 +1,7 @@
 import { isInNodeModules, slash } from 'storybook/internal/common';
 import {
+  type ComponentJsDocInfo,
+  extractComponentJsDocInfo,
   type FileSnapshotCache,
   ProgramBackedProject,
   ProjectFileTracker,
@@ -108,7 +110,15 @@ export class AngularComponentMetaProject extends ProgramBackedProject<
     const entry = this.pickEntry(fileMeta, sourceFile, names);
     if (entry) {
       this.debug(`${describe(entry)} from ${fileName}`);
-      return { entry, json: fileMeta };
+      return {
+        entry,
+        json: fileMeta,
+        ...jsDocInfoField(
+          this.typescript,
+          checker,
+          findClassDeclaration(this.typescript, sourceFile, entry.name)
+        ),
+      };
     }
     const viaExports = this.extractViaModuleExports(checker, sourceFile, fileMeta, names);
     if (viaExports) {
@@ -183,7 +193,11 @@ export class AngularComponentMetaProject extends ProgramBackedProject<
           : analyzeSourceFile(this.typescript, declarationFile, checker);
       const entry = findRecord(targetMeta, declaration.name.text);
       if (entry) {
-        return { entry, json: targetMeta };
+        return {
+          entry,
+          json: targetMeta,
+          ...jsDocInfoField(this.typescript, checker, declaration),
+        };
       }
     }
     return undefined;
@@ -234,7 +248,7 @@ const allRecords = (fileMeta: AngularFileMeta): AngularClassMeta[] => [
 const declaredNames = (fileMeta: AngularFileMeta): string[] =>
   allRecords(fileMeta).map((record) => `${record.name} (${record.type})`);
 
-/** Enough of a record's shape to tell "found nothing" apart from "found it, and it was empty". */
+// Enough of a record's shape to tell "found nothing" apart from "found it, and it was empty".
 const describe = (entry: AngularClassMeta): string => {
   const counts =
     'inputsClass' in entry
@@ -249,6 +263,26 @@ const findRecord = (
   name: string | undefined
 ): AngularClassMeta | undefined =>
   name ? allRecords(fileMeta).find((record) => record.name === name) : undefined;
+
+function findClassDeclaration(
+  typescript: typeof ts,
+  sourceFile: ts.SourceFile,
+  name: string
+): ts.ClassDeclaration | undefined {
+  return sourceFile.statements.find(
+    (statement): statement is ts.ClassDeclaration =>
+      typescript.isClassDeclaration(statement) && statement.name?.text === name
+  );
+}
+
+function jsDocInfoField(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  declaration: ts.ClassDeclaration | undefined
+): { jsDocInfo?: ComponentJsDocInfo } {
+  const symbol = declaration?.name && checker.getSymbolAtLocation(declaration.name);
+  return symbol ? { jsDocInfo: extractComponentJsDocInfo(typescript, checker, symbol) } : {};
+}
 
 function findDefaultExportedClassName(
   typescript: typeof ts,

--- a/code/lib/angular-cm/src/types.ts
+++ b/code/lib/angular-cm/src/types.ts
@@ -4,6 +4,8 @@
  * The raw shape below stays close to Compodoc's JSON schema, while analyzer-owned fields use the
  * stronger contracts its successor pipeline needs. This package owns these types outright.
  */
+import type { ComponentJsDocInfo } from 'storybook/internal/component-meta';
+
 type Html = string;
 
 export interface Decorator {
@@ -203,4 +205,6 @@ export interface AngularComponentMetaResult {
   entry: AngularClassMeta;
   /** Every class in the file, for the extractor's alias and enum resolution. */
   json: MetadataJson;
+  /** Omitted when extraction reaches analyzer metadata without a class symbol. */
+  jsDocInfo?: ComponentJsDocInfo;
 }


### PR DESCRIPTION
## What I did

Angular's component-level tags now come from the shared extractor instead of the provider's own walk over the analyzer's `jsdoctags` nodes, so Angular resolves them identically to React and (next) Vue.

> [!NOTE]
>  Angular's analyzer already used TypeScript's JSDoc APIs, so what counts as a tag is unchanged by this PR — a mid-prose `@Input()` already truncated the description and already surfaced as a tag. What changes is that component tags now come from the shared extractor, so Angular resolves them identically to React and (next) Vue.
>
> The description keeps coming from the analyzer, deliberately. Its `cleanCommentText` works around bugs in TypeScript's comment renderer that would otherwise show up as:
>
> | Input | Analyzer (kept) | `displayPartsToString` (avoided) |
> | --- | --- | --- |
> | `**Bold** matters.` on an undecorated line | `**Bold** matters.` | `*Bold** matters.` |
> | `/*****` comment opener | `A button.` | `***\nA button.` |
> | `{@link url\|caption}` | pipe preserved | separator becomes a space |
## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `yarn task sandbox --template angular-cli/default-ts --start-from auto`
2. In the sandbox `.storybook/main.ts` set `features: { componentsManifest: true }` — it defaults to `false` and gates the MCP docs toolset.
3. Add `@deprecated Use NewButton instead.` and `@since 8.0` to a component class's docblock.
4. `yarn storybook`, then call the `docs-show` MCP tool for that component against `http://localhost:6006/mcp`.
5. Expect a `> **Deprecated:** …` callout above the description and `> **Since:** 8.0` below it.
6. Also check a docblock containing `@Input()` in prose and confirm the truncation described above — that's expected, not a bug.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below