### PR TITLE
Vue: Substitute static arg values in template snippet expressions

### DIFF
--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-args-expression/TemplateArgsExpression.vue
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-args-expression/TemplateArgsExpression.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+defineProps<{
+  status: object;
+  release: object;
+  updateProgressInfo: object | null;
+  isCollapsed: boolean;
+}>();
+</script>
+
+<template>
+  <aside>
+    <pre>{{ status }}</pre>
+    <pre>{{ release }}</pre>
+    <span>{{ updateProgressInfo }}</span>
+    <span>{{ isCollapsed }}</span>
+  </aside>
+</template>

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-args-expression/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-args-expression/input.stories.ts
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import TemplateArgsExpression from './TemplateArgsExpression.vue';
+
+const availableStatus = { state: 'available', version: '1.2.3' };
+const release = { tag: 'v1.2.3', name: 'Release 1.2.3' };
+
+const meta = {
+  component: TemplateArgsExpression,
+  title: 'Forms/template-args-expression',
+  args: {
+    status: availableStatus,
+    release,
+    updateProgressInfo: null,
+    isCollapsed: false,
+  },
+  render: (args) => ({
+    components: { TemplateArgsExpression },
+    setup: () => ({ args }),
+    template: `
+      <div
+        :style="{
+          '--sidebar-width-collapsed': '52px',
+          width: args.isCollapsed ? '52px' : '176px',
+          overflow: 'hidden'
+        }"
+      >
+        <TemplateArgsExpression v-bind="args" />
+      </div>
+    `,
+  }),
+} satisfies Meta<typeof TemplateArgsExpression>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+
+export const Collapsed: Story = {
+  args: { isCollapsed: true },
+};

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-args-expression/story-docs.payload.snapshot
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-args-expression/story-docs.payload.snapshot
@@ -1,0 +1,61 @@
+{
+  "id": "template-args-expression",
+  "name": "TemplateArgsExpression",
+  "path": "__PATH__",
+  "stories": {
+    "forms-template-args-expression--collapsed": {
+      "description": undefined,
+      "id": "forms-template-args-expression--collapsed",
+      "name": "Collapsed",
+      "snippet": "<script lang="ts" setup>
+import TemplateArgsExpression from './TemplateArgsExpression.vue';
+
+const release = { tag: 'v1.2.3', name: 'Release 1.2.3' };
+
+const status = { state: 'available', version: '1.2.3' };
+</script>
+
+<template>
+  
+        <div
+          :style="{
+            '--sidebar-width-collapsed': '52px',
+            width: true ? '52px' : '176px',
+            overflow: 'hidden'
+          }"
+        >
+          <TemplateArgsExpression isCollapsed :release="release" :status="status" :updateProgressInfo="null" />
+        </div>
+      
+</template>",
+      "summary": undefined,
+    },
+    "forms-template-args-expression--primary": {
+      "description": undefined,
+      "id": "forms-template-args-expression--primary",
+      "name": "Primary",
+      "snippet": "<script lang="ts" setup>
+import TemplateArgsExpression from './TemplateArgsExpression.vue';
+
+const release = { tag: 'v1.2.3', name: 'Release 1.2.3' };
+
+const status = { state: 'available', version: '1.2.3' };
+</script>
+
+<template>
+  
+        <div
+          :style="{
+            '--sidebar-width-collapsed': '52px',
+            width: false ? '52px' : '176px',
+            overflow: 'hidden'
+          }"
+        >
+          <TemplateArgsExpression :isCollapsed="false" :release="release" :status="status" :updateProgressInfo="null" />
+        </div>
+      
+</template>",
+      "summary": undefined,
+    },
+  },
+}

--- a/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-unsupported/input.stories.ts
+++ b/code/lib/docgen-harness/src/vue3/story-docs/__testfixtures__/template-unsupported/input.stories.ts
@@ -21,6 +21,6 @@ export const Primary: Story = {
     setup() {
       return { args };
     },
-    template: '<TemplateUnsupportedPanel v-if="args.hidden" v-bind="args" />',
+    template: '<TemplateUnsupportedPanel v-bind="{ ...args }" />',
   }),
 };

