### PR TITLE
Tools: Add `loadTools` to import storybook tools from the correct directory

### DIFF
--- a/code/core/build-config.ts
+++ b/code/core/build-config.ts
@@ -106,6 +106,12 @@ const config: BuildEntries = {
         exportEntries: ['./internal/tools'],
         entryPoint: './src/cli/tools/sdk/index.ts',
       },
+      {
+        // Loader for the tools SDK, kept as its own entry so an embedder that bundles `storybook`
+        // gets the shim rather than the SDK it must not run: it imports nothing but node builtins.
+        exportEntries: ['./internal/tools/loader'],
+        entryPoint: './src/cli/tools/sdk/loader.ts',
+      },
     ],
     browser: [
       {

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -208,6 +208,11 @@
       "code": "./src/cli/tools/sdk/index.ts",
       "default": "./dist/cli/tools/sdk/index.js"
     },
+    "./internal/tools/loader": {
+      "types": "./dist/cli/tools/sdk/loader.d.ts",
+      "code": "./src/cli/tools/sdk/loader.ts",
+      "default": "./dist/cli/tools/sdk/loader.js"
+    },
     "./internal/toolsets-docs": {
       "types": "./dist/shared/open-service/toolsets/docs/public.d.ts",
       "code": "./src/shared/open-service/toolsets/docs/public.ts",

--- a/code/core/src/cli/tools/sdk/loader.test.ts
+++ b/code/core/src/cli/tools/sdk/loader.test.ts
@@ -1,15 +1,22 @@
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { loadTools } from './loader.ts';
 
-vi.mock('node:module', { spy: true });
-
-// Real files on disk, not memfs: Node's resolver and dynamic import bypass a virtual filesystem.
+// Real files on disk, not memfs: Node's resolver, dynamic import, and Yarn PnP bypass a virtual filesystem.
 const temporaryDirectories: string[] = [];
 
 function createTemporaryDirectory() {
@@ -38,9 +45,56 @@ function namedExport(marker: string) {
   return `export const createTools = async (options) => ({ marker: '${marker}', options });`;
 }
 
-beforeEach(() => {
-  vi.mocked(createRequire).mockReset();
-});
+function findYarnRelease(from: string) {
+  let current = from;
+  for (;;) {
+    const candidate = join(current, '.yarn', 'releases', 'yarn-4.18.0.cjs');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      throw new Error('Could not find the Yarn 4.18.0 release used to build this fixture.');
+    }
+    current = parent;
+  }
+}
+
+function createYarnPnpProject() {
+  const projectDir = createTemporaryDirectory();
+  writeToolsPackage(join(projectDir, 'vendor', 'storybook'), 'dist/tools.js', namedExport('pnp'));
+  writeFileSync(
+    join(projectDir, 'package.json'),
+    JSON.stringify({
+      name: 'pnp-tools-fixture',
+      private: true,
+      packageManager: 'yarn@4.18.0',
+      dependencies: { storybook: 'portal:./vendor/storybook' },
+    })
+  );
+  writeFileSync(join(projectDir, '.yarnrc.yml'), 'nodeLinker: pnp\nenableGlobalCache: false\n');
+  execFileSync(process.execPath, [findYarnRelease(fileURLToPath(import.meta.url)), 'install'], {
+    cwd: projectDir,
+    encoding: 'utf8',
+  });
+  return projectDir;
+}
+
+function loadToolsInPlainNode(projectDir: string) {
+  const loaderUrl = pathToFileURL(fileURLToPath(new URL('./loader.ts', import.meta.url))).href;
+  const script = `
+    import { loadTools } from ${JSON.stringify(loaderUrl)};
+    process.stdout.write(JSON.stringify(await loadTools(${JSON.stringify(projectDir)})));
+  `;
+  const env = { ...process.env };
+  delete env.NODE_OPTIONS;
+  return JSON.parse(
+    execFileSync(process.execPath, ['--input-type=module', '--eval', script], {
+      encoding: 'utf8',
+      env,
+    })
+  );
+}
 
 afterEach(() => {
   for (const directory of temporaryDirectories) {
@@ -59,6 +113,22 @@ describe('loadTools', () => {
     );
 
     await expect(loadTools(projectDir)).resolves.toEqual({
+      marker: 'npm',
+      options: { cwd: projectDir },
+    });
+  });
+
+  it('loads the SDK from a relative project directory', async () => {
+    const projectDir = createTemporaryDirectory();
+    writeToolsPackage(
+      join(projectDir, 'node_modules', 'storybook'),
+      'dist/tools.js',
+      namedExport('npm')
+    );
+    const relativeProjectDir = relative(process.cwd(), projectDir);
+    expect(isAbsolute(relativeProjectDir)).toBe(false);
+
+    await expect(loadTools(relativeProjectDir)).resolves.toEqual({
       marker: 'npm',
       options: { cwd: projectDir },
     });
@@ -84,31 +154,14 @@ describe('loadTools', () => {
     });
   });
 
-  describe('a Yarn PnP project, where PnP owns resolution', () => {
-    const resolve = vi.fn();
+  it('loads the SDK a Yarn PnP project installed, from a plain Node process', () => {
+    const projectDir = createYarnPnpProject();
 
-    beforeEach(() => {
-      const entryPath = writeToolsPackage(
-        join(createTemporaryDirectory(), 'node_modules', 'storybook-virtual'),
-        'dist/tools.js',
-        namedExport('pnp')
-      );
-      resolve.mockReset();
-      resolve.mockReturnValue(entryPath);
-      vi.mocked(createRequire).mockReturnValue({ resolve } as unknown as NodeRequire);
+    expect(loadToolsInPlainNode(projectDir)).toEqual({
+      marker: 'pnp',
+      options: { cwd: projectDir },
     });
-
-    it('imports what PnP resolves, asking it from the project directory', async () => {
-      const projectDir = createTemporaryDirectory();
-
-      await expect(loadTools(projectDir)).resolves.toEqual({
-        marker: 'pnp',
-        options: { cwd: projectDir },
-      });
-      expect(createRequire).toHaveBeenCalledWith(join(projectDir, 'package.json'));
-      expect(resolve).toHaveBeenCalledWith('storybook/internal/tools', { paths: [projectDir] });
-    });
-  });
+  }, 60_000);
 
   it('forwards every option, letting the caller override the project directory as cwd', async () => {
     const projectDir = createTemporaryDirectory();

--- a/code/core/src/cli/tools/sdk/loader.test.ts
+++ b/code/core/src/cli/tools/sdk/loader.test.ts
@@ -72,11 +72,25 @@ function createYarnPnpProject() {
       dependencies: { storybook: 'portal:./vendor/storybook' },
     })
   );
-  writeFileSync(join(projectDir, '.yarnrc.yml'), 'nodeLinker: pnp\nenableGlobalCache: false\n');
-  execFileSync(process.execPath, [findYarnRelease(fileURLToPath(import.meta.url)), 'install'], {
-    cwd: projectDir,
-    encoding: 'utf8',
-  });
+  writeFileSync(
+    join(projectDir, '.yarnrc.yml'),
+    'nodeLinker: pnp\nenableGlobalCache: false\nenableImmutableInstalls: false\n'
+  );
+  const env = { ...process.env };
+  // CI turns on Yarn immutable installs, which refuse a fixture that has no lockfile yet.
+  delete env.CI;
+  env.YARN_ENABLE_IMMUTABLE_INSTALLS = 'false';
+  env.YARN_ENABLE_GLOBAL_CACHE = 'false';
+  try {
+    execFileSync(process.execPath, [findYarnRelease(fileURLToPath(import.meta.url)), 'install'], {
+      cwd: projectDir,
+      encoding: 'utf8',
+      env,
+    });
+  } catch (error) {
+    const failure = error as { message: string; stderr?: string; stdout?: string };
+    throw new Error([failure.message, failure.stderr, failure.stdout].filter(Boolean).join('\n'));
+  }
   return projectDir;
 }
 

--- a/code/core/src/cli/tools/sdk/loader.test.ts
+++ b/code/core/src/cli/tools/sdk/loader.test.ts
@@ -9,6 +9,7 @@ import { loadTools } from './loader.ts';
 
 vi.mock('node:module', { spy: true });
 
+// Real files on disk, not memfs: Node's resolver and dynamic import bypass a virtual filesystem.
 const temporaryDirectories: string[] = [];
 
 function createTemporaryDirectory() {
@@ -83,22 +84,30 @@ describe('loadTools', () => {
     });
   });
 
-  it('resolves from the project directory, which is what Yarn PnP hooks into', async () => {
-    const projectDir = createTemporaryDirectory();
-    const entryPath = writeToolsPackage(
-      join(createTemporaryDirectory(), 'node_modules', 'storybook-virtual'),
-      'dist/tools.js',
-      namedExport('pnp')
-    );
-    const resolve = vi.fn().mockReturnValue(entryPath);
-    vi.mocked(createRequire).mockReturnValue({ resolve } as unknown as NodeRequire);
+  describe('a Yarn PnP project, where PnP owns resolution', () => {
+    const resolve = vi.fn();
 
-    await expect(loadTools(projectDir)).resolves.toEqual({
-      marker: 'pnp',
-      options: { cwd: projectDir },
+    beforeEach(() => {
+      const entryPath = writeToolsPackage(
+        join(createTemporaryDirectory(), 'node_modules', 'storybook-virtual'),
+        'dist/tools.js',
+        namedExport('pnp')
+      );
+      resolve.mockReset();
+      resolve.mockReturnValue(entryPath);
+      vi.mocked(createRequire).mockReturnValue({ resolve } as unknown as NodeRequire);
     });
-    expect(createRequire).toHaveBeenCalledWith(join(projectDir, 'package.json'));
-    expect(resolve).toHaveBeenCalledWith('storybook/internal/tools', { paths: [projectDir] });
+
+    it('imports what PnP resolves, asking it from the project directory', async () => {
+      const projectDir = createTemporaryDirectory();
+
+      await expect(loadTools(projectDir)).resolves.toEqual({
+        marker: 'pnp',
+        options: { cwd: projectDir },
+      });
+      expect(createRequire).toHaveBeenCalledWith(join(projectDir, 'package.json'));
+      expect(resolve).toHaveBeenCalledWith('storybook/internal/tools', { paths: [projectDir] });
+    });
   });
 
   it('forwards every option, letting the caller override the project directory as cwd', async () => {

--- a/code/core/src/cli/tools/sdk/loader.test.ts
+++ b/code/core/src/cli/tools/sdk/loader.test.ts
@@ -1,0 +1,184 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { loadTools } from './loader.ts';
+
+vi.mock('node:module', { spy: true });
+
+const temporaryDirectories: string[] = [];
+
+function createTemporaryDirectory() {
+  const directory = mkdtempSync(join(tmpdir(), 'storybook-tools-loader-'));
+  temporaryDirectories.push(directory);
+  return realpathSync(directory);
+}
+
+function writeToolsPackage(packageDir: string, entryFile: string, source: string) {
+  const entryPath = join(packageDir, entryFile);
+  mkdirSync(dirname(entryPath), { recursive: true });
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    JSON.stringify({
+      name: 'storybook',
+      version: '10.0.0',
+      type: 'module',
+      exports: { './internal/tools': `./${entryFile}` },
+    })
+  );
+  writeFileSync(entryPath, source);
+  return entryPath;
+}
+
+function namedExport(marker: string) {
+  return `export const createTools = async (options) => ({ marker: '${marker}', options });`;
+}
+
+beforeEach(() => {
+  vi.mocked(createRequire).mockReset();
+});
+
+afterEach(() => {
+  for (const directory of temporaryDirectories) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+  temporaryDirectories.length = 0;
+});
+
+describe('loadTools', () => {
+  it('loads the SDK an npm layout installed, not the copy this loader ships inside', async () => {
+    const projectDir = createTemporaryDirectory();
+    writeToolsPackage(
+      join(projectDir, 'node_modules', 'storybook'),
+      'dist/tools.js',
+      namedExport('npm')
+    );
+
+    await expect(loadTools(projectDir)).resolves.toEqual({
+      marker: 'npm',
+      options: { cwd: projectDir },
+    });
+  });
+
+  it('loads the SDK a pnpm layout linked into the project', async () => {
+    const projectDir = createTemporaryDirectory();
+    const storeDir = join(
+      projectDir,
+      'node_modules',
+      '.pnpm',
+      'storybook@10.0.0',
+      'node_modules',
+      'storybook'
+    );
+    writeToolsPackage(storeDir, 'dist/tools.js', namedExport('pnpm'));
+    // 'junction' so the fixture also works on Windows, where dir symlinks need elevation.
+    symlinkSync(storeDir, join(projectDir, 'node_modules', 'storybook'), 'junction');
+
+    await expect(loadTools(projectDir)).resolves.toEqual({
+      marker: 'pnpm',
+      options: { cwd: projectDir },
+    });
+  });
+
+  it('resolves from the project directory, which is what Yarn PnP hooks into', async () => {
+    const projectDir = createTemporaryDirectory();
+    const entryPath = writeToolsPackage(
+      join(createTemporaryDirectory(), 'node_modules', 'storybook-virtual'),
+      'dist/tools.js',
+      namedExport('pnp')
+    );
+    const resolve = vi.fn().mockReturnValue(entryPath);
+    vi.mocked(createRequire).mockReturnValue({ resolve } as unknown as NodeRequire);
+
+    await expect(loadTools(projectDir)).resolves.toEqual({
+      marker: 'pnp',
+      options: { cwd: projectDir },
+    });
+    expect(createRequire).toHaveBeenCalledWith(join(projectDir, 'package.json'));
+    expect(resolve).toHaveBeenCalledWith('storybook/internal/tools', { paths: [projectDir] });
+  });
+
+  it('forwards every option, letting the caller override the project directory as cwd', async () => {
+    const projectDir = createTemporaryDirectory();
+    writeToolsPackage(
+      join(projectDir, 'node_modules', 'storybook'),
+      'dist/tools.js',
+      namedExport('npm')
+    );
+
+    await expect(
+      loadTools(projectDir, {
+        cwd: join(projectDir, 'packages', 'app'),
+        configDir: '.storybook',
+        mode: 'local',
+        clientInfo: { name: 'embedder', version: '1.2.3' },
+      })
+    ).resolves.toEqual({
+      marker: 'npm',
+      options: {
+        cwd: join(projectDir, 'packages', 'app'),
+        configDir: '.storybook',
+        mode: 'local',
+        clientInfo: { name: 'embedder', version: '1.2.3' },
+      },
+    });
+  });
+
+  it('reads createTools off a default export', async () => {
+    const projectDir = createTemporaryDirectory();
+    writeToolsPackage(
+      join(projectDir, 'node_modules', 'storybook'),
+      'dist/tools.js',
+      `const createTools = async (options) => ({ marker: 'default', options });
+       export default { createTools };`
+    );
+
+    await expect(loadTools(projectDir)).resolves.toEqual({
+      marker: 'default',
+      options: { cwd: projectDir },
+    });
+  });
+
+  it('reads createTools off a CommonJS entry', async () => {
+    const projectDir = createTemporaryDirectory();
+    writeToolsPackage(
+      join(projectDir, 'node_modules', 'storybook'),
+      'dist/tools.cjs',
+      `module.exports = { createTools: async (options) => ({ marker: 'cjs', options }) };`
+    );
+
+    await expect(loadTools(projectDir)).resolves.toEqual({
+      marker: 'cjs',
+      options: { cwd: projectDir },
+    });
+  });
+
+  it('names the project directory when it has no Storybook installed', async () => {
+    const projectDir = createTemporaryDirectory();
+
+    const failure = loadTools(projectDir);
+
+    await expect(failure).rejects.toThrow(
+      `Could not resolve \`storybook/internal/tools\` from ${projectDir}`
+    );
+    await expect(failure).rejects.toMatchObject({
+      cause: expect.objectContaining({ code: 'MODULE_NOT_FOUND' }),
+    });
+  });
+
+  it('rejects an entry that exposes no createTools', async () => {
+    const projectDir = createTemporaryDirectory();
+    const entryPath = writeToolsPackage(
+      join(projectDir, 'node_modules', 'storybook'),
+      'dist/tools.js',
+      `export const somethingElse = 1;`
+    );
+
+    await expect(loadTools(projectDir)).rejects.toThrow(
+      `The \`storybook/internal/tools\` entry at ${entryPath} exposes no \`createTools\`.`
+    );
+  });
+});

--- a/code/core/src/cli/tools/sdk/loader.ts
+++ b/code/core/src/cli/tools/sdk/loader.ts
@@ -1,10 +1,21 @@
-import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { createRequire, register } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import type { CreateToolsOptions, LocalTools, Tools } from './types.ts';
 
 const TOOLS_ENTRY = 'storybook/internal/tools';
+const PNP_API_FILES = ['.pnp.cjs', '.pnp.js'] as const;
+
+type YarnPnpApi = {
+  setup?: () => void;
+  resolveRequest?: (
+    request: string,
+    issuer: string,
+    opts?: { considerBuiltins?: boolean }
+  ) => string | null;
+};
 
 type CreateTools = (options?: CreateToolsOptions) => Promise<Tools>;
 
@@ -13,7 +24,8 @@ type CreateTools = (options?: CreateToolsOptions) => Promise<Tools>;
  *
  * Toolset code has to run against the Storybook a project depends on, so this resolves
  * `storybook/internal/tools` from `projectDir`, imports that copy, and forwards the options to its
- * `createTools`, with `cwd` defaulting to `projectDir`. Nothing else in the SDK is loaded here,
+ * `createTools`, with `cwd` defaulting to `projectDir`. Yarn PnP projects are resolved through the
+ * target `.pnp.cjs`, not this process's Node resolver. Nothing else in the SDK is loaded here,
  * which keeps this entry stable for embedders that bundle their own `storybook`.
  *
  * @throws {Error} When the project has no resolvable `storybook/internal/tools`, or when that entry
@@ -28,24 +40,75 @@ export async function loadTools(
   projectDir: string,
   options: CreateToolsOptions = {}
 ): Promise<Tools> {
-  const entryPath = resolveToolsEntry(projectDir);
+  const resolvedProjectDir = resolve(projectDir);
+  const entryPath = await resolveToolsEntry(resolvedProjectDir);
   const namespace: unknown = await import(pathToFileURL(entryPath).href);
-  return selectCreateTools(namespace, entryPath)({ cwd: projectDir, ...options });
+  return selectCreateTools(namespace, entryPath)({ cwd: resolvedProjectDir, ...options });
 }
 
-function resolveToolsEntry(projectDir: string): string {
+async function resolveToolsEntry(projectDir: string): Promise<string> {
+  const pnpApiPath = findPnpApi(projectDir);
+  if (pnpApiPath) {
+    try {
+      return await resolveThroughPnp(projectDir, pnpApiPath);
+    } catch (cause) {
+      throw cannotResolve(projectDir, cause);
+    }
+  }
+
   // Issued from the project rather than from this file: this loader ships inside `storybook`, and
   // Node's self-reference resolution would hand back its own package's entry before reading `paths`.
   const projectRequire = createRequire(join(projectDir, 'package.json'));
   try {
     return projectRequire.resolve(TOOLS_ENTRY, { paths: [projectDir] });
   } catch (cause) {
-    // eslint-disable-next-line local-rules/no-uncategorized-errors -- the shim imports no taxonomy
-    throw new Error(
-      `Could not resolve \`${TOOLS_ENTRY}\` from ${projectDir}. Install Storybook in that project, then retry.`,
-      { cause }
-    );
+    throw cannotResolve(projectDir, cause);
   }
+}
+
+async function resolveThroughPnp(projectDir: string, pnpApiPath: string): Promise<string> {
+  const { default: pnpApi } = (await import(pathToFileURL(pnpApiPath).href)) as {
+    default: YarnPnpApi;
+  };
+  // `pnpapi` is only injected when Node was started via Yarn.
+  pnpApi.setup?.();
+  const pnpLoader = join(dirname(pnpApiPath), '.pnp.loader.mjs');
+  if (existsSync(pnpLoader)) {
+    register(pathToFileURL(pnpLoader).href);
+  }
+
+  const issuer = join(projectDir, 'package.json');
+  const resolved = pnpApi.resolveRequest?.(TOOLS_ENTRY, issuer, { considerBuiltins: false });
+  if (resolved) {
+    return resolved;
+  }
+
+  return createRequire(issuer).resolve(TOOLS_ENTRY, { paths: [projectDir] });
+}
+
+function findPnpApi(projectDir: string): string | undefined {
+  let current = projectDir;
+  for (;;) {
+    for (const name of PNP_API_FILES) {
+      const candidate = join(current, name);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+function cannotResolve(projectDir: string, cause: unknown): Error {
+  // eslint-disable-next-line local-rules/no-uncategorized-errors -- the shim imports no taxonomy
+  return new Error(
+    `Could not resolve \`${TOOLS_ENTRY}\` from ${projectDir}. Install Storybook in that project, then retry.`,
+    { cause }
+  );
 }
 
 function selectCreateTools(namespace: unknown, entryPath: string): CreateTools {

--- a/code/core/src/cli/tools/sdk/loader.ts
+++ b/code/core/src/cli/tools/sdk/loader.ts
@@ -1,0 +1,61 @@
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { CreateToolsOptions, LocalTools, Tools } from './types.ts';
+
+const TOOLS_ENTRY = 'storybook/internal/tools';
+
+type CreateTools = (options?: CreateToolsOptions) => Promise<Tools>;
+
+/**
+ * Create a tools host with the SDK the target project installed, never this process's own copy.
+ *
+ * Toolset code has to run against the Storybook a project depends on, so this resolves
+ * `storybook/internal/tools` from `projectDir`, imports that copy, and forwards the options to its
+ * `createTools`, with `cwd` defaulting to `projectDir`. Nothing else in the SDK is loaded here,
+ * which keeps this entry stable for embedders that bundle their own `storybook`.
+ *
+ * @throws {Error} When the project has no resolvable `storybook/internal/tools`, or when that entry
+ *   exposes no `createTools`.
+ */
+export function loadTools(
+  projectDir: string,
+  options: CreateToolsOptions & { mode: 'local' }
+): Promise<LocalTools>;
+export function loadTools(projectDir: string, options?: CreateToolsOptions): Promise<Tools>;
+export async function loadTools(
+  projectDir: string,
+  options: CreateToolsOptions = {}
+): Promise<Tools> {
+  const entryPath = resolveToolsEntry(projectDir);
+  const namespace: unknown = await import(pathToFileURL(entryPath).href);
+  return selectCreateTools(namespace, entryPath)({ cwd: projectDir, ...options });
+}
+
+function resolveToolsEntry(projectDir: string): string {
+  // Issued from the project rather than from this file: this loader ships inside `storybook`, and
+  // Node's self-reference resolution would hand back its own package's entry before reading `paths`.
+  const projectRequire = createRequire(join(projectDir, 'package.json'));
+  try {
+    return projectRequire.resolve(TOOLS_ENTRY, { paths: [projectDir] });
+  } catch (cause) {
+    // eslint-disable-next-line local-rules/no-uncategorized-errors -- the shim imports no taxonomy
+    throw new Error(
+      `Could not resolve \`${TOOLS_ENTRY}\` from ${projectDir}. Install Storybook in that project, then retry.`,
+      { cause }
+    );
+  }
+}
+
+function selectCreateTools(namespace: unknown, entryPath: string): CreateTools {
+  const candidates = [namespace, (namespace as { default?: unknown } | undefined)?.default];
+  for (const candidate of candidates) {
+    const createTools = (candidate as { createTools?: unknown } | undefined)?.createTools;
+    if (typeof createTools === 'function') {
+      return createTools as CreateTools;
+    }
+  }
+  // eslint-disable-next-line local-rules/no-uncategorized-errors -- the shim imports no taxonomy
+  throw new Error(`The \`${TOOLS_ENTRY}\` entry at ${entryPath} exposes no \`createTools\`.`);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## What I did

This PR adds a `loadTools`-function that can be used by applications embedding Storybook, to load the correct Storybook instance for the user project the application is integrating with. It ensures, that when an application imports it's own dependency of Storybook, it can still later get the correct Storybook dependency to interact with a project via the Tools SDK.

**It is not used by the CLI anywhere, and since the Node SDK is still external only, this is not used anywhere at all, and we can close it if we want to. We can also keep it for future usage.**

Linear: SB-1876. Base is `jeppe-cursor/tools-sdk-skeleton-900b`, not `next`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No UI change. After SB-1874 is on the machine, confirm `storybook tools` still starts via the CLI package.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732e6c14-a542-4611-b1f8-ff132284900b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732e6c14-a542-4611-b1f8-ff132284900b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

