### PR TITLE
Core: Add security token to instance registry record

### DIFF
--- a/code/core/src/cli/tools/instances/registry.test.ts
+++ b/code/core/src/cli/tools/instances/registry.test.ts
@@ -140,6 +140,22 @@ describe('readRegistry', () => {
     await expect(readRegistry(REGISTRY_DIR)).resolves.toEqual([withConfigDir]);
   });
 
+  it('accepts records with an optional channel token', async () => {
+    const withToken = { ...aliveRecord, token: 'a4d1f0c2-1e2b-4c3d-8e9f-0a1b2c3d4e5f' };
+    vol.fromNestedJSON({ [REGISTRY_DIR]: { 'token.json': JSON.stringify(withToken) } });
+
+    await expect(readRegistry(REGISTRY_DIR)).resolves.toEqual([withToken]);
+  });
+
+  it('accepts records without a token (written by Storybooks that predate it)', async () => {
+    vol.fromNestedJSON({ [REGISTRY_DIR]: { 'tokenless.json': JSON.stringify(aliveRecord) } });
+
+    const [record] = await readRegistry(REGISTRY_DIR);
+
+    expect(record).toEqual(aliveRecord);
+    expect(record.token).toBeUndefined();
+  });
+
   it('accepts records with optional agent provenance', async () => {
     const agentRecord = { ...aliveRecord, agent: 'claude-preview' };
     vol.fromNestedJSON({ [REGISTRY_DIR]: { 'agent.json': JSON.stringify(agentRecord) } });

--- a/code/core/src/cli/tools/instances/types.ts
+++ b/code/core/src/cli/tools/instances/types.ts
@@ -31,6 +31,11 @@ export const StorybookInstanceRecordSchema = v.object({
   configDir: v.optional(v.string()),
   url: v.string(),
   port: v.pipe(v.number(), v.minValue(1), v.maxValue(65535), v.integer()),
+  /**
+   * Token authenticating clients against the instance's WebSocket channel. Optional: records
+   * written by older Storybooks lack it.
+   */
+  token: v.optional(v.string()),
   agent: v.optional(v.string()),
   storybookVersion: v.optional(v.string()),
   startedAt: v.optional(v.string()),

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -318,6 +318,7 @@ export async function buildDevStandalone(
     mcp,
     port,
     storybookVersion,
+    token: getWsToken(),
   }).catch((error: unknown) => {
     logger.warn('Storybook failed to write its runtime instance registry record.');
     logger.debug(error instanceof Error ? (error.stack ?? error.message) : String(error));

--- a/code/core/src/core-server/utils/runtime-instance-registry.memfs.test.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.memfs.test.ts
@@ -1,3 +1,4 @@
+import { execFile } from 'node:child_process';
 import { chmod, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 
 import { vol } from 'memfs';
@@ -12,6 +13,7 @@ import {
 // Spy-only mock: keep the real `node:fs/promises` shape and redirect the calls the writer makes to
 // `memfs`, so file modes can be asserted without touching the developer's home directory.
 vi.mock('node:fs/promises', { spy: true });
+vi.mock('node:child_process', { spy: true });
 
 const REGISTRY_DIR = '/home/tester/.storybook/instances';
 
@@ -42,6 +44,13 @@ beforeEach(async () => {
   vi.mocked(writeFile).mockImplementation(
     memfs.fs.promises.writeFile as unknown as typeof import('node:fs/promises').writeFile
   );
+  vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+    const callback = args.find((arg) => typeof arg === 'function') as
+      | ((error: Error | null, stdout: string, stderr: string) => void)
+      | undefined;
+    callback?.(null, '', '');
+    return { pid: 0 } as ReturnType<typeof execFile>;
+  });
 });
 
 afterEach(() => {

--- a/code/core/src/core-server/utils/runtime-instance-registry.memfs.test.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.memfs.test.ts
@@ -1,0 +1,153 @@
+import { chmod, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+
+import { vol } from 'memfs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createRuntimeInstanceRecord,
+  writeRuntimeInstanceRecord,
+  writeStorybookRuntimeInstanceRecord,
+} from './runtime-instance-registry.ts';
+
+// Spy-only mock: keep the real `node:fs/promises` shape and redirect the calls the writer makes to
+// `memfs`, so file modes can be asserted without touching the developer's home directory.
+vi.mock('node:fs/promises', { spy: true });
+
+const REGISTRY_DIR = '/home/tester/.storybook/instances';
+
+beforeEach(async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs');
+
+  vi.mocked(chmod).mockImplementation(
+    memfs.fs.promises.chmod as unknown as typeof import('node:fs/promises').chmod
+  );
+  vi.mocked(mkdir).mockImplementation(
+    memfs.fs.promises.mkdir as unknown as typeof import('node:fs/promises').mkdir
+  );
+  vi.mocked(readFile).mockImplementation(
+    memfs.fs.promises.readFile as unknown as typeof import('node:fs/promises').readFile
+  );
+  vi.mocked(readdir).mockImplementation(
+    memfs.fs.promises.readdir as unknown as typeof import('node:fs/promises').readdir
+  );
+  vi.mocked(rename).mockImplementation(
+    memfs.fs.promises.rename as unknown as typeof import('node:fs/promises').rename
+  );
+  vi.mocked(rm).mockImplementation(
+    memfs.fs.promises.rm as unknown as typeof import('node:fs/promises').rm
+  );
+  vi.mocked(stat).mockImplementation(
+    memfs.fs.promises.stat as unknown as typeof import('node:fs/promises').stat
+  );
+  vi.mocked(writeFile).mockImplementation(
+    memfs.fs.promises.writeFile as unknown as typeof import('node:fs/promises').writeFile
+  );
+});
+
+afterEach(() => {
+  vol.reset();
+  vi.restoreAllMocks();
+});
+
+function modeOf(path: string) {
+  return vol.statSync(path).mode & 0o777;
+}
+
+function readRecordFile(path: string) {
+  return JSON.parse(vol.readFileSync(path, 'utf-8') as string);
+}
+
+describe('writeRuntimeInstanceRecord', () => {
+  it('round-trips the channel token through the record file', async () => {
+    const record = createRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      instanceId: 'with-token',
+      port: 6006,
+      storybookVersion: '10.5.0-alpha.0',
+      token: 'a4d1f0c2-1e2b-4c3d-8e9f-0a1b2c3d4e5f',
+    });
+
+    const recordPath = await writeRuntimeInstanceRecord(record, REGISTRY_DIR);
+
+    expect(readRecordFile(recordPath)).toMatchObject({
+      instanceId: 'with-token',
+      token: 'a4d1f0c2-1e2b-4c3d-8e9f-0a1b2c3d4e5f',
+    });
+  });
+
+  it('omits the token key when no token is provided', async () => {
+    const record = createRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      instanceId: 'without-token',
+      port: 6006,
+      storybookVersion: '10.5.0-alpha.0',
+    });
+
+    const recordPath = await writeRuntimeInstanceRecord(record, REGISTRY_DIR);
+
+    expect(record).not.toHaveProperty('token');
+    expect(readRecordFile(recordPath)).not.toHaveProperty('token');
+  });
+
+  it('creates the registry dir as 0700 and the record file as 0600', async () => {
+    const record = createRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      instanceId: 'modes',
+      port: 6006,
+      storybookVersion: '10.5.0-alpha.0',
+      token: 'secret-token',
+    });
+
+    const recordPath = await writeRuntimeInstanceRecord(record, REGISTRY_DIR);
+
+    expect(modeOf(REGISTRY_DIR)).toBe(0o700);
+    expect(modeOf(recordPath)).toBe(0o600);
+  });
+
+  it('tightens an already existing world-readable registry dir to 0700', async () => {
+    vol.mkdirSync(REGISTRY_DIR, { recursive: true, mode: 0o755 });
+
+    const record = createRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      instanceId: 'tightened',
+      port: 6006,
+      storybookVersion: '10.5.0-alpha.0',
+    });
+
+    await writeRuntimeInstanceRecord(record, REGISTRY_DIR);
+
+    expect(modeOf(REGISTRY_DIR)).toBe(0o700);
+  });
+
+  it('leaves no temp file behind', async () => {
+    const record = createRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      instanceId: 'no-temp',
+      port: 6006,
+      storybookVersion: '10.5.0-alpha.0',
+      token: 'secret-token',
+    });
+
+    await writeRuntimeInstanceRecord(record, REGISTRY_DIR);
+
+    expect(Object.keys(vol.toJSON())).toEqual([`${REGISTRY_DIR}/no-temp.json`]);
+  });
+});
+
+describe('writeStorybookRuntimeInstanceRecord', () => {
+  it('writes the supplied token to disk with a 0600 record file', async () => {
+    const { record, recordPath } = await writeStorybookRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      port: 6006,
+      registryDir: REGISTRY_DIR,
+      registerCleanup: false,
+      storybookVersion: '10.5.0-alpha.0',
+      token: 'ws-token',
+    });
+
+    expect(record.token).toBe('ws-token');
+    expect(readRecordFile(recordPath).token).toBe('ws-token');
+    expect(modeOf(recordPath)).toBe(0o600);
+    expect(modeOf(REGISTRY_DIR)).toBe(0o700);
+  });
+});