--- a/code/renderers/vue3/src/story-docs/render-primitives.ts
+++ b/code/renderers/vue3/src/story-docs/render-primitives.ts
@@ -33,6 +33,8 @@ export interface RenderContext {
   bindings: Set<string>;
   /** Const declarations hoisted into `<script setup>`. */
   variables: Map<string, string>;
+  /** Value-identical arg hoists already declared in `<script setup>`. */
+  hoistedArgs: Map<string, { binding: string; source: string }>;
   /** Import statements for components the rendered markup references. */
   componentImports: Set<string>;
 }
@@ -87,6 +89,7 @@ export function createRenderContext(): RenderContext {
     // `ref` is reserved up front so no hoisted arg can shadow the Vue import a v-model may need.
     bindings: new Set(['ref']),
     variables: new Map(),
+    hoistedArgs: new Map(),
     componentImports: new Set(),
   };
 }
@@ -334,8 +337,15 @@ export function renderBoundArgAttribute(
 
 /** Hoist an arg value into `<script setup>` and return the binding name that replaces it. */
 export function hoistArgValue(name: string, value: t.Node, ctx: RenderContext): string {
+  const source = printValue(unwrapExpression(value));
+  const existing = ctx.hoistedArgs.get(name);
+  if (existing?.source === source) {
+    return existing.binding;
+  }
+
   const bindingName = allocateBindingName(name, ctx);
-  ctx.variables.set(bindingName, printValue(unwrapExpression(value)));
+  ctx.variables.set(bindingName, source);
+  ctx.hoistedArgs.set(name, { binding: bindingName, source });
   return bindingName;
 }
 

--- a/code/renderers/vue3/src/story-docs/transform-template.test.ts
+++ b/code/renderers/vue3/src/story-docs/transform-template.test.ts
@@ -15,10 +15,17 @@ const STORY_PATH = '/stories/MyButton.stories.ts';
 
 const DOCGEN_CATEGORIES: Record<string, string> = {
   active: 'props',
+  columns: 'props',
   count: 'props',
+  isCollapsed: 'props',
   label: 'props',
   options: 'props',
+  release: 'props',
   ref: 'props',
+  row: 'props',
+  status: 'props',
+  theme: 'props',
+  updateProgressInfo: 'props',
   click: 'events',
   'update:modelValue': 'events',
   default: 'slots',
@@ -51,14 +58,15 @@ const ENTRY: IndexEntry = {
 
 async function buildPayload(
   storySource: string,
-  importSource = "import MyButton from './MyButton.vue';"
+  importSource = "import MyButton from './MyButton.vue';",
+  componentName = 'MyButton'
 ) {
   vol.fromJSON({
     [STORY_PATH]: `
 ${importSource}
 
 const meta = {
-  component: MyButton,
+  component: ${componentName},
   title: 'Example/MyButton',
 };
 
@@ -78,8 +86,8 @@ ${storySource}
   return payload;
 }
 
-async function primarySnippet(storySource: string, importSource?: string) {
-  const payload = await buildPayload(storySource, importSource);
+async function primarySnippet(storySource: string, importSource?: string, componentName?: string) {
+  const payload = await buildPayload(storySource, importSource, componentName);
   return payload.stories['example-mybutton--primary']?.snippet;
 }
 
@@ -298,6 +306,314 @@ export const Primary = {
     `);
   });
 
+  it('substitutes args references inside a wrapper style expression and expands v-bind args', async () => {
+    expect(
+      await primarySnippet(
+        `
+export const Primary = {
+  args: {
+    isCollapsed: false,
+    release: { version: '1.2.3' },
+    status: { label: 'Ready' },
+    updateProgressInfo: null,
+  },
+  render: (args) => ({
+    components: { UpdateStatusItem },
+    setup: () => ({ args }),
+    template: '<div :style="{ \\'--w\\': \\'52px\\', width: args.isCollapsed ? \\'52px\\' : \\'176px\\' }"><UpdateStatusItem v-bind="args" /></div>',
+  }),
+};
+`,
+        "import UpdateStatusItem from './UpdateStatusItem.vue';",
+        'UpdateStatusItem'
+      )
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import UpdateStatusItem from './UpdateStatusItem.vue';
+
+      const release = { version: '1.2.3' };
+
+      const status = { label: 'Ready' };
+      </script>
+
+      <template>
+        <div :style="{ '--w': '52px', width: false ? '52px' : '176px' }"><UpdateStatusItem :isCollapsed="false" :release="release" :status="status" :updateProgressInfo="null" /></div>
+      </template>"
+    `);
+  });
+
+  it('substitutes inline string args as JavaScript literals inside directive expressions', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Ready' },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :aria-label="\\'Status: \\' + args.label" />',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
+        <MyButton :aria-label="'Status: ' + 'Ready'" />
+      </template>"
+    `);
+  });
+
+  it('bails when a substituted string would terminate a single-quoted attribute', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Hi' },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :aria-label=\\'args.label + "!"\\' v-bind="args" />',
+  }),
+};
+`)
+    ).toBeUndefined();
+  });
+
+  it('substitutes args references inside interpolation expressions', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { count: 2 },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<p>{{ args.count + 1 }}</p>',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<template>
+        <p>{{ 2 + 1 }}</p>
+      </template>"
+    `);
+  });
+
+  it('allows double quotes from substituted args inside interpolation expressions', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: "it's" },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<p>{{ args.label + "!" }}</p>',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<template>
+        <p>{{ "it's" + "!" }}</p>
+      </template>"
+    `);
+  });
+
+  it('wraps negative inline args before exponentiation', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { count: -2 },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :x="args.count ** 2" />',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
+        <MyButton :x="(-2) ** 2" />
+      </template>"
+    `);
+  });
+
+  it('substitutes hoisted object args before member access in directive expressions', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { theme: { color: 'red' } },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :style="{ color: args.theme.color }" />',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+
+      const theme = { color: 'red' };
+      </script>
+
+      <template>
+        <MyButton :style="{ color: theme.color }" />
+      </template>"
+    `);
+  });
+
+  it('renames hoisted args that collide with slot and v-for template bindings', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: {
+    columns: ['a'],
+    row: { id: 1 },
+  },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<MyButton :columns="args.columns"><template #cell="{ row }"><b :title="args.row.id" /></template></MyButton>',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+
+      const columns = ['a'];
+
+      const row2 = { id: 1 };
+      </script>
+
+      <template>
+        <MyButton :columns="columns"><template #cell="{ row }"><b :title="row2.id" /></template></MyButton>
+      </template>"
+    `);
+
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: {
+    columns: ['a'],
+    row: { cells: ['b'] },
+  },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<ul><li v-for="row in args.columns" :key="row"><b v-for="c in args.row.cells" :key="c">{{ c }}</b></li></ul>',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      const columns = ['a'];
+
+      const row2 = { cells: ['b'] };
+      </script>
+
+      <template>
+        <ul><li v-for="row in columns" :key="row"><b v-for="c in row2.cells" :key="c">{{ c }}</b></li></ul>
+      </template>"
+    `);
+  });
+
+  it('bails when expression substitution would entity-decode an arg value', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'a&amp;b' },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :x="args.label + 1" />',
+  }),
+};
+`)
+    ).toBeUndefined();
+  });
+
+  it('bails on unquoted directive expressions but still substitutes quoted ones', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Hi' },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :x=args.label+1 />',
+  }),
+};
+`)
+    ).toBeUndefined();
+
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Hi' },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :x="args.label+1" />',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
+        <MyButton :x="'Hi'+1" />
+      </template>"
+    `);
+  });
+
+  it('bails on delete expressions that mutate args', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { count: 2 },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :x="delete args.count" />',
+  }),
+};
+`)
+    ).toBeUndefined();
+  });
+
+  it('substitutes optional args member references inside expression branches', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { isCollapsed: false },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :x="args?.isCollapsed ? \\'closed\\' : \\'open\\'" />',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
+        <MyButton :x="false ? 'closed' : 'open'" />
+      </template>"
+    `);
+  });
+
+  it('bails when Vue entity-decodes the original directive expression', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { count: 2 },
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: '<MyButton :disabled="args.count &gt; 1" />',
+  }),
+};
+`)
+    ).toBeUndefined();
+  });
+
   it('keeps author-written slot templates, including the shorthand, untouched', async () => {
     expect(
       await primarySnippet(`
