### PR TITLE
Tools: Keep --json stdout parseable by silencing the logger

### DIFF
--- a/code/core/src/cli/tools/register.test.ts
+++ b/code/core/src/cli/tools/register.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The commander wiring of `storybook tools`: the parts `run.test.ts` cannot see because they live
+ * around the run, not inside it — how the result reaches stdout, and the logger silencing that
+ * keeps a `--json` stdout parseable.
+ */
+import { logger } from 'storybook/internal/node-logger';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Command } from 'commander';
+
+import { registerToolsPassthrough } from './register.ts';
+import type { ToolsRunResult } from './run.ts';
+
+const { runToolsCommand } = vi.hoisted(() => ({ runToolsCommand: vi.fn() }));
+
+vi.mock('./run.ts', () => ({ runToolsCommand }));
+vi.mock('node:fs/promises', () => ({ writeFile: vi.fn() }));
+// The shared setup replaces the logger with spies; this file is about the real one's level.
+vi.mock('storybook/internal/node-logger', async (importOriginal) =>
+  importOriginal<typeof import('storybook/internal/node-logger')>()
+);
+vi.mock('storybook/internal/core-server', () => ({
+  withTelemetry: (_name: string, _options: unknown, run: () => Promise<void>) => run(),
+  sendTelemetryError: vi.fn(),
+}));
+vi.mock('storybook/internal/telemetry', () => ({ telemetry: vi.fn() }));
+
+/** Runs the registered action for `storybook tools <argv>` and returns what reached stdout. */
+async function runCli(argv: string[]): Promise<string> {
+  const program = new Command();
+  program.exitOverride();
+  const toolsCommand = program.command('tools').exitOverride();
+  registerToolsPassthrough(program, toolsCommand, () => async () => {
+    throw new Error('unexpected command failure');
+  });
+
+  let stdout = '';
+  const writeSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: string | Uint8Array, ...rest: unknown[]) => {
+      stdout += String(chunk);
+      const callback = rest.at(-1);
+      if (typeof callback === 'function') {
+        (callback as () => void)();
+      }
+      return true;
+    });
+  try {
+    await program.parseAsync(['node', 'storybook', 'tools', ...argv]);
+  } finally {
+    writeSpy.mockRestore();
+  }
+  return stdout;
+}
+
+describe('registerToolsPassthrough', () => {
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+
+  beforeEach(() => {
+    logger.setLogLevel('info');
+    runToolsCommand.mockImplementation(
+      async (): Promise<ToolsRunResult> => ({
+        exitCode: 0,
+        output: '{"ok":true}',
+        outcome: { kind: 'success' },
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    logger.setLogLevel('info');
+  });
+
+  afterEach(() => exitSpy.mockClear());
+
+  it('keeps a --json stdout free of log output while the tool runs', async () => {
+    runToolsCommand.mockImplementation(async (): Promise<ToolsRunResult> => {
+      logger.warn('Multiple story files share the component id');
+      return { exitCode: 0, output: '{"ok":true}', outcome: { kind: 'success' } };
+    });
+
+    const stdout = await runCli(['docs', 'show', '--json']);
+
+    expect(() => JSON.parse(stdout)).not.toThrow();
+    expect(stdout).not.toContain('Multiple story files');
+  });
+
+  it('restores the log level once the run is over, including when it throws', async () => {
+    runToolsCommand.mockRejectedValue(new Error('boom'));
+
+    await expect(runCli(['docs', 'show', '--json'])).rejects.toThrow('unexpected command failure');
+
+    expect(logger.getLogLevel()).toBe('info');
+  });
+
+  it('leaves logging on without --json, and when the JSON goes to a file', async () => {
+    const outputs: string[] = [];
+    runToolsCommand.mockImplementation(async (): Promise<ToolsRunResult> => {
+      outputs.push(logger.getLogLevel());
+      return { exitCode: 0, output: 'markdown', outcome: { kind: 'success' } };
+    });
+
+    await runCli(['docs', 'show']);
+    await runCli(['docs', 'show', '--json', '--output', 'out.json']);
+
+    expect(outputs).toEqual(['info', 'info']);
+  });
+});

--- a/code/core/src/cli/tools/register.test.ts
+++ b/code/core/src/cli/tools/register.test.ts
@@ -7,14 +7,13 @@ import { logger } from 'storybook/internal/node-logger';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Command } from 'commander';
+import { writeFile } from 'node:fs/promises';
 
 import { registerToolsPassthrough } from './register.ts';
-import type { ToolsRunResult } from './run.ts';
+import { runToolsCommand, type ToolsRunResult } from './run.ts';
 
-const { runToolsCommand } = vi.hoisted(() => ({ runToolsCommand: vi.fn() }));
-
-vi.mock('./run.ts', () => ({ runToolsCommand }));
-vi.mock('node:fs/promises', () => ({ writeFile: vi.fn() }));
+vi.mock('./run.ts', { spy: true });
+vi.mock('node:fs/promises', { spy: true });
 // The shared setup replaces the logger with spies; this file is about the real one's level.
 vi.mock('storybook/internal/node-logger', async (importOriginal) =>
   importOriginal<typeof import('storybook/internal/node-logger')>()
@@ -55,55 +54,78 @@ async function runCli(argv: string[]): Promise<string> {
 
 describe('registerToolsPassthrough', () => {
   const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+  const success = (output: string): ToolsRunResult => ({
+    exitCode: 0,
+    output,
+    outcome: { kind: 'success' },
+  });
 
   beforeEach(() => {
     logger.setLogLevel('info');
-    runToolsCommand.mockImplementation(
-      async (): Promise<ToolsRunResult> => ({
-        exitCode: 0,
-        output: '{"ok":true}',
-        outcome: { kind: 'success' },
-      })
-    );
+    // `-o/--output` reaches the real `writeFile` otherwise, and these runs are about the log level.
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+    vi.mocked(runToolsCommand).mockImplementation(async () => success('{"ok":true}'));
   });
 
   afterEach(() => {
     vi.clearAllMocks();
     logger.setLogLevel('info');
+    exitSpy.mockClear();
   });
 
-  afterEach(() => exitSpy.mockClear());
-
-  it('keeps a --json stdout free of log output while the tool runs', async () => {
-    runToolsCommand.mockImplementation(async (): Promise<ToolsRunResult> => {
-      logger.warn('Multiple story files share the component id');
-      return { exitCode: 0, output: '{"ok":true}', outcome: { kind: 'success' } };
+  describe('when the tool logs while a --json result is on its way to stdout', () => {
+    beforeEach(() => {
+      vi.mocked(runToolsCommand).mockImplementation(async () => {
+        logger.warn('Multiple story files share the component id');
+        return success('{"ok":true}');
+      });
     });
 
-    const stdout = await runCli(['docs', 'show', '--json']);
+    it('keeps stdout free of log output', async () => {
+      const stdout = await runCli(['docs', 'show', '--json']);
 
-    expect(() => JSON.parse(stdout)).not.toThrow();
-    expect(stdout).not.toContain('Multiple story files');
+      expect(() => JSON.parse(stdout)).not.toThrow();
+      expect(stdout).not.toContain('Multiple story files');
+    });
   });
 
-  it('restores the log level once the run is over, including when it throws', async () => {
-    runToolsCommand.mockRejectedValue(new Error('boom'));
-
-    await expect(runCli(['docs', 'show', '--json'])).rejects.toThrow('unexpected command failure');
-
-    expect(logger.getLogLevel()).toBe('info');
-  });
-
-  it('leaves logging on without --json, and when the JSON goes to a file', async () => {
-    const outputs: string[] = [];
-    runToolsCommand.mockImplementation(async (): Promise<ToolsRunResult> => {
-      outputs.push(logger.getLogLevel());
-      return { exitCode: 0, output: 'markdown', outcome: { kind: 'success' } };
+  describe('when the run throws', () => {
+    beforeEach(() => {
+      vi.mocked(runToolsCommand).mockRejectedValue(new Error('boom'));
     });
 
-    await runCli(['docs', 'show']);
-    await runCli(['docs', 'show', '--json', '--output', 'out.json']);
+    it('restores the log level anyway', async () => {
+      await expect(runCli(['docs', 'show', '--json'])).rejects.toThrow(
+        'unexpected command failure'
+      );
 
-    expect(outputs).toEqual(['info', 'info']);
+      expect(logger.getLogLevel()).toBe('info');
+    });
+  });
+
+  describe('when stdout is not a JSON document', () => {
+    const levels: string[] = [];
+
+    beforeEach(() => {
+      levels.length = 0;
+      vi.mocked(runToolsCommand).mockImplementation(async () => {
+        levels.push(logger.getLogLevel());
+        return success('markdown');
+      });
+    });
+
+    it('leaves logging on without --json, and when the JSON goes to a file', async () => {
+      await runCli(['docs', 'show']);
+      await runCli(['docs', 'show', '--json', '--output', 'out.json']);
+
+      expect(levels).toEqual(['info', 'info']);
+    });
+
+    it('leaves logging on for an incomplete command path, which lists tools as markdown', async () => {
+      await runCli(['--json']);
+      await runCli(['docs', '--json']);
+
+      expect(levels).toEqual(['info', 'info']);
+    });
   });
 });

--- a/code/core/src/cli/tools/register.ts
+++ b/code/core/src/cli/tools/register.ts
@@ -80,7 +80,7 @@ export function registerToolsPassthrough(
         // ahead of the payload and breaks `JSON.parse` for the agent reading it. Silence the
         // logger for the duration of the run: `logTracker` records log calls before the level is
         // consulted, so `--logfile` still captures everything that was suppressed.
-        const silenceLogger = printsJsonToStdout(tokens, flags);
+        const silenceLogger = printsJsonToStdout({ toolset, tool, tokens, flags });
         const previousLogLevel = logger.getLogLevel();
         // Like `init`, the fallback keeps telemetry on when no main config is loadable: running
         // from a cwd without a Storybook is a failure this event exists to measure. The explicit

--- a/code/core/src/cli/tools/register.ts
+++ b/code/core/src/cli/tools/register.ts
@@ -11,7 +11,7 @@ import type { Command } from 'commander';
 import type { ToolsetTelemetry } from '../../shared/open-service/toolset-definition.ts';
 import { resolveStorybookConfigDir } from './config-dir.ts';
 import { runToolsCommand, type ToolsCommandOutcome, type ToolsRunResult } from './run.ts';
-import { TOOLS_OPTION_SPECS, type ToolsOutputFlags } from './tool-tokens.ts';
+import { TOOLS_OPTION_SPECS, printsJsonToStdout, type ToolsOutputFlags } from './tool-tokens.ts';
 
 /** `handleCommandFailure` from `bin/core.ts`, passed in to avoid an import cycle. */
 export type CommandFailureHandler = (
@@ -69,6 +69,19 @@ export function registerToolsPassthrough(
         options: ToolsPassthroughOptions
       ) => {
         const cliOptions = pickCliOptions(options);
+        const flags: ToolsOutputFlags = {
+          input: options.input,
+          json: options.json,
+          output: options.output,
+          help: options.help,
+        };
+        // A `--json` run makes stdout a JSON document, and the logger writes to stdout (see
+        // `node-logger`), so any warning a toolset or the indexer emits while the tool runs lands
+        // ahead of the payload and breaks `JSON.parse` for the agent reading it. Silence the
+        // logger for the duration of the run: `logTracker` records log calls before the level is
+        // consulted, so `--logfile` still captures everything that was suppressed.
+        const silenceLogger = printsJsonToStdout(tokens, flags);
+        const previousLogLevel = logger.getLogLevel();
         // Like `init`, the fallback keeps telemetry on when no main config is loadable: running
         // from a cwd without a Storybook is a failure this event exists to measure. The explicit
         // opt-outs (env var, flag, loadable `core.disableTelemetry`) still apply.
@@ -83,6 +96,9 @@ export function registerToolsPassthrough(
             const keepAlive = setInterval(() => {}, 60_000);
             const start = Date.now();
             let result: ToolsRunResult;
+            if (silenceLogger) {
+              logger.setLogLevel('silent');
+            }
             try {
               result = await runToolsCommand(
                 {
@@ -90,17 +106,17 @@ export function registerToolsPassthrough(
                   tool,
                   tokens,
                   target: { cwd: options.cwd, configDir: options.configDir },
-                  flags: {
-                    input: options.input,
-                    json: options.json,
-                    output: options.output,
-                    help: options.help,
-                  },
+                  flags,
                 },
                 { methodTelemetry: createMethodTelemetrySink(cliOptions) }
               );
             } finally {
               clearInterval(keepAlive);
+              // Restored before anything is printed, so the result, the failure handler's own
+              // output and the `--logfile` notice are never swallowed.
+              if (silenceLogger) {
+                logger.setLogLevel(previousLogLevel);
+              }
             }
             const duration = Date.now() - start;
             try {

--- a/code/core/src/cli/tools/tool-tokens.test.ts
+++ b/code/core/src/cli/tools/tool-tokens.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseToolsTokens } from './tool-tokens.ts';
+import { parseToolsTokens, printsJsonToStdout } from './tool-tokens.ts';
 
 describe('parseToolsTokens', () => {
   it('parses --key value pairs with JSON coercion', () => {
@@ -72,5 +72,29 @@ describe('parseToolsTokens', () => {
   it('rejects values on the bare flags', () => {
     expect(parseToolsTokens(['--json=data'])).toMatchObject({ ok: false });
     expect(parseToolsTokens(['--help=me'])).toMatchObject({ ok: false });
+  });
+});
+
+describe('printsJsonToStdout', () => {
+  it('is true when --json is given on either side of the tool name', () => {
+    expect(printsJsonToStdout(['--json'])).toBe(true);
+    expect(printsJsonToStdout([], { json: true })).toBe(true);
+  });
+
+  it('is false without --json', () => {
+    expect(printsJsonToStdout(['--id', 'button-docs'])).toBe(false);
+  });
+
+  it('is false when the document goes to a file instead of stdout', () => {
+    expect(printsJsonToStdout(['--json', '-o', 'out.json'])).toBe(false);
+    expect(printsJsonToStdout(['--json'], { output: 'out.json' })).toBe(false);
+  });
+
+  it('is false for help, which renders markdown even under --json', () => {
+    expect(printsJsonToStdout(['--json', '--help'])).toBe(false);
+  });
+
+  it('is false when the tokens do not parse, since no JSON is produced', () => {
+    expect(printsJsonToStdout(['--json', 'button'])).toBe(false);
   });
 });

--- a/code/core/src/cli/tools/tool-tokens.test.ts
+++ b/code/core/src/cli/tools/tool-tokens.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseToolsTokens, printsJsonToStdout } from './tool-tokens.ts';
+import { parseToolsTokens, printsJsonToStdout, type ToolsOutputFlags } from './tool-tokens.ts';
 
 describe('parseToolsTokens', () => {
   it('parses --key value pairs with JSON coercion', () => {
@@ -76,25 +76,38 @@ describe('parseToolsTokens', () => {
 });
 
 describe('printsJsonToStdout', () => {
+  /** A complete command path, which is what `--json` turns into a JSON document. */
+  const invocation = (tokens: string[], flags?: ToolsOutputFlags) => ({
+    toolset: 'docs',
+    tool: 'show',
+    tokens,
+    flags,
+  });
+
   it('is true when --json is given on either side of the tool name', () => {
-    expect(printsJsonToStdout(['--json'])).toBe(true);
-    expect(printsJsonToStdout([], { json: true })).toBe(true);
+    expect(printsJsonToStdout(invocation(['--json']))).toBe(true);
+    expect(printsJsonToStdout(invocation([], { json: true }))).toBe(true);
   });
 
   it('is false without --json', () => {
-    expect(printsJsonToStdout(['--id', 'button-docs'])).toBe(false);
+    expect(printsJsonToStdout(invocation(['--id', 'button-docs']))).toBe(false);
   });
 
   it('is false when the document goes to a file instead of stdout', () => {
-    expect(printsJsonToStdout(['--json', '-o', 'out.json'])).toBe(false);
-    expect(printsJsonToStdout(['--json'], { output: 'out.json' })).toBe(false);
+    expect(printsJsonToStdout(invocation(['--json', '-o', 'out.json']))).toBe(false);
+    expect(printsJsonToStdout(invocation(['--json'], { output: 'out.json' }))).toBe(false);
   });
 
   it('is false for help, which renders markdown even under --json', () => {
-    expect(printsJsonToStdout(['--json', '--help'])).toBe(false);
+    expect(printsJsonToStdout(invocation(['--json', '--help']))).toBe(false);
   });
 
   it('is false when the tokens do not parse, since no JSON is produced', () => {
-    expect(printsJsonToStdout(['--json', 'button'])).toBe(false);
+    expect(printsJsonToStdout(invocation(['--json', 'button']))).toBe(false);
+  });
+
+  it('is false for an incomplete command path, which lists what is available as markdown', () => {
+    expect(printsJsonToStdout({ tokens: [], flags: { json: true } })).toBe(false);
+    expect(printsJsonToStdout({ toolset: 'docs', tokens: ['--json'] })).toBe(false);
   });
 });

--- a/code/core/src/cli/tools/tool-tokens.ts
+++ b/code/core/src/cli/tools/tool-tokens.ts
@@ -152,6 +152,18 @@ function coerceValue(raw: string): unknown {
 }
 
 /**
+ * Whether this invocation will write a JSON document to stdout, which makes stdout a
+ * machine-readable stream that nothing else may write to.
+ *
+ * `--help` renders markdown even under `--json`, and `-o/--output` sends the document to a file
+ * and leaves stdout human-facing; both keep stdout free for log output.
+ */
+export function printsJsonToStdout(tokens: string[], flags: ToolsOutputFlags = {}): boolean {
+  const parsed = parseToolsTokens(tokens, flags);
+  return parsed.ok && parsed.json && !parsed.help && parsed.output === undefined;
+}
+
+/**
  * The generic flags of `storybook tools`, in display order. One list serves both the commander
  * registration and the help renderer: commander's own help is disabled (the command surface is
  * derived from the target project's toolset registry at runtime), so the custom help must document

--- a/code/core/src/cli/tools/tool-tokens.ts
+++ b/code/core/src/cli/tools/tool-tokens.ts
@@ -155,10 +155,21 @@ function coerceValue(raw: string): unknown {
  * Whether this invocation will write a JSON document to stdout, which makes stdout a
  * machine-readable stream that nothing else may write to.
  *
+ * Only a complete command path produces JSON: an incomplete one (`storybook tools --json`, or
+ * `storybook tools <toolset> --json`) renders the markdown listing of what is available instead.
  * `--help` renders markdown even under `--json`, and `-o/--output` sends the document to a file
- * and leaves stdout human-facing; both keep stdout free for log output.
+ * and leaves stdout human-facing. All of those keep stdout human-facing, so log output may go there.
  */
-export function printsJsonToStdout(tokens: string[], flags: ToolsOutputFlags = {}): boolean {
+export function printsJsonToStdout(invocation: {
+  toolset?: string;
+  tool?: string;
+  tokens: string[];
+  flags?: ToolsOutputFlags;
+}): boolean {
+  const { toolset, tool, tokens, flags = {} } = invocation;
+  if (!toolset || !tool) {
+    return false;
+  }
   const parsed = parseToolsTokens(tokens, flags);
   return parsed.ok && parsed.json && !parsed.help && parsed.output === undefined;
 }


### PR DESCRIPTION
Fixes #35955

## Problem

`storybook tools <toolset> <tool> --json` documents its `--json` flag as "Print the tool's structured result data as JSON instead of markdown", but `node-logger` writes to **stdout** (`npmLog.stream = process.stdout`, and the clack path likewise). Any warning emitted while the tool runs — the indexer's `Multiple story files share the component id …` is the easy one to hit — is printed ahead of the payload, so the stream a `--json` consumer reads starts with a clack-styled box instead of `{`:

```
JSON.parse fails: Unexpected token '│', "│\n▲  Multi"... is not valid JSON
```

Redirecting stderr does not help, because the warning is not on stderr.

## Fix

When a run will write a JSON document to stdout, stdout is a machine-readable stream and nothing else may write to it — so the logger is silenced for the duration of that run.

Runs whose stdout is *not* a JSON document deliberately keep logging on:

- an incomplete command path (`storybook tools --json`, `storybook tools <toolset> --json`) lists what is available as markdown;
- `--help` renders markdown even under `--json`;
- `-o` / `--output` sends the document to a file and leaves stdout human-facing.

The predicate (`printsJsonToStdout`) takes the toolset and tool names plus the same `parseToolsTokens` the run itself uses, so the flags are read identically on both sides of the toolset name and a token that fails to parse — which produces an error message, not JSON — keeps logging.

Two details worth calling out:

- The level is restored in the `finally` that already clears the keep-alive, i.e. **before** anything is printed. The result, the failure handler's own output, and the `--logfile` notice are never swallowed, including when the run throws.
- `logTracker.addLog()` runs before the level is consulted in `createLogger`, so `--logfile` still captures every message that was suppressed on stdout. Nothing is lost, only relocated.

#### Manual testing

Against a sandbox with two stories sharing a component id (which makes the indexer warn):

```bash
cd code && yarn task sandbox --template react-vite/default-ts --start-from auto
cd ../storybook-sandboxes/react-vite-default-ts

# before: stdout starts with a clack box, so piping it into a JSON parser throws
npx storybook tools docs list --json > out.txt; head -c 80 out.txt

# after: stdout is pure JSON, `node -e 'JSON.parse(...)'` on out.txt succeeds
npx storybook tools docs list --json > out.txt; head -c 80 out.txt

# the suppressed warning is still recorded
npx storybook tools docs list --json --logfile tools.log > /dev/null
grep -c 'component id' tools.log

# still human-facing, logging on, markdown out
npx storybook tools --json
npx storybook tools docs --json
npx storybook tools docs list --json --help
npx storybook tools docs list --json -o out.json
```

## Validation

New `register.test.ts` covers the commander wiring, which `run.test.ts` cannot see (it starts inside the run). It drives the registered action through commander with `runToolsCommand` stubbed, captures `process.stdout`, and asserts:

- a warning logged during a `--json` run does not reach stdout, and `JSON.parse(stdout)` succeeds — **this test fails on `next`** with exactly the error from the issue (`Unexpected token '│'`);
- the level is restored after the run, including when it rejects;
- no `--json`, `--json -o file`, and the incomplete command paths all leave the level untouched.

`tool-tokens.test.ts` covers `printsJsonToStdout` directly (both flag positions, `--output`, `--help`, unparseable tokens, incomplete paths).

```
vitest run code/core/src/cli/tools/  →  10 files, 151 tests passed, no type errors
yarn --cwd code lint:js:cmd          →  clean
```

