### PR TITLE
CLI: Point the init outro at `storybook skills get setup` and remove duplicate sandbox addon

### DIFF
--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -410,8 +410,7 @@ export const baseTemplates = {
     },
     modifications: {
       useCsfFactory: true,
-      extraDevDependencies: ['prop-types', '@types/prop-types', '@storybook/addon-mcp'],
-      editAddons: (addons) => [...addons, '@storybook/addon-mcp'],
+      extraDevDependencies: ['prop-types', '@types/prop-types'],
       mainConfig: {
         features: {
           developmentModeForBuild: true,

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
@@ -22,7 +22,7 @@ describe('FinalizationCommand', () => {
       logfile: undefined,
       showAgentFollowUp: false,
       showAiInstructions: false,
-      aiSetupCommand: 'npx storybook ai setup',
+      setupSkillCommand: 'npx storybook skills get setup',
     });
 
     vi.mocked(getProjectRoot).mockReturnValue('/test/project');
@@ -119,7 +119,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: true,
         showAiInstructions: true,
-        aiSetupCommand: 'pnpm exec storybook ai setup',
+        setupSkillCommand: 'pnpm exec storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -129,7 +129,7 @@ describe('FinalizationCommand', () => {
         expect.stringContaining('is not entirely set up yet')
       );
       expect(logger.step).toHaveBeenCalledWith(
-        expect.stringContaining('pnpm exec storybook ai setup')
+        expect.stringContaining('pnpm exec storybook skills get setup')
       );
       const logCalls = vi.mocked(logger.log).mock.calls.map((c) => String(c[0]));
       expect(logCalls.some((msg) => msg.includes('https://storybook.js.org/llms.txt'))).toBe(true);
@@ -141,7 +141,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: true,
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -160,7 +160,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -185,7 +185,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: true,
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -194,7 +194,9 @@ describe('FinalizationCommand', () => {
       expect(logger.step).toHaveBeenCalledWith(
         expect.stringContaining('To finalize setting up with AI')
       );
-      expect(logger.step).toHaveBeenCalledWith(expect.stringContaining('npx storybook ai setup'));
+      expect(logger.step).toHaveBeenCalledWith(
+        expect.stringContaining('npx storybook skills get setup')
+      );
     });
 
     it('should NOT show AI instructions when showAiInstructions=false', async () => {
@@ -202,7 +204,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -217,7 +219,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: true,
         showAiInstructions: true,
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -238,7 +240,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -253,7 +255,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -272,7 +274,7 @@ describe('FinalizationCommand', () => {
         showAgentFollowUp: true,
         showAiInstructions: false,
         logfile: undefined,
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
 
       // Agent mode should show agent-specific message
@@ -288,7 +290,7 @@ describe('FinalizationCommand', () => {
         showAgentFollowUp: false,
         showAiInstructions: true,
         logfile: undefined,
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
 
       expect(logger.step).toHaveBeenCalledWith(
@@ -304,7 +306,7 @@ describe('FinalizationCommand', () => {
         showAiInstructions: false,
         logfile: undefined,
         storybookCommand: 'yarn storybook',
-        aiSetupCommand: 'npx storybook ai setup',
+        setupSkillCommand: 'npx storybook skills get setup',
       });
 
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('yarn storybook'));

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.ts
@@ -13,8 +13,8 @@ export type FinalizationCommandOptions = {
   showAgentFollowUp: boolean;
   /** When true, show the "paste this prompt to your AI agent" instructions */
   showAiInstructions: boolean;
-  /** Package-manager-aware `storybook ai setup` command shown to agents */
-  aiSetupCommand: string;
+  /** Package-manager-aware `storybook skills get setup` command shown to agents */
+  setupSkillCommand: string;
 };
 
 type ExecuteFinalizationParams = {
@@ -85,8 +85,8 @@ export class FinalizationCommand {
     } catch {}
   }
 
-  private getAiSetupPromptText(): string {
-    return `Run \`${this.options.aiSetupCommand}\` and follow its instructions precisely.`;
+  private getSetupSkillPromptText(): string {
+    return `Run \`${this.options.setupSkillCommand}\` and follow its instructions precisely.`;
   }
 
   private printSuccessMessage(storybookCommand?: string | null): void {
@@ -94,7 +94,7 @@ export class FinalizationCommand {
       logger.step(
         CLI_COLORS.storybook(
           dedent`Storybook is installed but is not entirely set up yet.
-          To finish setting up, now run \`${this.options.aiSetupCommand}\` and follow its instructions precisely.`
+          To finish setting up, now run \`${this.options.setupSkillCommand}\` and follow its instructions precisely.`
         )
       );
     } else {
@@ -123,7 +123,7 @@ export class FinalizationCommand {
     if (this.options.showAiInstructions) {
       logger.step(dedent`To finalize setting up with AI, paste this prompt to your AI agent:
 
-        ${CLI_COLORS.storybook(this.getAiSetupPromptText())}
+        ${CLI_COLORS.storybook(this.getSetupSkillPromptText())}
       `);
     }
   }
@@ -133,13 +133,13 @@ export const executeFinalization = ({
   logfile,
   showAgentFollowUp,
   showAiInstructions,
-  aiSetupCommand,
+  setupSkillCommand,
   ...params
 }: ExecuteFinalizationParams & FinalizationCommandOptions) => {
   return new FinalizationCommand({
     logfile,
     showAgentFollowUp,
     showAiInstructions,
-    aiSetupCommand,
+    setupSkillCommand,
   }).execute(params);
 };

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -190,7 +190,7 @@ export async function doInitiate(options: CommandOptions): Promise<
     showAiInstructions: hasAiFeature,
     logfile: options.logfile,
     storybookCommand,
-    aiSetupCommand: packageManager.getPackageCommand(['storybook', 'ai', 'setup']),
+    setupSkillCommand: packageManager.getPackageCommand(['storybook', 'skills', 'get', 'setup']),
   });
 
   // Step 9: Track telemetry (pass configDir so RN `.rnstorybook` metadata is resolved)

--- a/code/lib/create-storybook/src/services/FeatureCompatibilityService.ts
+++ b/code/lib/create-storybook/src/services/FeatureCompatibilityService.ts
@@ -33,7 +33,7 @@ export class FeatureCompatibilityService {
     );
   }
 
-  /** Check if AI-assisted setup (storybook ai setup) is supported for this project configuration */
+  /** Check if AI-assisted setup (storybook skills get setup) is supported for this project configuration */
   static supportsAISetupFeature(
     renderer: SupportedRenderer,
     builder: SupportedBuilder,

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -905,14 +905,7 @@ export const extendMain: Task['run'] = async ({ template, sandboxDir, key }, { d
     },
     ...(template.modifications?.editAddons
       ? {
-          // Dedupe: `storybook init` may already register an addon the template appends
-          // (e.g. addon-mcp), and a twice-listed addon shows up doubled in agent-facing
-          // surfaces like `storybook skills get setup`.
-          addons: [
-            ...new Set(
-              template.modifications?.editAddons(mainConfig.getFieldValue(['addons']) || [])
-            ),
-          ],
+          addons: template.modifications?.editAddons(mainConfig.getFieldValue(['addons']) || []),
         }
       : {}),
     core: {

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -905,7 +905,14 @@ export const extendMain: Task['run'] = async ({ template, sandboxDir, key }, { d
     },
     ...(template.modifications?.editAddons
       ? {
-          addons: template.modifications?.editAddons(mainConfig.getFieldValue(['addons']) || []),
+          // Dedupe: `storybook init` may already register an addon the template appends
+          // (e.g. addon-mcp), and a twice-listed addon shows up doubled in agent-facing
+          // surfaces like `storybook skills get setup`.
+          addons: [
+            ...new Set(
+              template.modifications?.editAddons(mainConfig.getFieldValue(['addons']) || [])
+            ),
+          ],
         }
       : {}),
     core: {


### PR DESCRIPTION
Closes #35960
Closes #35956

## What I did

Two small `next`-only alignments with the new `storybook skills` CLI, split out of #35957 (Milestone 7 QA):

- **Init outro** (#35960): the agent-mode outro after `storybook init` still recommended the deprecated `npx storybook ai setup`, contradicting the plugin skills on the very version that ships both. The command is now built as `getPackageCommand(['storybook', 'skills', 'get', 'setup'])` so pnpm/yarn users get their package manager's spelling, and `aiSetupCommand` is renamed to `setupSkillCommand` throughout `FinalizationCommand` and its tests (stale `FeatureCompatibilityService` comment updated too).
- **Duplicate sandbox addon** (#35956): generated `react-vite/default-ts` sandboxes listed `@storybook/addon-mcp` twice in `main.ts`. Root cause: the template's `editAddons` append (704cf4d507c, Jan 2026) predates c14cdda9dcc (Mar 2026), which taught `storybook init` itself to add addon-mcp on React+Vite installs — leaving two writers. Fixed at the source per review feedback: the template no longer appends addon-mcp (nor lists it in `extraDevDependencies`; init installs the package too), so init is the single writer and no dedupe is needed — `scripts/` is untouched. The vue/angular server-docgen templates keep their `editAddons` append because init only adds addon-mcp for React+Vite. (The related worry from the issue is fine: user-facing `storybook add` is already idempotent — it logs "already present" and skips.)

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests

`code/lib/create-storybook/src/commands/FinalizationCommand.test.ts` covers the renamed option and the printed command.

#### Manual testing

1. In an empty Vite project, run `npm create storybook@next -- --yes` with an agent env marker (e.g. `CLAUDECODE=1`): the outro should say ``Run `npx storybook skills get setup` and follow its instructions precisely`` — and that command works on the installed version.
2. Generate a sandbox (`yarn task sandbox --template react-vite/default-ts --start-from auto`) and check `.storybook/main.ts`: `@storybook/addon-mcp` appears once.

### Documentation

- [x] No documentation update needed.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below: `maintenance`