@@ -433,14 +749,53 @@ export const Primary = {
     ).toBeUndefined();
   });
 
-  it('bails when args are used in unsupported directive expressions', async () => {
+  it('substitutes args references inside v-if expressions', async () => {
     expect(
       await primarySnippet(`
 export const Primary = {
-  args: { count: 2 },
+  args: { isCollapsed: false },
   render: (args) => ({
     setup: () => ({ args }),
-    template: '<MyButton v-if="args.count" />',
+    template: '<MyButton v-if="args.isCollapsed" />',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
+        <MyButton v-if="false" />
+      </template>"
+    `);
+  });
+
+  it.each([
+    ['spread args', '<MyButton v-bind="{ ...args }" />', { count: 2 }],
+    ['computed args member', '<MyButton :x="args[key]" />', { count: 2 }],
+    ['update expression in event handler', '<MyButton @click="args.count++" />', { count: 2 }],
+    ['assignment in event handler', '<MyButton @click="args.count = 1" />', { count: 2 }],
+    ['missing arg name', '<MyButton :x="args.missing + 1" />', { count: 2 }],
+    [
+      'inline string value containing a double quote',
+      `<MyButton :aria-label="'Status: ' + args.label" />`,
+      { label: 'say "hi"' },
+    ],
+    ['v-for args shadowing', '<MyButton v-for="args in items" :key="args.id" />', { count: 2 }],
+    [
+      'v-slot args shadowing',
+      '<MyButton><template v-slot="{ args }">{{ args.label }}</template></MyButton>',
+      { label: 'Hi' },
+    ],
+  ])('bails on %s in directive expressions', async (_name, template, args) => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: ${JSON.stringify(args)},
+  render: (args) => ({
+    setup: () => ({ args }),
+    template: ${JSON.stringify(template)},
   }),
 };
 `)

--- a/code/renderers/vue3/src/story-docs/transform-template.test.ts
+++ b/code/renderers/vue3/src/story-docs/transform-template.test.ts
@@ -27,6 +27,7 @@ const DOCGEN_CATEGORIES: Record<string, string> = {
   theme: 'props',
   updateProgressInfo: 'props',
   click: 'events',
+  submit: 'events',
   'update:modelValue': 'events',
   default: 'slots',
   header: 'slots',
@@ -460,6 +461,39 @@ export const Primary = {
     `);
   });
 
