### PR TITLE
Core: Allow token-only WebSocket upgrade without Origin

### DIFF
--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -101,6 +101,16 @@ describe('ServerChannelTransport', () => {
     vi.restoreAllMocks();
   });
 
+  it('unregisters the SIGTERM listener when closed', () => {
+    const before = process.listenerCount('SIGTERM');
+    const server = new EventEmitter() as any as Server;
+    const transport = createTransport(server);
+    expect(process.listenerCount('SIGTERM')).toBe(before + 1);
+    transport.close();
+    transport.close();
+    expect(process.listenerCount('SIGTERM')).toBe(before);
+  });
+
   it('parses simple JSON', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter();

--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'node:events';
 import { createServer, type Server } from 'node:http';
 import { connect } from 'node:net';
 import { stringify } from 'telejson';
+import type { WebSocketServer } from 'ws';
 
 import { ServerChannelTransport, getServerChannel } from '../get-server-channel.ts';
 
@@ -37,6 +38,10 @@ function closeCreatedTransports() {
   for (const transport of createdTransports.splice(0)) {
     transport.close();
   }
+}
+
+function websocketServer(transport: ServerChannelTransport) {
+  return (transport as unknown as { socket: WebSocketServer }).socket;
 }
 
 async function readRejectedUpgrade(requestLines: string[]): Promise<string> {
@@ -118,8 +123,7 @@ describe('ServerChannelTransport', () => {
     const handler = vi.fn();
     transport.setHandler(handler);
 
-    // @ts-expect-error (an internal API)
-    transport.socket.emit('connection', socket);
+    websocketServer(transport).emit('connection', socket);
     socket.emit('message', '"hello"');
 
     expect(handler).toHaveBeenCalledWith('hello');
@@ -132,8 +136,7 @@ describe('ServerChannelTransport', () => {
     const handler = vi.fn();
     transport.setHandler(handler);
 
-    // @ts-expect-error (an internal API)
-    transport.socket.emit('connection', socket);
+    websocketServer(transport).emit('connection', socket);
     socket.emit('message', JSON.stringify({ type: 'hello' }));
 
     expect(handler).toHaveBeenCalledWith({ type: 'hello' });
@@ -146,8 +149,7 @@ describe('ServerChannelTransport', () => {
     const handler = vi.fn();
     transport.setHandler(handler);
 
-    // @ts-expect-error (an internal API)
-    transport.socket.emit('connection', socket);
+    websocketServer(transport).emit('connection', socket);
 
     const input: any = { a: 1 };
     input.b = input;
@@ -210,7 +212,7 @@ describe('ServerChannelTransport', () => {
     const endSpy = vi.spyOn(socket, 'end');
     const transport = createTransport(server);
     const handleUpgradeSpy = vi
-      .spyOn(transport.socket, 'handleUpgrade')
+      .spyOn(websocketServer(transport), 'handleUpgrade')
       .mockImplementation(() => {});
 
     // Simulate upgrade request with correct token and valid origin
@@ -256,7 +258,7 @@ describe('ServerChannelTransport', () => {
     const endSpy = vi.spyOn(socket, 'end');
     const transport = createTransport(server);
     const handleUpgradeSpy = vi
-      .spyOn(transport.socket, 'handleUpgrade')
+      .spyOn(websocketServer(transport), 'handleUpgrade')
       .mockImplementation(() => {});
 
     const request = {
@@ -278,7 +280,7 @@ describe('ServerChannelTransport', () => {
     const endSpy = vi.spyOn(socket, 'end');
     const transport = createTransport(server);
     const handleUpgradeSpy = vi
-      .spyOn(transport.socket, 'handleUpgrade')
+      .spyOn(websocketServer(transport), 'handleUpgrade')
       .mockImplementation(() => {});
 
     const request = {
@@ -300,7 +302,7 @@ describe('ServerChannelTransport', () => {
     const endSpy = vi.spyOn(socket, 'end');
     const transport = createTransport(server);
     const handleUpgradeSpy = vi
-      .spyOn(transport.socket, 'handleUpgrade')
+      .spyOn(websocketServer(transport), 'handleUpgrade')
       .mockImplementation(() => {});
 
     const request = {
@@ -322,7 +324,7 @@ describe('ServerChannelTransport', () => {
     const endSpy = vi.spyOn(socket, 'end');
     const transport = createTransport(server);
     const handleUpgradeSpy = vi
-      .spyOn(transport.socket, 'handleUpgrade')
+      .spyOn(websocketServer(transport), 'handleUpgrade')
       .mockImplementation(() => {});
 
     // Simulate upgrade request with network address origin
@@ -347,7 +349,7 @@ describe('ServerChannelTransport', () => {
     const endSpy = vi.spyOn(socket, 'end');
     const transport = createTransport(server);
     const handleUpgradeSpy = vi
-      .spyOn(transport.socket, 'handleUpgrade')
+      .spyOn(websocketServer(transport), 'handleUpgrade')
       .mockImplementation(() => {});
 
     // Simulate upgrade request with 127.0.0.1 origin
@@ -372,7 +374,7 @@ describe('ServerChannelTransport', () => {
     const endSpy = vi.spyOn(socket, 'end');
     const transport = createTransport(server);
     const handleUpgradeSpy = vi
-      .spyOn(transport.socket, 'handleUpgrade')
+      .spyOn(websocketServer(transport), 'handleUpgrade')
       .mockImplementation(() => {});
 
     // Simulate upgrade request to wrong path
@@ -398,7 +400,7 @@ describe('ServerChannelTransport', () => {
     const endSpy = vi.spyOn(socket, 'end');
     const transport = createTransport(server, webContainerOptions);
     const handleUpgradeSpy = vi
-      .spyOn(transport.socket, 'handleUpgrade')
+      .spyOn(websocketServer(transport), 'handleUpgrade')
       .mockImplementation(() => {});
 
     const request = {
@@ -422,7 +424,7 @@ describe('ServerChannelTransport', () => {
     const endSpy = vi.spyOn(socket, 'end');
     const transport = createTransport(server, webContainerOptions);
     const handleUpgradeSpy = vi
-      .spyOn(transport.socket, 'handleUpgrade')
+      .spyOn(websocketServer(transport), 'handleUpgrade')
       .mockImplementation(() => {});
 
     const request = {

--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -22,6 +22,23 @@ const webContainerOptions = {
   skipValidation: true,
 } as any;
 
+const createdTransports: ServerChannelTransport[] = [];
+
+function createTransport(
+  server: Server,
+  transportOptions: typeof options = options
+): ServerChannelTransport {
+  const transport = new ServerChannelTransport(server, transportOptions);
+  createdTransports.push(transport);
+  return transport;
+}
+
+function closeCreatedTransports() {
+  for (const transport of createdTransports.splice(0)) {
+    transport.close();
+  }
+}
+
 async function readRejectedUpgrade(requestLines: string[]): Promise<string> {
   const server = createServer();
   await new Promise<void>((resolve) => {
@@ -31,7 +48,7 @@ async function readRejectedUpgrade(requestLines: string[]): Promise<string> {
   if (!address || typeof address === 'string') {
     throw new Error('expected a TCP address');
   }
-  new ServerChannelTransport(server, options);
+  const transport = new ServerChannelTransport(server, options);
   const client = connect({ host: '127.0.0.1', port: address.port });
   try {
     return await new Promise<string>((resolve, reject) => {
@@ -45,6 +62,7 @@ async function readRejectedUpgrade(requestLines: string[]): Promise<string> {
     });
   } finally {
     client.destroy();
+    transport.close();
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });
@@ -52,15 +70,23 @@ async function readRejectedUpgrade(requestLines: string[]): Promise<string> {
 }
 
 describe('getServerChannel', () => {
+  afterEach(() => {
+    closeCreatedTransports();
+  });
+
   it('should return a channel', () => {
     const server = { on: vi.fn() } as any as Server;
     const result = getServerChannel(server, options);
+    // @ts-expect-error private transports
+    createdTransports.push(...result.transports);
     expect(result).toBeInstanceOf(Channel);
   });
 
   it('should attach to the http server', () => {
     const server = { on: vi.fn() } as any as Server;
-    getServerChannel(server, options);
+    const result = getServerChannel(server, options);
+    // @ts-expect-error private transports
+    createdTransports.push(...result.transports);
     expect(server.on).toHaveBeenCalledWith('upgrade', expect.any(Function));
   });
 });
@@ -71,13 +97,14 @@ describe('ServerChannelTransport', () => {
   });
 
   afterEach(() => {
+    closeCreatedTransports();
     vi.restoreAllMocks();
   });
 
   it('parses simple JSON', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter();
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handler = vi.fn();
     transport.setHandler(handler);
 
@@ -91,7 +118,7 @@ describe('ServerChannelTransport', () => {
   it('parses object JSON', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter();
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handler = vi.fn();
     transport.setHandler(handler);
 
@@ -105,7 +132,7 @@ describe('ServerChannelTransport', () => {
   it('supports telejson cyclical data', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter();
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handler = vi.fn();
     transport.setHandler(handler);
 
@@ -129,7 +156,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
 
     // Simulate upgrade request without token
     const request = {
@@ -150,7 +177,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    new ServerChannelTransport(server, options);
+    createTransport(server);
 
     // Simulate upgrade request with wrong token
     const request = {
@@ -171,7 +198,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
       .mockImplementation(() => {});
@@ -196,7 +223,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
 
     // Simulate upgrade request with invalid origin
     const request = {
@@ -217,7 +244,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
       .mockImplementation(() => {});
@@ -239,7 +266,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
       .mockImplementation(() => {});
@@ -261,7 +288,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
       .mockImplementation(() => {});
@@ -283,7 +310,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
       .mockImplementation(() => {});
@@ -308,7 +335,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
       .mockImplementation(() => {});
@@ -333,7 +360,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, options);
+    const transport = createTransport(server);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
       .mockImplementation(() => {});
@@ -359,7 +386,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, webContainerOptions);
+    const transport = createTransport(server, webContainerOptions);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
       .mockImplementation(() => {});
@@ -383,7 +410,7 @@ describe('ServerChannelTransport', () => {
     const socket = new EventEmitter() as any;
     socket.end = vi.fn();
     const endSpy = vi.spyOn(socket, 'end');
-    const transport = new ServerChannelTransport(server, webContainerOptions);
+    const transport = createTransport(server, webContainerOptions);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
       .mockImplementation(() => {});

--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Channel } from 'storybook/internal/channels';
 
-import { EventEmitter } from 'events';
-import type { Server } from 'http';
+import { EventEmitter } from 'node:events';
+import { createServer, type Server } from 'node:http';
+import { connect } from 'node:net';
 import { stringify } from 'telejson';
 
 import { ServerChannelTransport, getServerChannel } from '../get-server-channel.ts';
@@ -20,6 +21,35 @@ const webContainerOptions = {
   ...options,
   skipValidation: true,
 } as any;
+
+async function readRejectedUpgrade(requestLines: string[]): Promise<string> {
+  const server = createServer();
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('expected a TCP address');
+  }
+  new ServerChannelTransport(server, options);
+  const client = connect({ host: '127.0.0.1', port: address.port });
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      client.on('data', (chunk) => chunks.push(chunk));
+      client.on('error', reject);
+      client.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      client.on('connect', () => {
+        client.write(`${requestLines.join('\r\n')}\r\n\r\n`);
+      });
+    });
+  } finally {
+    client.destroy();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
 describe('getServerChannel', () => {
   it('should return a channel', () => {
@@ -97,9 +127,8 @@ describe('ServerChannelTransport', () => {
   it('rejects connections without token', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, options);
 
     // Simulate upgrade request without token
@@ -113,18 +142,14 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).toHaveBeenCalledWith(
-      'HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'
-    );
-    expect(destroySpy).toHaveBeenCalled();
+    expect(endSpy).toHaveBeenCalledWith('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
   });
 
   it('rejects connections with invalid token', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     new ServerChannelTransport(server, options);
 
     // Simulate upgrade request with wrong token
@@ -138,18 +163,14 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).toHaveBeenCalledWith(
-      'HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'
-    );
-    expect(destroySpy).toHaveBeenCalled();
+    expect(endSpy).toHaveBeenCalledWith('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
   });
 
   it('accepts connections with valid token', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, options);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
@@ -166,17 +187,15 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).not.toHaveBeenCalled();
-    expect(destroySpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
     expect(handleUpgradeSpy).toHaveBeenCalled();
   });
 
   it('rejects connections with invalid origin', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, options);
 
     // Simulate upgrade request with invalid origin
@@ -190,18 +209,14 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).toHaveBeenCalledWith(
-      'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
-    );
-    expect(destroySpy).toHaveBeenCalled();
+    expect(endSpy).toHaveBeenCalledWith('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
   });
 
   it('accepts connections without origin header when the token is valid', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, options);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
@@ -215,17 +230,15 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).not.toHaveBeenCalled();
-    expect(destroySpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
     expect(handleUpgradeSpy).toHaveBeenCalled();
   });
 
   it('rejects connections without origin header when the token is invalid', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, options);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
@@ -239,19 +252,15 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).toHaveBeenCalledWith(
-      'HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'
-    );
-    expect(destroySpy).toHaveBeenCalled();
+    expect(endSpy).toHaveBeenCalledWith('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
     expect(handleUpgradeSpy).not.toHaveBeenCalled();
   });
 
   it('rejects connections without origin header and without token', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, options);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
@@ -265,19 +274,15 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).toHaveBeenCalledWith(
-      'HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'
-    );
-    expect(destroySpy).toHaveBeenCalled();
+    expect(endSpy).toHaveBeenCalledWith('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
     expect(handleUpgradeSpy).not.toHaveBeenCalled();
   });
 
   it('accepts connections with network address origin', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, options);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
@@ -294,17 +299,15 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).not.toHaveBeenCalled();
-    expect(destroySpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
     expect(handleUpgradeSpy).toHaveBeenCalled();
   });
 
   it('accepts connections with 127.0.0.1 origin', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, options);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
@@ -321,17 +324,15 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).not.toHaveBeenCalled();
-    expect(destroySpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
     expect(handleUpgradeSpy).toHaveBeenCalled();
   });
 
   it('rejects connections to wrong path', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, options);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
@@ -350,16 +351,14 @@ describe('ServerChannelTransport', () => {
 
     // Should not call handleUpgrade for wrong path
     expect(handleUpgradeSpy).not.toHaveBeenCalled();
-    // Socket should not be destroyed for wrong path (just ignored)
-    expect(destroySpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
   });
 
   it('accepts connections without token when validation is disabled', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, webContainerOptions);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
@@ -375,17 +374,15 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).not.toHaveBeenCalled();
-    expect(destroySpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
     expect(handleUpgradeSpy).toHaveBeenCalled();
   });
 
   it('accepts connections with invalid origin when validation is disabled', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
-    socket.write = vi.fn();
-    socket.destroy = vi.fn();
-    const destroySpy = vi.spyOn(socket, 'destroy');
+    socket.end = vi.fn();
+    const endSpy = vi.spyOn(socket, 'end');
     const transport = new ServerChannelTransport(server, webContainerOptions);
     const handleUpgradeSpy = vi
       .spyOn(transport.socket, 'handleUpgrade')
@@ -401,8 +398,28 @@ describe('ServerChannelTransport', () => {
 
     server.listeners('upgrade')[0](request, socket, head);
 
-    expect(socket.write).not.toHaveBeenCalled();
-    expect(destroySpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
     expect(handleUpgradeSpy).toHaveBeenCalled();
+  });
+
+  it('flushes HTTP 401 to a real client when the token is missing', async () => {
+    const response = await readRejectedUpgrade([
+      'GET /storybook-server-channel HTTP/1.1',
+      'Host: 127.0.0.1',
+      'Connection: Upgrade',
+      'Upgrade: websocket',
+    ]);
+    expect(response).toContain('HTTP/1.1 401 Unauthorized');
+  });
+
+  it('flushes HTTP 403 to a real client when Origin is invalid', async () => {
+    const response = await readRejectedUpgrade([
+      `GET /storybook-server-channel?token=${mockToken} HTTP/1.1`,
+      'Host: 127.0.0.1',
+      'Connection: Upgrade',
+      'Upgrade: websocket',
+      'Origin: http://malicious-site.com',
+    ]);
+    expect(response).toContain('HTTP/1.1 403 Forbidden');
   });
 });

--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -114,7 +114,7 @@ describe('ServerChannelTransport', () => {
     server.listeners('upgrade')[0](request, socket, head);
 
     expect(socket.write).toHaveBeenCalledWith(
-      'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
+      'HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'
     );
     expect(destroySpy).toHaveBeenCalled();
   });
@@ -139,7 +139,7 @@ describe('ServerChannelTransport', () => {
     server.listeners('upgrade')[0](request, socket, head);
 
     expect(socket.write).toHaveBeenCalledWith(
-      'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
+      'HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'
     );
     expect(destroySpy).toHaveBeenCalled();
   });
@@ -150,12 +150,10 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, options);
-
-    // Mock handleUpgrade to track if it's called
-    // @ts-expect-error (accessing private property)
-    transport.socket.handleUpgrade = handleUpgradeSpy;
+    const handleUpgradeSpy = vi
+      .spyOn(transport.socket, 'handleUpgrade')
+      .mockImplementation(() => {});
 
     // Simulate upgrade request with correct token and valid origin
     const request = {
@@ -204,11 +202,10 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, options);
-
-    // @ts-expect-error (accessing private property)
-    transport.socket.handleUpgrade = handleUpgradeSpy;
+    const handleUpgradeSpy = vi
+      .spyOn(transport.socket, 'handleUpgrade')
+      .mockImplementation(() => {});
 
     const request = {
       url: `/storybook-server-channel?token=${mockToken}`,
@@ -229,11 +226,10 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, options);
-
-    // @ts-expect-error (accessing private property)
-    transport.socket.handleUpgrade = handleUpgradeSpy;
+    const handleUpgradeSpy = vi
+      .spyOn(transport.socket, 'handleUpgrade')
+      .mockImplementation(() => {});
 
     const request = {
       url: '/storybook-server-channel?token=wrong-token',
@@ -244,7 +240,7 @@ describe('ServerChannelTransport', () => {
     server.listeners('upgrade')[0](request, socket, head);
 
     expect(socket.write).toHaveBeenCalledWith(
-      'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
+      'HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'
     );
     expect(destroySpy).toHaveBeenCalled();
     expect(handleUpgradeSpy).not.toHaveBeenCalled();
@@ -256,11 +252,10 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, options);
-
-    // @ts-expect-error (accessing private property)
-    transport.socket.handleUpgrade = handleUpgradeSpy;
+    const handleUpgradeSpy = vi
+      .spyOn(transport.socket, 'handleUpgrade')
+      .mockImplementation(() => {});
 
     const request = {
       url: '/storybook-server-channel',
@@ -271,7 +266,7 @@ describe('ServerChannelTransport', () => {
     server.listeners('upgrade')[0](request, socket, head);
 
     expect(socket.write).toHaveBeenCalledWith(
-      'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
+      'HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'
     );
     expect(destroySpy).toHaveBeenCalled();
     expect(handleUpgradeSpy).not.toHaveBeenCalled();
@@ -283,12 +278,10 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, options);
-
-    // Mock handleUpgrade to track if it's called
-    // @ts-expect-error (accessing private property)
-    transport.socket.handleUpgrade = handleUpgradeSpy;
+    const handleUpgradeSpy = vi
+      .spyOn(transport.socket, 'handleUpgrade')
+      .mockImplementation(() => {});
 
     // Simulate upgrade request with network address origin
     const request = {
@@ -312,12 +305,10 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, options);
-
-    // Mock handleUpgrade to track if it's called
-    // @ts-expect-error (accessing private property)
-    transport.socket.handleUpgrade = handleUpgradeSpy;
+    const handleUpgradeSpy = vi
+      .spyOn(transport.socket, 'handleUpgrade')
+      .mockImplementation(() => {});
 
     // Simulate upgrade request with 127.0.0.1 origin
     const request = {
@@ -341,12 +332,10 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, options);
-
-    // Mock handleUpgrade to track if it's called
-    // @ts-expect-error (accessing private property)
-    transport.socket.handleUpgrade = handleUpgradeSpy;
+    const handleUpgradeSpy = vi
+      .spyOn(transport.socket, 'handleUpgrade')
+      .mockImplementation(() => {});
 
     // Simulate upgrade request to wrong path
     const request = {
@@ -371,12 +360,10 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, webContainerOptions);
-
-    // Mock handleUpgrade to track if it's called
-    // @ts-expect-error (accessing private property)
-    transport.socket.handleUpgrade = handleUpgradeSpy;
+    const handleUpgradeSpy = vi
+      .spyOn(transport.socket, 'handleUpgrade')
+      .mockImplementation(() => {});
 
     const request = {
       url: '/storybook-server-channel',
@@ -399,12 +386,10 @@ describe('ServerChannelTransport', () => {
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
-    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, webContainerOptions);
-
-    // Mock handleUpgrade to track if it's called
-    // @ts-expect-error (accessing private property)
-    transport.socket.handleUpgrade = handleUpgradeSpy;
+    const handleUpgradeSpy = vi
+      .spyOn(transport.socket, 'handleUpgrade')
+      .mockImplementation(() => {});
 
     const request = {
       url: '/storybook-server-channel?token=wrong-token',

--- a/code/core/src/core-server/utils/__tests__/server-channel.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-channel.test.ts
@@ -198,17 +198,45 @@ describe('ServerChannelTransport', () => {
     expect(destroySpy).toHaveBeenCalled();
   });
 
-  it('rejects connections without origin header', () => {
+  it('accepts connections without origin header when the token is valid', () => {
     const server = new EventEmitter() as any as Server;
     const socket = new EventEmitter() as any;
     socket.write = vi.fn();
     socket.destroy = vi.fn();
     const destroySpy = vi.spyOn(socket, 'destroy');
+    const handleUpgradeSpy = vi.fn();
     const transport = new ServerChannelTransport(server, options);
 
-    // Simulate upgrade request without origin header
+    // @ts-expect-error (accessing private property)
+    transport.socket.handleUpgrade = handleUpgradeSpy;
+
     const request = {
       url: `/storybook-server-channel?token=${mockToken}`,
+      headers: {},
+    } as any;
+    const head = Buffer.from('');
+
+    server.listeners('upgrade')[0](request, socket, head);
+
+    expect(socket.write).not.toHaveBeenCalled();
+    expect(destroySpy).not.toHaveBeenCalled();
+    expect(handleUpgradeSpy).toHaveBeenCalled();
+  });
+
+  it('rejects connections without origin header when the token is invalid', () => {
+    const server = new EventEmitter() as any as Server;
+    const socket = new EventEmitter() as any;
+    socket.write = vi.fn();
+    socket.destroy = vi.fn();
+    const destroySpy = vi.spyOn(socket, 'destroy');
+    const handleUpgradeSpy = vi.fn();
+    const transport = new ServerChannelTransport(server, options);
+
+    // @ts-expect-error (accessing private property)
+    transport.socket.handleUpgrade = handleUpgradeSpy;
+
+    const request = {
+      url: '/storybook-server-channel?token=wrong-token',
       headers: {},
     } as any;
     const head = Buffer.from('');
@@ -219,6 +247,34 @@ describe('ServerChannelTransport', () => {
       'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
     );
     expect(destroySpy).toHaveBeenCalled();
+    expect(handleUpgradeSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects connections without origin header and without token', () => {
+    const server = new EventEmitter() as any as Server;
+    const socket = new EventEmitter() as any;
+    socket.write = vi.fn();
+    socket.destroy = vi.fn();
+    const destroySpy = vi.spyOn(socket, 'destroy');
+    const handleUpgradeSpy = vi.fn();
+    const transport = new ServerChannelTransport(server, options);
+
+    // @ts-expect-error (accessing private property)
+    transport.socket.handleUpgrade = handleUpgradeSpy;
+
+    const request = {
+      url: '/storybook-server-channel',
+      headers: {},
+    } as any;
+    const head = Buffer.from('');
+
+    server.listeners('upgrade')[0](request, socket, head);
+
+    expect(socket.write).toHaveBeenCalledWith(
+      'HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n'
+    );
+    expect(destroySpy).toHaveBeenCalled();
+    expect(handleUpgradeSpy).not.toHaveBeenCalled();
   });
 
   it('accepts connections with network address origin', () => {

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -90,6 +90,10 @@ export class ServerChannelTransport {
     });
   }
 
+  close() {
+    this.socket.close();
+  }
+
   setHandler(handler: ChannelHandler) {
     this.handler = handler;
   }

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -44,15 +44,13 @@ export class ServerChannelTransport {
           // which the token alone authenticates.
           const { origin } = request.headers;
           if (origin && !isValidHost(new URL(origin).host, options)) {
-            socket.write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
-            socket.destroy();
+            socket.end('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
             return;
           }
 
           const requestToken = url.searchParams.get('token');
           if (!isValidToken(requestToken, options.token)) {
-            socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
-            socket.destroy();
+            socket.end('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
             return;
           }
         }
@@ -62,8 +60,7 @@ export class ServerChannelTransport {
         });
       } catch (error) {
         logger.warn(`Rejecting WebSocket connection: ${error}`);
-        socket.write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
-        socket.destroy();
+        socket.end('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
       }
     });
 

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -29,6 +29,17 @@ export class ServerChannelTransport {
 
   private handler?: ChannelHandler;
 
+  private closed = false;
+
+  private readonly onSigterm = () => {
+    this.socket.clients.forEach((client) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.close(1001, 'Server is shutting down');
+      }
+    });
+    this.socket.close(() => process.exit(0));
+  };
+
   constructor(server: Server, options: ServerChannelTransportOptions) {
     this.socket = new WebSocketServer({ noServer: true });
 
@@ -80,17 +91,15 @@ export class ServerChannelTransport {
       clearInterval(interval);
     });
 
-    process.on('SIGTERM', () => {
-      this.socket.clients.forEach((client) => {
-        if (client.readyState === WebSocket.OPEN) {
-          client.close(1001, 'Server is shutting down');
-        }
-      });
-      this.socket.close(() => process.exit(0));
-    });
+    process.on('SIGTERM', this.onSigterm);
   }
 
   close() {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    process.removeListener('SIGTERM', this.onSigterm);
     this.socket.close();
   }
 

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -40,8 +40,10 @@ export class ServerChannelTransport {
         }
 
         if (!options.skipValidation) {
-          const originHost = request.headers.origin && new URL(request.headers.origin).host;
-          if (!isValidHost(originHost, options)) {
+          // Browsers always send Origin on upgrades, so an absent one means a non-browser client,
+          // which the token alone authenticates.
+          const { origin } = request.headers;
+          if (origin && !isValidHost(new URL(origin).host, options)) {
             throw new Error('Invalid websocket origin');
           }
 

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -44,12 +44,16 @@ export class ServerChannelTransport {
           // which the token alone authenticates.
           const { origin } = request.headers;
           if (origin && !isValidHost(new URL(origin).host, options)) {
-            throw new Error('Invalid websocket origin');
+            socket.write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
+            socket.destroy();
+            return;
           }
 
           const requestToken = url.searchParams.get('token');
           if (!isValidToken(requestToken, options.token)) {
-            throw new Error('Invalid websocket token');
+            socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+            socket.destroy();
+            return;
           }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What I did

For security reasons, the WebSocket connection was rejecting upgrade requests without an `Origin` header or with an invalid `Origin` header. However, for Node clients (like our attached tools CLI), an `Origin` header is not sent (and doesn't make sense), so the absence of the header should be allowed as long as the security token is correct. Browsers always send the `Origin` header.

Also improved the closing of the connection - when the server is stopped (SIGTERM), clients are now notified.

Outline for you to rewrite:

Linear: SB-1870

## Checklist

- [ ] The PR title references an [open Issue](https://github.com/storybookjs/storybook/issues?q=is%3Aopen+is%3Aissue) or an [open discussion](https://github.com/storybookjs/storybook/discussions)
- [ ] The PR targets the `next` branch
- [ ] Make sure all of the relevant checks are passing
- [ ] Add a test if applicable
- [ ] List your changes in the changelog

#### Manual testing

1. Start the internal Storybook UI: `cd code && yarn storybook:ui`.
2. Confirm it is up: `curl --fail --silent --show-error localhost:6006/index.json`.
3. Read `attachToken` from a live record in `~/.storybook/instances/*.json`.
4. Open a TCP WebSocket upgrade to `/storybook-server-channel?token=<attachToken>` with no `Origin` header. The upgrade should succeed.
5. Repeat with a wrong token and no `Origin`. Expect `HTTP/1.1 401 Unauthorized`.
6. Repeat with a valid token and `Origin: http://malicious-site.com`. Expect `HTTP/1.1 403 Forbidden`.

Unit coverage: `cd code && yarn vitest run --config core/vitest.config.ts core/src/core-server/utils/__tests__/server-channel.test.ts`

## QA

```bash
yarn test get-server-channel
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732e6c14-a542-4611-b1f8-ff132284900b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732e6c14-a542-4611-b1f8-ff132284900b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

