### PR TITLE
Build: Surface the Storybook log tail when the eval MCP startup fails

### DIFF
--- a/agent-eval/README.md
+++ b/agent-eval/README.md
@@ -70,7 +70,7 @@ EVAL_ONLY=803-edit-component yarn workspace agent-eval run eval
 ```
 
 Before a local run, rebuild the local `@storybook/addon-mcp`/`@storybook/mcp`
-builds the sandboxes inject (`yarn nx run-many -t compile -p addon-mcp mcp`
+builds the sandboxes inject (`yarn nx run-many -t compile --projects mcp,addon-mcp`
 from the repository root). A stale `dist` importing since-renamed core exports
 crashes the sandbox Storybook at preset load, which surfaces as the readiness
 timeout below rather than a build error.

--- a/agent-eval/README.md
+++ b/agent-eval/README.md
@@ -69,6 +69,12 @@ EVAL_EXTRA_EVALS=1 yarn workspace agent-eval run eval
 EVAL_ONLY=803-edit-component yarn workspace agent-eval run eval
 ```
 
+Before a local run, rebuild the local `@storybook/addon-mcp`/`@storybook/mcp`
+builds the sandboxes inject (`yarn nx run-many -t compile -p addon-mcp mcp`
+from the repository root). A stale `dist` importing since-renamed core exports
+crashes the sandbox Storybook at preset load, which surfaces as the readiness
+timeout below rather than a build error.
+
 A full `EVAL_EXTRA_EVALS=1` run (12 workflow evals × 4 experiments + 3
 lifecycle evals × 2 plugin experiments) costs roughly **$30–45** in agent
 tokens at current per-run averages ($0.30–0.80 per workflow eval, $1–2 per

--- a/agent-eval/lib/mcp/start-storybook-mcp.mjs
+++ b/agent-eval/lib/mcp/start-storybook-mcp.mjs
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { closeSync, openSync } from 'node:fs';
-import { copyFile, mkdir, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { setTimeout as delay } from 'node:timers/promises';
 
 const port = process.env.STORYBOOK_MCP_PORT || '6006';
@@ -58,15 +58,29 @@ if (child.pid !== undefined) {
   }
 }
 
-throw new Error(
+// The sandbox is torn down with this failure, so the only diagnostics that
+// survive are the final stderr lines: the eval harness snapshots a failed
+// npm install as its last 10 lines of output, and npm's own error trailer
+// takes about half of that window. Print the log tail last and exit without
+// throwing — an uncaught error's stack and Node's version banner would push
+// the log out of the window (and the in-sandbox dumpMcpDebug() files die
+// with the sandbox, so there is no point writing them here). Setting
+// exitCode instead of calling process.exit() lets the pending pipe write
+// flush — exit() would truncate it at the pipe buffer.
+const logTail = await readFile(logPath, 'utf8')
+  .then((content) => content.trimEnd().split('\n').slice(-5).join('\n'))
+  .catch(() => '(no Storybook log was written)');
+
+process.stderr.write(
   'Storybook MCP server did not become ready at ' +
     mcpUrl +
     ' within ' +
     timeoutMs +
-    'ms. See ' +
-    logPath +
-    ' for Storybook logs.'
+    'ms. Storybook log tail:\n' +
+    logTail +
+    '\n'
 );
+process.exitCode = 1;
 
 async function isReady() {
   try {
@@ -84,6 +98,10 @@ async function dumpMcpDebug() {
   const debugDir = '.storybook/mcp-debug';
   try {
     await mkdir(debugDir, { recursive: true });
+
+    // The startup log first: on the failure path the fetches below throw, and the
+    // log is the one artifact that explains why Storybook never became ready.
+    await copyFile(logPath, debugDir + '/storybook.log').catch(() => {});
 
     const landing = await fetch(mcpUrl, {
       headers: { Accept: 'text/html' },
@@ -110,8 +128,6 @@ async function dumpMcpDebug() {
       signal: AbortSignal.timeout(5_000),
     });
     await writeFile(debugDir + '/initialize.txt', await init.text());
-
-    await copyFile(logPath, debugDir + '/storybook.log').catch(() => {});
   } catch (error) {
     await writeFile(debugDir + '/error.txt', String(error)).catch(() => {});
   }

--- a/agent-eval/lib/mcp/start-storybook-mcp.mjs
+++ b/agent-eval/lib/mcp/start-storybook-mcp.mjs
@@ -58,12 +58,16 @@ if (child.pid !== undefined) {
   }
 }
 
-// The sandbox dies with this failure, taking dumpMcpDebug()'s files with it;
-// only the final stderr lines survive — the harness keeps the last 10 lines
-// of output (errorBody: 'last10') and npm's error trailer takes about half.
-// So: log tail last, no throw (a stack trace would push the tail out of the
-// window), and exitCode rather than process.exit(), which would truncate the
-// pending pipe write.
+// Failure path. This script runs from a package.json postinstall hook during
+// `npm install`, inside a disposable @vercel/agent-eval sandbox. When
+// Storybook never becomes ready, the sandbox is destroyed: files written in
+// it (like the ones dumpMcpDebug() would write) are lost, and the eval
+// report keeps only the last 10 lines of npm's output — about half of which
+// npm's own "npm error" trailer fills. Those few surviving lines are the
+// only diagnostics anyone will ever see. So: print the Storybook log tail
+// as the very last stderr output, don't throw (a stack trace would push the
+// tail out of the window), and set exitCode rather than calling
+// process.exit(), which can truncate a pending pipe write.
 const logTail = await readFile(logPath, 'utf8')
   .then((content) => content.trimEnd().split('\n').slice(-5).join('\n'))
   .catch(() => '')

--- a/agent-eval/lib/mcp/start-storybook-mcp.mjs
+++ b/agent-eval/lib/mcp/start-storybook-mcp.mjs
@@ -58,18 +58,16 @@ if (child.pid !== undefined) {
   }
 }
 
-// The sandbox is torn down with this failure, so the only diagnostics that
-// survive are the final stderr lines: the eval harness snapshots a failed
-// npm install as its last 10 lines of output, and npm's own error trailer
-// takes about half of that window. Print the log tail last and exit without
-// throwing — an uncaught error's stack and Node's version banner would push
-// the log out of the window (and the in-sandbox dumpMcpDebug() files die
-// with the sandbox, so there is no point writing them here). Setting
-// exitCode instead of calling process.exit() lets the pending pipe write
-// flush — exit() would truncate it at the pipe buffer.
+// The sandbox dies with this failure, taking dumpMcpDebug()'s files with it;
+// only the final stderr lines survive — the harness keeps the last 10 lines
+// of output (errorBody: 'last10') and npm's error trailer takes about half.
+// So: log tail last, no throw (a stack trace would push the tail out of the
+// window), and exitCode rather than process.exit(), which would truncate the
+// pending pipe write.
 const logTail = await readFile(logPath, 'utf8')
   .then((content) => content.trimEnd().split('\n').slice(-5).join('\n'))
-  .catch(() => '(no Storybook log was written)');
+  .catch(() => '')
+  .then((tail) => tail || '(no Storybook log was written)');
 
 process.stderr.write(
   'Storybook MCP server did not become ready at ' +
@@ -99,8 +97,7 @@ async function dumpMcpDebug() {
   try {
     await mkdir(debugDir, { recursive: true });
 
-    // The startup log first: on the failure path the fetches below throw, and the
-    // log is the one artifact that explains why Storybook never became ready.
+    // The startup log first, so it is captured even when the fetches below throw.
     await copyFile(logPath, debugDir + '/storybook.log').catch(() => {});
 
     const landing = await fetch(mcpUrl, {


### PR DESCRIPTION
Closes #35961

## What I did

Split out of #35957 (from its commit d96fc74ccf), so this eval-harness fix can land independently of the plugin-delegation work.

### The problem

The eval sandboxes are disposable VMs. When Storybook failed to start inside one, the error said "See `/tmp/storybook-mcp.log`" — but that file lives inside the sandbox, and the sandbox is destroyed on failure. So every startup failure was undebuggable: the one that motivated this issue cost a blind paid retry before the real cause (a stale local `@storybook/addon-mcp` build) was found.

The only thing that survives a failed sandbox setup is the error report, and `@vercel/agent-eval` truncates it to the **last 10 lines** of the `npm install` output. npm's own `npm error …` trailer fills about half of those, leaving roughly 5 lines for actual diagnostics.

### The fix

Make the last 5 lines of the Storybook log the last thing on stderr, so they land inside that surviving window:

- **Print the log tail as the final stderr output.** On readiness timeout, the script reads `/tmp/storybook-mcp.log` and prints its last 5 lines — the preset-load crash, port conflict, or build error that explains the failure.
- **Exit without throwing.** An uncaught throw would append a stack trace and Node's version banner after the tail, pushing it out of the 10-line window.
- **Set `process.exitCode = 1` instead of calling `process.exit(1)`.** npm captures stderr through a pipe, and `process.exit()` right after a write can truncate it — this addresses CodeRabbit's [review finding on #35957](https://github.com/storybookjs/storybook/pull/35957#discussion_r3842001599). Verified with a probe: a 1 MB payload through a pipe survives in full with `exitCode` (1,048,600 bytes) but is cut at 65,536 bytes by `exit(1)`. Nothing holds the event loop open at that point (the Storybook child is detached, unref'd, and already SIGTERM'd), so the process still exits immediately.
- **Skip the debug dump on failure.** `dumpMcpDebug()` writes files into the sandbox, which are lost when it is destroyed — so the failure path no longer calls it. It still runs on success, where the workspace survives, and now copies the startup log first so the log is captured even when its later fetches throw.
- **Document the most common cause.** `agent-eval/README.md` now tells local eval runners to rebuild `@storybook/addon-mcp`/`@storybook/mcp` first: a stale `dist` crashes the sandbox Storybook at preset load, which shows up as this readiness timeout rather than as a build error.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

No automated tests: the change is the eval harness's own sandbox-startup script, exercised by every eval run.

#### Manual testing

1. From a directory without a runnable Storybook, run the failure path directly:
   `STORYBOOK_MCP_PORT=59999 STORYBOOK_MCP_LOG_PATH=$PWD/sb.log STORYBOOK_MCP_TIMEOUT_MS=1500 node <repo>/agent-eval/lib/mcp/start-storybook-mcp.mjs`
   The process exits with status 1, and the final stderr lines are the last 5 lines of the Storybook log instead of a pointer to a log file. Piping stderr must not truncate the tail.
2. (Faithful but paid) Run a local eval per `agent-eval/README.md` with a deliberately stale `addon-mcp` build — skip the rebuild step: setup fails and the captured output ends with the log tail naming the preset-load crash.

### Documentation

- [x] Add or update documentation reflecting your changes (`agent-eval/README.md` local-run note)
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below: `build`