--- a/code/core/src/core-server/utils/runtime-instance-registry.test.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.test.ts
@@ -7,7 +7,9 @@ import {
   utimesSync,
   writeFileSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { tmpdir, userInfo } from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 
 import { join, resolve } from 'pathe';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -596,6 +598,7 @@ describe('writeStorybookRuntimeInstanceRecord', () => {
       registerCleanup: false,
       registryDir: makeTempDir(),
       storybookVersion: '10.5.0-alpha.0',
+      token: 'ws-token',
     });
 
     expect(registration.record.agent).toBe('claude-preview');
@@ -611,6 +614,7 @@ describe('writeStorybookRuntimeInstanceRecord', () => {
       registerCleanup: false,
       registryDir: makeTempDir(),
       storybookVersion: '10.5.0-alpha.0',
+      token: 'ws-token',
     });
 
     expect(registration.record.agent).toBe('codex');
@@ -626,6 +630,7 @@ describe('writeStorybookRuntimeInstanceRecord', () => {
       registerCleanup: false,
       registryDir: makeTempDir(),
       storybookVersion: '10.5.0-alpha.0',
+      token: 'ws-token',
     });
 
     expect(registration.record.agent).toBe('claude');
@@ -639,6 +644,7 @@ describe('writeStorybookRuntimeInstanceRecord', () => {
       registerCleanup: false,
       registryDir,
       storybookVersion: '10.5.0-alpha.0',
+      token: 'ws-token',
     });
 
     expect(existsSync(registration.recordPath)).toBe(true);
@@ -647,4 +653,23 @@ describe('writeStorybookRuntimeInstanceRecord', () => {
 
     expect(existsSync(registration.recordPath)).toBe(false);
   });
+
+  it.runIf(process.platform === 'win32')(
+    'restricts the record ACL to the current Windows user',
+    async () => {
+      const registryDir = makeTempDir();
+      const registration = await writeStorybookRuntimeInstanceRecord({
+        address: 'http://localhost:6006/',
+        port: 6006,
+        registerCleanup: false,
+        registryDir,
+        storybookVersion: '10.5.0-alpha.0',
+        token: 'ws-token',
+      });
+
+      const { stdout } = await promisify(execFile)('icacls', [registration.recordPath]);
+      expect(stdout).toContain(userInfo().username);
+      expect(stdout).not.toMatch(/Everyone|(BUILTIN\\Users)/i);
+    }
+  );
 });