+  it('reuses a hoisted object arg across directive expressions', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: {
+    theme: {
+      color: 'red',
+      mode: 'dark',
+    },
+  },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<section><MyButton :style="{ color: args.theme.color }" /><div :data-mode="args.theme.mode" /></section>',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+
+      const theme = {
+        color: 'red',
+        mode: 'dark',
+      };
+      </script>
+
+      <template>
+        <section><MyButton :style="{ color: theme.color }" /><div :data-mode="theme.mode" /></section>
+      </template>"
+    `);
+  });
+
   it('renames hoisted args that collide with slot and v-for template bindings', async () => {
     expect(
       await primarySnippet(`
@@ -658,6 +692,31 @@ export const Primary = {
 
       <template>
         <MyButton @click="onClick" />
+      </template>"
+    `);
+  });
+
+  it('reuses a hoisted handler across repeated event bindings', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { onSubmit: () => {} },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<section><MyButton @submit="args.onSubmit" /><MyButton @submit="args.onSubmit" /></section>',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+
+      const onSubmit = () => {};
+      </script>
+
+      <template>
+        <section><MyButton @submit="onSubmit" /><MyButton @submit="onSubmit" /></section>
       </template>"
     `);
   });

--- a/code/renderers/vue3/src/story-docs/transform-template.ts
+++ b/code/renderers/vue3/src/story-docs/transform-template.ts
@@ -4,10 +4,11 @@ import {
   type AttributeNode,
   type DirectiveNode,
   type ElementNode,
+  type SimpleExpressionNode,
   type TemplateChildNode,
 } from '@vue/compiler-dom';
 
