### PR TITLE
Angular: Decide the migration's zone.js import from the dependency tree

### DIFF
--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -70,7 +70,7 @@ export const core: PresetProperty<'core'> = async (config, options) => {
   };
 };
 
-function resolveZoneless(angularBuilderOptions: StandaloneOptions['angularBuilderOptions']) {
+export function resolveZoneless(angularBuilderOptions: StandaloneOptions['angularBuilderOptions']) {
   return angularBuilderOptions?.zoneless ?? true;
 }
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts
@@ -11,6 +11,7 @@ import { logger, prompt } from 'storybook/internal/node-logger';
 
 import { ANALOG_VITE_PLUGIN_ANGULAR_VERSION } from 'storybook/internal/cli';
 
+import { resolveZoneless } from '../../../../../frameworks/angular-vite/src/preset.ts';
 import { add } from '../../add.ts';
 import { updateMainConfig } from '../helpers/mainConfigFile.ts';
 import type { CheckOptions } from './index.ts';
@@ -87,6 +88,7 @@ const mockUpdateMainConfig = vi.mocked(updateMainConfig);
 describe('angular-to-angular-vite', () => {
   const mockPackageManager = {
     getAllDependencies: vi.fn(),
+    isDependencyInstalled: vi.fn(),
     packageJsonPaths: ['/project/package.json'],
     removeDependencies: vi.fn().mockResolvedValue(undefined),
     addDependencies: vi.fn().mockResolvedValue(undefined),
@@ -118,6 +120,11 @@ describe('angular-to-angular-vite', () => {
     vi.mocked(mockPackageManager.addDependencies).mockResolvedValue(undefined);
     mockAngularCore({ declared: null, resolved: null });
     vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({});
+    // Derived exactly as `JsPackageManager` derives it, so a test only ever states the dependency
+    // tree once.
+    vi.mocked(mockPackageManager.isDependencyInstalled).mockImplementation((dependency) =>
+      Object.keys(mockPackageManager.getAllDependencies()).includes(dependency)
+    );
     // Default: angular.json doesn't exist (AngularJSON gracefully skips it). Tests that need
     // angular.json content override this via `mockAngularJson(...)`.
     mockExistsSync.mockReturnValue(false);
@@ -1395,8 +1402,47 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         });
       };
 
-      it("prepends `import 'zone.js';` and logs a step when the flag is unset", async () => {
+      /** Serve a single Nx `project.json` from the workspace glob, plus an empty preview. */
+      const mockNxProjectJson = async (zonelessOption: Record<string, unknown>) => {
+        // eslint-disable-next-line depend/ban-dependencies
+        const { globby } = await import('globby');
+        vi.mocked(globby).mockResolvedValueOnce(['/project/libs/soba/project.json']);
+
+        const projectJson = JSON.stringify({
+          name: 'soba',
+          targets: {
+            storybook: {
+              executor: '@storybook/angular:start-storybook',
+              options: zonelessOption,
+            },
+          },
+        });
+
+        mockReadFile.mockImplementation((filePath: any) => {
+          const p = String(filePath);
+          if (p.endsWith('project.json')) {
+            return Promise.resolve(projectJson) as any;
+          }
+          if (p === previewConfigPath) {
+            return Promise.resolve('export default {};') as any;
+          }
+          return Promise.resolve(`export default { framework: '${ANGULAR_PACKAGE}' };`) as any;
+        });
+      };
+
+      /** Put `zone.js` in the project's dependency tree; `isDependencyInstalled` follows it. */
+      const declareZoneJs = () =>
+        vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue({ 'zone.js': '~0.15.0' });
+
+      const zoneJsWarnings = () =>
+        vi
+          .mocked(logger.warn)
+          .mock.calls.map(([message]) => String(message))
+          .filter((message) => message.includes('does not depend on'));
+
+      it("prepends `import 'zone.js';` and logs a step when the project declares zone.js", async () => {
         mockPromptConfirm.mockResolvedValue(false);
+        declareZoneJs();
         mockFilesFor(angularJsonWithFlag(undefined), 'export default {};');
 
         await angularToAngularVite.run!({
@@ -1417,9 +1463,12 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         expect(logger.step).toHaveBeenCalledWith(expect.stringContaining(previewConfigPath));
       });
 
-      it('does not modify the preview when every storybook target sets experimentalZoneless: true', async () => {
+      // The common case, and the one this migration writes itself: a target that declares no
+      // `zoneless` option in a project with no `zone.js` to import. `@storybook/angular-vite`
+      // reads the same absence as zoneless, so an import here would be unresolvable.
+      it('leaves the preview alone when the target declares nothing and zone.js is not a dependency', async () => {
         mockPromptConfirm.mockResolvedValue(false);
-        mockFilesFor(angularJsonWithFlag(true), 'export default {};');
+        mockFilesFor(angularJsonWithFlag(undefined), 'export default {};');
 
         await angularToAngularVite.run!({
           result: baseResult,
@@ -1433,12 +1482,38 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         } as any);
 
         expect(mockWriteFile).not.toHaveBeenCalledWith(previewConfigPath, expect.anything());
+        expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('does not depend on'));
+      });
+
+      // The declared dependency outranks the option: skipping the import costs a dead preview
+      // (NG0908), writing a resolvable one costs a console warning (NG0914).
+      it('writes the import when zone.js is declared, even for a target that sets zoneless: true', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        declareZoneJs();
+        mockFilesFor(angularJsonWithFlag(true), 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).toHaveBeenCalledWith(
+          previewConfigPath,
+          expect.stringContaining('import "zone.js";')
+        );
       });
 
       // A multi-project upgrade runs every project's `run()` against the tree the first project's
       // run already rewrote, so projects 2..N only ever see angular-vite refs.
       it('still injects zone.js when an earlier run already rewrote the targets', async () => {
         mockPromptConfirm.mockResolvedValue(false);
+        declareZoneJs();
         mockFilesFor(
           JSON.stringify({
             projects: {
@@ -1469,7 +1544,34 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         );
       });
 
-      it('reads the zoneless flag an earlier run renamed, so a zoneless preview stays untouched', async () => {
+      // Unchanged behaviour, pinned so the new dependency check cannot swallow the one row that
+      // was already correct: this passes on `next` too.
+      it('injects for an explicitly zone-based target, without warning, when zone.js is declared', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        declareZoneJs();
+        mockFilesFor(angularJsonWithFlag(false), 'export default {};');
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).toHaveBeenCalledWith(
+          previewConfigPath,
+          expect.stringContaining('import "zone.js";')
+        );
+        expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('does not depend on'));
+      });
+
+      // Writing the import here guarantees an unresolvable specifier, so name the contradiction
+      // instead. The `zoneless` spelling is what an earlier run leaves behind.
+      it('warns instead of writing when a target sets zoneless: false but zone.js is missing', async () => {
         mockPromptConfirm.mockResolvedValue(false);
         mockFilesFor(
           JSON.stringify({
@@ -1478,8 +1580,82 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
                 architect: {
                   storybook: {
                     builder: `${ANGULAR_VITE_PACKAGE}:start-storybook`,
-                    options: { zoneless: true },
+                    options: { zoneless: false },
                   },
+                },
+              },
+            },
+          }),
+          'export default {};'
+        );
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).not.toHaveBeenCalledWith(previewConfigPath, expect.anything());
+        expect(zoneJsWarnings()).toMatchInlineSnapshot(`
+          [
+            "A Storybook builder target sets \`zoneless: false\`, but this project does not depend on \`zone.js\`, so no \`import 'zone.js';\` was added to your preview - it could not resolve, and every story would fail to load. Install \`zone.js\`, or set \`zoneless: true\` on that target if your app uses zoneless change detection.",
+          ]
+        `);
+      });
+
+      it('warns once when any of several storybook targets is zone-based and zone.js is missing', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        mockFilesFor(
+          JSON.stringify({
+            projects: {
+              myApp: {
+                architect: {
+                  storybook: {
+                    builder: '@storybook/angular:start-storybook',
+                    options: { experimentalZoneless: false },
+                  },
+                  'build-storybook': {
+                    builder: '@storybook/angular:build-storybook',
+                    options: {},
+                  },
+                },
+              },
+            },
+          }),
+          'export default {};'
+        );
+
+        await angularToAngularVite.run!({
+          result: baseResult,
+          dryRun: false,
+          packageManager: mockPackageManager,
+          mainConfigPath: '/project/.storybook/main.ts',
+          previewConfigPath,
+          storiesPaths: [],
+          configDir: '.storybook',
+          storybookVersion: '9.0.0',
+        } as any);
+
+        expect(mockWriteFile).not.toHaveBeenCalledWith(previewConfigPath, expect.anything());
+        expect(zoneJsWarnings()).toHaveLength(1);
+      });
+
+      // Unchanged behaviour, pinned: `zone.js` in the dependency tree must not be enough on its
+      // own. This passes on `next` too.
+      it('writes nothing when the workspace has no storybook target, even with zone.js declared', async () => {
+        mockPromptConfirm.mockResolvedValue(false);
+        declareZoneJs();
+        mockFilesFor(
+          JSON.stringify({
+            projects: {
+              myApp: {
+                architect: {
+                  build: { builder: '@angular/build:application', options: {} },
                 },
               },
             },
@@ -1501,29 +1677,9 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         expect(mockWriteFile).not.toHaveBeenCalledWith(previewConfigPath, expect.anything());
       });
 
-      it('behaves like unset when experimentalZoneless is explicitly false: injection happens', async () => {
-        mockPromptConfirm.mockResolvedValue(false);
-        mockFilesFor(angularJsonWithFlag(false), 'export default {};');
-
-        await angularToAngularVite.run!({
-          result: baseResult,
-          dryRun: false,
-          packageManager: mockPackageManager,
-          mainConfigPath: '/project/.storybook/main.ts',
-          previewConfigPath,
-          storiesPaths: [],
-          configDir: '.storybook',
-          storybookVersion: '9.0.0',
-        } as any);
-
-        expect(mockWriteFile).toHaveBeenCalledWith(
-          previewConfigPath,
-          expect.stringContaining('import "zone.js";')
-        );
-      });
-
       it('is idempotent: leaves a preview that already imports zone.js (incl. deep imports) untouched', async () => {
         mockPromptConfirm.mockResolvedValue(false);
+        declareZoneJs();
         mockFilesFor(
           angularJsonWithFlag(undefined),
           "import 'zone.js/testing';\nexport default {};"
@@ -1544,6 +1700,7 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
       });
 
       it('performs no file writes in --dry-run while still reporting the planned change', async () => {
+        declareZoneJs();
         mockFilesFor(angularJsonWithFlag(undefined), 'export default {};');
 
         await angularToAngularVite.run!({
@@ -1563,6 +1720,7 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
 
       it('works with a .tsx preview file', async () => {
         mockPromptConfirm.mockResolvedValue(false);
+        declareZoneJs();
         const tsxPreviewPath = '/project/.storybook/preview.tsx';
         mockAngularJson(angularJsonWithFlag(undefined));
         mockReadFile.mockImplementation((filePath: any) => {
@@ -1595,6 +1753,7 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
 
       it('warns with manual-import guidance when no preview file was found, without throwing', async () => {
         mockPromptConfirm.mockResolvedValue(false);
+        declareZoneJs();
         mockFilesFor(angularJsonWithFlag(undefined), 'export default {};');
 
         await expect(
@@ -1639,30 +1798,8 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
 
       it('handles Nx project.json storybook targets identically to angular.json targets', async () => {
         mockPromptConfirm.mockResolvedValue(false);
-        // eslint-disable-next-line depend/ban-dependencies
-        const { globby } = await import('globby');
-        vi.mocked(globby).mockResolvedValueOnce(['/project/libs/soba/project.json']);
-
-        const projectJsonContent = JSON.stringify({
-          name: 'soba',
-          targets: {
-            storybook: {
-              executor: '@storybook/angular:start-storybook',
-              options: {},
-            },
-          },
-        });
-
-        mockReadFile.mockImplementation((filePath: any) => {
-          const p = String(filePath);
-          if (p.endsWith('project.json')) {
-            return Promise.resolve(projectJsonContent) as any;
-          }
-          if (p === previewConfigPath) {
-            return Promise.resolve('export default {};') as any;
-          }
-          return Promise.resolve(`export default { framework: '${ANGULAR_PACKAGE}' };`) as any;
-        });
+        declareZoneJs();
+        await mockNxProjectJson({});
 
         await angularToAngularVite.run!({
           result: baseResult,
@@ -1681,62 +1818,9 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         );
       });
 
-      it('injects when one of multiple storybook targets leaves the flag unset (multi-target rule)', async () => {
+      it('warns for a zone-based Nx project.json target in a project without zone.js', async () => {
         mockPromptConfirm.mockResolvedValue(false);
-        const angularJsonContent = JSON.stringify({
-          projects: {
-            myApp: {
-              architect: {
-                storybook: {
-                  builder: '@storybook/angular:start-storybook',
-                  options: { experimentalZoneless: true },
-                },
-                'build-storybook': {
-                  builder: '@storybook/angular:build-storybook',
-                  options: {},
-                },
-              },
-            },
-          },
-        });
-        mockFilesFor(angularJsonContent, 'export default {};');
-
-        await angularToAngularVite.run!({
-          result: baseResult,
-          dryRun: false,
-          packageManager: mockPackageManager,
-          mainConfigPath: '/project/.storybook/main.ts',
-          previewConfigPath,
-          storiesPaths: [],
-          configDir: '.storybook',
-          storybookVersion: '9.0.0',
-        } as any);
-
-        expect(mockWriteFile).toHaveBeenCalledWith(
-          previewConfigPath,
-          expect.stringContaining('import "zone.js";')
-        );
-      });
-
-      it('skips injection when every one of multiple storybook targets sets the flag true', async () => {
-        mockPromptConfirm.mockResolvedValue(false);
-        const angularJsonContent = JSON.stringify({
-          projects: {
-            myApp: {
-              architect: {
-                storybook: {
-                  builder: '@storybook/angular:start-storybook',
-                  options: { experimentalZoneless: true },
-                },
-                'build-storybook': {
-                  builder: '@storybook/angular:build-storybook',
-                  options: { experimentalZoneless: true },
-                },
-              },
-            },
-          },
-        });
-        mockFilesFor(angularJsonContent, 'export default {};');
+        await mockNxProjectJson({ zoneless: false });
 
         await angularToAngularVite.run!({
           result: baseResult,
@@ -1750,10 +1834,12 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         } as any);
 
         expect(mockWriteFile).not.toHaveBeenCalledWith(previewConfigPath, expect.anything());
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('does not depend on'));
       });
 
       it('only renames/detects the correct project when two projects name their storybook target identically', async () => {
         mockPromptConfirm.mockResolvedValue(false);
+        declareZoneJs();
         const angularJsonContent = JSON.stringify({
           projects: {
             appA: {
@@ -1787,7 +1873,6 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
           storybookVersion: '9.0.0',
         } as any);
 
-        // Injection fires because appB's target is unset (multi-target rule).
         expect(mockWriteFile).toHaveBeenCalledWith(
           previewConfigPath,
           expect.stringContaining('import "zone.js";')
@@ -1801,6 +1886,110 @@ export default { framework: { name: '${ANGULAR_VITE_PACKAGE}', options: {} } };`
         // Only appA's target (which explicitly carried the old key) is renamed.
         expect(written.projects.appA.architect.storybook.options).toEqual({ zoneless: true });
         expect(written.projects.appB.architect.storybook.options).toEqual({});
+      });
+
+      // This migration and `@storybook/angular-vite` both read the `zoneless` builder option, and
+      // they used to default it in opposite directions: the framework read an absent option as
+      // zoneless while this migration read it as zone-based and wrote an `import 'zone.js'` the
+      // framework had already excluded from `optimizeDeps` - unresolvable in a project with no
+      // zone.js. Walking every (option x dependency tree) pair through both sides in one test is
+      // what keeps them from drifting apart again.
+      it('agrees with the framework: an absent zoneless option never means zone-based', async () => {
+        const observed: Record<
+          string,
+          { frameworkTreatsAsZoneless: boolean; migrationWritesImport: boolean }
+        > = {};
+
+        for (const zoneless of [undefined, true, false] as const) {
+          for (const zoneJsDeclared of [false, true] as const) {
+            vi.clearAllMocks();
+            mockPromptConfirm.mockResolvedValue(false);
+            vi.mocked(mockPackageManager.getAllDependencies).mockReturnValue(
+              zoneJsDeclared ? { 'zone.js': '~0.15.0' } : {}
+            );
+            mockFilesFor(
+              JSON.stringify({
+                projects: {
+                  myApp: {
+                    architect: {
+                      storybook: {
+                        builder: '@storybook/angular:start-storybook',
+                        options: zoneless === undefined ? {} : { zoneless },
+                      },
+                    },
+                  },
+                },
+              }),
+              'export default {};'
+            );
+
+            await angularToAngularVite.run!({
+              result: baseResult,
+              dryRun: false,
+              packageManager: mockPackageManager,
+              mainConfigPath: '/project/.storybook/main.ts',
+              previewConfigPath,
+              storiesPaths: [],
+              configDir: '.storybook',
+              storybookVersion: '9.0.0',
+            } as any);
+
+            observed[`zoneless=${zoneless} zone.js=${zoneJsDeclared}`] = {
+              // The framework's own reading of the same builder option, imported from its preset.
+              frameworkTreatsAsZoneless: resolveZoneless(
+                zoneless === undefined ? {} : { zoneless }
+              ),
+              migrationWritesImport: mockWriteFile.mock.calls.some(
+                ([path, contents]) =>
+                  path === previewConfigPath && String(contents).includes('zone.js')
+              ),
+            };
+          }
+        }
+
+        expect(observed).toMatchInlineSnapshot(`
+          {
+            "zoneless=false zone.js=false": {
+              "frameworkTreatsAsZoneless": false,
+              "migrationWritesImport": false,
+            },
+            "zoneless=false zone.js=true": {
+              "frameworkTreatsAsZoneless": false,
+              "migrationWritesImport": true,
+            },
+            "zoneless=true zone.js=false": {
+              "frameworkTreatsAsZoneless": true,
+              "migrationWritesImport": false,
+            },
+            "zoneless=true zone.js=true": {
+              "frameworkTreatsAsZoneless": true,
+              "migrationWritesImport": true,
+            },
+            "zoneless=undefined zone.js=false": {
+              "frameworkTreatsAsZoneless": true,
+              "migrationWritesImport": false,
+            },
+            "zoneless=undefined zone.js=true": {
+              "frameworkTreatsAsZoneless": true,
+              "migrationWritesImport": true,
+            },
+          }
+        `);
+
+        // The framework reads an absent option as zoneless. The migration must not read that same
+        // absence as zone-based, which is the row the original defect landed on.
+        expect(observed['zoneless=undefined zone.js=false']).toEqual({
+          frameworkTreatsAsZoneless: true,
+          migrationWritesImport: false,
+        });
+
+        // Independent of the recorded table: an import is only ever written where `zone.js` is
+        // declared, so it can always resolve.
+        expect(
+          Object.keys(observed).filter(
+            (input) => observed[input].migrationWritesImport && input.endsWith('zone.js=false')
+          )
+        ).toEqual([]);
       });
     });
   });

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -699,11 +699,6 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
       }
     }
 
-    // `@storybook/angular-vite` reads the same `zoneless` builder option and treats its absence as
-    // zoneless, so the option cannot decide this: a target declaring nothing - what this migration
-    // itself writes - would get an `import 'zone.js'` the framework has already decided the project
-    // does not need, and that the project may not even be able to resolve. The dependency tree is
-    // the signal that survives an option nobody wrote.
     const hasZoneJsDependency = packageManager.isDependencyInstalled('zone.js');
 
     if (anyStorybookTarget && anyZoneBasedTarget && !hasZoneJsDependency) {

--- a/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
@@ -184,7 +184,8 @@ const transformMainConfig = async (
 interface JsonTargetTransformResult {
   changed: boolean;
   hasStorybookTarget: boolean;
-  allStorybookTargetsZonelessTrue: boolean;
+  /** True when at least one storybook target explicitly declares `zoneless: false`. */
+  anyZoneBasedTarget: boolean;
 }
 
 /** Map a migratable builder/executor ref to its angular-vite equivalent, or `null` if unrelated. */
@@ -248,18 +249,17 @@ class TextJsonEditor implements TargetEditor {
 }
 
 /**
- * Rewrite builder/executor references, detect Compodoc/zone.js signals, and rename any leftover
- * `experimentalZoneless` key to `zoneless`, across every storybook target in `targetGroups`.
+ * Rewrite builder/executor references and rename any leftover `experimentalZoneless` key to
+ * `zoneless`, across every storybook target in `targetGroups`, reporting whether any of them
+ * explicitly opts out of zoneless change detection.
  */
 const processStorybookTargets = (
   editor: TargetEditor,
   targetGroups: AngularTargetGroup[]
-): Omit<JsonTargetTransformResult, 'allStorybookTargetsZonelessTrue'> & {
-  allZonelessTrue: boolean;
-} => {
+): JsonTargetTransformResult => {
   let changed = false;
   let hasStorybookTarget = false;
-  let allZonelessTrue = true;
+  let anyZoneBasedTarget = false;
 
   for (const { pathPrefix, targets } of targetGroups) {
     for (const [targetName, target] of Object.entries(targets)) {
@@ -277,11 +277,11 @@ const processStorybookTargets = (
       // Snapshot before editing: `AngularJSON.edit()` reparses `json`, invalidating `target`.
       const currentRef = target.builder ?? target.executor ?? null;
       const hasOldZonelessKey = !!target.options && 'experimentalZoneless' in target.options;
-      // An earlier run may already have renamed the key, so both spellings count as zoneless.
+      // An earlier run may already have renamed the key, so both spellings count.
       const zonelessValue = target.options?.zoneless ?? target.options?.experimentalZoneless;
 
-      if (zonelessValue !== true) {
-        allZonelessTrue = false;
+      if (zonelessValue === false) {
+        anyZoneBasedTarget = true;
       }
 
       if (!isMigratableStorybookTarget(target)) {
@@ -303,7 +303,7 @@ const processStorybookTargets = (
     }
   }
 
-  return { changed, hasStorybookTarget, allZonelessTrue };
+  return { changed, hasStorybookTarget, anyZoneBasedTarget };
 };
 
 const transformAngularJson = (
@@ -317,24 +317,17 @@ const transformAngularJson = (
     return {
       changed: false,
       hasStorybookTarget: false,
-      allStorybookTargetsZonelessTrue: true,
+      anyZoneBasedTarget: false,
     };
   }
 
-  const { changed, hasStorybookTarget, allZonelessTrue } = processStorybookTargets(
-    angularJSON,
-    getTargetGroups(angularJSON.json)
-  );
+  const result = processStorybookTargets(angularJSON, getTargetGroups(angularJSON.json));
 
-  if (changed && !dryRun) {
+  if (result.changed && !dryRun) {
     angularJSON.write();
   }
 
-  return {
-    changed,
-    hasStorybookTarget,
-    allStorybookTargetsZonelessTrue: allZonelessTrue,
-  };
+  return result;
 };
 
 /**
@@ -349,25 +342,18 @@ const transformProjectJson = async (
     const original = await readFile(projectJsonPath, 'utf-8');
     const json = JSON.parse(original);
     const editor = new TextJsonEditor(original);
-    const { changed, hasStorybookTarget, allZonelessTrue } = processStorybookTargets(
-      editor,
-      getTargetGroups(json)
-    );
+    const result = processStorybookTargets(editor, getTargetGroups(json));
 
-    if (changed && !dryRun) {
+    if (result.changed && !dryRun) {
       await writeFile(projectJsonPath, editor.content);
     }
 
-    return {
-      changed,
-      hasStorybookTarget,
-      allStorybookTargetsZonelessTrue: allZonelessTrue,
-    };
+    return result;
   } catch {
     return {
       changed: false,
       hasStorybookTarget: false,
-      allStorybookTargetsZonelessTrue: true,
+      anyZoneBasedTarget: false,
     };
   }
 };
@@ -624,22 +610,22 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
       ]);
     }
 
-    // Injection fires unless EVERY storybook target is declared zoneless.
     let anyStorybookTarget = false;
-    let allZonelessTrue = true;
+    let anyZoneBasedTarget = false;
 
     // 3. Rewrite Angular CLI builder references in angular.json.
     // Search for angular.json beside every package.json we know about.
     for (const pkgJsonPath of packageManager.packageJsonPaths) {
       const dir = pkgJsonPath.replace(/[/\\]package\.json$/, '');
       const angularJsonPath = `${dir}/angular.json`;
-      const { changed, hasStorybookTarget, allStorybookTargetsZonelessTrue } = transformAngularJson(
-        angularJsonPath,
-        dryRun
-      );
+      const {
+        changed,
+        hasStorybookTarget,
+        anyZoneBasedTarget: zoneBased,
+      } = transformAngularJson(angularJsonPath, dryRun);
       if (hasStorybookTarget) {
         anyStorybookTarget = true;
-        allZonelessTrue = allZonelessTrue && allStorybookTargetsZonelessTrue;
+        anyZoneBasedTarget = anyZoneBasedTarget || zoneBased;
       }
       if (changed) {
         logger.debug(`Updated Angular CLI builder references in ${angularJsonPath}`);
@@ -654,11 +640,14 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
     // with package.json the way angular.json is.
     const projectJsonFiles = await findWorkspaceFiles('project.json');
     for (const projectJsonPath of projectJsonFiles) {
-      const { changed, hasStorybookTarget, allStorybookTargetsZonelessTrue } =
-        await transformProjectJson(projectJsonPath, dryRun);
+      const {
+        changed,
+        hasStorybookTarget,
+        anyZoneBasedTarget: zoneBased,
+      } = await transformProjectJson(projectJsonPath, dryRun);
       if (hasStorybookTarget) {
         anyStorybookTarget = true;
-        allZonelessTrue = allZonelessTrue && allStorybookTargetsZonelessTrue;
+        anyZoneBasedTarget = anyZoneBasedTarget || zoneBased;
       }
       if (changed) {
         logger.debug(`Updated Nx builder references in ${projectJsonPath}`);
@@ -710,7 +699,23 @@ export const angularToAngularVite: Fix<AngularToAngularViteOptions> = {
       }
     }
 
-    const needsZoneJs = anyStorybookTarget && !allZonelessTrue;
+    // `@storybook/angular-vite` reads the same `zoneless` builder option and treats its absence as
+    // zoneless, so the option cannot decide this: a target declaring nothing - what this migration
+    // itself writes - would get an `import 'zone.js'` the framework has already decided the project
+    // does not need, and that the project may not even be able to resolve. The dependency tree is
+    // the signal that survives an option nobody wrote.
+    const hasZoneJsDependency = packageManager.isDependencyInstalled('zone.js');
+
+    if (anyStorybookTarget && anyZoneBasedTarget && !hasZoneJsDependency) {
+      logger.warn(
+        'A Storybook builder target sets `zoneless: false`, but this project does not depend on ' +
+          "`zone.js`, so no `import 'zone.js';` was added to your preview - it could not resolve, " +
+          'and every story would fail to load. Install `zone.js`, or set `zoneless: true` on that ' +
+          'target if your app uses zoneless change detection.'
+      );
+    }
+
+    const needsZoneJs = anyStorybookTarget && hasZoneJsDependency;
     if (needsZoneJs && previewConfigPath) {
       await addZoneJsPreviewImport(previewConfigPath, dryRun);
     } else if (needsZoneJs && !previewConfigPath) {


### PR DESCRIPTION
## What I did

`@storybook/angular-vite` and the `angular-to-angular-vite` automigration both read the same input, a Storybook builder target's `zoneless` option, and they disagreed about what its absence means. The framework reads an absent option as zoneless. The migration read the same absence as zone-based and wrote a static `import 'zone.js';` into `preview.ts`.

A target that declares nothing is the common case, and it is exactly what the migration itself writes, so a freshly migrated project landed on the one disagreeing row by construction. This PR takes that decision away from the option and gives it to the dependency tree: the import is written when the project declares `zone.js`, and a target that says `zoneless: false` in a project without `zone.js` gets a warning instead of an unresolvable import.

```
angular.json storybook target ──┐
   zoneless: true|false|absent  │
                                ├──► needs zone.js? ──► write `import 'zone.js';` into preview.ts
   package.json dependencies ───┘        ▲                    or warn, when the target says
   zone.js declared? ───────────────────-┘                    zoneless: false and it is missing
```

Before, only the left input was read. Now the decision comes from the right one, and the left one only decides whether to warn.

### The truth table

| storybook target | `zone.js` declared | `next` | this PR |
| --- | --- | --- | --- |
| declares nothing (**the common case**) | no | writes `import 'zone.js'` -> **unresolvable, every story fails** | nothing written |
| declares nothing | yes | writes `import 'zone.js'` | writes `import 'zone.js'` |
| `zoneless: true` | no | nothing written | nothing written |
| `zoneless: true` | yes | nothing written | writes `import 'zone.js'` |
| `zoneless: false` | no | writes `import 'zone.js'` -> **unresolvable, every story fails** | warns, writes nothing |
| `zoneless: false` | yes | writes `import 'zone.js'` | writes `import 'zone.js'` |

The row that changed for the worse is `zoneless: true` + `zone.js` declared. The reasoning is in "Why the dependency tree wins over an explicit `zoneless: true`" below.

### The failure, captured

A minimal Angular 21 workspace: a `storybook` target that declares no `zoneless` option, and a `package.json` with no `zone.js`.

```jsonc
// angular.json
{ "projects": { "demo": { "architect": { "storybook": {
  "builder": "@storybook/angular:start-storybook",
  "options": { "configDir": ".storybook" } } } } } }
```

```jsonc
// package.json
{ "dependencies": { "@angular/core": "^21.0.0" },
  "devDependencies": { "@storybook/angular": "^10.0.0", "storybook": "^10.0.0" } }
```

On `next`, `storybook automigrate angular-to-angular-vite`:

```
◇  Migrating from @storybook/angular to @storybook/angular-vite...
│
◇  Added a `zone.js` import to .storybook/preview.ts
```

```ts
// .storybook/preview.ts, after the migration on `next`
import "zone.js";
export default {};
```

There is no `zone.js` in that project to import, and the framework already excluded it from `optimizeDeps` because it read the same absent option as zoneless.

On this branch, the same workspace: `preview.ts` is left as `export default {};`, and the migration says nothing about zone.js.

The contradictory case, a target that explicitly declares `zoneless: false` in a project without `zone.js`, now gets named instead:

```
◇  Migrating from @storybook/angular to @storybook/angular-vite...
│
▲  A Storybook builder target sets `zoneless: false`, but this project
│  does not depend on `zone.js`, so no `import 'zone.js';` was added to
│  your preview - it could not resolve, and every story would fail to
│  load. Install `zone.js`, or set `zoneless: true` on that target if
│  your app uses zoneless change detection.
```

### The decision

```ts
// code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.ts
-    const needsZoneJs = anyStorybookTarget && !allZonelessTrue;
+    const hasZoneJsDependency = packageManager.isDependencyInstalled('zone.js');
+
+    if (anyStorybookTarget && anyZoneBasedTarget && !hasZoneJsDependency) {
+      logger.warn(/* the message above */);
+    }
+
+    const needsZoneJs = anyStorybookTarget && hasZoneJsDependency;
```

`allZonelessTrue` / `allStorybookTargetsZonelessTrue` are deleted. Nothing outside this file read them, including the Nx `project.json` path, which used them only to feed the same decision. What the target scan now reports is `anyZoneBasedTarget`, an explicit `zoneless: false` on any storybook target, and that only drives the warning.

`resolveZoneless` in the framework is unchanged. `?? true` is the right direction, and removing the migration's competing default is what makes the two agree.

### Why the dependency tree wins over an explicit `zoneless: true`

Honouring `zoneless: true` and skipping the import would be defensible, and it keeps a stale option from adding an import nobody asked for. I went the other way, for three reasons:

1. Special-casing one option value re-derives a zoneless verdict inside the migration, which is exactly the second rule that let the two sides drift apart in the first place.
2. The failure modes are asymmetric. Writing an import the project does not need costs an `NG0914` console warning, because `zone.js` is declared and therefore resolves. Not writing one the project does need costs `NG0908` and a preview that does not boot.
3. The declared dependency is a stronger statement than an option this migration generates itself and that most projects never write.

If maintainers prefer explicit config to win here, gating `needsZoneJs` on "no storybook target explicitly declares `zoneless: true`" is a two-line follow-up. I would like a second opinion on this row specifically.

### Not in this PR

- The framework's own `zone.js` injection (`preset.ts`, `imports.push('zone.js')`) is not guarded against an unresolvable `zone.js`. A project with `zoneless: false` and no `zone.js` installed still breaks when Storybook runs through the Angular builder. Real, but a separate change.
- `optimizeDeps` and `preview.ts` can still disagree in the "target declares nothing, `zone.js` declared" row: the framework reads that target as zoneless and leaves `zone.js` out of `optimizeDeps` while the preview imports it. Vite's dep scanner discovers it, so this costs a re-optimize rather than a failure.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Six tests in the zone.js block fail on `next` and pass here. Two more are labelled in-source as pins on behaviour that was already correct and pass on both.

The regression pin walks every `(zoneless option x zone.js declared)` pair through the real migration and through the framework's own `resolveZoneless` in a single test, so neither side can move without the other noticing. Its recorded table on `next`:

```diff
- Expected     <- this PR
+ Received     <- next

@@ -1,9 +1,9 @@
  {
    "zoneless=false zone.js=false": {
      "frameworkTreatsAsZoneless": false,
-     "migrationWritesImport": false,
+     "migrationWritesImport": true,
    },
    "zoneless=false zone.js=true": {
      "frameworkTreatsAsZoneless": false,
      "migrationWritesImport": true,
    },
@@ -11,15 +11,15 @@
      "frameworkTreatsAsZoneless": true,
      "migrationWritesImport": false,
    },
    "zoneless=true zone.js=true": {
      "frameworkTreatsAsZoneless": true,
-     "migrationWritesImport": true,
+     "migrationWritesImport": false,
    },
    "zoneless=undefined zone.js=false": {
      "frameworkTreatsAsZoneless": true,
-     "migrationWritesImport": false,
+     "migrationWritesImport": true,
    },
    "zoneless=undefined zone.js=true": {
      "frameworkTreatsAsZoneless": true,
      "migrationWritesImport": true,
    },
```

Run them with:

| Command | What it does |
| --- | --- |
| `yarn vitest run code/lib/cli-storybook/src/automigrate/fixes/angular-to-angular-vite.test.ts` | 78 tests, the zone.js block included |
| `yarn vitest run --project '@storybook/cli' --project '@storybook/angular-vite'` | both touched packages, 1024 passing plus 2 todo |
| `yarn nx run-many -t check -p cli angular-vite` | typecheck both packages |

All from the repository root.

#### Manual testing

1. Check out this branch and build the CLI: `yarn && yarn nx run-many -t compile`.
2. Create a throwaway workspace outside the repo, e.g. `/tmp/zonejs-demo`, with these four files:
   - `package.json` and `angular.json` exactly as quoted under "The failure, captured" above.
   - `.storybook/main.ts` containing `export default { stories: ['../src/**/*.stories.ts'], framework: { name: '@storybook/angular', options: {} } };`
   - `.storybook/preview.ts` containing `export default {};`
3. From that directory, run the migration against the CLI you just built:
   `node <repo>/code/core/dist/bin/dispatcher.js automigrate angular-to-angular-vite --yes --config-dir .storybook`
   (the dependency install at the very end fails on this hand-written `package.json`; that happens after everything under test).
4. Look at `.storybook/preview.ts`. On this branch it is still `export default {};`. On `next` it is `import "zone.js";` followed by `export default {};`, which cannot resolve because the project has no `zone.js`.
5. Reset the workspace, add `"zone.js": "~0.15.0"` to `dependencies`, and run step 3 again. On both branches the import is written, and the CLI logs ``Added a `zone.js` import to .storybook/preview.ts``.
6. Reset the workspace once more, add `"zoneless": false` to the storybook target's `options`, leave `zone.js` out, and run step 3 again. On this branch the CLI warns that the target says `zoneless: false` while `zone.js` is missing and writes nothing. On `next` it silently writes the unresolvable import.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation change: `@storybook/angular-vite` is in preview and the `zoneless` option's meaning is unchanged. What changed is which signal the migration acts on.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
