### PR TITLE
CLI: Default agent commands to silent log level

### DIFF
--- a/code/core/src/bin/cli-command.test.ts
+++ b/code/core/src/bin/cli-command.test.ts
@@ -1,11 +1,15 @@
-import { logger, type LogLevel } from 'storybook/internal/node-logger';
+import { logTracker, logger, type LogLevel } from 'storybook/internal/node-logger';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Command } from 'commander';
 
 import { globalSettings, Settings } from '../cli/globalSettings.ts';
-import { addSharedCliOptions } from './cli-command.ts';
+import {
+  addSharedCliOptions,
+  defaultLogLevelForCommand,
+  writeCommandFailureDiagnostics,
+} from './cli-command.ts';
 
 vi.mock('storybook/internal/node-logger', { spy: true });
 vi.mock('../cli/globalSettings.ts', { spy: true });
@@ -13,13 +17,27 @@ vi.mock('../cli/globalSettings.ts', { spy: true });
 const parse = (program: Command, argv: string[]) =>
   program.parseAsync(['node', 'storybook', ...argv]);
 
-function buildProgram(name: string, defaultLogLevel: LogLevel) {
+function buildProgram(name: string, defaultLogLevel?: LogLevel) {
   const program = new Command();
   program.exitOverride();
   const action = vi.fn();
-  addSharedCliOptions(program.command(name), defaultLogLevel).action(action);
+  addSharedCliOptions(
+    program.command(name),
+    defaultLogLevel ?? defaultLogLevelForCommand(name)
+  ).action(action);
   return { program, action };
 }
+
+describe('defaultLogLevelForCommand', () => {
+  it('defaults ai, tools, and skills to silent, and every other command to info', () => {
+    expect(defaultLogLevelForCommand('ai')).toBe('silent');
+    expect(defaultLogLevelForCommand('tools')).toBe('silent');
+    expect(defaultLogLevelForCommand('skills')).toBe('silent');
+    expect(defaultLogLevelForCommand('dev')).toBe('info');
+    expect(defaultLogLevelForCommand('build')).toBe('info');
+    expect(defaultLogLevelForCommand('index')).toBe('info');
+  });
+});
 
 describe('addSharedCliOptions log level', () => {
   beforeEach(() => {
@@ -34,17 +52,20 @@ describe('addSharedCliOptions log level', () => {
     vi.mocked(globalSettings).mockReset();
   });
 
-  it('defaults agent commands to silent so logger output stays off', async () => {
-    const { program, action } = buildProgram('tools', 'silent');
+  it.each(['ai', 'tools', 'skills'] as const)(
+    'defaults the registered %s command to silent so logger chatter stays off',
+    async (name) => {
+      const { program, action } = buildProgram(name);
 
-    await parse(program, ['tools']);
+      await parse(program, [name]);
 
-    expect(action).toHaveBeenCalledOnce();
-    expect(logger.setLogLevel).toHaveBeenCalledWith('silent');
-  });
+      expect(action).toHaveBeenCalledOnce();
+      expect(logger.setLogLevel).toHaveBeenCalledWith('silent');
+    }
+  );
 
   it('keeps human-facing commands at info when no log flags are passed', async () => {
-    const { program } = buildProgram('dev', 'info');
+    const { program } = buildProgram('dev');
 
     await parse(program, ['dev']);
 
@@ -52,7 +73,7 @@ describe('addSharedCliOptions log level', () => {
   });
 
   it('lets --loglevel override the silent default', async () => {
-    const { program } = buildProgram('tools', 'silent');
+    const { program } = buildProgram('tools');
 
     await parse(program, ['tools', '--loglevel', 'warn']);
 
@@ -60,7 +81,7 @@ describe('addSharedCliOptions log level', () => {
   });
 
   it('lets --debug override both the silent default and --loglevel', async () => {
-    const { program } = buildProgram('ai', 'silent');
+    const { program } = buildProgram('ai');
 
     await parse(program, ['ai', '--loglevel', 'error', '--debug']);
 
@@ -71,12 +92,42 @@ describe('addSharedCliOptions log level', () => {
     const program = new Command();
     program.exitOverride();
     const action = vi.fn();
-    const ai = addSharedCliOptions(program.command('ai'), 'silent');
+    const ai = addSharedCliOptions(program.command('ai'), defaultLogLevelForCommand('ai'));
     ai.command('setup').action(action);
 
     await parse(program, ['ai', 'setup']);
 
     expect(action).toHaveBeenCalledOnce();
     expect(logger.setLogLevel).toHaveBeenCalledWith('silent');
+  });
+});
+
+describe('writeCommandFailureDiagnostics', () => {
+  beforeEach(() => {
+    vi.mocked(logger.diagnostic).mockImplementation(() => {});
+    vi.mocked(logTracker.writeToFile).mockResolvedValue('/tmp/debug-storybook.log');
+  });
+
+  afterEach(() => {
+    vi.mocked(logger.diagnostic).mockReset();
+    vi.mocked(logTracker.writeToFile).mockReset();
+  });
+
+  it('writes the logfile location and exit notice through the diagnostic channel', async () => {
+    await writeCommandFailureDiagnostics(true);
+
+    expect(logger.diagnostic).toHaveBeenCalledWith(
+      'Debug logs are written to: /tmp/debug-storybook.log'
+    );
+    expect(logger.diagnostic).toHaveBeenCalledWith('Storybook exited with an error');
+  });
+
+  it('still writes the exit notice when the logfile cannot be written', async () => {
+    vi.mocked(logTracker.writeToFile).mockRejectedValue(new Error('EACCES'));
+
+    await writeCommandFailureDiagnostics(true);
+
+    expect(logger.diagnostic).toHaveBeenCalledOnce();
+    expect(logger.diagnostic).toHaveBeenCalledWith('Storybook exited with an error');
   });
 });

--- a/code/core/src/bin/cli-command.test.ts
+++ b/code/core/src/bin/cli-command.test.ts
@@ -1,0 +1,78 @@
+import { logger, type LogLevel } from 'storybook/internal/node-logger';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Command } from 'commander';
+
+import { globalSettings } from '../cli/globalSettings.ts';
+import { addSharedCliOptions } from './cli-command.ts';
+
+vi.mock('../cli/globalSettings.ts', { spy: true });
+
+const parse = (program: Command, argv: string[]) =>
+  program.parseAsync(['node', 'storybook', ...argv]);
+
+function buildProgram(name: string, defaultLogLevel: LogLevel) {
+  const program = new Command();
+  program.exitOverride();
+  const action = vi.fn();
+  addSharedCliOptions(program.command(name), defaultLogLevel).action(action);
+  return { program, action };
+}
+
+describe('addSharedCliOptions log level', () => {
+  beforeEach(() => {
+    logger.setLogLevel = vi.fn();
+    vi.mocked(globalSettings).mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults agent commands to silent so logger output stays off', async () => {
+    const { program, action } = buildProgram('tools', 'silent');
+
+    await parse(program, ['tools']);
+
+    expect(action).toHaveBeenCalledOnce();
+    expect(logger.setLogLevel).toHaveBeenCalledWith('silent');
+  });
+
+  it('keeps human-facing commands at info when no log flags are passed', async () => {
+    const { program } = buildProgram('dev', 'info');
+
+    await parse(program, ['dev']);
+
+    expect(logger.setLogLevel).toHaveBeenCalledWith('info');
+  });
+
+  it('lets --loglevel override the silent default', async () => {
+    const { program } = buildProgram('tools', 'silent');
+
+    await parse(program, ['tools', '--loglevel', 'warn']);
+
+    expect(logger.setLogLevel).toHaveBeenCalledWith('warn');
+  });
+
+  it('lets --debug override both the silent default and --loglevel', async () => {
+    const { program } = buildProgram('ai', 'silent');
+
+    await parse(program, ['ai', '--loglevel', 'error', '--debug']);
+
+    expect(logger.setLogLevel).toHaveBeenCalledWith('debug');
+  });
+
+  it('applies the parent default when an agent subcommand runs', async () => {
+    const program = new Command();
+    program.exitOverride();
+    const action = vi.fn();
+    const ai = addSharedCliOptions(program.command('ai'), 'silent');
+    ai.command('setup').action(action);
+
+    await parse(program, ['ai', 'setup']);
+
+    expect(action).toHaveBeenCalledOnce();
+    expect(logger.setLogLevel).toHaveBeenCalledWith('silent');
+  });
+});

--- a/code/core/src/bin/cli-command.test.ts
+++ b/code/core/src/bin/cli-command.test.ts
@@ -4,9 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Command } from 'commander';
 
-import { globalSettings } from '../cli/globalSettings.ts';
+import { globalSettings, Settings } from '../cli/globalSettings.ts';
 import { addSharedCliOptions } from './cli-command.ts';
 
+vi.mock('storybook/internal/node-logger', { spy: true });
 vi.mock('../cli/globalSettings.ts', { spy: true });
 
 const parse = (program: Command, argv: string[]) =>
@@ -22,12 +23,15 @@ function buildProgram(name: string, defaultLogLevel: LogLevel) {
 
 describe('addSharedCliOptions log level', () => {
   beforeEach(() => {
-    logger.setLogLevel = vi.fn();
-    vi.mocked(globalSettings).mockResolvedValue(undefined as never);
+    vi.mocked(logger.setLogLevel).mockImplementation(() => {});
+    vi.mocked(globalSettings).mockResolvedValue(
+      new Settings('/unused-settings.json', { version: 1 })
+    );
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.mocked(logger.setLogLevel).mockReset();
+    vi.mocked(globalSettings).mockReset();
   });
 
   it('defaults agent commands to silent so logger output stays off', async () => {

--- a/code/core/src/bin/cli-command.ts
+++ b/code/core/src/bin/cli-command.ts
@@ -6,8 +6,20 @@ import { Option, type Command } from 'commander';
 import { globalSettings } from '../cli/globalSettings.ts';
 
 const CLI_LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'silent'] as const;
+const AGENT_CLI_COMMANDS = new Set(['ai', 'tools', 'skills']);
 
-// Agent-facing commands pass `silent` so logger chatter cannot mix into parseable stdout.
+export function defaultLogLevelForCommand(commandName: string): LogLevel {
+  return AGENT_CLI_COMMANDS.has(commandName) ? 'silent' : 'info';
+}
+
+export async function writeCommandFailureDiagnostics(logFilePath: string | boolean): Promise<void> {
+  try {
+    const logFile = await logTracker.writeToFile(logFilePath);
+    logger.diagnostic(`Debug logs are written to: ${logFile}`);
+  } catch {}
+  logger.diagnostic('Storybook exited with an error');
+}
+
 export function addSharedCliOptions(command: Command, defaultLogLevel: LogLevel = 'info'): Command {
   return command
     .option(
@@ -38,7 +50,7 @@ export function addSharedCliOptions(command: Command, defaultLogLevel: LogLevel 
 
         await globalSettings();
       } catch (e) {
-        logger.error('Error loading global settings:\n' + String(e));
+        logger.diagnostic('Error loading global settings:\n' + String(e));
       }
     });
 }

--- a/code/core/src/bin/cli-command.ts
+++ b/code/core/src/bin/cli-command.ts
@@ -1,0 +1,44 @@
+import { optionalEnvToBoolean } from 'storybook/internal/common';
+import { logTracker, logger, type LogLevel } from 'storybook/internal/node-logger';
+
+import { Option, type Command } from 'commander';
+
+import { globalSettings } from '../cli/globalSettings.ts';
+
+const CLI_LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'silent'] as const;
+
+// Agent-facing commands pass `silent` so logger chatter cannot mix into parseable stdout.
+export function addSharedCliOptions(command: Command, defaultLogLevel: LogLevel = 'info'): Command {
+  return command
+    .option(
+      '--disable-telemetry',
+      'Disable sending telemetry data',
+      optionalEnvToBoolean(process.env.STORYBOOK_DISABLE_TELEMETRY)
+    )
+    .option('--debug', 'Get more logs in debug mode', false)
+    .option('--enable-crash-reports', 'Enable sending crash reports to telemetry data')
+    .addOption(
+      new Option('--loglevel <level>', 'Define log level')
+        .choices([...CLI_LOG_LEVELS])
+        .default(defaultLogLevel)
+    )
+    .option(
+      '--logfile [path]',
+      'Write all debug logs to the specified file at the end of the run. Defaults to debug-storybook.log when [path] is not provided'
+    )
+    .hook('preAction', async (self) => {
+      try {
+        const options = self.opts();
+        const loglevel = options.debug ? 'debug' : options.loglevel;
+        logger.setLogLevel(loglevel);
+
+        if (options.logfile) {
+          logTracker.enableLogWriting();
+        }
+
+        await globalSettings();
+      } catch (e) {
+        logger.error('Error loading global settings:\n' + String(e));
+      }
+    });
+}

--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -6,7 +6,7 @@ import {
   parseList,
 } from 'storybook/internal/common';
 import { withTelemetry } from 'storybook/internal/core-server';
-import { logTracker, logger, type LogLevel } from 'storybook/internal/node-logger';
+import { logTracker, logger } from 'storybook/internal/node-logger';
 import { addToGlobalContext } from 'storybook/internal/telemetry';
 
 import { Option, program } from 'commander';
@@ -21,7 +21,11 @@ import { registerToolsPassthrough } from '../cli/tools/register.ts';
 import { build } from '../cli/build.ts';
 import { buildIndex as index } from '../cli/buildIndex.ts';
 import { dev } from '../cli/dev.ts';
-import { addSharedCliOptions } from './cli-command.ts';
+import {
+  addSharedCliOptions,
+  defaultLogLevelForCommand,
+  writeCommandFailureDiagnostics,
+} from './cli-command.ts';
 import { resolveDevCommandOptions } from './dev-options.ts';
 
 addToGlobalContext('cliVersion', version);
@@ -42,16 +46,12 @@ process.env.STORYBOOK = 'true';
  */
 
 const handleCommandFailure = async (logFilePath: string | boolean): Promise<never> => {
-  try {
-    const logFile = await logTracker.writeToFile(logFilePath);
-    logger.log(`Debug logs are written to: ${logFile}`);
-  } catch {}
-  logger.outro('Storybook exited with an error');
+  await writeCommandFailureDiagnostics(logFilePath);
   process.exit(1);
 };
 
-const command = (name: string, defaultLogLevel?: LogLevel) =>
-  addSharedCliOptions(program.command(name), defaultLogLevel).hook(
+const command = (name: string) =>
+  addSharedCliOptions(program.command(name), defaultLogLevelForCommand(name)).hook(
     'postAction',
     async (command) => {
       if (logTracker.shouldWriteLogsToFile) {
@@ -206,12 +206,12 @@ const handleCliCommandFailure =
   (logFilePath: string | boolean | undefined) =>
   async (error: unknown): Promise<never> => {
     if (!(error instanceof HandledError)) {
-      logger.error(String(error));
+      logger.diagnostic(String(error));
     }
     return handleCommandFailure(logFilePath ?? false);
   };
 
-const aiCommand = command('ai', 'silent')
+const aiCommand = command('ai')
   .description('AI agent helpers for Storybook (deprecated — see `storybook skills`)')
   .option(
     '-o, --output <path>',
@@ -251,12 +251,12 @@ if (isAiCliFeatureEnabled()) {
 
 // `storybook tools <toolset> <tool>`: runs the toolsets registered by the target Storybook
 // configuration in this process, disconnected from any dev server (storybookjs/storybook#35716).
-const toolsCommand = command('tools', 'silent').description(
+const toolsCommand = command('tools').description(
   'Run the agent tools provided by the target Storybook configuration'
 );
 registerToolsPassthrough(program, toolsCommand, handleCliCommandFailure);
 
-const skillsCommand = command('skills', 'silent').description(
+const skillsCommand = command('skills').description(
   'Agent skills served by the target Storybook configuration'
 );
 registerSkillsCommand(program, skillsCommand, handleCliCommandFailure);

--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -256,8 +256,6 @@ const toolsCommand = command('tools', 'silent').description(
 );
 registerToolsPassthrough(program, toolsCommand, handleCliCommandFailure);
 
-// `storybook skills`: agent-facing instruction documents served by the target Storybook
-// configuration (storybookjs/storybook#35526, Milestone 6).
 const skillsCommand = command('skills', 'silent').description(
   'Agent skills served by the target Storybook configuration'
 );

--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -6,7 +6,7 @@ import {
   parseList,
 } from 'storybook/internal/common';
 import { withTelemetry } from 'storybook/internal/core-server';
-import { logTracker, logger } from 'storybook/internal/node-logger';
+import { logTracker, logger, type LogLevel } from 'storybook/internal/node-logger';
 import { addToGlobalContext } from 'storybook/internal/telemetry';
 
 import { Option, program } from 'commander';
@@ -21,7 +21,7 @@ import { registerToolsPassthrough } from '../cli/tools/register.ts';
 import { build } from '../cli/build.ts';
 import { buildIndex as index } from '../cli/buildIndex.ts';
 import { dev } from '../cli/dev.ts';
-import { globalSettings } from '../cli/globalSettings.ts';
+import { addSharedCliOptions } from './cli-command.ts';
 import { resolveDevCommandOptions } from './dev-options.ts';
 
 addToGlobalContext('cliVersion', version);
@@ -50,41 +50,10 @@ const handleCommandFailure = async (logFilePath: string | boolean): Promise<neve
   process.exit(1);
 };
 
-const command = (name: string) =>
-  program
-    .command(name)
-    .option(
-      '--disable-telemetry',
-      'Disable sending telemetry data',
-      optionalEnvToBoolean(process.env.STORYBOOK_DISABLE_TELEMETRY)
-    )
-    .option('--debug', 'Get more logs in debug mode', false)
-    .option('--enable-crash-reports', 'Enable sending crash reports to telemetry data')
-    .addOption(
-      new Option('--loglevel <level>', 'Define log level')
-        .choices(['trace', 'debug', 'info', 'warn', 'error', 'silent'])
-        .default('info')
-    )
-    .option(
-      '--logfile [path]',
-      'Write all debug logs to the specified file at the end of the run. Defaults to debug-storybook.log when [path] is not provided'
-    )
-    .hook('preAction', async (self) => {
-      try {
-        const options = self.opts();
-        const loglevel = options.debug ? 'debug' : options.loglevel;
-        logger.setLogLevel(loglevel);
-
-        if (options.logfile) {
-          logTracker.enableLogWriting();
-        }
-
-        await globalSettings();
-      } catch (e) {
-        logger.error('Error loading global settings:\n' + String(e));
-      }
-    })
-    .hook('postAction', async (command) => {
+const command = (name: string, defaultLogLevel?: LogLevel) =>
+  addSharedCliOptions(program.command(name), defaultLogLevel).hook(
+    'postAction',
+    async (command) => {
       if (logTracker.shouldWriteLogsToFile) {
         try {
           const logFile = await logTracker.writeToFile(command.getOptionValue('logfile'));
@@ -95,7 +64,8 @@ const command = (name: string) =>
       if (command.name() === 'build') {
         process.exit(0);
       }
-    });
+    }
+  );
 
 command('dev')
   .option('-p, --port <number>', 'Port to run Storybook')
@@ -241,7 +211,7 @@ const handleCliCommandFailure =
     return handleCommandFailure(logFilePath ?? false);
   };
 
-const aiCommand = command('ai')
+const aiCommand = command('ai', 'silent')
   .description('AI agent helpers for Storybook (deprecated — see `storybook skills`)')
   .option(
     '-o, --output <path>',
@@ -281,14 +251,14 @@ if (isAiCliFeatureEnabled()) {
 
 // `storybook tools <toolset> <tool>`: runs the toolsets registered by the target Storybook
 // configuration in this process, disconnected from any dev server (storybookjs/storybook#35716).
-const toolsCommand = command('tools').description(
+const toolsCommand = command('tools', 'silent').description(
   'Run the agent tools provided by the target Storybook configuration'
 );
 registerToolsPassthrough(program, toolsCommand, handleCliCommandFailure);
 
 // `storybook skills`: agent-facing instruction documents served by the target Storybook
 // configuration (storybookjs/storybook#35526, Milestone 6).
-const skillsCommand = command('skills').description(
+const skillsCommand = command('skills', 'silent').description(
   'Agent skills served by the target Storybook configuration'
 );
 registerSkillsCommand(program, skillsCommand, handleCliCommandFailure);

--- a/code/core/src/cli/ai/index.ts
+++ b/code/core/src/cli/ai/index.ts
@@ -27,9 +27,9 @@ export async function aiSetup(options: AiSetupOptions): Promise<void> {
 
   if (!result.ok) {
     const [firstLine, ...rest] = result.message.split('\n');
-    logger.error(firstLine);
+    logger.diagnostic(firstLine);
     if (rest.length > 0) {
-      logger.log(rest.join('\n'));
+      logger.diagnostic(rest.join('\n'));
     }
     return;
   }
@@ -40,7 +40,7 @@ export async function aiSetup(options: AiSetupOptions): Promise<void> {
     projectInfo.rendererPackage !== '@storybook/react' ||
     projectInfo.builderPackage !== '@storybook/builder-vite'
   ) {
-    logger.log(
+    logger.diagnostic(
       'AI-assisted setup is currently only available for projects using the React renderer with Vite builder. Detected renderer: ' +
         projectInfo.rendererPackage +
         ', builder: ' +

--- a/code/core/src/node-logger/logger/logger.diagnostic.test.ts
+++ b/code/core/src/node-logger/logger/logger.diagnostic.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { diagnostic, setLogLevel } from './logger.ts';
+
+describe('diagnostic', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setLogLevel('info');
+  });
+
+  it('writes to stderr when the log level is silent', () => {
+    const stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setLogLevel('silent');
+
+    diagnostic('Could not write tools output');
+
+    expect(stderr).toHaveBeenCalledWith('Could not write tools output');
+  });
+});

--- a/code/core/src/node-logger/logger/logger.ts
+++ b/code/core/src/node-logger/logger/logger.ts
@@ -161,6 +161,12 @@ export const error = createLogger('error', (...args: LogFunctionArgs<typeof LOG_
   LOG_FUNCTIONS.error()(...args)
 );
 
+/** Write a failure diagnostic to stderr, ignoring the log level and prompt library. */
+export const diagnostic = (message: string): void => {
+  logTracker.addLog('error', message);
+  console.error(message);
+};
+
 export type BoxOptions = {
   title?: string;
 } & clack.BoxOptions;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I realized that now that we have CLI commands that are supposed to be parsed programmatically or via agents, we can't just willy nilly include all our logging in the output. the output of the cli must be only its result, and nothing else. especially where in JSON mode, where any logs injected would make the command unparseable.

So agent commands are now in silent logging mode by default.
`--loglevel` and `--debug` are still override. If you raise the level, stdout can mix with the tool result and is no longer reliably parseable.

However `silent` also filters `logger.error` and `logger.outro`, and those calls go through clack, which writes to stdout. That hid predictable failures: an unwritable `tools --output` path, the logfile location, and "Storybook exited with an error" all vanished, and `ai setup` loses its project-info and unsupported-framework guidance.
So here we add a new level, `logger.diagnostic`, that writes those notices straight to stderr so they stay visible under the silent default, without mixing logger chatter into parseable stdout.

If you have other suggestions for how to get around this, or if you think this whole PR is fixing a non-existent problem, I'm open to feedback.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.
-->

1. From a project with Storybook installed, run `npx storybook tools --help` and confirm `--loglevel` defaults to `silent`.
2. Run `npx storybook dev --help` and confirm `--loglevel` still defaults to `info`.
3. Run a local tool that prints JSON, for example `npx storybook tools docs list --json`. Confirm stdout is only JSON (parse it with `JSON.parse` / `jq`). No `[open-service-*-command-sync-demo]` or other logger lines on stdout. (Internal-UI sync demos still use raw `console.log`; that is out of scope here. Prefer a user sandbox for this check.)
4. Repeat the same command with `--loglevel info`. Confirm Storybook logger lines can appear, and that stdout may no longer parse as JSON.
5. Repeat with `--debug` and confirm debug logs appear even if `--loglevel silent` is also passed.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update the [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732e6c14-a542-4611-b1f8-ff132284900b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732e6c14-a542-4611-b1f8-ff132284900b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

