### PR TITLE
Docs: Describe staticDirs fix for lazy-loaded custom elements

### DIFF
--- a/docs/get-started/frameworks/web-components-vite.mdx
+++ b/docs/get-started/frameworks/web-components-vite.mdx
@@ -52,6 +52,16 @@ Then, update your `.storybook/main.js|ts` to change the framework property:
 
 <CodeSnippets path="web-components-vite-add-framework.md" />
 
+### Why don't my components load after building for production?
+
+Some web component libraries, such as [Stencil](https://stenciljs.com/), lazy-load component definitions from a separate `loader` output directory using dynamically computed import paths. Vite's dev server can serve these files directly from disk, so everything works with `storybook dev`. A production build only includes files Vite can statically discover, so those dynamically loaded chunks are missing once you run `build-storybook` and your components fail to render.
+
+To fix this, add the loader's output directory to [`staticDirs`](../../api/main-config/main-config-static-dirs.mdx) so Storybook copies it into the build:
+
+<CodeSnippets path="main-config-static-dirs.md" />
+
+Replace `../public` and `../static` with the path to your loader output (for example, Stencil's default is `../loader`). See [Images, fonts, and assets](../../configure/integration/images-and-assets.mdx) for more on serving static files.
+
 ## API
 
 ### Options


### PR DESCRIPTION
Closes #25704

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--
Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute
-->

## What I did

Components built with Stencil (and similar frameworks that lazy-load custom element definitions from a separate `loader` directory) work in `storybook dev` but fail to render after `build-storybook`. This happens because Vite's production build can only bundle files it can statically discover, and Stencil's lazy-loading loader uses dynamically computed import paths that aren't statically analyzable — so those chunks never make it into `storybook-static`.

This PR adds a new FAQ entry to the Web Components (Vite) framework docs explaining the cause and the fix: adding the loader's output directory to `staticDirs` in `.storybook/main.js|ts` so it gets copied into the build.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

This is a documentation-only change (no code affected), so no functional manual test is needed. To verify:

1. Check out this branch and run the docs site locally (`cd docs && yarn install && yarn start`)
2. Navigate to Get Started > Frameworks > Web components (Vite)
3. Confirm the new FAQ entry "Why don't my components load after building for production?" renders correctly, with no broken links and the `staticDirs` code snippet displaying properly

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_
<!-- CANARY_RELEASE_SECTION -->
<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->