### PR TITLE
Angular Vite: Resolve tsConfig against the workspace root

### DIFF
--- a/code/frameworks/angular-vite/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular-vite/src/builders/build-storybook/index.ts
@@ -29,7 +29,7 @@ import * as pkg from 'empathic/package';
 import { errorSummary, printErrorDetails } from '../utils/error-handler.ts';
 import type { StandaloneOptions } from '../utils/standalone-options.ts';
 import { Channel } from 'storybook/internal/channels';
-import { findTsconfigUp } from '../../find-tsconfig.ts';
+import { resolveTsconfig } from '../../find-tsconfig.ts';
 
 addToGlobalContext('cliVersion', versions.storybook);
 
@@ -170,7 +170,12 @@ async function setup(options: StorybookBuilderOptions, context: BuilderContext) 
   }
 
   return {
-    tsConfig: options.tsConfig ?? findTsconfigUp(options.configDir) ?? browserOptions.tsConfig,
+    tsConfig: resolveTsconfig({
+      workspaceRoot: context.workspaceRoot,
+      configDir: options.configDir,
+      tsConfig: options.tsConfig,
+      browserTsConfig: browserOptions?.tsConfig,
+    }),
   };
 }
 

--- a/code/frameworks/angular-vite/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular-vite/src/builders/start-storybook/index.ts
@@ -30,7 +30,7 @@ import * as pkg from 'empathic/package';
 import { errorSummary, printErrorDetails } from '../utils/error-handler.ts';
 import type { StandaloneOptions } from '../utils/standalone-options.ts';
 import { Channel } from 'storybook/internal/channels';
-import { findTsconfigUp } from '../../find-tsconfig.ts';
+import { resolveTsconfig } from '../../find-tsconfig.ts';
 
 addToGlobalContext('cliVersion', versions.storybook);
 
