### PR TITLE
fix(core): avoid user-event singleton pollution in portable stories (#35928)

### DIFF
--- a/code/core/src/test/preview.test.ts
+++ b/code/core/src/test/preview.test.ts
@@ -7,7 +7,7 @@ const nativeFocus = HTMLElement.prototype.focus;
 
 describe('focus instrumentation', () => {
   beforeAll(async () => {
-    await enhanceContext({ canvasElement: document.body } as any);
+    await enhanceContext({ canvasElement: document.body, parameters: {} } as any);
   });
 
   afterEach(() => {
@@ -43,5 +43,32 @@ describe('focus instrumentation', () => {
 
     expect(() => button.focus()).not.toThrow();
     expect(detachedDocument.activeElement).not.toBe(button);
+  });
+});
+
+describe('portable story context', () => {
+  it('skips userEvent setup and returns undefined when __isPortableStory is true', async () => {
+    const context = {
+      canvasElement: document.body,
+      parameters: { __isPortableStory: true },
+    } as any;
+
+    const cleanup = await enhanceContext(context);
+
+    // No userEvent instance should be set on the context for portable stories
+    expect(context.userEvent).toBeUndefined();
+    // No cleanup is returned since nothing was set up
+    expect(cleanup).toBeUndefined();
+  });
+
+  it('does not skip userEvent setup when __isPortableStory is false', async () => {
+    const context = {
+      canvasElement: document.body,
+      parameters: { __isPortableStory: false },
+    } as any;
+
+    // Should not throw and should proceed normally (userEvent may or may not be set
+    // depending on the environment's navigator.clipboard availability)
+    await expect(enhanceContext(context)).resolves.not.toThrow();
   });
 });

--- a/code/core/src/test/preview.ts
+++ b/code/core/src/test/preview.ts
@@ -93,13 +93,24 @@ export const enhanceContext: LoaderFunction = async (context) => {
     context.canvas = within(context.canvasElement);
   }
 
+  // In portable story contexts (Story.run() / Story.load()), the consumer owns
+  // userEvent setup. Installing our own uninstrumentedUserEvent.setup() would
+  // register a second set of Symbol-keyed document interceptors (isPrepared,
+  // Interceptor, UIValue, …) that conflict with the consumer's
+  // @testing-library/user-event copy, corrupting its event queue.
+  // See: https://github.com/storybookjs/storybook/issues/35928
+  if (context.parameters.__isPortableStory) {
+    return;
+  }
+
   try {
     // userEvent.setup() cannot be called in non browser environment and will attempt to access window.navigator.clipboard
     // which will throw an error in react native for example.
     const clipboard = globalThis.window?.navigator?.clipboard;
     if (clipboard) {
+      const userEventInstance = uninstrumentedUserEvent.setup();
       context.userEvent = instrument(
-        { userEvent: uninstrumentedUserEvent.setup() },
+        { userEvent: userEventInstance },
         {
           intercept: true,
           getKeys: (obj) => Object.keys(obj).filter((key) => key !== 'eventWrapper'),
@@ -165,6 +176,15 @@ export const enhanceContext: LoaderFunction = async (context) => {
 
         patchedFocus = true;
       }
+
+      // Return a cleanup function so the userEvent instance's document interceptors
+      // (Symbol-keyed state like `isPrepared`, `Interceptor`) are torn down after
+      // each story, preventing leakage into subsequent tests.
+      return async () => {
+        try {
+          await (userEventInstance as any)?.cleanup?.();
+        } catch {}
+      };
     }
   } catch {}
 };


### PR DESCRIPTION
Closes #35928

### Description
Portable stories running in unit test runners (Jest/Vitest with \@testing-library/user-event\) were experiencing duplicate symbol interceptor conflicts and method call collisions because \enhanceContext\ globally initialized \uninstrumentedUserEvent.setup()\ without proper teardown.

### Changes
- Check \context.parameters.__isPortableStory\ before invoking userEvent setup in \code/core/src/test/preview.ts\.
- Added cleanup teardown handlers via \userEventInstance.cleanup()\.
- Added unit tests in \code/core/src/test/preview.test.ts\.