### PR TITLE
Core: Keep the docs page visible when a per-story tag is filtered out

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -1095,6 +1095,25 @@ describe('StoryIndexGenerator', () => {
         );
       });
 
+      it('does not leak a single story tag into the generated docs entry (#35968)', async () => {
+        // Regression test: a tag that only the file's first story carries must not end up
+        // on the docs entry, otherwise tag filters that hide that story also hide the docs page.
+        const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
+          './tag-leak/Button.stories.(ts|js|mjs|jsx)',
+          options
+        );
+
+        const generator = new StoryIndexGenerator([specifier], autodocsOptions);
+        await generator.initialize();
+
+        const index = await generator.getIndex();
+        const docsEntry = Object.values(index.entries).find((entry) => entry.type === 'docs');
+        expect(docsEntry).toBeDefined();
+        expect(docsEntry?.tags).not.toContain('anatomy');
+        expect(docsEntry?.tags).not.toContain('showcase');
+        expect(docsEntry?.tags).toContain('autodocs');
+      });
+
       it('throws an error if you attach a named MetaOf entry which clashes with a tagged autodocs entry', async () => {
         const csfSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
           './src/B.stories.ts',
@@ -1656,6 +1675,30 @@ describe('StoryIndexGenerator', () => {
             "v": 5,
           }
         `);
+      });
+
+      it('does not leak a single story tag into a docs entry attached via `<Meta of={}>` (#35968)', async () => {
+        // Regression test: a tag that only the CSF file's first story carries must not end up
+        // on the attached docs entry, otherwise tag filters that hide that story also hide the
+        // docs page.
+        const tagLeakStoriesSpecifier = normalizeStoriesEntry(
+          './tag-leak/Widget.stories.(ts|js|mjs|jsx)',
+          options
+        );
+        const tagLeakDocsSpecifier = normalizeStoriesEntry('./tag-leak/Widget.mdx', options);
+
+        const generator = new StoryIndexGenerator(
+          [tagLeakStoriesSpecifier, tagLeakDocsSpecifier],
+          options
+        );
+        await generator.initialize();
+
+        const index = await generator.getIndex();
+        const docsEntry = Object.values(index.entries).find((entry) => entry.type === 'docs');
+        expect(docsEntry).toBeDefined();
+        expect(docsEntry?.tags).not.toContain('anatomy');
+        expect(docsEntry?.tags).not.toContain('showcase');
+        expect(docsEntry?.tags).toContain('attached-mdx');
       });
 
       it('does not append title prefix if meta references a CSF file', async () => {

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -486,7 +486,17 @@ export class StoryIndexGenerator {
       const { metaId } = indexInputs[0];
       const entry = storyEntries[0];
       const id = toId(metaId ?? entry.title, name);
-      const tags = combineTags(...projectTags, ...(indexInputs[0].tags ?? []));
+      // Use tags shared by every story in the file, not just the first one. A tag that only
+      // some stories carry is not a property of the component, and leaking it onto the docs
+      // entry means tag filters that hide those stories also hide the docs page. See #35968.
+      const sharedStoryTags = storyEntries
+        .filter((storyEntry) => storyEntry.type === 'story' && storyEntry.subtype !== 'test')
+        .reduce<Tag[] | null>(
+          (acc, storyEntry) =>
+            acc === null ? storyEntry.tags : acc.filter((tag) => storyEntry.tags.includes(tag)),
+          null
+        );
+      const tags = combineTags(...projectTags, ...(sharedStoryTags ?? []));
 
       const docsEntry: DocsCacheEntry & { tags: Tag[] } = {
         id,
@@ -546,6 +556,7 @@ export class StoryIndexGenerator {
       // Also, if `result.of` is set, it means that we're using the `<Meta of={XStories} />` syntax,
       // so find the `title` defined the file that `meta` points to.
       let csfEntry: StoryIndexEntryWithExtra | undefined;
+      let sharedCsfTags: Tag[] | null = null;
       if (result.of) {
         const absoluteOf = makeAbsolute(result.of, normalizedPath, this.options.workingDir);
         let metaDependency: StoriesCacheEntry | undefined;
@@ -570,6 +581,19 @@ export class StoryIndexGenerator {
             metaDependency,
             ...dependencies.filter((d) => d !== metaDependency),
           ];
+
+          // Use tags shared by every story in the referenced CSF file, not just the first one
+          // found. A tag that only some stories carry is not a property of the component, and
+          // leaking it onto the docs entry means tag filters that hide those stories also hide
+          // the docs page. See #35968.
+          sharedCsfTags = metaDependency.entries
+            .filter(
+              (e): e is StoryIndexEntryWithExtra => e.type === 'story' && e.subtype !== 'test'
+            )
+            .reduce<Tag[] | null>((acc, e) => {
+              const entryTags = e.tags ?? [];
+              return acc === null ? entryTags : acc.filter((tag) => entryTags.includes(tag));
+            }, null);
         }
 
         invariant(
@@ -606,7 +630,7 @@ export class StoryIndexGenerator {
 
       const tags = combineTags(
         ...projectTags,
-        ...(csfEntry?.tags ?? []),
+        ...(sharedCsfTags ?? csfEntry?.tags ?? []),
         ...(result.metaTags ?? []),
         csfEntry ? Tag.ATTACHED_MDX : Tag.UNATTACHED_MDX
       );

--- a/code/core/src/core-server/utils/__mockdata__/tag-leak/Button.stories.ts
+++ b/code/core/src/core-server/utils/__mockdata__/tag-leak/Button.stories.ts
@@ -1,0 +1,16 @@
+const component = {};
+export default {
+  title: 'TagLeak/Button',
+  component,
+  tags: ['autodocs'],
+};
+
+// Declared first on purpose: the generated docs entry must not pick up this
+// story's own tag, only tags shared by the whole component (see #35968).
+export const Anatomy = {
+  tags: ['anatomy'],
+};
+
+export const Default = {
+  tags: ['showcase'],
+};

--- a/code/core/src/core-server/utils/__mockdata__/tag-leak/Widget.mdx
+++ b/code/core/src/core-server/utils/__mockdata__/tag-leak/Widget.mdx
@@ -1,0 +1,5 @@
+import * as WidgetStories from './Widget.stories';
+
+<Meta of={WidgetStories} />
+
+# Widget docs

--- a/code/core/src/core-server/utils/__mockdata__/tag-leak/Widget.stories.ts
+++ b/code/core/src/core-server/utils/__mockdata__/tag-leak/Widget.stories.ts
@@ -1,0 +1,15 @@
+const component = {};
+export default {
+  title: 'TagLeak/Widget',
+  component,
+};
+
+// Declared first on purpose: the docs entry attached via `<Meta of={}>` must not pick up
+// this story's own tag, only tags shared by the whole component (see #35968).
+export const Anatomy = {
+  tags: ['anatomy'],
+};
+
+export const Default = {
+  tags: ['showcase'],
+};


### PR DESCRIPTION
Closes #35968.

## What I did

A component's docs page, autodocs or a custom `<Meta of={...} />` MDX page, disappeared from the sidebar when a tag filter hid every story for that component, leaving an empty sidebar.

The story index derived the docs entry's tags from the first story in the file (`combineTags(...projectTags, ...indexInputs[0].tags)`). Those already include the meta tags plus that story's own tags, so a tag set on just one story leaked onto the docs entry, and excluding that tag filtered out the docs page along with the story.

The docs entry now takes the tags shared by every story in the file (their intersection), the same way the sidebar already derives a group node's tags from its children in `manager-api/lib/stories.ts`. A tag only some stories carry no longer reaches the docs entry, while a tag present on every story (a genuine component-level tag) still does, so the docs page can still be filtered by it. Both the autodocs path and the `<Meta of={...} />` MDX path are covered.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. In the sandbox, tag only one story of a component that has a docs page and at least two stories, e.g. `tags: ['special']` on one story only.
3. In `.storybook/main.ts`, add `tags: { special: { defaultFilterSelection: 'exclude' } }`.
4. Open Storybook. The docs page stays in the sidebar while the `special` story is hidden. On `next` without this fix, the docs page disappears too.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
