### PR TITLE
Manifest debugger: Show the API description and snippet warnings

### DIFF
--- a/code/core/src/core-server/utils/manifests/render-components-manifest.test.ts
+++ b/code/core/src/core-server/utils/manifests/render-components-manifest.test.ts
@@ -104,6 +104,37 @@ describe('renderComponentsManifest component API panel', () => {
     expect(html).toContain('no API description');
   });
 
+  it('surfaces components without an API description as a top-level filter', () => {
+    const html = renderComponentsManifest({
+      v: 1,
+      components: {
+        bare: component({ id: 'bare', name: 'Bare' }),
+        documented: component({
+          id: 'documented',
+          name: 'Documented',
+          apiDescription: '## Inputs',
+        }),
+      },
+    });
+
+    expect(html).toContain('1/2 without API description');
+    expect(html).toContain('missing-api');
+  });
+
+  it('offers no such filter when every component describes its API', () => {
+    const html = renderComponentsManifest({
+      v: 1,
+      components: {
+        documented: component({ id: 'documented', apiDescription: '## Inputs' }),
+        broken: component({ id: 'broken', error: { name: 'Boom', message: 'boom' } }),
+      },
+    });
+
+    // An extraction failure is its own state and says what went wrong, so it must not be
+    // counted as a component that merely has nothing to describe.
+    expect(html).not.toContain('without API description');
+  });
+
   it('keeps the React prop-type output untouched', () => {
     const html = renderComponentsManifest({
       v: 1,

--- a/code/core/src/core-server/utils/manifests/render-components-manifest.test.ts
+++ b/code/core/src/core-server/utils/manifests/render-components-manifest.test.ts
@@ -44,12 +44,145 @@ describe('renderComponentsManifest deep-link anchors', () => {
 
     // Sanity: an errored component is duplicated into a separate error-group section, so the same
     // card is in the DOM twice — the case that would produce a duplicate id if anchored naively.
-    expect(html).toContain('Prop type error groups');
+    expect(html).toContain('API error groups');
 
     // The deep-link anchor must stay unique: only the main-grid card carries it.
     const anchorCount = (html.match(/id="broken-input"/g) ?? []).length;
     expect(anchorCount).toBe(1);
     // The healthy component still gets its own anchor.
     expect(html).toContain('id="example-button"');
+  });
+});
+
+describe('renderComponentsManifest component API panel', () => {
+  it('folds out the apiDescription markdown for a component that carries no React docgen', () => {
+    const html = renderComponentsManifest({
+      v: 1,
+      components: {
+        'color-picker': component({
+          id: 'color-picker',
+          name: 'ColorPickerComponent',
+          apiDescription:
+            '## Inputs\n\n```\nexport type ColorPickerComponentInputs = {\n  color?: string;\n}\n```',
+        }),
+      },
+      meta: { docgen: 'angular-component-meta', durationMs: 0 },
+    });
+
+    expect(html).toContain('API description');
+    expect(html).toContain('export type ColorPickerComponentInputs');
+    // Angular and Vue never set the React docgen blobs, so the props wording must not appear.
+    expect(html).not.toContain('prop type');
+  });
+
+  it('reports an API error instead of an API description when extraction failed', () => {
+    const html = renderComponentsManifest({
+      v: 1,
+      components: {
+        broken: component({
+          id: 'broken',
+          name: 'Broken',
+          error: { name: 'CompodocError', message: 'compodoc produced no metadata' },
+        }),
+      },
+    });
+
+    expect(html).toContain('API error');
+    expect(html).toContain('compodoc produced no metadata');
+    expect(html).not.toContain('API description');
+  });
+
+  it('states that a component has no API description rather than rendering nothing', () => {
+    const html = renderComponentsManifest({
+      v: 1,
+      components: {
+        bare: component({ id: 'bare', name: 'Bare' }),
+      },
+    });
+
+    // Without this the "docgen found nothing" case is indistinguishable from "component binds nothing".
+    expect(html).toContain('no API description');
+  });
+
+  it('keeps the React prop-type output untouched', () => {
+    const html = renderComponentsManifest({
+      v: 1,
+      components: {
+        button: component({
+          id: 'button',
+          name: 'Button',
+          reactComponentMeta: {
+            exportName: 'Button',
+            filePath: '/repo/Button.tsx',
+            description: '',
+            props: {
+              label: {
+                name: 'label',
+                description: 'The button label',
+                required: true,
+                type: { name: 'string' },
+                defaultValue: null,
+              },
+            },
+          },
+        } as Partial<RendererComponent>),
+      },
+    });
+
+    expect(html).toContain('1 prop type');
+    expect(html).toContain('label: string');
+    expect(html).not.toContain('API description');
+  });
+});
+
+describe('renderComponentsManifest snippet warnings', () => {
+  const storyWithWarning = {
+    id: 'storydocs-local-component--primary',
+    name: 'Primary',
+    snippet: '<sb-local-component [heading]="\'Declared here\'"></sb-local-component>',
+    warning:
+      'LocalComponent is declared in the story file, so the snippet references it without importing it.',
+  };
+
+  it('flags a story whose snippet is an incomplete example and shows why', () => {
+    const html = renderComponentsManifest({
+      v: 1,
+      components: {
+        'local-component': component({ stories: [storyWithWarning] }),
+      },
+    });
+
+    expect(html).toContain('incomplete example');
+    expect(html).toContain('so the snippet references it without importing it');
+  });
+
+  it('surfaces incomplete snippets as a top-level filter so they can be found', () => {
+    const html = renderComponentsManifest({
+      v: 1,
+      components: {
+        'local-component': component({ stories: [storyWithWarning] }),
+        clean: component({
+          id: 'clean',
+          stories: [{ id: 'clean--primary', name: 'Primary', snippet: '<sb-clean></sb-clean>' }],
+        }),
+      },
+    });
+
+    expect(html).toContain('1/2 incomplete snippets');
+    expect(html).toContain('has-story-warning');
+  });
+
+  it('says nothing about incompleteness when no story carries a warning', () => {
+    const html = renderComponentsManifest({
+      v: 1,
+      components: {
+        clean: component({
+          stories: [{ id: 'clean--primary', name: 'Primary', snippet: '<sb-clean></sb-clean>' }],
+        }),
+      },
+    });
+
+    expect(html).not.toContain('incomplete example');
+    expect(html).not.toContain('incomplete snippets');
   });
 });

--- a/code/core/src/core-server/utils/manifests/render-components-manifest.ts
+++ b/code/core/src/core-server/utils/manifests/render-components-manifest.ts
@@ -1277,10 +1277,6 @@ type ComponentApi =
 /**
  * The component's API surface, as the one question this page exists to answer: is there an API
  * description, and if not, did extraction fail or did the component simply bind nothing?
- *
- * Renderers describe a component in two different shapes. React ships raw docgen that gets parsed
- * into a props list here; Angular and Vue ship `apiDescription`, Markdown they rendered themselves,
- * which also covers members `argTypes` has no room for (Vue slots and exposed refs).
  */
 function resolveComponentApi(component: ComponentManifestLikeWithDocgen): ComponentApi {
   if (component.error) {

--- a/code/core/src/core-server/utils/manifests/render-components-manifest.ts
+++ b/code/core/src/core-server/utils/manifests/render-components-manifest.ts
@@ -85,6 +85,7 @@ export function renderComponentsManifest(
     stories: analyses.reduce((sum, a) => sum + a.totalStories, 0),
     storyErrors: analyses.reduce((sum, a) => sum + a.storyErrors, 0),
     storyWarnings: analyses.reduce((sum, a) => sum + a.storyWarnings, 0),
+    componentsWithoutApi: analyses.filter((a) => a.api.kind === 'none').length,
     docs: docsEntries.length + attachedDocs,
     docsWithError: unattachedDocsWithError + attachedDocsWithError,
   };
@@ -113,6 +114,10 @@ export function renderComponentsManifest(
   const snippetWarningsPill =
     totals.storyWarnings > 0
       ? `<a class="filter-pill info" data-k="story-warnings" href="#filter-story-warnings">${totals.storyWarnings}/${totals.stories} incomplete snippets</a>`
+      : '';
+  const noApiPill =
+    totals.componentsWithoutApi > 0
+      ? `<a class="filter-pill" data-k="no-api" href="#filter-no-api">${totals.componentsWithoutApi}/${totals.components} without API description</a>`
       : '';
   const docsPill =
     totals.docs > 0
@@ -279,6 +284,7 @@ export function renderComponentsManifest(
       #filter-infos:target ~ header .filter-pill[data-k='infos'],
       #filter-story-errors:target ~ header .filter-pill[data-k='story-errors'],
       #filter-story-warnings:target ~ header .filter-pill[data-k='story-warnings'],
+      #filter-no-api:target ~ header .filter-pill[data-k='no-api'],
       #filter-doc-errors:target ~ header .filter-pill[data-k='docs'],
       #filter-docs:target ~ header .filter-pill[data-k='docs'] {
           box-shadow: 0 0 0 var(--active-ring) currentColor;
@@ -291,6 +297,7 @@ export function renderComponentsManifest(
       #filter-infos,
       #filter-story-errors,
       #filter-story-warnings,
+      #filter-no-api,
       #filter-doc-errors,
       #filter-docs {
           display: none;
@@ -634,6 +641,10 @@ export function renderComponentsManifest(
           display: none;
       }
 
+      #filter-no-api:target ~ main .card:not(.missing-api) {
+          display: none;
+      }
+
       #filter-doc-errors:target ~ main .card:not(.has-doc-error) {
           display: none;
       }
@@ -762,12 +773,13 @@ export function renderComponentsManifest(
 <span id="filter-infos"></span>
 <span id="filter-story-errors"></span>
 <span id="filter-story-warnings"></span>
+<span id="filter-no-api"></span>
 <span id="filter-doc-errors"></span>
 <span id="filter-docs"></span>
 <header>
   <div class="wrap">
     <h1>Manifest Debugger</h1>
-    <div class="summary">${allPill}${compErrorsPill}${compInfosPill}${storiesPill}${snippetWarningsPill}${docsPill}</div>
+    <div class="summary">${allPill}${compErrorsPill}${compInfosPill}${noApiPill}${storiesPill}${snippetWarningsPill}${docsPill}</div>
   </div>
 </header>
 <main>
@@ -833,7 +845,8 @@ const esc = (s: unknown) =>
 const plural = (n: number, one: string, many = `${one}s`) => (n === 1 ? one : many);
 
 function analyzeComponent(c: ComponentManifestWithDocs) {
-  const hasApiError = !!c.error;
+  const api = resolveComponentApi(c);
+  const hasApiError = api.kind === 'error';
   const warns: string[] = [];
 
   if (!c.description?.trim()) {
@@ -861,6 +874,7 @@ function analyzeComponent(c: ComponentManifestWithDocs) {
   const hasAnyError = hasApiError || storyErrors > 0 || docsErrors > 0; // for status dot (red if any errors)
 
   return {
+    api,
     hasApiError,
     hasAnyError,
     hasWarns: warns.length > 0,
@@ -979,7 +993,7 @@ function renderComponentCard(
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')}`;
 
-  const api = resolveComponentApi(c);
+  const { api } = a;
   const primaryBadge =
     api.kind === 'error'
       ? `<label for="${slug}-err" class="badge err as-toggle">API error</label>`
@@ -1054,6 +1068,7 @@ function renderComponentCard(
   ${a.hasWarns ? 'has-info' : 'no-info'}
   ${a.storyErrors ? 'has-story-error' : 'no-story-error'}
   ${a.storyWarnings ? 'has-story-warning' : 'no-story-warning'}
+  ${api.kind === 'none' ? 'missing-api' : ''}
   ${a.docsErrors ? 'has-doc-error' : 'no-doc-error'}"
   role="listitem"
   aria-label="${esc(c.name || key)}">

--- a/code/core/src/core-server/utils/manifests/render-components-manifest.ts
+++ b/code/core/src/core-server/utils/manifests/render-components-manifest.ts
@@ -80,10 +80,11 @@ export function renderComponentsManifest(
   const unattachedDocsWithError = docsAnalyses.filter((a) => a.hasError).length;
   const totals = {
     components: entries.length,
-    componentsWithPropTypeError: analyses.filter((a) => a.hasPropTypeError).length,
+    componentsWithApiError: analyses.filter((a) => a.hasApiError).length,
     infos: analyses.filter((a) => a.hasWarns).length,
     stories: analyses.reduce((sum, a) => sum + a.totalStories, 0),
     storyErrors: analyses.reduce((sum, a) => sum + a.storyErrors, 0),
+    storyWarnings: analyses.reduce((sum, a) => sum + a.storyWarnings, 0),
     docs: docsEntries.length + attachedDocs,
     docsWithError: unattachedDocsWithError + attachedDocsWithError,
   };
@@ -94,8 +95,8 @@ export function renderComponentsManifest(
   // Top filters (clickable), no <b> tags; 1px active ring lives in CSS via :target
   const allPill = `<a class="filter-pill all" data-k="all" href="#filter-all">All</a>`;
   const compErrorsPill =
-    totals.componentsWithPropTypeError > 0
-      ? `<a class="filter-pill err" data-k="errors" href="#filter-errors">${totals.componentsWithPropTypeError}/${totals.components} prop type ${plural(totals.componentsWithPropTypeError, 'error')}</a>`
+    totals.componentsWithApiError > 0
+      ? `<a class="filter-pill err" data-k="errors" href="#filter-errors">${totals.componentsWithApiError}/${totals.components} API ${plural(totals.componentsWithApiError, 'error')}</a>`
       : totals.components > 0
         ? `<span class="filter-pill ok" aria-disabled="true">${totals.components} components ok</span>`
         : '';
@@ -109,6 +110,10 @@ export function renderComponentsManifest(
       : totals.stories > 0
         ? `<span class="filter-pill ok" aria-disabled="true">${totals.stories} ${plural(totals.stories, 'story', 'stories')} ok</span>`
         : '';
+  const snippetWarningsPill =
+    totals.storyWarnings > 0
+      ? `<a class="filter-pill info" data-k="story-warnings" href="#filter-story-warnings">${totals.storyWarnings}/${totals.stories} incomplete snippets</a>`
+      : '';
   const docsPill =
     totals.docs > 0
       ? totals.docsWithError > 0
@@ -273,6 +278,7 @@ export function renderComponentsManifest(
       #filter-errors:target ~ header .filter-pill[data-k='errors'],
       #filter-infos:target ~ header .filter-pill[data-k='infos'],
       #filter-story-errors:target ~ header .filter-pill[data-k='story-errors'],
+      #filter-story-warnings:target ~ header .filter-pill[data-k='story-warnings'],
       #filter-doc-errors:target ~ header .filter-pill[data-k='docs'],
       #filter-docs:target ~ header .filter-pill[data-k='docs'] {
           box-shadow: 0 0 0 var(--active-ring) currentColor;
@@ -284,6 +290,7 @@ export function renderComponentsManifest(
       #filter-errors,
       #filter-infos,
       #filter-story-errors,
+      #filter-story-warnings,
       #filter-doc-errors,
       #filter-docs {
           display: none;
@@ -398,6 +405,16 @@ export function renderComponentsManifest(
           border-color: color-mix(in srgb, var(--err) 55%, var(--border));
       }
 
+      .snippet-warning {
+          margin-top: 8px;
+          padding: 8px 10px;
+          border-radius: 8px;
+          border: 1px solid color-mix(in srgb, var(--info) 45%, var(--border));
+          background: var(--info-bg);
+          color: #b3d9ff;
+          font-size: 12px;
+      }
+
       .as-toggle {
           cursor: pointer;
       }
@@ -457,7 +474,7 @@ export function renderComponentsManifest(
           display: grid;
       }
 
-      /* Colored notes for prop type error + info */
+      /* Colored notes for API error + info */
       .note {
           padding: 12px;
           border: 1px solid var(--border);
@@ -613,6 +630,10 @@ export function renderComponentsManifest(
           display: none;
       }
 
+      #filter-story-warnings:target ~ main .card:not(.has-story-warning) {
+          display: none;
+      }
+
       #filter-doc-errors:target ~ main .card:not(.has-doc-error) {
           display: none;
       }
@@ -740,12 +761,13 @@ export function renderComponentsManifest(
 <span id="filter-errors"></span>
 <span id="filter-infos"></span>
 <span id="filter-story-errors"></span>
+<span id="filter-story-warnings"></span>
 <span id="filter-doc-errors"></span>
 <span id="filter-docs"></span>
 <header>
   <div class="wrap">
     <h1>Manifest Debugger</h1>
-    <div class="summary">${allPill}${compErrorsPill}${compInfosPill}${storiesPill}${docsPill}</div>
+    <div class="summary">${allPill}${compErrorsPill}${compInfosPill}${storiesPill}${snippetWarningsPill}${docsPill}</div>
   </div>
 </header>
 <main>
@@ -782,7 +804,7 @@ export function renderComponentsManifest(
     }
     ${
       errorGroups.length
-        ? `<div class="error-groups" role="region" aria-label="Prop type error groups">${errorGroupsHTML}</div>`
+        ? `<div class="error-groups" role="region" aria-label="API error groups">${errorGroupsHTML}</div>`
         : ''
     }
     ${
@@ -811,7 +833,7 @@ const esc = (s: unknown) =>
 const plural = (n: number, one: string, many = `${one}s`) => (n === 1 ? one : many);
 
 function analyzeComponent(c: ComponentManifestWithDocs) {
-  const hasPropTypeError = !!c.error;
+  const hasApiError = !!c.error;
   const warns: string[] = [];
 
   if (!c.description?.trim()) {
@@ -827,6 +849,7 @@ function analyzeComponent(c: ComponentManifestWithDocs) {
   const allStories = storyEntries(c.stories);
   const totalStories = allStories.length;
   const storyErrors = allStories.filter((e) => !!e?.error).length;
+  const storyWarnings = allStories.filter((e) => !!e?.warning).length;
   const storyOk = totalStories - storyErrors;
 
   // Analyze attached docs
@@ -835,15 +858,16 @@ function analyzeComponent(c: ComponentManifestWithDocs) {
   const docsErrors = docsEntries.filter((d) => !!d?.error).length;
   const docsOk = totalDocs - docsErrors;
 
-  const hasAnyError = hasPropTypeError || storyErrors > 0 || docsErrors > 0; // for status dot (red if any errors)
+  const hasAnyError = hasApiError || storyErrors > 0 || docsErrors > 0; // for status dot (red if any errors)
 
   return {
-    hasPropTypeError,
+    hasApiError,
     hasAnyError,
     hasWarns: warns.length > 0,
     warns,
     totalStories,
     storyErrors,
+    storyWarnings,
     storyOk,
     totalDocs,
     docsErrors,
@@ -955,9 +979,15 @@ function renderComponentCard(
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')}`;
 
-  const componentErrorBadge = a.hasPropTypeError
-    ? `<label for="${slug}-err" class="badge err as-toggle">prop type error</label>`
-    : '';
+  const api = resolveComponentApi(c);
+  const primaryBadge =
+    api.kind === 'error'
+      ? `<label for="${slug}-err" class="badge err as-toggle">API error</label>`
+      : api.kind === 'markdown'
+        ? `<label for="${slug}-props" class="badge ok as-toggle">API description</label>`
+        : api.kind === 'props'
+          ? `<label for="${slug}-props" class="badge ok as-toggle">${api.entries.length} ${plural(api.entries.length, 'prop type')}</label>`
+          : `<span class="badge">no API description</span>`;
 
   const infosBadge = a.hasWarns
     ? `<label for="${slug}-info" class="badge info as-toggle">${a.warns.length} ${plural(a.warns.length, 'info', 'infos')}</label>`
@@ -965,7 +995,7 @@ function renderComponentCard(
 
   const storiesBadge =
     a.totalStories > 0
-      ? `<label for="${slug}-stories" class="badge ${a.storyErrors > 0 ? 'err' : 'ok'} as-toggle">${a.storyErrors > 0 ? `${a.storyErrors}/${a.totalStories} story errors` : `${a.totalStories} ${plural(a.totalStories, 'story', 'stories')}`}</label>`
+      ? `<label for="${slug}-stories" class="badge ${a.storyErrors > 0 ? 'err' : 'ok'} as-toggle">${a.storyErrors > 0 ? `${a.storyErrors}/${a.totalStories} story errors` : `${a.totalStories} ${plural(a.totalStories, 'story', 'stories')}`}${a.storyWarnings > 0 ? ` · ${a.storyWarnings} incomplete` : ''}</label>`
       : '';
 
   const docsBadge =
@@ -978,37 +1008,32 @@ function renderComponentCard(
       ? `<label for="${slug}-subcomponents" class="badge ok as-toggle">${subcomponentEntries.length} ${plural(subcomponentEntries.length, 'subcomponent')}</label>`
       : '';
 
-  const {
-    parsed: activeParsed,
-    engine: cardEngine,
-    filePath,
-    exportName,
-  } = docgenRenderData(c, a.hasPropTypeError);
-  const propEntries = activeParsed ? Object.entries(activeParsed.props ?? {}) : [];
-  const propTypesBadge =
-    !a.hasPropTypeError && propEntries.length > 0
-      ? `<label for="${slug}-props" class="badge ok as-toggle">${propEntries.length} ${plural(propEntries.length, 'prop type')}</label>`
-      : '';
-
-  const primaryBadge = componentErrorBadge || propTypesBadge;
-
-  const propsCode =
-    propEntries.length > 0
-      ? propEntries
-          .sort(([aName], [bName]) => aName.localeCompare(bName))
-          .map(([propName, info]) => {
-            const description = (info?.description ?? '').trim();
-            const t = (info?.type ?? 'any').trim();
-            const optional = info?.required ? '' : '?';
-            const defaultVal = (info?.defaultValue ?? '').trim();
-            const def = defaultVal ? ` = ${defaultVal}` : '';
-            const doc =
-              ['/**', ...description.split('\n').map((line) => ` * ${line}`), ' */'].join('\n') +
-              '\n';
-            return `${description ? doc : ''}${propName}${optional}: ${t}${def}`;
-          })
-          .join('\n\n')
-      : '';
+  const apiPanel =
+    api.kind === 'markdown'
+      ? `
+        <div class="panel panel-props">
+          <div class="note ok">
+            <div class="row">
+              <span class="ex-name">API description</span>
+              ${c.renderer ? `<span class="badge ok">${esc(c.renderer)}</span>` : ''}
+            </div>
+            <pre><code>${esc(api.markdown)}</code></pre>
+          </div>
+        </div>`
+      : api.kind === 'props'
+        ? `
+        <div class="panel panel-props">
+          <div class="note ok">
+            <div class="row">
+              <span class="ex-name">Prop types <small>(${api.engine})</small></span>
+              <span class="badge ok">${api.entries.length} ${plural(api.entries.length, 'prop type')}</span>
+            </div>
+            <pre><code>Component: ${api.filePath ? esc(path.relative(process.cwd(), api.filePath)) : ''}${api.exportName ? '::' + esc(api.exportName) : ''}</code></pre>
+            <pre><code>Props:</code></pre>
+            <pre><code>${esc(renderPropsCode(api.entries))}</code></pre>
+          </div>
+        </div>`
+        : '';
 
   const tags =
     c.jsDocTags && typeof c.jsDocTags === 'object'
@@ -1025,9 +1050,10 @@ function renderComponentCard(
 <article
   ${anchorId ? `id="${esc(anchorId)}"` : ''}
   class="card 
-  ${a.hasPropTypeError ? 'has-error' : 'no-error'} 
-  ${a.hasWarns ? 'has-info' : 'no-info'} 
+  ${a.hasApiError ? 'has-error' : 'no-error'}
+  ${a.hasWarns ? 'has-info' : 'no-info'}
   ${a.storyErrors ? 'has-story-error' : 'no-story-error'}
+  ${a.storyWarnings ? 'has-story-warning' : 'no-story-warning'}
   ${a.docsErrors ? 'has-doc-error' : 'no-doc-error'}"
   role="listitem"
   aria-label="${esc(c.name || key)}">
@@ -1049,19 +1075,19 @@ function renderComponentCard(
   </div>
 
   <!-- ⬇️ Hidden toggles must be siblings BEFORE .panels -->
-  ${a.hasPropTypeError ? `<input id="${slug}-err" class="tg tg-err" type="checkbox" hidden />` : ''}
+  ${api.kind === 'error' ? `<input id="${slug}-err" class="tg tg-err" type="checkbox" hidden />` : ''}
   ${a.hasWarns ? `<input id="${slug}-info" class="tg tg-info" type="checkbox" hidden />` : ''}
   ${a.totalStories > 0 ? `<input id="${slug}-stories" class="tg tg-stories" type="checkbox" hidden />` : ''}
   ${a.totalDocs > 0 ? `<input id="${slug}-docs" class="tg tg-docs" type="checkbox" hidden />` : ''}
   ${subcomponentEntries.length > 0 ? `<input id="${slug}-subcomponents" class="tg tg-subcomponents" type="checkbox" hidden />` : ''}
-  ${!a.hasPropTypeError && propEntries.length > 0 ? `<input id="${slug}-props" class="tg tg-props" type="checkbox" hidden />` : ''}
+  ${apiPanel ? `<input id="${slug}-props" class="tg tg-props" type="checkbox" hidden />` : ''}
 
   <div class="panels">
     ${
-      a.hasPropTypeError
+      api.kind === 'error'
         ? `
         <div class="panel panel-err">
-          ${note('Prop type error', `<pre><code>${esc(c.error?.message || 'Unknown error')}</code></pre>`, 'err')}
+          ${note('API error', `<pre><code>${esc(api.message)}</code></pre>`, 'err')}
         </div>`
         : ''
     }
@@ -1073,22 +1099,7 @@ function renderComponentCard(
         </div>`
         : ''
     }
-    ${
-      !a.hasPropTypeError && propEntries.length > 0
-        ? `
-        <div class="panel panel-props">
-          <div class="note ok">
-            <div class="row">
-              <span class="ex-name">Prop types <small>(${cardEngine})</small></span>
-              <span class="badge ok">${propEntries.length} ${plural(propEntries.length, 'prop type')}</span>
-            </div>
-            <pre><code>Component: ${filePath ? esc(path.relative(process.cwd(), filePath)) : ''}${exportName ? '::' + esc(exportName) : ''}</code></pre>
-            <pre><code>Props:</code></pre>
-            <pre><code>${esc(propsCode)}</code></pre>
-          </div>
-        </div>`
-        : ''
-    }
+    ${apiPanel}
     ${
       a.totalStories > 0
         ? `
@@ -1100,10 +1111,12 @@ function renderComponentCard(
               <div class="row">
                 <span class="ex-name">${esc(ex.name)}</span>
                 <span class="badge err">story error</span>
+                ${ex?.warning ? `<span class="badge info">incomplete example</span>` : ''}
               </div>
               ${ex?.summary ? `<div class=\"hint\">Summary: ${esc(ex.summary)}</div>` : ''}
               ${ex?.description ? `<div class=\"hint\">${esc(ex.description)}</div>` : ''}
               ${ex?.snippet ? `<pre><code>${esc(ex.snippet)}</code></pre>` : ''}
+              ${ex?.warning ? `<div class="snippet-warning">${esc(ex.warning)}</div>` : ''}
               ${ex?.error?.message ? `<pre><code>${esc(ex.error.message)}</code></pre>` : ''}
             </div>`
             )
@@ -1127,11 +1140,12 @@ function renderComponentCard(
             <div class="note ok">
               <div class="row">
                 <span class="ex-name">${esc(ex.name)}</span>
-                <span class="badge ok">story ok</span>
+                <span class="badge ${ex?.warning ? 'info' : 'ok'}">${ex?.warning ? 'incomplete example' : 'story ok'}</span>
               </div>
               ${ex?.summary ? `<div>${esc(ex.summary)}</div>` : ''}
               ${ex?.description ? `<div class=\"hint\">${esc(ex.description)}</div>` : ''}
               ${ex?.snippet ? `<pre><code>${esc(ex.snippet)}</code></pre>` : ''}
+              ${ex?.warning ? `<div class="snippet-warning">${esc(ex.warning)}</div>` : ''}
             </div>`
             )
             .join('')}
@@ -1208,14 +1222,7 @@ type DocgenRenderData = {
   exportName?: string;
 };
 
-const docgenRenderData = (
-  component: ComponentManifestLikeWithDocgen,
-  hasPropTypeError: boolean
-): DocgenRenderData => {
-  if (hasPropTypeError) {
-    return {};
-  }
-
+const docgenRenderData = (component: ComponentManifestLikeWithDocgen): DocgenRenderData => {
   if (component.reactDocgen) {
     return {
       parsed: parseReactDocgen(component.reactDocgen),
@@ -1246,13 +1253,57 @@ const docgenRenderData = (
   return {};
 };
 
+type ComponentApi =
+  | { kind: 'error'; message: string }
+  | { kind: 'markdown'; markdown: string }
+  | ({ kind: 'props'; entries: [string, ParsedProp][] } & Omit<DocgenRenderData, 'parsed'>)
+  | { kind: 'none' };
+
+/**
+ * The component's API surface, as the one question this page exists to answer: is there an API
+ * description, and if not, did extraction fail or did the component simply bind nothing?
+ *
+ * Renderers describe a component in two different shapes. React ships raw docgen that gets parsed
+ * into a props list here; Angular and Vue ship `apiDescription`, Markdown they rendered themselves,
+ * which also covers members `argTypes` has no room for (Vue slots and exposed refs).
+ */
+function resolveComponentApi(component: ComponentManifestLikeWithDocgen): ComponentApi {
+  if (component.error) {
+    return { kind: 'error', message: component.error.message || 'Unknown error' };
+  }
+
+  const markdown = component.apiDescription?.trim();
+  if (markdown) {
+    return { kind: 'markdown', markdown };
+  }
+
+  const { parsed, ...source } = docgenRenderData(component);
+  const entries = Object.entries(parsed?.props ?? {}).sort(([a], [b]) => a.localeCompare(b));
+  return entries.length > 0 ? { kind: 'props', entries, ...source } : { kind: 'none' };
+}
+
+/** Renders the parsed React props as the pseudo-TypeScript block shown in the API panel. */
+function renderPropsCode(entries: [string, ParsedProp][]) {
+  return entries
+    .map(([propName, info]) => {
+      const description = (info?.description ?? '').trim();
+      const type = (info?.type ?? 'any').trim();
+      const optional = info?.required ? '' : '?';
+      const defaultValue = (info?.defaultValue ?? '').trim();
+      const fallback = defaultValue ? ` = ${defaultValue}` : '';
+      const doc =
+        ['/**', ...description.split('\n').map((line) => ` * ${line}`), ' */'].join('\n') + '\n';
+
+      return `${description ? doc : ''}${propName}${optional}: ${type}${fallback}`;
+    })
+    .join('\n\n');
+}
+
 function renderSubcomponentNote(
   subcomponentName: string,
   subcomponent: ComponentManifestLikeWithDocgen
 ) {
-  const hasPropTypeError = Boolean(subcomponent.error);
-  const { parsed, engine, filePath, exportName } = docgenRenderData(subcomponent, hasPropTypeError);
-  const propEntries = Object.entries(parsed?.props ?? {});
+  const api = resolveComponentApi(subcomponent);
   const tags =
     subcomponent.jsDocTags && typeof subcomponent.jsDocTags === 'object'
       ? Object.entries(subcomponent.jsDocTags)
@@ -1263,37 +1314,22 @@ function renderSubcomponentNote(
           )
           .join('')
       : '';
-  const propsCode =
-    propEntries.length > 0
-      ? propEntries
-          .sort(([aName], [bName]) => aName.localeCompare(bName))
-          .map(([propName, info]) => {
-            const description = (info?.description ?? '').trim();
-            const type = (info?.type ?? 'any').trim();
-            const optional = info?.required ? '' : '?';
-            const defaultValue = (info?.defaultValue ?? '').trim();
-            const fallback = defaultValue ? ` = ${defaultValue}` : '';
-            const doc =
-              ['/**', ...description.split('\n').map((line) => ` * ${line}`), ' */'].join('\n') +
-              '\n';
 
-            return `${description ? doc : ''}${propName}${optional}: ${type}${fallback}`;
-          })
-          .join('\n\n')
-      : '';
+  const badgeLabel =
+    api.kind === 'error'
+      ? 'API error'
+      : api.kind === 'markdown'
+        ? 'API description'
+        : api.kind === 'props'
+          ? `${api.entries.length} ${plural(api.entries.length, 'prop type')}`
+          : 'no API description';
 
   return `
-    <div class="note ${hasPropTypeError ? 'err' : 'ok'}">
+    <div class="note ${api.kind === 'error' ? 'err' : 'ok'}">
       <div class="row">
         <span class="ex-name">${esc(subcomponentName)}</span>
-        <span class="badge ${hasPropTypeError ? 'err' : 'ok'}">
-          ${
-            hasPropTypeError
-              ? 'prop type error'
-              : propEntries.length > 0
-                ? `${propEntries.length} ${plural(propEntries.length, 'prop type')}`
-                : 'no prop types'
-          }
+        <span class="badge ${api.kind === 'error' ? 'err' : api.kind === 'none' ? '' : 'ok'}">
+          ${badgeLabel}
         </span>
       </div>
       <div class="hint">${esc(subcomponent.path)}</div>
@@ -1301,16 +1337,13 @@ function renderSubcomponentNote(
       ${subcomponent.description ? `<div class="hint">${esc(subcomponent.description)}</div>` : ''}
       ${tags ? `<div class="kv">${tags}</div>` : ''}
       ${subcomponent.import ? `<pre><code>${esc(subcomponent.import)}</code></pre>` : ''}
+      ${api.kind === 'error' ? `<pre><code>${esc(api.message)}</code></pre>` : ''}
+      ${api.kind === 'markdown' ? `<pre><code>${esc(api.markdown)}</code></pre>` : ''}
       ${
-        hasPropTypeError
-          ? `<pre><code>${esc(subcomponent.error?.message ?? 'Unknown error')}</code></pre>`
-          : ''
-      }
-      ${
-        !hasPropTypeError && propEntries.length > 0
+        api.kind === 'props'
           ? `
-          <pre><code>Component: ${filePath ? esc(path.relative(process.cwd(), filePath)) : ''}${exportName ? '::' + esc(exportName) : ''}${engine ? ` (${esc(engine)})` : ''}</code></pre>
-          <pre><code>${esc(propsCode)}</code></pre>`
+          <pre><code>Component: ${api.filePath ? esc(path.relative(process.cwd(), api.filePath)) : ''}${api.exportName ? '::' + esc(api.exportName) : ''}${api.engine ? ` (${esc(api.engine)})` : ''}</code></pre>
+          <pre><code>${esc(renderPropsCode(api.entries))}</code></pre>`
           : ''
       }
     </div>


### PR DESCRIPTION
## What I did

The manifest debugger showed Angular and Vue components with no props section at all. Their cards had stories, snippets and docs, but nothing about the component's API, and subcomponent notes literally read "no prop types". The props panel only knew how to read React's raw docgen, and Angular and Vue do not produce any. On top of that, the `warning` a story snippet can carry ("this example is incomplete, and here is why") travelled all the way from `core/story-docs` into the renderer and was then dropped on the floor, for every renderer including React.

This replaces the React-only props badge with a single API state, renders the Markdown that Angular and Vue already produce, and surfaces the snippet warning. The React prop-type output is untouched.

```
docgen payload                          manifest debugger
  error              ────────────────►  "API error"          + message
  apiDescription     ────────────────►  "API description"    + the Markdown        (NEW)
  reactDocgen*       ──► parsed props ► "N prop types"       + props block         (unchanged)
  (none of the above) ───────────────►  "no API description" + filter pill         (NEW)

story-docs payload
  stories[].snippet  ────────────────►  <pre> snippet
  stories[].warning  ────────────────►  "incomplete example" + why + filter pill   (NEW)
```

This is deliberately not the debugger rewrite. That file is still ~1450 lines of string-concatenated HTML and it stays that way here.

### The decision that matters

One state machine, replacing the branch that only ever asked "did React docgen give me props?":

```ts
function resolveComponentApi(component: ComponentManifestLikeWithDocgen): ComponentApi {
  if (component.error) {
    return { kind: 'error', message: component.error.message || 'Unknown error' };
  }

  const markdown = component.apiDescription?.trim();
  if (markdown) {
    return { kind: 'markdown', markdown };
  }

  const { parsed, ...source } = docgenRenderData(component);
  const entries = Object.entries(parsed?.props ?? {}).sort(([a], [b]) => a.localeCompare(b));
  return entries.length > 0 ? { kind: 'props', entries, ...source } : { kind: 'none' };
}
```

React never sets `apiDescription`, and Angular and Vue never set the `reactDocgen*` blobs, so the two paths cannot collide.

### What the page shows now

Header pills, captured from freshly generated sandboxes:

```
# angular-vite/docgen-server-ts
All | 79/112 API errors | 112/112 infos | 14/112 without API description | 281 stories ok | 43/281 incomplete snippets | 14 docs ok

# vue3-vite/docgen-server-ts
All | 76/102 API errors | 102/102 infos | 4/102 without API description | 277 stories ok | 21/277 incomplete snippets | 11 docs ok
```

Folding out "API description" on a Vue component, verbatim from the page:

````
## Props

```
export type BaseLayoutProps = {
  label?: string;
}
```

## Slots

Each slot is typed with the props it passes to its content.

```
export type BaseLayoutSlots = {
  header: { title: string; };
  default: {};
  footer: {};
}
```
````

That `## Slots` section is the reason this reads `apiDescription` rather than the framework-neutral `argTypes`. Slots and exposed refs have no representation in `argTypes` at all, so the cheaper-looking route would have silently dropped them.

### Snippet warnings turned out to have three producers, not one

I expected only the Angular `standalone: false` rule. Real warnings now visible on the pages:

| Renderer | Warning |
| --- | --- |
| Angular | ``AttributeSelectorComponent is declared with `standalone: false`, so it cannot be listed in the host component's `imports`. …`` |
| Angular | ``Incomplete snippet: `fn()` could not be resolved statically.`` |
| Vue | `Omitted args that cannot be resolved statically: footer: h('p', 'Footer VNode Slot')` |
| React | `The story snippet is incomplete. Variable X couldn't be resolved due to static analysis` |

The React one comes from this repo's own `storybook-static/manifests/components.json`, so we have been hiding these on the React path too.

### "no API description" is a success state, and now a filter

Worth being explicit, because it reads like an error and is not one. `buildApiDescription` returns `undefined` when a component exposes nothing template-bindable, and the payload carries no `error`. Across every Angular payload in the sandbox that has no `apiDescription` and no `error`, the argTypes fall into exactly two categories:

```
properties: 25
methods:    11
inputs:      0
outputs:     0
```

The 14 components behind that number are things like `DocInjectableService`, `DocPipe`, `WithNgContentComponent` and `ClassSelectorComponent`: a service, a pipe, and components whose whole point is that they take no bindings. Extraction worked. There is nothing to describe.

Before this change they rendered identically to a component whose docgen quietly produced nothing, as no badge at all. They now say `no API description`, and there is a header pill to filter down to them, because that state is also where a provider that fails *without* setting `error` would hide. Countable was not enough; you want to be able to eyeball the list.

### Copy change

`prop type error` becomes `API error`, on the badge, the header pill and the error-group heading. An Angular extraction failure was never a "prop type" error. This is visible churn on the React path, but only in wording.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`render-components-manifest.test.ts` previously covered deep-link anchors only. It now also covers each API state, the React regression guard, and the snippet warning.

#### Manual testing

Angular:

1. `yarn task sandbox --template angular-vite/docgen-server-ts --start-from auto`
2. `cd ../storybook-sandboxes/angular-vite-docgen-server-ts && yarn build-storybook`
3. Serve `storybook-static` and open `/manifests/components.html`
4. `ButtonComponent` (`example-button`) shows an `API description` badge with an `angular` chip. Fold it out to see the `## Inputs` block. Before this change the card had no badge and no panel.
5. `AttributeSelectorComponent` shows `no API description`, and its story is badged `incomplete example` with the reason underneath the snippet.
6. Click `43/281 incomplete snippets` in the header to filter down to the cards carrying a warning
7. Click `14/112 without API description` to filter down to the components that expose nothing bindable. Expect `DocInjectableService` and `DocPipe` among them

Vue, same steps with `--template vue3-vite/docgen-server-ts`. On `BaseLayout` the folded-out panel includes a `## Slots` section.

React, to confirm nothing moved:

1. Build any React Storybook with `componentsManifest` enabled and open `/manifests/components.html`
2. A component with props still shows `N prop types` and the same props block, with the same `Component: path::Export` line
3. Only the error wording differs

I checked that last point by rendering this repo's own 288-component React manifest through the old and the new renderer and diffing them. The only differences are the error copy, the new `no API description` badges, and two previously hidden snippet warnings. Nothing under `Props:`, `Component: ` or the props code block changed.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No prose changes needed. `docs/ai/manifests.mdx` still describes the page accurately. Its screenshot (`docs/_assets/ai/manifest-debugger.png`) now shows the old `prop type error` wording, though. Happy to refresh it in this PR if we care.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
