### PR TITLE
Core: Add createNodeChannel for Node WebSocket clients

### DIFF
--- a/code/core/build-config.ts
+++ b/code/core/build-config.ts
@@ -100,6 +100,13 @@ const config: BuildEntries = {
         exportEntries: ['./internal/mocking-utils'],
         entryPoint: './src/mocking-utils/index.ts',
       },
+      {
+        // Node client for a dev server's websocket channel. Deliberately not re-exported from the
+        // `./internal/channels` barrel, which is a browser entry: neither `ws` nor `server-errors.ts`
+        // may reach a manager or preview bundle.
+        exportEntries: ['./internal/channels/node'],
+        entryPoint: './src/channels/node/index.ts',
+      },
     ],
     browser: [
       {

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -78,6 +78,11 @@
       "code": "./src/channels/index.ts",
       "default": "./dist/channels/index.js"
     },
+    "./internal/channels/node": {
+      "types": "./dist/channels/node/index.d.ts",
+      "code": "./src/channels/node/index.ts",
+      "default": "./dist/channels/node/index.js"
+    },
     "./internal/cli": {
       "types": "./dist/cli/index.d.ts",
       "code": "./src/cli/index.ts",

--- a/code/core/src/channels/index.ts
+++ b/code/core/src/channels/index.ts
@@ -4,7 +4,7 @@ import { UniversalStore } from '../shared/universal-store/index.ts';
 import { Channel } from './main.ts';
 import { PostMessageTransport } from './postmessage/index.ts';
 import type { ChannelTransport, Config } from './types.ts';
-import { WebsocketTransport } from './websocket/index.ts';
+import { SERVER_CHANNEL_PATH, WebsocketTransport } from './websocket/index.ts';
 
 export * from './main.ts';
 export {
@@ -23,7 +23,9 @@ export {
   WebsocketTransport,
   HEARTBEAT_INTERVAL,
   HEARTBEAT_MAX_LATENCY,
+  SERVER_CHANNEL_PATH,
 } from './websocket/index.ts';
+export type { ChannelWebSocket } from './websocket/index.ts';
 
 type Options = Config & {
   extraTransports?: ChannelTransport[];
@@ -45,7 +47,7 @@ export function createBrowserChannel({ page, extraTransports = [] }: Options): C
     const protocol = window.location.protocol === 'http:' ? 'ws' : 'wss';
     const { hostname, port } = window.location;
     const { wsToken } = globalThis.CHANNEL_OPTIONS || {};
-    const channelUrl = `${protocol}://${hostname}:${port}/storybook-server-channel?token=${wsToken}`;
+    const channelUrl = `${protocol}://${hostname}:${port}${SERVER_CHANNEL_PATH}?token=${wsToken}`;
 
     transports.push(new WebsocketTransport({ url: channelUrl, onError: () => {}, page }));
   }

--- a/code/core/src/channels/node/index.test.ts
+++ b/code/core/src/channels/node/index.test.ts
@@ -5,7 +5,7 @@ import { CHANNEL_WS_DISCONNECT } from 'storybook/internal/core-events';
 
 import { isJSON, parse, stringify } from 'telejson';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type WebSocket, WebSocketServer } from 'ws';
+import { WebSocket, WebSocketServer } from 'ws';
 
 import { SERVER_CHANNEL_PATH } from '../websocket/index.ts';
 import { createNodeChannel } from './index.ts';
@@ -19,10 +19,19 @@ let upgradeUrls: string[];
 let originHeaders: (string | undefined)[];
 let connections: WebSocket[];
 let receivedByServer: any[];
+let created: ReturnType<typeof createNodeChannel>[] = [];
 
 const firstConnection = async () => {
   await vi.waitFor(() => expect(connections).toHaveLength(1));
   return connections[0];
+};
+
+const openNodeChannel = (
+  options: { url: string; token: string } = { url: baseUrl, token: TOKEN }
+) => {
+  const connection = createNodeChannel(options);
+  created.push(connection);
+  return connection;
 };
 
 beforeEach(async () => {
@@ -30,6 +39,7 @@ beforeEach(async () => {
   originHeaders = [];
   connections = [];
   receivedByServer = [];
+  created = [];
 
   httpServer = createServer();
   wsServer = new WebSocketServer({ noServer: true });
@@ -55,6 +65,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  created.forEach((connection) => connection.close());
+  created = [];
   connections.forEach((ws) => ws.terminate());
   wsServer.close();
   await new Promise<void>((resolve) => httpServer.close(() => resolve()));
@@ -62,28 +74,28 @@ afterEach(async () => {
 
 describe('createNodeChannel', () => {
   it('connects to the server channel path with the token in the query string', async () => {
-    createNodeChannel({ url: baseUrl, token: TOKEN });
+    openNodeChannel({ url: baseUrl, token: TOKEN });
 
     await firstConnection();
     expect(upgradeUrls).toEqual([`${SERVER_CHANNEL_PATH}?token=${TOKEN}`]);
   });
 
   it('sends no Origin header, which browsers cannot omit', async () => {
-    createNodeChannel({ url: baseUrl, token: TOKEN });
+    openNodeChannel({ url: baseUrl, token: TOKEN });
 
     await firstConnection();
     expect(originHeaders).toEqual([undefined]);
   });
 
   it('replaces the path and query of the given base url', async () => {
-    createNodeChannel({ url: `${baseUrl}/some/base/path?existing=param`, token: TOKEN });
+    openNodeChannel({ url: `${baseUrl}/some/base/path?existing=param`, token: TOKEN });
 
     await firstConnection();
     expect(upgradeUrls).toEqual([`${SERVER_CHANNEL_PATH}?token=${TOKEN}`]);
   });
 
   it('replies to a server ping with a pong', async () => {
-    createNodeChannel({ url: baseUrl, token: TOKEN });
+    openNodeChannel({ url: baseUrl, token: TOKEN });
     const connection = await firstConnection();
 
     connection.send(stringify({ type: 'ping' }));
@@ -92,7 +104,7 @@ describe('createNodeChannel', () => {
   });
 
   it('does not surface transport pings as channel events', async () => {
-    const { channel } = createNodeChannel({ url: baseUrl, token: TOKEN });
+    const { channel } = openNodeChannel({ url: baseUrl, token: TOKEN });
     const onPing = vi.fn();
     channel.on('ping', onPing);
     const connection = await firstConnection();
@@ -104,7 +116,7 @@ describe('createNodeChannel', () => {
   });
 
   it('round-trips telejson-only values in both directions', async () => {
-    const { channel } = createNodeChannel({ url: baseUrl, token: TOKEN });
+    const { channel } = openNodeChannel({ url: baseUrl, token: TOKEN });
     const connection = await firstConnection();
 
     channel.emit('outgoing', { when: new Date('2026-08-20T00:00:00.000Z'), pattern: /token/gi });
@@ -133,7 +145,7 @@ describe('createNodeChannel', () => {
   });
 
   it('emits CHANNEL_WS_DISCONNECT and rejects with a dev server disconnected error on close', async () => {
-    const { channel, disconnected } = createNodeChannel({ url: baseUrl, token: TOKEN });
+    const { channel, disconnected } = openNodeChannel({ url: baseUrl, token: TOKEN });
     const disconnects: any[] = [];
     channel.on(CHANNEL_WS_DISCONNECT, (payload) => disconnects.push(payload));
     const connection = await firstConnection();
@@ -147,8 +159,17 @@ describe('createNodeChannel', () => {
   it('rejects with a dev server disconnected error when the server was never reachable', async () => {
     await new Promise<void>((resolve) => httpServer.close(() => resolve()));
 
-    const { disconnected } = createNodeChannel({ url: baseUrl, token: TOKEN });
+    const { disconnected } = openNodeChannel({ url: baseUrl, token: TOKEN });
 
     await expect(disconnected).rejects.toThrow('Storybook dev server disconnected');
+  });
+
+  it('closes the client socket from the caller', async () => {
+    const connection = openNodeChannel({ url: baseUrl, token: TOKEN });
+    const serverSocket = await firstConnection();
+
+    connection.close();
+
+    await vi.waitFor(() => expect(serverSocket.readyState).toBe(WebSocket.CLOSED));
   });
 });

--- a/code/core/src/channels/node/index.test.ts
+++ b/code/core/src/channels/node/index.test.ts
@@ -1,0 +1,154 @@
+import { type Server, createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { CHANNEL_WS_DISCONNECT } from 'storybook/internal/core-events';
+
+import { isJSON, parse, stringify } from 'telejson';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type WebSocket, WebSocketServer } from 'ws';
+
+import { SERVER_CHANNEL_PATH } from '../websocket/index.ts';
+import { createNodeChannel } from './index.ts';
+
+const TOKEN = 'a-dev-server-token';
+
+let httpServer: Server;
+let wsServer: WebSocketServer;
+let baseUrl: string;
+let upgradeUrls: string[];
+let originHeaders: (string | undefined)[];
+let connections: WebSocket[];
+let receivedByServer: any[];
+
+const firstConnection = async () => {
+  await vi.waitFor(() => expect(connections).toHaveLength(1));
+  return connections[0];
+};
+
+beforeEach(async () => {
+  upgradeUrls = [];
+  originHeaders = [];
+  connections = [];
+  receivedByServer = [];
+
+  httpServer = createServer();
+  wsServer = new WebSocketServer({ noServer: true });
+
+  httpServer.on('upgrade', (request, socket, head) => {
+    upgradeUrls.push(request.url!);
+    originHeaders.push(request.headers.origin);
+    wsServer.handleUpgrade(request, socket, head, (ws) => {
+      wsServer.emit('connection', ws, request);
+    });
+  });
+
+  wsServer.on('connection', (ws) => {
+    connections.push(ws);
+    ws.on('message', (raw) => {
+      const data = raw.toString();
+      receivedByServer.push(isJSON(data) ? parse(data) : data);
+    });
+  });
+
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${(httpServer.address() as AddressInfo).port}`;
+});
+
+afterEach(async () => {
+  connections.forEach((ws) => ws.terminate());
+  wsServer.close();
+  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+});
+
+describe('createNodeChannel', () => {
+  it('connects to the server channel path with the token in the query string', async () => {
+    createNodeChannel({ url: baseUrl, token: TOKEN });
+
+    await firstConnection();
+    expect(upgradeUrls).toEqual([`${SERVER_CHANNEL_PATH}?token=${TOKEN}`]);
+  });
+
+  it('sends no Origin header, which browsers cannot omit', async () => {
+    createNodeChannel({ url: baseUrl, token: TOKEN });
+
+    await firstConnection();
+    expect(originHeaders).toEqual([undefined]);
+  });
+
+  it('replaces the path and query of the given base url', async () => {
+    createNodeChannel({ url: `${baseUrl}/some/base/path?existing=param`, token: TOKEN });
+
+    await firstConnection();
+    expect(upgradeUrls).toEqual([`${SERVER_CHANNEL_PATH}?token=${TOKEN}`]);
+  });
+
+  it('replies to a server ping with a pong', async () => {
+    createNodeChannel({ url: baseUrl, token: TOKEN });
+    const connection = await firstConnection();
+
+    connection.send(stringify({ type: 'ping' }));
+
+    await vi.waitFor(() => expect(receivedByServer).toContainEqual({ type: 'pong' }));
+  });
+
+  it('does not surface transport pings as channel events', async () => {
+    const { channel } = createNodeChannel({ url: baseUrl, token: TOKEN });
+    const onPing = vi.fn();
+    channel.on('ping', onPing);
+    const connection = await firstConnection();
+
+    connection.send(stringify({ type: 'ping' }));
+
+    await vi.waitFor(() => expect(receivedByServer).toContainEqual({ type: 'pong' }));
+    expect(onPing).not.toHaveBeenCalled();
+  });
+
+  it('round-trips telejson-only values in both directions', async () => {
+    const { channel } = createNodeChannel({ url: baseUrl, token: TOKEN });
+    const connection = await firstConnection();
+
+    channel.emit('outgoing', { when: new Date('2026-08-20T00:00:00.000Z'), pattern: /token/gi });
+
+    await vi.waitFor(() => expect(receivedByServer).toHaveLength(1));
+    expect(receivedByServer[0]).toMatchObject({
+      type: 'outgoing',
+      args: [{ when: new Date('2026-08-20T00:00:00.000Z'), pattern: /token/gi }],
+    });
+
+    const received: any[] = [];
+    channel.on('incoming', (payload) => received.push(payload));
+    connection.send(
+      stringify({
+        type: 'incoming',
+        args: [{ when: new Date('2025-01-02T03:04:05.000Z'), pattern: /server/g }],
+        from: 'server',
+      })
+    );
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    expect(received[0]).toEqual({
+      when: new Date('2025-01-02T03:04:05.000Z'),
+      pattern: /server/g,
+    });
+  });
+
+  it('emits CHANNEL_WS_DISCONNECT and rejects with a dev server disconnected error on close', async () => {
+    const { channel, disconnected } = createNodeChannel({ url: baseUrl, token: TOKEN });
+    const disconnects: any[] = [];
+    channel.on(CHANNEL_WS_DISCONNECT, (payload) => disconnects.push(payload));
+    const connection = await firstConnection();
+
+    connection.close(3008, 'timeout');
+
+    await expect(disconnected).rejects.toThrow('Storybook dev server disconnected');
+    expect(disconnects).toEqual([{ code: 3008, reason: 'timeout' }]);
+  });
+
+  it('rejects with a dev server disconnected error when the server was never reachable', async () => {
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+
+    const { disconnected } = createNodeChannel({ url: baseUrl, token: TOKEN });
+
+    await expect(disconnected).rejects.toThrow('Storybook dev server disconnected');
+  });
+});

--- a/code/core/src/channels/node/index.ts
+++ b/code/core/src/channels/node/index.ts
@@ -1,0 +1,64 @@
+import { CHANNEL_WS_DISCONNECT } from 'storybook/internal/core-events';
+
+import { WebSocket } from 'ws';
+
+import { StorybookDevServerDisconnectedError } from '../../server-errors.ts';
+import { UniversalStore } from '../../shared/universal-store/index.ts';
+import { setChannel } from '../channel-slot.ts';
+import { Channel } from '../main.ts';
+import { SERVER_CHANNEL_PATH, WebsocketTransport } from '../websocket/index.ts';
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+export interface NodeChannelOptions {
+  /** Base URL a Storybook dev server is listening on, e.g. `http://localhost:6006`. */
+  url: string;
+  /** The dev server's websocket token, as recorded alongside its URL. */
+  token: string;
+}
+
+export interface NodeChannelConnection {
+  channel: Channel;
+  /**
+   * Rejects with `StorybookDevServerDisconnectedError` when the dev server closes the socket. Race
+   * it against in-flight work so a dropped connection surfaces as an error instead of a hang.
+   */
+  disconnected: Promise<never>;
+}
+
+/**
+ * Connect this Node process to a running Storybook dev server's channel and install it as the
+ * process-wide addons channel.
+ *
+ * The channel joins as a UniversalStore follower: the dev server leads, this process mirrors. TLS
+ * verification is relaxed for loopback hosts only, so a `wss://` dev server using a self-signed
+ * development certificate is reachable while remote hosts keep full verification.
+ */
+export function createNodeChannel({ url, token }: NodeChannelOptions): NodeChannelConnection {
+  const socketUrl = new URL(url);
+  socketUrl.protocol = socketUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+  socketUrl.pathname = SERVER_CHANNEL_PATH;
+  socketUrl.search = new URLSearchParams({ token }).toString();
+
+  const rejectUnauthorized = !LOOPBACK_HOSTNAMES.has(socketUrl.hostname);
+
+  const transport = new WebsocketTransport({
+    url: socketUrl.href,
+    onError: () => {},
+    createSocket: (target) => new WebSocket(target, { rejectUnauthorized }),
+  });
+
+  const channel = new Channel({ transports: [transport] });
+  setChannel(channel);
+  UniversalStore.__prepare(channel, UniversalStore.Environment.UNKNOWN);
+
+  const disconnected = new Promise<never>((_, reject) => {
+    channel.once(CHANNEL_WS_DISCONNECT, ({ code, reason }: { code?: number; reason?: string }) => {
+      reject(new StorybookDevServerDisconnectedError({ code, reason }));
+    });
+  });
+  // A caller that never races `disconnected` must not get an unhandled rejection on server shutdown.
+  void disconnected.catch(() => {});
+
+  return { channel, disconnected };
+}

--- a/code/core/src/channels/node/index.ts
+++ b/code/core/src/channels/node/index.ts
@@ -24,6 +24,8 @@ export interface NodeChannelConnection {
    * it against in-flight work so a dropped connection surfaces as an error instead of a hang.
    */
   disconnected: Promise<never>;
+  /** Close the client socket and stop the transport heartbeat. */
+  close(): void;
 }
 
 /**
@@ -60,5 +62,5 @@ export function createNodeChannel({ url, token }: NodeChannelOptions): NodeChann
   // A caller that never races `disconnected` must not get an unhandled rejection on server shutdown.
   void disconnected.catch(() => {});
 
-  return { channel, disconnected };
+  return { channel, disconnected, close: () => transport.close() };
 }

--- a/code/core/src/channels/websocket/index.ts
+++ b/code/core/src/channels/websocket/index.ts
@@ -110,6 +110,15 @@ export class WebsocketTransport implements ChannelTransport {
     }
   }
 
+  close() {
+    if (this.isClosed) {
+      return;
+    }
+    this.isClosed = true;
+    clearTimeout(this.pingTimeout);
+    this.socket.close();
+  }
+
   private sendLater(event: any) {
     this.buffer.push(event);
   }

--- a/code/core/src/channels/websocket/index.ts
+++ b/code/core/src/channels/websocket/index.ts
@@ -8,13 +8,31 @@ import type { ChannelHandler, ChannelTransport, Config } from '../types.ts';
 
 type OnError = (message: Event) => void;
 
+/**
+ * The slice of the WebSocket API this transport drives, so a Node runtime can supply a `ws` socket
+ * where the DOM `WebSocket` global is unusable.
+ */
+export interface ChannelWebSocket {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  // The handler parameters stay `any` so both the DOM `WebSocket` and a `ws` socket satisfy this
+  // interface: their event types share no common supertype, and property assignment is checked
+  // contravariantly.
+  onopen: ((event: any) => void) | null;
+  onmessage: ((event: any) => void) | null;
+  onerror: ((event: any) => void) | null;
+  onclose: ((event: any) => void) | null;
+}
+
 interface WebsocketTransportArgs extends Partial<Config> {
   url: string;
   onError: OnError;
+  createSocket?: (url: string) => ChannelWebSocket;
 }
 
 export const HEARTBEAT_INTERVAL = 15000;
 export const HEARTBEAT_MAX_LATENCY = 5000;
+export const SERVER_CHANNEL_PATH = '/storybook-server-channel';
 
 const CHANNEL_OPTIONS = globalThis.CHANNEL_OPTIONS || {};
 
@@ -23,7 +41,7 @@ export class WebsocketTransport implements ChannelTransport {
 
   private handler?: ChannelHandler;
 
-  private socket: WebSocket;
+  private socket: ChannelWebSocket;
 
   private isReady = false;
 
@@ -39,15 +57,15 @@ export class WebsocketTransport implements ChannelTransport {
     }, HEARTBEAT_INTERVAL + HEARTBEAT_MAX_LATENCY);
   }
 
-  constructor({ url, onError, page }: WebsocketTransportArgs) {
+  constructor({ url, onError, page, createSocket }: WebsocketTransportArgs) {
     // eslint-disable-next-line compat/compat
-    this.socket = new WebSocket(url);
+    this.socket = createSocket ? createSocket(url) : new WebSocket(url);
     this.socket.onopen = () => {
       this.isReady = true;
       this.heartbeat();
       this.flush();
     };
-    this.socket.onmessage = ({ data }) => {
+    this.socket.onmessage = ({ data }: { data: any }) => {
       const event = typeof data === 'string' && isJSON(data) ? parse(data) : data;
       invariant(this.handler, 'WebsocketTransport handler should be set');
 
@@ -61,12 +79,12 @@ export class WebsocketTransport implements ChannelTransport {
 
       this.handler(event);
     };
-    this.socket.onerror = (e) => {
+    this.socket.onerror = (e: Event) => {
       if (onError) {
         onError(e);
       }
     };
-    this.socket.onclose = (ev) => {
+    this.socket.onclose = (ev: { code: number; reason: string }) => {
       invariant(this.handler, 'WebsocketTransport handler should be set');
       this.handler({
         type: EVENTS.CHANNEL_WS_DISCONNECT,

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -1,7 +1,12 @@
 import type { IncomingMessage } from 'node:http';
 
 import type { ChannelHandler } from 'storybook/internal/channels';
-import { Channel, HEARTBEAT_INTERVAL, setChannel } from 'storybook/internal/channels';
+import {
+  Channel,
+  HEARTBEAT_INTERVAL,
+  SERVER_CHANNEL_PATH,
+  setChannel,
+} from 'storybook/internal/channels';
 
 import { isJSON, parse, stringify } from 'telejson';
 import WebSocket, { WebSocketServer } from 'ws';
@@ -35,7 +40,7 @@ export class ServerChannelTransport {
     server.on('upgrade', (request: IncomingMessage, socket, head) => {
       try {
         const url = request.url && new URL(request.url, options.localAddress);
-        if (!url || url.pathname !== '/storybook-server-channel') {
+        if (!url || url.pathname !== SERVER_CHANNEL_PATH) {
           return;
         }
 

--- a/code/core/src/core-server/utils/server-address.ts
+++ b/code/core/src/core-server/utils/server-address.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 
+import { SERVER_CHANNEL_PATH } from 'storybook/internal/channels';
 import { logger } from 'storybook/internal/node-logger';
 import { NoFreePortError } from 'storybook/internal/server-errors';
 
@@ -54,7 +55,7 @@ export const getServerPort = (port?: number, { exactPort }: PortOptions = {}) =>
     });
 
 export const getServerChannelUrl = (port: number, { https }: { https?: boolean }) => {
-  return `${https ? 'wss' : 'ws'}://localhost:${port}/storybook-server-channel`;
+  return `${https ? 'wss' : 'ws'}://localhost:${port}${SERVER_CHANNEL_PATH}`;
 };
 
 const getLocalIp = () => {

--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -490,6 +490,7 @@ export default {
     'HEARTBEAT_INTERVAL',
     'HEARTBEAT_MAX_LATENCY',
     'PostMessageTransport',
+    'SERVER_CHANNEL_PATH',
     'WebsocketTransport',
     'clearChannel',
     'createBrowserChannel',

--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -769,6 +769,20 @@ export class NoFreePortError extends StorybookError {
   }
 }
 
+export class StorybookDevServerDisconnectedError extends StorybookError {
+  constructor(public data: { code?: number; reason?: string } = {}) {
+    super({
+      name: 'StorybookDevServerDisconnectedError',
+      category: Category.CORE_SERVER,
+      code: 19,
+      message: dedent`
+        Storybook dev server disconnected${data.code ? ` (close code ${data.code}${data.reason ? `: ${data.reason}` : ''})` : ''}.
+        Any request that was still in flight has been abandoned.
+        Make sure the dev server is still running, then try again.`,
+    });
+  }
+}
+
 export class GenerateNewProjectOnInitError extends StorybookError {
   constructor(
     public data: { error: unknown | Error; packageManager: string; projectType: string }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## What I did

Added a `createNodeChannel` function similar to `createBrowserChannel`, so that we can create a Node-based client to the dev server, which is necessary in our attached tools CLI

Linear: SB-1871

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No UI change. Maintainer QA:

```bash
yarn test node-channel
```

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732e6c14-a542-4611-b1f8-ff132284900b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732e6c14-a542-4611-b1f8-ff132284900b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