-import { types as t } from 'storybook/internal/babel';
+import { babelParseExpression, types as t } from 'storybook/internal/babel';
 import {
   keyOf,
   propertyValue,
@@ -17,7 +18,7 @@ import {
 } from 'storybook/internal/csf-tools';
 
 import type { ClassifiedArg } from './classify-args.ts';
-import { isFunctionExpression } from './classify-value.ts';
+import { isFunctionExpression, printValue } from './classify-value.ts';
 import {
   createRenderContext,
   hoistArgValue,
@@ -72,6 +73,14 @@ interface TransformState {
   template: string;
 }
 
+interface ArgsReference {
+  start: number;
+  end: number;
+  name: string;
+}
+
+type ExpressionContext = 'directive' | 'interpolation';
+
 const ARGS_NAME = 'args';
 const ARGS_IDENTIFIER_REGEXP = /(^|[^\w$])args([^\w$]|$)/;
 const ARGS_MEMBER_REGEXP = /^args\.([A-Za-z_$][\w$]*)$/;
@@ -108,10 +117,9 @@ export function readTemplateRenderConfig(
 /**
  * Transform supported template-render markup into a static SFC snippet.
  *
- * The template is parsed with Vue's own parser, and only the ranges this pass fully understands
- * (`v-bind="args"`, `:prop="args.x"`, `@event="args.onX"`, `v-model="args.x"`, `{{ args.x }}`) are
- * spliced in the original source, so every untouched author byte survives verbatim. Anything else
- * that references args, and anything Vue itself refuses to parse, bails to the runtime source
+ * The template is parsed with Vue's own parser, and only understood args ranges are spliced in the
+ * original source, so every untouched author byte survives verbatim. Args usage that cannot be
+ * substituted safely, and anything Vue itself refuses to parse, bails to the runtime source
  * fallback.
  */
 export function transformTemplate(
@@ -130,6 +138,10 @@ export function transformTemplate(
     componentImports: input.componentImports,
     template: input.template,
   };
+
+  if (!collectTemplateScopeBindings(ast.children, state.ctx)) {
+    return undefined;
+  }
 
   if (!ast.children.every((child) => transformNode(child, state))) {
     return undefined;
@@ -160,12 +172,22 @@ function transformInterpolation(
   node: Extract<TemplateChildNode, { type: NodeTypes.INTERPOLATION }>,
   state: TransformState
 ): boolean {
-  const expression =
-    node.content.type === NodeTypes.SIMPLE_EXPRESSION ? node.content.content.trim() : '';
+  const expressionNode =
+    node.content.type === NodeTypes.SIMPLE_EXPRESSION ? node.content : undefined;
+  const expression = expressionNode?.content.trim() ?? '';
   const argName = exactArgsMemberName(expression);
 
   if (!argName) {
-    return !valueReferencesArgs(expression);
+    if (!expressionNode || !valueReferencesArgs(expression)) {
+      return true;
+    }
+
+    const edit = substituteArgsExpression(expressionNode, state, 'interpolation');
+    if (!edit) {
+      return false;
+    }
+    state.edits.push(edit);
+    return true;
   }
 
   const arg = state.argsByName.get(argName);
@@ -223,8 +245,9 @@ function transformDirective(
     return false;
   }
 
-  const expression =
-    directive.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? directive.exp.content.trim() : undefined;
+  const expressionNode =
+    directive.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? directive.exp : undefined;
+  const expression = expressionNode?.content.trim();
 
   // <MyButton v-bind="args" />
   if (directive.name === 'bind' && !directive.arg && expression === ARGS_NAME) {
@@ -258,35 +281,263 @@ function transformDirective(
   }
 
   // <MyButton @click="args.onClick" />
-  if (directive.name === 'on' && boundProp && argName && directive.exp) {
+  if (directive.name === 'on' && boundProp && argName && expressionNode) {
     const arg = state.argsByName.get(argName);
     if (!arg || !isFunctionExpression(arg.value)) {
       return false;
     }
     state.edits.push({
-      start: directive.exp.loc.start.offset,
-      end: directive.exp.loc.end.offset,
+      start: expressionNode.loc.start.offset,
+      end: expressionNode.loc.end.offset,
       text: hoistArgValue(argName, arg.value, state.ctx),
     });
     return true;
   }
 
   // <MyButton v-model="args.modelValue" />
-  if (directive.name === 'model' && argName && directive.exp) {
+  if (directive.name === 'model' && argName && expressionNode) {
     const arg = state.argsByName.get(argName);
     if (!arg || arg.role === 'slot' || arg.role === 'event') {
       return false;
     }
     state.edits.push({
-      start: directive.exp.loc.start.offset,
-      end: directive.exp.loc.end.offset,
+      start: expressionNode.loc.start.offset,
+      end: expressionNode.loc.end.offset,
       text: hoistModelRef(argName, arg.value, state.ctx),
     });
     return true;
   }
 
-  // Any other args usage is beyond what a static snippet can honestly represent.
-  return expression === undefined || !valueReferencesArgs(expression);
+  if (!expressionNode || !expression || !valueReferencesArgs(expression)) {
+    return true;
+  }
+
+  if (directive.name === 'on' || directive.name === 'model' || directive.name === 'slot') {
+    return false;
+  }
+
+  const edit = substituteArgsExpression(expressionNode, state, 'directive');
+  if (!edit) {
+    return false;
+  }
+  state.edits.push(edit);
+  return true;
+}
+
+function substituteArgsExpression(
+  exp: SimpleExpressionNode,
+  state: TransformState,
+  context: ExpressionContext
+): Edit | undefined {
+  const source = state.template.slice(exp.loc.start.offset, exp.loc.end.offset);
+  if (source !== exp.content) {
+    return undefined;
+  }
+
+  let ast: t.Expression;
+  try {
+    ast = babelParseExpression(exp.content);
+  } catch {
+    return undefined;
+  }
+
+  const references = collectArgsReferences(ast);
+  if (!references) {
+    return undefined;
+  }
+
+  const quote =
+    context === 'directive' ? surroundingAttributeQuote(exp, state.template) : undefined;
+  if (context === 'directive' && !quote) {
+    return undefined;
+  }
+
+  const replacements = new Map<string, string>();
+  for (const reference of references) {
+    const replacement =
+      replacements.get(reference.name) ?? replacementForArgsReference(reference, quote, state);
+    if (!replacement) {
+      return undefined;
+    }
+    replacements.set(reference.name, replacement);
+  }
+
+  const text = references
+    .sort((a, b) => b.start - a.start)
+    .reduce((expression, reference) => {
+      return (
+        expression.slice(0, reference.start) +
+        replacements.get(reference.name)! +
+        expression.slice(reference.end)
+      );
+    }, exp.content);
+
+  return { start: exp.loc.start.offset, end: exp.loc.end.offset, text };
+}
+
+function collectTemplateScopeBindings(nodes: TemplateChildNode[], ctx: RenderContext): boolean {
+  for (const node of nodes) {
+    if (node.type !== NodeTypes.ELEMENT) {
+      continue;
+    }
+
+    for (const prop of node.props) {
+      if (prop.type !== NodeTypes.DIRECTIVE) {
+        continue;
+      }
+
+      const pattern = bindingPatternForDirective(prop);
+      if (pattern && !addBindingPattern(pattern, ctx)) {
+        return false;
+      }
+    }
+
+    if (!collectTemplateScopeBindings(node.children, ctx)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function bindingPatternForDirective(directive: DirectiveNode): string | undefined {
+  const expression =
+    directive.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? directive.exp.content.trim() : undefined;
+  if (!expression) {
+    return undefined;
+  }
+
+  if (directive.name === 'for') {
+    const match = /\s+(?:in|of)\s+/.exec(expression);
+    return match ? expression.slice(0, match.index).trim() : expression;
+  }
+
+  return directive.name === 'slot' ? expression : undefined;
+}
+
+function addBindingPattern(pattern: string, ctx: RenderContext): boolean {
+  let ast: t.Expression;
+  try {
+    ast = babelParseExpression(`${arrowParamsForPattern(pattern)} => 0`);
+  } catch {
+    return false;
+  }
+
+  if (!t.isArrowFunctionExpression(ast)) {
+    return false;
+  }
+
+  for (const param of ast.params) {
+    for (const name of Object.keys(t.getBindingIdentifiers(param))) {
+      ctx.bindings.add(name);
+    }
+  }
+
+  return true;
+}
+
+function arrowParamsForPattern(pattern: string): string {
+  const trimmed = pattern.trim();
+  return trimmed.startsWith('(') && trimmed.endsWith(')') ? trimmed : `(${trimmed})`;
+}
+
+function surroundingAttributeQuote(
+  exp: SimpleExpressionNode,
+  template: string
+): '"' | "'" | undefined {
+  const quote = template[exp.loc.start.offset - 1];
+  return quote === '"' || quote === "'" ? quote : undefined;
+}
+
+function collectArgsReferences(expression: t.Expression): ArgsReference[] | undefined {
+  const references: ArgsReference[] = [];
+  let invalid = false;
+
+  const visit = (node: t.Node | null | undefined, parent?: t.Node): void => {
+    if (!node || invalid) {
+      return;
+    }
+
+    if (
+      t.isAssignmentExpression(node) ||
+      t.isUpdateExpression(node) ||
+      (t.isUnaryExpression(node) && node.operator === 'delete')
+    ) {
+      invalid = true;
+      return;
+    }
+
+    const reference = argsReference(node);
+    if (reference) {
+      references.push(reference);
+    }
+
+    if (t.isIdentifier(node, { name: ARGS_NAME }) && !isAllowedArgsObject(node, parent)) {
+      invalid = true;
+      return;
+    }
+
+    for (const key of t.VISITOR_KEYS[node.type] ?? []) {
+      const value = node[key as keyof typeof node];
+      if (Array.isArray(value)) {
+        value.forEach((child) => {
+          if (t.isNode(child)) {
+            visit(child, node);
+          }
+        });
+      } else if (t.isNode(value)) {
+        visit(value, node);
+      }
+    }
+  };
+
+  visit(expression);
+
+  return invalid ? undefined : references;
+}
+
+function argsReference(node: t.Node): ArgsReference | undefined {
+  const member =
+    t.isMemberExpression(node) || t.isOptionalMemberExpression(node) ? node : undefined;
+  if (!member || member.computed || !t.isIdentifier(member.object, { name: ARGS_NAME })) {
+    return undefined;
+  }
+  if (!t.isIdentifier(member.property) || member.start == null || member.end == null) {
+    return undefined;
+  }
+
+  return { start: member.start, end: member.end, name: member.property.name };
+}
+
+function isAllowedArgsObject(node: t.Identifier, parent: t.Node | undefined): boolean {
+  if (!parent || (!t.isMemberExpression(parent) && !t.isOptionalMemberExpression(parent))) {
+    return false;
+  }
+  return parent.object === node && !parent.computed;
+}
+
+function replacementForArgsReference(
+  reference: ArgsReference,
+  quote: '"' | "'" | undefined,
+  state: TransformState
+): string | undefined {
+  const arg = state.argsByName.get(reference.name);
+  // Non-slot args are typed with renderable plans only, so no 'function-slot' check is needed.
+  if (!arg || arg.role === 'slot') {
+    return undefined;
+  }
+
+  const text =
+    arg.plan.kind === 'inline'
+      ? printValue(unwrapExpression(arg.value))
+      : hoistArgValue(arg.name, arg.value, state.ctx);
+
+  // Vue entity-decodes generated markup on re-parse, so `&` cannot be substituted faithfully.
+  if ((quote && text.includes(quote)) || text.includes('}}') || text.includes('&')) {
+    return undefined;
+  }
+
+  return text.startsWith('-') ? `(${text})` : text;
 }
 
 /**


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Vue story-docs snippet generator only supported a few exact `args` patterns in template renders:

- `v-bind="args"`
-  `:prop="args.x"` 
- `{{ args.x }}` etc...


Any other expression referencing `args`  made the whole story bail to the runtime source fallback, losing the generated snippet.

This PR makes `transformTemplate` substitute the story's static arg values into such expressions instead of bailing: each `args.<name>` reference is replaced with the arg's value, while the rest of the author's expression stays verbatim. 

Values are substituted, never evaluated, so the snippet stays faithful to what the story renders and each story shows its own values.

Shapes that can't be substituted faithfully still bail to the runtime fallback as before.



<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing


1. Generate a Vue sandbox and enable the docgen server:

   ```bash
   yarn task sandbox --template vue3-vite/default-ts --start-from auto
   ```

   In the sandbox's `.storybook/main.ts`, set `features: { experimentalDocgenServer: true }`.

2. Add a story that references `args` inside a wrapper expression — the shape that previously lost its snippet:

   ```ts
   // src/stories/Wrapped.stories.ts
   import type { Meta, StoryObj } from '@storybook/vue3-vite';
   import Button from './Button.vue';

   const meta = {
     title: 'QA/Wrapped',
     component: Button,
     args: { primary: false, label: 'Button' },
     render: (args) => ({
       components: { Button },
       setup: () => ({ args }),
       template: `
         <div :style="{ width: args.primary ? '300px' : '150px', border: '1px solid red' }">
           <Button v-bind="args" />
         </div>
       `,
     }),
   } satisfies Meta<typeof Button>;

   export default meta;
   type Story = StoryObj<typeof meta>;

   export const Default: Story = {};
   export const Primary: Story = { args: { primary: true } };
   ```

3. Run `yarn storybook`, open **QA/Wrapped** docs page, and expand the code panel for each story:
   - **Before this PR**: both stories show the runtime-generated source (no synthesized SFC snippet).
   - **After this PR**: each story shows a complete SFC snippet with its own value substituted into the ternary — `width: false ? '300px' : '150px'` for *Default*, `width: true ? …` for *Primary* — with the wrapper markup otherwise byte-identical to the story source, and `v-bind="args"` expanded to explicit props.



> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-36027-sha-1f955b5e`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-36027-sha-1f955b5e sandbox` or in an existing project with `npx storybook@0.0.0-pr-36027-sha-1f955b5e upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-36027-sha-1f955b5e`](https://npmjs.com/package/storybook/v/0.0.0-pr-36027-sha-1f955b5e) |
| **Triggered by** | @huang-julien |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`julien/vue_static_args`](https://github.com/storybookjs/storybook/tree/julien/vue_static_args) |
| **Commit** | [`1f955b5e`](https://github.com/storybookjs/storybook/commit/1f955b5e803bc5c0e792a9ddc07566e8e6c8b337) |
| **Datetime** | Mon Aug 24 11:29:01 UTC 2026 (`1787570941`) |
| **Workflow run** | [32722065280](https://github.com/storybookjs/storybook/actions/runs/32722065280) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=36027`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
