### PR TITLE
CLI: Fix outro message to `storybook skills get setup` instead of old `storybook ai setup`

### DIFF
--- a/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
@@ -22,7 +22,7 @@ describe('FinalizationCommand', () => {
       logfile: undefined,
       showAgentFollowUp: false,
       showAiInstructions: false,
-      aiSetupCommand: 'npx storybook ai setup',
+      aiSetupCommand: 'npx storybook skills get setup',
     });
 
     vi.mocked(getProjectRoot).mockReturnValue('/test/project');
@@ -119,7 +119,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: true,
         showAiInstructions: true,
-        aiSetupCommand: 'pnpm exec storybook ai setup',
+        aiSetupCommand: 'pnpm exec storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -129,7 +129,7 @@ describe('FinalizationCommand', () => {
         expect.stringContaining('is not entirely set up yet')
       );
       expect(logger.step).toHaveBeenCalledWith(
-        expect.stringContaining('pnpm exec storybook ai setup')
+        expect.stringContaining('pnpm exec storybook skills get setup')
       );
       const logCalls = vi.mocked(logger.log).mock.calls.map((c) => String(c[0]));
       expect(logCalls.some((msg) => msg.includes('https://storybook.js.org/llms.txt'))).toBe(true);
@@ -141,7 +141,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: true,
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -160,7 +160,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -185,7 +185,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: true,
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -194,7 +194,9 @@ describe('FinalizationCommand', () => {
       expect(logger.step).toHaveBeenCalledWith(
         expect.stringContaining('To finalize setting up with AI')
       );
-      expect(logger.step).toHaveBeenCalledWith(expect.stringContaining('npx storybook ai setup'));
+      expect(logger.step).toHaveBeenCalledWith(
+        expect.stringContaining('npx storybook skills get setup')
+      );
     });
 
     it('should NOT show AI instructions when showAiInstructions=false', async () => {
@@ -202,7 +204,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -217,7 +219,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: true,
         showAiInstructions: true,
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -238,7 +240,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -253,7 +255,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -272,7 +274,7 @@ describe('FinalizationCommand', () => {
         showAgentFollowUp: true,
         showAiInstructions: false,
         logfile: undefined,
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
 
       // Agent mode should show agent-specific message
@@ -288,7 +290,7 @@ describe('FinalizationCommand', () => {
         showAgentFollowUp: false,
         showAiInstructions: true,
         logfile: undefined,
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
 
       expect(logger.step).toHaveBeenCalledWith(
@@ -304,7 +306,7 @@ describe('FinalizationCommand', () => {
         showAiInstructions: false,
         logfile: undefined,
         storybookCommand: 'yarn storybook',
-        aiSetupCommand: 'npx storybook ai setup',
+        aiSetupCommand: 'npx storybook skills get setup',
       });
 
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('yarn storybook'));

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.ts
@@ -13,7 +13,7 @@ export type FinalizationCommandOptions = {
   showAgentFollowUp: boolean;
   /** When true, show the "paste this prompt to your AI agent" instructions */
   showAiInstructions: boolean;
-  /** Package-manager-aware `storybook ai setup` command shown to agents */
+  /** Package-manager-aware `storybook skills get setup` command shown to agents */
   aiSetupCommand: string;
 };
 

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -190,7 +190,7 @@ export async function doInitiate(options: CommandOptions): Promise<
     showAiInstructions: hasAiFeature,
     logfile: options.logfile,
     storybookCommand,
-    aiSetupCommand: packageManager.getPackageCommand(['storybook', 'ai', 'setup']),
+    aiSetupCommand: packageManager.getPackageCommand(['storybook', 'skills', 'get', 'setup']),
   });
 
   // Step 9: Track telemetry (pass configDir so RN `.rnstorybook` metadata is resolved)


### PR DESCRIPTION
Closes #35960

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed the outro message shown after `npm create storybook` it was was showing the following `storybook ai setup`, which is deprecated. Now the message is `storybook skills get setup`. 

Updated comments, and tests to reflect the new message.

<img width="609" height="446" alt="CleanShot 2026-08-20" src="https://github.com/user-attachments/assets/84db3782-0887-4b54-9cd9-0be5aa4cba64" />


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a new project: `npm create vite@latest my-app -- --template react-ts && cd my-app && npm install`
2. Run Storybook init: `npx storybook@next init --yes`
3. Observe the outro message printed after installation completes.
4. Confirm it reads `npx storybook skills get setup` (not `npx storybook ai setup`).

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
