### PR TITLE
Vue: Extract component JSDoc through TypeScript's APIs

### DIFF
--- a/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
@@ -19,7 +19,7 @@ const checker = createCheckerByJson(fixturesDir, { include: ['**/*'] }, CHECKER_
 async function apiDescriptionFor(fixtureCase: string): Promise<string | undefined> {
   const testDir = join(fixturesDir, fixtureCase);
   const [sfcFile] = readdirSync(testDir).filter((file) => file.endsWith('.vue'));
-  const sources = await collectComponentMetaSources(ts, checker, join(testDir, sfcFile));
+  const sources = await collectComponentMetaSources(checker, join(testDir, sfcFile), ts);
   const meta = sources.find((source) => source.exportName === 'default');
   return meta && buildApiDescription(meta);
 }

--- a/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+import ts from 'typescript';
 import { createCheckerByJson } from 'vue-component-meta';
 
 import { buildApiDescription } from '../../../../renderers/vue3/src/docgen/api-description.ts';
@@ -18,7 +19,7 @@ const checker = createCheckerByJson(fixturesDir, { include: ['**/*'] }, CHECKER_
 async function apiDescriptionFor(fixtureCase: string): Promise<string | undefined> {
   const testDir = join(fixturesDir, fixtureCase);
   const [sfcFile] = readdirSync(testDir).filter((file) => file.endsWith('.vue'));
-  const sources = await collectComponentMetaSources(checker, join(testDir, sfcFile));
+  const sources = await collectComponentMetaSources(ts, checker, join(testDir, sfcFile));
   const meta = sources.find((source) => source.exportName === 'default');
   return meta && buildApiDescription(meta);
 }

--- a/code/renderers/vue3/src/docgen/__testfixtures__/Button.stories.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/Button.stories.ts
@@ -5,6 +5,7 @@ import Button from './Button.vue';
 /**
  * A button.
  *
+ * @deprecated Use OptionsButton.
  * @summary Clickable
  */
 export default {

--- a/code/renderers/vue3/src/docgen/__testfixtures__/Button.vue
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/Button.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+/**
+ * Script setup component-file docs are not attached to the component symbol.
+ *
+ * @deprecated This component-file tag should not surface.
+ */
 defineProps<{
   /** Text shown inside the button. */
   label: string;

--- a/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/DescriptionOnlyButton.stories.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/DescriptionOnlyButton.stories.ts
@@ -1,0 +1,13 @@
+import DescriptionOnlyButton from './DescriptionOnlyButton.vue';
+
+/**
+ * Story-level description.
+ *
+ * @deprecated Use OptionsButton.
+ */
+export default {
+  title: 'Example/DescriptionOnlyButton',
+  component: DescriptionOnlyButton,
+};
+
+export const Default = { args: { label: 'Hello' } };

--- a/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/DescriptionOnlyButton.vue
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/DescriptionOnlyButton.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+/**
+ * Component description only.
+ */
+export default defineComponent({
+  props: {
+    label: String,
+  },
+});
+</script>
+
+<template>
+  <button>{{ label }}</button>
+</template>

--- a/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/MixedPrecedenceButton.stories.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/MixedPrecedenceButton.stories.ts
@@ -1,0 +1,14 @@
+import OptionsButton from './OptionsButton.vue';
+
+/**
+ * Story-level description.
+ *
+ * @summary Story summary.
+ * @deprecated Use StoryButton.
+ */
+export default {
+  title: 'Example/MixedPrecedenceButton',
+  component: OptionsButton,
+};
+
+export const Default = { args: { label: 'Hello' } };

--- a/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/OptionsButton.stories.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/OptionsButton.stories.ts
@@ -1,0 +1,8 @@
+import OptionsButton from './OptionsButton.vue';
+
+export default {
+  title: 'Example/OptionsButton',
+  component: OptionsButton,
+};
+
+export const Default = { args: { label: 'Hello' } };

--- a/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/OptionsButton.vue
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/OptionsButton.vue
@@ -1,0 +1,23 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+/**
+ * Renders with {@link IconButton} in prose.
+ * Use together with @see ButtonGroup for accessibility.
+ *
+ * @deprecated Use NewButton.
+ * @example
+ * <sb-button label="Save">
+ *   Save
+ * </sb-button>
+ */
+export default defineComponent({
+  props: {
+    label: String,
+  },
+});
+</script>
+
+<template>
+  <button>{{ label }}</button>
+</template>

--- a/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/PlainButton.stories.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/PlainButton.stories.ts
@@ -1,4 +1,4 @@
-import { PlainButton } from './PlainButton';
+import { PlainButton } from './PlainButton.ts';
 
 export default {
   title: 'Example/PlainButton',

--- a/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/PlainButton.stories.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/PlainButton.stories.ts
@@ -1,0 +1,8 @@
+import { PlainButton } from './PlainButton';
+
+export default {
+  title: 'Example/PlainButton',
+  component: PlainButton,
+};
+
+export const Default = { args: { label: 'Hello' } };

--- a/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/PlainButton.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/jsdoc/PlainButton.ts
@@ -1,0 +1,17 @@
+import { defineComponent } from 'vue';
+
+/**
+ * Renders with {@link IconButton} in prose.
+ * Use together with @see ButtonGroup for accessibility.
+ *
+ * @deprecated Use NewButton.
+ * @example
+ * <sb-button label="Save">
+ *   Save
+ * </sb-button>
+ */
+export const PlainButton = defineComponent({
+  props: {
+    label: String,
+  },
+});

--- a/code/renderers/vue3/src/docgen/build-docgen.ts
+++ b/code/renderers/vue3/src/docgen/build-docgen.ts
@@ -132,7 +132,7 @@ export async function buildDocgenPayload(
     path: component.path,
     exportName: component.exportName,
   };
-  const metaSources = await collectComponentMetaSources(context.typescript, checker, declared.path);
+  const metaSources = await collectComponentMetaSources(checker, declared.path, context.typescript);
   const componentMeta = metaSources.find((meta) => meta.exportName === declared.exportName);
 
   if (!componentMeta) {

--- a/code/renderers/vue3/src/docgen/build-docgen.ts
+++ b/code/renderers/vue3/src/docgen/build-docgen.ts
@@ -9,6 +9,8 @@ import {
 } from 'storybook/internal/csf-tools';
 import type { DocgenPayload, DocgenProviderInput } from 'storybook/internal/types';
 
+import type ts from 'typescript';
+
 import { extractArgTypes } from '../extractArgTypes.ts';
 
 import type { ComponentMetaChecker } from 'vue-component-meta';
@@ -23,6 +25,7 @@ type VueDocgenPayload = DocgenPayload & { vueComponentMeta?: MetaSource };
 export interface BuildDocgenContext {
   getChecker: (componentFilePath: string) => ComponentMetaChecker;
   resolvePath?: (importPath: string) => string;
+  typescript: typeof ts;
 }
 
 const UNRESOLVED_COMPONENT_ERRORS: Record<
@@ -129,7 +132,7 @@ export async function buildDocgenPayload(
     path: component.path,
     exportName: component.exportName,
   };
-  const metaSources = await collectComponentMetaSources(checker, declared.path);
+  const metaSources = await collectComponentMetaSources(context.typescript, checker, declared.path);
   const componentMeta = metaSources.find((meta) => meta.exportName === declared.exportName);
 
   if (!componentMeta) {
@@ -142,9 +145,11 @@ export async function buildDocgenPayload(
     };
   }
 
+  const metaJsDoc = extractDescription(csf._metaStatement) || undefined;
   const { description, summary, jsDocTags } = extractComponentDescription(
-    extractDescription(csf._metaStatement) || undefined,
-    componentMeta.description
+    metaJsDoc,
+    componentMeta.description,
+    componentMeta.jsDocTags
   );
 
   return {

--- a/code/renderers/vue3/src/docgen/component-meta.ts
+++ b/code/renderers/vue3/src/docgen/component-meta.ts
@@ -11,6 +11,11 @@ import { readFile, stat } from 'node:fs/promises';
 import { join, parse } from 'node:path';
 
 import { getProjectRoot } from 'storybook/internal/common';
+import {
+  type ComponentJsDocInfo,
+  extractComponentJsDocInfo,
+  resolveExportedSymbol,
+} from 'storybook/internal/component-meta';
 
 import {
   TypeMeta,
@@ -23,6 +28,7 @@ import {
   type SlotMeta,
 } from 'vue-component-meta';
 import { parseMulti, type ComponentDoc } from 'vue-docgen-api';
+import type ts from 'typescript';
 
 // Mirrors the JSON round-trip in toSerializableMeta: methods (e.g. `getDeclarations`) do not
 // survive it, so their keys are dropped rather than kept as unconstructible phantom fields.
@@ -36,11 +42,18 @@ type Serializable<T> = T extends AnyFunction
       ? { [K in keyof T as T[K] extends AnyFunction ? never : K]: Serializable<T[K]> }
       : T;
 
+type MetaSourceEntry = {
+  name: string;
+  meta: ComponentMeta;
+  jsDocInfo: ComponentJsDocInfo | undefined;
+};
+
 /** One component's normalized `vue-component-meta` output, tagged with the export it came from. */
 export type MetaSource = {
   exportName: string;
   displayName: string;
   sourceFiles: string;
+  jsDocTags?: Record<string, string[]>;
 } & Serializable<ComponentMeta> &
   MetaCheckerOptions['schema'];
 
@@ -92,29 +105,42 @@ export async function createVueComponentMetaChecker(
  * export cannot suppress the docgen of its siblings.
  */
 export async function collectComponentMetaSources(
+  typescript: typeof ts,
   checker: ComponentMetaChecker,
   id: string
 ): Promise<MetaSource[]> {
-  const exportNames: string[] = [];
-  let componentsMeta: ComponentMeta[] = [];
+  let entries: MetaSourceEntry[] = [];
 
   for (const name of checker.getExportNames(id)) {
+    let meta: ComponentMeta | undefined;
     try {
-      const meta = checker.getComponentMeta(id, name);
-      exportNames.push(name);
-      componentsMeta.push(meta);
+      meta = checker.getComponentMeta(id, name);
     } catch {}
+
+    if (!meta) {
+      continue;
+    }
+
+    entries.push({
+      name,
+      meta,
+      jsDocInfo: extractVueComponentJsDocInfo(typescript, checker, id, name),
+    });
   }
 
-  if (componentsMeta.length === 0) {
+  if (entries.length === 0) {
     return [];
   }
 
-  componentsMeta = await applyVueDocgenApiTempFixes(id, componentsMeta);
+  const fixedComponentsMeta = await applyVueDocgenApiTempFixes(
+    id,
+    entries.map((entry) => entry.meta)
+  );
+  entries = entries.map((entry, index) => ({ ...entry, meta: fixedComponentsMeta[index]! }));
 
   const metaSources: MetaSource[] = [];
 
-  componentsMeta.forEach((meta, index) => {
+  entries.forEach(({ name, meta, jsDocInfo }) => {
     // filter out empty meta
     const isEmpty =
       !meta.props.length && !meta.events.length && !meta.slots.length && !meta.exposed.length;
@@ -122,8 +148,6 @@ export async function collectComponentMetaSources(
     if (isEmpty || meta.type === TypeMeta.Unknown) {
       return;
     }
-
-    const exportName = exportNames[index];
 
     // we remove nested object schemas here since they are not used inside Storybook (we don't generate controls for object properties)
     // and they can cause "out of memory" issues for large/complex schemas (e.g. HTMLElement)
@@ -161,9 +185,11 @@ export async function collectComponentMetaSources(
 
     metaSources.push(
       toSerializableMeta({
-        exportName,
-        displayName: exportName === 'default' ? getFilenameWithoutExtension(id) : exportName,
+        exportName: name,
+        displayName: name === 'default' ? getFilenameWithoutExtension(id) : name,
         ...meta,
+        description: jsDocInfo?.description,
+        jsDocTags: jsDocInfo?.jsDocTags,
         exposed,
         sourceFiles: id,
       })
@@ -171,6 +197,27 @@ export async function collectComponentMetaSources(
   });
 
   return metaSources;
+}
+
+function extractVueComponentJsDocInfo(
+  typescript: typeof ts,
+  checker: ComponentMetaChecker,
+  id: string,
+  exportName: string
+): ComponentJsDocInfo | undefined {
+  const program = checker.getProgram();
+  const sourceFile = program?.getSourceFile(id.replace(/\\/g, '/'));
+  if (!program || !sourceFile) {
+    return undefined;
+  }
+
+  const typeChecker = program.getTypeChecker();
+  const symbol = resolveExportedSymbol(typescript, typeChecker, sourceFile, exportName);
+  if (!symbol) {
+    return undefined;
+  }
+
+  return extractComponentJsDocInfo(typescript, typeChecker, symbol);
 }
 
 /** Gets the filename without file extension. */

--- a/code/renderers/vue3/src/docgen/component-meta.ts
+++ b/code/renderers/vue3/src/docgen/component-meta.ts
@@ -12,11 +12,12 @@ import { join, parse } from 'node:path';
 
 import { getProjectRoot } from 'storybook/internal/common';
 import {
-  type ComponentJsDocInfo,
   extractComponentJsDocInfo,
   resolveExportedSymbol,
+  type ComponentJsDocInfo,
 } from 'storybook/internal/component-meta';
 
+import type ts from 'typescript';
 import {
   TypeMeta,
   createChecker,
@@ -28,7 +29,6 @@ import {
   type SlotMeta,
 } from 'vue-component-meta';
 import { parseMulti, type ComponentDoc } from 'vue-docgen-api';
-import type ts from 'typescript';
 
 // Mirrors the JSON round-trip in toSerializableMeta: methods (e.g. `getDeclarations`) do not
 // survive it, so their keys are dropped rather than kept as unconstructible phantom fields.
@@ -105,9 +105,9 @@ export async function createVueComponentMetaChecker(
  * export cannot suppress the docgen of its siblings.
  */
 export async function collectComponentMetaSources(
-  typescript: typeof ts,
   checker: ComponentMetaChecker,
-  id: string
+  id: string,
+  typescript?: typeof ts
 ): Promise<MetaSource[]> {
   let entries: MetaSourceEntry[] = [];
 
@@ -124,7 +124,9 @@ export async function collectComponentMetaSources(
     entries.push({
       name,
       meta,
-      jsDocInfo: extractVueComponentJsDocInfo(typescript, checker, id, name),
+      jsDocInfo: typescript
+        ? extractVueComponentJsDocInfo(typescript, checker, id, name)
+        : undefined,
     });
   }
 

--- a/code/renderers/vue3/src/docgen/docgen-worker.ts
+++ b/code/renderers/vue3/src/docgen/docgen-worker.ts
@@ -43,6 +43,7 @@ export const createDocgenProvider = (): DocgenMiddleware =>
     extract: async (manager, input) => {
       const ours = await buildDocgenPayload(input, {
         getChecker: (componentPath) => manager.getCheckerForFile(componentPath),
+        typescript: manager.typeScriptModule,
       });
       // Volar programs hold large type caches; check heap pressure after each extraction since Vue
       // has no batch surface to hang this on.

--- a/code/renderers/vue3/src/docgen/follow-re-export.test.ts
+++ b/code/renderers/vue3/src/docgen/follow-re-export.test.ts
@@ -30,6 +30,7 @@ const docgenFor = (importPath: string, title: string) =>
     {
       getChecker: (componentPath: string) => manager.getCheckerForFile(componentPath),
       resolvePath: (path: string) => join(barrelDir, path),
+      typescript: ts,
     }
   );
 

--- a/code/renderers/vue3/src/docgen/vue-project-manager.test.ts
+++ b/code/renderers/vue3/src/docgen/vue-project-manager.test.ts
@@ -19,6 +19,26 @@ const referencesDir = join(fixturesDir, 'references');
 const manager = new VueComponentMetaManager(ts);
 afterAll(() => manager.dispose());
 
+const entryFor = (importPath: string, title: string) =>
+  ({
+    type: 'story',
+    subtype: 'story',
+    id: title.toLowerCase().replace(/\W+/g, '-'),
+    name: 'Default',
+    title,
+    importPath,
+  }) as unknown as IndexEntry;
+
+const docgenForFixture = (importPath: string, title: string) =>
+  buildDocgenPayload(
+    { entry: entryFor(importPath, title) },
+    {
+      getChecker: (componentPath) => manager.getCheckerForFile(componentPath),
+      resolvePath: (path) => join(fixturesDir, path),
+      typescript: ts,
+    }
+  );
+
 describe('VueComponentMetaManager', () => {
   // The stock `create-vue` scaffold: the root tsconfig is nothing but `references`. The previous
   // single-checker path bailed to a whole-project `include: ['**/*']` fallback here (upstream:
@@ -38,20 +58,14 @@ describe('VueComponentMetaManager', () => {
   });
 
   it('extracts docgen end to end through the manager-resolved checker', async () => {
-    const entry = {
-      type: 'story',
-      subtype: 'story',
-      id: 'example-refbutton--default',
-      name: 'Default',
-      title: 'Example/RefButton',
-      importPath: './src/RefButton.stories.ts',
-    } as unknown as IndexEntry;
+    const entry = entryFor('./src/RefButton.stories.ts', 'Example/RefButton');
 
     const payload = await buildDocgenPayload(
       { entry },
       {
         getChecker: (componentPath) => manager.getCheckerForFile(componentPath),
         resolvePath: (importPath) => join(referencesDir, importPath),
+        typescript: ts,
       }
     );
 
@@ -71,6 +85,140 @@ describe('VueComponentMetaManager', () => {
     expect(payload?.apiDescription).toContain('## Props');
     // And the payload still satisfies the worker transport.
     expect(() => structuredClone(payload)).not.toThrow();
+  });
+
+  it('extracts component-level JSDoc tags from an options API SFC', async () => {
+    const payload = await docgenForFixture(
+      './jsdoc/OptionsButton.stories.ts',
+      'Example/OptionsButton'
+    );
+
+    expect(payload?.error).toBeUndefined();
+    expect({ description: payload?.description, jsDocTags: payload?.jsDocTags })
+      .toMatchInlineSnapshot(`
+        {
+          "description": "Renders with {@link IconButton } in prose.
+        Use together with",
+          "jsDocTags": {
+            "deprecated": [
+              "Use NewButton.",
+            ],
+            "example": [
+              "<sb-button label="Save">
+        Save
+        </sb-button>",
+            ],
+            "see": [
+              "ButtonGroup for accessibility.",
+            ],
+          },
+        }
+      `);
+  });
+
+  it('uses component JSDoc tags before story meta tags while keeping story-only tags', async () => {
+    const payload = await docgenForFixture(
+      './jsdoc/MixedPrecedenceButton.stories.ts',
+      'Example/MixedPrecedenceButton'
+    );
+
+    expect(payload?.error).toBeUndefined();
+    expect({
+      description: payload?.description,
+      summary: payload?.summary,
+      jsDocTags: payload?.jsDocTags,
+    }).toMatchInlineSnapshot(`
+        {
+          "description": "Story-level description.",
+          "jsDocTags": {
+            "deprecated": [
+              "Use NewButton.",
+            ],
+            "example": [
+              "<sb-button label="Save">
+        Save
+        </sb-button>",
+            ],
+            "see": [
+              "ButtonGroup for accessibility.",
+            ],
+            "summary": [
+              "Story summary.",
+            ],
+          },
+          "summary": "Story summary.",
+        }
+      `);
+  });
+
+  it('extracts component-level JSDoc tags from a plain TS component', async () => {
+    const payload = await docgenForFixture('./jsdoc/PlainButton.stories.ts', 'Example/PlainButton');
+
+    expect(payload?.error).toBeUndefined();
+    expect({ description: payload?.description, jsDocTags: payload?.jsDocTags })
+      .toMatchInlineSnapshot(`
+        {
+          "description": "Renders with {@link IconButton } in prose.
+        Use together with",
+          "jsDocTags": {
+            "deprecated": [
+              "Use NewButton.",
+            ],
+            "example": [
+              "<sb-button label="Save">
+        Save
+        </sb-button>",
+            ],
+            "see": [
+              "ButtonGroup for accessibility.",
+            ],
+          },
+        }
+      `);
+  });
+
+  it('uses story meta tags when component JSDoc has only a description', async () => {
+    const payload = await docgenForFixture(
+      './jsdoc/DescriptionOnlyButton.stories.ts',
+      'Example/DescriptionOnlyButton'
+    );
+
+    expect(payload?.error).toBeUndefined();
+    expect({
+      componentJsDocTags: payload?.vueComponentMeta?.jsDocTags,
+      description: payload?.description,
+      jsDocTags: payload?.jsDocTags,
+    }).toMatchInlineSnapshot(`
+      {
+        "componentJsDocTags": {},
+        "description": "Story-level description.",
+        "jsDocTags": {
+          "deprecated": [
+            "Use OptionsButton.",
+          ],
+        },
+      }
+    `);
+  });
+
+  it('keeps script setup component tags empty and uses the story meta docblock fallback', async () => {
+    const payload = await docgenForFixture('./Button.stories.ts', 'Example/Button');
+
+    expect(payload?.error).toBeUndefined();
+    expect({ description: payload?.description, jsDocTags: payload?.jsDocTags })
+      .toMatchInlineSnapshot(`
+        {
+          "description": "A button.",
+          "jsDocTags": {
+            "deprecated": [
+              "Use OptionsButton.",
+            ],
+            "summary": [
+              "Clickable ",
+            ],
+          },
+        }
+      `);
   });
 
   // `__testfixtures__/tsconfig.json` has no `include`, so it covers everything beneath it — but

--- a/code/renderers/vue3/src/docgen/vue-project-manager.test.ts
+++ b/code/renderers/vue3/src/docgen/vue-project-manager.test.ts
@@ -214,7 +214,7 @@ describe('VueComponentMetaManager', () => {
               "Use OptionsButton.",
             ],
             "summary": [
-              "Clickable ",
+              "Clickable",
             ],
           },
         }

--- a/code/renderers/vue3/src/docgen/vue-project-manager.ts
+++ b/code/renderers/vue3/src/docgen/vue-project-manager.ts
@@ -261,7 +261,8 @@ export class VueComponentMetaManager extends ComponentMetaManager<
   VueComponentMetaProject,
   ts.ParsedCommandLine
 > {
-  constructor(typescript: typeof ts) {
+  constructor(public readonly typeScriptModule: typeof ts) {
+    const typescript = typeScriptModule;
     super(typescript, createVueProjectFactory(typescript));
   }
 


### PR DESCRIPTION
## What I did

Last of the three. PR 1 added the shared `extractComponentJsDocInfo` in core and settled that we follow TypeScript's JSDoc semantics; PR 2 moved Angular over. 

Vue wasn't forwarding component-level tags at all, so this hooks it up: we resolve the component's export symbol through core's `resolveExportedSymbol` and pass the resulting tag map into `extractComponentDescription`.

That works for 
- plain `.ts` components (`export const Foo = defineComponent(...)`) 
- options-API SFCs. 


It doesn't work for `<script setup>`, we don't have anything in Vue SFC that allows to describe a compobnent.


## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `yarn task sandbox --template vue3-vite/default-ts --start-from auto`
2. Set `features: { componentsManifest: true }` in the sandbox's `.storybook/main.ts` — it defaults to `false` and gates the MCP docs toolset.
3. Add an options-API component (`<script>` with `export default defineComponent({...})`) and put `@deprecated Use NewButton instead.` and `@since 8.0` on its docblock.
4. `yarn storybook`, then call the `docs-show` MCP tool for it against `http://localhost:6006/mcp`.
5. You should see a `> **Deprecated:** …` line above the description and `> **Since:** 8.0` below it.
6. Try the same on a `<script setup>` component: nothing from the component file (expected), but the same tags on the story's `meta` still come through.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it
- [ ] Decl