### PR TITLE
Test: Scope instance-level focus assignments to their element

### DIFF
--- a/code/core/src/test/preview.test.ts
+++ b/code/core/src/test/preview.test.ts
@@ -37,6 +37,58 @@ describe('focus instrumentation', () => {
     expect(document.activeElement).toBe(button);
   });
 
+  it('keeps an instance-level focus assignment scoped to that element', () => {
+    const custom = vi.fn(function (this: HTMLElement) {});
+    const overridden = document.createElement('input');
+    const untouched = document.createElement('input');
+    document.body.append(overridden, untouched);
+
+    overridden.focus = custom;
+
+    // Native semantics: the assignment creates an own property on the element,
+    // it must not replace the focus method shared through the prototype.
+    expect(Object.prototype.hasOwnProperty.call(overridden, 'focus')).toBe(true);
+
+    untouched.focus();
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(untouched);
+
+    overridden.focus();
+
+    expect(custom).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(untouched);
+  });
+
+  it('does not let an instance-level focus assignment leak to elements created later', () => {
+    const custom = vi.fn(function (this: HTMLElement) {});
+    const overridden = document.createElement('input');
+    document.body.appendChild(overridden);
+    overridden.focus = custom;
+
+    const later = document.createElement('input');
+    document.body.appendChild(later);
+    later.focus();
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(later);
+  });
+
+  it('keeps a subclass prototype focus assignment scoped to that subclass', () => {
+    class Widget extends HTMLElement {}
+    const custom = function (this: HTMLElement) {};
+
+    Widget.prototype.focus = custom;
+
+    expect(Object.prototype.hasOwnProperty.call(Widget.prototype, 'focus')).toBe(true);
+
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    button.focus();
+
+    expect(document.activeElement).toBe(button);
+  });
+
   it('returns a no-op for nodes without a browsing context', () => {
     const detachedDocument = document.implementation.createHTMLDocument();
     const button = detachedDocument.createElement('button');

--- a/code/core/src/test/preview.ts
+++ b/code/core/src/test/preview.ts
@@ -121,8 +121,24 @@ export const enhanceContext: LoaderFunction = async (context) => {
         Object.defineProperties(HTMLElement.prototype, {
           focus: {
             configurable: true,
-            set: (newFocus: () => void) => {
-              currentFocus = newFocus;
+            set(this: HTMLElement, newFocus: () => void) {
+              /*
+               * Only assignments to `HTMLElement.prototype.focus` itself replace the shared
+               * focus method. An assignment on an element (`el.focus = fn`) natively creates
+               * an own property scoped to that element; routing it into `currentFocus` would
+               * hijack programmatic focus for every element on the page, so mirror the native
+               * behavior with an own data property instead.
+               */
+              if (this === HTMLElement.prototype) {
+                currentFocus = newFocus;
+                return;
+              }
+              Object.defineProperty(this, 'focus', {
+                value: newFocus,
+                writable: true,
+                configurable: true,
+                enumerable: true,
+              });
             },
             get() {
               /*


### PR DESCRIPTION
Closes #35973

## What I did

The test addon installs `focus` as an accessor on `HTMLElement.prototype` so it can intercept focus-management libraries that replace `HTMLElement.prototype.focus` (capture-and-wrap). But because the property is an accessor, an ordinary **instance-level** assignment — `el.focus = fn`, a common pattern for focus delegation in web components, test doubles, or `Object.assign` — no longer creates an own property on the element. It invokes the prototype setter instead, and since that setter was an arrow function it could not see its receiver: every instance assignment was routed into the shared `currentFocus`, silently replacing the focus method **for every element on the page**, including elements created later.

Measured on a built Storybook 10.4.6 preview (Playwright, real browser):

| probe | patched (before) | native / fixed |
| --- | --- | --- |
| `a.focus = fn` creates an own property on `a` | ❌ | ✅ |
| `b.focus()` focuses `b` | ❌ invokes `fn` with `this === b`, `b` never focused | ✅ |
| later-created `c.focus()` | ❌ invokes `fn` again | ✅ |

This PR makes the setter receiver-aware:

- Assignments to `HTMLElement.prototype.focus` itself keep the existing behavior (stored in `currentFocus`, so capture-and-wrap libraries keep working).
- Assignments on an element (or on a subclass prototype) mirror native semantics: an own, writable, configurable, enumerable data property scoped to that receiver.

Verifying the exact same change patched into the built `10.4.6` preview runtime makes all probes above return the native results. Full measurements in https://github.com/storybookjs/storybook/issues/35973#issuecomment-5371821468.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Run with:

```
node_modules/.bin/vitest run --config code/core/vitest.config.ts code/core/src/test/preview.test.ts
```

The three new tests fail on `next` without the fix (instance assignment leaks to other elements / later-created elements / subclass prototypes) and pass with it. The pre-existing tests for prototype reads, capture-and-wrap, and detached nodes still pass.

#### Manual testing

1. Run any sandbox, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open a story and, in the preview iframe's console, run:
   ```js
   const a = document.createElement('input');
   const b = document.createElement('input');
   document.body.append(a, b);
   a.focus = () => console.log('custom focus for a');
   b.focus();
   console.log(document.activeElement === b); // must be true; without this fix it logs "custom focus for a" and false
   ```
3. Also verify capture-and-wrap still works: reading `HTMLElement.prototype.focus`, assigning a wrapper to it, and calling `el.focus()` should invoke the wrapper (covered by existing unit tests as well).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## AI usage disclosure

I used an AI assistant (Claude) to help investigate this issue (browser-level measurements of the patched vs. native behavior) and to draft the implementation and tests. I reviewed, verified, and take responsibility for every change in this PR.