--- a/code/core/src/core-server/utils/runtime-instance-registry.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.ts
@@ -1,7 +1,9 @@
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync } from 'node:fs';
 import { chmod, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
-import { randomUUID } from 'node:crypto';
-import { homedir } from 'node:os';
+import { homedir, userInfo } from 'node:os';
+import { promisify } from 'node:util';
 
 import { normalizeAddonName } from 'storybook/internal/common';
 import type { StorybookConfig } from 'storybook/internal/types';
@@ -18,6 +20,25 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * ONE_DAY_MS;
 const REGISTRY_DIR_MODE = 0o700;
 const RECORD_FILE_MODE = 0o600;
+const execFileAsync = promisify(execFile);
+
+async function restrictOwnerAccess(targetPath: string, mode: number) {
+  await chmod(targetPath, mode);
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  // chmod on Windows only toggles the writable bit; it does not create an owner-only ACL.
+  const { username } = userInfo();
+  try {
+    await execFileAsync('icacls', [targetPath, '/inheritance:r', '/grant:r', `${username}:(F)`]);
+  } catch (error) {
+    throw new Error(
+      `Could not restrict ${targetPath} to the current Windows user. The instance record would be readable by other accounts.`,
+      { cause: error }
+    );
+  }
+}
 
 export type RuntimeInstanceRecord = {
   schemaVersion: 1;
@@ -146,7 +167,7 @@ export async function writeRuntimeInstanceRecord(
 ) {
   await mkdir(registryDir, { recursive: true, mode: REGISTRY_DIR_MODE });
   // `mkdir` ignores `mode` for an existing dir and umask can clear bits, so modes are enforced.
-  await chmod(registryDir, REGISTRY_DIR_MODE);
+  await restrictOwnerAccess(registryDir, REGISTRY_DIR_MODE);
   await cleanupRuntimeInstanceRegistry(registryDir);
 
   const recordPath = join(registryDir, `${record.instanceId}.json`);
@@ -160,7 +181,7 @@ export async function writeRuntimeInstanceRecord(
       encoding: 'utf-8',
       mode: RECORD_FILE_MODE,
     });
-    await chmod(tempPath, RECORD_FILE_MODE);
+    await restrictOwnerAccess(tempPath, RECORD_FILE_MODE);
     await rename(tempPath, recordPath);
   } catch (error) {
     await rm(tempPath, { force: true }).catch(() => undefined);
@@ -362,7 +383,7 @@ export async function writeStorybookRuntimeInstanceRecord({
   registryDir?: string;
   registerCleanup?: boolean;
   storybookVersion: string;
-  token?: string;
+  token: string;
 }): Promise<RuntimeInstanceRegistration> {
   const record = createRuntimeInstanceRecord({
     address,

--- a/code/core/src/core-server/utils/runtime-instance-registry.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.ts
@@ -1,5 +1,5 @@
 import { existsSync, rmSync } from 'node:fs';
-import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
@@ -16,6 +16,8 @@ const STORYBOOK_MCP_ADDON = '@storybook/addon-mcp';
 const DEFAULT_MCP_ENDPOINT = '/mcp';
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * ONE_DAY_MS;
+const REGISTRY_DIR_MODE = 0o700;
+const RECORD_FILE_MODE = 0o600;
 
 export type RuntimeInstanceRecord = {
   schemaVersion: 1;
@@ -30,6 +32,8 @@ export type RuntimeInstanceRecord = {
   configDir?: string;
   url: string;
   port: number;
+  /** Token authenticating clients against this instance's WebSocket channel. */
+  token?: string;
   agent?: string;
   storybookVersion: string;
   startedAt: string;
@@ -102,6 +106,7 @@ export function createRuntimeInstanceRecord({
   pid = process.pid,
   port,
   storybookVersion,
+  token,
 }: {
   address: string;
   agent?: string;
@@ -113,6 +118,7 @@ export function createRuntimeInstanceRecord({
   pid?: number;
   port: number;
   storybookVersion: string;
+  token?: string;
 }): RuntimeInstanceRecord {
   const storybookBaseUrl = getStorybookBaseUrl(address);
   const timestamp = now.toISOString();
@@ -125,6 +131,7 @@ export function createRuntimeInstanceRecord({
     ...(configDir ? { configDir: resolve(cwd, configDir) } : {}),
     url: storybookBaseUrl,
     port,
+    ...(token ? { token } : {}),
     ...(agent ? { agent } : {}),
     storybookVersion,
     startedAt: timestamp,
@@ -137,7 +144,9 @@ export async function writeRuntimeInstanceRecord(
   record: RuntimeInstanceRecord,
   registryDir = getDefaultRuntimeInstanceRegistryDir()
 ) {
-  await mkdir(registryDir, { recursive: true });
+  await mkdir(registryDir, { recursive: true, mode: REGISTRY_DIR_MODE });
+  // `mkdir` ignores `mode` for an existing dir and umask can clear bits, so modes are enforced.
+  await chmod(registryDir, REGISTRY_DIR_MODE);
   await cleanupRuntimeInstanceRegistry(registryDir);
 
   const recordPath = join(registryDir, `${record.instanceId}.json`);
@@ -147,7 +156,11 @@ export async function writeRuntimeInstanceRecord(
   );
 
   try {
-    await writeFile(tempPath, `${JSON.stringify(record, null, 2)}\n`, 'utf-8');
+    await writeFile(tempPath, `${JSON.stringify(record, null, 2)}\n`, {
+      encoding: 'utf-8',
+      mode: RECORD_FILE_MODE,
+    });
+    await chmod(tempPath, RECORD_FILE_MODE);
     await rename(tempPath, recordPath);
   } catch (error) {
     await rm(tempPath, { force: true }).catch(() => undefined);
@@ -337,6 +350,7 @@ export async function writeStorybookRuntimeInstanceRecord({
   registryDir,
   registerCleanup = true,
   storybookVersion,
+  token,
 }: {
   address: string;
   agent?: string;
@@ -348,6 +362,7 @@ export async function writeStorybookRuntimeInstanceRecord({
   registryDir?: string;
   registerCleanup?: boolean;
   storybookVersion: string;
+  token?: string;
 }): Promise<RuntimeInstanceRegistration> {
   const record = createRuntimeInstanceRecord({
     address,
@@ -358,6 +373,7 @@ export async function writeStorybookRuntimeInstanceRecord({
     pid,
     port,
     storybookVersion,
+    token,
   });
   const recordPath = await writeRuntimeInstanceRecord(record, registryDir);
   const unregisterProcessCleanup = registerCleanup ? registerProcessCleanup(recordPath) : () => {};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## What I did

1. Added the WS security token to the global SB instance record, so other clients on the same machine can connect to the running instances with the token.
2. Improved security about the instance record by changing the file permissions to be current-user only (like `chmod 600`). This is inspired by CDP. We'll see if this causes issues with some agent harnesses, and then we'll reconsider.

Linear: SB-1869. Independent of other tickets. Base: `next`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No UI change. Maintainer QA:

```bash
yarn test instances.test
```

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732e6c14-a542-4611-b1f8-ff132284900b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732e6c14-a542-4611-b1f8-ff132284900b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

