### PR TITLE
Open Service: Add delegated mode for Open Service transports

### DIFF
--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -287,12 +287,14 @@ export class OpenServiceRemoteCommandDisconnectedError extends StorybookError {
 }
 
 export class OpenServiceRemoteCommandUnhandledError extends StorybookError {
-  constructor(public data: { serviceId: ServiceId; commandName: string }) {
+  constructor(public data: { serviceId: ServiceId; commandName: string; delegated?: boolean }) {
     super({
       name: 'OpenServiceRemoteCommandUnhandledError',
       category: Category.CORE_COMMON,
       code: 15,
-      message: `No runtime acknowledged remote command "${data.serviceId}.${data.commandName}"; its handler is not implemented in any connected runtime.`,
+      message: data.delegated
+        ? `No runtime acknowledged remote command "${data.serviceId}.${data.commandName}"; this runtime delegates every command to the Storybook it is attached to, and that Storybook was started with a different configuration. Restart it so the command's handler is available.`
+        : `No runtime acknowledged remote command "${data.serviceId}.${data.commandName}"; its handler is not implemented in any connected runtime.`,
     });
   }
 }

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -710,8 +710,10 @@ Every registered runtime plays **both** roles at once, decided per command:
   validates input, mutates state, and broadcasts the post-mutation snapshot through the normal command
   wrappers so every peer converges — then emits `services:command-result` or `services:command-error`.
 
-A runtime never requests a command it implements (it runs that locally), so a responder never answers
-its own invoke echo: `onInvoke` only acts on commands in its `implementedCommandNames` set.
+Outside [delegated mode](#delegated-mode), a runtime never requests a command it implements (it runs
+that locally), so a responder never answers its own invoke echo: `onInvoke` only acts on commands in
+its `implementedCommandNames` set. A delegated runtime does request commands it implements — that is
+how dispatch reaches the Storybook it attached to.
 
 ### Events
 
@@ -805,10 +807,12 @@ rejects outstanding calls with `OpenServiceRemoteCommandDisconnectedError`.
 ### Delegated mode
 
 A runtime that attaches to an already-running Storybook (rather than starting its own) must not
-execute anything itself: the Storybook it attached to owns the story index, the module graph, and the
-providers, so it is the implementer for every command. `setDelegatedMode(true)` in
-[service-registry.ts](./service-registry.ts) puts the whole runtime in that role; `isDelegatedMode()`
-reads it and the default is `false`.
+dispatch commands locally: the Storybook it attached to owns the story index, the module graph, and
+the providers, so it is the implementer for every command. Loads, toolset methods, and query handlers
+still run in this process. `setDelegatedMode(true)` in [service-registry.ts](./service-registry.ts)
+puts command dispatch in that role; `isDelegatedMode()` reads it and the default is `false`. The flag
+lives on the same realm-global inventory as the service map, so every import path in one realm sees
+the same value.
 
 What changes is **dispatch**, not registration:
 

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -72,7 +72,7 @@ Internal tests and implementation code may import from the individual modules di
 - [errors.ts](./errors.ts): validation metadata formatting helpers
 - [service-runtime.ts](./service-runtime.ts): signal-backed runtime construction (state, commands, static loader) that assembles one service instance
 - [query-runtime.ts](./query-runtime.ts): the query surface (`.get()` / `.loaded()` / `.subscribe()`), the in-flight load registry, the `.loaded()` drain logic, and subscriptions
-- [service-registry.ts](./service-registry.ts): the single `registerService`, the realm-global registry, and the shared registry API passed into runtimes — used identically by server, manager, and preview
+- [service-registry.ts](./service-registry.ts): the single `registerService`, the realm-global registry, the runtime-wide delegated-mode flag, and the shared registry API passed into runtimes — used identically by server, manager, and preview
 - [service-channel.ts](./service-channel.ts): `ServiceChannel` interface, event name constants, and payload types
 - [service-error-serialization.ts](./service-error-serialization.ts): transport-safe (de)serialization of thrown errors and their `cause` chains, used by remote command replies
 - [channel-slot.ts](../../channels/channel-slot.ts): `getChannel` / `setChannel` — the shared channel install surface
@@ -213,8 +213,9 @@ Query handlers do **not** receive `commands` or `setState`. Mutations belong in 
 
 The runtime guards re-firing: a superseded run (its dependencies changed again before it finished) cannot overwrite a newer run's state, and changes batched together produce a single re-load.
 
-**Keep `load` bodies as small as possible.** Almost always, `load` should be a one-liner that calls a command — the real work (input resolution, side effects, validation, state mutation) belongs in the command. This pays off for three reasons:
+**A `load` body triggers commands; it never computes.** Almost always, `load` is a one-liner that calls a command — the real work (input resolution, side effects, validation, state mutation) belongs in the command. `core/docgen` is the canonical shape: its `docgen` load is `await ctx.self.commands.extractDocgen(input)` and nothing else. This pays off for four reasons:
 
+- **Delegation.** A command is the unit that can cross the channel; a load body is not. When a runtime runs in [delegated mode](#delegated-mode), a thin load stays correct unchanged — the load runs locally, the command executes on the peer, and the state comes back as a patch. Work done inline in the load would instead run in the wrong runtime, where the server context it needs does not exist. Thin loads are what make delegation transitive: every query that only triggers commands delegates for free.
 - **Reusability.** Anyone can call the command directly (other services, tests, integrations) without going through the query's load path. Logic stuck inside a load is unreachable from outside the drain.
 - **Testability.** Commands have a typed input/output contract you can assert against. Load bodies don't return anything useful.
 - **Clear contract.** A query says "read state". A command says "do work that produces state". A bloated load blurs the line and makes the service harder to reason about.
@@ -801,6 +802,34 @@ query's `load` calls a server-only command. Once a peer acknowledges, the reques
 `services:command-result` or `services:command-error` as before. Unregistering the service still
 rejects outstanding calls with `OpenServiceRemoteCommandDisconnectedError`.
 
+### Delegated mode
+
+A runtime that attaches to an already-running Storybook (rather than starting its own) must not
+execute anything itself: the Storybook it attached to owns the story index, the module graph, and the
+providers, so it is the implementer for every command. `setDelegatedMode(true)` in
+[service-registry.ts](./service-registry.ts) puts the whole runtime in that role; `isDelegatedMode()`
+reads it and the default is `false`.
+
+What changes is **dispatch**, not registration:
+
+- Every command call routes over the channel (`services:command-invoke` → ack → result), including
+  commands this runtime implements locally. Local implementations become inert for dispatch.
+- Incoming `services:command-invoke` is ignored. This runtime is the caller, so answering its own
+  request would ack and execute locally — exactly what delegation exists to prevent.
+- Load bodies follow the same route, which is why [thin loads](#load) matter: the load runs locally,
+  the command runs on the peer, and the state returns as a patch.
+- Implementations stay registered and inspectable. Handlers are **not** stripped at registration, and
+  there is no `delegated` field on per-service `ServiceRegistrationOptions` — service authors write
+  one definition that works in both roles.
+
+The flag is runtime-wide and read at registration time, like the installed channel, so set it once at
+the entry boundary before the first `registerService` call. `clearRegistry()` resets it.
+
+When nothing acknowledges within `REMOTE_COMMAND_ACK_TIMEOUT_MS`, the resulting
+`OpenServiceRemoteCommandUnhandledError` carries delegation-specific guidance instead of "not
+implemented in any connected runtime": the attached Storybook was started with a different
+configuration, so it must be restarted for that command's handler to exist.
+
 ## React Hooks
 
 ### `useServiceQuery`
@@ -914,7 +943,7 @@ const ready = await exampleService.queries.value.loaded({ entryId: 'a' });
 - State must be a plain object — no primitives, `null`, or top-level arrays (see [State must be an object](#state-must-be-an-object)). Wrap collections in a field: `{ items: [] }`.
 - Always declare both `input` and `output` schemas on every query and command.
 - Use `load` for read-side warming. The hook is async and must mutate via commands.
-- **Keep `load` bodies minimal — ideally one line that calls a command.** Push input resolution, side effects, and state mutation into the command itself so it stays callable, testable, and reusable on its own.
+- **Keep `load` bodies minimal — a load triggers commands, it never computes.** Push input resolution, side effects, and state mutation into the command itself so it stays callable, testable, reusable, and delegable to another runtime.
 - Query handlers are strict readers: sync, no commands, no `setState`.
 - Use commands for all state mutation.
 - Manager addons import from `storybook/manager-api`; preview code imports from `storybook/preview-api`. Server presets use [server.ts](./server.ts). Import modules in this directory directly only from tests or implementation code.
@@ -928,7 +957,7 @@ const ready = await exampleService.queries.value.loaded({ entryId: 'a' });
 - Validation behavior belongs in [service-validation.test.ts](./service-validation.test.ts)
 - Server registration and static snapshot behavior belong in [server.test.ts](./server.test.ts)
 - Leaf channel sync (`relay: false`, preview path) belongs in [service-transport-leaf.test.ts](./service-transport-leaf.test.ts); hub channel sync (dev server) in [service-registration-sync.test.ts](./service-registration-sync.test.ts)
-- Remote command execution (requester/responder protocol) belongs in [service-command-transport.test.ts](./service-command-transport.test.ts); error (de)serialization in [service-error-serialization.test.ts](./service-error-serialization.test.ts)
+- Remote command execution (requester/responder protocol) belongs in [service-command-transport.test.ts](./service-command-transport.test.ts); delegated dispatch in [service-delegated-mode.test.ts](./service-delegated-mode.test.ts); error (de)serialization in [service-error-serialization.test.ts](./service-error-serialization.test.ts)
 - React hook behavior belongs in [use-service-query.test.tsx](./use-service-query.test.tsx) and [use-service-command.test.tsx](./use-service-command.test.tsx)
 - Reusable scenario definitions belong in [fixtures.ts](./fixtures.ts)
 
@@ -944,7 +973,7 @@ React hook tests must include `// @vitest-environment happy-dom` as the first li
 - If you need to change validation wording, start in [errors.ts](./errors.ts).
 - If you need to change schema handling, start in [service-validation.ts](./service-validation.ts).
 - If you need to change service authoring ergonomics, start in [service-definition.ts](./service-definition.ts) and [types.ts](./types.ts).
-- If you need to change channel transport, relay behavior, or remote command execution, start in [service-transport.ts](./service-transport.ts).
+- If you need to change channel transport, relay behavior, remote command execution, or delegated dispatch, start in [service-transport.ts](./service-transport.ts) — the delegated-mode flag itself lives in [service-registry.ts](./service-registry.ts).
 - If you need to change how thrown errors cross the channel for remote commands, start in [service-error-serialization.ts](./service-error-serialization.ts).
 - If you need to change last-write-wins ordering or the structural merge, start in [service-sync.ts](./service-sync.ts).
 - If you need to change the channel protocol (event names, payloads, channel reader), start in [service-channel.ts](./service-channel.ts).

--- a/code/core/src/shared/open-service/service-delegated-mode.test.ts
+++ b/code/core/src/shared/open-service/service-delegated-mode.test.ts
@@ -91,6 +91,19 @@ describe('delegated mode flag', () => {
     clearRegistry();
     expect(isDelegatedMode()).toBe(false);
   });
+
+  it('shares the flag with a separately loaded copy of this module', async () => {
+    setDelegatedMode(true);
+
+    vi.resetModules();
+    const other = await import('./service-registry.ts');
+
+    expect(isDelegatedMode()).toBe(true);
+    expect(other.isDelegatedMode()).toBe(true);
+
+    other.setDelegatedMode(false);
+    expect(isDelegatedMode()).toBe(false);
+  });
 });
 
 describe('delegated command dispatch', () => {

--- a/code/core/src/shared/open-service/service-delegated-mode.test.ts
+++ b/code/core/src/shared/open-service/service-delegated-mode.test.ts
@@ -1,0 +1,263 @@
+import * as v from 'valibot';
+
+import { afterEach, describe, expect, it, onTestFinished, vi } from 'vitest';
+
+import { createTestChannel, installTestChannel } from '../../channels/test-channel.ts';
+import { OpenServiceRemoteCommandUnhandledError } from '../../server-errors.ts';
+import { mutableRecordLookupServiceDef } from './fixtures.ts';
+import {
+  SERVICE_COMMAND_ACK,
+  SERVICE_COMMAND_INVOKE,
+  SERVICE_COMMAND_RESULT,
+  SERVICE_PATCHES,
+  type CommandInvokePayload,
+} from './service-channel.ts';
+import { defineService } from './service-definition.ts';
+import {
+  clearRegistry,
+  isDelegatedMode,
+  registerService,
+  setDelegatedMode,
+} from './service-registry.ts';
+import { REMOTE_COMMAND_ACK_TIMEOUT_MS } from './service-transport.ts';
+
+const locallyImplementedServiceDef = defineService({
+  id: 'internal-fixture/delegated-local-implementation',
+  description: 'Implements its command locally, so only delegation can route it to a peer.',
+  initialState: {} as Record<string, never>,
+  queries: {},
+  commands: {
+    doThing: {
+      description: 'Returns a marker naming the runtime that ran it.',
+      input: v.object({ value: v.string() }),
+      output: v.string(),
+      handler: async () => 'ran-locally',
+    },
+  },
+});
+
+const componentIdInputSchema = v.object({ id: v.string() });
+const docgenOutputSchema = v.optional(v.string());
+
+// Mirrors `core/docgen`: the query's load only triggers the extraction command, which writes state.
+const thinLoadServiceDef = defineService({
+  id: 'internal-fixture/delegated-thin-load',
+  description: 'Reads extracted docgen that a command writes into state.',
+  initialState: { components: {} } as { components: Record<string, string> },
+  queries: {
+    docgen: {
+      description: 'Returns the docgen for one component id, or undefined when not extracted.',
+      input: componentIdInputSchema,
+      output: docgenOutputSchema,
+      handler: (input, ctx) => ctx.self.state.components[input.id],
+      load: async (input, ctx) => {
+        await ctx.self.commands.extractDocgen(input);
+      },
+    },
+  },
+  commands: {
+    extractDocgen: {
+      description: 'Extracts docgen for one component id and stores it.',
+      input: componentIdInputSchema,
+      output: docgenOutputSchema,
+      handler: async (input, ctx) => {
+        ctx.self.setState((state) => {
+          state.components[input.id] = 'extracted-locally';
+        });
+        return 'extracted-locally';
+      },
+    },
+  },
+});
+
+function emittedCalls(channel: ReturnType<typeof createTestChannel>, event: string) {
+  return channel.emit.mock.calls.filter(([name]) => name === event);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearRegistry();
+  setDelegatedMode(false);
+  installTestChannel(null);
+});
+
+describe('delegated mode flag', () => {
+  it('defaults to off and is reset by clearRegistry', () => {
+    expect(isDelegatedMode()).toBe(false);
+
+    setDelegatedMode(true);
+    expect(isDelegatedMode()).toBe(true);
+
+    clearRegistry();
+    expect(isDelegatedMode()).toBe(false);
+  });
+});
+
+describe('delegated command dispatch', () => {
+  it('invokes a locally implemented command over the channel and never runs the local handler', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+    const handlerSpy = vi.spyOn(
+      mutableRecordLookupServiceDef.commands.assignRecordField,
+      'handler'
+    );
+    onTestFinished(() => {
+      handlerSpy.mockRestore();
+    });
+
+    setDelegatedMode(true);
+    const service = registerService(mutableRecordLookupServiceDef);
+
+    const promise = service.commands.assignRecordField({
+      entryId: 'a',
+      fieldKey: 'k',
+      fieldValue: 'v',
+    });
+
+    const invokes = emittedCalls(channel, SERVICE_COMMAND_INVOKE);
+    expect(invokes).toHaveLength(1);
+    expect(invokes[0][1]).toMatchObject({
+      serviceId: mutableRecordLookupServiceDef.id,
+      commandName: 'assignRecordField',
+      input: { entryId: 'a', fieldKey: 'k', fieldValue: 'v' },
+    });
+
+    const { callId } = invokes[0][1] as CommandInvokePayload;
+    channel.emitExternal(SERVICE_COMMAND_ACK, {
+      serviceId: mutableRecordLookupServiceDef.id,
+      callId,
+      clientId: 'peer',
+    });
+    channel.emitExternal(SERVICE_PATCHES, {
+      serviceId: mutableRecordLookupServiceDef.id,
+      state: { a: { k: 'v' } },
+      version: 1,
+      clientId: 'peer',
+    });
+    channel.emitExternal(SERVICE_COMMAND_RESULT, {
+      serviceId: mutableRecordLookupServiceDef.id,
+      callId,
+      result: undefined,
+      clientId: 'peer',
+    });
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(handlerSpy).not.toHaveBeenCalled();
+    expect(service.queries.recordFields.get({ entryId: 'a' })).toEqual({ k: 'v' });
+  });
+
+  it('ignores an incoming invoke for a command it implements', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+    const handlerSpy = vi.spyOn(
+      mutableRecordLookupServiceDef.commands.assignRecordField,
+      'handler'
+    );
+    onTestFinished(() => {
+      handlerSpy.mockRestore();
+    });
+
+    setDelegatedMode(true);
+    registerService(mutableRecordLookupServiceDef);
+
+    channel.emitExternal(SERVICE_COMMAND_INVOKE, {
+      serviceId: mutableRecordLookupServiceDef.id,
+      commandName: 'assignRecordField',
+      input: { entryId: 'a', fieldKey: 'k', fieldValue: 'v' },
+      callId: 'call-1',
+      clientId: 'requester',
+    });
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+    expect(emittedCalls(channel, SERVICE_COMMAND_ACK)).toHaveLength(0);
+    expect(emittedCalls(channel, SERVICE_COMMAND_RESULT)).toHaveLength(0);
+    expect(handlerSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects with restart guidance when no peer acknowledges the invoke', async () => {
+    vi.useFakeTimers();
+
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    setDelegatedMode(true);
+    const service = registerService(locallyImplementedServiceDef);
+
+    const failure = service.commands.doThing({ value: 'hi' }).catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(REMOTE_COMMAND_ACK_TIMEOUT_MS);
+
+    const error = await failure;
+    expect(error).toBeInstanceOf(OpenServiceRemoteCommandUnhandledError);
+    expect((error as Error).message).toBe(
+      'No runtime acknowledged remote command "internal-fixture/delegated-local-implementation.doThing"; this runtime delegates every command to the Storybook it is attached to, and that Storybook was started with a different configuration. Restart it so the command\'s handler is available.'
+    );
+  });
+
+  it('runs the local handler without touching the channel when delegated mode is off', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+    const handlerSpy = vi.spyOn(
+      mutableRecordLookupServiceDef.commands.assignRecordField,
+      'handler'
+    );
+    onTestFinished(() => {
+      handlerSpy.mockRestore();
+    });
+
+    const service = registerService(mutableRecordLookupServiceDef);
+
+    await service.commands.assignRecordField({ entryId: 'a', fieldKey: 'k', fieldValue: 'v' });
+
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+    expect(emittedCalls(channel, SERVICE_COMMAND_INVOKE)).toHaveLength(0);
+    expect(service.queries.recordFields.get({ entryId: 'a' })).toEqual({ k: 'v' });
+  });
+});
+
+describe('delegated thin loads', () => {
+  it('delegates the command a query load triggers and reads the peer-patched state back', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+    const handlerSpy = vi.spyOn(thinLoadServiceDef.commands.extractDocgen, 'handler');
+    onTestFinished(() => {
+      handlerSpy.mockRestore();
+    });
+
+    setDelegatedMode(true);
+    const service = registerService(thinLoadServiceDef);
+
+    const promise = service.queries.docgen.loaded({ id: 'button' });
+
+    await vi.waitFor(() => expect(emittedCalls(channel, SERVICE_COMMAND_INVOKE)).toHaveLength(1));
+
+    const invoke = emittedCalls(channel, SERVICE_COMMAND_INVOKE)[0][1] as CommandInvokePayload;
+    expect(invoke).toMatchObject({
+      serviceId: thinLoadServiceDef.id,
+      commandName: 'extractDocgen',
+      input: { id: 'button' },
+    });
+
+    channel.emitExternal(SERVICE_COMMAND_ACK, {
+      serviceId: thinLoadServiceDef.id,
+      callId: invoke.callId,
+      clientId: 'peer',
+    });
+    channel.emitExternal(SERVICE_PATCHES, {
+      serviceId: thinLoadServiceDef.id,
+      state: { components: { button: 'extracted-on-peer' } },
+      version: 1,
+      clientId: 'peer',
+    });
+    channel.emitExternal(SERVICE_COMMAND_RESULT, {
+      serviceId: thinLoadServiceDef.id,
+      callId: invoke.callId,
+      result: 'extracted-on-peer',
+      clientId: 'peer',
+    });
+
+    await expect(promise).resolves.toBe('extracted-on-peer');
+    expect(handlerSpy).not.toHaveBeenCalled();
+    expect(service.queries.docgen.get({ id: 'button' })).toBe('extracted-on-peer');
+  });
+});

--- a/code/core/src/shared/open-service/service-registry.ts
+++ b/code/core/src/shared/open-service/service-registry.ts
@@ -54,24 +54,34 @@ type RegistryEntry = {
 
 const REGISTRY_SYMBOL = Symbol.for('storybook.open-service.registry');
 
+type RegistryInventory = {
+  entries: Map<string, RegistryEntry>;
+  delegatedMode: boolean;
+};
+
 /**
- * Returns the realm-global registry backing service registration.
+ * Returns the realm-global inventory backing service registration and delegated mode.
  *
  * Lazily created so importing the module does not eagerly mutate global state. Anchoring it on a
- * `globalThis` symbol keeps runtime lookups, static builds, and tests pointed at one service inventory
- * even when the module is reached through different import paths.
+ * `globalThis` symbol keeps the service map and the delegated-mode flag shared even when this file is
+ * reached through different import paths.
  */
-function getRegistry(): Map<string, RegistryEntry> {
+function getInventory(): RegistryInventory {
   const registryGlobal = globalThis as {
-    [key: symbol]: Map<string, RegistryEntry> | undefined;
+    [key: symbol]: RegistryInventory | undefined;
   };
 
-  registryGlobal[REGISTRY_SYMBOL] ??= new Map<string, RegistryEntry>();
+  registryGlobal[REGISTRY_SYMBOL] ??= {
+    entries: new Map<string, RegistryEntry>(),
+    delegatedMode: false,
+  };
 
   return registryGlobal[REGISTRY_SYMBOL];
 }
 
-let delegatedMode = false;
+function getRegistry(): Map<string, RegistryEntry> {
+  return getInventory().entries;
+}
 
 /**
  * Marks this runtime as delegated, so every registered service dispatches its commands over the
@@ -83,12 +93,12 @@ let delegatedMode = false;
  * attached to is the implementer.
  */
 export function setDelegatedMode(enabled: boolean): void {
-  delegatedMode = enabled;
+  getInventory().delegatedMode = enabled;
 }
 
 /** Whether this runtime delegates command dispatch to the Storybook it is attached to. */
 export function isDelegatedMode(): boolean {
-  return delegatedMode;
+  return getInventory().delegatedMode;
 }
 
 function assertUniqueOperationNames(definition: AnyServiceDefinition): void {
@@ -316,7 +326,7 @@ export function registerService<
     commands: runtime.commands as Record<string, (input: unknown) => Promise<unknown>>,
     implementedCommandNames,
     commandNames: Object.keys(resolvedDefinition.commands),
-    delegated: delegatedMode,
+    delegated: isDelegatedMode(),
     runtime,
   });
 
@@ -420,5 +430,5 @@ export function clearRegistry(): void {
   }
 
   registry.clear();
-  delegatedMode = false;
+  getInventory().delegatedMode = false;
 }

--- a/code/core/src/shared/open-service/service-registry.ts
+++ b/code/core/src/shared/open-service/service-registry.ts
@@ -71,6 +71,26 @@ function getRegistry(): Map<string, RegistryEntry> {
   return registryGlobal[REGISTRY_SYMBOL];
 }
 
+let delegatedMode = false;
+
+/**
+ * Marks this runtime as delegated, so every registered service dispatches its commands over the
+ * channel instead of running local handlers.
+ *
+ * Set it once at the runtime entry boundary, before any `registerService` call — it is read at
+ * registration time, like the installed channel. Service definitions are unaffected: their handlers
+ * stay registered and inspectable, they simply never run here because the Storybook this runtime
+ * attached to is the implementer.
+ */
+export function setDelegatedMode(enabled: boolean): void {
+  delegatedMode = enabled;
+}
+
+/** Whether this runtime delegates command dispatch to the Storybook it is attached to. */
+export function isDelegatedMode(): boolean {
+  return delegatedMode;
+}
+
 function assertUniqueOperationNames(definition: AnyServiceDefinition): void {
   const duplicateName = Object.keys(definition.queries).find((name) =>
     Object.hasOwn(definition.commands, name)
@@ -276,7 +296,8 @@ export function registerService<
 
   // A command may only have a handler in some runtimes (e.g. supplied at server registration). Where
   // a local handler exists, callers run it locally and broadcast; where it does not, the resulting
-  // command routes calls to a peer that implements it and awaits the reply.
+  // command routes calls to a peer that implements it and awaits the reply. A delegated runtime
+  // routes every command to its peer regardless.
   const implementedCommandNames = new Set<string>(
     Object.entries(resolvedDefinition.commands)
       .filter(([, command]) => typeof command.handler === 'function')
@@ -295,6 +316,7 @@ export function registerService<
     commands: runtime.commands as Record<string, (input: unknown) => Promise<unknown>>,
     implementedCommandNames,
     commandNames: Object.keys(resolvedDefinition.commands),
+    delegated: delegatedMode,
     runtime,
   });
 
@@ -384,7 +406,8 @@ export function unregisterService(serviceId: ServiceId): void {
 }
 
 /**
- * Clears the registry, tearing down each service's channel listeners first.
+ * Clears the registry, tearing down each service's channel listeners first, and resets delegated
+ * mode.
  *
  * Tests call this after each case so registrations — and the channel listeners a registration attaches
  * — from one scenario do not leak into the next.
@@ -397,4 +420,5 @@ export function clearRegistry(): void {
   }
 
   registry.clear();
+  delegatedMode = false;
 }

--- a/code/core/src/shared/open-service/service-transport.ts
+++ b/code/core/src/shared/open-service/service-transport.ts
@@ -289,6 +289,13 @@ export function connectRuntimeToChannel(
  * can invoke a command implemented in either. Command events are *not* relayed across a hub's other
  * transports, so a preview cannot directly invoke a server-only command (and vice versa) — route such
  * calls through the manager or implement the command on a directly-connected peer.
+ *
+ * ## Delegated mode
+ *
+ * A delegated runtime (one attached to an already-running Storybook) owns no dispatch at all: it
+ * requests *every* command over the channel and answers no invoke, because the runtime it attached
+ * to is the implementer. Local handlers stay registered and inspectable but never run, so a service
+ * author writes the same definition either way.
  */
 export function connectCommandTransport(context: {
   /** Id of the service these commands belong to; stamped on every emitted envelope. */
@@ -305,9 +312,23 @@ export function connectCommandTransport(context: {
   implementedCommandNames: ReadonlySet<string>;
   /** Every command name declared by the service definition. */
   commandNames: readonly string[];
+  /** Whether this runtime delegates all dispatch to the peer it is attached to. */
+  delegated: boolean;
 }): { commands: Record<string, RuntimeCommand>; disconnect: () => void } {
-  const { serviceId, ownClientId, channel, localCommands, implementedCommandNames, commandNames } =
-    context;
+  const {
+    serviceId,
+    ownClientId,
+    channel,
+    localCommands,
+    implementedCommandNames,
+    commandNames,
+    delegated,
+  } = context;
+
+  // A delegated runtime dispatches nothing itself, so its local handlers are inert on both sides of
+  // the protocol: it requests every command and answers no invoke.
+  const dispatchesLocally = (commandName: string): boolean =>
+    !delegated && implementedCommandNames.has(commandName);
 
   // Requester bookkeeping: in-flight remote calls keyed by callId, settled by the first reply.
   const pending = new Map<string, PendingRemoteCommand>();
@@ -328,7 +349,7 @@ export function connectCommandTransport(context: {
     if (
       !parsed.success ||
       parsed.output.serviceId !== serviceId ||
-      !implementedCommandNames.has(parsed.output.commandName)
+      !dispatchesLocally(parsed.output.commandName)
     ) {
       return;
     }
@@ -410,6 +431,7 @@ export function connectCommandTransport(context: {
             new OpenServiceRemoteCommandUnhandledError({
               serviceId,
               commandName: entry.commandName,
+              delegated,
             })
           )
         );
@@ -428,7 +450,7 @@ export function connectCommandTransport(context: {
 
   const commands: Record<string, RuntimeCommand> = {};
   for (const name of commandNames) {
-    commands[name] = implementedCommandNames.has(name)
+    commands[name] = dispatchesLocally(name)
       ? localCommands[name]
       : (input: unknown) => requestRemote(name, input);
   }
@@ -479,6 +501,8 @@ export function connectServiceToChannel(
     implementedCommandNames: ReadonlySet<string>;
     /** Every command name declared by the service definition. */
     commandNames: readonly string[];
+    /** Whether this runtime delegates all dispatch to the peer it is attached to. */
+    delegated: boolean;
     /** Runtime to wire with the channel-routed command map for load bodies. */
     runtime: ChannelConnectedRuntime;
   }
@@ -493,6 +517,7 @@ export function connectServiceToChannel(
     commands,
     implementedCommandNames,
     commandNames,
+    delegated,
     runtime,
   } = context;
 
@@ -515,6 +540,7 @@ export function connectServiceToChannel(
     localCommands: broadcastCommands,
     implementedCommandNames,
     commandNames,
+    delegated,
   });
 
   const disconnectSync = connectRuntimeToChannel({
@@ -527,8 +553,12 @@ export function connectServiceToChannel(
   });
 
   // Load bodies call commands through the channel-routed map so a command implemented only on a peer
-  // is requested remotely instead of throwing locally.
-  runtime.attachChannelCommands(commandTransport.commands, implementedCommandNames);
+  // is requested remotely instead of throwing locally. A delegated runtime dispatches none of its
+  // commands, so every name counts as remote here too.
+  runtime.attachChannelCommands(
+    commandTransport.commands,
+    delegated ? new Set<string>() : implementedCommandNames
+  );
 
   return {
     commands: commandTransport.commands,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## What I did

Adds a new `delegateMode` to the open service runtime. When this is enabled, no local commands are ever executed even if they are implemented in the locally registered service - the runtime acts as if they are not registered, and asks other runtimes (via the channel) to execute the command instead.

This is necessary for the attached tools CLI, as it _will_ have local implementations for eg. `docgen.extractDocgen` (because its service registry is identical to that of the dev server's), but we don't want to run the command in the tools CLI, we want to run the command on the dev server instead, to re-use its warm cache.

Linear: SB-1872. Independent. Base: `next`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No UI change. Maintainer QA:

```bash
yarn test server.test
```

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732e6c14-a542-4611-b1f8-ff132284900b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732e6c14-a542-4611-b1f8-ff132284900b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