@@ -214,7 +214,12 @@ async function setup(options: StorybookBuilderOptions, context: BuilderContext) 
   }
 
   return {
-    tsConfig: options.tsConfig ?? findTsconfigUp(options.configDir) ?? browserOptions.tsConfig,
+    tsConfig: resolveTsconfig({
+      workspaceRoot: context.workspaceRoot,
+      configDir: options.configDir,
+      tsConfig: options.tsConfig,
+      browserTsConfig: browserOptions?.tsConfig,
+    }),
   };
 }
 async function runInstance(options: StandaloneOptions) {

--- a/code/frameworks/angular-vite/src/find-tsconfig.test.ts
+++ b/code/frameworks/angular-vite/src/find-tsconfig.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getProjectRoot } from 'storybook/internal/common';
+
+import { resolve } from 'node:path';
+
+import * as find from 'empathic/find';
+
+import { findTsconfigUp, resolveTsconfig } from './find-tsconfig.ts';
+
+vi.mock('storybook/internal/common', { spy: true });
+vi.mock('empathic/find', { spy: true });
+
+const WORKSPACE_ROOT = resolve('/workspace');
+const CONFIG_DIR = resolve('/workspace/projects/lib/.storybook');
+
+beforeEach(() => {
+  vi.mocked(getProjectRoot).mockReturnValue(WORKSPACE_ROOT);
+  vi.mocked(find.up).mockReturnValue(undefined);
+});
+
+describe('findTsconfigUp', () => {
+  it('walks up from the config dir, bounded by the project root', () => {
+    const found = resolve(WORKSPACE_ROOT, 'projects/lib/tsconfig.json');
+    vi.mocked(find.up).mockReturnValue(found);
+
+    expect(findTsconfigUp(CONFIG_DIR)).toBe(found);
+    expect(find.up).toHaveBeenCalledWith('tsconfig.json', {
+      cwd: CONFIG_DIR,
+      last: WORKSPACE_ROOT,
+    });
+  });
+
+  it('returns undefined when the walk finds nothing', () => {
+    expect(findTsconfigUp(CONFIG_DIR)).toBeUndefined();
+  });
+});
+
+describe('resolveTsconfig', () => {
+  it('resolves a workspace-relative `tsConfig` against the workspace root', () => {
+    const result = resolveTsconfig({
+      workspaceRoot: WORKSPACE_ROOT,
+      configDir: CONFIG_DIR,
+      tsConfig: 'projects/lib/.storybook/tsconfig.json',
+    });
+
+    expect(result).toBe(resolve(WORKSPACE_ROOT, 'projects/lib/.storybook/tsconfig.json'));
+  });
+
+  it('leaves an absolute `tsConfig` untouched', () => {
+    const absolute = resolve('/elsewhere/tsconfig.json');
+
+    const result = resolveTsconfig({
+      workspaceRoot: WORKSPACE_ROOT,
+      configDir: CONFIG_DIR,
+      tsConfig: absolute,
+    });
+
+    expect(result).toBe(absolute);
+  });
+
+  it('falls back to the nearest tsconfig above the config dir', () => {
+    const found = resolve(WORKSPACE_ROOT, 'projects/lib/.storybook/tsconfig.json');
+    vi.mocked(find.up).mockReturnValue(found);
+
+    const result = resolveTsconfig({ workspaceRoot: WORKSPACE_ROOT, configDir: CONFIG_DIR });
+
+    expect(result).toBe(found);
+  });
+
+  it('falls back to the browser target tsConfig, also workspace-relative', () => {
+    const result = resolveTsconfig({
+      workspaceRoot: WORKSPACE_ROOT,
+      configDir: CONFIG_DIR,
+      browserTsConfig: 'projects/lib/tsconfig.app.json',
+    });
+
+    expect(result).toBe(resolve(WORKSPACE_ROOT, 'projects/lib/tsconfig.app.json'));
+  });
+
+  it('prefers an explicit `tsConfig` over both fallbacks', () => {
+    vi.mocked(find.up).mockReturnValue(resolve(WORKSPACE_ROOT, 'walked/tsconfig.json'));
+
+    const result = resolveTsconfig({
+      workspaceRoot: WORKSPACE_ROOT,
+      configDir: CONFIG_DIR,
+      tsConfig: 'explicit/tsconfig.json',
+      browserTsConfig: 'browser/tsconfig.app.json',
+    });
+
+    expect(result).toBe(resolve(WORKSPACE_ROOT, 'explicit/tsconfig.json'));
+  });
+
+  it('returns undefined when no tsconfig can be found', () => {
+    const result = resolveTsconfig({ workspaceRoot: WORKSPACE_ROOT, configDir: CONFIG_DIR });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/code/frameworks/angular-vite/src/find-tsconfig.ts
+++ b/code/frameworks/angular-vite/src/find-tsconfig.ts
@@ -1,5 +1,7 @@
 import { getProjectRoot } from 'storybook/internal/common';
 
+import { resolve } from 'node:path';
+
 import * as find from 'empathic/find';
 
 /**
@@ -12,3 +14,21 @@ import * as find from 'empathic/find';
  */
 export const findTsconfigUp = (configDir: string): string | undefined =>
   find.up('tsconfig.json', { cwd: configDir, last: getProjectRoot() });
+
+export type ResolveTsconfigOptions = {
+  workspaceRoot: string;
+  configDir: string;
+  tsConfig?: string;
+  browserTsConfig?: string;
+};
+
+export const resolveTsconfig = ({
+  workspaceRoot,
+  configDir,
+  tsConfig,
+  browserTsConfig,
+}: ResolveTsconfigOptions): string | undefined => {
+  const configured = tsConfig ?? findTsconfigUp(configDir) ?? browserTsConfig;
+
+  return configured ? resolve(workspaceRoot, configured) : undefined;
+};


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Supersedes #35779 (rebased onto current `next`; the Compodoc half of that PR is already in `generate-documentation.ts`).

Both builder schemas say `tsConfig` is "relative to the current workspace", but `setup()` returned the raw value. It ends up in `@analogjs/vite-plugin-angular`, which resolves it against Vite's root. Vite's root is the project directory, not the workspace root. When the Storybook project is not at the workspace root you get a duplicated segment:

```
Unable to resolve tsconfig at /ws/projects/lib/projects/lib/.storybook/tsconfig.json
```

Analog then falls back to its own default, so the build silently uses a different tsconfig than the one that was configured.

`resolveTsconfig` keeps the existing precedence (explicit `tsConfig`, then the nearest `tsconfig.json` above `configDir`, then the browser target) and resolves the result against `workspaceRoot`. Absolute paths come back unchanged.

`viteFinal`'s default `'./.storybook/tsconfig.json'` is left as-is: that fallback is Vite-root relative on purpose when the builder did not pass a path.

`browserOptions?.tsConfig` is now optional, matching its type. It is only assigned when `options.browserTarget` is set.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`find-tsconfig.test.ts` covers `findTsconfigUp` (walk bounded by `getProjectRoot()`, empty walk) and `resolveTsconfig` (workspace-relative input, absolute input, each fallback, precedence, and nothing found).

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

The stock `angular-vite` sandbox will not catch this: its workspace root and project root are the same folder.

1. `yarn task --task sandbox --start-from auto --template angular-vite/default-ts`
2. In the sandbox, make the project root different from the workspace root: set `"root": "projects/app"` in `angular.json`, move `src/` to `projects/app/src/`, and update `sourceRoot`.
3. Move `.storybook/` to `projects/app/.storybook/` and set `"tsConfig": "projects/app/.storybook/tsconfig.json"` on the `storybook` target.
4. `ng run app:storybook`

On the old code the Analog plugin logs `Unable to resolve tsconfig at <workspaceRoot>/projects/app/projects/app/.storybook/tsconfig.json` and falls back. With this change the path resolves and the warning is gone.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->