### PR TITLE
Vue: Fix docgen fidelity gaps

### DIFF
--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/ModelWithRuntimeEmits.vue
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/ModelWithRuntimeEmits.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+// Runtime-array emits on purpose: beside `defineModel`, Volar drops runtime-declared events
+// (typed `defineEmits<...>` survives), so this guards the vue-docgen-api fallback restoring them.
+const modelValue = defineModel<string>();
+
+const emit = defineEmits(['blur']);
+</script>
+
+<template>
+  <input
+    :value="modelValue"
+    @input="modelValue = ($event.target as HTMLInputElement).value"
+    @blur="emit('blur')"
+  />
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/argtypes.snapshot
@@ -1,0 +1,20 @@
+{
+  "blur": {
+    "control": {
+      "disable": true,
+    },
+    "description": undefined,
+    "name": "blur",
+    "table": {
+      "category": "events",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/cm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/cm-argtypes.snapshot
@@ -1,0 +1,52 @@
+{
+  "blur": {
+    "control": {
+      "disable": true,
+    },
+    "description": "",
+    "name": "blur",
+    "table": {
+      "category": "events",
+      "type": {
+        "summary": "any[]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "any[]",
+    },
+  },
+  "modelValue": {
+    "defaultValue": undefined,
+    "description": "",
+    "name": "modelValue",
+    "table": {
+      "category": "props",
+      "defaultValue": undefined,
+      "type": {
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+      "required": false,
+    },
+  },
+  "update:modelValue": {
+    "control": {
+      "disable": true,
+    },
+    "description": "",
+    "name": "update:modelValue",
+    "table": {
+      "category": "events",
+      "type": {
+        "summary": "[value: string]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "[value: string | undefined]",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/cm-snippet-Bound.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/cm-snippet-Bound.snapshot
@@ -1,0 +1,9 @@
+<script lang="ts" setup>
+import { ref } from "vue";
+
+const modelValue = ref("draft");
+</script>
+
+<template>
+  <ModelWithRuntimeEmits v-model="modelValue" />
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/input.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import ModelWithRuntimeEmits from './ModelWithRuntimeEmits.vue';
+
+const meta = {
+  title: 'VueFixtures/ModelWithRuntimeEmits',
+  component: ModelWithRuntimeEmits,
+} satisfies Meta<typeof ModelWithRuntimeEmits>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Bound: Story = {
+  args: { modelValue: 'draft' },
+};

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/snippet-Bound.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/snippet-Bound.snapshot
@@ -1,0 +1,3 @@
+<template>
+  <ModelWithRuntimeEmits modelValue="draft" />
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/model-with-runtime-emits/story-docs.payload.snapshot
@@ -1,0 +1,23 @@
+{
+  "id": "model-with-runtime-emits",
+  "name": "ModelWithRuntimeEmits",
+  "path": "__PATH__",
+  "stories": {
+    "forms-model-with-runtime-emits--bound": {
+      "description": undefined,
+      "id": "forms-model-with-runtime-emits--bound",
+      "name": "Bound",
+      "snippet": "<script lang="ts" setup>
+import { ref } from "vue";
+import ModelWithRuntimeEmits from './ModelWithRuntimeEmits.vue';
+
+const modelValue = ref('draft');
+</script>
+
+<template>
+  <ModelWithRuntimeEmits v-model="modelValue" />
+</template>",
+      "summary": undefined,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/OptionsApiEmits.vue
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/OptionsApiEmits.vue
@@ -1,0 +1,23 @@
+<script lang="ts">
+// Options API on purpose: Volar reports `emits` entries only as `onX` handler props, never as
+// events, so this guards the vue-docgen-api fallback restoring the events list.
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'OptionsApiEmits',
+  props: {
+    step: { type: Number, default: 1 },
+  },
+  emits: ['update:by-step', 'stepped'],
+  methods: {
+    bump(): void {
+      this.$emit('stepped');
+      this.$emit('update:by-step', this.step);
+    },
+  },
+});
+</script>
+
+<template>
+  <button @click="bump">+{{ step }}</button>
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/argtypes.snapshot
@@ -1,0 +1,59 @@
+{
+  "step": {
+    "description": undefined,
+    "name": "step",
+    "table": {
+      "category": "props",
+      "defaultValue": {
+        "detail": undefined,
+        "summary": "1",
+      },
+      "jsDocTags": undefined,
+      "type": {
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+      "required": false,
+    },
+  },
+  "stepped": {
+    "control": {
+      "disable": true,
+    },
+    "description": undefined,
+    "name": "stepped",
+    "table": {
+      "category": "events",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+  "update:by-step": {
+    "control": {
+      "disable": true,
+    },
+    "description": undefined,
+    "name": "update:by-step",
+    "table": {
+      "category": "events",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": {
+        "summary": "undefined",
+      },
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "undefined",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/cm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/cm-argtypes.snapshot
@@ -1,0 +1,56 @@
+{
+  "step": {
+    "defaultValue": {
+      "summary": "1",
+    },
+    "description": "",
+    "name": "step",
+    "table": {
+      "category": "props",
+      "defaultValue": {
+        "summary": "1",
+      },
+      "type": {
+        "summary": "number",
+      },
+    },
+    "type": {
+      "name": "number",
+      "required": false,
+    },
+  },
+  "stepped": {
+    "control": {
+      "disable": true,
+    },
+    "description": "",
+    "name": "stepped",
+    "table": {
+      "category": "events",
+      "type": {
+        "summary": "any[]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "any[]",
+    },
+  },
+  "update:by-step": {
+    "control": {
+      "disable": true,
+    },
+    "description": "",
+    "name": "update:by-step",
+    "table": {
+      "category": "events",
+      "type": {
+        "summary": "any[]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "any[]",
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/cm-snippet-Stepper.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/cm-snippet-Stepper.snapshot
@@ -1,0 +1,3 @@
+<template>
+  <OptionsApiEmits :step="2" />
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/input.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import OptionsApiEmits from './OptionsApiEmits.vue';
+
+const meta = {
+  title: 'VueFixtures/OptionsApiEmits',
+  component: OptionsApiEmits,
+} satisfies Meta<typeof OptionsApiEmits>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Stepper: Story = {
+  args: { step: 2 },
+};

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/snippet-Stepper.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/snippet-Stepper.snapshot
@@ -1,0 +1,3 @@
+<template>
+  <OptionsApiEmits :step="2" />
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/options-api-emits/story-docs.payload.snapshot
@@ -1,0 +1,20 @@
+{
+  "id": "options-api-emits",
+  "name": "OptionsApiEmits",
+  "path": "__PATH__",
+  "stories": {
+    "forms-options-api-emits--stepper": {
+      "description": undefined,
+      "id": "forms-options-api-emits--stepper",
+      "name": "Stepper",
+      "snippet": "<script lang="ts" setup>
+import OptionsApiEmits from './OptionsApiEmits.vue';
+</script>
+
+<template>
+  <OptionsApiEmits :step="2" />
+</template>",
+      "summary": undefined,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/props-generic/PropsGeneric.vue
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/props-generic/PropsGeneric.vue
@@ -1,3 +1,9 @@
+<script lang="ts">
+// Plain script block on purpose: `generic` lives on the setup tag only, and the extractor must
+// not stop at (or mis-attribute) this first tag.
+export const PROPS_GENERIC_KIND = 'list';
+</script>
+
 <script setup lang="ts" generic="T">
 defineProps<{
   /** Items rendered in order. */

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/SlotsWithEvents.vue
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/SlotsWithEvents.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineProps<{
+  /** Card title shown in the header. */
+  title: string;
+}>();
+
+const emit = defineEmits<{
+  /** Fired when the card is dismissed. */
+  (e: 'dismiss'): void;
+}>();
+</script>
+
+<template>
+  <section>
+    <header>
+      <!-- @slot Rendered before the title. -->
+      <slot name="leading" />
+      <h2>{{ title }}</h2>
+      <button @click="emit('dismiss')">×</button>
+    </header>
+    <!-- @slot The card body. -->
+    <slot />
+  </section>
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/argtypes.snapshot
@@ -1,0 +1,66 @@
+{
+  "default": {
+    "description": "The card body.",
+    "name": "default",
+    "table": {
+      "category": "slots",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+  "dismiss": {
+    "control": {
+      "disable": true,
+    },
+    "description": "Fired when the card is dismissed.",
+    "name": "dismiss",
+    "table": {
+      "category": "events",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+  "leading": {
+    "description": "Rendered before the title.",
+    "name": "leading",
+    "table": {
+      "category": "slots",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": undefined,
+    },
+    "type": {
+      "name": "other",
+      "required": false,
+      "value": "",
+    },
+  },
+  "title": {
+    "description": "Card title shown in the header.",
+    "name": "title",
+    "table": {
+      "category": "props",
+      "defaultValue": undefined,
+      "jsDocTags": undefined,
+      "type": {
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+      "required": true,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/cm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/cm-argtypes.snapshot
@@ -1,0 +1,63 @@
+{
+  "default": {
+    "description": "The card body.",
+    "name": "default",
+    "table": {
+      "category": "slots",
+      "type": {
+        "summary": "{}",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "{}",
+    },
+  },
+  "dismiss": {
+    "control": {
+      "disable": true,
+    },
+    "description": "Fired when the card is dismissed.",
+    "name": "dismiss",
+    "table": {
+      "category": "events",
+      "type": {
+        "summary": "[]",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "[]",
+    },
+  },
+  "leading": {
+    "description": "Rendered before the title.",
+    "name": "leading",
+    "table": {
+      "category": "slots",
+      "type": {
+        "summary": "{}",
+      },
+    },
+    "type": {
+      "name": "other",
+      "value": "{}",
+    },
+  },
+  "title": {
+    "defaultValue": undefined,
+    "description": "Card title shown in the header.",
+    "name": "title",
+    "table": {
+      "category": "props",
+      "defaultValue": undefined,
+      "type": {
+        "summary": "string",
+      },
+    },
+    "type": {
+      "name": "string",
+      "required": true,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/cm-snippet-StringChild.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/cm-snippet-StringChild.snapshot
@@ -1,0 +1,6 @@
+<template>
+  <SlotsWithEvents title="Notice">
+    Body text
+    <template #leading>!</template>
+  </SlotsWithEvents>
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/input.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import SlotsWithEvents from './SlotsWithEvents.vue';
+
+const meta = {
+  title: 'VueFixtures/SlotsWithEvents',
+  component: SlotsWithEvents,
+} satisfies Meta<typeof SlotsWithEvents>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const StringChild: Story = {
+  args: { title: 'Notice', leading: '!', default: 'Body text' },
+};

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/snippet-StringChild.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/snippet-StringChild.snapshot
@@ -1,0 +1,6 @@
+<template>
+  <SlotsWithEvents title="Notice">
+    Body text
+    <template #leading>!</template>
+  </SlotsWithEvents>
+</template>

--- a/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/__testfixtures__/slots-with-events/story-docs.payload.snapshot
@@ -1,0 +1,25 @@
+{
+  "id": "slots-with-events",
+  "name": "SlotsWithEvents",
+  "path": "__PATH__",
+  "stories": {
+    "forms-slots-with-events--string-child": {
+      "description": undefined,
+      "id": "forms-slots-with-events--string-child",
+      "name": "String Child",
+      "snippet": "<script lang="ts" setup>
+import SlotsWithEvents from './SlotsWithEvents.vue';
+</script>
+
+<template>
+  <SlotsWithEvents title="Notice">
+    Body text
+    <template #leading>
+      !
+    </template>
+  </SlotsWithEvents>
+</template>",
+      "summary": undefined,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-api-description.test.ts
@@ -64,6 +64,21 @@ describe('vue3 api description from real vue-component-meta output', () => {
     `);
   });
 
+  it('props-generic', async () => {
+    expect(await apiDescriptionFor('props-generic')).toMatchInlineSnapshot(`
+      "## Props
+
+      \`\`\`
+      export type PropsGenericProps<T> = {
+        /** Items rendered in order. */
+        items: T[];
+        /** Currently selected item. */
+        selected?: T;
+      }
+      \`\`\`"
+    `);
+  });
+
   it('v-model', async () => {
     expect(await apiDescriptionFor('v-model')).toMatchInlineSnapshot(`
       "## Models

--- a/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
+++ b/code/lib/docgen-harness/src/vue3/vue3-component-meta-baselines.test.ts
@@ -65,21 +65,22 @@ async function buildComponentMetaDocgen(sfcPath: string): Promise<object | undef
     }
     meta = checker.getComponentMeta(sfcPath, 'default');
 
-    // The shared temp-fix pass pairs metas with parseMulti results by export position, so keep
-    // the array aligned with the file's export order the way collectComponentMetaSources does.
-    const metas = exportNames.map((name) => {
+    // The shared temp-fix pass pairs metas with parseMulti results by export name, so hand it
+    // every extractable export the way collectComponentMetaSources does.
+    const entries = exportNames.flatMap((name) => {
       if (name === 'default') {
-        return meta;
+        return [{ name, meta }];
       }
       try {
-        return checker.getComponentMeta(sfcPath, name);
+        return [{ name, meta: checker.getComponentMeta(sfcPath, name) }];
       } catch {
-        return undefined;
+        return [];
       }
     });
     await applyVueDocgenApiTempFixes(
       sfcPath,
-      metas.filter((entry): entry is ComponentMeta => entry !== undefined)
+      entries.map((entry) => entry.meta),
+      entries.map((entry) => entry.name)
     );
   } catch {
     // the production transform swallows checker failures and attaches nothing

--- a/code/renderers/vue3/src/docgen/__testfixtures__/CastComponent.stories.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/CastComponent.stories.ts
@@ -1,0 +1,10 @@
+import Button from './Button.vue';
+
+type LooseComponent = unknown;
+
+export default {
+  title: 'Example/CastComponent',
+  component: Button as unknown as LooseComponent,
+};
+
+export const Default = { args: { label: 'Hello' } };

--- a/code/renderers/vue3/src/docgen/__testfixtures__/MissingImportComponent.stories.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/MissingImportComponent.stories.ts
@@ -1,0 +1,8 @@
+import MissingButton from './DoesNotExist.vue';
+
+export default {
+  title: 'Example/MissingImportComponent',
+  component: MissingButton,
+};
+
+export const Default = {};

--- a/code/renderers/vue3/src/docgen/__testfixtures__/NullComponent.stories.ts
+++ b/code/renderers/vue3/src/docgen/__testfixtures__/NullComponent.stories.ts
@@ -1,0 +1,6 @@
+export default {
+  title: 'Example/NullComponent',
+  component: null,
+};
+
+export const Default = {};

--- a/code/renderers/vue3/src/docgen/api-description.test.ts
+++ b/code/renderers/vue3/src/docgen/api-description.test.ts
@@ -232,6 +232,39 @@ describe('buildApiDescription', () => {
     `);
   });
 
+  it('uses an authored default tag instead of appending the runtime default', () => {
+    const result = buildApiDescription(
+      source({
+        props: [
+          prop({
+            name: 'placeholder',
+            type: 'string | undefined',
+            description: 'Placeholder shown while empty.',
+            required: false,
+            default: "'runtime-search'",
+            tags: [{ name: 'default', text: '"Search…"' }],
+          }),
+        ],
+      })
+    );
+
+    expect(result?.match(/@default/g)).toHaveLength(1);
+    expect(result).toMatchInlineSnapshot(`
+      "## Props
+
+      \`\`\`
+      export type ButtonProps = {
+        /**
+         * Placeholder shown while empty.
+         *
+         * @default "Search…"
+         */
+        placeholder?: string;
+      }
+      \`\`\`"
+    `);
+  });
+
   it('keeps multiline descriptions in a multiline doc comment', () => {
     const result = buildApiDescription(
       source({

--- a/code/renderers/vue3/src/docgen/api-description.ts
+++ b/code/renderers/vue3/src/docgen/api-description.ts
@@ -121,10 +121,9 @@ function modelBinding(propName: string): string {
 // declared types, so both reads stay guarded.
 function docComment(member: DocMember, defaultValue?: string): string[] {
   const description = member.description?.trim() ?? '';
-  const tagLines = (member.tags ?? []).map(
-    (tag) => `@${tag.name}${tag.text ? ` ${tag.text}` : ''}`
-  );
-  if (defaultValue !== undefined) {
+  const tags = member.tags ?? [];
+  const tagLines = tags.map((tag) => `@${tag.name}${tag.text ? ` ${tag.text}` : ''}`);
+  if (defaultValue !== undefined && !tags.some((tag) => tag.name === 'default')) {
     tagLines.push(`@default ${defaultValue}`);
   }
 

--- a/code/renderers/vue3/src/docgen/api-description.ts
+++ b/code/renderers/vue3/src/docgen/api-description.ts
@@ -4,7 +4,7 @@ import type { MetaSource } from './component-meta.ts';
 /** The slice of a component's normalized `vue-component-meta` output the api description reads. */
 export type ApiDescriptionSource = Pick<
   MetaSource,
-  'displayName' | 'props' | 'events' | 'slots' | 'exposed'
+  'displayName' | 'typeParams' | 'props' | 'events' | 'slots' | 'exposed'
 >;
 
 type PropMeta = ApiDescriptionSource['props'][number];
@@ -44,6 +44,7 @@ export function buildApiDescription(meta: ApiDescriptionSource): string | undefi
       ...section(
         'Models',
         `${typePrefix}Models`,
+        meta.typeParams,
         models.flatMap((model) => {
           const event = eventsByName.get(`update:${model.name}`);
           const description = model.description?.trim() ? model.description : event?.description;
@@ -62,6 +63,7 @@ export function buildApiDescription(meta: ApiDescriptionSource): string | undefi
       ...section(
         'Props',
         `${typePrefix}Props`,
+        meta.typeParams,
         props.flatMap((prop) => propLine(prop))
       )
     );
@@ -72,6 +74,7 @@ export function buildApiDescription(meta: ApiDescriptionSource): string | undefi
       ...section(
         'Events',
         `${typePrefix}Events`,
+        meta.typeParams,
         events.flatMap((event) => [
           ...docComment(event),
           `${memberKey(event.name)}: ${event.type};`,
@@ -85,6 +88,7 @@ export function buildApiDescription(meta: ApiDescriptionSource): string | undefi
       ...section(
         'Slots',
         `${typePrefix}Slots`,
+        meta.typeParams,
         slots.flatMap((slot) => [...docComment(slot), `${memberKey(slot.name)}: ${slot.type};`]),
         'Each slot is typed with the props it passes to its content.'
       )
@@ -96,6 +100,7 @@ export function buildApiDescription(meta: ApiDescriptionSource): string | undefi
       ...section(
         'Exposed',
         `${typePrefix}Exposed`,
+        meta.typeParams,
         exposed.flatMap((member) => [
           ...docComment(member),
           `${memberKey(member.name)}: ${member.type};`,
@@ -157,13 +162,20 @@ function propLine(prop: PropMeta, marker = ''): string[] {
   ];
 }
 
-function section(heading: string, typeName: string, lines: string[], intro?: string): string[] {
+function section(
+  heading: string,
+  typeName: string,
+  typeParams: string | undefined,
+  lines: string[],
+  intro?: string
+): string[] {
+  const aliasTypeParams = typeParams ? `<${typeParams}>` : '';
   return [
     `## ${heading}`,
     '',
     ...(intro ? [intro, ''] : []),
     '```',
-    `export type ${typeName} = {`,
+    `export type ${typeName}${aliasTypeParams} = {`,
     ...indent(lines.join('\n')).split('\n'),
     '}',
     '```',

--- a/code/renderers/vue3/src/docgen/build-docgen.ts
+++ b/code/renderers/vue3/src/docgen/build-docgen.ts
@@ -22,6 +22,18 @@ import { type UnresolvedComponentReason, resolveMetaComponent } from './resolve-
 
 type VueDocgenPayload = DocgenPayload & { vueComponentMeta?: MetaSource };
 
+const META_COMPONENT_NAME = /^[A-Za-z_$][\w$]*(\.[A-Za-z_$][\w$]*)*$/;
+const NON_COMPONENT_NAMES = new Set([
+  'null',
+  'undefined',
+  'true',
+  'false',
+  'NaN',
+  'Infinity',
+  'this',
+  'import',
+]);
+
 export interface BuildDocgenContext {
   getChecker: (componentFilePath: string) => ComponentMetaChecker;
   resolvePath?: (importPath: string) => string;
@@ -52,6 +64,14 @@ const UNRESOLVED_COMPONENT_ERRORS: Record<
  */
 function componentNameFromTitle(title: string): string {
   return title.split('/').at(-1)!.replace(/\s+/g, '');
+}
+
+function getUsableComponentName(component: string | undefined): string | undefined {
+  const name = component?.trim();
+  if (!name || NON_COMPONENT_NAMES.has(name.split('.')[0]!) || !META_COMPONENT_NAME.test(name)) {
+    return undefined;
+  }
+  return name;
 }
 
 /**
@@ -108,7 +128,8 @@ export async function buildDocgenPayload(
     };
   }
 
-  const base = baseFor(csf._meta?.component ?? fallbackName);
+  const authoredComponentName = getUsableComponentName(csf._meta?.component);
+  const base = baseFor(authoredComponentName ?? fallbackName);
 
   const resolved = resolveMetaComponent(csf, storyPath);
   if ('reason' in resolved) {
@@ -153,7 +174,7 @@ export async function buildDocgenPayload(
   );
 
   return {
-    ...base,
+    ...baseFor((authoredComponentName ?? componentMeta.displayName) || fallbackName),
     description,
     summary,
     jsDocTags,

--- a/code/renderers/vue3/src/docgen/component-meta.ts
+++ b/code/renderers/vue3/src/docgen/component-meta.ts
@@ -24,6 +24,7 @@ import {
   createCheckerByJson,
   type ComponentMeta,
   type ComponentMetaChecker,
+  type EventMeta,
   type MetaCheckerOptions,
   type PropertyMetaSchema,
   type SlotMeta,
@@ -136,7 +137,8 @@ export async function collectComponentMetaSources(
 
   const fixedComponentsMeta = await applyVueDocgenApiTempFixes(
     id,
-    entries.map((entry) => entry.meta)
+    entries.map((entry) => entry.meta),
+    entries.map((entry) => entry.name)
   );
   entries = entries.map((entry, index) => ({ ...entry, meta: fixedComponentsMeta[index]! }));
 
@@ -246,6 +248,7 @@ async function fileExists(fullPath: string) {
  * Fills the gaps Volar cannot extract yet from a `vue-docgen-api` parse of the same file:
  *
  * - Event descriptions: https://github.com/vuejs/language-tools/issues/3893
+ * - Runtime-declared emits that Volar drops or leaks as handler props
  * - Template-declared slots: Volar only infers slots for `<script setup>` components, so an
  *   Options API component loses every template slot, and `@slot` comment descriptions are never
  *   read for anyone
@@ -256,25 +259,35 @@ async function fileExists(fullPath: string) {
  */
 export async function applyVueDocgenApiTempFixes(
   filename: string,
-  componentsMeta: ComponentMeta[]
+  componentsMeta: ComponentMeta[],
+  exportNames: string[]
 ): Promise<ComponentMeta[]> {
+  const source = await readVueDocgenApiFallbackSource(filename);
   const hasEvents = componentsMeta.some((meta) => meta.events.length > 0);
-  const needsSlots = await hasTemplateSlotGap(filename, componentsMeta);
+  const needsEventRestore = hasRuntimeEmitsDeclaration(source);
+  const needsSlots = hasTemplateSlotGap(filename, componentsMeta, source);
 
-  if (!hasEvents && !needsSlots) {
+  if (!hasEvents && !needsEventRestore && !needsSlots) {
     return componentsMeta;
   }
 
   try {
     const parsedComponentDocs = await parseMulti(filename);
 
+    // vue-docgen-api reorders its docs (default export first), so positional pairing would attach
+    // another export's events to this meta in multi-export files.
+    const parsedByExportName = new Map(parsedComponentDocs.map((doc) => [doc.exportName, doc]));
+
     componentsMeta.forEach((meta, index) => {
-      const parsed = parsedComponentDocs[index];
+      const parsed = parsedByExportName.get(exportNames[index]!);
       if (!parsed) {
         return;
       }
-      if (hasEvents) {
+      if (hasEvents || needsEventRestore) {
         mergeEventDescriptions(meta, parsed.events);
+      }
+      if (needsEventRestore) {
+        restoreMissingRuntimeEvents(meta, parsed.events);
       }
       if (needsSlots) {
         mergeTemplateSlots(meta, parsed.slots);
@@ -285,6 +298,26 @@ export async function applyVueDocgenApiTempFixes(
   }
 
   return componentsMeta;
+}
+
+async function readVueDocgenApiFallbackSource(filename: string): Promise<string | undefined> {
+  if (!/\.(?:vue|tsx?|jsx?)$/.test(filename)) {
+    return undefined;
+  }
+
+  try {
+    return await readFile(filename, 'utf-8');
+  } catch {
+    return undefined;
+  }
+}
+
+function hasRuntimeEmitsDeclaration(source: string | undefined): boolean {
+  if (!source) {
+    return false;
+  }
+
+  return /defineEmits\s*\(\s*[\[{]/.test(source) || /\bemits\s*:/.test(source);
 }
 
 function mergeEventDescriptions(meta: ComponentMeta, events: ComponentDoc['events']): void {
@@ -300,14 +333,49 @@ function mergeEventDescriptions(meta: ComponentMeta, events: ComponentDoc['event
   }
 }
 
+function restoreMissingRuntimeEvents(meta: ComponentMeta, events: ComponentDoc['events']): void {
+  for (const event of events ?? []) {
+    if (meta.events.some((candidate) => candidate.name === event.name)) {
+      continue;
+    }
+
+    meta.events.push({
+      name: event.name,
+      description: event.description ?? '',
+      tags: [],
+      type: 'any[]',
+      signature: `(event: "${event.name}", ...args: any[]): void`,
+      schema: ['any'],
+      declarations: [],
+    } as unknown as EventMeta);
+    removeLeakedEventHandlerProp(meta, event.name);
+  }
+}
+
+/**
+ * A declared emit and its `onX` handler prop are one contract in Vue, so once the event is
+ * restored the handler prop is a duplicate — whether Volar synthesized it or the author spelled
+ * it out.
+ */
+function removeLeakedEventHandlerProp(meta: ComponentMeta, eventName: string): void {
+  const propName = `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`;
+
+  for (let index = meta.props.length - 1; index >= 0; index -= 1) {
+    if (meta.props[index]?.name === propName) {
+      meta.props.splice(index, 1);
+    }
+  }
+}
+
 /**
  * Whether the SFC template declares slots that the extracted meta misses, entirely or by
  * description. Reading the source keeps `parseMulti` away from the common slot-less component.
  */
-async function hasTemplateSlotGap(
+function hasTemplateSlotGap(
   filename: string,
-  componentsMeta: ComponentMeta[]
-): Promise<boolean> {
+  componentsMeta: ComponentMeta[],
+  source: string | undefined
+): boolean {
   if (!filename.endsWith('.vue')) {
     return false;
   }
@@ -319,12 +387,7 @@ async function hasTemplateSlotGap(
     return false;
   }
 
-  try {
-    const source = await readFile(filename, 'utf-8');
-    return /<slot[\s/>]/.test(source);
-  } catch {
-    return false;
-  }
+  return /<slot[\s/>]/.test(source ?? '');
 }
 
 /** Merges template-derived slots into the meta: descriptions onto known slots, missing slots whole. */

--- a/code/renderers/vue3/src/docgen/component-meta.ts
+++ b/code/renderers/vue3/src/docgen/component-meta.ts
@@ -53,6 +53,8 @@ type MetaSourceEntry = {
 export type MetaSource = {
   exportName: string;
   displayName: string;
+  /** Component-level TypeScript type parameters declared by the SFC. */
+  typeParams?: string;
   sourceFiles: string;
   jsDocTags?: Record<string, string[]>;
 } & Serializable<ComponentMeta> &
@@ -135,6 +137,7 @@ export async function collectComponentMetaSources(
     return [];
   }
 
+  const typeParams = await extractVueSfcTypeParams(id);
   const fixedComponentsMeta = await applyVueDocgenApiTempFixes(
     id,
     entries.map((entry) => entry.meta),
@@ -191,6 +194,7 @@ export async function collectComponentMetaSources(
       toSerializableMeta({
         exportName: name,
         displayName: name === 'default' ? getFilenameWithoutExtension(id) : name,
+        typeParams,
         ...meta,
         description: jsDocInfo?.description,
         jsDocTags: jsDocInfo?.jsDocTags,
@@ -201,6 +205,28 @@ export async function collectComponentMetaSources(
   });
 
   return metaSources;
+}
+
+async function extractVueSfcTypeParams(id: string): Promise<string | undefined> {
+  if (!id.endsWith('.vue')) {
+    return undefined;
+  }
+
+  try {
+    const source = await readFile(id, 'utf-8');
+    // Scan open tags one by one: only the `<script setup>` block may declare `generic`, and the
+    // attribute value may be unquoted.
+    for (const [openTag] of source.matchAll(/<script\b(?:"[^"]*"|'[^']*'|[^'">])*>/gi)) {
+      if (!/\bsetup\b/.test(openTag)) {
+        continue;
+      }
+      const generic = openTag.match(/\bgeneric\s*=\s*(?:(["'])(.*?)\1|([^\s'">]+))/);
+      return generic?.[2] ?? generic?.[3];
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function extractVueComponentJsDocInfo(

--- a/code/renderers/vue3/src/docgen/component-meta.ts
+++ b/code/renderers/vue3/src/docgen/component-meta.ts
@@ -292,13 +292,12 @@ function mergeEventDescriptions(meta: ComponentMeta, events: ComponentDoc['event
     return;
   }
 
-  meta.events = meta.events.map((event) => {
+  for (const event of meta.events) {
     const description = events.find((i) => i.name === event.name)?.description;
     if (description) {
       (event as typeof event & { description: string }).description = description;
     }
-    return event;
-  });
+  }
 }
 
 /**

--- a/code/renderers/vue3/src/docgen/vue-project-manager.test.ts
+++ b/code/renderers/vue3/src/docgen/vue-project-manager.test.ts
@@ -87,6 +87,29 @@ describe('VueComponentMetaManager', () => {
     expect(() => structuredClone(payload)).not.toThrow();
   });
 
+  it('uses the title-derived name when meta.component is null', async () => {
+    const payload = await docgenForFixture('./NullComponent.stories.ts', 'Example/NullComponent');
+
+    expect(payload?.name).toBe('NullComponent');
+  });
+
+  it('uses the resolved display name when meta.component is a cast expression', async () => {
+    const payload = await docgenForFixture('./CastComponent.stories.ts', 'Example/CastComponent');
+
+    expect(payload?.error).toBeUndefined();
+    expect(payload?.name).toBe('Button');
+  });
+
+  it('keeps the authored identifier as the name when the import cannot be resolved', async () => {
+    const payload = await docgenForFixture(
+      './MissingImportComponent.stories.ts',
+      'Example/MissingImportComponent'
+    );
+
+    expect(payload?.error?.name).toBe('No component import found');
+    expect(payload?.name).toBe('MissingButton');
+  });
+
   it('extracts component-level JSDoc tags from an options API SFC', async () => {
     const payload = await docgenForFixture(
       './jsdoc/OptionsButton.stories.ts',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->
## What I did

A QA sweep of the experimental Vue docgen server across 21 OSS repositories found cases where generated docs lose or corrupt API that components actually declare. This PR fixes the five Storybook-side ones, one commit each, with docgen-harness regression fixtures.

### Slot descriptions were erased for any component with events

```vue
<script setup lang="ts">
const emit = defineEmits<{ (e: 'dismiss'): void }>();
</script>
<template>
  <!-- @slot The card body. -->  ← description came out empty
  <slot />
</template>
```

The fallback pass reassigned `meta.events`, which is getter-only in Volar. The throw was swallowed and killed the slot-description merge behind it. Fixed by mutating entries in place.

### Authored `@default` rendered twice

```ts
/**
 * @default "Search"
 * @default "Search"   ← runtime default appended again
 */
placeholder?: string;
```

The authored tag now wins.

### Casts and `null` leaked into component names

```ts
component: Button as unknown as SomeType
// manifest name: "Button as unknown as Omit<ConcreteComponent<...>, 'props'>"

component: null
// manifest name: "null"
```

`meta.component` is printed source text. It is now only used as a name when it's a plain identifier; otherwise we fall back to the resolved display name or the story title.

### Runtime-declared emits disappeared

```ts
const modelValue = defineModel<string>();
const emit = defineEmits(['blur']);   // ← blur vanished

emits: ['update:by-step', 'stepped']  // ← Options API: no events, leaked as
                                      //   onUpdate:by-step / onStepped props
```

Volar drops these; the legacy engine extracted them fine, so this was a regression for anyone moving to the docgen server. The `vue-docgen-api` fallback now restores the missing events (paired by export name) and removes the leaked handler props.

### Generic components produced invalid type aliases

```ts
// <script setup lang="ts" generic="T">
export type AutocompleteMenuProps = { items: T[] };     // before: TS2304
export type AutocompleteMenuProps<T> = { items: T[] };  // after
```
 
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

---


> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-36001-sha-a25c53cc`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-36001-sha-a25c53cc sandbox` or in an existing project with `npx storybook@0.0.0-pr-36001-sha-a25c53cc upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-36001-sha-a25c53cc`](https://npmjs.com/package/storybook/v/0.0.0-pr-36001-sha-a25c53cc) |
| **Triggered by** | @huang-julien |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`julien/vue-qa-sweep-2`](https://github.com/storybookjs/storybook/tree/julien/vue-qa-sweep-2) |
| **Commit** | [`a25c53cc`](https://github.com/storybookjs/storybook/commit/a25c53ccf4ab3a77c85f73987ba22ab3501a4f20) |
| **Datetime** | Fri Aug 21 11:29:05 UTC 2026 (`1787311745`) |
| **Workflow run** | [32477391972](https://github.com/storybookjs/storybook/actions/runs/32477391972) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=36001`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
