### PR TITLE
Angular: Resolve builder `styles` the way the Angular builders do

### DIFF
--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -573,6 +573,23 @@ export class AngularLegacyBuildOptionsError extends StorybookError {
   }
 }
 
+export class AngularUnresolvedStyleError extends StorybookError {
+  constructor(public data: { stylePath: string; workspaceRoot: string; extensions: string[] }) {
+    super({
+      name: 'AngularUnresolvedStyleError',
+      category: Category.FRAMEWORK_ANGULAR,
+      code: 2,
+      documentation: 'https://storybook.js.org/docs/get-started/frameworks/angular-vite',
+      message: dedent`
+        Cannot resolve the stylesheet '${data.stylePath}' from the Angular workspace root '${data.workspaceRoot}'.
+
+        No file matches it there, with or without a ${data.extensions.join(', ')} extension.
+
+        Angular resolves a 'styles' entry from the workspace root, so a relative entry has to point at a file below it. Check the 'styles' array on your Storybook builder target in angular.json.`,
+    });
+  }
+}
+
 export class CriticalPresetLoadError extends StorybookError {
   constructor(
     public data: {

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -1,10 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { findConfigFile } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
+import { AngularUnresolvedStyleError } from 'storybook/internal/server-errors';
 
+import { statSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+import { fs as memfs, vol } from 'memfs';
 import { mergeConfig, normalizePath } from 'vite';
 
 import { ensureCompodocDocumentation } from './compodoc/ensure-documentation.ts';
@@ -28,6 +31,9 @@ vi.mock(import('storybook/internal/common'), async (importOriginal) => ({
 vi.mock('storybook/internal/node-logger', { spy: true });
 vi.mock('./compodoc/ensure-documentation.ts', { spy: true });
 vi.mock('vite', { spy: true });
+// Spy-only mock: `styles` resolution stats candidate files, and only that call is redirected to a
+// memfs volume, so everything else in the preset keeps reading the real filesystem.
+vi.mock('node:fs', { spy: true });
 // The only mock that has to replace the module rather than spy on it: loading the real Angular
 // plugin drags a full Angular toolchain into the run, and none of these tests are about it.
 vi.mock('@analogjs/vite-plugin-angular', () => ({ default: (): unknown[] => [] }));
@@ -141,6 +147,22 @@ describe('angularOptionsPlugin global styles', () => {
 
   beforeEach(() => {
     vi.mocked(findConfigFile).mockReturnValue(previewPath);
+    vol.fromJSON(
+      {
+        'src/styles.css': '',
+        'src/styles.scss': '',
+        'src/theme.scss': '',
+        'apps/ui-storybook/.storybook/tailwind.css': '',
+        'node_modules/dso-toolkit/dist/dso.css': '',
+      },
+      WORKSPACE_ROOT
+    );
+    vi.mocked(statSync).mockImplementation(memfs.statSync as unknown as typeof statSync);
+  });
+
+  afterEach(() => {
+    vol.reset();
+    vi.mocked(statSync).mockReset();
   });
 
   const runTransform = (styles: unknown[]) => {
@@ -210,6 +232,51 @@ describe('angularOptionsPlugin global styles', () => {
     };
 
     expect(code).toContain("import 'zone.js';");
+  });
+
+  // A package specifier is a legitimate Angular `styles` entry: the builder hands it to a resolver
+  // anchored at the workspace root that falls through to node_modules, where dso-toolkit only is.
+  it('emits a package specifier bare, so Vite resolves it through node_modules', async () => {
+    const { code } = await runTransform(['dso-toolkit/dist/dso.css']);
+
+    expect(code).toContain("import 'dso-toolkit/dist/dso.css';");
+    expect(code).not.toContain(resolve(WORKSPACE_ROOT, 'dso-toolkit/dist/dso.css'));
+  });
+
+  it('resolves a `./`-prefixed entry against the workspace root, not the preview file', async () => {
+    const { code } = await runTransform(['./src/styles.css']);
+
+    expect(code).toContain(`import '${resolve(WORKSPACE_ROOT, 'src/styles.css')}';`);
+    expect(code).not.toContain("import './src/styles.css';");
+  });
+
+  it('resolves an extensionless entry to the stylesheet on disk', async () => {
+    const { code } = await runTransform(['src/theme']);
+
+    expect(code).toContain(`import '${resolve(WORKSPACE_ROOT, 'src/theme.scss')}';`);
+  });
+
+  // `dist/canopy/canopy.css` is a real corpus entry and a build output: on disk in a built
+  // workspace, absent in a clean checkout.
+  it('emits a bare-looking entry with no file on disk as a specifier, not a workspace path', async () => {
+    const { code } = await runTransform(['dist/canopy/canopy.css']);
+
+    expect(code).toContain("import 'dist/canopy/canopy.css';");
+    expect(code).not.toContain(resolve(WORKSPACE_ROOT, 'dist/canopy/canopy.css'));
+  });
+
+  it('never resolves a directory as a stylesheet', async () => {
+    const { code } = await runTransform(['src']);
+
+    expect(code).toContain("import 'src';");
+    expect(code).not.toContain(`import '${resolve(WORKSPACE_ROOT, 'src')}';`);
+  });
+
+  it('fails with the entry the user wrote when a path-shaped entry has no file', async () => {
+    await expect(runTransform(['./src/missing.css'])).rejects.toThrow(AngularUnresolvedStyleError);
+    await expect(runTransform(['./src/missing.css'])).rejects.toThrow(
+      /Cannot resolve the stylesheet '\.\/src\/missing\.css' from the Angular workspace root/
+    );
   });
 
   it('ignores malformed object-form styles from the environment bridge', async () => {

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -7,9 +7,10 @@ import {
   getRealPath,
 } from 'storybook/internal/mocking-utils';
 import { logger } from 'storybook/internal/node-logger';
+import { AngularUnresolvedStyleError } from 'storybook/internal/server-errors';
 import type { PresetProperty, StorybookConfigRaw } from 'storybook/internal/types';
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { basename, isAbsolute, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -300,6 +301,35 @@ export function compodocJsonStubPlugin(configDir: string): Plugin {
   };
 }
 
+const STYLE_EXTENSIONS = ['.css', '.scss', '.sass', '.less'];
+
+const isFile = (path: string) => statSync(path, { throwIfNoEntry: false })?.isFile() === true;
+
+// Angular resolves a `styles` entry relative-first from the workspace root and only then through
+// node_modules: `preferRelative` on the webpack builder's enhanced-resolve, an esbuild `@import`
+// with `resolveDir: workspaceRoot` on the esbuild builder. Both spellings occur in the wild.
+function resolveBuilderStyle(stylePath: string, workspaceRoot: string) {
+  const workspacePath = resolve(workspaceRoot, stylePath);
+  const onDisk = [workspacePath, ...STYLE_EXTENSIONS.map((ext) => workspacePath + ext)].find(
+    isFile
+  );
+  if (onDisk) {
+    return onDisk;
+  }
+
+  // Emitting a path-shaped entry verbatim would make Vite resolve it against `preview.ts` rather
+  // than the workspace root, and node_modules cannot rescue one either.
+  if (isAbsolute(stylePath) || /^\.\.?[/\\]/.test(stylePath)) {
+    throw new AngularUnresolvedStyleError({
+      stylePath,
+      workspaceRoot,
+      extensions: STYLE_EXTENSIONS,
+    });
+  }
+
+  return stylePath;
+}
+
 export function angularOptionsPlugin(
   options: StandaloneOptions,
   { normalizePath, zoneless }: any
@@ -358,11 +388,7 @@ export function angularOptionsPlugin(
                   ? style.input
                   : undefined;
             if (stylePath !== undefined) {
-              // Every `styles` entry is a path the Angular builder resolves against the workspace
-              // root - the schema has no package-specifier form - and in a monorepo that root sits
-              // above the Vite root. Left unresolved, Vite reads `apps/ui/styles.css` as a bare
-              // specifier and fails to find a package by that name.
-              imports.push(normalizePath(resolve(workspaceRoot, stylePath)));
+              imports.push(normalizePath(resolveBuilderStyle(stylePath, workspaceRoot)));
             }
           });
         }


### PR DESCRIPTION
Closes #

<!-- No issue to close: this came out of an internal Angular QA sweep, and the regression is mine, from #35974. -->

## What I did

An Angular `styles` entry is not a path that gets joined onto the workspace root. Both Angular builder families keep the string exactly as written and hand it to a module-aware resolver anchored at the workspace root, which tries the relative file first and only then falls through to `node_modules`. In #35974 I replaced a broken heuristic with `resolve(workspaceRoot, entry)` and left a code comment claiming "the schema has no package-specifier form". That was wrong, and it turned an ordinary entry like `"dso-toolkit/dist/dso.css"` into a filesystem path that does not exist, so the preview module stopped building.

This PR implements Angular's actual resolution ladder instead of the join, so both spellings work at the same time. A revert would not do: #35974 fixed the opposite spelling, and that one is far more common in practice, so reverting would trade one broken shape for many.

> [!NOTE]
> **Nothing published is affected.** `@storybook/angular-vite@10.5.10` (`latest`) and `10.6.0-alpha.7` (`next`) were both cut before #35974 merged. I checked both tarballs and they still carry the old `startsWith(".")` heuristic. The regression exists only on `next` at `a14aa35ff6f` and later, and would first reach users in 10.6.0-alpha.8 (#35970, still open). So this is a pre-release fix, not a hotfix.

## Before and after

Real `vite build` runs driving the compiled plugin over a workspace that has `src/styles.scss` on disk and `fake-toolkit/dist/fake.css` only in `node_modules`. "css bundled" is the CSS that actually landed in the build output.

```
                                                    next @ a14aa35ff6f            this PR
"fake-toolkit/dist/fake.css"      package specifier   UNRESOLVED_IMPORT      OK  .fake{color:#639}
"src/styles.scss"                 workspace-relative  OK .local{color:teal}  OK  .local{color:teal}
"src/styles"                      extensionless       UNRESOLVED_IMPORT      OK  .local{color:teal}
"node_modules/fake-toolkit/…"     node_modules-prefix OK .fake{color:#639}   OK  .fake{color:#639}
["src/styles.scss",               both spellings in
 "fake-toolkit/dist/fake.css"]    one array           UNRESOLVED_IMPORT      OK  both bundled
"./src/nope.css"                  typo                Vite error, wrong file AngularUnresolvedStyleError
```

The two `OK` rows on the left are the shapes #35974 fixed, and they stay fixed. Everything else on the left is what this PR repairs.

## How an entry resolves now

```
angular.json  "styles": [ <entry> ]
      │
      ├─ 1. <workspaceRoot>/<entry>                       is it a FILE?  ──yes──▶ emit that absolute path
      │
      ├─ 2. the same + .css / .scss / .sass / .less        is it a FILE?  ──yes──▶ emit that absolute path
      │
      ├─ 3. is <entry> path-shaped (absolute, ./ or ../)?  ──yes──▶ AngularUnresolvedStyleError
      │
      └─ 4. otherwise emit <entry> verbatim  ──▶  Vite resolves it through node_modules
```

Step 1 before step 4 is Angular's `preferRelative: true`. Step 3 exists because a path-shaped entry emitted verbatim would be resolved by Vite against `preview.ts` rather than the workspace root, so it could only ever fail somewhere confusing.

Worked through for the two entries that matter:

```
"fake-toolkit/dist/fake.css"                     "./src/nope.css"
  1. <root>/fake-toolkit/dist/fake.css   no        1. <root>/src/nope.css           no
  2. + .css/.scss/.sass/.less            no        2. + .css/.scss/.sass/.less      no
  3. path-shaped?                        no        3. path-shaped?                  YES
  4. emit 'fake-toolkit/dist/fake.css'   ✓         -> AngularUnresolvedStyleError
     -> Vite -> node_modules
```

## The failure this fixes

Captured from `ng run component-library:build-storybook` on [dso-toolkit](https://github.com/dso-toolkit/dso-toolkit), whose committed `angular.json` puts `"styles": ["dso-toolkit/dist/dso.css"]` on both Storybook targets, running a local build of `next` @ `a14aa35ff6f`:

```
●  Building preview..
│  Vite vite v8.2.1 building client environment for production...
✓ 1021 modules transformed.
■  Vite ✗ Build failed in 2.60s
■  Failed to build the preview
■  Build failed with 1 error:
│  [UNRESOLVED_IMPORT] Could not resolve './dso-toolkit/dist/dso.css' in .storybook/preview.ts
│  ╭─[ .storybook/preview.ts:2:20 ]
│  2 │             import './dso-toolkit/dist/dso.css';
│  ╰───── Module not found.
An unhandled exception occurred: Broken build, fix the error above.
```

`ng run …:storybook` is nastier, because it looks healthy. The server boots, the manager and sidebar render, and only the preview 500s on every request:

```
●  57 ms for manager and 1.27 s for preview
■  Vite Pre-transform error: Failed to resolve import
│  "./dso-toolkit/dist/dso.css" from ".storybook/preview.ts". Does the file exist?
│  Plugin: vite:import-analysis
```

Two notes on reading that, since it confused me at first:

- Vite renders the failing id relative to the Vite root, so `./dso-toolkit/…` is the *display* form. What the plugin emitted was the absolute `<workspaceRoot>/dso-toolkit/dist/dso.css`. The unit test below shows the emitted string unambiguously.
- On disk, `<workspaceRoot>/dso-toolkit/dist/dso.css` does not exist, while `<workspaceRoot>/node_modules/dso-toolkit/dist/dso.css` is a real 225 kB file. That is exactly the fall-through the join skipped.

## The change

```diff
  if (stylePath !== undefined) {
-   // Every `styles` entry is a path the Angular builder resolves against the workspace
-   // root - the schema has no package-specifier form - and in a monorepo that root sits
-   // above the Vite root. Left unresolved, Vite reads `apps/ui/styles.css` as a bare
-   // specifier and fails to find a package by that name.
-   imports.push(normalizePath(resolve(workspaceRoot, stylePath)));
+   imports.push(normalizePath(resolveBuilderStyle(stylePath, workspaceRoot)));
  }
```

```ts
function resolveBuilderStyle(stylePath: string, workspaceRoot: string) {
  const workspacePath = resolve(workspaceRoot, stylePath);
  const onDisk = [workspacePath, ...STYLE_EXTENSIONS.map((ext) => workspacePath + ext)].find(isFile);
  if (onDisk) {
    return onDisk;
  }

  // Emitting a path-shaped entry verbatim would make Vite resolve it against `preview.ts` rather
  // than the workspace root, and node_modules cannot rescue one either.
  if (isAbsolute(stylePath) || /^\.\.?[/\\]/.test(stylePath)) {
    throw new AngularUnresolvedStyleError({ stylePath, workspaceRoot, extensions: STYLE_EXTENSIONS });
  }

  return stylePath;
}
```

`isFile` rather than `existsSync` is deliberate. [canopy](https://github.com/Canopy-Tools/canopy) declares `"dist/canopy/canopy.css"` in its `styles` array, a build output, and `<root>/dist` is a directory that exists whether or not the workspace has been built. Requiring a file keeps a directory from ever being emitted as a stylesheet, and keeps the outcome from depending on build state.

That a `styles` array mixes both spellings is ordinary Angular, not an exotic corner. [ng-clarity](https://github.com/vmware-clarity/ng-clarity) writes `"styles": ["@clr/ui/clr-ui.min.css", "src/styles.scss"]`, a package specifier and a workspace-relative path side by side in one array.

## Why it is a real error class

A path-shaped entry that resolves to nothing used to reach Vite and surface as `Failed to resolve import` inside `preview.ts`, a file the user did not write and cannot fix. `AngularUnresolvedStyleError` names the entry as written and points at `angular.json` instead. Captured from a real build:

```
[plugin storybook-angular-vite-options-plugin] <workspaceRoot>/.storybook/preview.ts
SB_FRAMEWORK_ANGULAR_PLUGIN_ERROR (AngularUnresolvedStyleError): Cannot resolve the stylesheet
'./src/nope.css' from the Angular workspace root '<workspaceRoot>'.

No file matches it there, with or without a .css, .scss, .sass, .less extension.

Angular resolves a 'styles' entry from the workspace root, so a relative entry has to point at a
file below it. Check the 'styles' array on your Storybook builder target in angular.json.

More info: https://storybook.js.org/docs/get-started/frameworks/angular-vite?ref=error
```

The class itself is `SB_FRAMEWORK_ANGULAR_0002`; rolldown substitutes its own `PLUGIN_ERROR` slot when it re-frames a plugin throw, which is why the printed code differs. Worth knowing when grepping for it.

I deliberately did **not** extend that error to bare entries. Proving a bare specifier unresolvable means reimplementing Node and Vite resolution (exports maps, conditions, pnpm symlinks) inside a `transform` hook, and a false positive there would hard-fail builds that work today. A bare entry that really is wrong still fails, just in Vite, which is where the resolution actually happened.

## Known gap

`docs/configure/styling-and-css.mdx` teaches this exact array for Angular, and one of its six entries is `"@fontsource/material-icons"`, which is extensionless. That one is emitted bare and goes through Vite's *JS* resolution rather than Angular's stylesheet-restricted `mainFields`. The five explicit `.css` specifiers next to it are fixed here. I have not verified the extensionless package-entry shape in either direction, so I am flagging it rather than claiming it.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Six cases added to `code/frameworks/angular-vite/src/preset.test.ts`. #35974 added five `styles` tests and every one of them used a workspace-relative path, which is precisely why this slipped through.

Five of the six fail on `next` today:

```
❯ src/preset.test.ts (41 tests | 5 failed)
  × emits a package specifier bare, so Vite resolves it through node_modules
  × resolves an extensionless entry to the stylesheet on disk
  × emits a bare-looking entry with no file on disk as a specifier, not a workspace path
  × never resolves a directory as a stylesheet
  × fails with the entry the user wrote when a path-shaped entry has no file
```

The first one shows the emitted string directly, which is the clearest statement of the bug:

```
AssertionError: expected '\n import \'/workspace/dso…' to contain 'import \'dso-toolkit/dist/dso.css\';'
- Expected
+ Received
- import 'dso-toolkit/dist/dso.css';
+             import '/workspace/dso-toolkit/dist/dso.css';
```

The sixth (`./`-prefixed entries resolve against the workspace root) passes both before and after. It is there to pin down the behaviour #35974 got right, so a later change cannot quietly undo it.

With the fix: `Test Files 1 passed (1)`, `Tests 41 passed (41)`.

| check | run from | result |
| --- | --- | --- |
| `node ../../../node_modules/vitest/vitest.mjs run src/preset.test.ts` | `code/frameworks/angular-vite` | 41 passed |
| `yarn nx run-many -t check -p core angular-vite` | repo root | no type errors |
| `yarn lint:js:cmd frameworks/angular-vite/src/preset.ts …` | `code` | no new warnings |
| `yarn fmt:check …` | `code` | clean |

#### Manual testing

Everything below runs in the `angular-vite/default-ts` sandbox. No extra install is needed: that sandbox already carries `tablesort/tablesort.css` in `node_modules` as a Compodoc transitive dependency, and it is a real 779-byte stylesheet.

1. Build this branch: `yarn && yarn nx run-many -t compile`
2. `yarn task sandbox --template angular-vite/default-ts --start-from auto`
3. `cd ../storybook-sandboxes/angular-vite-default-ts`
4. Add a package specifier next to a workspace-relative path in the `styles` array of **both** the `storybook` and `build-storybook` targets in `angular.json`:
   ```jsonc
   // angular.json -> projects.angular-latest.architect.build-storybook.options
   "styles": ["src/styles.scss", "tablesort/tablesort.css"]
   ```
5. `yarn ng run angular-latest:build-storybook`
   - **on this branch**: build succeeds, and `grep -rl "columnheader" storybook-static/assets` finds the stylesheet in the output
   - **on `next` today**: fails with `[UNRESOLVED_IMPORT] Could not resolve … in .storybook/preview.ts`
6. `yarn ng run angular-latest:storybook`, then open http://localhost:6006
   - **on this branch**: stories render
   - **on `next` today**: manager and sidebar load, but every story is blank and the terminal repeats `Failed to resolve import … from ".storybook/preview.ts"`
7. Check the new error path. Change that entry to a typo, `"./src/nope.scss"`, and rerun step 5. You should get `Cannot resolve the stylesheet './src/nope.scss' from the Angular workspace root …` pointing at `angular.json`, rather than a Vite error pointing at `.storybook/preview.ts`.
8. Check nothing regressed for the shapes that already worked: `"src/styles.scss"` on its own, and `"node_modules/tablesort/tablesort.css"`, both still apply in dev and in build.
9. Optional, for the extensionless rung: use `"src/styles"` with no extension in step 4 and rerun. On this branch it resolves to `src/styles.scss`; on `next` it fails.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No docs change needed. `docs/configure/styling-and-css.mdx` already documents the package-specifier form, and this PR makes `angular-vite` match what the docs promise. Nothing is deprecated or removed.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
